### PR TITLE
Added support for query params on not found pages

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -116,10 +116,6 @@ class Container extends React.Component<{
     // - if rewrites in next.config.js match (may have rewrite params)
     if (
       router.isSsr &&
-      // We don't update for 404 requests as this can modify
-      // the asPath unexpectedly e.g. adding basePath when
-      // it wasn't originally present
-      initialData.page !== '/404' &&
       initialData.page !== '/_error' &&
       (initialData.isFallback ||
         (initialData.nextExport &&

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -116,7 +116,6 @@ class Container extends React.Component<{
     // - if rewrites in next.config.js match (may have rewrite params)
     if (
       router.isSsr &&
-      initialData.page !== '/_error' &&
       (initialData.isFallback ||
         (initialData.nextExport &&
           (isDynamicRoute(router.pathname) ||

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1671,8 +1671,6 @@ export default class Router implements BaseRouter {
         }
       }
 
-      // let { error, props, __N_SSG, __N_SSP } = routeInfo
-
       const component: any = routeInfo.Component
       if (component && component.unstable_scriptLoader) {
         const scripts = [].concat(component.unstable_scriptLoader())

--- a/test/e2e/404-page-router/app/components/debug-error.js
+++ b/test/e2e/404-page-router/app/components/debug-error.js
@@ -1,0 +1,35 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import Debug from './debug'
+
+function transform(router) {
+  return {
+    pathname: router.pathname,
+    asPath: router.asPath,
+    query: Object.entries(router.query)
+      .map(([key, value]) => [key, value].join('='))
+      .join('&'),
+    isReady: router.isReady ? 'true' : 'false',
+  }
+}
+
+export default function DebugError({ children }) {
+  const router = useRouter()
+  const [debug, setDebug] = useState({})
+
+  useEffect(() => {
+    setDebug(transform(router))
+  }, [router])
+
+  return (
+    <>
+      <dl>
+        <Debug name="pathname" value={debug.pathname} />
+        <Debug name="asPath" value={debug.asPath} />
+        <Debug name="query" value={debug.query} />
+        <Debug name="isReady" value={debug.isReady} />
+      </dl>
+      {children}
+    </>
+  )
+}

--- a/test/e2e/404-page-router/app/components/debug.js
+++ b/test/e2e/404-page-router/app/components/debug.js
@@ -1,0 +1,8 @@
+export default function Debug({ name, value }) {
+  return (
+    <>
+      <dt>{name}</dt>
+      <dd id={name}>{value}</dd>
+    </>
+  )
+}

--- a/test/e2e/404-page-router/app/middleware.js
+++ b/test/e2e/404-page-router/app/middleware.js
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export function middleware() {
+  return NextResponse.next()
+}

--- a/test/e2e/404-page-router/app/pages/404.js
+++ b/test/e2e/404-page-router/app/pages/404.js
@@ -1,40 +1,5 @@
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-
-function transform(router) {
-  return {
-    pathname: router.pathname,
-    asPath: router.asPath,
-    query: Object.entries(router.query)
-      .map(([key, value]) => [key, value].join('='))
-      .join('&'),
-    isReady: router.isReady ? 'true' : 'false',
-  }
-}
-
-function Debug({ name, value }) {
-  return (
-    <>
-      <dt>{name}</dt>
-      <dd id={name}>{value}</dd>
-    </>
-  )
-}
+import DebugError from '../components/debug-error'
 
 export default function Custom404() {
-  const router = useRouter()
-  const [debug, setDebug] = useState({})
-
-  useEffect(() => {
-    setDebug(transform(router))
-  }, [router])
-
-  return (
-    <dl>
-      <Debug name="pathname" value={debug.pathname} />
-      <Debug name="asPath" value={debug.asPath} />
-      <Debug name="query" value={debug.query} />
-      <Debug name="isReady" value={debug.isReady} />
-    </dl>
-  )
+  return <DebugError />
 }

--- a/test/e2e/404-page-router/app/pages/404.js
+++ b/test/e2e/404-page-router/app/pages/404.js
@@ -1,0 +1,40 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+function transform(router) {
+  return {
+    pathname: router.pathname,
+    asPath: router.asPath,
+    query: Object.entries(router.query)
+      .map(([key, value]) => [key, value].join('='))
+      .join('&'),
+    isReady: router.isReady ? 'true' : 'false',
+  }
+}
+
+function Debug({ name, value }) {
+  return (
+    <>
+      <dt>{name}</dt>
+      <dd id={name}>{value}</dd>
+    </>
+  )
+}
+
+export default function Custom404() {
+  const router = useRouter()
+  const [debug, setDebug] = useState({})
+
+  useEffect(() => {
+    setDebug(transform(router))
+  }, [router])
+
+  return (
+    <dl>
+      <Debug name="pathname" value={debug.pathname} />
+      <Debug name="asPath" value={debug.asPath} />
+      <Debug name="query" value={debug.query} />
+      <Debug name="isReady" value={debug.isReady} />
+    </dl>
+  )
+}

--- a/test/e2e/404-page-router/app/pages/_error.js
+++ b/test/e2e/404-page-router/app/pages/_error.js
@@ -1,5 +1,4 @@
 import DebugError from '../components/debug-error'
-import Debug from '../components/debug'
 
 function Error({ statusCode }) {
   return <DebugError />

--- a/test/e2e/404-page-router/app/pages/_error.js
+++ b/test/e2e/404-page-router/app/pages/_error.js
@@ -1,0 +1,13 @@
+import DebugError from '../components/debug-error'
+import Debug from '../components/debug'
+
+function Error({ statusCode }) {
+  return <DebugError />
+}
+
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404
+  return { statusCode }
+}
+
+export default Error

--- a/test/e2e/404-page-router/app/pages/error.js
+++ b/test/e2e/404-page-router/app/pages/error.js
@@ -1,0 +1,7 @@
+export default function Page() {
+  throw new Error('there was an error')
+}
+
+export const getServerSideProps = () => {
+  return { props: {} }
+}

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -1,0 +1,68 @@
+import { createNext, FileRef } from 'e2e-utils'
+import path from 'path'
+import { NextInstance } from 'test/lib/next-modes/base'
+import webdriver from 'next-webdriver'
+
+const basePath = '/docs'
+const i18n = { defaultLocale: 'en-ca', locales: ['en-ca', 'en-fr'] }
+
+const table = [
+  // Including the i18n and no basePath
+  { basePath: undefined, i18n, middleware: false },
+  // Including the basePath and no i18n
+  { basePath, i18n: undefined, middleware: false },
+  // Including both i18n and basePath
+  { basePath, i18n, middleware: false },
+  // Including no basePath or i18n
+  { basePath: undefined, i18n: undefined, middleware: false },
+  // Including middleware.
+  { basePath: undefined, i18n: undefined, middleware: true },
+]
+
+describe.each(table)(
+  '404-page-router with basePath of $basePath and i18n of $i18n and middleware %middleware',
+  ({ middleware, ...nextConfig }) => {
+    let next: NextInstance
+
+    beforeAll(async () => {
+      const files = {
+        pages: new FileRef(path.join(__dirname, 'app/pages')),
+      }
+
+      if (middleware) {
+        files['middleware.js'] = new FileRef(
+          path.join(__dirname, 'app/middleware.js')
+        )
+      }
+
+      next = await createNext({
+        files,
+        nextConfig,
+      })
+    })
+
+    afterAll(() => next.destroy())
+
+    describe.each(['/not/a/real/page?with=query', '/not/a/real/page'])(
+      'for url %s',
+      (url) => {
+        it('should have the correct router parameters after it is ready', async () => {
+          const query = url.split('?')[1] ?? ''
+          const browser = await webdriver(next.url, url)
+
+          try {
+            await browser.waitForCondition(
+              'document.getElementById("isReady")?.innerText === "true"'
+            )
+
+            expect(await browser.elementById('pathname').text()).toEqual('/404')
+            expect(await browser.elementById('asPath').text()).toEqual(url)
+            expect(await browser.elementById('query').text()).toEqual(query)
+          } finally {
+            await browser.close()
+          }
+        })
+      }
+    )
+  }
+)


### PR DESCRIPTION
Previously, query parameters were not available on 404 pages because calling the router methods would change the pathname in the browser. This change adds support for the query to update for those pages without updating the path to include the basePath.

This additionally narrows some Typescript types that were previous set to `any` which highlighted some type errors that were corrected.

Fixes: https://github.com/vercel/next.js/issues/35990