### PR TITLE
Remove additional `<div>` at each segment level in `app`

### DIFF
--- a/packages/next/client/components/layout-router.tsx
+++ b/packages/next/client/components/layout-router.tsx
@@ -95,7 +95,6 @@ class Scroller extends React.Component<{
     // Handle scroll and focus, it's only applied once in the first useEffect that triggers that changed.
     const { focusAndScrollRef } = this.props
     const domNode = findDOMNode(this)
-    console.log({ domNode })
 
     if (focusAndScrollRef.apply && domNode instanceof HTMLElement) {
       // State is mutated to ensure that the focus and scroll is applied only once.

--- a/packages/next/client/components/layout-router.tsx
+++ b/packages/next/client/components/layout-router.tsx
@@ -13,10 +13,7 @@ import type { FocusAndScrollRef } from './reducer'
 
 import React, { useContext, useEffect, use } from 'react'
 import { findDOMNode as ReactDOMfindDOMNode } from 'react-dom'
-import type {
-  ChildProp,
-  //Segment
-} from '../../server/app-render'
+import type { ChildProp } from '../../server/app-render'
 import {
   CacheStates,
   LayoutRouterContext,

--- a/packages/next/client/components/layout-router.tsx
+++ b/packages/next/client/components/layout-router.tsx
@@ -12,7 +12,7 @@ import type { ErrorComponent } from './error-boundary'
 import type { FocusAndScrollRef } from './reducer'
 
 import React, { useContext, useEffect, useRef, use } from 'react'
-import { findDOMNode } from 'react-dom'
+import { findDOMNode as ReactDOMfindDOMNode } from 'react-dom'
 import type {
   ChildProp,
   //Segment
@@ -77,6 +77,31 @@ function walkAddRefetch(
   }
 
   return treeToRecreate
+}
+
+// TODO-APP: Replace with new React API for finding dom nodes without a `ref` when available
+/**
+ * Wraps ReactDOM.findDOMNode with additional logic to hide React Strict Mode warning
+ */
+function findDOMNode(
+  instance: Parameters<typeof ReactDOMfindDOMNode>[0]
+): ReturnType<typeof ReactDOMfindDOMNode> {
+  // Only apply strict mode warning when not in production
+  if (process.env.NODE_ENV !== 'production') {
+    const originalConsoleError = console.error
+    try {
+      console.error = (...messages) => {
+        // Ignore strict mode warning for the findDomNode call below
+        if (!messages[0].includes('Warning: %s is deprecated in StrictMode.')) {
+          originalConsoleError(...messages)
+        }
+      }
+      return ReactDOMfindDOMNode(instance)
+    } finally {
+      console.error = originalConsoleError!
+    }
+  }
+  return ReactDOMfindDOMNode(instance)
 }
 
 /**

--- a/packages/next/client/components/layout-router.tsx
+++ b/packages/next/client/components/layout-router.tsx
@@ -11,7 +11,7 @@ import type {
 import type { ErrorComponent } from './error-boundary'
 import type { FocusAndScrollRef } from './reducer'
 
-import React, { useContext, useEffect, useRef, use } from 'react'
+import React, { useContext, useEffect, use } from 'react'
 import { findDOMNode as ReactDOMfindDOMNode } from 'react-dom'
 import type {
   ChildProp,

--- a/packages/next/client/components/layout-router.tsx
+++ b/packages/next/client/components/layout-router.tsx
@@ -6,7 +6,6 @@ import type {
 import type {
   FlightRouterState,
   FlightSegmentPath,
-  // FlightDataPath,
 } from '../../server/app-render'
 import type { ErrorComponent } from './error-boundary'
 import type { FocusAndScrollRef } from './reducer'

--- a/packages/next/client/components/layout-router.tsx
+++ b/packages/next/client/components/layout-router.tsx
@@ -87,41 +87,7 @@ function topOfElementInViewport(element: HTMLElement) {
   return rect.top >= 0
 }
 
-function Scroller({
-  focusAndScrollRef,
-  children,
-}: {
-  focusAndScrollRef: FocusAndScrollRef
-  children: React.ReactNode
-}) {
-  const focusAndScrollElementRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    // Handle scroll and focus, it's only applied once in the first useEffect that triggers that changed.
-    if (focusAndScrollRef.apply && focusAndScrollElementRef.current) {
-      // State is mutated to ensure that the focus and scroll is applied only once.
-      focusAndScrollRef.apply = false
-      // Set focus on the element
-      focusAndScrollElementRef.current.focus()
-      // Only scroll into viewport when the layout is not visible currently.
-      if (!topOfElementInViewport(focusAndScrollElementRef.current)) {
-        const htmlElement = document.documentElement
-        const existing = htmlElement.style.scrollBehavior
-        htmlElement.style.scrollBehavior = 'auto'
-        focusAndScrollElementRef.current.scrollIntoView()
-        htmlElement.style.scrollBehavior = existing
-      }
-    }
-  }, [focusAndScrollRef])
-
-  return (
-    <div ref={focusAndScrollElementRef} data-nextjs-scroll-focus-boundary={''}>
-      {children}
-    </div>
-  )
-}
-
-class Scroller2 extends React.Component<{
+class Scroller extends React.Component<{
   focusAndScrollRef: FocusAndScrollRef
   children: React.ReactNode
 }> {
@@ -304,7 +270,7 @@ export function InnerLayoutRouter({
 
   // Ensure root layout is not wrapped in a div as the root layout renders `<html>`
   return rootLayoutIncluded ? (
-    <Scroller2 focusAndScrollRef={focusAndScrollRef}>{subtree}</Scroller2>
+    <Scroller focusAndScrollRef={focusAndScrollRef}>{subtree}</Scroller>
   ) : (
     subtree
   )

--- a/packages/next/client/components/layout-router.tsx
+++ b/packages/next/client/components/layout-router.tsx
@@ -112,7 +112,7 @@ function topOfElementInViewport(element: HTMLElement) {
   return rect.top >= 0
 }
 
-class Scroller extends React.Component<{
+class ScrollAndFocusHandler extends React.Component<{
   focusAndScrollRef: FocusAndScrollRef
   children: React.ReactNode
 }> {
@@ -294,7 +294,9 @@ export function InnerLayoutRouter({
 
   // Ensure root layout is not wrapped in a div as the root layout renders `<html>`
   return rootLayoutIncluded ? (
-    <Scroller focusAndScrollRef={focusAndScrollRef}>{subtree}</Scroller>
+    <ScrollAndFocusHandler focusAndScrollRef={focusAndScrollRef}>
+      {subtree}
+    </ScrollAndFocusHandler>
   ) : (
     subtree
   )


### PR DESCRIPTION
As discussed with @sebmarkbage, this gets closer to the end state while Seb works on a proposal for a new API to get the DOM node in React.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
