### PR TITLE
Fix app page check on windows

### DIFF
--- a/packages/next/server/lib/find-page-file.ts
+++ b/packages/next/server/lib/find-page-file.ts
@@ -66,7 +66,7 @@ export async function findPageFile(
 // Determine if the file is leaf node page file under layouts,
 // The filename should start with 'page' and end with one of the allowed extensions
 export function isLayoutsLeafPage(filePath: string, pageExtensions: string[]) {
-  return new RegExp(`(^page|/page)\\.(?:${pageExtensions.join('|')})$`).test(
-    filePath
-  )
+  return new RegExp(
+    `(^page|[\\/]page)\\.(?:${pageExtensions.join('|')})$`
+  ).test(filePath)
 }


### PR DESCRIPTION
Ensures we check for backslashes as well when matching `/page`. Will investigate adding the app suite to windows CI in follow-up

x-ref: https://github.com/vercel/next.js/pull/42996
Fixes: https://github.com/vercel/next.js/issues/43019

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
