### PR TITLE
chore(examples): fix CLI commands for MobX examples

### DIFF
--- a/examples/with-mobx-state-tree/README.md
+++ b/examples/with-mobx-state-tree/README.md
@@ -12,24 +12,24 @@ The clock, under `components/Clock.js`, has access to the state using the `injec
 
 ## Deploy your own
 
-Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example) or preview live with [StackBlitz](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-mobx-state-tree-typescript)
+Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example) or preview live with [StackBlitz](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-mobx-state-tree)
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-mobx-state-tree-typescript&project-name=with-mobx-state-tree-typescript&repository-name=with-mobx-state-tree-typescript)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-mobx-state-tree&project-name=with-mobx-state-tree&repository-name=with-mobx-state-tree)
 
 ## How to use
 
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-mobx-state-tree-typescript with-mobx-state-tree-typescript-app
+npx create-next-app --example with-mobx-state-tree with-mobx-state-tree-app
 ```
 
 ```bash
-yarn create next-app --example with-mobx-state-tree-typescript with-mobx-state-tree-typescript-app
+yarn create next-app --example with-mobx-state-tree with-mobx-state-tree-app
 ```
 
 ```bash
-pnpm create next-app --example with-mobx-state-tree-typescript with-mobx-state-tree-typescript-app
+pnpm create next-app --example with-mobx-state-tree with-mobx-state-tree-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-mobx/README.md
+++ b/examples/with-mobx/README.md
@@ -27,15 +27,15 @@ Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_mediu
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-mobx-react-lite with-mobx-react-lite-app
+npx create-next-app --example with-mobx with-mobx-app
 ```
 
 ```bash
-yarn create next-app --example with-mobx-react-lite with-mobx-react-lite-app
+yarn create next-app --example with-mobx with-mobx-app
 ```
 
 ```bash
-pnpm create next-app --example with-mobx-react-lite with-mobx-react-lite-app
+pnpm create next-app --example with-mobx with-mobx-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-mobx/README.md
+++ b/examples/with-mobx/README.md
@@ -18,9 +18,9 @@ Both components are using a custom hook `useStore` to pull in the `Store` from t
 
 ## Deploy your own
 
-Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example) or preview live with [StackBlitz](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-mobx-react-lite)
+Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example) or preview live with [StackBlitz](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-mobx)
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-mobx-react-lite&project-name=with-mobx-react-lite&repository-name=with-mobx-react-lite)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-mobx&project-name=with-mobx&repository-name=with-mobx)
 
 ## How to use
 


### PR DESCRIPTION
Update [with-mobx](https://github.com/vercel/next.js/tree/canary/examples/with-mobx) example README.md

Fixes #43512 

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
