### PR TITLE
Remove `serverComponents` from next.conf.js because it's unused

### DIFF
--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -81,8 +81,6 @@ module.exports = {
             module.exports = {
               experimental: {
                 appDir: true,
-                // remove after next stable release (current v12.3.1)
-                serverComponents: true,
               },
               generateBuildId: () => 'BUILD_ID',
               webpack(config) {
@@ -103,8 +101,6 @@ module.exports = {
           module.exports = {
               experimental: {
                 appDir: true,
-                // remove after next stable relase (current v12.3.1)
-                serverComponents: true,
               },
               generateBuildId: () => 'BUILD_ID'
             }


### PR DESCRIPTION
It is causing warnings in the pipeline: https://github.com/vercel/next.js/actions/runs/3637072557/jobs/6137723936