### PR TITLE
Get correct chunks in flight-manifest on Windows

### DIFF
--- a/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
@@ -274,7 +274,10 @@ export class FlightManifestPlugin {
         moduleExportedKeys.forEach((name) => {
           // If the chunk is from `app/` chunkGroup, use it first.
           // This make sure not to load the overlapped chunk from `pages/` chunkGroup
-          if (!moduleExports[name] || chunkGroup.name?.startsWith('app/')) {
+          if (
+            !moduleExports[name] ||
+            (chunkGroup.name && /^app[\\/]/.test(chunkGroup.name))
+          ) {
             const requiredChunks = getAppPathRequiredChunks()
 
             moduleExports[name] = {


### PR DESCRIPTION
On Windows `cunkGroup.name` is `app\layout` rather than `app/layout`. This causes it to get the wrong chunks in `flight-manifest.json` for `next/script` in this case:
```json
"chunks": ["webpack:webpack", "amp:amp"],
```
After checking for backslash:
```json
"chunks":["app\\layout:app\\layout"],
```

fixes #42519

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
