### PR TITLE
Add fallback aliases for React

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -863,6 +863,9 @@ export default async function getBaseWebpackConfig(
     [COMPILER_NAMES.edgeServer]: ['browser', 'module', 'main'],
   }
 
+  const reactDir = path.dirname(require.resolve('react/package.json'))
+  const reactDomDir = path.dirname(require.resolve('react-dom/package.json'))
+
   const resolveConfig = {
     // Disable .mjs for node_modules bundling
     extensions: isNodeServer
@@ -928,7 +931,13 @@ export default async function getBaseWebpackConfig(
               'next/dist/compiled/react/jsx-dev-runtime',
             'react/jsx-runtime$': 'next/dist/compiled/react/jsx-runtime',
           }
-        : undefined),
+        : {
+            react: reactDir,
+            'react-dom$': reactDomDir,
+            'react-dom/server$': `${reactDomDir}/server`,
+            'react-dom/server.browser$': `${reactDomDir}/server.browser`,
+            'react-dom/client$': `${reactDomDir}/client`,
+          }),
 
       'styled-jsx/style$': require.resolve(`styled-jsx/style`),
       'styled-jsx$': require.resolve(`styled-jsx`),


### PR DESCRIPTION
These aliases are needed by default (removed in https://github.com/vercel/next.js/commit/b0f87fbc7c141e6548ab90d0153aa6d1d844a9bc) because when transpiling external packages specified via `file:./` in package.json, these external packages might not have `react` in their dependencies and the package manager might not move or link them into the current project's node_modules. In these cases, `react` can't be resolved unless we alias it.

Related discussions can be found in https://github.com/vercel/next.js/discussions/42136. This PR fixes the test case https://github.com/martpie/next-transpile-modules/blob/2f0b38197cafe7370aa6548d22c8d9bad244710f/src/__tests__/__files__/pages/test-local-typescript-module.tsx.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
