### PR TITLE
fix(next-swc/relay): make pages directory optional

### DIFF
--- a/packages/next-swc/crates/core/src/relay.rs
+++ b/packages/next-swc/crates/core/src/relay.rs
@@ -107,8 +107,10 @@ impl<'a> Relay<'a> {
 
         if let Some(artifact_directory) = &self.config.artifact_directory {
             Ok(self.root_dir.join(artifact_directory).join(filename))
-        } else if self.pages_dir.is_some()
-            && real_file_name.starts_with(self.pages_dir.as_ref().unwrap())
+        } else if self
+            .pages_dir
+            .as_ref()
+            .map_or(false, |pages_dir| real_file_name.starts_with(pages_dir))
         {
             Err(BuildRequirePathError::ArtifactDirectoryExpected {
                 file_name: real_file_name.display().to_string(),

--- a/packages/next-swc/crates/core/src/relay.rs
+++ b/packages/next-swc/crates/core/src/relay.rs
@@ -27,7 +27,7 @@ impl Default for RelayLanguageConfig {
 
 struct Relay<'a> {
     root_dir: PathBuf,
-    pages_dir: PathBuf,
+    pages_dir: Option<PathBuf>,
     file_name: FileName,
     config: &'a Config,
 }
@@ -107,7 +107,9 @@ impl<'a> Relay<'a> {
 
         if let Some(artifact_directory) = &self.config.artifact_directory {
             Ok(self.root_dir.join(artifact_directory).join(filename))
-        } else if real_file_name.starts_with(&self.pages_dir) {
+        } else if self.pages_dir.is_some()
+            && real_file_name.starts_with(self.pages_dir.as_ref().unwrap())
+        {
             Err(BuildRequirePathError::ArtifactDirectoryExpected {
                 file_name: real_file_name.display().to_string(),
             })
@@ -181,7 +183,7 @@ pub fn relay(config: &Config, file_name: FileName, pages_dir: Option<PathBuf>) -
     Relay {
         root_dir: std::env::current_dir().unwrap(),
         file_name,
-        pages_dir: pages_dir.unwrap_or_else(|| panic!("pages_dir is expected.")),
+        pages_dir,
         config,
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/relayjs/relay-examples/pull/241#issuecomment-1318756698

**Context:**
Current relay transformer requires `pages_dir` in its entry point:
https://github.com/vercel/next.js/blob/ecfd2f4cd6a1c3f6bc3cd1cca6b62a3cb705a4e2/packages/next-swc/crates/core/src/relay.rs#L184

But consider the case that `pages_dir` is not provided because the page system is built entirely in the app directory introduced from Next.js 13.

In this case, transformer causes unconditional panics even though there's nothing wrong with it.

This PR removes panic in entry point and changes the type of `pages_dir` into `Option<T>` so that keeps [build stability for existing page system](https://github.com/vercel/next.js/blob/ecfd2f4cd6a1c3f6bc3cd1cca6b62a3cb705a4e2/packages/next-swc/crates/core/src/relay.rs#L157-L160) even if `pages_dir` is not provided.