### PR TITLE
perf: disable prefetching for links in viewport in development for app routes

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -522,6 +522,11 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
 
     // Prefetch the URL if we haven't already and it's visible.
     React.useEffect(() => {
+      // in dev, we only prefetch on hover to avoid wasting resources
+      if (process.env.NODE_ENV !== 'production') {
+        return
+      }
+
       if (!router) {
         return
       }

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -522,7 +522,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
 
     // Prefetch the URL if we haven't already and it's visible.
     React.useEffect(() => {
-      // in dev, we only prefetch on hover to avoid wasting resources
+      // in dev, we only prefetch on hover to avoid wasting resources as the prefetch will trigger compiling the page.
       if (process.env.NODE_ENV !== 'production') {
         return
       }


### PR DESCRIPTION
There has been a few complaints about memory usage of the Next.js 13 dev server. One of the reasons why is that prefetching is always enabled when a link is visible on app routes (and not on pages). Disabling this behaviour, whilst keeping prefetching on hover/click, should help improve resources usage.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
