### PR TITLE
Fix error message for invalid `runtime` option in app dir

### DIFF
--- a/packages/next/build/analysis/get-page-static-info.ts
+++ b/packages/next/build/analysis/get-page-static-info.ts
@@ -316,7 +316,7 @@ export async function getPageStaticInfo(params: {
         )
       } else {
         Log.error(
-          `Provided runtime "${config.runtime}" is not supported. Please leave it empty or choose one of: ${options}`
+          `Provided runtime "${resolvedRuntime}" is not supported. Please leave it empty or choose one of: ${options}`
         )
       }
       if (!isDev) {

--- a/test/e2e/switchable-runtime/app/app-invalid-runtime/page.js
+++ b/test/e2e/switchable-runtime/app/app-invalid-runtime/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Hello from app</p>
+}

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -469,6 +469,34 @@ describe('Switchable runtime', () => {
           /Hello from page without errors/
         )
       })
+
+      it('should give proper errors for invalid runtime in app dir', async () => {
+        // Invalid runtime
+        await next.patchFile(
+          'app/app-invalid-runtime/page.js',
+          `
+          export default function Page() {
+            return <p>Hello from app</p>
+          }
+          export const runtime = 'invalid-runtime'
+          `
+        )
+        await check(
+          () => renderViaHTTP(next.url, '/app-invalid-runtime'),
+          /Hello from app/
+        )
+        expect(next.cliOutput).toInclude(
+          'error - Provided runtime "invalid-runtime" is not supported. Please leave it empty or choose one of:'
+        )
+
+        await next.patchFile(
+          'app/app-invalid-runtime/page.js',
+          `
+          export default function Page() {
+            return <p>Hello from app</p>
+          }`
+        )
+      })
     })
   } else {
     describe('Switchable runtime (prod)', () => {


### PR DESCRIPTION
Currently it shows `Provided runtime "undefined" is not supported`.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
