### PR TITLE
fix: apply default export interop to `next/error`

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2230,7 +2230,11 @@ export async function pages_app(task, opts) {
 export async function pages_error(task, opts) {
   await task
     .source('pages/_error.tsx')
-    .swc('client', { dev: opts.dev, keepImportAssertions: true })
+    .swc('client', {
+      dev: opts.dev,
+      keepImportAssertions: true,
+      interopClientDefaultExport: true,
+    })
     .target('dist/pages')
 }
 


### PR DESCRIPTION
Applies the same interop as we did for `next/jest` in #36824

We could potentially apply the same for other submodules, or do it on the basis of someone hitting the issue.

Fixes #43206
## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
