### PR TITLE
fix: prevent first full reload to be done

### DIFF
--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -182,6 +182,7 @@ export default class HotReloader {
   public activeConfigs?: Array<
     UnwrapPromise<ReturnType<typeof getBaseWebpackConfig>>
   >
+  private firstTimeCall = true;
 
   constructor(
     dir: string,
@@ -308,6 +309,10 @@ export default class HotReloader {
 
         try {
           const payload = JSON.parse(data)
+          if (payload.event === 'client-full-reload' && this.firstTimeCall) {
+            payload.event = ''
+            this.firstTimeCall = false
+          }
 
           let traceChild:
             | {


### PR DESCRIPTION
## Bug
https://github.com/vercel/next.js/issues/40184
- [ ] Related issues linked using fixes ([#40184](https://github.com/vercel/next.js/issues/40184))
- [No] Integration tests added