### PR TITLE
fix `output: "standalone"` returning 500 error on certain pages when built without pages/

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -2777,19 +2777,17 @@ export default async function build(
           })
           await promises.copyFile(filePath, outputPath)
         }
-        if (pagesDir) {
-          await recursiveCopy(
-            path.join(distDir, SERVER_DIRECTORY, 'pages'),
-            path.join(
-              distDir,
-              'standalone',
-              path.relative(outputFileTracingRoot, distDir),
-              SERVER_DIRECTORY,
-              'pages'
-            ),
-            { overwrite: true }
-          )
-        }
+        await recursiveCopy(
+          path.join(distDir, SERVER_DIRECTORY, 'pages'),
+          path.join(
+            distDir,
+            'standalone',
+            path.relative(outputFileTracingRoot, distDir),
+            SERVER_DIRECTORY,
+            'pages'
+          ),
+          { overwrite: true }
+        )
         if (appDir) {
           await recursiveCopy(
             path.join(distDir, SERVER_DIRECTORY, 'app'),


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

This reverts a part of the changes made in [PR 43268](https://github.com/vercel/next.js/pull/43268), which is checking whether pagesDir exists in the root/src dir before copying the output in .next/server to .next/standalone/.next/server as this causes certain pages to cause the script to log `Error: Cannot find module '.next/server/pages/_document.js'` and return a `Internal Server Error` page since Next today still depends on pages/ dir for 404 and 500 pages and as such needs that dir in .next/standalone/.next/server.