### PR TITLE
Revert "Adding head element checking for root layout"

### DIFF
--- a/packages/next/client/components/react-dev-overlay/internal/container/RootLayoutError.tsx
+++ b/packages/next/client/components/react-dev-overlay/internal/container/RootLayoutError.tsx
@@ -14,7 +14,7 @@ export type RootLayoutErrorProps = { missingTags: string[] }
 export const RootLayoutError: React.FC<RootLayoutErrorProps> =
   function BuildError({ missingTags }) {
     const message =
-      'Please make sure to include the following tags in your root layout: <html>, <head>, <body>.\n\n' +
+      'Please make sure to include the following tags in your root layout: <html>, <body>.\n\n' +
       `Missing required root layout tag${
         missingTags.length === 1 ? '' : 's'
       }: ` +

--- a/packages/next/server/node-web-streams-helper.ts
+++ b/packages/next/server/node-web-streams-helper.ts
@@ -288,18 +288,14 @@ export function createRootLayoutValidatorStream(
   getTree: () => FlightRouterState
 ): TransformStream<Uint8Array, Uint8Array> {
   let foundHtml = false
-  let foundHead = false
   let foundBody = false
 
   return new TransformStream({
     async transform(chunk, controller) {
-      if (!foundHtml || !foundHead || !foundBody) {
+      if (!foundHtml || !foundBody) {
         const content = decodeText(chunk)
         if (!foundHtml && content.includes('<html')) {
           foundHtml = true
-        }
-        if (!foundHead && content.includes('<head')) {
-          foundHead = true
         }
         if (!foundBody && content.includes('<body')) {
           foundBody = true
@@ -310,7 +306,6 @@ export function createRootLayoutValidatorStream(
     flush(controller) {
       const missingTags = [
         foundHtml ? null : 'html',
-        foundHead ? null : 'head',
         foundBody ? null : 'body',
       ].filter(nonNullable)
 

--- a/test/e2e/app-dir/root-layout.test.ts
+++ b/test/e2e/app-dir/root-layout.test.ts
@@ -40,9 +40,9 @@ describe('app-dir root layout', () => {
 
         expect(await hasRedbox(browser, true)).toBe(true)
         expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-          "Please make sure to include the following tags in your root layout: <html>, <head>, <body>.
+          "Please make sure to include the following tags in your root layout: <html>, <body>.
 
-          Missing required root layout tags: html, head, body"
+          Missing required root layout tags: html, body"
         `)
       })
 
@@ -54,9 +54,9 @@ describe('app-dir root layout', () => {
 
         expect(await hasRedbox(browser, true)).toBe(true)
         expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-          "Please make sure to include the following tags in your root layout: <html>, <head>, <body>.
+          "Please make sure to include the following tags in your root layout: <html>, <body>.
 
-          Missing required root layout tags: html, head, body"
+          Missing required root layout tags: html, body"
         `)
       })
 
@@ -67,9 +67,9 @@ describe('app-dir root layout', () => {
 
         expect(await hasRedbox(browser, true)).toBe(true)
         expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-          "Please make sure to include the following tags in your root layout: <html>, <head>, <body>.
+          "Please make sure to include the following tags in your root layout: <html>, <body>.
 
-          Missing required root layout tags: html, head, body"
+          Missing required root layout tags: html, body"
         `)
       })
     })

--- a/test/e2e/app-dir/root-layout/app/(required-tags)/has-tags/layout.js
+++ b/test/e2e/app-dir/root-layout/app/(required-tags)/has-tags/layout.js
@@ -4,9 +4,6 @@ export const revalidate = 0
 export default function Root({ children }) {
   return (
     <html>
-      <head>
-        <title>Hello World</title>
-      </head>
       <body>{children}</body>
     </html>
   )


### PR DESCRIPTION
Reverts vercel/next.js#43597

The tests were disabled and currently the checking of these components are not reliable, it also breaks the hmr. Revert it for now and then we'll revisit how to re-enable the required tags checking