### PR TITLE
Migrate from yarn to pnpm for test deps packing

### DIFF
--- a/test/development/acceptance-app/ReactRefresh.test.ts
+++ b/test/development/acceptance-app/ReactRefresh.test.ts
@@ -24,7 +24,7 @@ describe('ReactRefresh app', () => {
   })
   afterAll(() => next.destroy())
 
-  test.only('can edit a component without losing state', async () => {
+  test('can edit a component without losing state', async () => {
     const { session, cleanup } = await sandbox(next)
     await session.patch(
       'index.js',

--- a/test/development/acceptance-app/ReactRefresh.test.ts
+++ b/test/development/acceptance-app/ReactRefresh.test.ts
@@ -23,7 +23,7 @@ describe('ReactRefresh app', () => {
     })
   })
   afterAll(() => next.destroy())
-
+  // test
   test('can edit a component without losing state', async () => {
     const { session, cleanup } = await sandbox(next)
     await session.patch(

--- a/test/development/acceptance-app/ReactRefresh.test.ts
+++ b/test/development/acceptance-app/ReactRefresh.test.ts
@@ -24,7 +24,7 @@ describe('ReactRefresh app', () => {
   })
   afterAll(() => next.destroy())
 
-  test('can edit a component without losing state', async () => {
+  test.only('can edit a component without losing state', async () => {
     const { session, cleanup } = await sandbox(next)
     await session.patch(
       'index.js',


### PR DESCRIPTION
Followup on https://github.com/vercel/next.js/pull/44023

We wanted to remove yarn for a long time to unify our package managers.
`pnpm pack` is also a bit faster so it speeds up our tests.