### PR TITLE
Fix app routes are not correctly matched when src directory is used

### DIFF
--- a/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -203,7 +203,9 @@ export class FlightClientEntryPlugin {
           : entryRequest
 
         // Replace file suffix as `.js` will be added.
-        const bundlePath = relativeRequest.replace(/\.(js|ts)x?$/, '')
+        const bundlePath = relativeRequest
+          .replace(/\.(js|ts)x?$/, '')
+          .replace(/^src[\\/]/, '')
 
         promises.push(
           this.injectClientEntryAndSSRModules({

--- a/packages/next/server/get-app-route-from-entrypoint.ts
+++ b/packages/next/server/get-app-route-from-entrypoint.ts
@@ -1,7 +1,7 @@
 import matchBundle from './match-bundle'
 
-// matches app/:path*.js and src/app/:path*.js
-const APP_ROUTE_NAME_REGEX = /^(?:app|src[/\\]app)[/\\](.*)$/
+// matches app/:path*.js
+const APP_ROUTE_NAME_REGEX = /^app[/\\](.*)$/
 
 export default function getAppRouteFromEntrypoint(entryFile: string) {
   const pagePath = matchBundle(APP_ROUTE_NAME_REGEX, entryFile)

--- a/packages/next/server/get-app-route-from-entrypoint.ts
+++ b/packages/next/server/get-app-route-from-entrypoint.ts
@@ -1,7 +1,7 @@
 import matchBundle from './match-bundle'
 
-// matches app/:path*.js
-const APP_ROUTE_NAME_REGEX = /^app[/\\](.*)$/
+// matches app/:path*.js and src/app/:path*.js
+const APP_ROUTE_NAME_REGEX = /^(?:app|src[/\\]app)[/\\](.*)$/
 
 export default function getAppRouteFromEntrypoint(entryFile: string) {
   const pagePath = matchBundle(APP_ROUTE_NAME_REGEX, entryFile)

--- a/test/e2e/app-dir/app-alias.test.ts
+++ b/test/e2e/app-dir/app-alias.test.ts
@@ -44,7 +44,7 @@ describe('app-dir alias handling', () => {
   })
 
   if (!(global as any).isNextDev) {
-    it.only('should generate app-build-manifest correctly', async () => {
+    it('should generate app-build-manifest correctly', async () => {
       // Remove other page CSS files:
       const manifest = await readJSON(
         path.join(next.testDir, '.next', 'app-build-manifest.json')

--- a/test/e2e/app-dir/app-alias.test.ts
+++ b/test/e2e/app-dir/app-alias.test.ts
@@ -3,6 +3,7 @@ import { NextInstance } from 'test/lib/next-modes/base'
 import { renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import path from 'path'
+import { readJSON } from 'fs-extra'
 
 describe('app-dir alias handling', () => {
   if ((global as any).isNextDeploy) {
@@ -41,4 +42,15 @@ describe('app-dir alias handling', () => {
       .getComputedCss('font-size')
     expect(fontSize).toBe('50px')
   })
+
+  if (!(global as any).isNextDev) {
+    it.only('should generate app-build-manifest correctly', async () => {
+      // Remove other page CSS files:
+      const manifest = await readJSON(
+        path.join(next.testDir, '.next', 'app-build-manifest.json')
+      )
+
+      expect(manifest.pages).not.toBeEmptyObject()
+    })
+  }
 })


### PR DESCRIPTION
When creating the client entries, the `src/` prefix shouldn't be included in the entrypoint's name. Closes #42874.

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
