### PR TITLE
dynamic = 'error' should only throw if page didn't get exported

### DIFF
--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -328,17 +328,15 @@ export default async function exportPage({
           const revalidate = (curRenderOpts as any).revalidate
           results.fromBuildExportRevalidate = revalidate
 
-          if (isDynamicError) {
-            throw new Error(
-              `Page with dynamic = "error" encountered dynamic data method ${path}.`
-            )
-          }
-
           if (revalidate !== 0) {
             await promises.writeFile(htmlFilepath, html ?? '', 'utf8')
             await promises.writeFile(
               htmlFilepath.replace(/\.html$/, '.rsc'),
               flightData
+            )
+          } else if (isDynamicError) {
+            throw new Error(
+              `Page with dynamic = "error" encountered dynamic data method ${path}.`
             )
           }
         } catch (err: any) {

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -51,6 +51,9 @@ describe('app-dir static/dynamic handling', () => {
         'blog/tim.rsc',
         'blog/tim/first-post.html',
         'blog/tim/first-post.rsc',
+        'dynamic-error.html',
+        'dynamic-error.rsc',
+        'dynamic-error/page.js',
         'dynamic-no-gen-params-ssr/[slug]/page.js',
         'dynamic-no-gen-params/[slug]/page.js',
         'force-static/[slug]/page.js',
@@ -106,6 +109,11 @@ describe('app-dir static/dynamic handling', () => {
           initialRevalidateSeconds: false,
           srcRoute: '/blog/[author]/[slug]',
           dataRoute: '/blog/tim/first-post.rsc',
+        },
+        '/dynamic-error': {
+          dataRoute: '/dynamic-error.rsc',
+          initialRevalidateSeconds: false,
+          srcRoute: '/dynamic-error',
         },
         '/blog/seb/second-post': {
           initialRevalidateSeconds: false,

--- a/test/e2e/app-dir/app-static/app/dynamic-error/page.js
+++ b/test/e2e/app-dir/app-static/app/dynamic-error/page.js
@@ -1,0 +1,5 @@
+export const dynamic = 'error'
+
+export default function Page() {
+  return <p>Dynamic error</p>
+}


### PR DESCRIPTION
`export const dynamic = "error"` should only throw if the page actually didn't get exported during `next build`. Test already exist to make sure it throws: `test/integration/app-dynamic-error/app/dynamic-error/page.js`

Fixes #43059

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
