### PR TITLE
fix: forwarding props to no ssr dynamic

### DIFF
--- a/packages/next/shared/lib/dynamic.tsx
+++ b/packages/next/shared/lib/dynamic.tsx
@@ -64,10 +64,10 @@ export function noSSR<P = {}>(
     <Loading error={null} isLoading pastDelay={false} timedOut={false} />
   )
 
-  return () => (
+  return (props: any) => (
     <Suspense fallback={fallback}>
       <NoSSR>
-        <NoSSRComponent />
+        <NoSSRComponent {...props} />
       </NoSSR>
     </Suspense>
   )

--- a/test/e2e/app-dir/app/app/dashboard/dynamic/dynamic-imports/dynamic-client.js
+++ b/test/e2e/app-dir/app/app/dashboard/dynamic/dynamic-imports/dynamic-client.js
@@ -11,7 +11,7 @@ export function NextDynamicClientComponent() {
   return (
     <>
       <Dynamic />
-      <DynamicNoSSR />
+      <DynamicNoSSR name=":suffix" />
     </>
   )
 }

--- a/test/e2e/app-dir/app/app/dashboard/dynamic/text-dynamic-no-ssr-client.js
+++ b/test/e2e/app-dir/app/app/dashboard/dynamic/text-dynamic-no-ssr-client.js
@@ -3,8 +3,8 @@
 import { useState } from 'react'
 import styles from './dynamic.module.css'
 
-export default function Dynamic() {
-  let [state] = useState('dynamic no ssr on client')
+export default function Dynamic({ name }) {
+  let [state] = useState('dynamic no ssr on client' + name)
   return (
     <p id="css-text-dynamic-no-ssr-client" className={styles.dynamic}>
       {`next-dynamic ${state}`}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -171,7 +171,7 @@ describe('app dir', () => {
 
         expect(
           await browser.elementByCss('#css-text-dynamic-no-ssr-client').text()
-        ).toBe('next-dynamic dynamic no ssr on client')
+        ).toBe('next-dynamic dynamic no ssr on client:suffix')
       })
 
       it('should serve polyfills for browsers that do not support modules', async () => {


### PR DESCRIPTION
## Bug

Fixes: #43764

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

