### PR TITLE
fix(jest): pattern when detecting packages to transpile in next/jest

### DIFF
--- a/packages/next/build/jest/jest.ts
+++ b/packages/next/build/jest/jest.ts
@@ -157,7 +157,7 @@ export default function nextJest(options: { dir?: string } = {}) {
           // To match Next.js behavior node_modules is not transformed, only `transpiledPackages`
           ...(transpiled
             ? [
-                `/node_modules/(?!(${transpiled})/)`,
+                `/node_modules/(?!.pnpm)(?!(${transpiled})/)`,
                 `/node_modules/.pnpm/(?!(${transpiled.replace(
                   /\//g,
                   '\\+'

--- a/packages/next/build/jest/jest.ts
+++ b/packages/next/build/jest/jest.ts
@@ -157,7 +157,7 @@ export default function nextJest(options: { dir?: string } = {}) {
           // To match Next.js behavior node_modules is not transformed, only `transpiledPackages`
           ...(transpiled
             ? [
-                `/node_modules/(?!(${transpiled}))/`,
+                `/node_modules/(?!(${transpiled})/)`,
                 `/node_modules/.pnpm/(?!(${transpiled.replace(
                   /\//g,
                   '\\+'


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
In #42987 we added support for `transpilePackages` in `next/jest`, but the pattern is not functioning how we would expect here, and as a result all modules from `node_modules` are getting transformed. File patterns that should not be transformed should match, but due to the trailing `/`, no packages are matching.

Currently (no match, incorrectly gets transformed): https://regexr.com/73fvo

With this fix (matches, correctly does not get transformed): https://regexr.com/73fvr

As far as I can tell, the `pnpm` pattern is being generated correctly.

@balazsorban44 I wasn't sure the best way to test this one, let me know if you've got an idea. 🙏 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
