### PR TITLE
chore(examples): with-msw update msw

### DIFF
--- a/examples/with-msw/package.json
+++ b/examples/with-msw/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "msw": "0.47.3",
+    "msw": "^0.49.0",
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
CLOSES #43221 

Using msw `0.47.3` doesn't work in this example. Updating msw to `^0.49.0` and not locking it to an exact version.

Screenshots of errors using `0.47.3`


![Screenshot 2022-11-22 at 09 10 36](https://user-images.githubusercontent.com/4893048/203273444-e1316793-11b1-4659-b843-5b44f9c1eba6.png)
![Screenshot 2022-11-22 at 09 11 31](https://user-images.githubusercontent.com/4893048/203273460-991b1776-abcf-40a1-a1fe-f01e2f4d1758.png)


## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
