### PR TITLE
docs: add missing AppProps import

### DIFF
--- a/examples/with-styled-components-babel/pages/_app.tsx
+++ b/examples/with-styled-components-babel/pages/_app.tsx
@@ -1,3 +1,4 @@
+import type { AppProps } from 'next/app'
 import { createGlobalStyle, ThemeProvider } from 'styled-components'
 
 const GlobalStyle = createGlobalStyle`
@@ -20,7 +21,7 @@ const theme: ThemeInterface = {
   },
 }
 
-export default function App({ Component, pageProps }) {
+export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <GlobalStyle />


### PR DESCRIPTION
Styled-components example was missing `AppProps` typings in `_app.tsx`. This PR fixes it

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
