### PR TITLE
Update cache handling for app

### DIFF
--- a/packages/next/client/components/app-router-headers.ts
+++ b/packages/next/client/components/app-router-headers.ts
@@ -1,6 +1,7 @@
 export const RSC = 'RSC' as const
 export const NEXT_ROUTER_STATE_TREE = 'Next-Router-State-Tree' as const
 export const NEXT_ROUTER_PREFETCH = 'Next-Router-Prefetch' as const
+export const FETCH_CACHE_HEADER = 'x-vercel-sc-headers' as const
 export const RSC_VARY_HEADER =
   `${RSC}, ${NEXT_ROUTER_STATE_TREE}, ${NEXT_ROUTER_PREFETCH}` as const
 

--- a/packages/next/client/components/static-generation-async-storage.ts
+++ b/packages/next/client/components/static-generation-async-storage.ts
@@ -7,6 +7,9 @@ export interface StaticGenerationStore {
   fetchRevalidate?: number
   isStaticGeneration?: boolean
   forceStatic?: boolean
+  incrementalCache?: import('../../server/lib/incremental-cache').IncrementalCache
+  pendingRevalidates?: Promise<any>[]
+  isRevalidate?: boolean
 }
 
 export let staticGenerationAsyncStorage:

--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -12,7 +12,7 @@ import '../server/node-polyfill-fetch'
 import { loadRequireHook } from '../build/webpack/require-hook'
 
 import { extname, join, dirname, sep } from 'path'
-import { promises } from 'fs'
+import fs, { promises } from 'fs'
 import AmpHtmlValidator from 'next/dist/compiled/amphtml-validator'
 import { loadComponents } from '../server/load-components'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
@@ -32,6 +32,7 @@ import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import { REDIRECT_ERROR_CODE } from '../client/components/redirect'
 import { DYNAMIC_ERROR_CODE } from '../client/components/hooks-server-context'
 import { NOT_FOUND_ERROR_CODE } from '../client/components/not-found'
+import { IncrementalCache } from '../server/lib/incremental-cache'
 
 loadRequireHook()
 
@@ -98,6 +99,7 @@ interface RenderOpts {
   domainLocales?: DomainLocale[]
   trailingSlash?: boolean
   supportsDynamicHTML?: boolean
+  incrementalCache?: import('../server/lib/incremental-cache').IncrementalCache
 }
 
 // expose AsyncLocalStorage on globalThis for react usage
