### PR TITLE
Remove `unstable_revalidate`

### DIFF
--- a/packages/next/server/api-utils/node.ts
+++ b/packages/next/server/api-utils/node.ts
@@ -509,13 +509,6 @@ export async function apiResolver(
       }
     ) => revalidate(urlPath, opts || {}, req, apiContext)
 
-    // TODO: remove in next minor (current v12.2)
-    apiRes.unstable_revalidate = () => {
-      throw new Error(
-        `"unstable_revalidate" has been renamed to "revalidate" see more info here: https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#on-demand-revalidation`
-      )
-    }
-
     const resolver = interopDefault(resolverModule)
     let wasPiped = false
 

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -269,11 +269,6 @@ export type NextApiResponse<T = any> = ServerResponse & {
    */
   clearPreviewData: (options?: { path?: string }) => NextApiResponse<T>
 
-  /**
-   * @deprecated `unstable_revalidate` has been renamed to `revalidate`
-   */
-  unstable_revalidate: () => void
-
   revalidate: (
     urlPath: string,
     opts?: {

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -752,20 +752,6 @@ describe('Prerender', () => {
       expect(value).toMatch(/Hi \[third\] \[fourth\]/)
     })
 
-    if (!(global as any).isNextDeploy) {
-      it('should show error about renaming unstable_revalidate', async () => {
-        const res = await fetchViaHTTP(next.url, '/api/manual-revalidate', {
-          pathname: '/blog/first',
-          deprecated: '1',
-        })
-        expect(res.status).toBe(500)
-
-        expect(next.cliOutput).toContain(
-          '"unstable_revalidate" has been renamed to "revalidate"'
-        )
-      })
-    }
-
     if ((global as any).isNextStart) {
       // TODO: dev currently renders this page as blocking, meaning it shows the
       // server error instead of continuously retrying. Do we want to change this?

--- a/test/e2e/prerender/pages/api/manual-revalidate.js
+++ b/test/e2e/prerender/pages/api/manual-revalidate.js
@@ -1,7 +1,4 @@
 export default async function handler(req, res) {
-  if (req.query.deprecated) {
-    await res.unstable_revalidate(req.query.pathname)
-  }
   // WARNING: don't use user input in production
   // make sure to use trusted value for revalidating
   let revalidated = false


### PR DESCRIPTION
Reverts https://github.com/vercel/next.js/pull/38070

I stumbled upon @ijjk's TODO to remove the deprecated `unstable_revalidate` renaming error and e2e test after v12.2. 

```tsx
// TODO: remove in next minor (current v12.2)
```

I also removed the deprecated function stub, since it probably shouldn't exist if there's no error, e2e test, and doesn't match the new `revalidate` function signature anyways.

<img width="675" alt="image" src="https://user-images.githubusercontent.com/14317828/202842660-be9977e2-252c-4ccf-84fc-e0c00bf25e05.png">

