### PR TITLE
Only apply externals config with app dir

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1055,9 +1055,11 @@ export default async function getBaseWebpackConfig(
   const crossOrigin = config.crossOrigin
   const looseEsmExternals = config.experimental?.esmExternals === 'loose'
 
-  const optOutBundlingPackages = EXTERNAL_PACKAGES.concat(
-    ...(config.experimental.serverComponentsExternalPackages || [])
-  )
+  const optOutBundlingPackages = config.experimental.appDir
+    ? EXTERNAL_PACKAGES.concat(
+        ...(config.experimental.serverComponentsExternalPackages || [])
+      )
+    : []
 
   let resolvedExternalPackageDirs: Map<string, string>
 


### PR DESCRIPTION
Prevents potentially breaking change by applying externals for `pages` that weren't previously applied. 

x-ref: https://github.com/vercel/next.js/pull/42323
x-ref: https://github.com/vercel/next.js/issues/42641

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
