### PR TITLE
docs: update known Safari bug

### DIFF
--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -40,9 +40,30 @@ This `next/image` component uses browser native [lazy loading](https://caniuse.c
 
 ## Known Browser Bugs
 
-- [Safari 15](https://bugs.webkit.org/show_bug.cgi?id=243601) displays a gray border while loading. Possible solutions:
-  - Use CSS `@media not all and (min-resolution:.001dpcm) { img[loading="lazy"] { clip-path: inset(0.5px) } }`
+- [Safari 15+](https://bugs.webkit.org/show_bug.cgi?id=243601) displays a gray border while loading. Possible solutions:
+
+  - Use CSS
+
+  ```
+  /* For Safari from v10.1 to v15.6 */
+  @media not all and (min-resolution: 0.001dpcm) {
+    img[loading="lazy"] {
+      clip-path: inset(.5px);
+    }
+  }
+  /* For Safari v16.0+ */
+  @media (min-resolution: 0.001dpcm) {
+    @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+      img[loading="lazy"] {
+        clip-path: inset(.5px);
+      }
+    }
+  }
+
+  ```
+
   - Use [`priority`](#priority) if the image is above the fold
+
 - [Firefox 67+](https://bugzilla.mozilla.org/show_bug.cgi?id=1556156) displays a white background while loading. Possible solutions:
   - Enable [AVIF `formats`](#acceptable-formats)
   - Use [`placeholder="blur"`](#placeholder)

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -41,7 +41,7 @@ This `next/image` component uses browser native [lazy loading](https://caniuse.c
 ## Known Browser Bugs
 
 - [Safari 15+](https://bugs.webkit.org/show_bug.cgi?id=243601) displays a gray border while loading. Possible solutions:
-  - Use CSS `@supports (font: -apple-system-body) and (-webkit-appearance: none) { img[loading="lazy"] { clip-path: inset(0.5px) } }`
+  - Use CSS `@supports (font: -apple-system-body) and (-webkit-appearance: none) { img[loading="lazy"] { clip-path: inset(0.6px) } }`
   - Use [`priority`](#priority) if the image is above the fold
 - [Firefox 67+](https://bugzilla.mozilla.org/show_bug.cgi?id=1556156) displays a white background while loading. Possible solutions:
   - Enable [AVIF `formats`](#acceptable-formats)

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -45,21 +45,20 @@ This `next/image` component uses browser native [lazy loading](https://caniuse.c
   - Use CSS
 
   ```
-  /* For Safari from v10.1 to v15.6 */
+  /* Safari v10.1 to v15.6 */
   @media not all and (min-resolution: 0.001dpcm) {
     img[loading="lazy"] {
-      clip-path: inset(.5px);
+      clip-path: inset(0.5px);
     }
   }
-  /* For Safari v16.0+ */
+  /* Safari v16.0+ */
   @media (min-resolution: 0.001dpcm) {
     @supports (-webkit-appearance: none) and (stroke-color: transparent) {
       img[loading="lazy"] {
-        clip-path: inset(.5px);
+        clip-path: inset(0.5px);
       }
     }
   }
-
   ```
 
   - Use [`priority`](#priority) if the image is above the fold

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -43,7 +43,6 @@ This `next/image` component uses browser native [lazy loading](https://caniuse.c
 - [Safari 15+](https://bugs.webkit.org/show_bug.cgi?id=243601) displays a gray border while loading. Possible solutions:
   - Use CSS `@supports (font: -apple-system-body) and (-webkit-appearance: none) { img[loading="lazy"] { clip-path: inset(0.5px) } }`
   - Use [`priority`](#priority) if the image is above the fold
-
 - [Firefox 67+](https://bugzilla.mozilla.org/show_bug.cgi?id=1556156) displays a white background while loading. Possible solutions:
   - Enable [AVIF `formats`](#acceptable-formats)
   - Use [`placeholder="blur"`](#placeholder)

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -41,26 +41,7 @@ This `next/image` component uses browser native [lazy loading](https://caniuse.c
 ## Known Browser Bugs
 
 - [Safari 15+](https://bugs.webkit.org/show_bug.cgi?id=243601) displays a gray border while loading. Possible solutions:
-
-  - Use CSS
-
-  ```
-  /* Safari v10.1 to v15.6 */
-  @media not all and (min-resolution: 0.001dpcm) {
-    img[loading="lazy"] {
-      clip-path: inset(0.5px);
-    }
-  }
-  /* Safari v16.0+ */
-  @media (min-resolution: 0.001dpcm) {
-    @supports (-webkit-appearance: none) and (stroke-color: transparent) {
-      img[loading="lazy"] {
-        clip-path: inset(0.5px);
-      }
-    }
-  }
-  ```
-
+  - Use CSS `@supports (font: -apple-system-body) and (-webkit-appearance: none) { img[loading="lazy"] { clip-path: inset(0.5px) } }`
   - Use [`priority`](#priority) if the image is above the fold
 
 - [Firefox 67+](https://bugzilla.mozilla.org/show_bug.cgi?id=1556156) displays a white background while loading. Possible solutions:


### PR DESCRIPTION
# Why 
hey, teams!  
since Safari `v16` is supported [resolution media query](https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes), so this before docs the `@media not all and (min-resolution: 0.001dpcm)` media query will not work on Safari latest version. 

![image](https://user-images.githubusercontent.com/37520667/204539236-a6206146-3519-45ab-b05e-dfb5481551ec.png)

so I update the docs for `next/image` [Known Browser Bugs](https://nextjs.org/docs/api-reference/next/image#known-browser-bugs), hope this can help developers. 

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
