### PR TITLE
fix(ts): re-export `PageComponent` and `LayoutComponent` types

### DIFF
--- a/packages/next/build/webpack/plugins/flight-types-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-types-plugin.ts
@@ -35,8 +35,8 @@ interface LayoutProps {
   params: any
 }
 
-type PageComponent = (props: PageProps) => React.ReactNode | Promise<React.ReactNode>
-type LayoutComponent = (props: LayoutProps) => React.ReactNode | Promise<React.ReactNode>
+export type PageComponent = (props: PageProps) => React.ReactNode | Promise<React.ReactNode>
+export type LayoutComponent = (props: LayoutProps) => React.ReactNode | Promise<React.ReactNode>
 
 interface IEntry {
   ${


### PR DESCRIPTION
Fixes #43195, fixes #41901, fixes #42042
## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
