### PR TITLE
docs: add readme with development instructions for next/swc

### DIFF
--- a/packages/next-swc/README.md
+++ b/packages/next-swc/README.md
@@ -1,0 +1,26 @@
+# `@next/swc`
+
+This package is responsible for swc compilation customized for next.js
+
+### Development
+
+Run tests
+
+```sh
+cargo test
+
+# Update snapshots and fixtures for tests
+UPDATE=1 cargo test
+```
+
+Format code before submitting code
+
+```
+cargo fmt
+```
+
+Build the binary to integrate with next.js
+
+```
+pnpm build-native
+```


### PR DESCRIPTION
* Creating the readme for me `@next/swc` with basic development instructions
* Adding instructions for testing and updating the `next/swc` tests


## Documentation

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
