### PR TITLE
Leverage outputFileTracingIgnores for next-server trace as well

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1857,6 +1857,7 @@ export default async function build(
                 ...(!hasSsrAmpPages
                   ? ['**/next/dist/compiled/@ampproject/toolbox-optimizer/**/*']
                   : []),
+                ...(config.experimental.outputFileTracingIgnores || []),
               ]
               const ignoreFn = (pathname: string) => {
                 return isMatch(pathname, ignores, { contains: true, dot: true })


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/43103 this adds the ignores to the `next-server` trace as well since it may be needed for some cases as well. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
