### PR TITLE
Fix `AppType` to include parameters correctly

### DIFF
--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -170,15 +170,16 @@ export type AppInitialProps<P = any> = {
   pageProps: P
 }
 
-export type AppPropsType<
-  R extends NextRouter = NextRouter,
-  P = {}
-> = AppInitialProps<P> & {
-  Component: NextComponentType<NextPageContext, any, any>
-  router: R
-  __N_SSG?: boolean
-  __N_SSP?: boolean
-}
+export type AppPropsType<R extends NextRouter = NextRouter, P = {}> = Omit<
+  AppInitialProps,
+  keyof P
+> &
+  P & {
+    Component: NextComponentType<NextPageContext, any, any>
+    router: R
+    __N_SSG?: boolean
+    __N_SSP?: boolean
+  }
 
 export type DocumentContext = NextPageContext & {
   renderPage: RenderPage


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Fixes #42846.

`pageProps` defaults to `any` type if it wasn't overriden by developer.

The behaviour is following: 
```tsx
// extending "props" type
interface Props {
  foo: string;
}

const MyApp: AppType<Props> = (props) => {
  props.foo; // "foo" is string
  props.pageProps; // "pageProps" is any
}

// providing "pageProps" type
interface Props {
  foo: string;
  pageProps: {
    bar: string
  }
}

const MyApp: AppType<Props> = (props) => {
  props.foo; // "foo" is string
  props.pageProps.bar; // "bar" is string
}
```

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
