### PR TITLE
Remove app routes from _devPagesManifest

### DIFF
--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -1226,7 +1226,9 @@ export default class DevServer extends Server {
         res
           .body(
             JSON.stringify({
-              pages: this.sortedRoutes,
+              pages: this.sortedRoutes?.filter(
+                (route) => !this.appPathRoutes![route]
+              ),
             })
           )
           .send()

--- a/test/e2e/app-dir/app/app/dynamic-pages-route-app-overlap/app-dir/page.js
+++ b/test/e2e/app-dir/app/app/dynamic-pages-route-app-overlap/app-dir/page.js
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <p id="app-text">
+      hello from app/dynamic-pages-route-app-overlap/app-dir/page
+    </p>
+  )
+}

--- a/test/e2e/app-dir/app/pages/dynamic-pages-route-app-overlap.js
+++ b/test/e2e/app-dir/app/pages/dynamic-pages-route-app-overlap.js
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <Link id="pages-link" href="/dynamic-pages-route-app-overlap/app-dir">
+      To /dynamic-pages-route-app-overlap/app-dir
+    </Link>
+  )
+}

--- a/test/e2e/app-dir/app/pages/dynamic-pages-route-app-overlap/[slug].js
+++ b/test/e2e/app-dir/app/pages/dynamic-pages-route-app-overlap/[slug].js
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <p id="pages-text">
+      hello from pages/dynamic-pages-route-app-overlap/[slug]
+    </p>
+  )
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -615,6 +615,29 @@ describe('app dir', () => {
           await browser.close()
         }
       })
+
+      it('should navigate to pages dynamic route from pages page if it overlaps with an app page', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/dynamic-pages-route-app-overlap'
+        )
+
+        try {
+          // Click the link.
+          await browser.elementById('pages-link').click()
+          expect(await browser.waitForElementByCss('#pages-text').text()).toBe(
+            'hello from pages/dynamic-pages-route-app-overlap/[slug]'
+          )
+
+          // When refreshing the browser, the app page should be rendered
+          await browser.refresh()
+          expect(await browser.waitForElementByCss('#app-text').text()).toBe(
+            'hello from app/dynamic-pages-route-app-overlap/app-dir/page'
+          )
+        } finally {
+          await browser.close()
+        }
+      })
     })
 
     describe('server components', () => {


### PR DESCRIPTION
Currently in dev the `_devPagesManifest` includes the `/app` routes as well. However, In production, the `_buildManifest.js` does not include the `/app` routes. This causes the `/pages` router to behave differently in the two environments.

This change excludes the `/app` routes from `_devPagesManifest` to make it work the same in dev/prod.

Fixes #42513
Fixes #42532

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
