### PR TITLE
Remove `swcMinify` option from example configs

### DIFF
--- a/examples/with-ant-design/next.config.js
+++ b/examples/with-ant-design/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
 }
 
 module.exports = nextConfig

--- a/examples/with-grafbase/next.config.js
+++ b/examples/with-grafbase/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
   experimental: {
     appDir: true,
   },

--- a/examples/with-postgres/next.config.js
+++ b/examples/with-postgres/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
 }
 
 module.exports = nextConfig

--- a/examples/with-tigris/next.config.js
+++ b/examples/with-tigris/next.config.js
@@ -1,6 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  swcMinify: true,
-}
-
-module.exports = nextConfig

--- a/examples/with-turbopack/next.config.js
+++ b/examples/with-turbopack/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true, // Recommended for the `pages` directory, default in `app`.
-  swcMinify: true,
   experimental: {
     // Required:
     appDir: true,


### PR DESCRIPTION
SWC minification is now [enabled by default](https://nextjs.org/docs/advanced-features/compiler) in the Next.js compiler.

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm build && pnpm lint`
- [X] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
