### PR TITLE
not ie 11 is dead

### DIFF
--- a/docs/advanced-features/customizing-postcss-config.md
+++ b/docs/advanced-features/customizing-postcss-config.md
@@ -76,7 +76,7 @@ To customize browserslist, create a `browserslist` key in your `package.json` li
 
 ```json
 {
-  "browserslist": [">0.3%", "not ie 11", "not dead", "not op_mini all"]
+  "browserslist": [">0.3%", "not dead", "not op_mini all"]
 }
 ```
 


### PR DESCRIPTION
`not ie 11` is now included in `dead` by browserslist: https://browsersl.ist/#q=defaults%2C+not+ie+11%2C+not+dead

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
