### PR TITLE
Update experimental skipTrailingSlashRedirect handling

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -299,6 +299,9 @@ export function getDefineEnv({
     'process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE': JSON.stringify(
       config.experimental.skipMiddlewareUrlNormalize
     ),
+    'process.env.__NEXT_MANUAL_TRAILING_SLASH': JSON.stringify(
+      config.experimental?.skipTrailingSlashRedirect
+    ),
     'process.env.__NEXT_HAS_WEB_VITALS_ATTRIBUTION': JSON.stringify(
       config.experimental.webVitalsAttribution &&
         config.experimental.webVitalsAttribution.length > 0

--- a/packages/next/client/normalize-trailing-slash.ts
+++ b/packages/next/client/normalize-trailing-slash.ts
@@ -6,7 +6,7 @@ import { parsePath } from '../shared/lib/router/utils/parse-path'
  * in `next.config.js`.
  */
 export const normalizePathTrailingSlash = (path: string) => {
-  if (!path.startsWith('/')) {
+  if (!path.startsWith('/') || process.env.__NEXT_MANUAL_TRAILING_SLASH) {
     return path
   }
 

--- a/test/e2e/skip-trailing-slash-redirect/app/pages/index.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/pages/index.js
@@ -8,6 +8,10 @@ export default function Page(props) {
         to another
       </Link>
       <br />
+      <Link href="/another/" id="to-another-with-slash">
+        to another
+      </Link>
+      <br />
       <Link href="/blog/first" id="to-blog-first">
         to /blog/first
       </Link>


### PR DESCRIPTION
This ensures we don't apply the client-side trailing slash handling with this experimental config as it conflicts with manual handling of redirects. 

Fixes: [slack thread](https://vercel.slack.com/archives/C01224Q5M99/p1669029502713689?thread_ts=1668452468.314249&cid=C01224Q5M99)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

