### PR TITLE
Document regions config for experimental-edge

### DIFF
--- a/docs/api-routes/edge-api-routes.md
+++ b/docs/api-routes/edge-api-routes.md
@@ -106,6 +106,25 @@ export default async function handler(req: NextRequest) {
 }
 ```
 
+### Configuring Regions (for deploying)
+
+You may want to restrict your edge function to specific regions when deploying so that you can colocate near your data sources ensuring lower response times which can be achieved as shown.
+
+Note: this config is available in `v12.3.2` of Next.js and up.
+
+```js
+import { NextResponse } from 'next/server'
+
+export const config = {
+  regions: ['sfo1', 'iad1'], // defaults to 'all'
+}
+
+export default async function handler(req: NextRequest) {
+  const myData = await getNearbyData()
+  return NextResponse.json(myData)
+}
+```
+
 ## Differences between API Routes
 
 Edge API Routes use the [Edge Runtime](/docs/api-reference/edge-runtime.md), whereas API Routes use the [Node.js runtime](/docs/advanced-features/react-18/switchable-runtime.md).


### PR DESCRIPTION
This ensures we document the regions config for `experimental-edge`. 

x-ref: [slack thread](https://vercel.slack.com/archives/C0289CGVAR2/p1668624228564539)
x-ref: https://github.com/vercel/next.js/pull/40881

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
