### PR TITLE
use a function expression to access arguments binding

### DIFF
--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -52,7 +52,7 @@ const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 function preloadComponent(Component: any, props: any) {
   const prev = console.error
   // Hide invalid hook call warning when calling component
-  console.error = (msg) => {
+  console.error = function (msg) {
     if (msg.startsWith('Invalid hook call..')) {
       // ignore
     } else {


### PR DESCRIPTION
arrow function was trying to use arguments binding but wanted arguments of the lambda not the nearest normal function. The narrowest change is to convert to function expression. We could also use varargs rest syntax since this runs in runtimes that should all support that I think. I don't think it really matters though.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`