### PR TITLE
Update flakey GSSP preview test

### DIFF
--- a/test/integration/getserversideprops-preview/test/index.test.js
+++ b/test/integration/getserversideprops-preview/test/index.test.js
@@ -197,6 +197,7 @@ describe('ServerSide Props Preview Mode', () => {
 
     it('should return cookies to be expired after dev server reboot', async () => {
       await killApp(app)
+      appPort = await findPort()
       app = await launchApp(appDir, appPort)
 
       const res = await fetchViaHTTP(


### PR DESCRIPTION
Ensures we grab a new port when launching fresh server as the existing port may still be held up. 

x-ref: https://github.com/vercel/next.js/actions/runs/3611678257/jobs/6086329090