### PR TITLE
fix: Wrong link to source in "responsive" image example

### DIFF
--- a/examples/image-component/pages/responsive.tsx
+++ b/examples/image-component/pages/responsive.tsx
@@ -4,7 +4,7 @@ import mountains from '../public/mountains.jpg'
 
 const Responsive = () => (
   <div>
-    <ViewSource pathname="pages/layout-responsive.tsx" />
+    <ViewSource pathname="pages/responsive.tsx" />
     <h1>Image Component With Layout Responsive</h1>
     <Image
       alt="Mountains"


### PR DESCRIPTION
This fixes the link to source for the ["responsive" example](https://image-component.nextjs.gallery/responsive).

The link to source was coming from the old `<Image />` component, but the file name has changed.

---

### Unrelated bug
The link in the ["fill" example](https://image-component.nextjs.gallery/fill) is also wrong (`/layout-fill` instead of `/fill`):

![image](https://user-images.githubusercontent.com/29319414/202729361-479de340-99bf-4587-90f1-786320307639.png)

The "layout" is also coming from the old image component.

..but [the source code has `fill` correctly](https://github.com/vercel/next.js/blob/canary/examples/image-component/pages/fill.tsx#L7) instead! So maybe this has something to do with caching of the site?
