### PR TITLE
Changed output mode on app directory test application

### DIFF
--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -5,7 +5,8 @@ module.exports = {
       algorithm: 'sha256',
     },
   },
-  output: 'standalone',
+  // TODO: (wyattjoh) enable once we've resolved issues with app directory and standalone output mode
+  // output: 'standalone',
   rewrites: async () => {
     return {
       afterFiles: [


### PR DESCRIPTION
Disables standalone output mode for app directory tests until some issues are resolved around it. Should be re-enabled once the issues have been resolved.

x-ref: https://vercel.slack.com/archives/C035J346QQL/p1669829521120779