### PR TITLE
Fix React.cache() in layout/page file

### DIFF
--- a/test/e2e/app-dir/app/app/react-cache/client-component/page.js
+++ b/test/e2e/app-dir/app/app/react-cache/client-component/page.js
@@ -1,0 +1,16 @@
+'use client'
+import { cache } from 'react'
+
+const getRandomMemoized = cache(() => Math.random())
+
+export default function Page() {
+  const val1 = getRandomMemoized(1)
+  const val2 = getRandomMemoized(1)
+  return (
+    <>
+      <h1>React Cache Client Component</h1>
+      <p id="value-1">{val1}</p>
+      <p id="value-2">{val2}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/react-cache/client-component/page.js
+++ b/test/e2e/app-dir/app/app/react-cache/client-component/page.js
@@ -4,8 +4,8 @@ import { cache } from 'react'
 const getRandomMemoized = cache(() => Math.random())
 
 export default function Page() {
-  const val1 = getRandomMemoized(1)
-  const val2 = getRandomMemoized(1)
+  const val1 = getRandomMemoized()
+  const val2 = getRandomMemoized()
   return (
     <>
       <h1>React Cache Client Component</h1>

--- a/test/e2e/app-dir/app/app/react-cache/page.js
+++ b/test/e2e/app-dir/app/app/react-cache/page.js
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+export default function Page() {
+  return (
+    <>
+      <p>
+        <Link id="to-server-component" href="/react-cache/server-component">
+          To Server Component
+        </Link>
+      </p>
+      <p>
+        <Link id="to-client-component" href="/react-cache/client-component">
+          To Client Component
+        </Link>
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/react-cache/server-component/page.js
+++ b/test/e2e/app-dir/app/app/react-cache/server-component/page.js
@@ -3,8 +3,8 @@ import { cache } from 'react'
 const getRandomMemoized = cache(() => Math.random())
 
 export default function Page() {
-  const val1 = getRandomMemoized(1)
-  const val2 = getRandomMemoized(1)
+  const val1 = getRandomMemoized()
+  const val2 = getRandomMemoized()
   return (
     <>
       <h1>React Cache Server Component</h1>

--- a/test/e2e/app-dir/app/app/react-cache/server-component/page.js
+++ b/test/e2e/app-dir/app/app/react-cache/server-component/page.js
@@ -1,0 +1,15 @@
+import { cache } from 'react'
+
+const getRandomMemoized = cache(() => Math.random())
+
+export default function Page() {
+  const val1 = getRandomMemoized(1)
+  const val2 = getRandomMemoized(1)
+  return (
+    <>
+      <h1>React Cache Server Component</h1>
+      <p id="value-1">{val1}</p>
+      <p id="value-2">{val2}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/react-fetch/page.js
+++ b/test/e2e/app-dir/app/app/react-fetch/page.js
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+export default function Page() {
+  return (
+    <>
+      <p>
+        <Link id="to-server-component" href="/react-fetch/server-component">
+          To Server Component
+        </Link>
+      </p>
+      <p>
+        <Link id="to-client-component" href="/react-fetch/client-component">
+          To Client Component
+        </Link>
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/react-fetch/server-component/page.js
+++ b/test/e2e/app-dir/app/app/react-fetch/server-component/page.js
@@ -1,0 +1,18 @@
+async function getRandomMemoizedByFetch() {
+  const res = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random'
+  )
+  return res.text()
+}
+
+export default async function Page() {
+  const val1 = await getRandomMemoizedByFetch()
+  const val2 = await getRandomMemoizedByFetch()
+  return (
+    <>
+      <h1>React Fetch Server Component</h1>
+      <p id="value-1">{val1}</p>
+      <p id="value-2">{val2}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -2182,7 +2182,7 @@ describe('app dir', () => {
           await browser
             .elementByCss('#to-server-component')
             .click()
-            .waitForElementByCss('#value-1', 2000)
+            .waitForElementByCss('#value-1', 10000)
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
           expect(val1).toBe(val2)
@@ -2204,7 +2204,7 @@ describe('app dir', () => {
           await browser
             .elementByCss('#to-client-component')
             .click()
-            .waitForElementByCss('#value-1', 2000)
+            .waitForElementByCss('#value-1', 10000)
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
           expect(val1).toBe(val2)
@@ -2228,7 +2228,7 @@ describe('app dir', () => {
           await browser
             .elementByCss('#to-server-component')
             .click()
-            .waitForElementByCss('#value-1', 2000)
+            .waitForElementByCss('#value-1', 10000)
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
           expect(val1).toBe(val2)
@@ -2252,7 +2252,7 @@ describe('app dir', () => {
           await browser
             .elementByCss('#to-client-component')
             .click()
-            .waitForElementByCss('#value-1', 2000)
+            .waitForElementByCss('#value-1', 10000)
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
           expect(val1).toBe(val2)

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -2096,6 +2096,51 @@ describe('app dir', () => {
     })
 
     describe('known bugs', () => {
+      describe('should support React cache', () => {
+        it('server component', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/react-cache/server-component'
+          )
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        it('server component client-navigation', async () => {
+          const browser = await webdriver(next.url, '/react-cache')
+
+          await browser
+            .elementByCss('#to-server-component')
+            .click()
+            .waitForElementByCss('#value-1', 2000)
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        it('client component', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/react-cache/client-component'
+          )
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        it('client component client-navigation', async () => {
+          const browser = await webdriver(next.url, '/react-cache')
+
+          await browser
+            .elementByCss('#to-client-component')
+            .click()
+            .waitForElementByCss('#value-1', 2000)
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+      })
       it('should not share flight data between requests', async () => {
         const fetches = await Promise.all(
           [...new Array(5)].map(() =>

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -2141,6 +2141,54 @@ describe('app dir', () => {
           expect(val1).toBe(val2)
         })
       })
+
+      describe('should support React fetch instrumentation', () => {
+        it('server component', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/react-fetch/server-component'
+          )
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        it('server component client-navigation', async () => {
+          const browser = await webdriver(next.url, '/react-fetch')
+
+          await browser
+            .elementByCss('#to-server-component')
+            .click()
+            .waitForElementByCss('#value-1', 2000)
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        // TODO-APP: React doesn't have fetch deduping for client components yet.
+        it.skip('client component', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/react-fetch/client-component'
+          )
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        // TODO-APP: React doesn't have fetch deduping for client components yet.
+        it.skip('client component client-navigation', async () => {
+          const browser = await webdriver(next.url, '/react-fetch')
+
+          await browser
+            .elementByCss('#to-client-component')
+            .click()
+            .waitForElementByCss('#value-1', 2000)
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+      })
       it('should not share flight data between requests', async () => {
         const fetches = await Promise.all(
           [...new Array(5)].map(() =>

--- a/test/e2e/app-dir/rsc-errors.test.ts
+++ b/test/e2e/app-dir/rsc-errors.test.ts
@@ -104,7 +104,7 @@ describe('app dir - rsc errors', () => {
       '/server-with-errors/page-export'
     )
     expect(html).toContain(
-      'The default export is not a React Component in page: \\"/server-with-errors/page-export\\"'
+      'The default export is not a React Component in page:'
     )
   })
 })


### PR DESCRIPTION
Since the component preloading happened outside of React rendering it caused cache() to not have an available dispatcher, moving creating the component tree into a wrapper component solves this. Handled for both HTML rendering and client-side navigation. Added tests for both cases as well as server/client component.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
