### PR TITLE
Fix e2e deploy test for Node.js v18

### DIFF
--- a/test/e2e/proxy-request-with-middleware/app/pages/api/index.js
+++ b/test/e2e/proxy-request-with-middleware/app/pages/api/index.js
@@ -12,7 +12,7 @@ export default function handler(req, res) {
       request(
         `http://${
           // node v18 resolves to IPv6 by default so force IPv4
-          process.version.startsWith('v18.')
+          process.version.startsWith('v18.') && !process.env.VERCEL_URL
             ? `127.0.0.1:${req.headers.host.split(':').pop() || ''}`
             : req.headers.host
         }${req.url}/post`,


### PR DESCRIPTION
This updates the Node.js version check for proxying when running against a deployment. 

Fixes: https://github.com/vercel/next.js/actions/runs/3501049844/jobs/5864420602

