### PR TITLE
Add lodash to server components external packages

### DIFF
--- a/packages/next/lib/server-external-packages.ts
+++ b/packages/next/lib/server-external-packages.ts
@@ -1,5 +1,6 @@
 // A list of popular packages that cannot be bundled on the server.
 export const EXTERNAL_PACKAGES = [
+  'lodash',
   '@prisma/client',
   '@sentry/nextjs',
   '@sentry/node',

--- a/packages/next/lib/server-external-packages.ts
+++ b/packages/next/lib/server-external-packages.ts
@@ -1,6 +1,5 @@
 // A list of popular packages that cannot be bundled on the server.
 export const EXTERNAL_PACKAGES = [
-  'lodash',
   '@prisma/client',
   '@sentry/nextjs',
   '@sentry/node',
@@ -10,6 +9,7 @@ export const EXTERNAL_PACKAGES = [
   'express',
   'firebase-admin',
   'jest',
+  'lodash',
   'mongodb',
   'next-mdx-remote',
   'next-seo',


### PR DESCRIPTION
Makes compilation a tiny bit faster as it can skip lodash because it won't ship server components.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
