### PR TITLE
Refactor code

### DIFF
--- a/packages/next/build/output/index.ts
+++ b/packages/next/build/output/index.ts
@@ -11,10 +11,6 @@ export function startedDevelopmentServer(appUrl: string, bindAddr: string) {
   consoleStore.setState({ appUrl, bindAddr })
 }
 
-let previousClient: webpack.Compiler | null = null
-let previousServer: webpack.Compiler | null = null
-let previousEdgeServer: webpack.Compiler | null = null
-
 type CompilerDiagnostics = {
   modules: number
   errors: string[] | null
@@ -223,14 +219,6 @@ export function watchCompilers(
   server: webpack.Compiler,
   edgeServer: webpack.Compiler
 ) {
-  if (
-    previousClient === client &&
-    previousServer === server &&
-    previousEdgeServer === edgeServer
-  ) {
-    return
-  }
-
   buildStore.setState({
     client: { loading: true },
     server: { loading: true },
@@ -317,10 +305,6 @@ export function watchCompilers(
       })
     }
   })
-
-  previousClient = client
-  previousServer = server
-  previousEdgeServer = edgeServer
 }
 
 export function reportTrigger(trigger: string) {

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -537,20 +537,19 @@ export default class HotReloader {
     })
   }
 
-  public async start(initial?: boolean): Promise<void> {
+  public async start(): Promise<void> {
     const startSpan = this.hotReloaderSpan.traceChild('start')
     startSpan.stop() // Stop immediately to create an artificial parent span
 
-    if (initial) {
-      await this.clean(startSpan)
-      // Ensure distDir exists before writing package.json
-      await fs.mkdir(this.distDir, { recursive: true })
+    await this.clean(startSpan)
+    // Ensure distDir exists before writing package.json
+    await fs.mkdir(this.distDir, { recursive: true })
 
-      const distPackageJsonPath = join(this.distDir, 'package.json')
-      // Ensure commonjs handling is used for files in the distDir (generally .next)
-      // Files outside of the distDir can be "type": "module"
-      await fs.writeFile(distPackageJsonPath, '{"type": "commonjs"}')
-    }
+    const distPackageJsonPath = join(this.distDir, 'package.json')
+    // Ensure commonjs handling is used for files in the distDir (generally .next)
+    // Files outside of the distDir can be "type": "module"
+    await fs.writeFile(distPackageJsonPath, '{"type": "commonjs"}')
+
     this.activeConfigs = await this.getWebpackConfig(startSpan)
 
     for (const config of this.activeConfigs) {
@@ -1024,12 +1023,6 @@ export default class HotReloader {
         edgeServerStats: () => this.edgeServerStats,
       }),
     ]
-
-    // trigger invalidation to ensure any previous callbacks
-    // are handled in the on-demand-entry-handler
-    if (!initial) {
-      this.invalidate()
-    }
   }
 
   public invalidate() {

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -713,7 +713,7 @@ export default class DevServer extends Server {
     })
     await super.prepare()
     await this.addExportPathMapRoutes()
-    await this.hotReloader.start(true)
+    await this.hotReloader.start()
     await this.startWatcher()
     this.setDevReady!()
 


### PR DESCRIPTION
It seems that hot reloader's `start` method is only referenced in one single place.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
