### PR TITLE
fix(navigation): handle `redirect` and `notFound` in root layout

### DIFF
--- a/test/e2e/app-dir/root-layout-redirect.test.ts
+++ b/test/e2e/app-dir/root-layout-redirect.test.ts
@@ -1,0 +1,31 @@
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import path from 'path'
+import webdriver from 'next-webdriver'
+import { BrowserInterface } from 'test/lib/browsers/base'
+
+describe('app-dir root layout redirect', () => {
+  if ((global as any).isNextDeploy) {
+    it('should skip next deploy for now', () => {})
+    return
+  }
+
+  let next: NextInstance
+  let browser: BrowserInterface
+  beforeAll(async () => {
+    next = await createNext({
+      files: new FileRef(path.join(__dirname, 'root-layout-redirect')),
+    })
+
+    await next.start()
+  })
+
+  afterAll(() => Promise.all([next.destroy(), browser.close()]))
+
+  it('should redirect from root layout', async () => {
+    browser = await webdriver(next.appPort, '/')
+    expect(await browser.waitForElementByCss('#login').text()).toBe(
+      /Login page/
+    )
+  })
+})

--- a/test/e2e/app-dir/root-layout-redirect/app/layout.js
+++ b/test/e2e/app-dir/root-layout-redirect/app/layout.js
@@ -1,0 +1,4 @@
+import { redirect } from 'next/navigation'
+export default function Root() {
+  redirect('/login')
+}

--- a/test/e2e/app-dir/root-layout-redirect/app/login/page.js
+++ b/test/e2e/app-dir/root-layout-redirect/app/login/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div id="login">Login page</div>
+}

--- a/test/e2e/app-dir/root-layout-redirect/next.config.js
+++ b/test/e2e/app-dir/root-layout-redirect/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+  },
+}


### PR DESCRIPTION
Fixes #43464

We currently don't catch `redirect` and `notFound` errors in the root layout. Moving the corresponding error boundaries higher up should resolve the issue.