### PR TITLE
Fix next/dynamic types for resolving named export module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ coverage
 # test output
 test/**/out*
 test/**/next-env.d.ts
+test/**/tsconfig.json
 .DS_Store
 /e2e-tests
 test/tmp/**

--- a/test/production/typescript-basic/app/components/named.tsx
+++ b/test/production/typescript-basic/app/components/named.tsx
@@ -1,0 +1,3 @@
+export function NamedExport() {
+  return <>named-export</>
+}

--- a/test/production/typescript-basic/app/pages/dynamic.tsx
+++ b/test/production/typescript-basic/app/pages/dynamic.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import dynamic from 'next/dynamic'
+
+const NamedExport = dynamic(() =>
+  import('../components/named').then((mod) => mod.NamedExport)
+)
+
+export default function Dynamic() {
+  return <NamedExport />
+}


### PR DESCRIPTION
## Bug

Fixes: #43915

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

