### PR TITLE
Allow src/app dir for ts plugin

### DIFF
--- a/packages/next/server/next-typescript.ts
+++ b/packages/next/server/next-typescript.ts
@@ -9,6 +9,7 @@
  */
 
 import path from 'path'
+import { findDir } from '../lib/find-pages-dir'
 
 const DISALLOWED_SERVER_REACT_APIS: string[] = [
   'useState',
@@ -193,7 +194,7 @@ export function createTSPlugin(modules: {
   }
 
   function create(info: ts.server.PluginCreateInfo) {
-    const appDir = path.join(info.project.getCurrentDirectory(), 'app')
+    const appDir = findDir(info.project.getCurrentDirectory(), 'app')
     const isAppEntryFile = (filePath: string) => {
       return (
         filePath.startsWith(appDir) &&

--- a/packages/next/server/next-typescript.ts
+++ b/packages/next/server/next-typescript.ts
@@ -194,7 +194,7 @@ export function createTSPlugin(modules: {
   }
 
   function create(info: ts.server.PluginCreateInfo) {
-    const appDir = findDir(info.project.getCurrentDirectory(), 'app')
+    const appDir = findDir(info.project.getCurrentDirectory(), 'app') ?? path.join(info.project.getCurrentDirectory(), 'app')
     const isAppEntryFile = (filePath: string) => {
       return (
         filePath.startsWith(appDir) &&


### PR DESCRIPTION
The next-typescript plugin currently validates files in the root /app folder.

This small change makes use of the findDir function, which will fall back to /src/app if /app not found, allowing for validtion on both the root /app folder and the fallback /src/app folder.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`
