### PR TITLE
build(cargo): bump up swc_core, turbopack

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "serde",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -64,16 +64,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "any_key"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21bb2cdab8087ed9d69411dd99c608dbede1df847c255b4d609f0399a3cb452"
-dependencies = [
- "debugit",
- "mopa",
 ]
 
 [[package]]
@@ -133,7 +123,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "serde",
 ]
@@ -200,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.21.4"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2bc0a4b3fe61b2f5b1aeeff23cc4114c43e7b0bd00e999dd2f4324d8ca9c40"
+checksum = "0946623dfcacf16ff5ebc00a469d936c9e92a09961000ad16873845a42234e81"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -823,15 +813,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debugit"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c2f7e3034df2b09f750327e23c1adfe33301e6b7388f05bb4fcc0fa46825e3"
-dependencies = [
- "version_check 0.1.5",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,7 +1197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -1879,7 +1860,7 @@ checksum = "0c4bbd566f0dd80e0701ef5ca305e4404805eb37b95a6246ac1605acb71a6e9b"
 dependencies = [
  "markdown",
  "serde",
- "swc_core",
+ "swc_core 0.44.6",
 ]
 
 [[package]]
@@ -2054,16 +2035,16 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.25.7"
+version = "0.25.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ac677f509eabb57a5796bb363cb3141b64a5a215a693fd84e5349cb34de4d3"
+checksum = "9d840b5cc8f0ba7e0c339c14c7626a4588a41915503f41009f1f27fd01e096cf"
 dependencies = [
  "convert_case",
  "handlebars",
  "once_cell",
  "regex",
  "serde",
- "swc_core",
+ "swc_core 0.45.4",
 ]
 
 [[package]]
@@ -2231,19 +2212,17 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 [[package]]
 name = "next-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "indexmap",
- "rand",
+ "mime",
  "serde",
  "serde_json",
- "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-env",
  "turbo-tasks-fs",
- "turbo-tasks-hash",
  "turbopack",
  "turbopack-core",
  "turbopack-dev-server",
@@ -2255,7 +2234,7 @@ dependencies = [
 [[package]]
 name = "next-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2263,22 +2242,29 @@ dependencies = [
  "mime",
  "next-core",
  "owo-colors",
- "portpicker",
  "serde",
- "serde_json",
  "tokio",
  "turbo-malloc",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
  "turbo-tasks-memory",
- "turbopack",
  "turbopack-cli-utils",
  "turbopack-core",
  "turbopack-dev-server",
- "url",
  "vergen",
  "webbrowser",
+]
+
+[[package]]
+name = "next-font"
+version = "0.1.0"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
+dependencies = [
+ "fxhash",
+ "serde",
+ "serde_json",
+ "swc_core 0.45.4",
 ]
 
 [[package]]
@@ -2297,7 +2283,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core",
+ "swc_core 0.45.4",
  "swc_emotion",
  "testing",
  "tracing",
@@ -2322,7 +2308,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
- "swc_core",
+ "swc_core 0.45.4",
  "tracing",
  "tracing-chrome",
  "tracing-futures",
@@ -2332,10 +2318,9 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
- "owo-colors",
  "serde",
  "serde_json",
  "tokio",
@@ -2775,15 +2760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portpicker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
-dependencies = [
- "rand",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,7 +2822,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -2857,7 +2833,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -2893,6 +2869,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "qstring"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -3625,7 +3610,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -3742,26 +3727,26 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.52.7"
+version = "0.52.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9278187c95d3fba086db8121b2de60d1d41c7d7f6e2e826738b9f002a3b834"
+checksum = "f4e02c22491fd278caf0438b8875e726eebdc35f5cf7e12c799c04358bf3f33d"
 dependencies = [
  "Inflector",
  "once_cell",
  "regex",
  "serde",
- "swc_core",
+ "swc_core 0.45.4",
  "tracing",
 ]
 
 [[package]]
 name = "styled_jsx"
-version = "0.29.7"
+version = "0.29.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be22d79d6861fc5358b14d39aa6b3227573996ce76fecd0ce8252fab46143494"
+checksum = "04ea011d0e2e1344a23e28ec262bca7954100268475399f6890ef2f86cc2667b"
 dependencies = [
  "easy-error",
- "swc_core",
+ "swc_core 0.45.4",
  "tracing",
 ]
 
@@ -3801,9 +3786,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.233.4"
+version = "0.233.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033e1e6fb047f6a46e19756c80819d24512ab6d0d9baf8016e325aaf3d950fe5"
+checksum = "19de5dc9d4fb108b8bd23362a09ae31a84b448468844c917342b8fe6a7fba975"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3868,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.193.2"
+version = "0.193.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a67acb8bb8f01cfecb98a4517f9ce9d02c4bf4c02ab5dfbba020f2dbfabdbce"
+checksum = "cb0b53dcba537f7a9032a863a1a3fefee6809427b835bca879b4bc09fc0e422a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3916,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.17"
+version = "0.29.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295fb6ecf5c33599941e5dc38bf74517c9bfc9e1fd368db4fc4ca718e9005ee1"
+checksum = "90e2328ba5e7c8f83ff8273b352c890f981d80d215ee29cddcbe19aa789d3592"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3978,6 +3963,22 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9593e3d1dca44da09b4601bdf74f2eb5ade8768a31656834036aa5d3754ba9c0"
 dependencies = [
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_visit",
+ "vergen",
+]
+
+[[package]]
+name = "swc_core"
+version = "0.45.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8186ca543f4b0137bd63077933dd8a37b207b7d71c21f12d297e321b2f9093dd"
+dependencies = [
  "binding_macros",
  "swc",
  "swc_atoms",
@@ -4020,9 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.128.1"
+version = "0.128.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f193297ef3eb2c76052dbcf3a9c42bc509563f0943c875d783db71798cb514"
+checksum = "757343607819915125d715aa071be58d84cbec91782b0fc401264c2ecbbc9ba1"
 dependencies = [
  "is-macro",
  "serde",
@@ -4033,9 +4034,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.138.3"
+version = "0.138.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183ce66593dc14be82378a6e647caab79c7b76d7e6169ec2e5f458e38022baf"
+checksum = "651d0dbd5bdc54426537d44795f3ea9227abb4207c9878e699b52c8dc6e4b5ec"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -4063,9 +4064,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a468a59b5dc5f8dd0d338e7cd3dab09128a5abf2d9bedd7cd4bfd9f9136f077"
+checksum = "79a0199fbe012b2b54e35c6c171b371f86cec26358c8e86c891215600fcb529b"
 dependencies = [
  "once_cell",
  "serde",
@@ -4079,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f06de7293ca37fb7691d76469a716623bc35c00af0e1e9a25548197d271ebda"
+checksum = "af22ea54dbc32c3a3b3e36b33c02f844b56bd67b2133a180af06e3707be6b580"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -4095,9 +4096,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.137.3"
+version = "0.137.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969ba35f9770eab6d867bc2f0603fd1b133ad59c6b219608fbf0550fadbb6a4c"
+checksum = "7d6bb244bc9147c20c8cfe3265e65462b50bc7567a3a134bf22ddaf6f5188402"
 dependencies = [
  "bitflags",
  "lexical",
@@ -4109,9 +4110,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.139.3"
+version = "0.139.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608b2b72a3b672d60e14ceff6e981b8def774dd84fd0714c020da5704487370f"
+checksum = "f3e1852ed0453d928ec16c71b94bef3a11e75a3e3993f8e774691859a7d3fa2c"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -4126,9 +4127,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.125.1"
+version = "0.125.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d318c70fef968243de15285368328b3aeb8499c436a483a9ec8b3e19b2a4281"
+checksum = "985b7696db4c874bbd4018ac6647a056733f2c0b29cd212df37be125e4d3559c"
 dependencies = [
  "once_cell",
  "serde",
@@ -4141,9 +4142,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.127.1"
+version = "0.127.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6fc6af0899bb054ac17b7cfaf1cd5c1efbd594b95aefa5260ae8a08f528600"
+checksum = "3b776f203c7e68097a6aebfa9c1e4fe381260aeea5dad61cb5c7063f63ce33e6"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -4154,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.95.1"
+version = "0.95.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04fc3a7fafe8506b19506b455f18c875f2b5f546f6ecc7a6d22032c281b24888"
+checksum = "420947496193d5d7f47999ea2d438a3a41e1042393520e28dfb978655f5cacc8"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -4172,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.128.2"
+version = "0.128.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5be18c834f2fb158c88b4ae5dc0320663bb11fe4913a37f10355001194d41d0"
+checksum = "2f63f42f1df360e1228867bfe2cfaeec098b8ba44cc48b122b9eb47041804318"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -4204,9 +4205,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.92.2"
+version = "0.92.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9365760d251cd79e80fbe1c612c37e23fd2a6687bee46671ab7a17aad8c416"
+checksum = "2257948c8acea312281f314ad86e944cfe85f1d718b3af4a238f6e9fe24ebea5"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -4218,9 +4219,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.67.2"
+version = "0.67.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f83b7441598759492030801130127dfd0a39d236d641c1d466cfecf69d94c27"
+checksum = "7fec0121b0511f7efbefd7c0cefe433a322837c0fc9fb3eb48f08a642ebbe576"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -4239,9 +4240,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.41.18"
+version = "0.41.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801077c673830f07f4418969397ddb0c92413c0d6fb8b5a73b977ddb7d19b046"
+checksum = "41890cd5ae5718fea62576fc507026e1c905bc0a0fe9a87a91b014a1ea096b65"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4261,9 +4262,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.160.2"
+version = "0.160.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6ec9450992c70f0db8ebb0527efbf43d35a203a100fc749b78374a65fd7340"
+checksum = "8da0ff0a6aec502b475cd169288cb859d0629d2a1116de13e1e8e8e25d270862"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -4288,6 +4289,7 @@ dependencies = [
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_optimization",
+ "swc_ecma_usage_analyzer",
  "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_timer",
@@ -4296,9 +4298,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.123.2"
+version = "0.123.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9948268edb75b2a02cb5c919d791344f8a7379ec726039c04e437fe5eac1e7"
+checksum = "36e1f25619baa61f14bf19fcdf71b2608ff8e1ddfc3049c568d77be156db147d"
 dependencies = [
  "either",
  "enum_kind",
@@ -4315,9 +4317,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.175.2"
+version = "0.175.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0630d4bc64d096049a5ee300b7eb0e27c0edba83130fa7de08813403be3c2599"
+checksum = "cb90436304453e1eec7db4192e82c5244c72429ee50680b3c445c36b468c1b6c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4340,9 +4342,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.34.2"
+version = "0.34.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba912948f24aa3eb6bd72ce33235a97954873b61299bc0ec8fb7fddb486fa394"
+checksum = "81d5d4d2e0f592011f6ee75775995e4605aec31d518bfb2f52619f75e25a637b"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -4370,9 +4372,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.199.2"
+version = "0.199.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d727e0210e883a9da91906871771bcd3e4ecfc24464e4560891abea1a9a2f2"
+checksum = "fd0a6674ae81e267b3c97d04d74dae325e68c2480d965cfe5f713169ddf3f518"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -4390,9 +4392,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.112.2"
+version = "0.112.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8154f2ba2b3e27e995188d3d0ecd80068987b5d56b5e0c7f64ccf8926e7bb8e"
+checksum = "5fc5fa4c98c86fffcb728f4ae159ebf20d406d6fbfc398a8249e74f51b04f815"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -4413,9 +4415,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.101.2"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86024dc3ca060348cc016a880986cf8f147bcfb174875787a870fded970f5b25"
+checksum = "c823b7adb1a933d6fecc6958653dd3533e8d2a561a352997b69af23d43b16c0e"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -4427,9 +4429,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.137.2"
+version = "0.137.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9c9fa2b790b85aaf4d9acc9558e40e92b7508331ee971972c301f58b688bba"
+checksum = "3a43d83bea02bc3a360cc2be40ca675d2fcd5dacf85b96eff2f442715cfec79d"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -4467,9 +4469,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.154.2"
+version = "0.154.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bcf903603f02e2f3824b8aaabc8515198db988bd738012c68713f486c6e189e"
+checksum = "fd49a249022df7b3912478893543d3e9cca2e30c39f3f2aa5addbfd7a58e37af"
 dependencies = [
  "Inflector",
  "ahash",
@@ -4495,9 +4497,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.168.2"
+version = "0.168.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3edeb43c8bf28cc190b29a9229811df8c0ee1fc9cf704fbd2b297a36de791961"
+checksum = "cd9adad655e16a0559351ec7dddd412b215ce8a8ec9b85cbac0078acf585d10f"
 dependencies = [
  "ahash",
  "dashmap",
@@ -4521,9 +4523,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.145.2"
+version = "0.145.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c0afe63785d15d4bdf404ff1e83360cfb1537aad7a207cf3fb349b28f37837"
+checksum = "725d43f488680a7f6964006393fccf412337413c621ebd6a4562273e061648e0"
 dependencies = [
  "either",
  "serde",
@@ -4540,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.156.2"
+version = "0.156.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb642721f6d960c84898677c7ea14c689537ae335f6431e9640f33bc9ed58dc1"
+checksum = "73d30ec618b8c7df482bee6c301e6cd2e717bc6a110993ac93893c47f19da081"
 dependencies = [
  "ahash",
  "base64",
@@ -4567,9 +4569,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.115.3"
+version = "0.115.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b16828650b5431e28a83e83edfb6f52ba7c85bf63d2880ff6de0bdebb08ed0"
+checksum = "0afb1c49a8ab9692ece806d0b984ba7476e3042486fb021ff2f63a67fc9094aa"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -4593,9 +4595,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.160.2"
+version = "0.160.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c0190167b7adc388c6e62fc40a316ed851a09102f144e744f235b63ecbe899"
+checksum = "ec78fbc55d10c3bd69aceccf28aa3c0f89380552e3bab74efd68ccc18ff3d0a2"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -4608,10 +4610,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_utils"
-version = "0.106.2"
+name = "swc_ecma_usage_analyzer"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff832d27c2b8a5957853094c09e1b596f18b31160a4daf004f29f0e4f5bdc21"
+checksum = "f25f82674e4eb0d47c22b571b256fe536be53caee5a3f94179261ecfe4ed7e19"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "swc_timer",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "0.106.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d350bea15d0c71c36a65af37217b32f2675e9d88cd484c11e48beaf9dd2057a"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -4627,9 +4647,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.81.1"
+version = "0.81.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfce55b92a36aac12309518604ee46106177266bb5fd09cd2bb6b4a1210533f9"
+checksum = "9e4b92aa87251452508165d5e86100d35454857cd0c985a9a3bed3dd15a2eb24"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -4641,9 +4661,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.28.3"
+version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459955b8b106831cf6ea59682b6be65bcdd65c813a5204203973c55a80841067"
+checksum = "d438e7d17d254b0dc74f407086e3dbcb76321fb7c41508c94dfc12f83c27a1d3"
 dependencies = [
  "base64",
  "byteorder",
@@ -4653,7 +4673,7 @@ dependencies = [
  "regex",
  "serde",
  "sourcemap",
- "swc_core",
+ "swc_core 0.45.4",
  "tracing",
 ]
 
@@ -4671,9 +4691,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.18"
+version = "0.13.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119a391045e3c31ab38ff8e16428248bd0734626e19be28c9e9de4d6a6bb9c3a"
+checksum = "7b8dba54343538503f4e8f8110b569dcf2ac0781b0afd7a950fdc97814f14a4c"
 dependencies = [
  "anyhow",
  "miette",
@@ -4684,9 +4704,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.17.18"
+version = "0.17.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a0d380e2d53fd6d166e8f06ddf3846a3c9bb9d12bdd0fe123e820483c5be2c"
+checksum = "42fcf78c0d5bf767a862a125184b9e3e53dfd44a78e17df1a08eefe030712cae"
 dependencies = [
  "ahash",
  "indexmap",
@@ -4696,9 +4716,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.18.19"
+version = "0.18.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52fdb35f6289ca961d5fca80f2e1e284e3dcb6f0424c428cf00c1779c80fdfc"
+checksum = "859cc82647ccec27aacc4333c7c8c4436c9f6cf0df0ab42c8e0ee2510a9144d7"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -4731,9 +4751,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.16.17"
+version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fdebc066a603b2256957707e8127942cbc25a2d07a28d90747b5fd90a51caaa"
+checksum = "ef09fe835c26209bad4844d4dddf74f07659dc877af38e2a1878e6532b237eaf"
 dependencies = [
  "ahash",
  "dashmap",
@@ -4758,9 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624e53ccde0582e844b545df87dc3e8850fe813813c50c93a05ea4245fc381ba"
+checksum = "f3e86675e04908eb81ba42376166cb3bf9360b2f11b26d33ebd165f5d62a5d89"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -4772,9 +4792,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.78.4"
+version = "0.78.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fdfcc530821aac2902d0a060a4efe8647160ebb0196688a7fac2447ae7d0c3"
+checksum = "5108ad0a3c7c92bfb9c2f8b7c7f700a86a0128388a92f6873dba9ebdc0d47fc9"
 dependencies = [
  "anyhow",
  "enumset",
@@ -4795,9 +4815,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.17.18"
+version = "0.17.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328057c7f54f30534add2ac9e6570ff16e757cba5b20dd669148bba71eac6bf7"
+checksum = "8c76685d10cf9f94f69b193729830dc2e8cc8e840daa1f9bd2aada773ea6064e"
 dependencies = [
  "tracing",
 ]
@@ -4889,9 +4909,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.18"
+version = "0.31.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1bf3e1197f0dd71ea09b8540be7f735df3f86f7b7ce41304acb79fcf52f8fb"
+checksum = "9b96c1192fef3c7f6c7962e5861c3c90982ee0cfba5a5fbb1c666ab8df4b495e"
 dependencies = [
  "ansi_term",
  "difference",
@@ -5006,7 +5026,7 @@ dependencies = [
  "standback",
  "stdweb",
  "time-macros 0.1.1",
- "version_check 0.9.4",
+ "version_check",
  "winapi 0.3.9",
 ]
 
@@ -5301,7 +5321,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "mimalloc",
 ]
@@ -5309,12 +5329,11 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
- "any_key",
  "anyhow",
  "auto-hash-map",
- "bitflags",
+ "concurrent-queue",
  "dashmap",
  "erased-serde",
  "event-listener",
@@ -5323,6 +5342,7 @@ dependencies = [
  "mopa",
  "nohash-hasher",
  "once_cell",
+ "parking_lot",
  "pin-project-lite",
  "regex",
  "serde",
@@ -5333,36 +5353,29 @@ dependencies = [
  "turbo-tasks-build",
  "turbo-tasks-hash",
  "turbo-tasks-macros",
- "weak-table",
 ]
 
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "cargo-lock",
  "glob",
- "pmutil",
- "quote",
- "serde",
  "syn",
- "toml",
  "turbo-tasks-macros-shared",
 ]
 
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "dotenvy",
  "indexmap",
  "serde",
- "serde_json",
- "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -5371,7 +5384,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -5382,7 +5395,6 @@ dependencies = [
  "futures-retry",
  "include_dir",
  "jsonc-parser",
- "lazy_static",
  "mime",
  "notify",
  "serde",
@@ -5396,7 +5408,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "base16",
  "hex",
@@ -5408,11 +5420,10 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "convert_case",
- "pmutil",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -5423,9 +5434,8 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -5434,13 +5444,12 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
  "concurrent-queue",
  "dashmap",
- "lazy_static",
  "nohash-hasher",
  "num_cpus",
  "parking_lot",
@@ -5454,21 +5463,16 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "lazy_static",
- "num-bigint",
- "rand",
  "regex",
  "serde",
  "serde_json",
- "serde_regex",
- "swc_core",
  "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
- "turbo-tasks-env",
  "turbo-tasks-fs",
  "turbopack-core",
  "turbopack-css",
@@ -5476,33 +5480,28 @@ dependencies = [
  "turbopack-env",
  "turbopack-json",
  "turbopack-static",
- "url",
 ]
 
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "clap",
  "crossterm",
- "lazy_static",
  "owo-colors",
  "serde",
- "serde_json",
- "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
- "turbo-tasks-hash",
  "turbopack-core",
 ]
 
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5512,33 +5511,29 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "patricia_tree",
- "rand",
+ "qstring",
  "regex",
  "serde",
  "serde_json",
- "serde_regex",
  "sourcemap",
- "swc_core",
- "tokio",
+ "swc_core 0.45.4",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-env",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
- "url",
 ]
 
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "async-trait",
  "indexmap",
- "once_cell",
  "serde",
- "swc_core",
+ "swc_core 0.45.4",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -5551,15 +5546,13 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "futures",
- "httparse",
  "hyper",
  "hyper-tungstenite",
  "indexmap",
- "lazy_static",
  "mime",
  "mime_guess",
  "parking_lot",
@@ -5582,7 +5575,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5590,17 +5583,16 @@ dependencies = [
  "fxhash",
  "indexmap",
  "lazy_static",
+ "next-font",
  "num-bigint",
  "once_cell",
  "pin-project-lite",
- "rand",
  "regex",
  "serde",
  "serde_json",
- "serde_regex",
  "styled_components",
  "styled_jsx",
- "swc_core",
+ "swc_core 0.45.4",
  "swc_emotion",
  "tokio",
  "tracing",
@@ -5616,11 +5608,9 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
- "dotenvy",
- "indexmap",
  "serde",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -5633,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "serde",
@@ -5648,7 +5638,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
  "futures",
@@ -5672,11 +5662,9 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
  "anyhow",
- "async-trait",
- "md4",
  "serde",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -5690,14 +5678,11 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+source = "git+https://github.com/vercel/turbo.git?rev=cc024fa59f1c3ad253e74eefe86e0386455455d1#cc024fa59f1c3ad253e74eefe86e0386455455d1"
 dependencies = [
- "anyhow",
- "async-trait",
- "swc_core",
+ "swc_core 0.45.4",
  "turbo-tasks",
  "turbo-tasks-build",
- "turbo-tasks-fs",
  "turbopack-core",
 ]
 
@@ -5745,7 +5730,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -5860,12 +5845,6 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-
-[[package]]
-name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
@@ -5919,7 +5898,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "swc_core",
+ "swc_core 0.45.4",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -6312,12 +6291,6 @@ checksum = "4c347c4460ffb311e95aafccd8c29e4888f241b9e4b3bb0e0ccbd998de2c8c0d"
 dependencies = [
  "wast",
 ]
-
-[[package]]
-name = "weak-table"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"

--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -131,6 +131,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto-hash-map"
+version = "0.1.0"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "auto_impl"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.20.106"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4a9532d2267c46172d1512ee75a36060a2c419d3ec261055b200d389f1ed10"
+checksum = "3f2bc0a4b3fe61b2f5b1aeeff23cc4114c43e7b0bd00e999dd2f4324d8ca9c40"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -242,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "browserslist-rs"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c689fb4e42bd511c1927856b078d8a582690f5be196199d1c9005b9d4feae8c"
+checksum = "421478dde88feb4281328dea29dbf6d2b57bc19a8968214fc3694c8c574bc47f"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1001,18 +1009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flurry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0afc943ef18eebf6bc3335daeb8d338202093d18444a1784ea7f57fe7680f8"
-dependencies = [
- "ahash",
- "num_cpus",
- "parking_lot",
- "seize",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,12 +1296,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -1518,12 +1508,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.1",
+ "hashbrown 0.12.3",
  "rayon",
  "serde",
 ]
@@ -1846,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "markdown"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad4f4705119913653a71784beb4cb7f2ca652aaa3f8f87d069efcbe6231e245"
+checksum = "6f1bec93d41bf1ce695437433e87126cb127e147c3e5c3f35184282f97825cd9"
 dependencies = [
  "log",
  "regex",
@@ -1883,13 +1873,13 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ee4e6ff2cda3f98007dbe11faeda47dac045558aaefa52f1d620b07554c3b5"
+checksum = "0c4bbd566f0dd80e0701ef5ca305e4404805eb37b95a6246ac1605acb71a6e9b"
 dependencies = [
  "markdown",
  "serde",
- "swc_core 0.40.57",
+ "swc_core",
 ]
 
 [[package]]
@@ -2064,16 +2054,16 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.25.5"
+version = "0.25.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43debe5ab48d5c1400c4311dbc534554cad214566416a28bf64ced1b6548a28"
+checksum = "86ac677f509eabb57a5796bb363cb3141b64a5a215a693fd84e5349cb34de4d3"
 dependencies = [
  "convert_case",
  "handlebars",
  "once_cell",
  "regex",
  "serde",
- "swc_core 0.43.23",
+ "swc_core",
 ]
 
 [[package]]
@@ -2241,18 +2231,13 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 [[package]]
 name = "next-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
- "futures",
  "indexmap",
- "mime",
  "rand",
- "regex",
  "serde",
  "serde_json",
- "serde_qs",
- "sourcemap",
  "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -2264,13 +2249,13 @@ dependencies = [
  "turbopack-dev-server",
  "turbopack-ecmascript",
  "turbopack-env",
- "url",
+ "turbopack-node",
 ]
 
 [[package]]
 name = "next-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "clap",
@@ -2312,7 +2297,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core 0.43.23",
+ "swc_core",
  "swc_emotion",
  "testing",
  "tracing",
@@ -2326,7 +2311,6 @@ dependencies = [
  "anyhow",
  "backtrace",
  "fxhash",
- "indexmap",
  "mdxjs",
  "napi",
  "napi-build",
@@ -2338,7 +2322,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
- "swc_core 0.43.23",
+ "swc_core",
  "tracing",
  "tracing-chrome",
  "tracing-futures",
@@ -2348,7 +2332,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "owo-colors",
@@ -2813,9 +2797,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "preset_env_base"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "371fa3d5cd3a90724d8e8ad1e3201854dded11e79b5365dabd5e1e389274d001"
+checksum = "97cc85a18e7f8246f3ccdd764d1f51fa3c910293942f84483a1cf1647df47198"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3296,16 +3280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "seize"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5739de653b129b0a59da381599cf17caf24bc586f6a797c52d3d6147c5b85a"
-dependencies = [
- "num_cpus",
- "once_cell",
-]
-
-[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3768,26 +3742,26 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.52.5"
+version = "0.52.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea96f2dc8202734c0924f4d41235c4fcb9f9dbfbcc6e46644b39a712eb83f9d"
+checksum = "de9278187c95d3fba086db8121b2de60d1d41c7d7f6e2e826738b9f002a3b834"
 dependencies = [
  "Inflector",
  "once_cell",
  "regex",
  "serde",
- "swc_core 0.43.23",
+ "swc_core",
  "tracing",
 ]
 
 [[package]]
 name = "styled_jsx"
-version = "0.29.5"
+version = "0.29.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812632cbfad1d3a969ff041d8d063fdd30502f2261e40b7c922fa9387bccc34c"
+checksum = "be22d79d6861fc5358b14d39aa6b3227573996ce76fecd0ce8252fab46143494"
 dependencies = [
  "easy-error",
- "swc_core 0.43.23",
+ "swc_core",
  "tracing",
 ]
 
@@ -3827,9 +3801,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.232.103"
+version = "0.233.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3bff0919bab888c9d6a2d57bf22cf277a3f2292f1573462d9dae5392149239b"
+checksum = "033e1e6fb047f6a46e19756c80819d24512ab6d0d9baf8016e325aaf3d950fe5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3874,13 +3848,14 @@ dependencies = [
  "swc_timer",
  "swc_visit",
  "tracing",
+ "url",
 ]
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79642938ff437f2217718abf30a3450b014f600847c8f4bd60fa44f88a5210ea"
+checksum = "63b8033a868fbebf5829797ac0c543499622b657e2d33a08ca6ab12547b8bafc"
 dependencies = [
  "once_cell",
  "rkyv",
@@ -3893,9 +3868,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.192.89"
+version = "0.193.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc34dfeaaf7efdd7ebe3a7d6b5864289635ee7a531229a8b74a1e34f6dfeb36"
+checksum = "5a67acb8bb8f01cfecb98a4517f9ce9d02c4bf4c02ab5dfbba020f2dbfabdbce"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3941,9 +3916,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.14"
+version = "0.29.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bde01c52376971bc6839c42e1a71dec9526ac7acfbfcf1eb3e606e5aa1b2de0"
+checksum = "295fb6ecf5c33599941e5dc38bf74517c9bfc9e1fd368db4fc4ca718e9005ee1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3999,27 +3974,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.40.57"
+version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37598b9265a1b23c75c5d494a302e36eddddaa71bbca1d94caa87202450a6dab"
-dependencies = [
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_trace_macro",
- "vergen",
-]
-
-[[package]]
-name = "swc_core"
-version = "0.43.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdf3bc89454223076b8992ec1e17f9827fcc6139c34488c2be8d3189c2f7dbd"
+checksum = "9593e3d1dca44da09b4601bdf74f2eb5ade8768a31656834036aa5d3754ba9c0"
 dependencies = [
  "binding_macros",
  "swc",
@@ -4054,6 +4011,7 @@ dependencies = [
  "swc_nodejs_common",
  "swc_plugin_proxy",
  "swc_plugin_runner",
+ "swc_trace_macro",
  "testing",
  "vergen",
  "wasmer",
@@ -4062,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.127.1"
+version = "0.128.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2410a670c32146fe9941831c20f44203232a12e99738985d6f47ec9eaadd9bac"
+checksum = "77f193297ef3eb2c76052dbcf3a9c42bc509563f0943c875d783db71798cb514"
 dependencies = [
  "is-macro",
  "serde",
@@ -4075,9 +4033,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.137.2"
+version = "0.138.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb37f3a0c8bbaaeed41e3cc18cc4ec283b50bb93afeaf0dcd6e016d773a941ee"
+checksum = "a183ce66593dc14be82378a6e647caab79c7b76d7e6169ec2e5f458e38022baf"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -4105,9 +4063,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.12.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ac4a9455af86052b78f8e1b61f25c641189a9e832f1508826b38c8652acd2b"
+checksum = "4a468a59b5dc5f8dd0d338e7cd3dab09128a5abf2d9bedd7cd4bfd9f9136f077"
 dependencies = [
  "once_cell",
  "serde",
@@ -4121,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.13.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13098f975f042376984bdae233f0c4ef1ce7e83a2d01bb2a44a80e1862eaca2"
+checksum = "1f06de7293ca37fb7691d76469a716623bc35c00af0e1e9a25548197d271ebda"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -4137,9 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.136.2"
+version = "0.137.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ebfd30908c595b67616ad904c1e7571feee71a679d95cbb3f2e004e7474da3"
+checksum = "969ba35f9770eab6d867bc2f0603fd1b133ad59c6b219608fbf0550fadbb6a4c"
 dependencies = [
  "bitflags",
  "lexical",
@@ -4151,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.138.2"
+version = "0.139.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c1ebab660e55383142ec913913d633103f02f3ca0e939479f439718ad4f1d7"
+checksum = "608b2b72a3b672d60e14ceff6e981b8def774dd84fd0714c020da5704487370f"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -4168,9 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.124.1"
+version = "0.125.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70816edeb107425a1d0d8d8d46c428c6f62ab6a8f72718b0e51c4047d9e99481"
+checksum = "4d318c70fef968243de15285368328b3aeb8499c436a483a9ec8b3e19b2a4281"
 dependencies = [
  "once_cell",
  "serde",
@@ -4183,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.126.1"
+version = "0.127.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a36994c5088f58b878b0b6da120177f8e1abff73e18fa2d81ec3b7fec885a1"
+checksum = "fc6fc6af0899bb054ac17b7cfaf1cd5c1efbd594b95aefa5260ae8a08f528600"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -4196,9 +4154,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.94.19"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54bd55f94f02afe98be444e1808e068fa3dca0a113d0c38748d3fdd7a380c2b"
+checksum = "04fc3a7fafe8506b19506b455f18c875f2b5f546f6ecc7a6d22032c281b24888"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -4214,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.127.32"
+version = "0.128.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4946531b21cffd79a5bfc742450ddf2a6cfb6e024863f40f071fbd4e523c026"
+checksum = "a5be18c834f2fb158c88b4ae5dc0320663bb11fe4913a37f10355001194d41d0"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -4246,9 +4204,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.91.35"
+version = "0.92.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a1144158b126822e7d6e6844f770e8e3d8976561f3af366053498d88f80b3c"
+checksum = "fd9365760d251cd79e80fbe1c612c37e23fd2a6687bee46671ab7a17aad8c416"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -4260,9 +4218,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.66.51"
+version = "0.67.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b55273d6d442dd0c27bb90ed095e8c7e541bf1ed1a0b5fda0d3284e2e3091b"
+checksum = "7f83b7441598759492030801130127dfd0a39d236d641c1d466cfecf69d94c27"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -4281,9 +4239,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.41.15"
+version = "0.41.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b475a49f4c6cc848fe0084c89d202f35691035601ad1ff34e8d72f673c8759"
+checksum = "801077c673830f07f4418969397ddb0c92413c0d6fb8b5a73b977ddb7d19b046"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4303,9 +4261,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.159.89"
+version = "0.160.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95931d6b27c018cb89f638e0029b0c3bc2456c412a6436bfbfbd475deb986ce"
+checksum = "4d6ec9450992c70f0db8ebb0527efbf43d35a203a100fc749b78374a65fd7340"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -4338,9 +4296,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.122.27"
+version = "0.123.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b35ce974dd789d06e6ee4bca89b8d0c4313e952543e0ac89c2bbb33111d742"
+checksum = "bf9948268edb75b2a02cb5c919d791344f8a7379ec726039c04e437fe5eac1e7"
 dependencies = [
  "either",
  "enum_kind",
@@ -4357,9 +4315,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.174.54"
+version = "0.175.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c174f059ec8f684bdca6b1e723f2ae70c053efe79b094645a062a445f58b18b6"
+checksum = "0630d4bc64d096049a5ee300b7eb0e27c0edba83130fa7de08813403be3c2599"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4382,9 +4340,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.33.28"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2727e9b6dc65396f847ceb4f5e4a91823f0083636a22ca16b7a7116e0ca9fe85"
+checksum = "ba912948f24aa3eb6bd72ce33235a97954873b61299bc0ec8fb7fddb486fa394"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -4400,25 +4358,21 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ecc467eff7ef4ec0a64919402b94da637003015d019de4d649e8efeceafd3f"
+checksum = "25198f96ef93c4bb4cc8fa13c9b22a018cf2c0c7609ee91f7abc7968ebc2e2df"
 dependencies = [
  "anyhow",
  "hex",
  "sha-1",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "testing",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.198.54"
+version = "0.199.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2f6317bf464fc4c5cbc413f831dbdedae26f72e75751d9c2219bd260a7d6b8"
+checksum = "19d727e0210e883a9da91906871771bcd3e4ecfc24464e4560891abea1a9a2f2"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -4436,9 +4390,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.111.50"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6bec94a996b2001e19a1b28c758a2b6f5052dd4bddb03e5f45d01dd1291d9c"
+checksum = "b8154f2ba2b3e27e995188d3d0ecd80068987b5d56b5e0c7f64ccf8926e7bb8e"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -4459,9 +4413,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.100.49"
+version = "0.101.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81adaaf6e04a7a3e2ed9ae137bcc31fef749825efb21d507b8392e2ef50f5c5"
+checksum = "86024dc3ca060348cc016a880986cf8f147bcfb174875787a870fded970f5b25"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -4473,9 +4427,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.136.43"
+version = "0.137.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a706aa64921dcb9e7028713579e2d8feca0bf70cbc43e993839a704ba74d02"
+checksum = "5f9c9fa2b790b85aaf4d9acc9558e40e92b7508331ee971972c301f58b688bba"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -4513,9 +4467,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.153.47"
+version = "0.154.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5de110b193ff19023fd15c14b986719c9493ae450eda35a36b3d9ca3ab5483"
+checksum = "7bcf903603f02e2f3824b8aaabc8515198db988bd738012c68713f486c6e189e"
 dependencies = [
  "Inflector",
  "ahash",
@@ -4541,9 +4495,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.167.54"
+version = "0.168.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2623434be6cc5abc4ac65aa96263cc80fbcf6e078ad9676fff50fe51816a78cb"
+checksum = "3edeb43c8bf28cc190b29a9229811df8c0ee1fc9cf704fbd2b297a36de791961"
 dependencies = [
  "ahash",
  "dashmap",
@@ -4567,9 +4521,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.144.43"
+version = "0.145.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1954b8e786132ee82bb0562516f7c18a79a9130b98e8e6dae0bc0b876ad9c7b0"
+checksum = "87c0afe63785d15d4bdf404ff1e83360cfb1537aad7a207cf3fb349b28f37837"
 dependencies = [
  "either",
  "serde",
@@ -4586,9 +4540,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.155.47"
+version = "0.156.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b7d4860caf43a2ba5b6ae405f04060b01f30be3853e38edcba23fa26d15d8a"
+checksum = "cb642721f6d960c84898677c7ea14c689537ae335f6431e9640f33bc9ed58dc1"
 dependencies = [
  "ahash",
  "base64",
@@ -4613,9 +4567,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.114.35"
+version = "0.115.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17359705d6ada954a9cf8509d7cdebf57e98932d0036f5b2bd1ef3252adee62"
+checksum = "b4b16828650b5431e28a83e83edfb6f52ba7c85bf63d2880ff6de0bdebb08ed0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -4639,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.159.49"
+version = "0.160.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050df008d6371dd706537d7833bb2dbccbcc1fc31878b94869c2a7be934f6bc9"
+checksum = "e9c0190167b7adc388c6e62fc40a316ed851a09102f144e744f235b63ecbe899"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -4655,9 +4609,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.105.35"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b412e893d66fb56f1290714bf153d9bc38a114a669cf611445833cff7471ac"
+checksum = "5ff832d27c2b8a5957853094c09e1b596f18b31160a4daf004f29f0e4f5bdc21"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -4673,9 +4627,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.80.19"
+version = "0.81.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b42489b19f3451b65c01ed4a7926e44fab294ed9bfa8489634e58ecc96df88"
+checksum = "bfce55b92a36aac12309518604ee46106177266bb5fd09cd2bb6b4a1210533f9"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -4687,9 +4641,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44abd3c2caae9042ddb83d8bda66fd692db0ff769152d5857c2fc7113312bbe4"
+checksum = "459955b8b106831cf6ea59682b6be65bcdd65c813a5204203973c55a80841067"
 dependencies = [
  "base64",
  "byteorder",
@@ -4699,7 +4653,7 @@ dependencies = [
  "regex",
  "serde",
  "sourcemap",
- "swc_core 0.40.57",
+ "swc_core",
  "tracing",
 ]
 
@@ -4717,9 +4671,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.14"
+version = "0.13.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdfda46250b8d5ff325c4f9e7e50497125e8f357f3a2daa655ba0b4ad8d964a"
+checksum = "119a391045e3c31ab38ff8e16428248bd0734626e19be28c9e9de4d6a6bb9c3a"
 dependencies = [
  "anyhow",
  "miette",
@@ -4730,9 +4684,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.17.15"
+version = "0.17.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd95667b47445a6aec7994c6701ade4e250632d38a1a8676c633b99e09897d78"
+checksum = "28a0d380e2d53fd6d166e8f06ddf3846a3c9bb9d12bdd0fe123e820483c5be2c"
 dependencies = [
  "ahash",
  "indexmap",
@@ -4742,9 +4696,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.18.15"
+version = "0.18.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17e71f2e8c5e20c41d1aae22874e2735f235d3954e421eae34ed088310e5c09"
+checksum = "b52fdb35f6289ca961d5fca80f2e1e284e3dcb6f0424c428cf00c1779c80fdfc"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -4777,9 +4731,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.16.14"
+version = "0.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed7b4e6db6bd936ce05e368cdcafa81dcd1f1fe8ae21b7b7af1bbf0e8b55869"
+checksum = "5fdebc066a603b2256957707e8127942cbc25a2d07a28d90747b5fd90a51caaa"
 dependencies = [
  "ahash",
  "dashmap",
@@ -4804,9 +4758,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.22.21"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ee9fe5bd09db8d48a9f7839124b502a53910345eaa38875beac51ff8f2fa21"
+checksum = "624e53ccde0582e844b545df87dc3e8850fe813813c50c93a05ea4245fc381ba"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -4818,9 +4772,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.77.34"
+version = "0.78.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30626af2ed1b7e8497dccbc3a5bb13e070d1b1699dcec707bced8a79ea6a246"
+checksum = "83fdfcc530821aac2902d0a060a4efe8647160ebb0196688a7fac2447ae7d0c3"
 dependencies = [
  "anyhow",
  "enumset",
@@ -4841,9 +4795,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.17.14"
+version = "0.17.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34005d58739d4c115eaa8a4b3f5e82eba67dd9b84b55b1f3a8486b6575c83d76"
+checksum = "328057c7f54f30534add2ac9e6570ff16e757cba5b20dd669148bba71eac6bf7"
 dependencies = [
  "tracing",
 ]
@@ -4935,9 +4889,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.14"
+version = "0.31.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6ad9c35c9b4e4834c16b7cbce4209ee0cb6b8af7264d2a8f37f1834340d901"
+checksum = "3e1bf3e1197f0dd71ea09b8540be7f735df3f86f7b7ce41304acb79fcf52f8fb"
 dependencies = [
  "ansi_term",
  "difference",
@@ -5347,7 +5301,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "mimalloc",
 ]
@@ -5355,14 +5309,15 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "any_key",
  "anyhow",
+ "auto-hash-map",
  "bitflags",
+ "dashmap",
  "erased-serde",
  "event-listener",
- "flurry",
  "futures",
  "indexmap",
  "mopa",
@@ -5384,7 +5339,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -5400,7 +5355,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5416,9 +5371,10 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
+ "auto-hash-map",
  "bitflags",
  "bytes",
  "concurrent-queue",
@@ -5440,7 +5396,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "base16",
  "hex",
@@ -5452,7 +5408,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -5467,7 +5423,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -5478,12 +5434,12 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
+ "auto-hash-map",
  "concurrent-queue",
  "dashmap",
- "flurry",
  "lazy_static",
  "nohash-hasher",
  "num_cpus",
@@ -5498,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -5508,7 +5464,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
- "swc_core 0.43.23",
+ "swc_core",
  "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -5526,7 +5482,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "clap",
@@ -5546,10 +5502,11 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "async-trait",
+ "auto-hash-map",
  "browserslist-rs",
  "futures",
  "indexmap",
@@ -5561,7 +5518,7 @@ dependencies = [
  "serde_json",
  "serde_regex",
  "sourcemap",
- "swc_core 0.43.23",
+ "swc_core",
  "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -5574,14 +5531,14 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "async-trait",
  "indexmap",
  "once_cell",
  "serde",
- "swc_core 0.43.23",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -5594,7 +5551,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "futures",
@@ -5625,7 +5582,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5643,7 +5600,7 @@ dependencies = [
  "serde_regex",
  "styled_components",
  "styled_jsx",
- "swc_core 0.43.23",
+ "swc_core",
  "swc_emotion",
  "tokio",
  "tracing",
@@ -5659,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5676,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "serde",
@@ -5689,9 +5646,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbopack-node"
+version = "0.1.0"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
+dependencies = [
+ "anyhow",
+ "futures",
+ "indexmap",
+ "mime",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "tokio",
+ "turbo-tasks",
+ "turbo-tasks-build",
+ "turbo-tasks-fs",
+ "turbopack",
+ "turbopack-core",
+ "turbopack-dev-server",
+ "turbopack-ecmascript",
+ "url",
+]
+
+[[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5709,11 +5690,11 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?rev=5c2b933ce142d70e9774e933e805734f2c09248c#5c2b933ce142d70e9774e933e805734f2c09248c"
+source = "git+https://github.com/vercel/turbo.git?rev=c69298c4a31516129bb62263f163a1da9c5614da#c69298c4a31516129bb62263f163a1da9c5614da"
 dependencies = [
  "anyhow",
  "async-trait",
- "swc_core 0.43.23",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -5938,7 +5919,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "swc_core 0.43.23",
+ "swc_core",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -5951,8 +5932,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -19,10 +19,10 @@ pathdiff = "0.2.0"
 regex = "1.5"
 serde = "1"
 serde_json = "1"
-swc_emotion = "0.28.3"
-styled_components = "0.52.7"
-styled_jsx = "0.29.7"
-modularize_imports = "0.25.7"
+swc_emotion = "0.28.4"
+styled_components = "0.52.8"
+styled_jsx = "0.29.8"
+modularize_imports = "0.25.8"
 tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 
 swc_core = { features = [
@@ -42,9 +42,9 @@ swc_core = { features = [
   "ecma_parser_typescript",
   "cached",
   "base"
-], version = "0.44.2" }
+], version = "0.45.4" }
 
 [dev-dependencies]
-swc_core = { features = ["testing_transform"], version = "0.44.2" }
+swc_core = { features = ["testing_transform"], version = "0.45.4" }
 testing = "0.31.14"
 walkdir = "2.3.2"

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -19,10 +19,10 @@ pathdiff = "0.2.0"
 regex = "1.5"
 serde = "1"
 serde_json = "1"
-swc_emotion = "0.28.2"
-styled_components = "0.52.5"
-styled_jsx = "0.29.5"
-modularize_imports = "0.25.5"
+swc_emotion = "0.28.3"
+styled_components = "0.52.7"
+styled_jsx = "0.29.7"
+modularize_imports = "0.25.7"
 tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 
 swc_core = { features = [
@@ -42,9 +42,9 @@ swc_core = { features = [
   "ecma_parser_typescript",
   "cached",
   "base"
-], version = "0.43.23" }
+], version = "0.44.2" }
 
 [dev-dependencies]
-swc_core = { features = ["testing_transform"], version = "0.43.23" }
+swc_core = { features = ["testing_transform"], version = "0.44.2" }
 testing = "0.31.14"
 walkdir = "2.3.2"

--- a/packages/next-swc/crates/core/tests/errors/next-dynamic/no-arguments/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-dynamic/no-arguments/output.stderr
@@ -1,6 +1,7 @@
 
   x next/dynamic requires at least one argument
-   ,-[input.js:3:1]
+   ,-[input.js:2:1]
+ 2 | 
  3 | const DynamicComponent = dynamic()
    :                          ^^^^^^^
    `----

--- a/packages/next-swc/crates/core/tests/errors/next-dynamic/options-as-variable/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-dynamic/options-as-variable/output.stderr
@@ -1,7 +1,9 @@
 
   x next/dynamic options must be an object literal.
   | Read more: https://nextjs.org/docs/messages/invalid-dynamic-options-type
-   ,-[input.js:4:1]
+   ,-[input.js:3:1]
+ 3 | const options = { loading: () => <p>...</p>, ssr: false }
  4 | const DynamicComponentWithCustomLoading = dynamic(
    :                                           ^^^^^^^
+ 5 |   () => import('../components/hello'),
    `----

--- a/packages/next-swc/crates/core/tests/errors/next-dynamic/too-many-arguments/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-dynamic/too-many-arguments/output.stderr
@@ -1,6 +1,8 @@
 
   x next/dynamic only accepts 2 arguments
-   ,-[input.js:3:1]
+   ,-[input.js:2:1]
+ 2 | 
  3 | const DynamicComponentWithCustomLoading = dynamic(
    :                                           ^^^^^^^
+ 4 |   () => import('../components/hello'),
    `----

--- a/packages/next-swc/crates/core/tests/errors/next-font-loaders/export-let/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-font-loaders/export-let/output.stderr
@@ -1,12 +1,15 @@
 
   x Font loader calls must be assigned to a const
-   ,-[input.js:4:1]
+   ,-[input.js:3:1]
+ 3 | 
  4 | export let firaCode = Abel()
    :        ^^^^^^^^^^^^^^^^^^^^^
+ 5 | export var inter = Inter()
    `----
 
   x Font loader calls must be assigned to a const
-   ,-[input.js:5:1]
+   ,-[input.js:4:1]
+ 4 | export let firaCode = Abel()
  5 | export var inter = Inter()
    :        ^^^^^^^^^^^^^^^^^^^
    `----

--- a/packages/next-swc/crates/core/tests/errors/next-font-loaders/not-const/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-font-loaders/not-const/output.stderr
@@ -1,13 +1,15 @@
 
   x Font loader calls must be assigned to a const
-   ,-[input.js:4:1]
+   ,-[input.js:3:1]
+ 3 |     var i = 10
  4 | ,-> var inter1 = Inter({
  5 | |     variant: '400',
  6 | `-> })
    `----
 
   x Font loader calls must be assigned to a const
-    ,-[input.js:9:1]
+    ,-[input.js:8:1]
+  8 |     var i2 = 20
   9 | ,-> let inter2 = Inter({
  10 | |     variant: '400',
  11 | `-> })

--- a/packages/next-swc/crates/core/tests/errors/next-font-loaders/not-ident/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-font-loaders/not-ident/output.stderr
@@ -1,12 +1,16 @@
 
   x Font loader calls must be assigned to an identifier
-   ,-[input.js:3:1]
+   ,-[input.js:2:1]
+ 2 | 
  3 | const { a } = Inter({
    :       ^^^^^
+ 4 |   variant: '400',
    `----
 
   x Font loader calls must be assigned to an identifier
-   ,-[input.js:7:1]
+   ,-[input.js:6:1]
+ 6 | 
  7 | const [b] = Inter({
    :       ^^^
+ 8 |   variant: '400',
    `----

--- a/packages/next-swc/crates/core/tests/errors/next-font-loaders/options-object/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-font-loaders/options-object/output.stderr
@@ -1,24 +1,28 @@
 
   x Unexpected object key type
-   ,-[input.js:4:1]
+   ,-[input.js:3:1]
+ 3 | const a = fn({ 10: 'hello' })
  4 | const a = ABeeZee({ 10: 'hello' })
    :                     ^^
    `----
 
   x Font loader values must be explicitly written literals.
-   ,-[input.js:7:1]
+   ,-[input.js:6:1]
+ 6 | const a = fn({ variant: [i1] })
  7 | const a = ABeeZee({ variant: [i1] })
    :                               ^^
    `----
 
   x Font loader values must be explicitly written literals.
-    ,-[input.js:10:1]
+    ,-[input.js:9:1]
+  9 | const a = fn({ variant: () => {} })
  10 | const a = ABeeZee({ variant: () => {} })
     :                              ^^^^^^^^
     `----
 
   x Unexpected spread
-    ,-[input.js:13:1]
+    ,-[input.js:12:1]
+ 12 | const a = fn({ ...{} })
  13 | const a = ABeeZee({ ...{} })
     :                     ^^^
     `----

--- a/packages/next-swc/crates/core/tests/errors/next-font-loaders/spread-arg/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-font-loaders/spread-arg/output.stderr
@@ -1,12 +1,14 @@
 
   x Font loaders don't accept spreads
-   ,-[input.js:4:1]
+   ,-[input.js:3:1]
+ 3 | const a = fn(...{}, ...[])
  4 | const inter = Inter(...{}, ...[])
    :                     ^^^
    `----
 
   x Font loaders don't accept spreads
-   ,-[input.js:4:1]
+   ,-[input.js:3:1]
+ 3 | const a = fn(...{}, ...[])
  4 | const inter = Inter(...{}, ...[])
    :                            ^^^
    `----

--- a/packages/next-swc/crates/core/tests/errors/next-font-loaders/wrong-scope/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-font-loaders/wrong-scope/output.stderr
@@ -1,30 +1,38 @@
 
   x Font loaders must be called and assigned to a const in the module scope
-   ,-[input.js:3:1]
+   ,-[input.js:2:1]
+ 2 | 
  3 | Aladin({})
    : ^^^^^^
    `----
 
   x Font loaders must be called and assigned to a const in the module scope
-   ,-[input.js:6:1]
+   ,-[input.js:5:1]
+ 5 | let b
  6 | const a = (b = Aladin({ variant: '400' }))
    :                ^^^^^^
    `----
 
   x Font loaders must be called and assigned to a const in the module scope
-   ,-[input.js:9:3]
- 9 | const a = Aladin({
-   :           ^^^^^^
-   `----
-
-  x Font loaders must be called and assigned to a const in the module scope
-    ,-[input.js:16:5]
- 16 | Aladin({
-    : ^^^^^^
+    ,-[input.js:8:1]
+  8 | function Hello() {
+  9 |   const a = Aladin({
+    :             ^^^^^^
+ 10 |     variant: '400',
     `----
 
   x Font loaders must be called and assigned to a const in the module scope
-    ,-[input.js:23:3]
- 23 | Aladin({})
-    : ^^^^^^
+    ,-[input.js:15:1]
+ 15 |   constructor() {
+ 16 |     Aladin({
+    :     ^^^^^^
+ 17 |       variant: '400',
+    `----
+
+  x Font loaders must be called and assigned to a const in the module scope
+    ,-[input.js:22:1]
+ 22 | {
+ 23 |   Aladin({})
+    :   ^^^^^^
+ 24 | }
     `----

--- a/packages/next-swc/crates/core/tests/errors/next-ssg/server-side-after-static-paths/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-ssg/server-side-after-static-paths/output.stderr
@@ -1,6 +1,7 @@
 
   x You can not use getStaticProps or getStaticPaths with getServerSideProps. To use SSG, please remove getServerSideProps
-   ,-[input.js:2:1]
+   ,-[input.js:1:1]
+ 1 | export async function getStaticPaths() {}
  2 | export const getServerSideProps = function getServerSideProps() {}
    :              ^^^^^^^^^^^^^^^^^^
    `----

--- a/packages/next-swc/crates/core/tests/errors/next-ssg/server-side-after-static-props/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-ssg/server-side-after-static-props/output.stderr
@@ -1,6 +1,7 @@
 
   x You can not use getStaticProps or getStaticPaths with getServerSideProps. To use SSG, please remove getServerSideProps
-   ,-[input.js:2:1]
- 2 | export { a as getServerSideProps }
+   ,-[input.js:1:1]
+ 1 | const getStaticProps = async () => {}
+ 2 | export { a as getServerSideProps } 
    :               ^^^^^^^^^^^^^^^^^^
    `----

--- a/packages/next-swc/crates/core/tests/errors/next-ssg/static-paths-after-server-side/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/next-ssg/static-paths-after-server-side/output.stderr
@@ -1,6 +1,7 @@
 
   x You can not use getStaticProps or getStaticPaths with getServerSideProps. To use SSG, please remove getServerSideProps
-   ,-[input.js:2:1]
+   ,-[input.js:1:1]
+ 1 | export { a as getServerSideProps } from './input'
  2 | export { getStaticPaths } from 'a'
    :          ^^^^^^^^^^^^^^
    `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/client-graph/get-server-side-props/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/client-graph/get-server-side-props/output.stderr
@@ -3,4 +3,5 @@
    ,-[input.js:1:1]
  1 | export function getServerSideProps (){
    :                 ^^^^^^^^^^^^^^^^^^
+ 2 | }
    `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/client-graph/get-static-props/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/client-graph/get-static-props/output.stderr
@@ -3,4 +3,5 @@
    ,-[input.js:1:1]
  1 | export function getStaticProps (){
    :                 ^^^^^^^^^^^^^^
+ 2 | }
    `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/client-graph/server-only/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/client-graph/server-only/output.stderr
@@ -1,6 +1,7 @@
 
   x NEXT_RSC_ERR_CLIENT_IMPORT: server-only
-   ,-[input.js:9:1]
+   ,-[input.js:8:1]
+ 8 | 
  9 | import "server-only"
    : ^^^^^^^^^^^^^^^^^^^^
    `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/client-graph/use-client/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/client-graph/use-client/output.stderr
@@ -1,6 +1,7 @@
 
   x NEXT_RSC_ERR_CLIENT_DIRECTIVE
-   ,-[input.js:3:1]
+   ,-[input.js:2:1]
+ 2 | 
  3 | "use client"
    : ^^^^^^^^^^^^
    `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/client-only/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/client-only/output.stderr
@@ -1,6 +1,7 @@
 
   x NEXT_RSC_ERR_SERVER_IMPORT: client-only
-   ,-[input.js:9:1]
+   ,-[input.js:8:1]
+ 8 | 
  9 | import "client-only"
    : ^^^^^^^^^^^^^^^^^^^^
    `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/get-server-side-props/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/get-server-side-props/output.stderr
@@ -3,4 +3,5 @@
    ,-[input.js:1:1]
  1 | export function getServerSideProps (){
    :                 ^^^^^^^^^^^^^^^^^^
+ 2 | }
    `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/get-static-props/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/get-static-props/output.stderr
@@ -3,4 +3,5 @@
    ,-[input.js:1:1]
  1 | export function getStaticProps (){
    :                 ^^^^^^^^^^^^^^
+ 2 | }
    `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-api/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-api/output.stderr
@@ -6,73 +6,94 @@
    `----
 
   x NEXT_RSC_ERR_REACT_API: createContext
-   ,-[input.js:3:1]
+   ,-[input.js:2:1]
+ 2 | 
  3 | import { createContext } from 'react'
    :          ^^^^^^^^^^^^^
    `----
 
   x NEXT_RSC_ERR_REACT_API: useEffect
-   ,-[input.js:5:1]
+   ,-[input.js:4:1]
+ 4 | 
  5 | import { useEffect, useImperativeHandle } from 'react'
    :          ^^^^^^^^^
    `----
 
   x NEXT_RSC_ERR_REACT_API: useImperativeHandle
-   ,-[input.js:5:1]
+   ,-[input.js:4:1]
+ 4 | 
  5 | import { useEffect, useImperativeHandle } from 'react'
    :                     ^^^^^^^^^^^^^^^^^^^
    `----
 
   x NEXT_RSC_ERR_REACT_API: Component
-   ,-[input.js:8:5]
- 8 | Component,
-   : ^^^^^^^^^
+   ,-[input.js:7:1]
+ 7 | import {
+ 8 | 	Component,
+   :  ^^^^^^^^^
+ 9 | 	createFactory,
    `----
 
   x NEXT_RSC_ERR_REACT_API: createFactory
-   ,-[input.js:9:5]
- 9 | createFactory,
-   : ^^^^^^^^^^^^^
-   `----
+    ,-[input.js:8:1]
+  8 | 	Component,
+  9 | 	createFactory,
+    :  ^^^^^^^^^^^^^
+ 10 | 	PureComponent,
+    `----
 
   x NEXT_RSC_ERR_REACT_API: PureComponent
-    ,-[input.js:10:5]
- 10 | PureComponent,
-    : ^^^^^^^^^^^^^
+    ,-[input.js:9:1]
+  9 | 	createFactory,
+ 10 | 	PureComponent,
+    :  ^^^^^^^^^^^^^
+ 11 |   useDeferredValue,
     `----
 
   x NEXT_RSC_ERR_REACT_API: useDeferredValue
-    ,-[input.js:11:3]
- 11 | useDeferredValue,
-    : ^^^^^^^^^^^^^^^^
+    ,-[input.js:10:1]
+ 10 | 	PureComponent,
+ 11 |   useDeferredValue,
+    :   ^^^^^^^^^^^^^^^^
+ 12 | 	useInsertionEffect,
     `----
 
   x NEXT_RSC_ERR_REACT_API: useInsertionEffect
-    ,-[input.js:12:5]
- 12 | useInsertionEffect,
-    : ^^^^^^^^^^^^^^^^^^
+    ,-[input.js:11:1]
+ 11 |   useDeferredValue,
+ 12 | 	useInsertionEffect,
+    :  ^^^^^^^^^^^^^^^^^^
+ 13 | 	useLayoutEffect,
     `----
 
   x NEXT_RSC_ERR_REACT_API: useLayoutEffect
-    ,-[input.js:13:5]
- 13 | useLayoutEffect,
-    : ^^^^^^^^^^^^^^^
+    ,-[input.js:12:1]
+ 12 | 	useInsertionEffect,
+ 13 | 	useLayoutEffect,
+    :  ^^^^^^^^^^^^^^^
+ 14 | 	useReducer,
     `----
 
   x NEXT_RSC_ERR_REACT_API: useReducer
-    ,-[input.js:14:5]
- 14 | useReducer,
-    : ^^^^^^^^^^
+    ,-[input.js:13:1]
+ 13 | 	useLayoutEffect,
+ 14 | 	useReducer,
+    :  ^^^^^^^^^^
+ 15 | 	useRef,
     `----
 
   x NEXT_RSC_ERR_REACT_API: useRef
-    ,-[input.js:15:5]
- 15 | useRef,
-    : ^^^^^^
+    ,-[input.js:14:1]
+ 14 | 	useReducer,
+ 15 | 	useRef,
+    :  ^^^^^^
+ 16 | 	useSyncExternalStore
     `----
 
   x NEXT_RSC_ERR_REACT_API: useSyncExternalStore
-    ,-[input.js:16:5]
- 16 | useSyncExternalStore
-    : ^^^^^^^^^^^^^^^^^^^^
+    ,-[input.js:15:1]
+ 15 | 	useRef,
+ 16 | 	useSyncExternalStore
+    :  ^^^^^^^^^^^^^^^^^^^^
+ 17 | } from "react"
     `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-dom-api/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-dom-api/output.stderr
@@ -1,18 +1,24 @@
 
   x NEXT_RSC_ERR_REACT_API: findDOMNode
-   ,-[input.js:2:5]
- 2 | findDOMNode,
-   : ^^^^^^^^^^^
+   ,-[input.js:1:1]
+ 1 | import {
+ 2 | 	findDOMNode,
+   :  ^^^^^^^^^^^
+ 3 |   flushSync,
    `----
 
   x NEXT_RSC_ERR_REACT_API: flushSync
-   ,-[input.js:3:3]
- 3 | flushSync,
-   : ^^^^^^^^^
+   ,-[input.js:2:1]
+ 2 | 	findDOMNode,
+ 3 |   flushSync,
+   :   ^^^^^^^^^
+ 4 |   unstable_batchedUpdates,
    `----
 
   x NEXT_RSC_ERR_REACT_API: unstable_batchedUpdates
-   ,-[input.js:4:3]
- 4 | unstable_batchedUpdates,
-   : ^^^^^^^^^^^^^^^^^^^^^^^
+   ,-[input.js:3:1]
+ 3 |   flushSync,
+ 4 |   unstable_batchedUpdates,
+   :   ^^^^^^^^^^^^^^^^^^^^^^^
+ 5 | } from "react-dom"
    `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-dom-server-client/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-dom-server-client/output.stderr
@@ -1,12 +1,14 @@
 
   x NEXT_RSC_ERR_SERVER_IMPORT: react-dom/server
-   ,-[input.js:9:1]
+   ,-[input.js:8:1]
+ 8 | 
  9 | import "react-dom/server"
    : ^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
   x NEXT_RSC_ERR_SERVER_IMPORT: react-dom/client
-    ,-[input.js:11:1]
+    ,-[input.js:10:1]
+ 10 | 
  11 | import "react-dom/client"
     : ^^^^^^^^^^^^^^^^^^^^^^^^^
     `----

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -50,13 +50,13 @@ swc_core = { features = [
   "ecma_transforms_typescript",
   "ecma_utils",
   "ecma_visit",
-], version = "0.44.2" }
+], version = "0.45.4" }
 tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.9"
 tracing-chrome = "0.5.0"
-next-dev = { git = "https://github.com/vercel/turbo.git", rev = "c69298c4a31516129bb62263f163a1da9c5614da", features = ["serializable"] }
-node-file-trace = { git = "https://github.com/vercel/turbo.git", rev = "c69298c4a31516129bb62263f163a1da9c5614da", default-features = false, features = ["node-api"] }
+next-dev = { git = "https://github.com/vercel/turbo.git", rev = "cc024fa59f1c3ad253e74eefe86e0386455455d1", features = ["serializable"] }
+node-file-trace = { git = "https://github.com/vercel/turbo.git", rev = "cc024fa59f1c3ad253e74eefe86e0386455455d1", default-features = false, features = ["node-api"] }
 mdxjs = { version = "0.1.3", features = ["serializable"] }
 # There are few build targets we can't use native-tls which default features rely on,
 # allow to specify alternative (rustls) instead via features.

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -50,14 +50,14 @@ swc_core = { features = [
   "ecma_transforms_typescript",
   "ecma_utils",
   "ecma_visit",
-], version = "0.43.23" }
+], version = "0.44.2" }
 tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.9"
 tracing-chrome = "0.5.0"
-next-dev = { git = "https://github.com/vercel/turbo.git", rev = "5c2b933ce142d70e9774e933e805734f2c09248c", features = ["serializable"] }
-node-file-trace = { git = "https://github.com/vercel/turbo.git", rev = "5c2b933ce142d70e9774e933e805734f2c09248c", default-features = false, features = ["node-api"] }
-mdxjs = { version = "0.1.1", features = ["serializable"] }
+next-dev = { git = "https://github.com/vercel/turbo.git", rev = "c69298c4a31516129bb62263f163a1da9c5614da", features = ["serializable"] }
+node-file-trace = { git = "https://github.com/vercel/turbo.git", rev = "c69298c4a31516129bb62263f163a1da9c5614da", default-features = false, features = ["node-api"] }
+mdxjs = { version = "0.1.3", features = ["serializable"] }
 # There are few build targets we can't use native-tls which default features rely on,
 # allow to specify alternative (rustls) instead via features.
 # Note to opt in rustls default-features should be disabled
@@ -70,7 +70,6 @@ _sentry_rustls = { package = "sentry", version = "0.27.0", default-features = fa
   "rustls",
   "reqwest"
 ], optional = true }
-indexmap = "=1.6.2"
 
 [build-dependencies]
 napi-build = "2"

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -46,7 +46,7 @@ swc_core = { features = [
   "ecma_parser_typescript",
   "ecma_utils",
   "ecma_visit"
-], version = "0.44.2" }
+], version = "0.45.4" }
 
 
 # Workaround a bug

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -31,7 +31,7 @@ wasm-bindgen-futures = "0.4.8"
 getrandom = { version = "0.2.5", optional = true, default-features = false }
 js-sys = "0.3.59"
 serde-wasm-bindgen = "0.4.3"
-mdxjs = { version = "0.1.1", features = ["serializable"] }
+mdxjs = { version = "0.1.3", features = ["serializable"] }
 
 swc_core = { features = [
   "common_concurrent",
@@ -46,7 +46,7 @@ swc_core = { features = [
   "ecma_parser_typescript",
   "ecma_utils",
   "ecma_visit"
-], version = "0.43.23" }
+], version = "0.44.2" }
 
 
 # Workaround a bug

--- a/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -142,9 +142,12 @@ exports[`ReactRefreshLogBox app syntax > runtime error 2`] = `
 "./index.js
 Error: 
   x Expected '}', got '<eof>'
-   ,----
- 8 | export default function FunctionNamed() {
-   :                                         ^
+   ,-[5:1]
+ 5 |           i++
+ 6 |           throw Error('no ' + i)
+ 7 |         }, 1000)
+ 8 |         export default function FunctionNamed() {
+   :                                                 ^
    \`----
 
 Caused by:
@@ -157,9 +160,12 @@ exports[`ReactRefreshLogBox app syntax > runtime error 3`] = `
 "./index.js
 Error: 
   x Expected '}', got '<eof>'
-   ,----
- 8 | export default function FunctionNamed() {
-   :                                         ^
+   ,-[5:1]
+ 5 |           i++
+ 6 |           throw Error('no ' + i)
+ 7 |         }, 1000)
+ 8 |         export default function FunctionNamed() {
+   :                                                 ^
    \`----
 
 Caused by:
@@ -172,15 +178,21 @@ exports[`ReactRefreshLogBox app unterminated JSX 1`] = `
 "./index.js
 Error: 
   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
-   ,----
- 8 | }
-   : ^
+   ,-[5:1]
+ 5 |               <p>lol</p>
+ 6 |             div
+ 7 |           )
+ 8 |         }
+   :         ^
+ 9 |       
    \`----
 
   x Unexpected eof
-   ,----
- 9 |  
-   : ^
+   ,-[6:1]
+ 6 |             div
+ 7 |           )
+ 8 |         }
+ 9 |       
    \`----
 
 Caused by:

--- a/test/development/acceptance/__snapshots__/ReactRefreshLogBox-app-doc.test.ts.snap
+++ b/test/development/acceptance/__snapshots__/ReactRefreshLogBox-app-doc.test.ts.snap
@@ -4,16 +4,25 @@ exports[`ReactRefreshLogBox _app syntax error shows logbox 1`] = `
 "./pages/_app.js
 Error: 
   x Expression expected
-   ,----
- 3 | return <<Component {...pageProps} />;
-   :         ^
+   ,-[1:1]
+ 1 | 
+ 2 |             function MyApp({ Component, pageProps }) {
+ 3 |               return <<Component {...pageProps} />;
+   :                       ^
+ 4 |             }
+ 5 |             export default MyApp
+ 6 |           
    \`----
 
-  x Unexpected token \`jsx name (Component)\`. Expected this, import, async, function, [ for array literal, { for object literal, @ for decorator, function, class, null, true, false, number, bigint,
-  | string, regexp, \` for template literal, (, or an identifier
-   ,----
- 3 | return <<Component {...pageProps} />;
-   :          ^^^^^^^^^
+  x Expression expected
+   ,-[1:1]
+ 1 | 
+ 2 |             function MyApp({ Component, pageProps }) {
+ 3 |               return <<Component {...pageProps} />;
+   :                        ^^^^^^^^^
+ 4 |             }
+ 5 |             export default MyApp
+ 6 |           
    \`----
 
 Caused by:
@@ -25,9 +34,15 @@ exports[`ReactRefreshLogBox _document syntax error shows logbox 1`] = `
 "./pages/_document.js
 Error: 
   x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
-   ,----
- 4 | class MyDocument extends Document {{
-   :                                    ^
+   ,-[1:1]
+ 1 | 
+ 2 |             import Document, { Html, Head, Main, NextScript } from 'next/document'
+ 3 | 
+ 4 |             class MyDocument extends Document {{
+   :                                                ^
+ 5 |               static async getInitialProps(ctx) {
+ 6 |                 const initialProps = await Document.getInitialProps(ctx)
+ 7 |                 return { ...initialProps }
    \`----
 
 Caused by:

--- a/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -142,9 +142,12 @@ exports[`ReactRefreshLogBox syntax > runtime error 2`] = `
 "./index.js
 Error: 
   x Expected '}', got '<eof>'
-   ,----
- 8 | export default function FunctionNamed() {
-   :                                         ^
+   ,-[5:1]
+ 5 |           i++
+ 6 |           throw Error('no ' + i)
+ 7 |         }, 1000)
+ 8 |         export default function FunctionNamed() {
+   :                                                 ^
    \`----
 
 Caused by:
@@ -157,9 +160,12 @@ exports[`ReactRefreshLogBox syntax > runtime error 3`] = `
 "./index.js
 Error: 
   x Expected '}', got '<eof>'
-   ,----
- 8 | export default function FunctionNamed() {
-   :                                         ^
+   ,-[5:1]
+ 5 |           i++
+ 6 |           throw Error('no ' + i)
+ 7 |         }, 1000)
+ 8 |         export default function FunctionNamed() {
+   :                                                 ^
    \`----
 
 Caused by:
@@ -172,15 +178,21 @@ exports[`ReactRefreshLogBox unterminated JSX 1`] = `
 "./index.js
 Error: 
   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
-   ,----
- 8 | }
-   : ^
+   ,-[5:1]
+ 5 |               <p>lol</p>
+ 6 |             div
+ 7 |           )
+ 8 |         }
+   :         ^
+ 9 |       
    \`----
 
   x Unexpected eof
-   ,----
- 9 |  
-   : ^
+   ,-[6:1]
+ 6 |             div
+ 7 |           )
+ 8 |         }
+ 9 |       
    \`----
 
 Caused by:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

Fixes WEB-166.

This supersedes https://github.com/vercel/next.js/pull/43449, updating swc_core and turbopack both with its transititive dependencies. Version bump includes one important build side issues to having circular dependencies.
