### PR TITLE
Remove unnecessary code for the example

### DIFF
--- a/examples/with-google-analytics/lib/gtag.js
+++ b/examples/with-google-analytics/lib/gtag.js
@@ -6,12 +6,3 @@ export const pageview = (url) => {
     page_path: url,
   })
 }
-
-// https://developers.google.com/analytics/devguides/collection/gtagjs/events
-export const event = ({ action, category, label, value }) => {
-  window.gtag('event', action, {
-    event_category: category,
-    event_label: label,
-    value: value,
-  })
-}

--- a/examples/with-google-analytics/lib/gtag.js
+++ b/examples/with-google-analytics/lib/gtag.js
@@ -6,3 +6,12 @@ export const pageview = (url) => {
     page_path: url,
   })
 }
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  })
+}

--- a/examples/with-google-analytics/pages/_app.js
+++ b/examples/with-google-analytics/pages/_app.js
@@ -1,7 +1,7 @@
-import { useEffect } from 'react'
-import Script from 'next/script'
-import { useRouter } from 'next/router'
-import * as gtag from '../lib/gtag'
+import { useRouter } from 'next/router';
+import Script from 'next/script';
+import { useEffect } from 'react';
+import * as gtag from '../lib/gtag';
 
 const App = ({ Component, pageProps }) => {
   const router = useRouter()
@@ -25,7 +25,6 @@ const App = ({ Component, pageProps }) => {
         src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_TRACKING_ID}`}
       />
       <Script
-        id="gtag-init"
         strategy="afterInteractive"
         dangerouslySetInnerHTML={{
           __html: `

--- a/examples/with-google-analytics/pages/_app.js
+++ b/examples/with-google-analytics/pages/_app.js
@@ -1,7 +1,7 @@
-import { useEffect } from 'react';
-import Script from 'next/script';
-import { useRouter } from 'next/router';
-import * as gtag from '../lib/gtag';
+import { useEffect } from 'react'
+import Script from 'next/script'
+import { useRouter } from 'next/router'
+import * as gtag from '../lib/gtag'
 
 const App = ({ Component, pageProps }) => {
   const router = useRouter()

--- a/examples/with-google-analytics/pages/_app.js
+++ b/examples/with-google-analytics/pages/_app.js
@@ -10,10 +10,8 @@ const App = ({ Component, pageProps }) => {
       gtag.pageview(url)
     }
     router.events.on('routeChangeComplete', handleRouteChange)
-    router.events.on('hashChangeComplete', handleRouteChange)
     return () => {
       router.events.off('routeChangeComplete', handleRouteChange)
-      router.events.off('hashChangeComplete', handleRouteChange)
     }
   }, [router.events])
 

--- a/examples/with-google-analytics/pages/_app.js
+++ b/examples/with-google-analytics/pages/_app.js
@@ -1,6 +1,6 @@
-import { useRouter } from 'next/router';
-import Script from 'next/script';
 import { useEffect } from 'react';
+import Script from 'next/script';
+import { useRouter } from 'next/router';
 import * as gtag from '../lib/gtag';
 
 const App = ({ Component, pageProps }) => {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

Thanks for your time presenting these examples has been amazing for my day-to-day work.

1. The `event` hashChangeComplete should be removed since `/home` and `/home/#section` is not new pageview, but just reference to the same page. 

If we go from /home to /home/#section (with a button click or a link for example) this shouldn't trigger a new page visit on `gtag`. 

For this reason, I think we should revert the changes from https://github.com/vercel/next.js/pull/36079. If there is a better argument of why this should stay I am also open to creating comments to clarify this on the example since I don't think should be the default behavior and not useful in most cases.

2. The `id="gtag-init"` was added with no context to the example from https://github.com/vercel/next.js/pull/29530

If there is a reason for this id in the script to existing I am open to adding a comment that clarifies this since in my experience is not necessary at all.
