### PR TITLE
Avoid turbo cache miss on root package change

### DIFF
--- a/scripts/normalize-version-bump.js
+++ b/scripts/normalize-version-bump.js
@@ -63,4 +63,13 @@ const writeJson = async (filePath, data) =>
   await normalizeVersions(path.join(cwd, 'lerna.json'))
   await fs.unlink(path.join(cwd, 'pnpm-lock.yaml'))
   await fs.writeFile(path.join(cwd, 'pnpm-lock.yaml'), '')
+
+  const rootPkgJsonPath = path.join(cwd, 'package.json')
+  await writeJson(rootPkgJsonPath, {
+    name: 'nextjs-project',
+    version: '0.0.0',
+    private: true,
+    workspaces: ['packages/*'],
+    scripts: {},
+  })
 })()

--- a/scripts/run-for-change.js
+++ b/scripts/run-for-change.js
@@ -15,7 +15,7 @@ const CHANGE_ITEM_GROUPS = {
     'CODE_OF_CONDUCT.md',
     'readme.md',
   ],
-  'next-swc': ['packages/next-swc'],
+  'next-swc': ['packages/next-swc', 'scripts/normalize-version-bump.js'],
 }
 
 async function main() {


### PR DESCRIPTION
Since the `next-swc` package doesn't rely on any of the root dependencies this normalizes the `package.json` to avoid cache misses when the file changes. 

x-ref: https://github.com/vercel/next.js/actions/runs/3535337836/jobs/5933336967
x-ref: https://github.com/vercel/next.js/actions/runs/3535337836/jobs/5933338363
x-ref: [slack thread](https://vercel.slack.com/archives/C02HEJASXGD/p1669236151437999)