### PR TITLE
fix the code given in the per-page layouts documentation

### DIFF
--- a/docs/basic-features/layouts.md
+++ b/docs/basic-features/layouts.md
@@ -49,7 +49,7 @@ export default function MyApp({ Component, pageProps }) {
 
 ### Per-Page Layouts
 
-If you need multiple layouts, you can add a property `getLayout` to your page, allowing you to return a React component for the layout. This allows you to define the layout on a _per-page basis_. Since we're returning a function, we can have complex nested layouts if desired.
+If you need multiple layouts, you can add a property `Layout` to your page, allowing you to return a React component for the layout. This allows you to define the layout on a _per-page basis_. Since we're returning a function, we can have complex nested layouts if desired.
 
 ```jsx
 // pages/index.js
@@ -63,7 +63,8 @@ export default function Page() {
   )
 }
 
-Page.getLayout = function getLayout(page) {
+// Use the function name for the layout name (useful for debugging)
+Page.Layout = function PageLayout(page) {
   return (
     <Layout>
       <NestedLayout>{page}</NestedLayout>
@@ -75,11 +76,18 @@ Page.getLayout = function getLayout(page) {
 ```jsx
 // pages/_app.js
 
+import { Fragment } from 'react'
+
 export default function MyApp({ Component, pageProps }) {
   // Use the layout defined at the page level, if available
-  const getLayout = Component.getLayout || ((page) => page)
+  // Otherwise, use a fragment (or replace it with a default layout)
+  const Layout = Component.Layout || Fragment
 
-  return getLayout(<Component {...pageProps} />)
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  )
 }
 ```
 
@@ -91,7 +99,7 @@ This layout pattern enables state persistence because the React component tree i
 
 ### With TypeScript
 
-When using TypeScript, you must first create a new type for your pages which includes a `getLayout` function. Then, you must create a new type for your `AppProps` which overrides the `Component` property to use the previously created type.
+When using TypeScript, you must first create a new type for your pages which includes a `Layout` function. Then, you must create a new type for your `AppProps` which overrides the `Component` property to use the previously created type.
 
 ```tsx
 // pages/index.tsx
@@ -105,10 +113,11 @@ const Page: NextPageWithLayout = () => {
   return <p>hello world</p>
 }
 
-Page.getLayout = function getLayout(page: ReactElement) {
+// Use the function name for the layout name (useful for debugging)
+Page.Layout = function PageLayout({ children }: { children: ReactElement }) {
   return (
     <Layout>
-      <NestedLayout>{page}</NestedLayout>
+      <NestedLayout>{children}</NestedLayout>
     </Layout>
   )
 }
@@ -119,12 +128,13 @@ export default Page
 ```tsx
 // pages/_app.tsx
 
+import { Fragment } from 'react'
 import type { ReactElement, ReactNode } from 'react'
 import type { NextPage } from 'next'
 import type { AppProps } from 'next/app'
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
-  getLayout?: (page: ReactElement) => ReactNode
+  Layout?: React.FC
 }
 
 type AppPropsWithLayout = AppProps & {
@@ -133,9 +143,14 @@ type AppPropsWithLayout = AppProps & {
 
 export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   // Use the layout defined at the page level, if available
-  const getLayout = Component.getLayout ?? ((page) => page)
+  // Otherwise, use a fragment (or replace it with a default layout)
+  const Layout = Component.Layout ?? Fragment
 
-  return getLayout(<Component {...pageProps} />)
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  )
 }
 ```
 


### PR DESCRIPTION
Edit: I just realized that probably the intention of the `getLayout` function is to **generate the layout, not to be the layout**. If that it's the case, this PR should be closed. Also, it might be clearer if `getLayout` is defined like:

```tsx
Page.getLayout = (page: ReactElement) => (
  // return the layout directly
  <Layout>
    <NestedLayout>{page}</NestedLayout>
  </Layout>
)
```

So it implicitly shows that the function should not use hooks or other stuff that might cause an error.

---

## Documentation

- [X] Make sure the linting passes by running `pnpm build && pnpm lint`

---

## The problem:

The current documentation recommends this code to have [per-page layouts](https://nextjs.org/docs/basic-features/layouts#per-page-layouts):

```tsx
// pages/index.js

import Layout from '../components/layout'
import NestedLayout from '../components/nested-layout'

export default function Page() {
  return (
    /** Your content */
  )
}

Page.getLayout = function getLayout(page) {
  return (
    <Layout>
      <NestedLayout>{page}</NestedLayout>
    </Layout>
  )
}


// pages/_app.js

export default function MyApp({ Component, pageProps }) {
  // Use the layout defined at the page level, if available
  const getLayout = Component.getLayout || ((page) => page)

  return getLayout(<Component {...pageProps} />)
}
```

This will cause problems when adding a context which the layout requires (for example, a Navbar that requires an AuthContext):

```tsx
// pages/_auth.tsx
import { createContext, useContext } from "react";

const AuthContext = createContext(false);

export function AuthContextProvider(props) {
  return <AuthContext.Provider {...props} value={true} />;
}

export function useAuth() {
  const auth = useContext(AuthContext);
  if (!auth) throw new Error("useAuth must be used within an AuthContextProvider");
  return auth;
}


// pages/index.tsx

import { useAuth } from "./_auth";

export default function Home() {
  return <div>Home</div>;
}

Home.getLayout = function getLayout(page) {
  const isAuthenticated = useAuth();
  return (
    <>
      Is authenticated: {isAuthenticated ? "yes" : "no"}
      {page}
    </>
  );
};


// pages/_app.txt

import "../styles/globals.css";
import type { AppProps } from "next/app";
import { AuthContextProvider } from "./_auth";

export default function App({ Component, pageProps }: AppProps) {
  const getLayout = Component.getLayout || ((page) => page);
  return (
    <AuthContextProvider>{getLayout(<Component {...pageProps} />)}</AuthContextProvider>
  );
}
```

Gives `[Server Error] Error: useAuth must be used within an AuthContextProvider`.

### Why?

```tsx
return React.createElement(AuthContext, null,
  // getLayout is called before AuthContext
  getLayout(
    React.createElement(Component, pageProps)
  )
)
```

## The fix

Use the layout as a component, not a function:

```tsx
return React.createElement(AuthContext, null,
  // Layout is called after AuthContext
  React.createElement(Layout, null,
    React.createElement(Component, pageProps)
  )
)
```

Like this:

```tsx
export default function App({ Component, pageProps }: AppPropsWithLayout) {
  const Layout = Component.Layout ?? Fragment

  return (
    <Layout>
      <Component {...pageProps} />
    </Layout>
  )
}
```

## Other notes:

- The documentation should recommend adding a distinctive name to the `Layout` component, because this will show a discting name in every layout vs `<Layout/>` in all the layouts (see the components tab in React Dev Tools).
- ESLints gives the `react-hooks/rules-of-hooks` warning with `getLayout` when the layout uses a hook (_React component names must start with an uppercase letter_).
- This applies to the pages directory, not the new app directory.

Fix #36029
Fix #42363