### PR TITLE
fix: properly handle `trailingSlash: true` and `rewrites`

### DIFF
--- a/packages/next/shared/lib/router/adapters.tsx
+++ b/packages/next/shared/lib/router/adapters.tsx
@@ -117,7 +117,14 @@ export function PathnameContextProviderAdapter({
     // any query strings), so it should have that stripped. Read more about the
     // `asPath` option over at:
     // https://nextjs.org/docs/api-reference/next/router#router-object
-    const url = new URL(router.asPath, 'http://f')
+    let url: URL
+    try {
+      url = new URL(router.asPath, 'http://f')
+    } catch (_) {
+      // fallback to / for invalid asPath values e.g. //
+      return '/'
+    }
+
     return url.pathname
   }, [router.asPath, router.isFallback, router.isReady, router.pathname])
 

--- a/test/e2e/trailingslash-with-rewrite/app/next.config.js
+++ b/test/e2e/trailingslash-with-rewrite/app/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  trailingSlash: true,
+  async rewrites() {
+    return [{ source: '/country/', destination: '/' }]
+  },
+}

--- a/test/e2e/trailingslash-with-rewrite/app/pages/index.js
+++ b/test/e2e/trailingslash-with-rewrite/app/pages/index.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return <p>Welcome home</p>
+}
+
+export async function getStaticProps() {
+  return { props: {} }
+}

--- a/test/e2e/trailingslash-with-rewrite/index.test.ts
+++ b/test/e2e/trailingslash-with-rewrite/index.test.ts
@@ -1,0 +1,25 @@
+import { join } from 'path'
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { fetchViaHTTP } from 'next-test-utils'
+
+describe('trailingSlash:true with rewrites and getStaticProps', () => {
+  let next: NextInstance
+
+  if ((global as any).isNextDeploy) {
+    it('should skip for deploy mode for now', () => {})
+    return
+  }
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: new FileRef(join(__dirname, './app')),
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should work', async () => {
+    const res = await fetchViaHTTP(next.url, '/country')
+    expect(await res.text()).toContain('Welcome home')
+  })
+})


### PR DESCRIPTION
Fixes #43623

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
