### PR TITLE
Add docs for missing support on custom routes

### DIFF
--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -186,7 +186,7 @@ module.exports = {
 
 ## Header, Cookie, and Query Matching
 
-To only match a rewrite when header, cookie, or query values also match the `has` field or don't match the `missing` field can be used. Both the `source` and all `has` items must match and all `missing` items must not match for the rewrite to be applied.
+To only apply a header when header, cookie, or query values also match the `has` field or don't match the `missing` field can be used. Both the `source` and all `has` items must match and all `missing` items must not match for the header to be applied.
 
 `has` and `missing` items can have the following fields:
 

--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -54,6 +54,7 @@ module.exports = {
 - `basePath`: `false` or `undefined` - if false the basePath won't be included when matching, can be used for external rewrites only.
 - `locale`: `false` or `undefined` - whether the locale should not be included when matching.
 - `has` is an array of [has objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
+- `missing` is an array of [missing objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
 
 Headers are checked before the filesystem which includes pages and `/public` files.
 
@@ -185,9 +186,9 @@ module.exports = {
 
 ## Header, Cookie, and Query Matching
 
-To only apply a header when either header, cookie, or query values also match the `has` field can be used. Both the `source` and all `has` items must match for the header to be applied.
+To only match a rewrite when header, cookie, or query values also match the `has` field or don't match the `missing` field can be used. Both the `source` and all `has` items must match and all `missing` items must not match for the rewrite to be applied.
 
-`has` items have the following fields:
+`has` and `missing` items can have the following fields:
 
 - `type`: `String` - must be either `header`, `cookie`, `host`, or `query`.
 - `key`: `String` - the key from the selected type to match against.
@@ -205,6 +206,23 @@ module.exports = {
           {
             type: 'header',
             key: 'x-add-header',
+          },
+        ],
+        headers: [
+          {
+            key: 'x-another-header',
+            value: 'hello',
+          },
+        ],
+      },
+      // if the header `x-no-header` is not present,
+      // the `x-another-header` header will be applied
+      {
+        source: '/:path*',
+        missing: [
+          {
+            type: 'header',
+            key: 'x-no-header',
           },
         ],
         headers: [

--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -50,6 +50,7 @@ module.exports = {
 - `basePath`: `false` or `undefined` - if false the `basePath` won't be included when matching, can be used for external redirects only.
 - `locale`: `false` or `undefined` - whether the locale should not be included when matching.
 - `has` is an array of [has objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
+- `missing` is an array of [missing objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
 
 Redirects are checked before the filesystem which includes pages and `/public` files.
 
@@ -140,9 +141,9 @@ module.exports = {
 
 ## Header, Cookie, and Query Matching
 
-To only match a redirect when header, cookie, or query values also match the `has` field can be used. Both the `source` and all `has` items must match for the redirect to be applied.
+To only match a rewrite when header, cookie, or query values also match the `has` field or don't match the `missing` field can be used. Both the `source` and all `has` items must match and all `missing` items must not match for the rewrite to be applied.
 
-`has` items have the following fields:
+`has` and `missing` items can have the following fields:
 
 - `type`: `String` - must be either `header`, `cookie`, `host`, or `query`.
 - `key`: `String` - the key from the selected type to match against.
@@ -160,6 +161,19 @@ module.exports = {
           {
             type: 'header',
             key: 'x-redirect-me',
+          },
+        ],
+        permanent: false,
+        destination: '/another-page',
+      },
+      // if the header `x-dont-redirect` is present,
+      // this redirect will be applied
+      {
+        source: '/:path((?!another-page$).*)',
+        missing: [
+          {
+            type: 'header',
+            key: 'x-do-not-redirect',
           },
         ],
         permanent: false,

--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -141,7 +141,7 @@ module.exports = {
 
 ## Header, Cookie, and Query Matching
 
-To only match a rewrite when header, cookie, or query values also match the `has` field or don't match the `missing` field can be used. Both the `source` and all `has` items must match and all `missing` items must not match for the rewrite to be applied.
+To only match a redirect when header, cookie, or query values also match the `has` field or don't match the `missing` field can be used. Both the `source` and all `has` items must match and all `missing` items must not match for the redirect to be applied.
 
 `has` and `missing` items can have the following fields:
 

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -14,10 +14,11 @@ description: Add rewrites to your Next.js app.
 <details>
   <summary><b>Version History</b></summary>
 
-| Version   | Changes         |
-| --------- | --------------- |
-| `v10.2.0` | `has` added.    |
-| `v9.5.0`  | Rewrites added. |
+| Version   | Changes          |
+| --------- | ---------------- |
+| `v13.3.0` | `missing` added. |
+| `v10.2.0` | `has` added.     |
+| `v9.5.0`  | Rewrites added.  |
 
 </details>
 
@@ -49,6 +50,7 @@ Rewrites are applied to client-side routing, a `<Link href="/about">` will have 
 - `basePath`: `false` or `undefined` - if false the basePath won't be included when matching, can be used for external rewrites only.
 - `locale`: `false` or `undefined` - whether the locale should not be included when matching.
 - `has` is an array of [has objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
+- `missing` is an array of [missing objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
 
 When the `rewrites` function returns an array, rewrites are applied after checking the filesystem (pages and `/public` files) and before dynamic routes. When the `rewrites` function returns an object of arrays with a specific shape, this behavior can be changed and more finely controlled, as of `v10.1` of Next.js:
 
@@ -219,9 +221,9 @@ module.exports = {
 
 ## Header, Cookie, and Query Matching
 
-To only match a rewrite when header, cookie, or query values also match the `has` field can be used. Both the `source` and all `has` items must match for the rewrite to be applied.
+To only match a rewrite when header, cookie, or query values also match the `has` field or don't match the `missing` field can be used. Both the `source` and all `has` items must match and all `missing` items must not match for the rewrite to be applied.
 
-`has` items have the following fields:
+`has` and `missing` items can have the following fields:
 
 - `type`: `String` - must be either `header`, `cookie`, `host`, or `query`.
 - `key`: `String` - the key from the selected type to match against.
@@ -236,6 +238,18 @@ module.exports = {
       {
         source: '/:path*',
         has: [
+          {
+            type: 'header',
+            key: 'x-rewrite-me',
+          },
+        ],
+        destination: '/another-page',
+      },
+      // if the header `x-rewrite-me` is not present,
+      // this rewrite will be applied
+      {
+        source: '/:path*',
+        missing: [
           {
             type: 'header',
             key: 'x-rewrite-me',


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/pull/42660

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
