### PR TITLE
automatically map jest paths to ts paths

### DIFF
--- a/examples/with-jest/jest.config.js
+++ b/examples/with-jest/jest.config.js
@@ -1,4 +1,6 @@
 const nextJest = require('next/jest')
+const { pathsToModuleNameMapper } = require('ts-jest')
+const { compilerOptions } = require('./tsconfig')
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
@@ -8,12 +10,9 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  moduleNameMapper: {
-    // Handle module aliases (this will be automatically configured for you soon)
-    '^@/components/(.*)$': '<rootDir>/components/$1',
-
-    '^@/pages/(.*)$': '<rootDir>/pages/$1',
-  },
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl],
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
   testEnvironment: 'jest-environment-jsdom',
 }
 

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -19,6 +19,7 @@
     "@types/react": "18.0.9",
     "jest": "28.1.0",
     "jest-environment-jsdom": "28.1.0",
+    "ts-jest": "28.0.8",
     "typescript": "4.6.4"
   }
 }


### PR DESCRIPTION
This resolves the comment

```js
// Handle module aliases (this will be automatically configured for you soon)
```

by making it happen, with the `ts-jest` package.