### PR TITLE
chore: add `firebase-admin` to default `serverComponentsExternalPackages` list

### DIFF
--- a/packages/next/lib/server-external-packages.ts
+++ b/packages/next/lib/server-external-packages.ts
@@ -7,7 +7,7 @@ export const EXTERNAL_PACKAGES = [
   'cypress',
   'eslint',
   'express',
-  'firebase-admin'
+  'firebase-admin',
   'jest',
   'mongodb',
   'next-mdx-remote',

--- a/packages/next/lib/server-external-packages.ts
+++ b/packages/next/lib/server-external-packages.ts
@@ -7,6 +7,7 @@ export const EXTERNAL_PACKAGES = [
   'cypress',
   'eslint',
   'express',
+  'firebase-admin'
   'jest',
   'mongodb',
   'next-mdx-remote',


### PR DESCRIPTION
[Thread](https://vercel.slack.com/archives/C035J346QQL/p1669138364868509?thread_ts=1669131968.743009&cid=C035J346QQL)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
