### PR TITLE
Remove the timestamp query for CSS resources

### DIFF
--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -999,13 +999,17 @@ export async function renderToHTMLOrFlight(
         filePath,
         serverCSSForEntries
       )
-      const cacheBustingUrlSuffix = dev ? `?ts=${Date.now()}` : ''
 
       const styles = cssHrefs
         ? cssHrefs.map((href, index) => (
             <link
               rel="stylesheet"
-              href={`${assetPrefix}/_next/${href}${cacheBustingUrlSuffix}`}
+              // In dev, Safari will wrongly cache the resource if you preload it:
+              // - https://github.com/vercel/next.js/issues/5860
+              // - https://bugs.webkit.org/show_bug.cgi?id=187726
+              // We used to add a `?ts=` query for resources in `pages` to bypass it,
+              // but in this case it is fine as we don't need to preload the styles.
+              href={`${assetPrefix}/_next/${href}`}
               // @ts-ignore
               precedence={shouldPreload ? 'high' : undefined}
               key={index}
@@ -1324,10 +1328,6 @@ export async function renderToHTMLOrFlight(
 
       return {
         Component: () => {
-          // Add extra cache busting (DEV only) for https://github.com/vercel/next.js/issues/5860
-          // See also https://bugs.webkit.org/show_bug.cgi?id=187726
-          const cacheBustingUrlSuffix = dev ? `?ts=${Date.now()}` : ''
-
           return (
             <>
               {preloadedFontFiles.map((fontFile) => {
@@ -1347,7 +1347,12 @@ export async function renderToHTMLOrFlight(
                 ? stylesheets.map((href, index) => (
                     <link
                       rel="stylesheet"
-                      href={`${assetPrefix}/_next/${href}${cacheBustingUrlSuffix}`}
+                      // In dev, Safari will wrongly cache the resource if you preload it:
+                      // - https://github.com/vercel/next.js/issues/5860
+                      // - https://bugs.webkit.org/show_bug.cgi?id=187726
+                      // We used to add a `?ts=` query for resources in `pages` to bypass it,
+                      // but in this case it is fine as we don't need to preload the styles.
+                      href={`${assetPrefix}/_next/${href}`}
                       // `Precedence` is an opt-in signal for React to handle
                       // resource loading and deduplication, etc:
                       // https://github.com/facebook/react/pull/25060


### PR DESCRIPTION
As discussed [here](https://vercel.slack.com/archives/C035J346QQL/p1668425692084449), we don't need the timestamp for CSS resources in the app dir for now as we are not preloading them. Manually tested with Safari and added corresponding e2e tests.

Closes #42862.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
