### PR TITLE
chore: add repro links in "verify canary" comment

### DIFF
--- a/.github/actions/issue-validator/canary.md
+++ b/.github/actions/issue-validator/canary.md
@@ -10,7 +10,7 @@ If the issue does not reproduce with the `canary` version, then it has already b
 
 ### **How can I quickly verify if my issue has been fixed in `canary`?**
 
-The safest way is to install `next@canary` in your project and test it, but you can also search through [closed Next.js issues](https://github.com/vercel/next.js/issues?q=is%3Aissue+is%3Aclosed) for duplicates or check the [Next.js releases](https://github.com/vercel/next.js/releases).
+The safest way is to install `next@canary` in your project and test it, but you can also search through [closed Next.js issues](https://github.com/vercel/next.js/issues?q=is%3Aissue+is%3Aclosed) for duplicates or check the [Next.js releases](https://github.com/vercel/next.js/releases). You can also use the GitHub [template](https://github.com/vercel/next.js/tree/canary/examples/reproduction-template) (preferred), or the [CodeSandbox](https://codesandbox.io/s/github/vercel/next.js/tree/canary/examples/reproduction-template) or [StackBlitz](https://stackblitz.com/fork/github/vercel/next.js/tree/canary/examples/reproduction-template) templates to create a reproduction with `canary` from scratch.
 
 ### **My issue has been open for a long time, why do I need to verify `canary` now?**
 

--- a/examples/reproduction-template/package.json
+++ b/examples/reproduction-template/package.json
@@ -11,8 +11,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/node": "^18.0.0",
-    "@types/react": "^18.0.14",
-    "typescript": "^4.7.4"
+    "@types/node": "^18.11.13",
+    "@types/react": "^18.0.26",
+    "typescript": "^4.9.4"
   }
 }


### PR DESCRIPTION
[Slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1669918824743499)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
