### PR TITLE
Implement new core test API

### DIFF
--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -187,3 +187,58 @@ export async function createNext(
     flushAllTraces()
   }
 }
+
+export function createNextDescribe(
+  name: string,
+  options: Parameters<typeof createNext>[0] & {
+    skipDeployment?: boolean
+    dir?: string
+  },
+  fn: (context: {
+    isNextDev: boolean
+    isNextDeploy: boolean
+    isNextStart: boolean
+    next: NextInstance
+  }) => void
+): void {
+  describe(name, () => {
+    if (options.skipDeployment) {
+      // When the environment is running for deployment tests.
+      if ((global as any).isNextDeploy) {
+        it('should skip next deploy', () => {})
+        // No tests are run.
+        return
+      }
+    }
+
+    let next: NextInstance
+    beforeAll(async () => {
+      next = await createNext(options)
+    })
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    const nextProxy = new Proxy<NextInstance>({} as NextInstance, {
+      get: function (target, property) {
+        console.log(`Reading property ${property}`)
+        return next[property]
+      },
+    })
+    fn({
+      get isNextDev(): boolean {
+        return Boolean((global as any).isNextDev)
+      },
+
+      get isNextDeploy(): boolean {
+        return Boolean((global as any).isNextDeploy)
+      },
+      get isNextStart(): boolean {
+        return Boolean((global as any).isNextStart)
+      },
+      get next() {
+        return nextProxy
+      },
+    })
+  })
+}

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -220,8 +220,7 @@ export function createNextDescribe(
     })
 
     const nextProxy = new Proxy<NextInstance>({} as NextInstance, {
-      get: function (target, property) {
-        console.log(`Reading property ${property}`)
+      get: function (_target, property) {
         return next[property]
       },
     })

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -7,6 +7,9 @@ import { FileRef } from '../e2e-utils'
 import { ChildProcess } from 'child_process'
 import { createNextInstall } from '../create-next-install'
 import { Span } from 'next/trace'
+import webdriver from 'next-webdriver'
+import { renderViaHTTP, fetchViaHTTP } from 'next-test-utils'
+import cheerio from 'cheerio'
 
 type Event = 'stdout' | 'stderr' | 'error' | 'destroy'
 export type InstallCommand =
@@ -18,7 +21,7 @@ export type PackageJson = {
   [key: string]: unknown
 }
 export interface NextInstanceOpts {
-  files: FileRef | { [filename: string]: string | FileRef }
+  files: FileRef | string | { [filename: string]: string | FileRef }
   dependencies?: { [name: string]: string }
   packageJson?: PackageJson
   packageLockPath?: string
@@ -30,6 +33,16 @@ export interface NextInstanceOpts {
   dirSuffix?: string
   turbo?: boolean
 }
+
+/**
+ * Omit the first argument of a function
+ */
+type OmitFirstArgument<F> = F extends (
+  firstArgument: any,
+  ...args: infer P
+) => infer R
+  ? (...args: P) => R
+  : never
 
 export class NextInstance {
   protected files: FileRef | { [filename: string]: string | FileRef }
@@ -57,20 +70,23 @@ export class NextInstance {
   }
 
   protected async writeInitialFiles() {
-    if (this.files instanceof FileRef) {
+    // Handle case where files is a directory string
+    const files =
+      typeof this.files === 'string' ? new FileRef(this.files) : this.files
+    if (files instanceof FileRef) {
       // if a FileRef is passed directly to `files` we copy the
       // entire folder to the test directory
-      const stats = await fs.stat(this.files.fsPath)
+      const stats = await fs.stat(files.fsPath)
 
       if (!stats.isDirectory()) {
         throw new Error(
-          `FileRef passed to "files" in "createNext" is not a directory ${this.files.fsPath}`
+          `FileRef passed to "files" in "createNext" is not a directory ${files.fsPath}`
         )
       }
-      await fs.copy(this.files.fsPath, this.testDir)
+      await fs.copy(files.fsPath, this.testDir)
     } else {
-      for (const filename of Object.keys(this.files)) {
-        const item = this.files[filename]
+      for (const filename of Object.keys(files)) {
+        const item = files[filename]
         const outputFilename = path.join(this.testDir, filename)
 
         if (typeof item === 'string') {
@@ -361,6 +377,43 @@ export class NextInstance {
   }
   public async deleteFile(filename: string) {
     return fs.remove(path.join(this.testDir, filename))
+  }
+
+  /**
+   * Create new browser window for the Next.js app.
+   */
+  public async browser(
+    ...args: Parameters<OmitFirstArgument<typeof webdriver>>
+  ) {
+    return webdriver(this.url, ...args)
+  }
+
+  /**
+   * Fetch the HTML for the provided page. This is a shortcut for `renderViaHTTP().then(html => cheerio.load(html))`.
+   */
+  public async render$(
+    ...args: Parameters<OmitFirstArgument<typeof renderViaHTTP>>
+  ): Promise<ReturnType<typeof cheerio.load>> {
+    const html = await renderViaHTTP(this.url, ...args)
+    return cheerio.load(html)
+  }
+
+  /**
+   * Fetch the HTML for the provided page. This is a shortcut for `fetchViaHTTP().then(res => res.text())`.
+   */
+  public async render(
+    ...args: Parameters<OmitFirstArgument<typeof renderViaHTTP>>
+  ) {
+    return renderViaHTTP(this.url, ...args)
+  }
+
+  /**
+   * Fetch the HTML for the provided page.
+   */
+  public async fetch(
+    ...args: Parameters<OmitFirstArgument<typeof fetchViaHTTP>>
+  ) {
+    return fetchViaHTTP(this.url, ...args)
   }
 
   public on(event: Event, cb: (...args: any[]) => any) {


### PR DESCRIPTION
Adds a new way to write e2e tests for the Next.js core, mostly to reduce common boilerplate and make it easier to write tests for now team members.

```ts
// test/e2e/app-dir/head/head.test.ts
import { createNextDescribe } from 'e2e-utils'

createNextDescribe(
  'app dir head',
  {
    files: __dirname
  },
  ({ next }) => {
    test('handles ', async () => {
      // get cheerio (jQuery like API to traverse HTML)
      const $ = await next.render$('/')
      // get html
      const html = await next.render('/')
      // use fetch
      const res = await next.fetch('/')
      // get browser
      const browser = await next.browser('/')
    })
})
