### PR TITLE
Add experimental outputFileTracingIgnores config

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1993,13 +1993,15 @@ export default async function getBaseWebpackConfig(
       config.outputFileTracing &&
         (isNodeServer || isEdgeServer) &&
         !dev &&
-        new (require('./webpack/plugins/next-trace-entrypoints-plugin').TraceEntryPointsPlugin)(
+        new (require('./webpack/plugins/next-trace-entrypoints-plugin')
+          .TraceEntryPointsPlugin as typeof import('./webpack/plugins/next-trace-entrypoints-plugin').TraceEntryPointsPlugin)(
           {
             appDir: dir,
             esmExternals: config.experimental.esmExternals,
             outputFileTracingRoot: config.experimental.outputFileTracingRoot,
             appDirEnabled: hasAppDir,
             turbotrace: config.experimental.turbotrace,
+            traceIgnores: config.experimental.ouptutFileTracingIgnores || [],
           }
         ),
       // Moment.js is an extremely popular library that bundles large locale files

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -2001,7 +2001,7 @@ export default async function getBaseWebpackConfig(
             outputFileTracingRoot: config.experimental.outputFileTracingRoot,
             appDirEnabled: hasAppDir,
             turbotrace: config.experimental.turbotrace,
-            traceIgnores: config.experimental.ouptutFileTracingIgnores || [],
+            traceIgnores: config.experimental.outputFileTracingIgnores || [],
           }
         ),
       // Moment.js is an extremely popular library that bundles large locale files

--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -92,7 +92,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
   private appDirEnabled?: boolean
   private tracingRoot: string
   private entryTraces: Map<string, Set<string>>
-  private excludeFiles: string[]
+  private traceIgnores: string[]
   private esmExternals?: NextConfigComplete['experimental']['esmExternals']
   private turbotrace?: NextConfigComplete['experimental']['turbotrace']
   private chunksToTrace: string[] = []
@@ -102,14 +102,14 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
   constructor({
     appDir,
     appDirEnabled,
-    excludeFiles,
+    traceIgnores,
     esmExternals,
     outputFileTracingRoot,
     turbotrace,
   }: {
     appDir: string
     appDirEnabled?: boolean
-    excludeFiles?: string[]
+    traceIgnores?: string[]
     outputFileTracingRoot?: string
     esmExternals?: NextConfigComplete['experimental']['esmExternals']
     turbotrace?: NextConfigComplete['experimental']['turbotrace']
@@ -118,7 +118,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
     this.entryTraces = new Map()
     this.esmExternals = esmExternals
     this.appDirEnabled = appDirEnabled
-    this.excludeFiles = excludeFiles || []
+    this.traceIgnores = traceIgnores || []
     this.tracingRoot = outputFileTracingRoot || appDir
     this.turbotrace = turbotrace
   }
@@ -174,7 +174,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
           return
         }
       }
-      const ignores = [...TRACE_IGNORES, ...this.excludeFiles]
+      const ignores = [...TRACE_IGNORES, ...this.traceIgnores]
 
       const ignoreFn = (path: string) => {
         return isMatch(path, ignores, { contains: true, dot: true })
@@ -463,7 +463,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
             let reasons: NodeFileTraceReasons
             const ignores = [
               ...TRACE_IGNORES,
-              ...this.excludeFiles,
+              ...this.traceIgnores,
               '**/node_modules/**',
             ]
             const ignoreFn = (path: string) => {

--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -335,6 +335,9 @@ const configSchema = {
           minLength: 1,
           type: 'string',
         },
+        ouptutFileTracingIgnores: {
+          type: 'array',
+        },
         pageEnv: {
           type: 'boolean',
         },

--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -335,7 +335,7 @@ const configSchema = {
           minLength: 1,
           type: 'string',
         },
-        ouptutFileTracingIgnores: {
+        outputFileTracingIgnores: {
           type: 'array',
         },
         pageEnv: {

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -121,6 +121,7 @@ export interface ExperimentalConfig {
   fullySpecified?: boolean
   urlImports?: NonNullable<webpack.Configuration['experiments']>['buildHttp']
   outputFileTracingRoot?: string
+  ouptutFileTracingIgnores?: string[]
   modularizeImports?: Record<
     string,
     {

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -121,7 +121,7 @@ export interface ExperimentalConfig {
   fullySpecified?: boolean
   urlImports?: NonNullable<webpack.Configuration['experiments']>['buildHttp']
   outputFileTracingRoot?: string
-  ouptutFileTracingIgnores?: string[]
+  outputFileTracingIgnores?: string[]
   modularizeImports?: Record<
     string,
     {


### PR DESCRIPTION
This allows filtering out known traces that should be ignored even if `node-file-trace` detects them as being potentially used. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1668761350086149)


## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
