### PR TITLE
Update supported Node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "@babel/traverse": "7.18.0"
   },
   "engines": {
-    "node": ">=14.6.0 <18"
+    "node": ">=14.6.0 <17"
   },
   "packageManager": "pnpm@7.3.0"
 }

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "@babel/traverse": "7.18.0"
   },
   "engines": {
-    "node": ">=14.6.0"
+    "node": ">=14.6.0 <17"
   },
   "packageManager": "pnpm@7.3.0"
 }

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "@babel/traverse": "7.18.0"
   },
   "engines": {
-    "node": ">=14.6.0 <17"
+    "node": ">=14.6.0 <18"
   },
   "packageManager": "pnpm@7.3.0"
 }


### PR DESCRIPTION
msw does not support Node.js v18. Silently. Took me some time I realised that. Lets help to save time to others. Until https://github.com/mswjs/msw/issues/1388 is done, there should be some warning. I believe this is it. Thanks.