### PR TITLE
Run packing in tests in parallel

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -129,16 +129,19 @@ module.exports = (actionInfo) => {
 
       // wait to pack packages until after dependency paths have been updated
       // to the correct versions
-      for (const pkgName of pkgDatas.keys()) {
-        const { pkg, pkgPath } = pkgDatas.get(pkgName)
-        await exec(`cd ${pkgPath} && yarn pack -f ${pkg}-packed.tgz`, true, {
-          env: {
-            // Yarn installed through corepack will not run in pnpm project without this env var set
-            // This var works for corepack >=0.15.0
-            COREPACK_ENABLE_STRICT: '0',
-          },
+      await Promise.all(
+        Array.from(pkgDatas.keys()).map(async (pkgName) => {
+          const { pkg, pkgPath } = pkgDatas.get(pkgName)
+          await exec(`cd ${pkgPath} && yarn pack -f ${pkg}-packed.tgz`, true, {
+            env: {
+              // Yarn installed through corepack will not run in pnpm project without this env var set
+              // This var works for corepack >=0.15.0
+              COREPACK_ENABLE_STRICT: '0',
+            },
+          })
         })
-      }
+      )
+
       return pkgPaths
     },
   }


### PR DESCRIPTION
follow up on https://github.com/vercel/next.js/pull/44023

It runs packing in parallel - that should save us around 8 seconds in each `createNext` invocation.