### PR TITLE
Allow src/app dir usage for next-typescript plugin

### DIFF
--- a/packages/next/server/next-typescript.ts
+++ b/packages/next/server/next-typescript.ts
@@ -9,6 +9,7 @@
  */
 
 import path from 'path'
+import { findDir } from './lib/find-pages-dir'
 
 const DISALLOWED_SERVER_REACT_APIS: string[] = [
   'useState',
@@ -193,7 +194,7 @@ export function createTSPlugin(modules: {
   }
 
   function create(info: ts.server.PluginCreateInfo) {
-    const appDir = path.join(info.project.getCurrentDirectory(), 'app')
+    const appDir = findDir(info.project.getCurrentDirectory(), 'app')
     const isAppEntryFile = (filePath: string) => {
       return (
         filePath.startsWith(appDir) &&


### PR DESCRIPTION
Importing findDir which will fall back to src/app if /app not found

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
