### PR TITLE
Ensure backslash is correctly handled in find-page-file

### DIFF
--- a/packages/next/server/lib/find-page-file.ts
+++ b/packages/next/server/lib/find-page-file.ts
@@ -67,6 +67,6 @@ export async function findPageFile(
 // The filename should start with 'page' and end with one of the allowed extensions
 export function isLayoutsLeafPage(filePath: string, pageExtensions: string[]) {
   return new RegExp(
-    `(^page|[\\/]page)\\.(?:${pageExtensions.join('|')})$`
+    `(^page|[\\\\/]page)\\.(?:${pageExtensions.join('|')})$`
   ).test(filePath)
 }

--- a/test/unit/find-page-file.test.ts
+++ b/test/unit/find-page-file.test.ts
@@ -53,6 +53,9 @@ describe('isLayoutsLeafPage', () => {
     expect(isLayoutsLeafPage('./page.jsx', pageExtensions)).toBe(true)
     expect(isLayoutsLeafPage('/page.ts', pageExtensions)).toBe(true)
     expect(isLayoutsLeafPage('/path/page.tsx', pageExtensions)).toBe(true)
+    expect(isLayoutsLeafPage('\\path\\page.tsx', pageExtensions)).toBe(true)
+    expect(isLayoutsLeafPage('.\\page.jsx', pageExtensions)).toBe(true)
+    expect(isLayoutsLeafPage('\\page.js', pageExtensions)).toBe(true)
   })
 
   it('should determine other files under layout routes as non leaf node', () => {


### PR DESCRIPTION

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/43019#issuecomment-1319340037