### PR TITLE
refactor(next-swc): introduce next-binding to consolidate dependencies.

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "serde",
 ]
@@ -1500,12 +1500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
-
-[[package]]
 name = "inotify"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,7 +2212,7 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 [[package]]
 name = "next-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "mdxjs",
  "modularize_imports",
@@ -2234,23 +2228,17 @@ dependencies = [
 [[package]]
 name = "next-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
- "auto-hash-map",
  "indexmap",
- "indoc",
  "mime",
- "once_cell",
- "qstring",
  "serde",
  "serde_json",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-env",
- "turbo-tasks-fetch",
  "turbo-tasks-fs",
- "turbo-tasks-hash",
  "turbopack",
  "turbopack-core",
  "turbopack-dev-server",
@@ -2262,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "next-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2287,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "next-font"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "fxhash",
  "serde",
@@ -2342,7 +2330,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5347,7 +5335,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "mimalloc",
 ]
@@ -5355,7 +5343,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -5384,7 +5372,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -5396,7 +5384,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5408,25 +5396,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "turbo-tasks-fetch"
-version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
-dependencies = [
- "anyhow",
- "indexmap",
- "lazy_static",
- "reqwest",
- "serde",
- "tokio",
- "turbo-tasks",
- "turbo-tasks-build",
- "turbo-tasks-memory",
-]
-
-[[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -5450,7 +5422,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "base16",
  "hex",
@@ -5462,7 +5434,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -5476,7 +5448,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5486,7 +5458,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -5494,11 +5466,9 @@ dependencies = [
  "dashmap",
  "nohash-hasher",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "rustc-hash",
  "tokio",
- "turbo-malloc",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-hash",
@@ -5507,7 +5477,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -5529,7 +5499,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5545,7 +5515,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5571,7 +5541,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5590,7 +5560,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "futures",
@@ -5619,7 +5589,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5652,7 +5622,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "serde",
@@ -5667,7 +5637,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "serde",
@@ -5682,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "futures",
@@ -5706,7 +5676,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "serde",
@@ -5722,7 +5692,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "swc_core 0.45.4",
  "turbo-tasks",

--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "serde",
 ]
@@ -1500,6 +1500,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+
+[[package]]
 name = "inotify"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,19 +2216,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "next-binding"
+version = "0.1.0"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+dependencies = [
+ "mdxjs",
+ "modularize_imports",
+ "next-dev",
+ "node-file-trace",
+ "styled_components",
+ "styled_jsx",
+ "swc_core 0.45.4",
+ "swc_emotion",
+ "testing",
+]
+
+[[package]]
 name = "next-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
+ "auto-hash-map",
  "indexmap",
+ "indoc",
  "mime",
+ "once_cell",
+ "qstring",
  "serde",
  "serde_json",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-env",
+ "turbo-tasks-fetch",
  "turbo-tasks-fs",
+ "turbo-tasks-hash",
  "turbopack",
  "turbopack-core",
  "turbopack-dev-server",
@@ -2234,7 +2262,7 @@ dependencies = [
 [[package]]
 name = "next-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "clap",
@@ -2259,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "next-font"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "fxhash",
  "serde",
@@ -2276,6 +2304,7 @@ dependencies = [
  "either",
  "fxhash",
  "modularize_imports",
+ "next-binding",
  "once_cell",
  "pathdiff",
  "regex",
@@ -2283,9 +2312,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core 0.45.4",
  "swc_emotion",
- "testing",
  "tracing",
  "walkdir",
 ]
@@ -2297,18 +2324,15 @@ dependencies = [
  "anyhow",
  "backtrace",
  "fxhash",
- "mdxjs",
  "napi",
  "napi-build",
  "napi-derive",
- "next-dev",
+ "next-binding",
  "next-swc",
- "node-file-trace",
  "once_cell",
  "sentry",
  "serde",
  "serde_json",
- "swc_core 0.45.4",
  "tracing",
  "tracing-chrome",
  "tracing-futures",
@@ -2318,12 +2342,14 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
+ "clap",
  "serde",
  "serde_json",
  "tokio",
+ "turbo-malloc",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -3039,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "base64",
  "bytes",
@@ -5321,7 +5347,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "mimalloc",
 ]
@@ -5329,7 +5355,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -5358,7 +5384,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -5370,7 +5396,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5382,9 +5408,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbo-tasks-fetch"
+version = "0.1.0"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "lazy_static",
+ "reqwest",
+ "serde",
+ "tokio",
+ "turbo-tasks",
+ "turbo-tasks-build",
+ "turbo-tasks-memory",
+]
+
+[[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -5408,7 +5450,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "base16",
  "hex",
@@ -5420,7 +5462,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -5434,7 +5476,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5444,7 +5486,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -5452,9 +5494,11 @@ dependencies = [
  "dashmap",
  "nohash-hasher",
  "num_cpus",
+ "once_cell",
  "parking_lot",
  "rustc-hash",
  "tokio",
+ "turbo-malloc",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-hash",
@@ -5463,7 +5507,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -5485,7 +5529,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "clap",
@@ -5501,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5527,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5546,7 +5590,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "futures",
@@ -5575,7 +5619,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5608,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "serde",
@@ -5623,7 +5667,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "serde",
@@ -5638,7 +5682,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "futures",
@@ -5662,7 +5706,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "anyhow",
  "serde",
@@ -5678,7 +5722,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+source = "git+https://github.com/vercel/turbo.git?rev=11aba102d4b0709003d42f04e15a2cbfed98df2a#11aba102d4b0709003d42f04e15a2cbfed98df2a"
 dependencies = [
  "swc_core 0.45.4",
  "turbo-tasks",
@@ -5890,7 +5934,7 @@ dependencies = [
  "console_error_panic_hook",
  "getrandom",
  "js-sys",
- "mdxjs",
+ "next-binding",
  "next-swc",
  "once_cell",
  "parking_lot_core 0.8.0",
@@ -5898,7 +5942,6 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "swc_core 0.45.4",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -23,7 +23,7 @@ styled_jsx = "0.29.8"
 modularize_imports = "0.25.8"
 tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 
-next-binding = { git = "https://github.com/vercel/turbo.git", rev = "11aba102d4b0709003d42f04e15a2cbfed98df2a", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "cc024fa59f1c3ad253e74eefe86e0386455455d1", features = [
   "__swc_core",
   "__swc_core_next_core",
   "__swc_transform_styled_jsx",
@@ -33,7 +33,7 @@ next-binding = { git = "https://github.com/vercel/turbo.git", rev = "11aba102d4b
 ] }
 
 [dev-dependencies]
-next-binding = { git = "https://github.com/vercel/turbo.git", rev = "11aba102d4b0709003d42f04e15a2cbfed98df2a", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "cc024fa59f1c3ad253e74eefe86e0386455455d1", features = [
   "__swc_core_testing_transform",
   "__swc_testing",
 ] }

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -5,9 +5,7 @@ version = "0.0.0"
 publish = false
 
 [features]
-plugin = [
-  "swc_core/plugin_transform_host_native"
-]
+plugin = ["next-binding/__swc_core_binding_napi_plugin"]
 
 [dependencies]
 chrono = "0.4"
@@ -25,26 +23,19 @@ styled_jsx = "0.29.8"
 modularize_imports = "0.25.8"
 tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 
-swc_core = { features = [
-  "common_concurrent",
-  "ecma_ast",
-  "ecma_visit",
-  "ecma_loader_node",
-  "ecma_loader_lru",
-  "ecma_utils",
-  "ecma_minifier",
-  "ecma_transforms",
-  "__ecma_transforms",
-  "ecma_transforms_react",
-  "ecma_transforms_typescript",
-  "ecma_transforms_optimization",
-  "ecma_parser",
-  "ecma_parser_typescript",
-  "cached",
-  "base"
-], version = "0.45.4" }
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "bcf3461d2e7d63f55f722287ab7d5f99d39f52e6", features = [
+  "__swc_core",
+  "__swc_core_next_core",
+  "__swc_transform_styled_jsx",
+  "__swc_transform_emotion",
+  "__swc_transform_styled_components",
+  "__swc_transform_modularize_imports",
+] }
 
 [dev-dependencies]
-swc_core = { features = ["testing_transform"], version = "0.45.4" }
-testing = "0.31.14"
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "bcf3461d2e7d63f55f722287ab7d5f99d39f52e6", features = [
+  "__swc_core_testing_transform",
+  "__swc_testing",
+] }
+
 walkdir = "2.3.2"

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -23,7 +23,7 @@ styled_jsx = "0.29.8"
 modularize_imports = "0.25.8"
 tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 
-next-binding = { git = "https://github.com/vercel/turbo.git", rev = "bcf3461d2e7d63f55f722287ab7d5f99d39f52e6", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "11aba102d4b0709003d42f04e15a2cbfed98df2a", features = [
   "__swc_core",
   "__swc_core_next_core",
   "__swc_transform_styled_jsx",
@@ -33,7 +33,7 @@ next-binding = { git = "https://github.com/vercel/turbo.git", rev = "bcf3461d2e7
 ] }
 
 [dev-dependencies]
-next-binding = { git = "https://github.com/vercel/turbo.git", rev = "bcf3461d2e7d63f55f722287ab7d5f99d39f52e6", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "11aba102d4b0709003d42f04e15a2cbfed98df2a", features = [
   "__swc_core_testing_transform",
   "__swc_testing",
 ] }

--- a/packages/next-swc/crates/core/src/amp_attributes.rs
+++ b/packages/next-swc/crates/core/src/amp_attributes.rs
@@ -1,4 +1,4 @@
-use swc_core::{
+use next_binding::swc::core::{
     ecma::ast::{Ident, JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXElementName, JSXOpeningElement},
     ecma::atoms::JsWord,
     ecma::visit::Fold,

--- a/packages/next-swc/crates/core/src/auto_cjs/mod.rs
+++ b/packages/next-swc/crates/core/src/auto_cjs/mod.rs
@@ -1,4 +1,4 @@
-use swc_core::{
+use next_binding::swc::core::{
     ecma::ast::*,
     ecma::visit::{Visit, VisitWith},
 };

--- a/packages/next-swc/crates/core/src/disallow_re_export_all_in_page.rs
+++ b/packages/next-swc/crates/core/src/disallow_re_export_all_in_page.rs
@@ -1,4 +1,4 @@
-use swc_core::{
+use next_binding::swc::core::{
     common::errors::HANDLER,
     ecma::ast::ExportAll,
     ecma::transforms::base::pass::Optional,

--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -38,7 +38,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::{path::PathBuf, sync::Arc};
 
-use swc_core::{
+use next_binding::swc::core::{
     base::config::ModuleConfig,
     common::{chain, comments::Comments, pass::Optional, FileName, SourceFile, SourceMap},
     ecma::ast::EsVersion,
@@ -66,7 +66,7 @@ mod top_level_binding_collector;
 #[serde(rename_all = "camelCase")]
 pub struct TransformOptions {
     #[serde(flatten)]
-    pub swc: swc_core::base::config::Options,
+    pub swc: next_binding::swc::core::base::config::Options,
 
     #[serde(default)]
     pub disable_next_ssg: bool,
@@ -93,7 +93,7 @@ pub struct TransformOptions {
     pub styled_jsx: bool,
 
     #[serde(default)]
-    pub styled_components: Option<styled_components::Config>,
+    pub styled_components: Option<next_binding::swc::custom_transform::styled_components::Config>,
 
     #[serde(default)]
     pub remove_console: Option<remove_console::Config>,
@@ -115,10 +115,10 @@ pub struct TransformOptions {
     pub shake_exports: Option<shake_exports::Config>,
 
     #[serde(default)]
-    pub emotion: Option<swc_emotion::EmotionOptions>,
+    pub emotion: Option<next_binding::swc::custom_transform::emotion::EmotionOptions>,
 
     #[serde(default)]
-    pub modularize_imports: Option<modularize_imports::Config>,
+    pub modularize_imports: Option<next_binding::swc::custom_transform::modularize_imports::Config>,
 
     #[serde(default)]
     pub font_loaders: Option<next_font_loaders::Config>,
@@ -162,7 +162,7 @@ where
             _ => Either::Right(noop()),
         },
         if opts.styled_jsx {
-            Either::Left(styled_jsx::visitor::styled_jsx(
+            Either::Left(next_binding::swc::custom_transform::styled_jsx::visitor::styled_jsx(
                 cm.clone(),
                 file.name.clone(),
             ))
@@ -170,7 +170,7 @@ where
             Either::Right(noop())
         },
         match &opts.styled_components {
-            Some(config) => Either::Left(styled_components::styled_components(
+            Some(config) => Either::Left(next_binding::swc::custom_transform::styled_components::styled_components(
                 file.name.clone(),
                 file.src_hash,
                 config.clone(),
@@ -216,7 +216,7 @@ where
                 }
                 if let FileName::Real(path) = &file.name {
                     path.to_str().map(|_| {
-                        Either::Left(swc_emotion::EmotionTransformer::new(
+                        Either::Left(next_binding::swc::custom_transform::emotion::EmotionTransformer::new(
                             config.clone(),
                             path,
                             cm,
@@ -229,7 +229,7 @@ where
             })
             .unwrap_or_else(|| Either::Right(noop())),
         match &opts.modularize_imports {
-            Some(config) => Either::Left(modularize_imports::modularize_imports(config.clone())),
+            Some(config) => Either::Left(next_binding::swc::custom_transform::modularize_imports::modularize_imports(config.clone())),
             None => Either::Right(noop()),
         },
         match &opts.font_loaders {

--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -162,19 +162,23 @@ where
             _ => Either::Right(noop()),
         },
         if opts.styled_jsx {
-            Either::Left(next_binding::swc::custom_transform::styled_jsx::visitor::styled_jsx(
-                cm.clone(),
-                file.name.clone(),
-            ))
+            Either::Left(
+                next_binding::swc::custom_transform::styled_jsx::visitor::styled_jsx(
+                    cm.clone(),
+                    file.name.clone(),
+                ),
+            )
         } else {
             Either::Right(noop())
         },
         match &opts.styled_components {
-            Some(config) => Either::Left(next_binding::swc::custom_transform::styled_components::styled_components(
-                file.name.clone(),
-                file.src_hash,
-                config.clone(),
-            )),
+            Some(config) => Either::Left(
+                next_binding::swc::custom_transform::styled_components::styled_components(
+                    file.name.clone(),
+                    file.src_hash,
+                    config.clone(),
+                )
+            ),
             None => Either::Right(noop()),
         },
         Optional::new(
@@ -216,12 +220,14 @@ where
                 }
                 if let FileName::Real(path) = &file.name {
                     path.to_str().map(|_| {
-                        Either::Left(next_binding::swc::custom_transform::emotion::EmotionTransformer::new(
-                            config.clone(),
-                            path,
-                            cm,
-                            comments,
-                        ))
+                        Either::Left(
+                            next_binding::swc::custom_transform::emotion::EmotionTransformer::new(
+                                config.clone(),
+                                path,
+                                cm,
+                                comments,
+                            ),
+                        )
                     })
                 } else {
                     None
@@ -229,7 +235,11 @@ where
             })
             .unwrap_or_else(|| Either::Right(noop())),
         match &opts.modularize_imports {
-            Some(config) => Either::Left(next_binding::swc::custom_transform::modularize_imports::modularize_imports(config.clone())),
+            Some(config) => Either::Left(
+                next_binding::swc::custom_transform::modularize_imports::modularize_imports(
+                    config.clone()
+                )
+            ),
             None => Either::Right(noop()),
         },
         match &opts.font_loaders {

--- a/packages/next-swc/crates/core/src/next_dynamic.rs
+++ b/packages/next-swc/crates/core/src/next_dynamic.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use pathdiff::diff_paths;
 
-use swc_core::{
+use next_binding::swc::core::{
     common::{errors::HANDLER, FileName, DUMMY_SP},
     ecma::ast::{
         ArrayLit, ArrowExpr, BinExpr, BinaryOp, BlockStmtOrExpr, Bool, CallExpr, Callee, Expr,

--- a/packages/next-swc/crates/core/src/next_font_loaders/find_functions_outside_module_scope.rs
+++ b/packages/next-swc/crates/core/src/next_font_loaders/find_functions_outside_module_scope.rs
@@ -1,7 +1,7 @@
-use swc_core::common::errors::HANDLER;
-use swc_core::ecma::ast::*;
-use swc_core::ecma::visit::noop_visit_type;
-use swc_core::ecma::visit::Visit;
+use next_binding::swc::core::common::errors::HANDLER;
+use next_binding::swc::core::ecma::ast::*;
+use next_binding::swc::core::ecma::visit::noop_visit_type;
+use next_binding::swc::core::ecma::visit::Visit;
 
 pub struct FindFunctionsOutsideModuleScope<'a> {
     pub state: &'a super::State,

--- a/packages/next-swc/crates/core/src/next_font_loaders/font_functions_collector.rs
+++ b/packages/next-swc/crates/core/src/next_font_loaders/font_functions_collector.rs
@@ -1,8 +1,8 @@
-use swc_core::common::errors::HANDLER;
-use swc_core::ecma::ast::*;
-use swc_core::ecma::atoms::JsWord;
-use swc_core::ecma::visit::noop_visit_type;
-use swc_core::ecma::visit::Visit;
+use next_binding::swc::core::common::errors::HANDLER;
+use next_binding::swc::core::ecma::ast::*;
+use next_binding::swc::core::ecma::atoms::JsWord;
+use next_binding::swc::core::ecma::visit::noop_visit_type;
+use next_binding::swc::core::ecma::visit::Visit;
 
 pub struct FontFunctionsCollector<'a> {
     pub font_loaders: &'a [JsWord],

--- a/packages/next-swc/crates/core/src/next_font_loaders/font_imports_generator.rs
+++ b/packages/next-swc/crates/core/src/next_font_loaders/font_imports_generator.rs
@@ -1,9 +1,9 @@
-use serde_json::Value;
 use next_binding::swc::core::common::errors::HANDLER;
 use next_binding::swc::core::common::{Spanned, DUMMY_SP};
 use next_binding::swc::core::ecma::ast::*;
 use next_binding::swc::core::ecma::atoms::JsWord;
 use next_binding::swc::core::ecma::visit::{noop_visit_type, Visit};
+use serde_json::Value;
 
 pub struct FontImportsGenerator<'a> {
     pub state: &'a mut super::State,

--- a/packages/next-swc/crates/core/src/next_font_loaders/font_imports_generator.rs
+++ b/packages/next-swc/crates/core/src/next_font_loaders/font_imports_generator.rs
@@ -1,9 +1,9 @@
 use serde_json::Value;
-use swc_core::common::errors::HANDLER;
-use swc_core::common::{Spanned, DUMMY_SP};
-use swc_core::ecma::ast::*;
-use swc_core::ecma::atoms::JsWord;
-use swc_core::ecma::visit::{noop_visit_type, Visit};
+use next_binding::swc::core::common::errors::HANDLER;
+use next_binding::swc::core::common::{Spanned, DUMMY_SP};
+use next_binding::swc::core::ecma::ast::*;
+use next_binding::swc::core::ecma::atoms::JsWord;
+use next_binding::swc::core::ecma::visit::{noop_visit_type, Visit};
 
 pub struct FontImportsGenerator<'a> {
     pub state: &'a mut super::State,

--- a/packages/next-swc/crates/core/src/next_font_loaders/mod.rs
+++ b/packages/next-swc/crates/core/src/next_font_loaders/mod.rs
@@ -1,6 +1,6 @@
 use fxhash::FxHashSet;
 use serde::Deserialize;
-use swc_core::{
+use next_binding::swc::core::{
     common::{collections::AHashMap, BytePos, Spanned},
     ecma::{
         ast::Id,

--- a/packages/next-swc/crates/core/src/next_font_loaders/mod.rs
+++ b/packages/next-swc/crates/core/src/next_font_loaders/mod.rs
@@ -1,5 +1,4 @@
 use fxhash::FxHashSet;
-use serde::Deserialize;
 use next_binding::swc::core::{
     common::{collections::AHashMap, BytePos, Spanned},
     ecma::{
@@ -8,6 +7,7 @@ use next_binding::swc::core::{
     },
     ecma::{ast::ModuleItem, atoms::JsWord},
 };
+use serde::Deserialize;
 
 mod find_functions_outside_module_scope;
 mod font_functions_collector;

--- a/packages/next-swc/crates/core/src/next_ssg.rs
+++ b/packages/next-swc/crates/core/src/next_ssg.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use std::mem::take;
 use std::rc::Rc;
 
-use swc_core::{
+use next_binding::swc::core::{
     common::{
         errors::HANDLER,
         pass::{Repeat, Repeated},

--- a/packages/next-swc/crates/core/src/page_config.rs
+++ b/packages/next-swc/crates/core/src/page_config.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 
-use swc_core::{
+use next_binding::swc::core::{
     common::{errors::HANDLER, Span, DUMMY_SP},
     ecma::ast::*,
     ecma::visit::{Fold, FoldWith},

--- a/packages/next-swc/crates/core/src/react_remove_properties.rs
+++ b/packages/next-swc/crates/core/src/react_remove_properties.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use serde::Deserialize;
 
-use swc_core::{
+use next_binding::swc::core::{
     ecma::ast::*,
     ecma::visit::{noop_fold_type, Fold, FoldWith},
 };

--- a/packages/next-swc/crates/core/src/react_server_components.rs
+++ b/packages/next-swc/crates/core/src/react_server_components.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use serde::Deserialize;
 
-use swc_core::{
+use next_binding::swc::core::{
     common::{
         comments::{Comment, CommentKind, Comments},
         errors::HANDLER,

--- a/packages/next-swc/crates/core/src/relay.rs
+++ b/packages/next-swc/crates/core/src/relay.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
-use swc_core::{
+use next_binding::swc::core::{
     common::{errors::HANDLER, FileName},
     ecma::ast::*,
     ecma::atoms::JsWord,

--- a/packages/next-swc/crates/core/src/remove_console.rs
+++ b/packages/next-swc/crates/core/src/remove_console.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use swc_core::{
+use next_binding::swc::core::{
     common::{collections::AHashSet, DUMMY_SP},
     ecma::ast::*,
     ecma::atoms::JsWord,

--- a/packages/next-swc/crates/core/src/shake_exports.rs
+++ b/packages/next-swc/crates/core/src/shake_exports.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use swc_core::{
+use next_binding::swc::core::{
     common::Mark,
     ecma::ast::*,
     ecma::atoms::{js_word, JsWord},

--- a/packages/next-swc/crates/core/src/top_level_binding_collector.rs
+++ b/packages/next-swc/crates/core/src/top_level_binding_collector.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use swc_core::{
+use next_binding::swc::core::{
     common::{collections::AHashSet, SyntaxContext},
     ecma::ast::{
         ClassDecl, FnDecl, Ident, ImportDefaultSpecifier, ImportNamedSpecifier,

--- a/packages/next-swc/crates/core/tests/errors.rs
+++ b/packages/next-swc/crates/core/tests/errors.rs
@@ -1,3 +1,13 @@
+use next_binding::swc::{
+    core::{
+        common::FileName,
+        ecma::{
+            parser::{EsConfig, Syntax},
+            transforms::testing::{test_fixture, FixtureTestConfig},
+        },
+    },
+    testing::fixture,
+};
 use next_swc::{
     disallow_re_export_all_in_page::disallow_re_export_all_in_page,
     next_dynamic::next_dynamic,
@@ -6,14 +16,6 @@ use next_swc::{
     react_server_components::server_components,
 };
 use std::path::PathBuf;
-use swc_core::{
-    common::FileName,
-    ecma::{
-        parser::{EsConfig, Syntax},
-        transforms::testing::{test_fixture, FixtureTestConfig},
-    },
-};
-use testing::fixture;
 
 fn syntax() -> Syntax {
     Syntax::Es(EsConfig {

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -1,3 +1,12 @@
+use next_binding::swc::{
+    core::{
+        common::{chain, comments::SingleThreadedComments, FileName, Mark},
+        ecma::parser::{EsConfig, Syntax},
+        ecma::transforms::react::jsx,
+        ecma::transforms::testing::{test, test_fixture},
+    },
+    testing::fixture,
+};
 use next_swc::{
     amp_attributes::amp_attributes,
     next_dynamic::next_dynamic,
@@ -11,13 +20,6 @@ use next_swc::{
     shake_exports::{shake_exports, Config as ShakeExportsConfig},
 };
 use std::path::PathBuf;
-use swc_core::{
-    common::{chain, comments::SingleThreadedComments, FileName, Mark},
-    ecma::parser::{EsConfig, Syntax},
-    ecma::transforms::react::jsx,
-    ecma::transforms::testing::{test, test_fixture},
-};
-use testing::fixture;
 
 fn syntax() -> Syntax {
     Syntax::Es(EsConfig {
@@ -100,7 +102,7 @@ fn next_ssg_fixture(input: PathBuf) {
             let jsx = jsx::<SingleThreadedComments>(
                 tr.cm.clone(),
                 None,
-                swc_core::ecma::transforms::react::Options {
+                next_binding::swc::core::ecma::transforms::react::Options {
                     next: false.into(),
                     runtime: None,
                     import_source: Some("".into()),

--- a/packages/next-swc/crates/core/tests/full.rs
+++ b/packages/next-swc/crates/core/tests/full.rs
@@ -1,20 +1,22 @@
+use next_binding::swc::{
+    core::{
+        base::Compiler,
+        common::comments::SingleThreadedComments,
+        ecma::parser::{Syntax, TsConfig},
+        ecma::transforms::base::pass::noop,
+    },
+    testing::{NormalizedOutput, Tester},
+};
 use next_swc::{custom_before_pass, TransformOptions};
 use serde::de::DeserializeOwned;
 use std::path::{Path, PathBuf};
-use swc_core::{
-    base::Compiler,
-    common::comments::SingleThreadedComments,
-    ecma::parser::{Syntax, TsConfig},
-    ecma::transforms::base::pass::noop,
-};
-use testing::{NormalizedOutput, Tester};
 
-#[testing::fixture("tests/full/**/input.js")]
+#[next_binding::swc::testing::fixture("tests/full/**/input.js")]
 fn full(input: PathBuf) {
     test(&input, true);
 }
 
-#[testing::fixture("tests/loader/**/input.js")]
+#[next_binding::swc::testing::fixture("tests/loader/**/input.js")]
 fn loader(input: PathBuf) {
     test(&input, false);
 }
@@ -29,14 +31,14 @@ fn test(input: &Path, minify: bool) {
             let fm = cm.load_file(input).expect("failed to load file");
 
             let options = TransformOptions {
-                swc: swc_core::base::config::Options {
+                swc: next_binding::swc::core::base::config::Options {
                     swcrc: true,
                     output_path: Some(output.clone()),
 
-                    config: swc_core::base::config::Config {
-                        is_module: swc_core::base::config::IsModule::Bool(true),
+                    config: next_binding::swc::core::base::config::Config {
+                        is_module: next_binding::swc::core::base::config::IsModule::Bool(true),
 
-                        jsc: swc_core::base::config::JscConfig {
+                        jsc: next_binding::swc::core::base::config::JscConfig {
                             minify: if minify {
                                 Some(assert_json("{ \"compress\": true, \"mangle\": true }"))
                             } else {

--- a/packages/next-swc/crates/core/tests/telemetry.rs
+++ b/packages/next-swc/crates/core/tests/telemetry.rs
@@ -6,7 +6,7 @@ use fxhash::FxHashSet;
 use next_swc::next_ssg::next_ssg;
 use once_cell::sync::Lazy;
 
-use swc_core::{
+use next_binding::swc::core::{
     base::{try_with_handler, Compiler},
     common::{comments::SingleThreadedComments, FileName, FilePathMapping, SourceMap, GLOBALS},
     ecma::transforms::base::pass::noop,

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -55,8 +55,8 @@ tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.9"
 tracing-chrome = "0.5.0"
-next-dev = { git = "https://github.com/vercel/turbo.git", rev = "cc024fa59f1c3ad253e74eefe86e0386455455d1", features = ["serializable"] }
-node-file-trace = { git = "https://github.com/vercel/turbo.git", rev = "cc024fa59f1c3ad253e74eefe86e0386455455d1", default-features = false, features = ["node-api"] }
+next-dev = { git = "https://github.com/vercel/turbo.git", rev = "5c2b933ce142d70e9774e933e805734f2c09248c", features = ["serializable"] }
+node-file-trace = { git = "https://github.com/vercel/turbo.git", rev = "5c2b933ce142d70e9774e933e805734f2c09248c", default-features = false, features = ["node-api"] }
 mdxjs = { version = "0.1.3", features = ["serializable"] }
 # There are few build targets we can't use native-tls which default features rely on,
 # allow to specify alternative (rustls) instead via features.

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -13,10 +13,7 @@ default = []
 # when build (i.e napi --build --features plugin), same for the wasm as well.
 # this is due to some of transitive dependencies have features cannot be enabled at the same time
 # (i.e wasmer/default vs wasmer/js-default) while cargo merges all the features at once.
-plugin = [
-  "swc_core/plugin_transform_host_native",
-  "next-swc/plugin"
-]
+plugin = ["next-binding/__swc_core_binding_napi_plugin", "next-swc/plugin"]
 sentry_native_tls = ["_sentry_native_tls"]
 sentry_rustls = ["_sentry_rustls"]
 
@@ -24,40 +21,28 @@ sentry_rustls = ["_sentry_rustls"]
 anyhow = "1.0.66"
 backtrace = "0.3"
 fxhash = "0.2.1"
-napi = { version = "2", default-features = false, features = ["napi3", "serde-json", "tokio_rt", "error_anyhow"] }
+napi = { version = "2", default-features = false, features = [
+  "napi3",
+  "serde-json",
+  "tokio_rt",
+  "error_anyhow",
+] }
 napi-derive = "2"
-next-swc = {version = "0.0.0", path = "../core"}
+next-swc = { version = "0.0.0", path = "../core" }
 once_cell = "1.13.0"
 serde = "1"
 serde_json = "1"
-swc_core = { features = [
-  "allocator_node",
-  "base_concurrent", # concurrent?
-  "base_node",
-  "common_concurrent",
-  "ecma_ast",
-  "ecma_loader_node",
-  "ecma_loader_lru",
-  "bundler",
-  "bundler_concurrent",
-  "ecma_codegen",
-  "ecma_minifier",
-  "ecma_parser",
-  "ecma_parser_typescript",
-  "ecma_transforms",
-  "ecma_transforms_optimization",
-  "ecma_transforms_react",
-  "ecma_transforms_typescript",
-  "ecma_utils",
-  "ecma_visit",
-], version = "0.45.4" }
 tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.9"
 tracing-chrome = "0.5.0"
-next-dev = { git = "https://github.com/vercel/turbo.git", rev = "5c2b933ce142d70e9774e933e805734f2c09248c", features = ["serializable"] }
-node-file-trace = { git = "https://github.com/vercel/turbo.git", rev = "5c2b933ce142d70e9774e933e805734f2c09248c", default-features = false, features = ["node-api"] }
-mdxjs = { version = "0.1.3", features = ["serializable"] }
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "bcf3461d2e7d63f55f722287ab7d5f99d39f52e6", features = [
+  "__swc_core_binding_napi",
+  "__feature_next_dev_server",
+  "__feature_node_file_trace",
+  "__feature_mdx_rs",
+] }
+
 # There are few build targets we can't use native-tls which default features rely on,
 # allow to specify alternative (rustls) instead via features.
 # Note to opt in rustls default-features should be disabled
@@ -68,7 +53,7 @@ _sentry_rustls = { package = "sentry", version = "0.27.0", default-features = fa
   "contexts",
   "panic",
   "rustls",
-  "reqwest"
+  "reqwest",
 ], optional = true }
 
 [build-dependencies]

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -36,10 +36,10 @@ tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.9"
 tracing-chrome = "0.5.0"
-next-binding = { git = "https://github.com/vercel/turbo.git", rev = "bcf3461d2e7d63f55f722287ab7d5f99d39f52e6", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "11aba102d4b0709003d42f04e15a2cbfed98df2a", features = [
   "__swc_core_binding_napi",
-  "__feature_next_dev_server",
-  "__feature_node_file_trace",
+  "__turbo_next_dev_server",
+  "__turbo_node_file_trace",
   "__feature_mdx_rs",
 ] }
 

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -36,7 +36,7 @@ tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.9"
 tracing-chrome = "0.5.0"
-next-binding = { git = "https://github.com/vercel/turbo.git", rev = "11aba102d4b0709003d42f04e15a2cbfed98df2a", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "cc024fa59f1c3ad253e74eefe86e0386455455d1", features = [
   "__swc_core_binding_napi",
   "__turbo_next_dev_server",
   "__turbo_node_file_trace",

--- a/packages/next-swc/crates/napi/src/lib.rs
+++ b/packages/next-swc/crates/napi/src/lib.rs
@@ -32,14 +32,14 @@ DEALINGS IN THE SOFTWARE.
 #[macro_use]
 extern crate napi_derive;
 /// Explicit extern crate to use allocator.
-extern crate swc_core;
+extern crate next_binding;
 
 use std::{env, panic::set_hook, sync::Arc};
 
 use backtrace::Backtrace;
 use fxhash::FxHashSet;
 use napi::bindgen_prelude::*;
-use swc_core::{
+use next_binding::swc::core::{
     base::{Compiler, TransformOutput},
     common::{sync::Lazy, FilePathMapping, SourceMap},
 };

--- a/packages/next-swc/crates/napi/src/mdx.rs
+++ b/packages/next-swc/crates/napi/src/mdx.rs
@@ -1,5 +1,5 @@
 use napi::bindgen_prelude::*;
-use next_binding::features::mdx::{compile, Options};
+use next_binding::features::mdxjs::{compile, Options};
 
 pub struct MdxCompileTask {
     pub input: String,

--- a/packages/next-swc/crates/napi/src/mdx.rs
+++ b/packages/next-swc/crates/napi/src/mdx.rs
@@ -1,5 +1,5 @@
-use mdxjs::{compile, Options};
 use napi::bindgen_prelude::*;
+use next_binding::features::mdx::{compile, Options};
 
 pub struct MdxCompileTask {
     pub input: String,

--- a/packages/next-swc/crates/napi/src/minify.rs
+++ b/packages/next-swc/crates/napi/src/minify.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use fxhash::FxHashMap;
 use napi::bindgen_prelude::*;
 use serde::Deserialize;
-use swc_core::{
+use next_binding::swc::core::{
     base::{try_with_handler, TransformOutput},
     common::{errors::ColorConfig, sync::Lrc, FileName, SourceFile, SourceMap, GLOBALS},
 };
@@ -38,9 +38,9 @@ use swc_core::{
 use crate::{get_compiler, util::MapErr};
 
 pub struct MinifyTask {
-    c: Arc<swc_core::base::Compiler>,
+    c: Arc<next_binding::swc::core::base::Compiler>,
     code: MinifyTarget,
-    opts: swc_core::base::config::JsMinifyOptions,
+    opts: next_binding::swc::core::base::config::JsMinifyOptions,
 }
 
 #[derive(Deserialize)]
@@ -80,7 +80,7 @@ impl Task for MinifyTask {
     fn compute(&mut self) -> napi::Result<Self::Output> {
         try_with_handler(
             self.c.cm.clone(),
-            swc_core::base::HandlerOpts {
+            next_binding::swc::core::base::HandlerOpts {
                 color: ColorConfig::Never,
                 skip_filename: true,
             },
@@ -127,7 +127,7 @@ pub fn minify_sync(input: Buffer, opts: Buffer) -> napi::Result<TransformOutput>
 
     try_with_handler(
         c.cm.clone(),
-        swc_core::base::HandlerOpts {
+        next_binding::swc::core::base::HandlerOpts {
             color: ColorConfig::Never,
             skip_filename: true,
         },

--- a/packages/next-swc/crates/napi/src/minify.rs
+++ b/packages/next-swc/crates/napi/src/minify.rs
@@ -29,11 +29,11 @@ use std::sync::Arc;
 
 use fxhash::FxHashMap;
 use napi::bindgen_prelude::*;
-use serde::Deserialize;
 use next_binding::swc::core::{
     base::{try_with_handler, TransformOutput},
     common::{errors::ColorConfig, sync::Lrc, FileName, SourceFile, SourceMap, GLOBALS},
 };
+use serde::Deserialize;
 
 use crate::{get_compiler, util::MapErr};
 

--- a/packages/next-swc/crates/napi/src/parse.rs
+++ b/packages/next-swc/crates/napi/src/parse.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use napi::bindgen_prelude::*;
-use swc_core::{
+use next_binding::swc::core::{
     base::{config::ParseOptions, try_with_handler},
     common::{
         comments::Comments, errors::ColorConfig, FileName, FilePathMapping, SourceMap, GLOBALS,
@@ -25,7 +25,7 @@ impl Task for ParseTask {
     fn compute(&mut self) -> napi::Result<Self::Output> {
         GLOBALS.set(&Default::default(), || {
             let c =
-                swc_core::base::Compiler::new(Arc::new(SourceMap::new(FilePathMapping::empty())));
+                next_binding::swc::core::base::Compiler::new(Arc::new(SourceMap::new(FilePathMapping::empty())));
 
             let options: ParseOptions = serde_json::from_slice(self.options.as_ref())?;
             let comments = c.comments().clone();
@@ -38,7 +38,7 @@ impl Task for ParseTask {
                 c.cm.new_source_file(self.filename.clone(), self.src.clone());
             let program = try_with_handler(
                 c.cm.clone(),
-                swc_core::base::HandlerOpts {
+                next_binding::swc::core::base::HandlerOpts {
                     color: ColorConfig::Never,
                     skip_filename: false,
                 },

--- a/packages/next-swc/crates/napi/src/parse.rs
+++ b/packages/next-swc/crates/napi/src/parse.rs
@@ -24,8 +24,9 @@ impl Task for ParseTask {
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
         GLOBALS.set(&Default::default(), || {
-            let c =
-                next_binding::swc::core::base::Compiler::new(Arc::new(SourceMap::new(FilePathMapping::empty())));
+            let c = next_binding::swc::core::base::Compiler::new(Arc::new(SourceMap::new(
+                FilePathMapping::empty(),
+            )));
 
             let options: ParseOptions = serde_json::from_slice(self.options.as_ref())?;
             let comments = c.comments().clone();

--- a/packages/next-swc/crates/napi/src/transform.rs
+++ b/packages/next-swc/crates/napi/src/transform.rs
@@ -37,12 +37,12 @@ use std::{
 use anyhow::{anyhow, bail, Context as _};
 use fxhash::FxHashSet;
 use napi::bindgen_prelude::*;
-use next_swc::{custom_before_pass, TransformOptions};
 use next_binding::swc::core::{
     base::{try_with_handler, Compiler, TransformOutput},
-    common::{errors::ColorConfig, FileName, GLOBALS, comments::SingleThreadedComments},
+    common::{comments::SingleThreadedComments, errors::ColorConfig, FileName, GLOBALS},
     ecma::transforms::base::pass::noop,
 };
+use next_swc::{custom_before_pass, TransformOptions};
 
 use crate::{complete_output, get_compiler, util::MapErr};
 

--- a/packages/next-swc/crates/napi/src/transform.rs
+++ b/packages/next-swc/crates/napi/src/transform.rs
@@ -38,10 +38,9 @@ use anyhow::{anyhow, bail, Context as _};
 use fxhash::FxHashSet;
 use napi::bindgen_prelude::*;
 use next_swc::{custom_before_pass, TransformOptions};
-use swc_core::common::comments::SingleThreadedComments;
-use swc_core::{
+use next_binding::swc::core::{
     base::{try_with_handler, Compiler, TransformOutput},
-    common::{errors::ColorConfig, FileName, GLOBALS},
+    common::{errors::ColorConfig, FileName, GLOBALS, comments::SingleThreadedComments},
     ecma::transforms::base::pass::noop,
 };
 
@@ -72,7 +71,7 @@ impl Task for TransformTask {
             let res = catch_unwind(AssertUnwindSafe(|| {
                 try_with_handler(
                     self.c.cm.clone(),
-                    swc_core::base::HandlerOpts {
+                    next_binding::swc::core::base::HandlerOpts {
                         color: ColorConfig::Never,
                         skip_filename: true,
                     },

--- a/packages/next-swc/crates/napi/src/turbopack.rs
+++ b/packages/next-swc/crates/napi/src/turbopack.rs
@@ -1,6 +1,6 @@
 use crate::util::MapErr;
 use napi::bindgen_prelude::*;
-use next_dev::{devserver_options::DevServerOptions, start_server};
+use next_binding::turbo::dev_server::{devserver_options::DevServerOptions, start_server};
 
 #[napi]
 pub async fn start_turbo_dev(options: Buffer) -> napi::Result<()> {

--- a/packages/next-swc/crates/napi/src/turbopack.rs
+++ b/packages/next-swc/crates/napi/src/turbopack.rs
@@ -1,6 +1,6 @@
 use crate::util::MapErr;
 use napi::bindgen_prelude::*;
-use next_binding::turbo::dev_server::{devserver_options::DevServerOptions, start_server};
+use next_binding::turbo::next_dev::{devserver_options::DevServerOptions, start_server};
 
 #[napi]
 pub async fn start_turbo_dev(options: Buffer) -> napi::Result<()> {

--- a/packages/next-swc/crates/napi/src/turbotrace.rs
+++ b/packages/next-swc/crates/napi/src/turbotrace.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use napi::bindgen_prelude::*;
-use node_file_trace::{start, Args};
+use next_binding::turbo::node_file_trace::{start, Args};
 
 #[napi]
 pub async fn run_turbo_tracing(options: Buffer) -> napi::Result<Vec<String>> {

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -31,7 +31,7 @@ wasm-bindgen-futures = "0.4.8"
 getrandom = { version = "0.2.5", optional = true, default-features = false }
 js-sys = "0.3.59"
 serde-wasm-bindgen = "0.4.3"
-next-binding = { git = "https://github.com/vercel/turbo.git", rev = "bcf3461d2e7d63f55f722287ab7d5f99d39f52e6", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "11aba102d4b0709003d42f04e15a2cbfed98df2a", features = [
   "__swc_core_binding_wasm",
   "__feature_mdx_rs",
 ] }

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -31,7 +31,7 @@ wasm-bindgen-futures = "0.4.8"
 getrandom = { version = "0.2.5", optional = true, default-features = false }
 js-sys = "0.3.59"
 serde-wasm-bindgen = "0.4.3"
-next-binding = { git = "https://github.com/vercel/turbo.git", rev = "11aba102d4b0709003d42f04e15a2cbfed98df2a", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "cc024fa59f1c3ad253e74eefe86e0386455455d1", features = [
   "__swc_core_binding_wasm",
   "__feature_mdx_rs",
 ] }

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -13,7 +13,7 @@ swc_v1  = []
 
 plugin = [
   "getrandom/js",
-  "swc_core/plugin_transform_host_js"
+  "next-binding/__swc_core_binding_wasm_plugin"
 ]
 
 [dependencies]
@@ -31,22 +31,10 @@ wasm-bindgen-futures = "0.4.8"
 getrandom = { version = "0.2.5", optional = true, default-features = false }
 js-sys = "0.3.59"
 serde-wasm-bindgen = "0.4.3"
-mdxjs = { version = "0.1.3", features = ["serializable"] }
-
-swc_core = { features = [
-  "common_concurrent",
-  "binding_macro_wasm",
-  "ecma_codegen",
-  "ecma_minifier",
-  "ecma_transforms",
-  "ecma_transforms_typescript",
-  "ecma_transforms_optimization",
-  "ecma_transforms_react",
-  "ecma_parser",
-  "ecma_parser_typescript",
-  "ecma_utils",
-  "ecma_visit"
-], version = "0.45.4" }
+next-binding = { git = "https://github.com/vercel/turbo.git", rev = "bcf3461d2e7d63f55f722287ab7d5f99d39f52e6", features = [
+  "__swc_core_binding_wasm",
+  "__feature_mdx_rs",
+] }
 
 
 # Workaround a bug

--- a/packages/next-swc/crates/wasm/src/lib.rs
+++ b/packages/next-swc/crates/wasm/src/lib.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::future_to_promise;
 
-use swc_core::{
+use next_binding::swc::core::{
     base::{config::JsMinifyOptions, config::ParseOptions, try_with_handler, Compiler},
     common::{
         comments::{Comments, SingleThreadedComments},
@@ -31,7 +31,7 @@ pub fn minify_sync(s: JsString, opts: JsValue) -> Result<JsValue, JsValue> {
 
     let value = try_with_handler(
         c.cm.clone(),
-        swc_core::base::HandlerOpts {
+        next_binding::swc::core::base::HandlerOpts {
             color: ColorConfig::Never,
             skip_filename: false,
         },
@@ -68,7 +68,7 @@ pub fn transform_sync(s: JsValue, opts: JsValue) -> Result<JsValue, JsValue> {
     let s = s.dyn_into::<js_sys::JsString>();
     let out = try_with_handler(
         c.cm.clone(),
-        swc_core::base::HandlerOpts {
+        next_binding::swc::core::base::HandlerOpts {
             color: ColorConfig::Never,
             skip_filename: false,
         },
@@ -133,12 +133,12 @@ pub fn transform(s: JsValue, opts: JsValue) -> js_sys::Promise {
 pub fn parse_sync(s: JsString, opts: JsValue) -> Result<JsValue, JsValue> {
     console_error_panic_hook::set_once();
 
-    let c = swc_core::base::Compiler::new(Arc::new(SourceMap::new(FilePathMapping::empty())));
+    let c = next_binding::swc::core::base::Compiler::new(Arc::new(SourceMap::new(FilePathMapping::empty())));
     let opts: ParseOptions = serde_wasm_bindgen::from_value(opts)?;
 
     try_with_handler(
         c.cm.clone(),
-        swc_core::base::HandlerOpts {
+        next_binding::swc::core::base::HandlerOpts {
             ..Default::default()
         },
         |handler| {

--- a/packages/next-swc/crates/wasm/src/lib.rs
+++ b/packages/next-swc/crates/wasm/src/lib.rs
@@ -133,7 +133,9 @@ pub fn transform(s: JsValue, opts: JsValue) -> js_sys::Promise {
 pub fn parse_sync(s: JsString, opts: JsValue) -> Result<JsValue, JsValue> {
     console_error_panic_hook::set_once();
 
-    let c = next_binding::swc::core::base::Compiler::new(Arc::new(SourceMap::new(FilePathMapping::empty())));
+    let c = next_binding::swc::core::base::Compiler::new(Arc::new(SourceMap::new(
+        FilePathMapping::empty(),
+    )));
     let opts: ParseOptions = serde_wasm_bindgen::from_value(opts)?;
 
     try_with_handler(

--- a/packages/next-swc/crates/wasm/src/mdx.rs
+++ b/packages/next-swc/crates/wasm/src/mdx.rs
@@ -1,5 +1,5 @@
 use js_sys::JsString;
-use next_binding::features::mdx::{compile, Options};
+use next_binding::features::mdxjs::{compile, Options};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 

--- a/packages/next-swc/crates/wasm/src/mdx.rs
+++ b/packages/next-swc/crates/wasm/src/mdx.rs
@@ -1,5 +1,5 @@
 use js_sys::JsString;
-use mdxjs::{compile, Options};
+use next_binding::features::mdx::{compile, Options};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Partial solutions for WEB-225.

One of the issue we want to improve is version bump process across multiple dependencies sharing same transitive dependencies. There were known cases of last-minute build failures of next-swc due to this. The biggest thing is we have lot of dependenceis rely on swc_core, and consolidating it altogether is tricky.

PR introduces `next-binding`, which reexports all the related dependencies that next-swc and turbopack commonly uses. Unfortunately, this is not a complete solution, but at least it'll make `upfront` cost to turbopack when it try to update swc_core and others, so by the time upgrading it in next-swc we expect minimal friction. Note not 0 friction: due to how cargo behaves for the merging all of the features, there's still chances to have some build failures but meaningfully less I believe.

I think the easiest way to describe before / after is having some diagrams. This is rather simplified to illustrate problems easily, i.e when it comes to actual build if there are same version of deps cargo will dedupe, so below illustaration only would occur for non-compatible version cases, etcs.

**Before**
```mermaid
graph TD
    A[next-swc] --> B(next-dev)
    A --> C(swc_core)
    A --> D(swc_emotion)
    D --> E(swc_core)
    A --> F(styled_jsx)
    F --> E
    A --> G(mdxrs)
    G --> H(swc_core)
    B --> I(swc_core)
    B --> J(swc_emotion)
    J --> K(swc_core)
```

**After**
```mermaid
graph TD
    A[next-swc] --> B(next-binding)
    B --> C[swc_core]
    B --> D[swc_emotion]
    D --> I[swc_core]
    B --> H[styled_jsx]
    B --> F[next-dev]
    B --> J[node-file-trace]
    F --> C
    H --> I
    B --> E(mdxrs)
    E --> G(swc_core)
 ```

You can see repeated dependencies (`swc_core`, `swc_emotion`) occurs lot more in next-swc in `before`, including next-swc top level direct import itself. In result, update process have to align between next-swc, turbopack, swc-plugins and others.

With newly proposed changes, `next-swc` no longer directly owns deps reduces those repetaed deps. At the moment of version bump, only `next-binding` need to be updated.

This brings small caveat however : next-swc does not directly update `swc_core`, but have to bump turbopack and its transitive dependencies. Given our bump process usually requires to bump up turbopack anyway, I wouldn't consider this as hard blocking though.