### PR TITLE
Update dependencies for Convex demo

### DIFF
--- a/examples/convex/package.json
+++ b/examples/convex/package.json
@@ -16,9 +16,9 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/node": "~16.11.12",
-    "@types/react": "17.0.45",
-    "@types/react-dom": "17.0.17",
+    "@types/node": "^18.11.11",
+    "@types/react": "^18.0.26",
+    "@types/react-dom": "^18.0.9",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "typescript": "^4.7.3"


### PR DESCRIPTION
Resolves the issue described in https://github.com/microsoft/TypeScript/issues/51567 in the Convex demo by updating type definitions.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] **The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)** - actually updated dependencies this time
