### PR TITLE
Avoid bundling appDir rendering into pages edge SSR bundle

### DIFF
--- a/packages/next/client/components/app-router-headers.ts
+++ b/packages/next/client/components/app-router-headers.ts
@@ -3,3 +3,9 @@ export const NEXT_ROUTER_STATE_TREE = 'Next-Router-State-Tree' as const
 export const NEXT_ROUTER_PREFETCH = 'Next-Router-Prefetch' as const
 export const RSC_VARY_HEADER =
   `${RSC}, ${NEXT_ROUTER_STATE_TREE}, ${NEXT_ROUTER_PREFETCH}` as const
+
+export const FLIGHT_PARAMETERS = [
+  [RSC],
+  [NEXT_ROUTER_STATE_TREE],
+  [NEXT_ROUTER_PREFETCH],
+] as const

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -42,6 +42,7 @@ import {
   NEXT_ROUTER_PREFETCH,
   NEXT_ROUTER_STATE_TREE,
   RSC,
+  FLIGHT_PARAMETERS,
 } from '../client/components/app-router-headers'
 import type { StaticGenerationStore } from '../client/components/static-generation-async-storage'
 
@@ -703,12 +704,6 @@ function getScriptNonceFromHeader(cspHeaderValue: string): string | undefined {
 
   return nonce
 }
-
-export const FLIGHT_PARAMETERS = [
-  [RSC],
-  [NEXT_ROUTER_STATE_TREE],
-  [NEXT_ROUTER_PREFETCH],
-] as const
 
 function headersWithoutFlight(headers: IncomingHttpHeaders) {
   const newHeaders = { ...headers }

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -74,8 +74,11 @@ import { getHostname } from '../shared/lib/get-hostname'
 import { parseUrl as parseUrlUtil } from '../shared/lib/router/utils/parse-url'
 import { getNextPathnameInfo } from '../shared/lib/router/utils/get-next-pathname-info'
 import { MiddlewareMatcher } from '../build/analysis/get-page-static-info'
-import { RSC, RSC_VARY_HEADER } from '../client/components/app-router-headers'
-import { FLIGHT_PARAMETERS } from './app-render'
+import {
+  RSC,
+  RSC_VARY_HEADER,
+  FLIGHT_PARAMETERS,
+} from '../client/components/app-router-headers'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType


### PR DESCRIPTION
Do not directly import app-render into base-server since base-server is shared module for both nodejs SSR and edge SSR.

