### PR TITLE
Disable smooth scroll in navigation attempts

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -526,7 +526,8 @@ function Root({
   router,
   children,
 }: React.PropsWithChildren<{
-  callbacks: Array<() => void>
+  callbacks: Array<() => void>,
+  router: Router
 }>): React.ReactElement {
   // We use `useLayoutEffect` to guarantee the callbacks are executed
   // as soon as React flushes the update
@@ -751,7 +752,7 @@ function doRender(input: RenderRouteInfo): Promise<any> {
 
   // We catch runtime errors using componentDidCatch which will trigger renderError
   renderReactElement(appElement!, (callback) => (
-    <Root router={router} callbacks={[callback, onRootCommit]}>
+    <Root callbacks={[callback, onRootCommit]} router={router}>
       {process.env.__NEXT_STRICT_MODE ? (
         <React.StrictMode>{elem}</React.StrictMode>
       ) : (

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -655,14 +655,6 @@ interface FetchNextDataParams {
   unstable_skipClientCache?: boolean
 }
 
-function handleSmoothScroll(fn: () => void) {
-  const htmlElement = document.documentElement
-  const existing = htmlElement.style.scrollBehavior
-  htmlElement.style.scrollBehavior = 'auto'
-  fn()
-  htmlElement.style.scrollBehavior = existing
-}
-
 function tryToParseAsJSON(text: string) {
   try {
     return JSON.parse(text)
@@ -2228,7 +2220,7 @@ export default class Router implements BaseRouter {
     // Scroll to top if the hash is just `#` with no value or `#top`
     // To mirror browsers
     if (hash === '' || hash === 'top') {
-      handleSmoothScroll(() => window.scrollTo(0, 0))
+      window.scrollTo(0, 0)
       return
     }
 
@@ -2237,14 +2229,14 @@ export default class Router implements BaseRouter {
     // First we check if the element by id is found
     const idEl = document.getElementById(rawHash)
     if (idEl) {
-      handleSmoothScroll(() => idEl.scrollIntoView())
+      idEl.scrollIntoView()
       return
     }
     // If there's no element with the id, we check the `name` property
     // To mirror browsers
     const nameEl = document.getElementsByName(rawHash)[0]
     if (nameEl) {
-      handleSmoothScroll(() => nameEl.scrollIntoView())
+      nameEl.scrollIntoView()
     }
   }
 


### PR DESCRIPTION
Disable smooth scroll in navigation attempts, restore scroll behaviour when the navigation completes.

The current implementation seems to be wrong, as the scroll behaviour "auto" immediately or during scrolling switches back to "smooth" or the globally defined behaviour of the html tag.

Local experiments showed that the scrolling behaviour "auto" must be initiated at the start of a route change "routeChangeStart" and must be maintained until a route change is completed "routeChangeComplete".

Pre-condition:
The scroll behaviour "smooth" must either be defined globally in css for the html element. From the hook provided this is done once in the effect-lifecycle, however a user defined configuration seems better, especially as the behaviour can be integrated into Next as described in the next step.

Summary of the lifecycle:
- Subscribe to routeChangeStart, routeChangeComplete events.
- The route change starts Switch the scroll behavior to 'auto' Scroll immediately to the top and hold the value until the route change finishes.
- The route change finishes Switch back to the default value specified in global css for the html element. For smooth-scrolling smooth, the behavior is 'smooth'. Hash changes are no route changes; the result is smooth scrolling on hash changes.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
