### PR TITLE
Fix matchers in middleware manifest

### DIFF
--- a/packages/next/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/build/webpack/plugins/middleware-plugin.ts
@@ -28,6 +28,7 @@ import {
 import { Telemetry } from '../../../telemetry/storage'
 import { traceGlobals } from '../../../trace/shared'
 import { EVENT_BUILD_FEATURE_USAGE } from '../../../telemetry/events'
+import { normalizeAppPath } from '../../../shared/lib/router/utils/app-paths'
 
 export interface EdgeFunctionDefinition {
   env: string[]
@@ -160,9 +161,12 @@ function getCreateAssets(params: {
         continue
       }
 
-      const { namedRegex } = getNamedMiddlewareRegex(page, {
-        catchAll: !metadata.edgeSSR && !metadata.edgeApiFunction,
-      })
+      const { namedRegex } = getNamedMiddlewareRegex(
+        metadata.edgeSSR?.isAppDir ? normalizeAppPath(page) : page,
+        {
+          catchAll: !metadata.edgeSSR && !metadata.edgeApiFunction,
+        }
+      )
       const matchers = metadata?.edgeMiddleware?.matchers ?? [
         { regexp: namedRegex },
       ]

--- a/test/e2e/app-dir/app-edge.test.ts
+++ b/test/e2e/app-dir/app-edge.test.ts
@@ -54,4 +54,17 @@ describe('app-dir edge SSR', () => {
       }, /Edge!/)
     })
   }
+
+  if (!(globalThis as any).isNextDev) {
+    it('should generate matchers correctly in middleware manifest', async () => {
+      const manifest = JSON.parse(
+        await next.readFile('.next/server/middleware-manifest.json')
+      )
+      expect(manifest.functions['/(group)/group/page'].matchers).toEqual([
+        {
+          regexp: '^/group$',
+        },
+      ])
+    })
+  }
 })

--- a/test/e2e/app-dir/app-edge/app/(group)/group/page.tsx
+++ b/test/e2e/app-dir/app-edge/app/(group)/group/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  if ('EdgeRuntime' in globalThis) {
+    return <p>Edge!</p>
+  }
+  return <p>Node!</p>
+}
+
+export const runtime = 'experimental-edge'


### PR DESCRIPTION
Currently the generated matcher will be `"regexp": "^\(group\)/group$"` for groups which doesn't match the correct route. This is somehow related to #43458, but it only fixes the problem partially. Some other changes need to be made in the build process.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
