### PR TITLE
Add auto completion for prop names and types to the TS plugin

### DIFF
--- a/packages/next/server/next-typescript.ts
+++ b/packages/next/server/next-typescript.ts
@@ -441,21 +441,18 @@ export function createTSPlugin(modules: {
                   const nameNode = element.propertyName || element.name
 
                   if (isPositionInsideNode(position, nameNode)) {
-                    prior.entries = [
-                      ...prior.entries,
-                      ...validProps.map((name, index) => {
-                        return {
-                          name,
-                          insertText: name,
-                          sortText: index + '_' + name,
-                          kind: ts.ScriptElementKind.memberVariableElement,
-                          kindModifiers: ts.ScriptElementKindModifier.none,
-                          labelDetails: {
-                            description: `Next.js ${type} prop`,
-                          },
-                        } as ts.CompletionEntry
-                      }),
-                    ] as ts.CompletionEntry[]
+                    for (const name of validProps) {
+                      prior.entries.push({
+                        name,
+                        insertText: name,
+                        sortText: '_' + name,
+                        kind: ts.ScriptElementKind.memberVariableElement,
+                        kindModifiers: ts.ScriptElementKindModifier.none,
+                        labelDetails: {
+                          description: `Next.js ${type} prop`,
+                        },
+                      } as ts.CompletionEntry)
+                    }
                   }
 
                   break
@@ -466,21 +463,18 @@ export function createTSPlugin(modules: {
               if (paramNode.type && ts.isTypeLiteralNode(paramNode.type)) {
                 for (const member of paramNode.type.members) {
                   if (isPositionInsideNode(position, member)) {
-                    prior.entries = [
-                      ...prior.entries,
-                      ...validPropsWithType.map((name, index) => {
-                        return {
-                          name,
-                          insertText: name,
-                          sortText: index + '_' + name,
-                          kind: ts.ScriptElementKind.memberVariableElement,
-                          kindModifiers: ts.ScriptElementKindModifier.none,
-                          labelDetails: {
-                            description: `Next.js ${type} prop type`,
-                          },
-                        } as ts.CompletionEntry
-                      }),
-                    ] as ts.CompletionEntry[]
+                    for (const name of validPropsWithType) {
+                      prior.entries.push({
+                        name,
+                        insertText: name,
+                        sortText: '_' + name,
+                        kind: ts.ScriptElementKind.memberVariableElement,
+                        kindModifiers: ts.ScriptElementKindModifier.none,
+                        labelDetails: {
+                          description: `Next.js ${type} prop type`,
+                        },
+                      } as ts.CompletionEntry)
+                    }
 
                     break
                   }


### PR DESCRIPTION
For example, [named slots](https://nextjs.org/blog/layouts-rfc#convention:~:text=After%20this%20change%2C%20the%20layout%20will%20receive%20a%20prop%20called%C2%A0customProp%C2%A0instead%20of%C2%A0children.) should be hinted when typing:

```ts
export default function Layout({ f|
                                  ^foo
```

And the prop type:

```ts
export default function Layout({ foo }: { f|
                                           ^foo: React.ReactChildren
```

And [params](https://beta.nextjs.org/docs/api-reference/file-conventions/page#params-optional):

```ts
export default function Page({ p|
```

NEXT-178

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
