### PR TITLE
Use WeakRef to store previous compiler

### DIFF
--- a/packages/next/build/output/index.ts
+++ b/packages/next/build/output/index.ts
@@ -11,9 +11,9 @@ export function startedDevelopmentServer(appUrl: string, bindAddr: string) {
   consoleStore.setState({ appUrl, bindAddr })
 }
 
-let previousClient: webpack.Compiler | null = null
-let previousServer: webpack.Compiler | null = null
-let previousEdgeServer: webpack.Compiler | null = null
+let previousClient: WeakRef<webpack.Compiler> | null = null
+let previousServer: WeakRef<webpack.Compiler> | null = null
+let previousEdgeServer: WeakRef<webpack.Compiler> | null = null
 
 type CompilerDiagnostics = {
   modules: number
@@ -224,9 +224,9 @@ export function watchCompilers(
   edgeServer: webpack.Compiler
 ) {
   if (
-    previousClient === client &&
-    previousServer === server &&
-    previousEdgeServer === edgeServer
+    previousClient?.deref() === client &&
+    previousServer?.deref() === server &&
+    previousEdgeServer?.deref() === edgeServer
   ) {
     return
   }
@@ -318,9 +318,9 @@ export function watchCompilers(
     }
   })
 
-  previousClient = client
-  previousServer = server
-  previousEdgeServer = edgeServer
+  previousClient = new WeakRef(client)
+  previousServer = new WeakRef(server)
+  previousEdgeServer = new WeakRef(edgeServer)
 }
 
 export function reportTrigger(trigger: string) {


### PR DESCRIPTION
Not sure about the actual impact, but theoretically it can hold a lot of memory.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
