### PR TITLE
Fix `.images.remotePatterns[0].port` warning

### DIFF
--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -572,7 +572,6 @@ const configSchema = {
                 type: 'string',
               },
               port: {
-                minLength: 1,
                 type: 'string',
               },
               protocol: {


### PR DESCRIPTION
The json schema was incorrectly warning because `port: ''` is valid and we document and use it in examples. The empty string is different than undefined

- empty string: match only URLs without a port
- undefined: match URLs with any port

I noticed this when running one of our examples:

```
pnpm next dev examples/image-component
ready - started server on 0.0.0.0:3000, url: http://localhost:3000
warn  - Invalid next.config.js options detected:
  - The value at .images.remotePatterns[0].port must be 1 character or more but it was 0 characters.
See more info here: https://nextjs.org/docs/messages/invalid-next-config
```