### PR TITLE
Fix HMR issue after patching the client module

### DIFF
--- a/packages/next/client/app-index.tsx
+++ b/packages/next/client/app-index.tsx
@@ -29,7 +29,10 @@ __webpack_require__.u = (chunkId: any) => {
 // Ignore the module ID transform in client.
 // eslint-disable-next-line no-undef
 // @ts-expect-error TODO: fix type
-self.__next_require__ = __webpack_require__
+self.__next_require__ = (id: string) => {
+  const modId = id.replace(/\?.+$/, '')
+  return __webpack_require__(modId)
+}
 
 // eslint-disable-next-line no-undef
 ;(self as any).__next_chunk_load__ = (chunk: string) => {

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -1598,11 +1598,35 @@ export async function renderToHTMLOrFlight(
         ).slice(1),
       ]
 
+      const serverComponentManifestWithHMR = dev
+        ? new Proxy(serverComponentManifest, {
+            get: (target, prop) => {
+              if (
+                typeof prop === 'string' &&
+                !prop.startsWith('_') &&
+                target[prop]
+              ) {
+                // Attach TS query param to IDs to get rid of flight client's module cache on HMR.
+                const namedExports: any = {}
+                const ts = Date.now()
+                for (let key in target[prop]) {
+                  namedExports[key] = {
+                    ...target[prop][key],
+                    id: `${target[prop][key].id}?ts=${ts}`,
+                  }
+                }
+                return namedExports
+              }
+              return target[prop]
+            },
+          })
+        : serverComponentManifest
+
       // For app dir, use the bundled version of Fizz renderer (renderToReadableStream)
       // which contains the subset React.
       const readable = ComponentMod.renderToReadableStream(
         flightData,
-        serverComponentManifest,
+        serverComponentManifestWithHMR,
         {
           context: serverContexts,
           onError: flightDataRendererErrorHandler,

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -1606,7 +1606,7 @@ export async function renderToHTMLOrFlight(
                 !prop.startsWith('_') &&
                 target[prop]
               ) {
-                // Attach TS query param to IDs to get rid of flight client's module cache on HMR.
+                // Attach TS (timestamp) query param to IDs to get rid of flight client's module cache on HMR.
                 const namedExports: any = {}
                 const ts = Date.now()
                 for (let key in target[prop]) {

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -441,7 +441,7 @@ describe('app dir', () => {
         }
       })
 
-      it.skip('should HMR correctly when changing the component type', async () => {
+      it('should HMR correctly when changing the component type', async () => {
         const filePath = 'app/dashboard/page/page.jsx'
         const origContent = await next.readFile(filePath)
 
@@ -466,13 +466,12 @@ describe('app dir', () => {
           )
 
           // Change to client component
-          await new Promise((resolve) => setTimeout(resolve, 1000))
           await next.patchFile(
             filePath,
             origContent
               .replace("// 'use client'", "'use client'")
               .replace(
-                'hello dashboard/page in server component!',
+                'hello dashboard/page!',
                 'hello dashboard/page in client component!'
               )
           )
@@ -484,16 +483,29 @@ describe('app dir', () => {
           // Change back to server component
           await next.patchFile(
             filePath,
+            origContent.replace(
+              'hello dashboard/page!',
+              'hello dashboard/page in server component2!'
+            )
+          )
+          await check(
+            () => browser.elementByCss('p').text(),
+            /in server component2/
+          )
+
+          // Change to client component again
+          await next.patchFile(
+            filePath,
             origContent
-              .replace("'use client'", "// 'use client'")
+              .replace("// 'use client'", "'use client'")
               .replace(
-                'hello dashboard/page in client component!',
-                'hello dashboard/page in server component!'
+                'hello dashboard/page!',
+                'hello dashboard/page in client component2!'
               )
           )
           await check(
             () => browser.elementByCss('p').text(),
-            /in server component/
+            /in client component2/
           )
         } finally {
           await next.patchFile(filePath, origContent)


### PR DESCRIPTION
Follow-up to #43778, this PR implements the logic of adding a timestamp query to all client module reference's IDs. Note that this only applies to flight renders during dev, which only affects HMR.

The reason of changing the module ID for hot reloading is, after changing a client component to a server component, the module is completely removed in the client chunk. And Webpack disposes it along with all the React refresh registered callbacks. And when changing it back to a server component, a new module instance is generated and loaded by Webpack, but the Flight client still holds the reference to the old module instance. This is basically a way to force flight to reload the modules from Webpack.

NEXT-30

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
