### PR TITLE
chore: Updating Tigris example to use stable release

### DIFF
--- a/examples/with-tigris/package.json
+++ b/examples/with-tigris/package.json
@@ -9,7 +9,7 @@
     "setup": "npx ts-node scripts/setup.ts"
   },
   "dependencies": {
-    "@tigrisdata/core": "beta",
+    "@tigrisdata/core": "latest",
     "next": "latest",
     "react": "18.2.0",
     "react-dom": "18.2.0"


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