@@ -310,6 +312,31 @@ export default async function exportPage({
       // and bail when dynamic dependencies are detected
       // only fully static paths are fully generated here
       if (isAppDir) {
+        curRenderOpts.incrementalCache = new IncrementalCache({
+          dev: false,
+          requestHeaders: {},
+          flushToDisk: true,
+          maxMemoryCacheSize: 50 * 1024 * 1024,
+          getPrerenderManifest: () => ({
+            version: 3,
+            routes: {},
+            dynamicRoutes: {},
+            preview: {
+              previewModeEncryptionKey: '',
+              previewModeId: '',
+              previewModeSigningKey: '',
+            },
+            notFoundRoutes: [],
+          }),
+          fs: {
+            readFile: (f) => fs.promises.readFile(f, 'utf8'),
+            readFileSync: (f) => fs.readFileSync(f, 'utf8'),
+            writeFile: (f, d) => fs.promises.writeFile(f, d, 'utf8'),
+            mkdir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
+            stat: (f) => fs.promises.stat(f),
+          },
+          serverDistDir: join(distDir, 'server'),
+        })
         const { renderToHTMLOrFlight } =
           require('../server/app-render') as typeof import('../server/app-render')
 

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -1215,7 +1215,7 @@ export async function renderToHTMLOrFlight(
         // otherwise
         if (layoutOrPageMod.dynamic === 'force-static') {
           staticGenerationStore.forceStatic = true
-        } else {
+        } else if (layoutOrPageMod.dynamic !== 'error') {
           staticGenerationStore.forceStatic = false
         }
       }

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -80,6 +80,7 @@ function preloadComponent(Component: any, props: any) {
   return Component
 }
 
+const CACHE_ONE_YEAR = 31536000
 const INTERNAL_HEADERS_INSTANCE = Symbol('internal for headers readonly')
 
 function readonlyHeadersError() {
@@ -176,6 +177,8 @@ export type RenderOptsPartial = {
   assetPrefix?: string
   fontLoaderManifest?: FontLoaderManifest
   isBot?: boolean
+  incrementalCache?: import('./lib/incremental-cache').IncrementalCache
+  isRevalidate?: boolean
 }
 
 export type RenderOpts = LoadComponentsReturnType & RenderOptsPartial
@@ -245,12 +248,115 @@ function patchFetch(ComponentMod: any) {
   const originFetch = globalThis.fetch
   globalThis.fetch = async (input, init) => {
     const staticGenerationStore =
-      'getStore' in staticGenerationAsyncStorage
+      ('getStore' in staticGenerationAsyncStorage
         ? staticGenerationAsyncStorage.getStore()
-        : staticGenerationAsyncStorage
+        : staticGenerationAsyncStorage) || {}
 
-    const { isStaticGeneration, fetchRevalidate, pathname } =
-      staticGenerationStore || {}
+    const {
+      isStaticGeneration,
+      fetchRevalidate,
+      pathname,
+      incrementalCache,
+      isRevalidate,
+    } = (staticGenerationStore || {}) as StaticGenerationStore
+
+    let revalidate: number | undefined | boolean
+
+    if (typeof init?.next?.revalidate === 'number') {
+      revalidate = init.next.revalidate
+    }
+    if (init?.next?.revalidate === false) {
+      revalidate = CACHE_ONE_YEAR
+    }
+
+    if (
+      !staticGenerationStore.fetchRevalidate ||
+      (typeof revalidate === 'number' &&
+        revalidate < staticGenerationStore.fetchRevalidate)
+    ) {
+      staticGenerationStore.fetchRevalidate = revalidate
+    }
+
+    let cacheKey: string | undefined
+
+    const doOriginalFetch = async () => {
+      return originFetch(input, init).then(async (res) => {
+        if (
+          incrementalCache &&
+          cacheKey &&
+          typeof revalidate === 'number' &&
+          revalidate > 0
+        ) {
+          const clonedRes = res.clone()
+
+          let base64Body = ''
+
+          if (process.env.NEXT_RUNTIME === 'edge') {
+            let string = ''
+            new Uint8Array(await clonedRes.arrayBuffer()).forEach((byte) => {
+              string += String.fromCharCode(byte)
+            })
+            base64Body = btoa(string)
+          } else {
+            base64Body = Buffer.from(await clonedRes.arrayBuffer()).toString(
+              'base64'
+            )
+          }
+
+          await incrementalCache.set(
+            cacheKey,
+            {
+              kind: 'FETCH',
+              isStale: false,
+              age: 0,
+              data: {
+                headers: Object.fromEntries(clonedRes.headers.entries()),
+                body: base64Body,
+              },
+              revalidate,
+            },
+            revalidate,
+            true
+          )
+        }
+        return res
+      })
+    }
+
+    if (incrementalCache && typeof revalidate === 'number' && revalidate > 0) {
+      cacheKey = await incrementalCache?.fetchCacheKey(input.toString(), init)
+      const entry = await incrementalCache.get(cacheKey, true)
+
+      if (entry?.value && entry.value.kind === 'FETCH') {
+        // when stale and is revalidating we wait for fresh data
+        // so the revalidated entry has the updated data
+        if (!isRevalidate || !entry.isStale) {
+          if (entry.isStale) {
+            if (!staticGenerationStore.pendingRevalidates) {
+              staticGenerationStore.pendingRevalidates = []
+            }
+            staticGenerationStore.pendingRevalidates.push(
+              doOriginalFetch().catch(console.error)
+            )
+          }
+
+          const resData = entry.value.data
+          let decodedBody = ''
+
+          // TODO: handle non-text response bodies
+          if (process.env.NEXT_RUNTIME === 'edge') {
+            decodedBody = atob(resData.body)
+          } else {
+            decodedBody = Buffer.from(resData.body, 'base64').toString()
+          }
+
+          return new Response(decodedBody, {
+            headers: resData.headers,
+            status: resData.status,
+          })
+        }
+      }
+    }
 
     if (staticGenerationStore && isStaticGeneration) {
       if (init && typeof init === 'object') {
@@ -292,7 +398,7 @@ function patchFetch(ComponentMod: any) {
         if (hasNextConfig) delete init.next
       }
     }
-    return originFetch(input, init)
+    return doOriginalFetch()
   }
 }
 
@@ -771,9 +877,7 @@ export async function renderToHTMLOrFlight(
     supportsDynamicHTML,
   } = renderOpts
 
-  if (process.env.NODE_ENV === 'production') {
-    patchFetch(ComponentMod)
-  }
+  patchFetch(ComponentMod)
   const generateStaticHTML = supportsDynamicHTML !== true
 
   const staticGenerationAsyncStorage = ComponentMod.staticGenerationAsyncStorage
@@ -1726,6 +1830,10 @@ export async function renderToHTMLOrFlight(
     }
     const renderResult = new RenderResult(await bodyResult())
 
+    if (staticGenerationStore.pendingRevalidates) {
+      await Promise.all(staticGenerationStore.pendingRevalidates)
+    }
+
     if (isStaticGeneration) {
       const htmlResult = await streamToBufferedResult(renderResult)
 
@@ -1744,6 +1852,9 @@ export async function renderToHTMLOrFlight(
         await generateFlight()
       )
 
+      if (staticGenerationStore?.forceStatic === false) {
+        staticGenerationStore.fetchRevalidate = 0
+      }
       ;(renderOpts as any).pageData = filteredFlightData
       ;(renderOpts as any).revalidate =
         typeof staticGenerationStore?.fetchRevalidate === 'undefined'
@@ -1760,6 +1871,8 @@ export async function renderToHTMLOrFlight(
     isStaticGeneration,
     inUse: true,
     pathname,
+    incrementalCache: renderOpts.incrementalCache,
+    isRevalidate: renderOpts.isRevalidate,
   }
 
   const tryGetPreviewData =

--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -277,6 +277,9 @@ const configSchema = {
         fallbackNodePolyfills: {
           type: 'boolean',
         },
+        fetchCache: {
+          type: 'boolean',
+        },
         forceSwcTransforms: {
           type: 'boolean',
         },

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -79,6 +79,7 @@ export interface NextJsWebpackConfig {
 }
 
 export interface ExperimentalConfig {
+  fetchCache?: boolean
   allowMiddlewareResponseBody?: boolean
   skipMiddlewareUrlNormalize?: boolean
   skipTrailingSlashRedirect?: boolean
@@ -565,6 +566,7 @@ export const defaultConfig: NextConfig = {
   swcMinify: true,
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   experimental: {
+    fetchCache: false,
     middlewarePrefetch: 'flexible',
     optimisticClientCache: true,
     runtime: undefined,

--- a/packages/next/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/server/lib/incremental-cache/fetch-cache.ts
@@ -1,0 +1,162 @@
+import LRUCache from 'next/dist/compiled/lru-cache'
+import { FETCH_CACHE_HEADER } from '../../../client/components/app-router-headers'
+import type { CacheHandler, CacheHandlerContext, CacheHandlerValue } from './'
+
+let memoryCache: LRUCache<string, CacheHandlerValue> | undefined
+
+export default class FetchCache implements CacheHandler {
+  private headers: Record<string, string>
+  private cacheEndpoint: string
+  private debug: boolean
+
+  constructor(ctx: CacheHandlerContext) {
+    if (ctx.maxMemoryCacheSize && !memoryCache) {
+      memoryCache = new LRUCache({
+        max: ctx.maxMemoryCacheSize,
+        length({ value }) {
+          if (!value) {
+            return 25
+          } else if (value.kind === 'REDIRECT') {
+            return JSON.stringify(value.props).length
+          } else if (value.kind === 'IMAGE') {
+            throw new Error('invariant image should not be incremental-cache')
+          } else if (value.kind === 'FETCH') {
+            return JSON.stringify(value.data || '').length
+          }
+          // rough estimate of size of cache value
+          return (
+            value.html.length + (JSON.stringify(value.pageData)?.length || 0)
+          )
+        },
+      })
+    }
+    this.debug = !!process.env.NEXT_PRIVATE_DEBUG_CACHE
+    this.headers = {}
+    this.headers['Content-Type'] = 'application/json'
+
+    if (FETCH_CACHE_HEADER in ctx._requestHeaders) {
+      const newHeaders = JSON.parse(
+        ctx._requestHeaders[FETCH_CACHE_HEADER] as string
+      )
+      for (const k in newHeaders) {
+        this.headers[k] = newHeaders[k]
+      }
+    }
+    this.cacheEndpoint = `https://${ctx._requestHeaders['x-vercel-sc-host']}${
+      ctx._requestHeaders['x-vercel-sc-basepath'] || ''
+    }`
+    if (this.debug) {
+      console.log('using cache endpoint', this.cacheEndpoint)
+    }
+  }
+
+  public async get(key: string, fetchCache?: boolean) {
+    if (!fetchCache) return null
+
+    let data = memoryCache?.get(key)
+
+    // get data from fetch cache
+    if (!data) {
+      try {
+        const start = Date.now()
+        const res = await fetch(
+          `${this.cacheEndpoint}/v1/suspense-cache/getItems`,
+          {
+            method: 'POST',
+            body: JSON.stringify([key]),
+            headers: this.headers,
+          }
+        )
+
+        if (!res.ok) {
+          console.error(await res.text())
+          throw new Error(`invalid response from cache ${res.status}`)
+        }
+
+        const items = await res.json()
+        const item = items[key]
+
+        if (!item || !item.value) {
+          console.log({ item })
+          throw new Error(`invalid item returned`)
+        }
+
+        const cached = JSON.parse(item.value)
+
+        if (!cached || cached.kind !== 'FETCH') {
+          this.debug && console.log({ cached })
+          throw new Error(`invalid cache value`)
+        }
+
+        data = {
+          lastModified: Date.now() - item.age * 1000,
+          value: cached,
+        }
+        if (this.debug) {
+          console.log(
+            'got fetch cache entry duration:',
+            Date.now() - start,
+            data
+          )
+        }
+
+        if (data) {
+          memoryCache?.set(key, data)
+        }
+      } catch (err) {
+        // unable to get data from fetch-cache
+        console.error(`Failed to get from fetch-cache`, err)
+      }
+    }
+    return data || null
+  }
+
+  public async set(
+    key: string,
+    data: CacheHandlerValue['value'],
+    fetchCache?: boolean
+  ) {
+    if (!fetchCache) return
+
+    memoryCache?.set(key, {
+      value: data,
+      lastModified: Date.now(),
+    })
+
+    try {
+      const start = Date.now()
+      const body = JSON.stringify([
+        {
+          id: key,
+          value: JSON.stringify(data),
+        },
+      ])
+
+      const res = await fetch(
+        `${this.cacheEndpoint}/v1/suspense-cache/setItems`,
+        {
+          method: 'POST',
+          headers: this.headers,
+          body: body,
+        }
+      )
+
+      if (!res.ok) {
+        this.debug && console.log(await res.text())
+        throw new Error(`invalid response ${res.status}`)
+      }
+
+      if (this.debug) {
+        console.log(
+          'successfully set to fetch-cache duration:',
+          Date.now() - start,
+          body
+        )
+      }
+    } catch (err) {
+      // unable to set to fetch-cache
+      console.error(`Failed to update fetch cache`, err)
+    }
+    return
+  }
+}

--- a/packages/next/server/lib/incremental-cache/index.ts
+++ b/packages/next/server/lib/incremental-cache/index.ts
@@ -3,6 +3,7 @@ import FileSystemCache from './file-system-cache'
 import { PrerenderManifest } from '../../../build'
 import path from '../../../shared/lib/isomorphic/path'
 import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
+import FetchCache from './fetch-cache'
 import {
   IncrementalCacheValue,
   IncrementalCacheEntry,
@@ -18,7 +19,8 @@ export interface CacheHandlerContext {
   flushToDisk?: boolean
   serverDistDir: string
   maxMemoryCacheSize?: number
-  _appDir?: boolean
+  _appDir: boolean
+  _requestHeaders: IncrementalCache['requestHeaders']
 }
 
 export interface CacheHandlerValue {
@@ -30,13 +32,17 @@ export class CacheHandler {
   // eslint-disable-next-line
   constructor(_ctx: CacheHandlerContext) {}
 
-  public async get(_key: string): Promise<CacheHandlerValue | null> {
+  public async get(
+    _key: string,
+    _fetchCache?: boolean
+  ): Promise<CacheHandlerValue | null> {
     return {} as any
   }
 
   public async set(
     _key: string,
-    _data: IncrementalCacheValue | null
+    _data: IncrementalCacheValue | null,
+    _fetchCache?: boolean
   ): Promise<void> {}
 }
 
@@ -44,13 +50,18 @@ export class IncrementalCache {
   dev?: boolean
   cacheHandler: CacheHandler
   prerenderManifest: PrerenderManifest
+  requestHeaders: Record<string, undefined | string | string[]>
+  minimalMode?: boolean
 
   constructor({
     fs,
     dev,
     appDir,
     flushToDisk,
+    fetchCache,
+    minimalMode,
     serverDistDir,
+    requestHeaders,
     maxMemoryCacheSize,
     getPrerenderManifest,
     incrementalCacheHandlerPath,
@@ -58,8 +69,11 @@ export class IncrementalCache {
     fs: CacheFs
     dev: boolean
     appDir?: boolean
+    fetchCache?: boolean
+    minimalMode?: boolean
     serverDistDir: string
     flushToDisk?: boolean
+    requestHeaders: IncrementalCache['requestHeaders']
     maxMemoryCacheSize?: number
     incrementalCacheHandlerPath?: string
     getPrerenderManifest: () => PrerenderManifest
@@ -71,11 +85,17 @@ export class IncrementalCache {
       cacheHandlerMod = cacheHandlerMod.default || cacheHandlerMod
     }
 
+    if (minimalMode && fetchCache) {
+      cacheHandlerMod = FetchCache
+    }
+
     if (process.env.__NEXT_TEST_MAX_ISR_CACHE) {
       // Allow cache size to be overridden for testing purposes
       maxMemoryCacheSize = parseInt(process.env.__NEXT_TEST_MAX_ISR_CACHE, 10)
     }
     this.dev = dev
+    this.minimalMode = minimalMode
+    this.requestHeaders = requestHeaders
     this.prerenderManifest = getPrerenderManifest()
     this.cacheHandler = new (cacheHandlerMod as typeof CacheHandler)({
       dev,
@@ -83,7 +103,8 @@ export class IncrementalCache {
       flushToDisk,
       serverDistDir,
       maxMemoryCacheSize,
-      _appDir: appDir,
+      _appDir: !!appDir,
+      _requestHeaders: requestHeaders,
     })
   }
 
@@ -110,19 +131,75 @@ export class IncrementalCache {
     return revalidateAfter
   }
 
-  _getPathname(pathname: string) {
-    return normalizePagePath(pathname)
+  _getPathname(pathname: string, fetchCache?: boolean) {
+    return fetchCache ? pathname : normalizePagePath(pathname)
+  }
+
+  // x-ref: https://github.com/facebook/react/blob/2655c9354d8e1c54ba888444220f63e836925caa/packages/react/src/ReactFetch.js#L23
+  async fetchCacheKey(url: string, init: RequestInit = {}): Promise<string> {
+    const cacheString = JSON.stringify([
+      url,
+      init.method,
+      init.headers,
+      init.mode,
+      init.redirect,
+      init.credentials,
+      init.referrer,
+      init.referrerPolicy,
+      init.integrity,
+      init.next,
+      init.cache,
+    ])
+    let cacheKey: string
+
+    if (process.env.NEXT_RUNTIME === 'edge') {
+      function bufferToHex(buffer: ArrayBuffer): string {
+        return Array.prototype.map
+          .call(new Uint8Array(buffer), (b) => b.toString(16).padStart(2, '0'))
+          .join('')
+      }
+      const buffer = new TextEncoder().encode(cacheString)
+      cacheKey = bufferToHex(await crypto.subtle.digest('SHA-256', buffer))
+    } else {
+      const crypto = require('crypto') as typeof import('crypto')
+      cacheKey = crypto.createHash('sha256').update(cacheString).digest('hex')
+    }
+    return cacheKey
   }
 
   // get data from cache if available
-  async get(pathname: string): Promise<IncrementalCacheEntry | null> {
+  async get(
+    pathname: string,
+    fetchCache?: boolean
+  ): Promise<IncrementalCacheEntry | null> {
     // we don't leverage the prerender cache in dev mode
     // so that getStaticProps is always called for easier debugging
     if (this.dev) return null
 
-    pathname = this._getPathname(pathname)
+    pathname = this._getPathname(pathname, fetchCache)
     let entry: IncrementalCacheEntry | null = null
-    const cacheData = await this.cacheHandler.get(pathname)
+    const cacheData = await this.cacheHandler.get(pathname, fetchCache)
+
+    if (cacheData?.value?.kind === 'FETCH') {
+      const data = cacheData.value.data
+      const age = Math.round(
+        (Date.now() - (cacheData.lastModified || 0)) / 1000
+      )
+      const revalidate = cacheData.value.revalidate
+
+      return {
+        isStale: age > revalidate,
+        value: {
+          kind: 'FETCH',
+          data,
+          age,
+          revalidate,
+          isStale: age > revalidate,
+        },
+        revalidateAfter:
+          (cacheData.lastModified || Date.now()) + revalidate * 1000,
+      }
+    }
 
     const curRevalidate =
       this.prerenderManifest.routes[toRoute(pathname)]?.initialRevalidateSeconds
@@ -159,7 +236,7 @@ export class IncrementalCache {
         curRevalidate,
         revalidateAfter,
       }
-      this.set(pathname, entry.value, curRevalidate)
+      this.set(pathname, entry.value, curRevalidate, fetchCache)
     }
     return entry
   }
@@ -168,16 +245,17 @@ export class IncrementalCache {
   async set(
     pathname: string,
     data: IncrementalCacheValue | null,
-    revalidateSeconds?: number | false
+    revalidateSeconds?: number | false,
+    fetchCache?: boolean
   ) {
     if (this.dev) return
-    pathname = this._getPathname(pathname)
+    pathname = this._getPathname(pathname, fetchCache)
 
     try {
       // we use the prerender manifest memory instance
       // to store revalidate timings for calculating
       // revalidateAfter values so we update this on set
-      if (typeof revalidateSeconds !== 'undefined') {
+      if (typeof revalidateSeconds !== 'undefined' && !fetchCache) {
         this.prerenderManifest.routes[pathname] = {
           dataRoute: path.posix.join(
             '/_next/data',
@@ -187,7 +265,7 @@ export class IncrementalCache {
           initialRevalidateSeconds: revalidateSeconds,
         }
       }
-      await this.cacheHandler.set(pathname, data)
+      await this.cacheHandler.set(pathname, data, fetchCache)
     } catch (error) {
       console.warn('Failed to update prerender cache for', pathname, error)
     }

--- a/packages/next/server/response-cache/types.ts
+++ b/packages/next/server/response-cache/types.ts
@@ -7,8 +7,17 @@ export interface ResponseCacheBase {
     context: {
       isManualRevalidate?: boolean
       isPrefetch?: boolean
+      incrementalCache: IncrementalCache
     }
   ): Promise<ResponseCacheEntry | null>
+}
+
+export interface CachedFetchValue {
+  kind: 'FETCH'
+  data: any
+  isStale: boolean
+  age: number
+  revalidate: number
 }
 
 export interface CachedRedirectValue {
@@ -53,6 +62,7 @@ export type IncrementalCacheValue =
   | CachedRedirectValue
   | IncrementalCachedPageValue
   | CachedImageValue
+  | CachedFetchValue
 
 export type ResponseCacheValue =
   | CachedRedirectValue

--- a/packages/next/server/response-cache/web.ts
+++ b/packages/next/server/response-cache/web.ts
@@ -24,6 +24,7 @@ export default class WebResponseCache {
     context: {
       isManualRevalidate?: boolean
       isPrefetch?: boolean
+      incrementalCache: any
     }
   ): Promise<ResponseCacheEntry | null> {
     // ensure manual revalidate doesn't block normal requests

--- a/packages/next/server/web-server.ts
+++ b/packages/next/server/web-server.ts
@@ -54,6 +54,9 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
     // For the web server layer, compression is automatically handled by the
     // upstream proxy (edge runtime or node server) and we can simply skip here.
   }
+  protected getIncrementalCache() {
+    return {} as any
+  }
   protected getResponseCache() {
     return new WebResponseCache(this.minimalMode)
   }

--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -11,6 +11,7 @@ import { NextURL } from './next-url'
 import { stripInternalSearchParams } from '../internal-utils'
 import { normalizeRscPath } from '../../shared/lib/router/utils/app-paths'
 import {
+  FETCH_CACHE_HEADER,
   NEXT_ROUTER_PREFETCH,
   NEXT_ROUTER_STATE_TREE,
   RSC,
@@ -45,6 +46,7 @@ const FLIGHT_PARAMETERS = [
   [RSC],
   [NEXT_ROUTER_STATE_TREE],
   [NEXT_ROUTER_PREFETCH],
+  [FETCH_CACHE_HEADER],
 ] as const
 
 export async function adapter(params: {

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -39,7 +39,7 @@ interface Window {
 }
 
 interface NextFetchRequestConfig {
-  revalidate?: number
+  revalidate?: number | false
 }
 
 interface RequestInit {

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -76,6 +76,10 @@ describe('app-dir static/dynamic handling', () => {
         'ssr-auto/cache-no-store/page.js',
         'ssr-auto/fetch-revalidate-zero/page.js',
         'ssr-forced/page.js',
+        'variable-revalidate/no-store/page.js',
+        'variable-revalidate/revalidate-3.html',
+        'variable-revalidate/revalidate-3.rsc',
+        'variable-revalidate/revalidate-3/page.js',
       ])
     })
 
@@ -167,6 +171,11 @@ describe('app-dir static/dynamic handling', () => {
           initialRevalidateSeconds: false,
           srcRoute: '/ssg-preview/[[...route]]',
         },
+        '/variable-revalidate/revalidate-3': {
+          dataRoute: '/variable-revalidate/revalidate-3.rsc',
+          initialRevalidateSeconds: 3,
+          srcRoute: '/variable-revalidate/revalidate-3',
+        }
       })
       expect(manifest.dynamicRoutes).toEqual({
         '/blog/[author]/[slug]': {

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -175,7 +175,7 @@ describe('app-dir static/dynamic handling', () => {
           dataRoute: '/variable-revalidate/revalidate-3.rsc',
           initialRevalidateSeconds: 3,
           srcRoute: '/variable-revalidate/revalidate-3',
-        }
+        },
       })
       expect(manifest.dynamicRoutes).toEqual({
         '/blog/[author]/[slug]': {

--- a/test/e2e/app-dir/app-static/app/ssr-auto/fetch-revalidate-zero/page.js
+++ b/test/e2e/app-dir/app-static/app/ssr-auto/fetch-revalidate-zero/page.js
@@ -19,6 +19,3 @@ export default function Page() {
     </>
   )
 }
-
-// TODO-APP: remove revalidate config once next.revalidate is supported
-export const revalidate = 0

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/layout.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/layout.js
@@ -1,0 +1,18 @@
+import { cache, use } from 'react'
+
+export default function Layout({ children }) {
+  const getData = cache(() =>
+    fetch('https://next-data-api-endpoint.vercel.app/api/random?layout', {
+      next: { revalidate: 10 },
+    }).then((res) => res.text())
+  )
+  const dataPromise = getData()
+  const data = use(dataPromise)
+
+  return (
+    <>
+      <p id="layout-data">revalidate 10: {data}</p>
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/no-store/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/no-store/page.js
@@ -1,0 +1,19 @@
+import { cache, use } from 'react'
+
+export default function Page() {
+  const getData = cache(() =>
+    fetch('https://next-data-api-endpoint.vercel.app/api/random?page', {
+      cache: 'no-store',
+    }).then((res) => res.text())
+  )
+  const dataPromise = getData()
+  const data = use(dataPromise)
+
+  return (
+    <>
+      <p id="page">/variable-revalidate/no-cache</p>
+      <p id="page-data">no-store: {data}</p>
+      <p id="now">{Date.now()}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/revalidate-3/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/revalidate-3/page.js
@@ -1,0 +1,19 @@
+import { cache, use } from 'react'
+
+export default function Page() {
+  const getData = cache(() =>
+    fetch('https://next-data-api-endpoint.vercel.app/api/random?page', {
+      next: { revalidate: 3 },
+    }).then((res) => res.text())
+  )
+  const dataPromise = getData()
+  const data = use(dataPromise)
+
+  return (
+    <>
+      <p id="page">/variable-revalidate/revalidate-3</p>
+      <p id="page-data">revalidate 3: {data}</p>
+      <p id="now">{Date.now()}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/next.config.js
+++ b/test/e2e/app-dir/app-static/next.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   experimental: {
     appDir: true,
+    fetchCache: true,
   },
   // assetPrefix: '/assets',
   rewrites: async () => {


### PR DESCRIPTION
This updates the app directory caching. 

x-ref: [slack thread ](https://vercel.slack.com/archives/C042LHPJ1NX/p1669231119199339)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
