### PR TITLE
Add yarn berry dependency upgrade example for Next 12 to 13 upgrade documentation.

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -11,7 +11,9 @@ To update to Next.js version 13, run the following command using your preferred 
 ```bash
 npm i next@latest react@latest react-dom@latest eslint-config-next@latest
 # or
-yarn upgrade next react react-dom eslint-config-next --latest
+yarn upgrade next react react-dom eslint-config-next --latest (yarn classic)
+# or 
+yarn up next react react-dom eslint-config-next (yarn berry)
 # or
 pnpm up next react react-dom eslint-config-next --latest
 ```

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -12,7 +12,7 @@ To update to Next.js version 13, run the following command using your preferred 
 npm i next@latest react@latest react-dom@latest eslint-config-next@latest
 # or
 yarn upgrade next react react-dom eslint-config-next --latest (yarn classic)
-# or 
+# or
 yarn up next react react-dom eslint-config-next (yarn berry)
 # or
 pnpm up next react react-dom eslint-config-next --latest


### PR DESCRIPTION
This PR adds an example `yarn up` command to bump the relevant dependencies when using yarn berry for the Next 12 to Next 13 upgrade. One thing to possibly note is that `yarn up` is not scoped to a single workspace like `yarn upgrade` in classic - to get around this when in multiple workspaces, the `-i/--interactive` flag can be passed.

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm build && pnpm lint`
- [X] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
