### PR TITLE
test(integration): allow to run `--turbo` dev server tests dynamically 

### DIFF
--- a/packages/next/build/swc/index.js
+++ b/packages/next/build/swc/index.js
@@ -410,6 +410,9 @@ function loadNative(isCustomTurbopack = false) {
                   ...process.env,
                 },
               })
+              child.on('message', (message) => {
+                console.log(message)
+              })
               child.on('close', (code) => {
                 if (code !== 0) {
                   reject({

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -4,6 +4,7 @@ import { NextInstance, NextInstanceOpts } from './next-modes/base'
 import { NextDevInstance } from './next-modes/next-dev'
 import { NextStartInstance } from './next-modes/next-start'
 import { NextDeployInstance } from './next-modes/next-deploy'
+import { shouldRunTurboDevTest } from './next-test-utils'
 
 // increase timeout to account for yarn install time
 jest.setTimeout(240 * 1000)
@@ -117,15 +118,28 @@ export async function createNext(
       throw new Error(`createNext called without destroying previous instance`)
     }
 
+    const useTurbo = !!process.env.TEST_WASM
+      ? false
+      : opts?.turbo ?? shouldRunTurboDevTest()
+
     if (testMode === 'dev') {
       // next dev
-      nextInstance = new NextDevInstance(opts)
+      nextInstance = new NextDevInstance({
+        ...opts,
+        turbo: useTurbo,
+      })
     } else if (testMode === 'deploy') {
       // Vercel
-      nextInstance = new NextDeployInstance(opts)
+      nextInstance = new NextDeployInstance({
+        ...opts,
+        turbo: false,
+      })
     } else {
       // next build + next start
-      nextInstance = new NextStartInstance(opts)
+      nextInstance = new NextStartInstance({
+        ...opts,
+        turbo: false,
+      })
     }
 
     nextInstance.on('destroy', () => {

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -345,8 +345,10 @@ export function runNextCommandDev(argv, stdOut, opts = {}) {
 
 // Launch the app in dev mode.
 export function launchApp(dir, port, opts) {
-  const { turbo, ...options } = opts ?? {}
-  const useTurbo = !process.env.TEST_WASM && turbo
+  const options = opts ?? {}
+  const useTurbo = !!process.env.TEST_WASM
+    ? false
+    : options?.turbo ?? shouldRunTurboDevTest()
 
   return runNextCommandDev(
     [useTurbo ? '--turbo' : undefined, dir, '-p', port].filter(Boolean),
@@ -866,4 +868,52 @@ export function findAllTelemetryEvents(output, eventName) {
     JSON.parse(entry.pop())
   )
   return events.filter((e) => e.eventName === eventName).map((e) => e.payload)
+}
+
+/**
+ * Utility function to determine if a given test case needs to run with --turbo.
+ *
+ * This is primarily for the gradual test enablement with latest turbopack upstream changes.
+ *
+ * Note: it could be possible to dynamically create test cases itself (createDevTest(): it.each([...])), but
+ * it makes hard to conform with existing lint rules. Instead, starting off from manual fixture setup and
+ * update test cases accordingly as turbopack changes enable more test cases.
+ */
+export function shouldRunTurboDevTest() {
+  if (!!process.env.TEST_WASM) {
+    return false
+  }
+
+  const shouldRunTurboDev = !!process.env.__INTERNAL_NEXT_DEV_TEST_TURBO_DEV
+  // short-circuit to run all the test with --turbo enabled skips glob matching costs
+  if (shouldRunTurboDev) {
+    console.log(
+      `Running tests with --turbo via custom environment variable __INTERNAL_NEXT_DEV_TEST_TURBO_DEV`
+    )
+    return true
+  }
+
+  const shouldRunTurboDevWithMatches =
+    !!process.env.__INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH
+
+  // By default, we do not run any tests with `--turbo` flag.
+  if (!shouldRunTurboDevWithMatches) {
+    return false
+  }
+
+  const glob = require('glob')
+  const matches = glob.sync(
+    process.env.__INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH
+  )
+  const testPath = expect.getState().testPath
+  const isMatch = matches.some((match) => testPath.includes(match))
+
+  if (isMatch) {
+    console.log(
+      `Running tests with --turbo via custom environment variable __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH`
+    )
+  }
+
+  // If the test path matches the glob pattern, add additional case to run the test with `--turbo` flag.
+  return isMatch
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This PR is companion to https://github.com/vercel/next.js/pull/42656.

Previous PR https://github.com/vercel/next.js/pull/41908 allowed to set up integration / e2e tests spawn `next dev` with `--turbo` as needed. This PR leverages those, change all the tests suites to run with `--turbo`. One additional change is it can be configured dynamically via env variable. Setting env `__INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH` to glob pattern will selectively enables tests to run with --turbo, normally it'll skip and only current devserver will be used.

These changes allow gradual integration between https://github.com/vercel/turbo to next.js. Plan is to run these tests with latest turbopack dev branch. Each time turbopack fixes / implements changes to enable certain set of tests, its CI will change its env variable without manually patching next.js's test cases. Once those change goes to upstream `next-swc` those tests can be permanantly enabled.

For those reasons, PR have somewhat verbose changes to touch individual test cases runs devserver. Changed file counts are lot, but mostly identical changes.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
