### PR TITLE
Fix output: standalone test for app directory

### DIFF
--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -5,7 +5,7 @@ module.exports = {
       algorithm: 'sha256',
     },
   },
-  output: 'standalone',
+  // output: 'standalone',
   rewrites: async () => {
     return {
       afterFiles: [

--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -5,8 +5,7 @@ module.exports = {
       algorithm: 'sha256',
     },
   },
-  // TODO: (wyattjoh) enable once we've resolved issues with app directory and standalone output mode
-  // output: 'standalone',
+  output: 'standalone',
   rewrites: async () => {
     return {
       afterFiles: [

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1,14 +1,10 @@
-import os from 'os'
 import { createNext, FileRef } from 'e2e-utils'
 import crypto from 'crypto'
 import { NextInstance } from 'test/lib/next-modes/base'
 import {
   check,
   fetchViaHTTP,
-  findPort,
   getRedboxHeader,
-  initNextServerScript,
-  killApp,
   renderViaHTTP,
   waitFor,
   waitForAndOpenRuntimeError,
@@ -2554,44 +2550,4 @@ describe('app dir', () => {
   }
 
   runTests()
-
-  if ((global as any).isNextStart) {
-    it('should work correctly with output standalone', async () => {
-      const tmpFolder = path.join(os.tmpdir(), 'next-standalone-' + Date.now())
-      await fs.move(path.join(next.testDir, '.next/standalone'), tmpFolder)
-      let server
-
-      try {
-        const testServer = path.join(tmpFolder, 'server.js')
-        const appPort = await findPort()
-        server = await initNextServerScript(
-          testServer,
-          /Listening on/,
-          {
-            ...process.env,
-            PORT: appPort,
-          },
-          undefined,
-          {
-            cwd: tmpFolder,
-          }
-        )
-
-        for (const testPath of [
-          '/',
-          '/api/hello',
-          '/blog/first',
-          '/dashboard',
-          '/dashboard/deployments/123',
-          '/catch-all/first',
-        ]) {
-          const res = await fetchViaHTTP(appPort, testPath)
-          expect(res.status).toBe(200)
-        }
-      } finally {
-        if (server) await killApp(server)
-        await fs.remove(tmpFolder)
-      }
-    })
-  }
 })

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -12,7 +12,6 @@ import {
 import path from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
-import fs from 'fs-extra'
 
 describe('app dir', () => {
   const isDev = (global as any).isNextDev

--- a/test/e2e/app-dir/standalone.test.ts
+++ b/test/e2e/app-dir/standalone.test.ts
@@ -1,0 +1,80 @@
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import fs from 'fs-extra'
+import os from 'os'
+import path from 'path'
+import {
+  fetchViaHTTP,
+  findPort,
+  initNextServerScript,
+  killApp,
+} from 'next-test-utils'
+
+describe('output: standalone with app dir', () => {
+  let next: NextInstance
+
+  if (!(global as any).isNextStart) {
+    it('should skip for non-next start', () => {})
+    return
+  }
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: new FileRef(path.join(__dirname, 'app')),
+      dependencies: {
+        swr: '2.0.0-rc.0',
+        react: 'latest',
+        'react-dom': 'latest',
+        sass: 'latest',
+      },
+      skipStart: true,
+    })
+
+    await next.patchFile(
+      'next.config.js',
+      (await next.readFile('next.config.js')).replace('// output', 'output')
+    )
+    await next.start()
+  })
+  afterAll(async () => {
+    await next.destroy()
+  })
+
+  it('should work correctly with output standalone', async () => {
+    const tmpFolder = path.join(os.tmpdir(), 'next-standalone-' + Date.now())
+    await fs.move(path.join(next.testDir, '.next/standalone'), tmpFolder)
+    let server
+
+    try {
+      const testServer = path.join(tmpFolder, 'server.js')
+      const appPort = await findPort()
+      server = await initNextServerScript(
+        testServer,
+        /Listening on/,
+        {
+          ...process.env,
+          PORT: appPort,
+        },
+        undefined,
+        {
+          cwd: tmpFolder,
+        }
+      )
+
+      for (const testPath of [
+        '/',
+        '/api/hello',
+        '/blog/first',
+        '/dashboard',
+        '/dashboard/deployments/123',
+        '/catch-all/first',
+      ]) {
+        const res = await fetchViaHTTP(appPort, testPath)
+        expect(res.status).toBe(200)
+      }
+    } finally {
+      if (server) await killApp(server)
+      await fs.remove(tmpFolder)
+    }
+  })
+})


### PR DESCRIPTION
This test was ensuring `app` directory is working correctly with `output: 'standalone'`. Instead of removing config we should conditionally set it for the test. 

Reverts vercel/next.js#43607

x-ref: https://github.com/vercel/next.js/actions/runs/3594732606/jobs/6055832699
x-ref: https://github.com/vercel/next.js/actions/runs/3594732606/jobs/6055832421