### PR TITLE
Only require web-vitals when it's needed

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -28,7 +28,6 @@ import {
 import { Portal } from './portal'
 import initHeadManager from './head-manager'
 import PageLoader, { StyleSheetTuple } from './page-loader'
-import measureWebVitals from './performance-relayer'
 import { RouteAnnouncer } from './route-announcer'
 import { createRouter, makePublicRouterInstance } from './router'
 import { getProperError } from '../lib/is-error'
@@ -536,7 +535,9 @@ function Root({
   // We should ask to measure the Web Vitals after rendering completes so we
   // don't cause any hydration delay:
   React.useEffect(() => {
-    measureWebVitals(onPerfEntry)
+    if (process.env.__NEXT_ANALYTICS_ID) {
+      require('./performance-relayer')(onPerfEntry);
+    }
   }, [])
 
   if (process.env.__NEXT_TEST_MODE) {


### PR DESCRIPTION
Saves ~2.4kB.

Fixes https://github.com/vercel/next.js/discussions/15414

Inspired by work done here: https://github.com/vercel/next.js/pull/42252/files#diff-a06f34acf853329972a2ac95bfd4db786de63f672ffe91f5ba9f996f06f325efR157

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
