### PR TITLE
Docs: Update deployment.md with Firebase, Amplify and Cloudflare

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -105,7 +105,7 @@ The following services support Next.js `v12+`. Below, you’ll find examples or 
 
 > **Note:** There are also managed platforms that allow you to use a Dockerfile as shown in the [example above](/docs/deployment.md#docker-image).
 
-### Static Only
+### Static
 
 The following services support deploying Next.js using [`next export`](/docs/advanced-features/static-html-export.md).
 
@@ -117,12 +117,17 @@ You can also manually deploy the [`next export`](/docs/advanced-features/static-
 
 ### Serverless
 
+- [AWS Amplify](https://docs.aws.amazon.com/amplify/latest/userguide/ssr-Amplify-support.html)
 - [AWS Serverless](https://github.com/serverless-nextjs/serverless-next.js)
 - [Azure Static Web Apps](https://learn.microsoft.com/en-us/azure/static-web-apps/nextjs)
 - [Terraform](https://github.com/milliHQ/terraform-aws-next-js)
 - [Netlify](https://docs.netlify.com/integrations/frameworks/next-js)
 
 > **Note:** Not all serverless providers implement the [Next.js Build API](/docs/deployment.md#nextjs-build-api) from `next start`. Please check with the provider to see what features are supported.
+
+### Edge
+
+- [Cloudflare Pages](https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/)
 
 ## Automatic Updates
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -105,18 +105,17 @@ The following services support Next.js `v12+`. Below, you’ll find examples or 
 
 > **Note:** There are also managed platforms that allow you to use a Dockerfile as shown in the [example above](/docs/deployment.md#docker-image).
 
-### Static
+### Static Only
 
 The following services support deploying Next.js using [`next export`](/docs/advanced-features/static-html-export.md).
 
-- [Cloudflare Pages](https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/)
-- [Firebase](https://github.com/vercel/next.js/tree/canary/examples/with-firebase-hosting)
 - [GitHub Pages](https://github.com/vercel/next.js/tree/canary/examples/github-pages)
 
 You can also manually deploy the [`next export`](/docs/advanced-features/static-html-export.md) output to any static hosting provider, often through your CI/CD pipeline like GitHub Actions, Jenkins, AWS CodeBuild, Circle CI, Azure Pipelines, and more.
 
 ### Serverless
 
+- [Firebase](https://firebase.google.com/docs/hosting/nextjs)
 - [AWS Amplify](https://docs.aws.amazon.com/amplify/latest/userguide/ssr-Amplify-support.html)
 - [AWS Serverless](https://github.com/serverless-nextjs/serverless-next.js)
 - [Azure Static Web Apps](https://learn.microsoft.com/en-us/azure/static-web-apps/nextjs)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,7 +107,7 @@ The following services support Next.js `v12+`. Below, you’ll find examples or 
 
 ### Static Only
 
-The following services support deploying Next.js using [`next export`](/docs/advanced-features/static-html-export.md).
+The following services only support deploying Next.js using [`next export`](/docs/advanced-features/static-html-export.md).
 
 - [GitHub Pages](https://github.com/vercel/next.js/tree/canary/examples/github-pages)
 
@@ -115,18 +115,15 @@ You can also manually deploy the [`next export`](/docs/advanced-features/static-
 
 ### Serverless
 
-- [Firebase](https://firebase.google.com/docs/hosting/nextjs)
 - [AWS Amplify](https://docs.aws.amazon.com/amplify/latest/userguide/ssr-Amplify-support.html)
 - [AWS Serverless](https://github.com/serverless-nextjs/serverless-next.js)
 - [Azure Static Web Apps](https://learn.microsoft.com/en-us/azure/static-web-apps/nextjs)
-- [Terraform](https://github.com/milliHQ/terraform-aws-next-js)
+- [Cloudflare Pages](https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/)
+- [Firebase](https://firebase.google.com/docs/hosting/nextjs)
 - [Netlify](https://docs.netlify.com/integrations/frameworks/next-js)
+- [Terraform](https://github.com/milliHQ/terraform-aws-next-js)
 
 > **Note:** Not all serverless providers implement the [Next.js Build API](/docs/deployment.md#nextjs-build-api) from `next start`. Please check with the provider to see what features are supported.
-
-### Edge
-
-- [Cloudflare Pages](https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/)
 
 ## Automatic Updates
 


### PR DESCRIPTION
This proposes updates based on New Cloud Services that are supporting Next.js.

1. Cloudflare Pages and Firebase are not Static Only Anymore so moved them to respective sections
2. Added AWS Amplify

**Please merge this open source contribution if this seems valid to you. 🙏** 

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
