### PR TITLE
docs: Add default browserslist configuration as a starting point

### DIFF
--- a/docs/basic-features/supported-browsers-features.md
+++ b/docs/basic-features/supported-browsers-features.md
@@ -14,7 +14,19 @@ Next.js supports **modern browsers** with zero configuration.
 
 ## Browserslist
 
-If you would like to target specific browsers or features, Next.js supports [Browserslist](https://browsersl.ist) configuration.
+If you would like to target specific browsers or features, Next.js supports [Browserslist](https://browsersl.ist) configuration in your `package.json` file. Next.js uses the following Browserslist configuration by default:
+
+```json
+{
+  "browserslist": [
+    "chrome 64",
+    "edge 79",
+    "firefox 67",
+    "opera 51",
+    "safari 12"
+  ]
+}
+```
 
 ## Polyfills
 


### PR DESCRIPTION
This addition helps users figure out that this is the kind of expression they need to put in their `package.json`, and it provides the Next.js defaults to use as a starting point. (I was initially confused and thought the default configuration would just be "defaults".)

The list was pulled from `MODERN_BROWSERSLIST_TARGET` in [packages/next/shared/lib/constants.ts](https://github.com/vercel/next.js/blob/28454c6ddbc310419467e5415aee26e48d079b46/packages/next/shared/lib/constants.ts#L56-L62).

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
