### PR TITLE
Add missing quote in `next/script` example

### DIFF
--- a/docs/api-reference/next/script.md
+++ b/docs/api-reference/next/script.md
@@ -37,7 +37,7 @@ Here's a summary of the props available for the Script Component:
 | Prop                    | Example                           | Values   | Required                              |
 | ----------------------- | --------------------------------- | -------- | ------------------------------------- |
 | [`src`](#src)           | `src="http://example.com/script"` | String   | Required unless inline script is used |
-| [`strategy`](#strategy) | `strategy="lazyOnload`            | String   | Optional                              |
+| [`strategy`](#strategy) | `strategy="lazyOnload"`           | String   | Optional                              |
 | [`onLoad`](#onload)     | `onLoad={onLoadFunc}`             | Function | Optional                              |
 | [`onReady`](#onReady)   | `onReady={onReadyFunc}`           | Function | Optional                              |
 | [`onError`](#onerror)   | `onError={onErrorFunc}`           | Function | Optional                              |


### PR DESCRIPTION
It looks like a simple typo.