### PR TITLE
Refactor more tests to createNextDescribe

### DIFF
--- a/test/development/acceptance-app/ReactRefresh.test.ts
+++ b/test/development/acceptance-app/ReactRefresh.test.ts
@@ -5,11 +5,6 @@ import { NextInstance } from 'test/lib/next-modes/base'
 import path from 'path'
 
 describe('ReactRefresh app', () => {
-  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
-    it('should skip for react v17', () => {})
-    return
-  }
-
   let next: NextInstance
 
   beforeAll(async () => {

--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -5,11 +5,6 @@ import path from 'path'
 
 // TODO-APP: Investigate snapshot mismatch
 describe('ReactRefreshLogBox app', () => {
-  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
-    it('should skip for react v17', () => {})
-    return
-  }
-
   let next: NextInstance
 
   beforeAll(async () => {

--- a/test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts
@@ -7,11 +7,6 @@ import path from 'path'
 // TODO: figure out why snapshots mismatch on GitHub actions
 // specifically but work in docker and locally
 describe.skip('ReactRefreshLogBox app', () => {
-  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
-    it('should skip for react v17', () => {})
-    return
-  }
-
   let next: NextInstance
 
   beforeAll(async () => {

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -6,11 +6,6 @@ import { check } from 'next-test-utils'
 import path from 'path'
 
 describe('ReactRefreshLogBox app', () => {
-  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
-    it('should skip for react v17', () => {})
-    return
-  }
-
   let next: NextInstance
 
   beforeAll(async () => {

--- a/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
@@ -6,11 +6,6 @@ import path from 'path'
 // TODO: re-enable these tests after figuring out what is causing
 // them to be so unreliable in CI
 describe.skip('ReactRefreshLogBox app', () => {
-  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
-    it('should skip for react v17', () => {})
-    return
-  }
-
   let next: NextInstance
 
   beforeAll(async () => {

--- a/test/development/acceptance-app/ReactRefreshModule.test.ts
+++ b/test/development/acceptance-app/ReactRefreshModule.test.ts
@@ -4,11 +4,6 @@ import { NextInstance } from 'test/lib/next-modes/base'
 import { sandbox } from './helpers'
 
 describe('ReactRefreshModule app', () => {
-  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
-    it('should skip for react v17', () => {})
-    return
-  }
-
   let next: NextInstance
 
   beforeAll(async () => {

--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -5,11 +5,6 @@ import { NextInstance } from 'test/lib/next-modes/base'
 import path from 'path'
 
 describe('ReactRefreshRegression app', () => {
-  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
-    it('should skip for react v17', () => {})
-    return
-  }
-
   let next: NextInstance
 
   beforeAll(async () => {

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -6,11 +6,6 @@ import path from 'path'
 import { check } from 'next-test-utils'
 
 describe('Error Overlay for server components', () => {
-  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
-    it('should skip for react v17', () => {})
-    return
-  }
-
   let next: NextInstance
 
   beforeAll(async () => {

--- a/test/development/basic-basepath/hmr.test.ts
+++ b/test/development/basic-basepath/hmr.test.ts
@@ -532,14 +532,10 @@ describe('basic HMR', () => {
           )
         )
 
-        const isReact17 = process.env.NEXT_TEST_REACT_VERSION === '^17'
-
         expect(await hasRedbox(browser)).toBe(true)
         // TODO: Replace this when webpack 5 is the default
         expect(await getRedboxHeader(browser)).toMatch(
-          `Objects are not valid as a React child (found: ${
-            isReact17 ? '/search/' : '[object RegExp]'
-          }). If you meant to render a collection of children, use an array instead.`
+          `Objects are not valid as a React child (found: [object RegExp]). If you meant to render a collection of children, use an array instead.`
         )
 
         await next.patchFile(aboutPage, aboutContent)

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -597,14 +597,10 @@ describe('basic HMR', () => {
           )
         )
 
-        const isReact17 = process.env.NEXT_TEST_REACT_VERSION === '^17'
-
         expect(await hasRedbox(browser)).toBe(true)
         // TODO: Replace this when webpack 5 is the default
         expect(await getRedboxHeader(browser)).toMatch(
-          `Objects are not valid as a React child (found: ${
-            isReact17 ? '/search/' : '[object RegExp]'
-          }). If you meant to render a collection of children, use an array instead.`
+          `Objects are not valid as a React child (found: [object RegExp]). If you meant to render a collection of children, use an array instead.`
         )
 
         await next.patchFile(aboutPage, aboutContent)

--- a/test/e2e/app-dir/app-alias.test.ts
+++ b/test/e2e/app-dir/app-alias.test.ts
@@ -1,56 +1,45 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
-import { renderViaHTTP } from 'next-test-utils'
-import webdriver from 'next-webdriver'
+import { createNextDescribe } from 'e2e-utils'
 import path from 'path'
-import { readJSON } from 'fs-extra'
 
-describe('app-dir alias handling', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
-
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'app-alias')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-        typescript: 'latest',
-        '@types/react': 'latest',
-        '@types/node': 'latest',
-      },
-      packageJson: {
-        type: 'module',
-      },
+createNextDescribe(
+  'app-dir alias handling',
+  {
+    files: path.join(__dirname, 'app-alias'),
+    dependencies: {
+      react: 'latest',
+      'react-dom': 'latest',
+      typescript: 'latest',
+      '@types/react': 'latest',
+      '@types/node': 'latest',
+    },
+    packageJson: {
+      type: 'module',
+    },
+    skipDeployment: true,
+  },
+  ({ next, isNextDev }) => {
+    it('should handle typescript paths alias correctly', async () => {
+      const html = await next.render('/button')
+      expect(html).toContain('click</button>')
     })
-  })
-  afterAll(() => next.destroy())
 
-  it('should handle typescript paths alias correctly', async () => {
-    const html = await renderViaHTTP(next.url, '/button')
-    expect(html).toContain('click</button>')
-  })
-
-  it('should resolve css imports from outside with src folder presented', async () => {
-    const browser = await webdriver(next.url, '/button')
-    const fontSize = await browser
-      .elementByCss('button')
-      .getComputedCss('font-size')
-    expect(fontSize).toBe('50px')
-  })
-
-  if (!(global as any).isNextDev) {
-    it('should generate app-build-manifest correctly', async () => {
-      // Remove other page CSS files:
-      const manifest = await readJSON(
-        path.join(next.testDir, '.next', 'app-build-manifest.json')
-      )
-
-      expect(manifest.pages).not.toBeEmptyObject()
+    it('should resolve css imports from outside with src folder presented', async () => {
+      const browser = await next.browser('/button')
+      const fontSize = await browser
+        .elementByCss('button')
+        .getComputedCss('font-size')
+      expect(fontSize).toBe('50px')
     })
+
+    if (!isNextDev) {
+      it('should generate app-build-manifest correctly', async () => {
+        // Remove other page CSS files:
+        const manifest = await next.readJSON(
+          path.join('.next', 'app-build-manifest.json')
+        )
+
+        expect(manifest.pages).not.toBeEmptyObject()
+      })
+    }
   }
-})
+)

--- a/test/e2e/app-dir/app-edge-global.test.ts
+++ b/test/e2e/app-dir/app-edge-global.test.ts
@@ -1,32 +1,23 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
-import { renderViaHTTP } from 'next-test-utils'
+import { createNextDescribe } from 'e2e-utils'
 import path from 'path'
 
-describe('app-dir global edge configuration', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
-
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'app-edge-global')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-        typescript: 'latest',
-        '@types/react': 'latest',
-        '@types/node': 'latest',
-      },
+createNextDescribe(
+  'app-dir global edge configuration',
+  {
+    files: path.join(__dirname, 'app-edge-global'),
+    dependencies: {
+      react: 'latest',
+      'react-dom': 'latest',
+      typescript: 'latest',
+      '@types/react': 'latest',
+      '@types/node': 'latest',
+    },
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should handle edge only routes', async () => {
+      const html = await next.render('/app-edge')
+      expect(html).toContain('<p>Edge!</p>')
     })
-  })
-  afterAll(() => next.destroy())
-
-  it('should handle edge only routes', async () => {
-    const appHtml = await renderViaHTTP(next.url, '/app-edge')
-    expect(appHtml).toContain('<p>Edge!</p>')
-  })
-})
+  }
+)

--- a/test/e2e/app-dir/app-edge.test.ts
+++ b/test/e2e/app-dir/app-edge.test.ts
@@ -1,80 +1,72 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
-import { check, renderViaHTTP } from 'next-test-utils'
+import { createNextDescribe } from 'e2e-utils'
+import { check } from 'next-test-utils'
 import path from 'path'
 
-describe('app-dir edge SSR', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
+createNextDescribe(
+  'app-dir edge SSR',
+  {
+    files: path.join(__dirname, 'app-edge'),
+    dependencies: {
+      react: 'latest',
+      'react-dom': 'latest',
+      typescript: 'latest',
+      '@types/react': 'latest',
+      '@types/node': 'latest',
+    },
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should handle edge only routes', async () => {
+      const appHtml = await next.render('/app-edge')
+      expect(appHtml).toContain('<p>Edge!</p>')
 
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'app-edge')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-        typescript: 'latest',
-        '@types/react': 'latest',
-        '@types/node': 'latest',
-      },
+      const pageHtml = await next.render('/pages-edge')
+      expect(pageHtml).toContain('<p>pages-edge-ssr</p>')
     })
-  })
-  afterAll(() => next.destroy())
 
-  it('should handle edge only routes', async () => {
-    const appHtml = await renderViaHTTP(next.url, '/app-edge')
-    expect(appHtml).toContain('<p>Edge!</p>')
-
-    const pageHtml = await renderViaHTTP(next.url, '/pages-edge')
-    expect(pageHtml).toContain('<p>pages-edge-ssr</p>')
-  })
-
-  if ((globalThis as any).isNextDev) {
-    it('should resolve module without error in edge runtime', async () => {
-      const logs = []
-      next.on('stderr', (log) => {
-        logs.push(log)
+    if ((globalThis as any).isNextDev) {
+      it('should resolve module without error in edge runtime', async () => {
+        const logs = []
+        next.on('stderr', (log) => {
+          logs.push(log)
+        })
+        await next.render('app-edge')
+        expect(
+          logs.some((log) => log.includes(`Attempted import error:`))
+        ).toBe(false)
       })
-      await renderViaHTTP(next.url, 'app-edge')
-      expect(logs.some((log) => log.includes(`Attempted import error:`))).toBe(
-        false
-      )
-    })
 
-    it('should handle edge rsc hmr', async () => {
-      const pageFile = 'app/app-edge/page.tsx'
-      const content = await next.readFile(pageFile)
+      it('should handle edge rsc hmr', async () => {
+        const pageFile = 'app/app-edge/page.tsx'
+        const content = await next.readFile(pageFile)
 
-      // Update rendered content
-      const updatedContent = content.replace('Edge!', 'edge-hmr')
-      await next.patchFile(pageFile, updatedContent)
-      await check(async () => {
-        const html = await renderViaHTTP(next.url, '/app-edge')
-        return html
-      }, /edge-hmr/)
+        // Update rendered content
+        const updatedContent = content.replace('Edge!', 'edge-hmr')
+        await next.patchFile(pageFile, updatedContent)
+        await check(async () => {
+          const html = await next.render('/app-edge')
+          return html
+        }, /edge-hmr/)
 
-      // Revert
-      await next.patchFile(pageFile, content)
-      await check(async () => {
-        const html = await renderViaHTTP(next.url, '/app-edge')
-        return html
-      }, /Edge!/)
-    })
-  } else {
-    // Production tests
-    it('should generate matchers correctly in middleware manifest', async () => {
-      const manifest = JSON.parse(
-        await next.readFile('.next/server/middleware-manifest.json')
-      )
-      expect(manifest.functions['/(group)/group/page'].matchers).toEqual([
-        {
-          regexp: '^/group$',
-        },
-      ])
-    })
+        // Revert
+        await next.patchFile(pageFile, content)
+        await check(async () => {
+          const html = await next.render('/app-edge')
+          return html
+        }, /Edge!/)
+      })
+    } else {
+      // Production tests
+      it('should generate matchers correctly in middleware manifest', async () => {
+        const manifest = JSON.parse(
+          await next.readFile('.next/server/middleware-manifest.json')
+        )
+        expect(manifest.functions['/(group)/group/page'].matchers).toEqual([
+          {
+            regexp: '^/group$',
+          },
+        ])
+      })
+    }
   }
-})
+)

--- a/test/e2e/app-dir/app-external.test.ts
+++ b/test/e2e/app-dir/app-external.test.ts
@@ -1,8 +1,6 @@
 import path from 'path'
-import { renderViaHTTP, fetchViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
-import webdriver from 'next-webdriver'
+import { renderViaHTTP } from 'next-test-utils'
+import { createNextDescribe } from 'e2e-utils'
 
 async function resolveStreamResponse(response: any, onData?: any) {
   let result = ''
@@ -18,182 +16,178 @@ async function resolveStreamResponse(response: any, onData?: any) {
   return result
 }
 
-describe('app dir - external dependency', () => {
-  let next: NextInstance
-
-  if ((global as any).isNextDeploy) {
-    it('should skip for deploy mode for now', () => {})
-    return
-  }
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, './app-external')),
-      dependencies: {
-        '@next/font': 'canary',
-        react: 'latest',
-        'react-dom': 'latest',
-        swr: '2.0.0-rc.0',
+createNextDescribe(
+  'app dir - external dependency',
+  {
+    files: path.join(__dirname, './app-external'),
+    dependencies: {
+      '@next/font': 'canary',
+      react: 'latest',
+      'react-dom': 'latest',
+      swr: '2.0.0-rc.0',
+    },
+    packageJson: {
+      scripts: {
+        setup: `cp -r ./node_modules_bak/* ./node_modules`,
+        build: 'yarn setup && next build',
+        dev: 'yarn setup && next dev',
+        start: 'next start',
       },
-      packageJson: {
-        scripts: {
-          setup: `cp -r ./node_modules_bak/* ./node_modules`,
-          build: 'yarn setup && next build',
-          dev: 'yarn setup && next dev',
-          start: 'next start',
-        },
-      },
-      installCommand: 'yarn',
-      startCommand: (global as any).isNextDev ? 'yarn dev' : 'yarn start',
-      buildCommand: 'yarn build',
-    })
-  })
-  afterAll(() => next.destroy())
-
-  const { isNextDeploy } = global as any
-  if (isNextDeploy) {
-    it('should skip tests for next-deploy', () => {})
-    return
-  }
-
-  it('should be able to opt-out 3rd party packages being bundled in server components', async () => {
-    await fetchViaHTTP(next.url, '/react-server/optout').then(
-      async (response) => {
+    },
+    installCommand: 'yarn',
+    startCommand: (global as any).isNextDev ? 'yarn dev' : 'yarn start',
+    buildCommand: 'yarn build',
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should be able to opt-out 3rd party packages being bundled in server components', async () => {
+      await next.fetch('/react-server/optout').then(async (response) => {
         const result = await resolveStreamResponse(response)
         expect(result).toContain('Server: index.default')
         expect(result).toContain('Server subpath: subpath.default')
         expect(result).toContain('Client: index.default')
         expect(result).toContain('Client subpath: subpath.default')
-      }
-    )
-  })
-
-  it('should handle external async module libraries correctly', async () => {
-    const clientHtml = await renderViaHTTP(next.url, '/external-imports/client')
-    const serverHtml = await renderViaHTTP(next.url, '/external-imports/server')
-    const sharedHtml = await renderViaHTTP(next.url, '/shared-esm-dep')
-
-    const browser = await webdriver(next.url, '/external-imports/client')
-    const browserClientText = await browser.elementByCss('#content').text()
-
-    function containClientContent(content) {
-      expect(content).toContain('module type:esm-export')
-      expect(content).toContain('export named:named')
-      expect(content).toContain('export value:123')
-      expect(content).toContain('export array:4,5,6')
-      expect(content).toContain('export object:{x:1}')
-      expect(content).toContain('swr-state')
-    }
-
-    containClientContent(clientHtml)
-    containClientContent(browserClientText)
-
-    // support esm module imports on server side, and indirect imports from shared components
-    expect(serverHtml).toContain('pure-esm-module')
-    expect(sharedHtml).toContain(
-      'node_modules instance from client module pure-esm-module'
-    )
-  })
-
-  it('should transpile specific external packages with the `transpilePackages` option', async () => {
-    const clientHtml = await renderViaHTTP(next.url, '/external-imports/client')
-    expect(clientHtml).toContain('transpilePackages:5')
-  })
-
-  it('should resolve the subset react in server components based on the react-server condition', async () => {
-    await fetchViaHTTP(next.url, '/react-server').then(async (response) => {
-      const result = await resolveStreamResponse(response)
-      expect(result).toContain('Server: <!-- -->subset')
-      expect(result).toContain('Client: <!-- -->full')
+      })
     })
-  })
 
-  it('should resolve 3rd party package exports based on the react-server condition', async () => {
-    await fetchViaHTTP(next.url, '/react-server/3rd-party-package').then(
-      async (response) => {
+    it('should handle external async module libraries correctly', async () => {
+      const clientHtml = await renderViaHTTP(
+        next.url,
+        '/external-imports/client'
+      )
+      const serverHtml = await renderViaHTTP(
+        next.url,
+        '/external-imports/server'
+      )
+      const sharedHtml = await next.render('/shared-esm-dep')
+
+      const browser = await next.browser('/external-imports/client')
+      const browserClientText = await browser.elementByCss('#content').text()
+
+      function containClientContent(content) {
+        expect(content).toContain('module type:esm-export')
+        expect(content).toContain('export named:named')
+        expect(content).toContain('export value:123')
+        expect(content).toContain('export array:4,5,6')
+        expect(content).toContain('export object:{x:1}')
+        expect(content).toContain('swr-state')
+      }
+
+      containClientContent(clientHtml)
+      containClientContent(browserClientText)
+
+      // support esm module imports on server side, and indirect imports from shared components
+      expect(serverHtml).toContain('pure-esm-module')
+      expect(sharedHtml).toContain(
+        'node_modules instance from client module pure-esm-module'
+      )
+    })
+
+    it('should transpile specific external packages with the `transpilePackages` option', async () => {
+      const clientHtml = await renderViaHTTP(
+        next.url,
+        '/external-imports/client'
+      )
+      expect(clientHtml).toContain('transpilePackages:5')
+    })
+
+    it('should resolve the subset react in server components based on the react-server condition', async () => {
+      await next.fetch('/react-server').then(async (response) => {
+        const result = await resolveStreamResponse(response)
+        expect(result).toContain('Server: <!-- -->subset')
+        expect(result).toContain('Client: <!-- -->full')
+      })
+    })
+
+    it('should resolve 3rd party package exports based on the react-server condition', async () => {
+      await next
+        .fetch('/react-server/3rd-party-package')
+        .then(async (response) => {
+          const result = await resolveStreamResponse(response)
+
+          // Package should be resolved based on the react-server condition,
+          // as well as package's internal & external dependencies.
+          expect(result).toContain(
+            'Server: index.react-server:react.subset:dep.server'
+          )
+          expect(result).toContain(
+            'Client: index.default:react.full:dep.default'
+          )
+
+          // Subpath exports should be resolved based on the condition too.
+          expect(result).toContain('Server subpath: subpath.react-server')
+          expect(result).toContain('Client subpath: subpath.default')
+        })
+    })
+
+    it('should correctly collect global css imports and mark them as side effects', async () => {
+      await next.fetch('/css/a').then(async (response) => {
         const result = await resolveStreamResponse(response)
 
-        // Package should be resolved based on the react-server condition,
-        // as well as package's internal & external dependencies.
-        expect(result).toContain(
-          'Server: index.react-server:react.subset:dep.server'
+        // It should include the global CSS import
+        expect(result).toMatch(/\.css/)
+      })
+    })
+
+    it('should handle external css modules', async () => {
+      const browser = await next.browser('/css/modules')
+
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.querySelector('h1')).color`
         )
-        expect(result).toContain('Client: index.default:react.full:dep.default')
-
-        // Subpath exports should be resolved based on the condition too.
-        expect(result).toContain('Server subpath: subpath.react-server')
-        expect(result).toContain('Client subpath: subpath.default')
-      }
-    )
-  })
-
-  it('should correctly collect global css imports and mark them as side effects', async () => {
-    await fetchViaHTTP(next.url, '/css/a').then(async (response) => {
-      const result = await resolveStreamResponse(response)
-
-      // It should include the global CSS import
-      expect(result).toMatch(/\.css/)
-    })
-  })
-
-  it('should handle external css modules', async () => {
-    const browser = await webdriver(next.url, '/css/modules')
-
-    expect(
-      await browser.eval(
-        `window.getComputedStyle(document.querySelector('h1')).color`
-      )
-    ).toBe('rgb(255, 0, 0)')
-  })
-
-  it('should use the same export type for packages in both ssr and client', async () => {
-    const browser = await webdriver(next.url, '/client-dep')
-    expect(await browser.eval(`window.document.body.innerText`)).toBe('hello')
-  })
-
-  it('should handle external css modules in pages', async () => {
-    const browser = await webdriver(next.url, '/test-pages')
-
-    expect(
-      await browser.eval(
-        `window.getComputedStyle(document.querySelector('h1')).color`
-      )
-    ).toBe('rgb(255, 0, 0)')
-  })
-
-  it('should handle external @next/font', async () => {
-    const browser = await webdriver(next.url, '/font')
-
-    expect(
-      await browser.eval(
-        `window.getComputedStyle(document.querySelector('p')).fontFamily`
-      )
-    ).toMatch(/^__myFont_.{6}, __myFont_Fallback_.{6}$/)
-  })
-
-  describe('react in external esm packages', () => {
-    it('should use the same react in client app', async () => {
-      const html = await renderViaHTTP(next.url, '/esm/client')
-
-      const v1 = html.match(/App React Version: ([^<]+)</)[1]
-      const v2 = html.match(/External React Version: ([^<]+)</)[1]
-      expect(v1).toBe(v2)
+      ).toBe('rgb(255, 0, 0)')
     })
 
-    it('should use the same react in server app', async () => {
-      const html = await renderViaHTTP(next.url, '/esm/server')
-
-      const v1 = html.match(/App React Version: ([^<]+)</)[1]
-      const v2 = html.match(/External React Version: ([^<]+)</)[1]
-      expect(v1).toBe(v2)
+    it('should use the same export type for packages in both ssr and client', async () => {
+      const browser = await next.browser('/client-dep')
+      expect(await browser.eval(`window.document.body.innerText`)).toBe('hello')
     })
 
-    it('should use the same react in pages', async () => {
-      const html = await renderViaHTTP(next.url, '/test-pages-esm')
+    it('should handle external css modules in pages', async () => {
+      const browser = await next.browser('/test-pages')
 
-      const v1 = html.match(/App React Version: ([^<]+)</)[1]
-      const v2 = html.match(/External React Version: ([^<]+)</)[1]
-      expect(v1).toBe(v2)
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.querySelector('h1')).color`
+        )
+      ).toBe('rgb(255, 0, 0)')
     })
-  })
-})
+
+    it('should handle external @next/font', async () => {
+      const browser = await next.browser('/font')
+
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.querySelector('p')).fontFamily`
+        )
+      ).toMatch(/^__myFont_.{6}, __myFont_Fallback_.{6}$/)
+    })
+
+    describe('react in external esm packages', () => {
+      it('should use the same react in client app', async () => {
+        const html = await next.render('/esm/client')
+
+        const v1 = html.match(/App React Version: ([^<]+)</)[1]
+        const v2 = html.match(/External React Version: ([^<]+)</)[1]
+        expect(v1).toBe(v2)
+      })
+
+      it('should use the same react in server app', async () => {
+        const html = await next.render('/esm/server')
+
+        const v1 = html.match(/App React Version: ([^<]+)</)[1]
+        const v2 = html.match(/External React Version: ([^<]+)</)[1]
+        expect(v1).toBe(v2)
+      })
+
+      it('should use the same react in pages', async () => {
+        const html = await next.render('/test-pages-esm')
+
+        const v1 = html.match(/App React Version: ([^<]+)</)[1]
+        const v2 = html.match(/External React Version: ([^<]+)</)[1]
+        expect(v1).toBe(v2)
+      })
+    })
+  }
+)

--- a/test/e2e/app-dir/app-external.test.ts
+++ b/test/e2e/app-dir/app-external.test.ts
@@ -51,9 +51,8 @@ describe('app dir - external dependency', () => {
   afterAll(() => next.destroy())
 
   const { isNextDeploy } = global as any
-  const isReact17 = process.env.NEXT_TEST_REACT_VERSION === '^17'
-  if (isNextDeploy || isReact17) {
-    it('should skip tests for next-deploy and react 17', () => {})
+  if (isNextDeploy) {
+    it('should skip tests for next-deploy', () => {})
     return
   }
 

--- a/test/e2e/app-dir/app-external.test.ts
+++ b/test/e2e/app-dir/app-external.test.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import { renderViaHTTP } from 'next-test-utils'
 import { createNextDescribe } from 'e2e-utils'
 
 async function resolveStreamResponse(response: any, onData?: any) {
@@ -51,14 +50,8 @@ createNextDescribe(
     })
 
     it('should handle external async module libraries correctly', async () => {
-      const clientHtml = await renderViaHTTP(
-        next.url,
-        '/external-imports/client'
-      )
-      const serverHtml = await renderViaHTTP(
-        next.url,
-        '/external-imports/server'
-      )
+      const clientHtml = await next.render('/external-imports/client')
+      const serverHtml = await next.render('/external-imports/server')
       const sharedHtml = await next.render('/shared-esm-dep')
 
       const browser = await next.browser('/external-imports/client')
@@ -84,10 +77,7 @@ createNextDescribe(
     })
 
     it('should transpile specific external packages with the `transpilePackages` option', async () => {
-      const clientHtml = await renderViaHTTP(
-        next.url,
-        '/external-imports/client'
-      )
+      const clientHtml = await next.render('/external-imports/client')
       expect(clientHtml).toContain('transpilePackages:5')
     })
 

--- a/test/e2e/app-dir/app-middleware.test.ts
+++ b/test/e2e/app-dir/app-middleware.test.ts
@@ -1,158 +1,150 @@
 /* eslint-env jest */
-
-import { NextInstance } from 'test/lib/next-modes/base'
-import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNextDescribe, FileRef } from 'e2e-utils'
 import cheerio from 'cheerio'
 import path from 'path'
 
-describe('app-dir with middleware', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
-
-  let next: NextInstance
-
-  afterAll(() => next.destroy())
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'app-middleware')),
-    })
-  })
-
-  describe.each([
-    {
-      title: 'Serverless Functions',
-      path: '/api/dump-headers-serverless',
-      toJson: (res: Response) => res.json(),
-    },
-    {
-      title: 'Edge Functions',
-      path: '/api/dump-headers-edge',
-      toJson: (res: Response) => res.json(),
-    },
-    {
-      title: 'next/headers',
-      path: '/headers',
-      toJson: async (res: Response) => {
-        const $ = cheerio.load(await res.text())
-        return JSON.parse($('#headers').text())
+createNextDescribe(
+  'app-dir with middleware',
+  {
+    files: path.join(__dirname, 'app-middleware'),
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    describe.each([
+      {
+        title: 'Serverless Functions',
+        path: '/api/dump-headers-serverless',
+        toJson: (res: Response) => res.json(),
       },
-    },
-  ])('Mutate request headers for $title', ({ path, toJson }) => {
-    it(`Adds new headers`, async () => {
-      const res = await fetchViaHTTP(next.url, path, null, {
-        headers: {
+      {
+        title: 'Edge Functions',
+        path: '/api/dump-headers-edge',
+        toJson: (res: Response) => res.json(),
+      },
+      {
+        title: 'next/headers',
+        path: '/headers',
+        toJson: async (res: Response) => {
+          const $ = cheerio.load(await res.text())
+          return JSON.parse($('#headers').text())
+        },
+      },
+    ])('Mutate request headers for $title', ({ path, toJson }) => {
+      it(`Adds new headers`, async () => {
+        const res = await next.fetch(path, null, {
+          headers: {
+            'x-from-client': 'hello-from-client',
+          },
+        })
+        expect(await toJson(res)).toMatchObject({
           'x-from-client': 'hello-from-client',
-        },
+          'x-from-middleware': 'hello-from-middleware',
+        })
       })
-      expect(await toJson(res)).toMatchObject({
-        'x-from-client': 'hello-from-client',
-        'x-from-middleware': 'hello-from-middleware',
-      })
-    })
 
-    it(`Deletes headers`, async () => {
-      const res = await fetchViaHTTP(
-        next.url,
-        path,
-        {
-          'remove-headers': 'x-from-client1,x-from-client2',
-        },
-        {
-          headers: {
-            'x-from-client1': 'hello-from-client',
-            'X-From-Client2': 'hello-from-client',
+      it(`Deletes headers`, async () => {
+        const res = await next.fetch(
+          path,
+          {
+            'remove-headers': 'x-from-client1,x-from-client2',
           },
-        }
-      )
+          {
+            headers: {
+              'x-from-client1': 'hello-from-client',
+              'X-From-Client2': 'hello-from-client',
+            },
+          }
+        )
 
-      const json = await toJson(res)
-      expect(json).not.toHaveProperty('x-from-client1')
-      expect(json).not.toHaveProperty('X-From-Client2')
-      expect(json).toMatchObject({
-        'x-from-middleware': 'hello-from-middleware',
+        const json = await toJson(res)
+        expect(json).not.toHaveProperty('x-from-client1')
+        expect(json).not.toHaveProperty('X-From-Client2')
+        expect(json).toMatchObject({
+          'x-from-middleware': 'hello-from-middleware',
+        })
+
+        // Should not be included in response headers.
+        expect(res.headers.get('x-middleware-override-headers')).toBeNull()
+        expect(
+          res.headers.get('x-middleware-request-x-from-middleware')
+        ).toBeNull()
+        expect(
+          res.headers.get('x-middleware-request-x-from-client1')
+        ).toBeNull()
+        expect(
+          res.headers.get('x-middleware-request-x-from-client2')
+        ).toBeNull()
       })
 
-      // Should not be included in response headers.
-      expect(res.headers.get('x-middleware-override-headers')).toBeNull()
-      expect(
-        res.headers.get('x-middleware-request-x-from-middleware')
-      ).toBeNull()
-      expect(res.headers.get('x-middleware-request-x-from-client1')).toBeNull()
-      expect(res.headers.get('x-middleware-request-x-from-client2')).toBeNull()
-    })
-
-    it(`Updates headers`, async () => {
-      const res = await fetchViaHTTP(
-        next.url,
-        path,
-        {
-          'update-headers':
-            'x-from-client1=new-value1,x-from-client2=new-value2',
-        },
-        {
-          headers: {
-            'x-from-client1': 'old-value1',
-            'X-From-Client2': 'old-value2',
-            'x-from-client3': 'old-value3',
+      it(`Updates headers`, async () => {
+        const res = await next.fetch(
+          path,
+          {
+            'update-headers':
+              'x-from-client1=new-value1,x-from-client2=new-value2',
           },
-        }
-      )
-      expect(await toJson(res)).toMatchObject({
-        'x-from-client1': 'new-value1',
-        'x-from-client2': 'new-value2',
-        'x-from-client3': 'old-value3',
-        'x-from-middleware': 'hello-from-middleware',
+          {
+            headers: {
+              'x-from-client1': 'old-value1',
+              'X-From-Client2': 'old-value2',
+              'x-from-client3': 'old-value3',
+            },
+          }
+        )
+        expect(await toJson(res)).toMatchObject({
+          'x-from-client1': 'new-value1',
+          'x-from-client2': 'new-value2',
+          'x-from-client3': 'old-value3',
+          'x-from-middleware': 'hello-from-middleware',
+        })
+
+        // Should not be included in response headers.
+        expect(res.headers.get('x-middleware-override-headers')).toBeNull()
+        expect(
+          res.headers.get('x-middleware-request-x-from-middleware')
+        ).toBeNull()
+        expect(
+          res.headers.get('x-middleware-request-x-from-client1')
+        ).toBeNull()
+        expect(
+          res.headers.get('x-middleware-request-x-from-client2')
+        ).toBeNull()
+        expect(
+          res.headers.get('x-middleware-request-x-from-client3')
+        ).toBeNull()
       })
-
-      // Should not be included in response headers.
-      expect(res.headers.get('x-middleware-override-headers')).toBeNull()
-      expect(
-        res.headers.get('x-middleware-request-x-from-middleware')
-      ).toBeNull()
-      expect(res.headers.get('x-middleware-request-x-from-client1')).toBeNull()
-      expect(res.headers.get('x-middleware-request-x-from-client2')).toBeNull()
-      expect(res.headers.get('x-middleware-request-x-from-client3')).toBeNull()
     })
-  })
-})
-
-describe('app dir middleware without pages dir', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
   }
+)
 
-  let next: NextInstance
+createNextDescribe(
+  'app dir middleware without pages dir',
+  {
+    files: {
+      app: new FileRef(path.join(__dirname, 'app-middleware/app')),
+      'next.config.js': new FileRef(
+        path.join(__dirname, 'app-middleware/next.config.js')
+      ),
+      'middleware.js': `
+      import { NextResponse } from 'next/server'
 
-  afterAll(() => next.destroy())
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        app: new FileRef(path.join(__dirname, 'app-middleware/app')),
-        'next.config.js': new FileRef(
-          path.join(__dirname, 'app-middleware/next.config.js')
-        ),
-        'middleware.js': `
-          import { NextResponse } from 'next/server'
+      export async function middleware(request) {
+        return new NextResponse('redirected')
+      }
 
-          export async function middleware(request) {
-            return new NextResponse('redirected')
-          }
+      export const config = {
+        matcher: '/headers'
+      }
+    `,
+    },
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    // eslint-disable-next-line jest/no-identical-title
+    it('Updates headers', async () => {
+      const html = await next.render('/headers')
 
-          export const config = {
-            matcher: '/headers'
-          }
-        `,
-      },
+      expect(html).toContain('redirected')
     })
-  })
-
-  it(`Updates headers`, async () => {
-    const html = await renderViaHTTP(next.url, '/headers')
-
-    expect(html).toContain('redirected')
-  })
-})
+  }
+)

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -225,7 +225,7 @@ createNextDescribe(
     }
 
     it('Should not throw Dynamic Server Usage error when using generateStaticParams with previewData', async () => {
-      const browserOnIndexPage = await webdriver(next.url, '/ssg-preview')
+      const browserOnIndexPage = await next.browser('/ssg-preview')
 
       const content = await browserOnIndexPage
         .elementByCss('#preview-data')
@@ -235,7 +235,7 @@ createNextDescribe(
     })
 
     it('should force SSR correctly for headers usage', async () => {
-      const res = await fetchViaHTTP(next.url, '/force-static', undefined, {
+      const res = await next.fetch('/force-static', undefined, {
         headers: {
           Cookie: 'myCookie=cookieValue',
           another: 'header',
@@ -260,7 +260,7 @@ createNextDescribe(
       const firstTime = $('#now').text()
 
       if (!(global as any).isNextDev) {
-        const res2 = await fetchViaHTTP(next.url, '/force-static')
+        const res2 = await next.fetch('/force-static')
         expect(res2.status).toBe(200)
 
         const $2 = cheerio.load(await res2.text())
@@ -269,7 +269,7 @@ createNextDescribe(
     })
 
     it('should honor dynamic = "force-static" correctly', async () => {
-      const res = await fetchViaHTTP(next.url, '/force-static/first')
+      const res = await next.fetch('/force-static/first')
       expect(res.status).toBe(200)
 
       const html = await res.text()
@@ -282,7 +282,7 @@ createNextDescribe(
       const firstTime = $('#now').text()
 
       if (!(global as any).isNextDev) {
-        const res2 = await fetchViaHTTP(next.url, '/force-static/first')
+        const res2 = await next.fetch('/force-static/first')
         expect(res2.status).toBe(200)
 
         const $2 = cheerio.load(await res2.text())
@@ -291,7 +291,7 @@ createNextDescribe(
     })
 
     it('should honor dynamic = "force-static" correctly (lazy)', async () => {
-      const res = await fetchViaHTTP(next.url, '/force-static/random')
+      const res = await next.fetch('/force-static/random')
       expect(res.status).toBe(200)
 
       const html = await res.text()
@@ -304,7 +304,7 @@ createNextDescribe(
       const firstTime = $('#now').text()
 
       if (!(global as any).isNextDev) {
-        const res2 = await fetchViaHTTP(next.url, '/force-static/random')
+        const res2 = await next.fetch('/force-static/random')
         expect(res2.status).toBe(200)
 
         const $2 = cheerio.load(await res2.text())
@@ -316,7 +316,7 @@ createNextDescribe(
       const validParams = ['tim', 'seb', 'styfle']
 
       for (const param of validParams) {
-        const res = await fetchViaHTTP(next.url, `/blog/${param}`, undefined, {
+        const res = await next.fetch(`/blog/${param}`, undefined, {
           redirect: 'manual',
         })
         expect(res.status).toBe(200)
@@ -331,12 +331,9 @@ createNextDescribe(
       const invalidParams = ['timm', 'non-existent']
 
       for (const param of invalidParams) {
-        const invalidRes = await fetchViaHTTP(
-          next.url,
-          `/blog/${param}`,
-          undefined,
-          { redirect: 'manual' }
-        )
+        const invalidRes = await next.fetch(`/blog/${param}`, undefined, {
+          redirect: 'manual',
+        })
         expect(invalidRes.status).toBe(404)
         expect(await invalidRes.text()).toContain('page could not be found')
       }
@@ -344,8 +341,7 @@ createNextDescribe(
 
     it('should work with forced dynamic path', async () => {
       for (const slug of ['first', 'second']) {
-        const res = await fetchViaHTTP(
-          next.url,
+        const res = await next.fetch(
           `/dynamic-no-gen-params-ssr/${slug}`,
           undefined,
           { redirect: 'manual' }
@@ -357,8 +353,7 @@ createNextDescribe(
 
     it('should work with dynamic path no generateStaticParams', async () => {
       for (const slug of ['first', 'second']) {
-        const res = await fetchViaHTTP(
-          next.url,
+        const res = await next.fetch(
           `/dynamic-no-gen-params/${slug}`,
           undefined,
           { redirect: 'manual' }
@@ -389,8 +384,7 @@ createNextDescribe(
       ]
 
       for (const params of paramsToCheck) {
-        const res = await fetchViaHTTP(
-          next.url,
+        const res = await next.fetch(
           `/blog/${params.author}/${params.slug}`,
           undefined,
           {
@@ -407,7 +401,7 @@ createNextDescribe(
     })
 
     it('should navigate to static path correctly', async () => {
-      const browser = await webdriver(next.url, '/blog/tim')
+      const browser = await next.browser('/blog/tim')
       await browser.eval('window.beforeNav = 1')
 
       expect(
@@ -443,7 +437,7 @@ createNextDescribe(
 
     it('should ssr dynamically when detected automatically with fetch cache option', async () => {
       const pathname = '/ssr-auto/cache-no-store'
-      const initialRes = await fetchViaHTTP(next.url, pathname, undefined, {
+      const initialRes = await next.fetch(pathname, undefined, {
         redirect: 'manual',
       })
       expect(initialRes.status).toBe(200)
@@ -456,7 +450,7 @@ createNextDescribe(
 
       expect(initialHtml).toContain('Example Domain')
 
-      const secondRes = await fetchViaHTTP(next.url, pathname, undefined, {
+      const secondRes = await next.fetch(pathname, undefined, {
         redirect: 'manual',
       })
       expect(secondRes.status).toBe(200)
@@ -472,7 +466,7 @@ createNextDescribe(
     })
 
     it('should render not found pages correctly and fallback to the default one', async () => {
-      const res = await fetchViaHTTP(next.url, `/blog/shu/hi`, undefined, {
+      const res = await next.fetch(`/blog/shu/hi`, undefined, {
         redirect: 'manual',
       })
       expect(res.status).toBe(404)
@@ -484,7 +478,7 @@ createNextDescribe(
     // TODO-APP: support fetch revalidate case for dynamic rendering
     it.skip('should ssr dynamically when detected automatically with fetch revalidate option', async () => {
       const pathname = '/ssr-auto/fetch-revalidate-zero'
-      const initialRes = await fetchViaHTTP(next.url, pathname, undefined, {
+      const initialRes = await next.fetch(pathname, undefined, {
         redirect: 'manual',
       })
       expect(initialRes.status).toBe(200)
@@ -497,7 +491,7 @@ createNextDescribe(
 
       expect(initialHtml).toContain('Example Domain')
 
-      const secondRes = await fetchViaHTTP(next.url, pathname, undefined, {
+      const secondRes = await next.fetch(pathname, undefined, {
         redirect: 'manual',
       })
       expect(secondRes.status).toBe(200)
@@ -513,14 +507,9 @@ createNextDescribe(
     })
 
     it('should ssr dynamically when forced via config', async () => {
-      const initialRes = await fetchViaHTTP(
-        next.url,
-        '/ssr-forced',
-        undefined,
-        {
-          redirect: 'manual',
-        }
-      )
+      const initialRes = await next.fetch('/ssr-forced', undefined, {
+        redirect: 'manual',
+      })
       expect(initialRes.status).toBe(200)
 
       const initialHtml = await initialRes.text()
@@ -529,7 +518,7 @@ createNextDescribe(
       expect(initial$('#page').text()).toBe('/ssr-forced')
       const initialDate = initial$('#date').text()
 
-      const secondRes = await fetchViaHTTP(next.url, '/ssr-forced', undefined, {
+      const secondRes = await next.fetch('/ssr-forced', undefined, {
         redirect: 'manual',
       })
       expect(secondRes.status).toBe(200)
@@ -546,8 +535,7 @@ createNextDescribe(
     describe('useSearchParams', () => {
       describe('client', () => {
         it('should bailout to client rendering - without suspense boundary', async () => {
-          const browser = await webdriver(
-            next.url,
+          const browser = await next.browser(
             '/hooks/use-search-params?first=value&second=other&third'
           )
 
@@ -564,8 +552,7 @@ createNextDescribe(
         })
 
         it('should bailout to client rendering - with suspense boundary', async () => {
-          const browser = await webdriver(
-            next.url,
+          const browser = await next.browser(
             '/hooks/use-search-params/with-suspense?first=value&second=other&third'
           )
 
@@ -582,8 +569,7 @@ createNextDescribe(
         })
 
         it.skip('should have empty search params on force-static', async () => {
-          const browser = await webdriver(
-            next.url,
+          const browser = await next.browser(
             '/hooks/use-search-params/force-static?first=value&second=other&third'
           )
 
@@ -611,8 +597,7 @@ createNextDescribe(
         // TODO-APP: re-enable after investigating rewrite params
         if (!(global as any).isNextDeploy) {
           it('should have values from canonical url on rewrite', async () => {
-            const browser = await webdriver(
-              next.url,
+            const browser = await next.browser(
               '/rewritten-use-search-params?first=a&second=b&third=c'
             )
 
@@ -631,14 +616,13 @@ createNextDescribe(
       if (!isDev) {
         describe('server response', () => {
           it('should bailout to client rendering - without suspense boundary', async () => {
-            const res = await fetchViaHTTP(next.url, '/hooks/use-search-params')
+            const res = await next.fetch('/hooks/use-search-params')
             const html = await res.text()
             expect(html).toInclude('<html id="__next_error__">')
           })
 
           it('should bailout to client rendering - with suspense boundary', async () => {
-            const res = await fetchViaHTTP(
-              next.url,
+            const res = await next.fetch(
               '/hooks/use-search-params/with-suspense'
             )
             const html = await res.text()
@@ -646,8 +630,7 @@ createNextDescribe(
           })
 
           it.skip('should have empty search params on force-static', async () => {
-            const res = await fetchViaHTTP(
-              next.url,
+            const res = await next.fetch(
               '/hooks/use-search-params/force-static?first=value&second=other&third'
             )
             const html = await res.text()
@@ -670,14 +653,14 @@ createNextDescribe(
     describe.skip('usePathname', () => {
       if (isDev) {
         it('should bail out to client rendering during SSG', async () => {
-          const res = await fetchViaHTTP(next.url, '/hooks/use-pathname/slug')
+          const res = await next.fetch('/hooks/use-pathname/slug')
           const html = await res.text()
           expect(html).toInclude('<html id="__next_error__">')
         })
       }
 
       it('should have the correct values', async () => {
-        const browser = await webdriver(next.url, '/hooks/use-pathname/slug')
+        const browser = await next.browser('/hooks/use-pathname/slug')
 
         expect(await browser.elementByCss('#pathname').text()).toBe(
           '/hooks/use-pathname/slug'
@@ -685,7 +668,7 @@ createNextDescribe(
       })
 
       it('should have values from canonical url on rewrite', async () => {
-        const browser = await webdriver(next.url, '/rewritten-use-pathname')
+        const browser = await next.browser('/rewritten-use-pathname')
 
         expect(await browser.elementByCss('#pathname').text()).toBe(
           '/rewritten-use-pathname'
@@ -702,7 +685,7 @@ createNextDescribe(
     }
 
     it('should keep querystring on static page', async () => {
-      const browser = await webdriver(next.url, '/blog/tim?message=hello-world')
+      const browser = await next.browser('/blog/tim?message=hello-world')
       const checkUrl = async () =>
         expect(await browser.url()).toBe(
           next.url + '/blog/tim?message=hello-world'

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -2,712 +2,715 @@ import globOrig from 'glob'
 import cheerio from 'cheerio'
 import { promisify } from 'util'
 import path, { join } from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 import { check, fetchViaHTTP, normalizeRegEx, waitFor } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
 const glob = promisify(globOrig)
 
-describe('app-dir static/dynamic handling', () => {
-  const isDev = (global as any).isNextDev
+createNextDescribe(
+  'app-dir static/dynamic handling',
+  {
+    files: path.join(__dirname, 'app-static'),
+  },
+  ({ next, isNextDev: isDev, isNextStart }) => {
+    if (isNextStart) {
+      it('should output HTML/RSC files for static paths', async () => {
+        const files = (
+          await glob('**/*', {
+            cwd: join(next.testDir, '.next/server/app'),
+          })
+        ).filter((file) => file.match(/.*\.(js|html|rsc)$/))
 
-  let next: NextInstance
+        expect(files).toEqual([
+          '(new)/custom/page.js',
+          'blog/[author]/[slug]/page.js',
+          'blog/[author]/page.js',
+          'blog/seb.html',
+          'blog/seb.rsc',
+          'blog/seb/second-post.html',
+          'blog/seb/second-post.rsc',
+          'blog/styfle.html',
+          'blog/styfle.rsc',
+          'blog/styfle/first-post.html',
+          'blog/styfle/first-post.rsc',
+          'blog/styfle/second-post.html',
+          'blog/styfle/second-post.rsc',
+          'blog/tim.html',
+          'blog/tim.rsc',
+          'blog/tim/first-post.html',
+          'blog/tim/first-post.rsc',
+          'dynamic-error.html',
+          'dynamic-error.rsc',
+          'dynamic-error/page.js',
+          'dynamic-no-gen-params-ssr/[slug]/page.js',
+          'dynamic-no-gen-params/[slug]/page.js',
+          'force-static/[slug]/page.js',
+          'force-static/first.html',
+          'force-static/first.rsc',
+          'force-static/page.js',
+          'force-static/second.html',
+          'force-static/second.rsc',
+          'hooks/use-pathname/[slug]/page.js',
+          'hooks/use-pathname/slug.html',
+          'hooks/use-pathname/slug.rsc',
+          'hooks/use-search-params.html',
+          'hooks/use-search-params.rsc',
+          'hooks/use-search-params/force-static.html',
+          'hooks/use-search-params/force-static.rsc',
+          'hooks/use-search-params/force-static/page.js',
+          'hooks/use-search-params/page.js',
+          'hooks/use-search-params/with-suspense.html',
+          'hooks/use-search-params/with-suspense.rsc',
+          'hooks/use-search-params/with-suspense/page.js',
+          'ssg-preview.html',
+          'ssg-preview.rsc',
+          'ssg-preview/[[...route]]/page.js',
+          'ssg-preview/test-2.html',
+          'ssg-preview/test-2.rsc',
+          'ssg-preview/test.html',
+          'ssg-preview/test.rsc',
+          'ssr-auto/cache-no-store/page.js',
+          'ssr-auto/fetch-revalidate-zero/page.js',
+          'ssr-forced/page.js',
+          'variable-revalidate/no-store/page.js',
+          'variable-revalidate/revalidate-3.html',
+          'variable-revalidate/revalidate-3.rsc',
+          'variable-revalidate/revalidate-3/page.js',
+        ])
+      })
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'app-static')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
-    })
-  })
-  afterAll(() => next.destroy())
+      it('should have correct prerender-manifest entries', async () => {
+        const manifest = JSON.parse(
+          await next.readFile('.next/prerender-manifest.json')
+        )
 
-  if ((global as any).isNextStart) {
-    it('should output HTML/RSC files for static paths', async () => {
-      const files = (
-        await glob('**/*', {
-          cwd: join(next.testDir, '.next/server/app'),
+        Object.keys(manifest.dynamicRoutes).forEach((key) => {
+          const item = manifest.dynamicRoutes[key]
+
+          if (item.dataRouteRegex) {
+            item.dataRouteRegex = normalizeRegEx(item.dataRouteRegex)
+          }
+          if (item.routeRegex) {
+            item.routeRegex = normalizeRegEx(item.routeRegex)
+          }
         })
-      ).filter((file) => file.match(/.*\.(js|html|rsc)$/))
 
-      expect(files).toEqual([
-        '(new)/custom/page.js',
-        'blog/[author]/[slug]/page.js',
-        'blog/[author]/page.js',
-        'blog/seb.html',
-        'blog/seb.rsc',
-        'blog/seb/second-post.html',
-        'blog/seb/second-post.rsc',
-        'blog/styfle.html',
-        'blog/styfle.rsc',
-        'blog/styfle/first-post.html',
-        'blog/styfle/first-post.rsc',
-        'blog/styfle/second-post.html',
-        'blog/styfle/second-post.rsc',
-        'blog/tim.html',
-        'blog/tim.rsc',
-        'blog/tim/first-post.html',
-        'blog/tim/first-post.rsc',
-        'dynamic-error.html',
-        'dynamic-error.rsc',
-        'dynamic-error/page.js',
-        'dynamic-no-gen-params-ssr/[slug]/page.js',
-        'dynamic-no-gen-params/[slug]/page.js',
-        'force-static/[slug]/page.js',
-        'force-static/first.html',
-        'force-static/first.rsc',
-        'force-static/page.js',
-        'force-static/second.html',
-        'force-static/second.rsc',
-        'hooks/use-pathname/[slug]/page.js',
-        'hooks/use-pathname/slug.html',
-        'hooks/use-pathname/slug.rsc',
-        'hooks/use-search-params.html',
-        'hooks/use-search-params.rsc',
-        'hooks/use-search-params/force-static.html',
-        'hooks/use-search-params/force-static.rsc',
-        'hooks/use-search-params/force-static/page.js',
-        'hooks/use-search-params/page.js',
-        'hooks/use-search-params/with-suspense.html',
-        'hooks/use-search-params/with-suspense.rsc',
-        'hooks/use-search-params/with-suspense/page.js',
-        'ssg-preview.html',
-        'ssg-preview.rsc',
-        'ssg-preview/[[...route]]/page.js',
-        'ssg-preview/test-2.html',
-        'ssg-preview/test-2.rsc',
-        'ssg-preview/test.html',
-        'ssg-preview/test.rsc',
-        'ssr-auto/cache-no-store/page.js',
-        'ssr-auto/fetch-revalidate-zero/page.js',
-        'ssr-forced/page.js',
-        'variable-revalidate/no-store/page.js',
-        'variable-revalidate/revalidate-3.html',
-        'variable-revalidate/revalidate-3.rsc',
-        'variable-revalidate/revalidate-3/page.js',
-      ])
+        expect(manifest.version).toBe(3)
+        expect(manifest.routes).toEqual({
+          '/blog/tim': {
+            initialRevalidateSeconds: 10,
+            srcRoute: '/blog/[author]',
+            dataRoute: '/blog/tim.rsc',
+          },
+          '/blog/seb': {
+            initialRevalidateSeconds: 10,
+            srcRoute: '/blog/[author]',
+            dataRoute: '/blog/seb.rsc',
+          },
+          '/blog/styfle': {
+            initialRevalidateSeconds: 10,
+            srcRoute: '/blog/[author]',
+            dataRoute: '/blog/styfle.rsc',
+          },
+          '/blog/tim/first-post': {
+            initialRevalidateSeconds: false,
+            srcRoute: '/blog/[author]/[slug]',
+            dataRoute: '/blog/tim/first-post.rsc',
+          },
+          '/dynamic-error': {
+            dataRoute: '/dynamic-error.rsc',
+            initialRevalidateSeconds: false,
+            srcRoute: '/dynamic-error',
+          },
+          '/blog/seb/second-post': {
+            initialRevalidateSeconds: false,
+            srcRoute: '/blog/[author]/[slug]',
+            dataRoute: '/blog/seb/second-post.rsc',
+          },
+          '/blog/styfle/first-post': {
+            initialRevalidateSeconds: false,
+            srcRoute: '/blog/[author]/[slug]',
+            dataRoute: '/blog/styfle/first-post.rsc',
+          },
+          '/blog/styfle/second-post': {
+            initialRevalidateSeconds: false,
+            srcRoute: '/blog/[author]/[slug]',
+            dataRoute: '/blog/styfle/second-post.rsc',
+          },
+          '/hooks/use-pathname/slug': {
+            dataRoute: '/hooks/use-pathname/slug.rsc',
+            initialRevalidateSeconds: false,
+            srcRoute: '/hooks/use-pathname/[slug]',
+          },
+          '/hooks/use-search-params': {
+            dataRoute: '/hooks/use-search-params.rsc',
+            initialRevalidateSeconds: false,
+            srcRoute: '/hooks/use-search-params',
+          },
+          '/hooks/use-search-params/force-static': {
+            dataRoute: '/hooks/use-search-params/force-static.rsc',
+            initialRevalidateSeconds: false,
+            srcRoute: '/hooks/use-search-params/force-static',
+          },
+          '/hooks/use-search-params/with-suspense': {
+            dataRoute: '/hooks/use-search-params/with-suspense.rsc',
+            initialRevalidateSeconds: false,
+            srcRoute: '/hooks/use-search-params/with-suspense',
+          },
+          '/force-static/first': {
+            dataRoute: '/force-static/first.rsc',
+            initialRevalidateSeconds: false,
+            srcRoute: '/force-static/[slug]',
+          },
+          '/force-static/second': {
+            dataRoute: '/force-static/second.rsc',
+            initialRevalidateSeconds: false,
+            srcRoute: '/force-static/[slug]',
+          },
+          '/ssg-preview': {
+            dataRoute: '/ssg-preview.rsc',
+            initialRevalidateSeconds: false,
+            srcRoute: '/ssg-preview/[[...route]]',
+          },
+          '/ssg-preview/test': {
+            dataRoute: '/ssg-preview/test.rsc',
+            initialRevalidateSeconds: false,
+            srcRoute: '/ssg-preview/[[...route]]',
+          },
+          '/ssg-preview/test-2': {
+            dataRoute: '/ssg-preview/test-2.rsc',
+            initialRevalidateSeconds: false,
+            srcRoute: '/ssg-preview/[[...route]]',
+          },
+          '/variable-revalidate/revalidate-3': {
+            dataRoute: '/variable-revalidate/revalidate-3.rsc',
+            initialRevalidateSeconds: 3,
+            srcRoute: '/variable-revalidate/revalidate-3',
+          },
+        })
+        expect(manifest.dynamicRoutes).toEqual({
+          '/blog/[author]/[slug]': {
+            routeRegex: normalizeRegEx('^/blog/([^/]+?)/([^/]+?)(?:/)?$'),
+            dataRoute: '/blog/[author]/[slug].rsc',
+            fallback: null,
+            dataRouteRegex: normalizeRegEx('^/blog/([^/]+?)/([^/]+?)\\.rsc$'),
+          },
+          '/blog/[author]': {
+            dataRoute: '/blog/[author].rsc',
+            dataRouteRegex: normalizeRegEx('^\\/blog\\/([^\\/]+?)\\.rsc$'),
+            fallback: false,
+            routeRegex: normalizeRegEx('^\\/blog\\/([^\\/]+?)(?:\\/)?$'),
+          },
+          '/hooks/use-pathname/[slug]': {
+            dataRoute: '/hooks/use-pathname/[slug].rsc',
+            dataRouteRegex: '^\\/hooks\\/use\\-pathname\\/([^\\/]+?)\\.rsc$',
+            fallback: null,
+            routeRegex: '^\\/hooks\\/use\\-pathname\\/([^\\/]+?)(?:\\/)?$',
+          },
+          '/force-static/[slug]': {
+            dataRoute: '/force-static/[slug].rsc',
+            dataRouteRegex: '^\\/force\\-static\\/([^\\/]+?)\\.rsc$',
+            fallback: null,
+            routeRegex: '^\\/force\\-static\\/([^\\/]+?)(?:\\/)?$',
+          },
+          '/ssg-preview/[[...route]]': {
+            dataRoute: '/ssg-preview/[[...route]].rsc',
+            dataRouteRegex: '^\\/ssg\\-preview(?:\\/(.+?))?\\.rsc$',
+            fallback: null,
+            routeRegex: '^\\/ssg\\-preview(?:\\/(.+?))?(?:\\/)?$',
+          },
+        })
+      })
+    }
+
+    it('Should not throw Dynamic Server Usage error when using generateStaticParams with previewData', async () => {
+      const browserOnIndexPage = await webdriver(next.url, '/ssg-preview')
+
+      const content = await browserOnIndexPage
+        .elementByCss('#preview-data')
+        .text()
+
+      expect(content).toContain('previewData')
     })
 
-    it('should have correct prerender-manifest entries', async () => {
-      const manifest = JSON.parse(
-        await next.readFile('.next/prerender-manifest.json')
-      )
-
-      Object.keys(manifest.dynamicRoutes).forEach((key) => {
-        const item = manifest.dynamicRoutes[key]
-
-        if (item.dataRouteRegex) {
-          item.dataRouteRegex = normalizeRegEx(item.dataRouteRegex)
-        }
-        if (item.routeRegex) {
-          item.routeRegex = normalizeRegEx(item.routeRegex)
-        }
-      })
-
-      expect(manifest.version).toBe(3)
-      expect(manifest.routes).toEqual({
-        '/blog/tim': {
-          initialRevalidateSeconds: 10,
-          srcRoute: '/blog/[author]',
-          dataRoute: '/blog/tim.rsc',
+    it('should force SSR correctly for headers usage', async () => {
+      const res = await fetchViaHTTP(next.url, '/force-static', undefined, {
+        headers: {
+          Cookie: 'myCookie=cookieValue',
+          another: 'header',
         },
-        '/blog/seb': {
-          initialRevalidateSeconds: 10,
-          srcRoute: '/blog/[author]',
-          dataRoute: '/blog/seb.rsc',
-        },
-        '/blog/styfle': {
-          initialRevalidateSeconds: 10,
-          srcRoute: '/blog/[author]',
-          dataRoute: '/blog/styfle.rsc',
-        },
-        '/blog/tim/first-post': {
-          initialRevalidateSeconds: false,
-          srcRoute: '/blog/[author]/[slug]',
-          dataRoute: '/blog/tim/first-post.rsc',
-        },
-        '/dynamic-error': {
-          dataRoute: '/dynamic-error.rsc',
-          initialRevalidateSeconds: false,
-          srcRoute: '/dynamic-error',
-        },
-        '/blog/seb/second-post': {
-          initialRevalidateSeconds: false,
-          srcRoute: '/blog/[author]/[slug]',
-          dataRoute: '/blog/seb/second-post.rsc',
-        },
-        '/blog/styfle/first-post': {
-          initialRevalidateSeconds: false,
-          srcRoute: '/blog/[author]/[slug]',
-          dataRoute: '/blog/styfle/first-post.rsc',
-        },
-        '/blog/styfle/second-post': {
-          initialRevalidateSeconds: false,
-          srcRoute: '/blog/[author]/[slug]',
-          dataRoute: '/blog/styfle/second-post.rsc',
-        },
-        '/hooks/use-pathname/slug': {
-          dataRoute: '/hooks/use-pathname/slug.rsc',
-          initialRevalidateSeconds: false,
-          srcRoute: '/hooks/use-pathname/[slug]',
-        },
-        '/hooks/use-search-params': {
-          dataRoute: '/hooks/use-search-params.rsc',
-          initialRevalidateSeconds: false,
-          srcRoute: '/hooks/use-search-params',
-        },
-        '/hooks/use-search-params/force-static': {
-          dataRoute: '/hooks/use-search-params/force-static.rsc',
-          initialRevalidateSeconds: false,
-          srcRoute: '/hooks/use-search-params/force-static',
-        },
-        '/hooks/use-search-params/with-suspense': {
-          dataRoute: '/hooks/use-search-params/with-suspense.rsc',
-          initialRevalidateSeconds: false,
-          srcRoute: '/hooks/use-search-params/with-suspense',
-        },
-        '/force-static/first': {
-          dataRoute: '/force-static/first.rsc',
-          initialRevalidateSeconds: false,
-          srcRoute: '/force-static/[slug]',
-        },
-        '/force-static/second': {
-          dataRoute: '/force-static/second.rsc',
-          initialRevalidateSeconds: false,
-          srcRoute: '/force-static/[slug]',
-        },
-        '/ssg-preview': {
-          dataRoute: '/ssg-preview.rsc',
-          initialRevalidateSeconds: false,
-          srcRoute: '/ssg-preview/[[...route]]',
-        },
-        '/ssg-preview/test': {
-          dataRoute: '/ssg-preview/test.rsc',
-          initialRevalidateSeconds: false,
-          srcRoute: '/ssg-preview/[[...route]]',
-        },
-        '/ssg-preview/test-2': {
-          dataRoute: '/ssg-preview/test-2.rsc',
-          initialRevalidateSeconds: false,
-          srcRoute: '/ssg-preview/[[...route]]',
-        },
-        '/variable-revalidate/revalidate-3': {
-          dataRoute: '/variable-revalidate/revalidate-3.rsc',
-          initialRevalidateSeconds: 3,
-          srcRoute: '/variable-revalidate/revalidate-3',
-        },
-      })
-      expect(manifest.dynamicRoutes).toEqual({
-        '/blog/[author]/[slug]': {
-          routeRegex: normalizeRegEx('^/blog/([^/]+?)/([^/]+?)(?:/)?$'),
-          dataRoute: '/blog/[author]/[slug].rsc',
-          fallback: null,
-          dataRouteRegex: normalizeRegEx('^/blog/([^/]+?)/([^/]+?)\\.rsc$'),
-        },
-        '/blog/[author]': {
-          dataRoute: '/blog/[author].rsc',
-          dataRouteRegex: normalizeRegEx('^\\/blog\\/([^\\/]+?)\\.rsc$'),
-          fallback: false,
-          routeRegex: normalizeRegEx('^\\/blog\\/([^\\/]+?)(?:\\/)?$'),
-        },
-        '/hooks/use-pathname/[slug]': {
-          dataRoute: '/hooks/use-pathname/[slug].rsc',
-          dataRouteRegex: '^\\/hooks\\/use\\-pathname\\/([^\\/]+?)\\.rsc$',
-          fallback: null,
-          routeRegex: '^\\/hooks\\/use\\-pathname\\/([^\\/]+?)(?:\\/)?$',
-        },
-        '/force-static/[slug]': {
-          dataRoute: '/force-static/[slug].rsc',
-          dataRouteRegex: '^\\/force\\-static\\/([^\\/]+?)\\.rsc$',
-          fallback: null,
-          routeRegex: '^\\/force\\-static\\/([^\\/]+?)(?:\\/)?$',
-        },
-        '/ssg-preview/[[...route]]': {
-          dataRoute: '/ssg-preview/[[...route]].rsc',
-          dataRouteRegex: '^\\/ssg\\-preview(?:\\/(.+?))?\\.rsc$',
-          fallback: null,
-          routeRegex: '^\\/ssg\\-preview(?:\\/(.+?))?(?:\\/)?$',
-        },
-      })
-    })
-  }
-
-  it('Should not throw Dynamic Server Usage error when using generateStaticParams with previewData', async () => {
-    const browserOnIndexPage = await webdriver(next.url, '/ssg-preview')
-
-    const content = await browserOnIndexPage
-      .elementByCss('#preview-data')
-      .text()
-
-    expect(content).toContain('previewData')
-  })
-
-  it('should force SSR correctly for headers usage', async () => {
-    const res = await fetchViaHTTP(next.url, '/force-static', undefined, {
-      headers: {
-        Cookie: 'myCookie=cookieValue',
-        another: 'header',
-      },
-    })
-    expect(res.status).toBe(200)
-
-    const html = await res.text()
-    const $ = cheerio.load(html)
-
-    expect(JSON.parse($('#headers').text())).toIncludeAllMembers([
-      'cookie',
-      'another',
-    ])
-    expect(JSON.parse($('#cookies').text())).toEqual([
-      {
-        name: 'myCookie',
-        value: 'cookieValue',
-      },
-    ])
-
-    const firstTime = $('#now').text()
-
-    if (!(global as any).isNextDev) {
-      const res2 = await fetchViaHTTP(next.url, '/force-static')
-      expect(res2.status).toBe(200)
-
-      const $2 = cheerio.load(await res2.text())
-      expect(firstTime).not.toBe($2('#now').text())
-    }
-  })
-
-  it('should honor dynamic = "force-static" correctly', async () => {
-    const res = await fetchViaHTTP(next.url, '/force-static/first')
-    expect(res.status).toBe(200)
-
-    const html = await res.text()
-    const $ = cheerio.load(html)
-
-    expect(JSON.parse($('#params').text())).toEqual({ slug: 'first' })
-    expect(JSON.parse($('#headers').text())).toEqual([])
-    expect(JSON.parse($('#cookies').text())).toEqual([])
-
-    const firstTime = $('#now').text()
-
-    if (!(global as any).isNextDev) {
-      const res2 = await fetchViaHTTP(next.url, '/force-static/first')
-      expect(res2.status).toBe(200)
-
-      const $2 = cheerio.load(await res2.text())
-      expect(firstTime).toBe($2('#now').text())
-    }
-  })
-
-  it('should honor dynamic = "force-static" correctly (lazy)', async () => {
-    const res = await fetchViaHTTP(next.url, '/force-static/random')
-    expect(res.status).toBe(200)
-
-    const html = await res.text()
-    const $ = cheerio.load(html)
-
-    expect(JSON.parse($('#params').text())).toEqual({ slug: 'random' })
-    expect(JSON.parse($('#headers').text())).toEqual([])
-    expect(JSON.parse($('#cookies').text())).toEqual([])
-
-    const firstTime = $('#now').text()
-
-    if (!(global as any).isNextDev) {
-      const res2 = await fetchViaHTTP(next.url, '/force-static/random')
-      expect(res2.status).toBe(200)
-
-      const $2 = cheerio.load(await res2.text())
-      expect(firstTime).toBe($2('#now').text())
-    }
-  })
-
-  it('should handle dynamicParams: false correctly', async () => {
-    const validParams = ['tim', 'seb', 'styfle']
-
-    for (const param of validParams) {
-      const res = await fetchViaHTTP(next.url, `/blog/${param}`, undefined, {
-        redirect: 'manual',
       })
       expect(res.status).toBe(200)
+
       const html = await res.text()
       const $ = cheerio.load(html)
 
-      expect(JSON.parse($('#params').text())).toEqual({
-        author: param,
+      expect(JSON.parse($('#headers').text())).toIncludeAllMembers([
+        'cookie',
+        'another',
+      ])
+      expect(JSON.parse($('#cookies').text())).toEqual([
+        {
+          name: 'myCookie',
+          value: 'cookieValue',
+        },
+      ])
+
+      const firstTime = $('#now').text()
+
+      if (!(global as any).isNextDev) {
+        const res2 = await fetchViaHTTP(next.url, '/force-static')
+        expect(res2.status).toBe(200)
+
+        const $2 = cheerio.load(await res2.text())
+        expect(firstTime).not.toBe($2('#now').text())
+      }
+    })
+
+    it('should honor dynamic = "force-static" correctly', async () => {
+      const res = await fetchViaHTTP(next.url, '/force-static/first')
+      expect(res.status).toBe(200)
+
+      const html = await res.text()
+      const $ = cheerio.load(html)
+
+      expect(JSON.parse($('#params').text())).toEqual({ slug: 'first' })
+      expect(JSON.parse($('#headers').text())).toEqual([])
+      expect(JSON.parse($('#cookies').text())).toEqual([])
+
+      const firstTime = $('#now').text()
+
+      if (!(global as any).isNextDev) {
+        const res2 = await fetchViaHTTP(next.url, '/force-static/first')
+        expect(res2.status).toBe(200)
+
+        const $2 = cheerio.load(await res2.text())
+        expect(firstTime).toBe($2('#now').text())
+      }
+    })
+
+    it('should honor dynamic = "force-static" correctly (lazy)', async () => {
+      const res = await fetchViaHTTP(next.url, '/force-static/random')
+      expect(res.status).toBe(200)
+
+      const html = await res.text()
+      const $ = cheerio.load(html)
+
+      expect(JSON.parse($('#params').text())).toEqual({ slug: 'random' })
+      expect(JSON.parse($('#headers').text())).toEqual([])
+      expect(JSON.parse($('#cookies').text())).toEqual([])
+
+      const firstTime = $('#now').text()
+
+      if (!(global as any).isNextDev) {
+        const res2 = await fetchViaHTTP(next.url, '/force-static/random')
+        expect(res2.status).toBe(200)
+
+        const $2 = cheerio.load(await res2.text())
+        expect(firstTime).toBe($2('#now').text())
+      }
+    })
+
+    it('should handle dynamicParams: false correctly', async () => {
+      const validParams = ['tim', 'seb', 'styfle']
+
+      for (const param of validParams) {
+        const res = await fetchViaHTTP(next.url, `/blog/${param}`, undefined, {
+          redirect: 'manual',
+        })
+        expect(res.status).toBe(200)
+        const html = await res.text()
+        const $ = cheerio.load(html)
+
+        expect(JSON.parse($('#params').text())).toEqual({
+          author: param,
+        })
+        expect($('#page').text()).toBe('/blog/[author]')
+      }
+      const invalidParams = ['timm', 'non-existent']
+
+      for (const param of invalidParams) {
+        const invalidRes = await fetchViaHTTP(
+          next.url,
+          `/blog/${param}`,
+          undefined,
+          { redirect: 'manual' }
+        )
+        expect(invalidRes.status).toBe(404)
+        expect(await invalidRes.text()).toContain('page could not be found')
+      }
+    })
+
+    it('should work with forced dynamic path', async () => {
+      for (const slug of ['first', 'second']) {
+        const res = await fetchViaHTTP(
+          next.url,
+          `/dynamic-no-gen-params-ssr/${slug}`,
+          undefined,
+          { redirect: 'manual' }
+        )
+        expect(res.status).toBe(200)
+        expect(await res.text()).toContain(`${slug}`)
+      }
+    })
+
+    it('should work with dynamic path no generateStaticParams', async () => {
+      for (const slug of ['first', 'second']) {
+        const res = await fetchViaHTTP(
+          next.url,
+          `/dynamic-no-gen-params/${slug}`,
+          undefined,
+          { redirect: 'manual' }
+        )
+        expect(res.status).toBe(200)
+        expect(await res.text()).toContain(`${slug}`)
+      }
+    })
+
+    it('should handle dynamicParams: true correctly', async () => {
+      const paramsToCheck = [
+        {
+          author: 'tim',
+          slug: 'first-post',
+        },
+        {
+          author: 'seb',
+          slug: 'second-post',
+        },
+        {
+          author: 'styfle',
+          slug: 'first-post',
+        },
+        {
+          author: 'new-author',
+          slug: 'first-post',
+        },
+      ]
+
+      for (const params of paramsToCheck) {
+        const res = await fetchViaHTTP(
+          next.url,
+          `/blog/${params.author}/${params.slug}`,
+          undefined,
+          {
+            redirect: 'manual',
+          }
+        )
+        expect(res.status).toBe(200)
+        const html = await res.text()
+        const $ = cheerio.load(html)
+
+        expect(JSON.parse($('#params').text())).toEqual(params)
+        expect($('#page').text()).toBe('/blog/[author]/[slug]')
+      }
+    })
+
+    it('should navigate to static path correctly', async () => {
+      const browser = await webdriver(next.url, '/blog/tim')
+      await browser.eval('window.beforeNav = 1')
+
+      expect(
+        await browser.eval('document.documentElement.innerHTML')
+      ).toContain('/blog/[author]')
+      await browser.elementByCss('#author-2').click()
+
+      await check(async () => {
+        const params = JSON.parse(await browser.elementByCss('#params').text())
+        return params.author === 'seb' ? 'found' : params
+      }, 'found')
+
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+      await browser.elementByCss('#author-1-post-1').click()
+
+      await check(async () => {
+        const params = JSON.parse(await browser.elementByCss('#params').text())
+        return params.author === 'tim' && params.slug === 'first-post'
+          ? 'found'
+          : params
+      }, 'found')
+
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+      await browser.back()
+
+      await check(async () => {
+        const params = JSON.parse(await browser.elementByCss('#params').text())
+        return params.author === 'seb' ? 'found' : params
+      }, 'found')
+
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+    })
+
+    it('should ssr dynamically when detected automatically with fetch cache option', async () => {
+      const pathname = '/ssr-auto/cache-no-store'
+      const initialRes = await fetchViaHTTP(next.url, pathname, undefined, {
+        redirect: 'manual',
       })
-      expect($('#page').text()).toBe('/blog/[author]')
-    }
-    const invalidParams = ['timm', 'non-existent']
+      expect(initialRes.status).toBe(200)
 
-    for (const param of invalidParams) {
-      const invalidRes = await fetchViaHTTP(
+      const initialHtml = await initialRes.text()
+      const initial$ = cheerio.load(initialHtml)
+
+      expect(initial$('#page').text()).toBe(pathname)
+      const initialDate = initial$('#date').text()
+
+      expect(initialHtml).toContain('Example Domain')
+
+      const secondRes = await fetchViaHTTP(next.url, pathname, undefined, {
+        redirect: 'manual',
+      })
+      expect(secondRes.status).toBe(200)
+
+      const secondHtml = await secondRes.text()
+      const second$ = cheerio.load(secondHtml)
+
+      expect(second$('#page').text()).toBe(pathname)
+      const secondDate = second$('#date').text()
+
+      expect(secondHtml).toContain('Example Domain')
+      expect(secondDate).not.toBe(initialDate)
+    })
+
+    it('should render not found pages correctly and fallback to the default one', async () => {
+      const res = await fetchViaHTTP(next.url, `/blog/shu/hi`, undefined, {
+        redirect: 'manual',
+      })
+      expect(res.status).toBe(404)
+      const html = await res.text()
+      expect(html).toInclude('"noindex"')
+      expect(html).toInclude('This page could not be found.')
+    })
+
+    // TODO-APP: support fetch revalidate case for dynamic rendering
+    it.skip('should ssr dynamically when detected automatically with fetch revalidate option', async () => {
+      const pathname = '/ssr-auto/fetch-revalidate-zero'
+      const initialRes = await fetchViaHTTP(next.url, pathname, undefined, {
+        redirect: 'manual',
+      })
+      expect(initialRes.status).toBe(200)
+
+      const initialHtml = await initialRes.text()
+      const initial$ = cheerio.load(initialHtml)
+
+      expect(initial$('#page').text()).toBe(pathname)
+      const initialDate = initial$('#date').text()
+
+      expect(initialHtml).toContain('Example Domain')
+
+      const secondRes = await fetchViaHTTP(next.url, pathname, undefined, {
+        redirect: 'manual',
+      })
+      expect(secondRes.status).toBe(200)
+
+      const secondHtml = await secondRes.text()
+      const second$ = cheerio.load(secondHtml)
+
+      expect(second$('#page').text()).toBe(pathname)
+      const secondDate = second$('#date').text()
+
+      expect(secondHtml).toContain('Example Domain')
+      expect(secondDate).not.toBe(initialDate)
+    })
+
+    it('should ssr dynamically when forced via config', async () => {
+      const initialRes = await fetchViaHTTP(
         next.url,
-        `/blog/${param}`,
-        undefined,
-        { redirect: 'manual' }
-      )
-      expect(invalidRes.status).toBe(404)
-      expect(await invalidRes.text()).toContain('page could not be found')
-    }
-  })
-
-  it('should work with forced dynamic path', async () => {
-    for (const slug of ['first', 'second']) {
-      const res = await fetchViaHTTP(
-        next.url,
-        `/dynamic-no-gen-params-ssr/${slug}`,
-        undefined,
-        { redirect: 'manual' }
-      )
-      expect(res.status).toBe(200)
-      expect(await res.text()).toContain(`${slug}`)
-    }
-  })
-
-  it('should work with dynamic path no generateStaticParams', async () => {
-    for (const slug of ['first', 'second']) {
-      const res = await fetchViaHTTP(
-        next.url,
-        `/dynamic-no-gen-params/${slug}`,
-        undefined,
-        { redirect: 'manual' }
-      )
-      expect(res.status).toBe(200)
-      expect(await res.text()).toContain(`${slug}`)
-    }
-  })
-
-  it('should handle dynamicParams: true correctly', async () => {
-    const paramsToCheck = [
-      {
-        author: 'tim',
-        slug: 'first-post',
-      },
-      {
-        author: 'seb',
-        slug: 'second-post',
-      },
-      {
-        author: 'styfle',
-        slug: 'first-post',
-      },
-      {
-        author: 'new-author',
-        slug: 'first-post',
-      },
-    ]
-
-    for (const params of paramsToCheck) {
-      const res = await fetchViaHTTP(
-        next.url,
-        `/blog/${params.author}/${params.slug}`,
+        '/ssr-forced',
         undefined,
         {
           redirect: 'manual',
         }
       )
-      expect(res.status).toBe(200)
-      const html = await res.text()
-      const $ = cheerio.load(html)
+      expect(initialRes.status).toBe(200)
 
-      expect(JSON.parse($('#params').text())).toEqual(params)
-      expect($('#page').text()).toBe('/blog/[author]/[slug]')
-    }
-  })
+      const initialHtml = await initialRes.text()
+      const initial$ = cheerio.load(initialHtml)
 
-  it('should navigate to static path correctly', async () => {
-    const browser = await webdriver(next.url, '/blog/tim')
-    await browser.eval('window.beforeNav = 1')
+      expect(initial$('#page').text()).toBe('/ssr-forced')
+      const initialDate = initial$('#date').text()
 
-    expect(await browser.eval('document.documentElement.innerHTML')).toContain(
-      '/blog/[author]'
-    )
-    await browser.elementByCss('#author-2').click()
-
-    await check(async () => {
-      const params = JSON.parse(await browser.elementByCss('#params').text())
-      return params.author === 'seb' ? 'found' : params
-    }, 'found')
-
-    expect(await browser.eval('window.beforeNav')).toBe(1)
-    await browser.elementByCss('#author-1-post-1').click()
-
-    await check(async () => {
-      const params = JSON.parse(await browser.elementByCss('#params').text())
-      return params.author === 'tim' && params.slug === 'first-post'
-        ? 'found'
-        : params
-    }, 'found')
-
-    expect(await browser.eval('window.beforeNav')).toBe(1)
-    await browser.back()
-
-    await check(async () => {
-      const params = JSON.parse(await browser.elementByCss('#params').text())
-      return params.author === 'seb' ? 'found' : params
-    }, 'found')
-
-    expect(await browser.eval('window.beforeNav')).toBe(1)
-  })
-
-  it('should ssr dynamically when detected automatically with fetch cache option', async () => {
-    const pathname = '/ssr-auto/cache-no-store'
-    const initialRes = await fetchViaHTTP(next.url, pathname, undefined, {
-      redirect: 'manual',
-    })
-    expect(initialRes.status).toBe(200)
-
-    const initialHtml = await initialRes.text()
-    const initial$ = cheerio.load(initialHtml)
-
-    expect(initial$('#page').text()).toBe(pathname)
-    const initialDate = initial$('#date').text()
-
-    expect(initialHtml).toContain('Example Domain')
-
-    const secondRes = await fetchViaHTTP(next.url, pathname, undefined, {
-      redirect: 'manual',
-    })
-    expect(secondRes.status).toBe(200)
-
-    const secondHtml = await secondRes.text()
-    const second$ = cheerio.load(secondHtml)
-
-    expect(second$('#page').text()).toBe(pathname)
-    const secondDate = second$('#date').text()
-
-    expect(secondHtml).toContain('Example Domain')
-    expect(secondDate).not.toBe(initialDate)
-  })
-
-  it('should render not found pages correctly and fallback to the default one', async () => {
-    const res = await fetchViaHTTP(next.url, `/blog/shu/hi`, undefined, {
-      redirect: 'manual',
-    })
-    expect(res.status).toBe(404)
-    const html = await res.text()
-    expect(html).toInclude('"noindex"')
-    expect(html).toInclude('This page could not be found.')
-  })
-
-  // TODO-APP: support fetch revalidate case for dynamic rendering
-  it.skip('should ssr dynamically when detected automatically with fetch revalidate option', async () => {
-    const pathname = '/ssr-auto/fetch-revalidate-zero'
-    const initialRes = await fetchViaHTTP(next.url, pathname, undefined, {
-      redirect: 'manual',
-    })
-    expect(initialRes.status).toBe(200)
-
-    const initialHtml = await initialRes.text()
-    const initial$ = cheerio.load(initialHtml)
-
-    expect(initial$('#page').text()).toBe(pathname)
-    const initialDate = initial$('#date').text()
-
-    expect(initialHtml).toContain('Example Domain')
-
-    const secondRes = await fetchViaHTTP(next.url, pathname, undefined, {
-      redirect: 'manual',
-    })
-    expect(secondRes.status).toBe(200)
-
-    const secondHtml = await secondRes.text()
-    const second$ = cheerio.load(secondHtml)
-
-    expect(second$('#page').text()).toBe(pathname)
-    const secondDate = second$('#date').text()
-
-    expect(secondHtml).toContain('Example Domain')
-    expect(secondDate).not.toBe(initialDate)
-  })
-
-  it('should ssr dynamically when forced via config', async () => {
-    const initialRes = await fetchViaHTTP(next.url, '/ssr-forced', undefined, {
-      redirect: 'manual',
-    })
-    expect(initialRes.status).toBe(200)
-
-    const initialHtml = await initialRes.text()
-    const initial$ = cheerio.load(initialHtml)
-
-    expect(initial$('#page').text()).toBe('/ssr-forced')
-    const initialDate = initial$('#date').text()
-
-    const secondRes = await fetchViaHTTP(next.url, '/ssr-forced', undefined, {
-      redirect: 'manual',
-    })
-    expect(secondRes.status).toBe(200)
-
-    const secondHtml = await secondRes.text()
-    const second$ = cheerio.load(secondHtml)
-
-    expect(second$('#page').text()).toBe('/ssr-forced')
-    const secondDate = second$('#date').text()
-
-    expect(secondDate).not.toBe(initialDate)
-  })
-
-  describe('useSearchParams', () => {
-    describe('client', () => {
-      it('should bailout to client rendering - without suspense boundary', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/hooks/use-search-params?first=value&second=other&third'
-        )
-
-        expect(await browser.elementByCss('#params-first').text()).toBe('value')
-        expect(await browser.elementByCss('#params-second').text()).toBe(
-          'other'
-        )
-        expect(await browser.elementByCss('#params-third').text()).toBe('')
-        expect(await browser.elementByCss('#params-not-real').text()).toBe(
-          'N/A'
-        )
+      const secondRes = await fetchViaHTTP(next.url, '/ssr-forced', undefined, {
+        redirect: 'manual',
       })
+      expect(secondRes.status).toBe(200)
 
-      it('should bailout to client rendering - with suspense boundary', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/hooks/use-search-params/with-suspense?first=value&second=other&third'
-        )
+      const secondHtml = await secondRes.text()
+      const second$ = cheerio.load(secondHtml)
 
-        expect(await browser.elementByCss('#params-first').text()).toBe('value')
-        expect(await browser.elementByCss('#params-second').text()).toBe(
-          'other'
-        )
-        expect(await browser.elementByCss('#params-third').text()).toBe('')
-        expect(await browser.elementByCss('#params-not-real').text()).toBe(
-          'N/A'
-        )
-      })
+      expect(second$('#page').text()).toBe('/ssr-forced')
+      const secondDate = second$('#date').text()
 
-      it.skip('should have empty search params on force-static', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/hooks/use-search-params/force-static?first=value&second=other&third'
-        )
+      expect(secondDate).not.toBe(initialDate)
+    })
 
-        expect(await browser.elementByCss('#params-first').text()).toBe('N/A')
-        expect(await browser.elementByCss('#params-second').text()).toBe('N/A')
-        expect(await browser.elementByCss('#params-third').text()).toBe('N/A')
-        expect(await browser.elementByCss('#params-not-real').text()).toBe(
-          'N/A'
-        )
-
-        await browser.elementById('to-use-search-params').click()
-        await browser.waitForElementByCss('#hooks-use-search-params')
-
-        // Should not be empty after navigating to another page with useSearchParams
-        expect(await browser.elementByCss('#params-first').text()).toBe('1')
-        expect(await browser.elementByCss('#params-second').text()).toBe('2')
-        expect(await browser.elementByCss('#params-third').text()).toBe('3')
-        expect(await browser.elementByCss('#params-not-real').text()).toBe(
-          'N/A'
-        )
-      })
-
-      // TODO-APP: re-enable after investigating rewrite params
-      if (!(global as any).isNextDeploy) {
-        it('should have values from canonical url on rewrite', async () => {
+    describe('useSearchParams', () => {
+      describe('client', () => {
+        it('should bailout to client rendering - without suspense boundary', async () => {
           const browser = await webdriver(
             next.url,
-            '/rewritten-use-search-params?first=a&second=b&third=c'
+            '/hooks/use-search-params?first=value&second=other&third'
           )
 
-          expect(await browser.elementByCss('#params-first').text()).toBe('a')
-          expect(await browser.elementByCss('#params-second').text()).toBe('b')
-          expect(await browser.elementByCss('#params-third').text()).toBe('c')
+          expect(await browser.elementByCss('#params-first').text()).toBe(
+            'value'
+          )
+          expect(await browser.elementByCss('#params-second').text()).toBe(
+            'other'
+          )
+          expect(await browser.elementByCss('#params-third').text()).toBe('')
           expect(await browser.elementByCss('#params-not-real').text()).toBe(
             'N/A'
           )
         })
-      }
-    })
-    // Don't run these tests in dev mode since they won't be statically generated
-    if (!isDev) {
-      describe('server response', () => {
-        it('should bailout to client rendering - without suspense boundary', async () => {
-          const res = await fetchViaHTTP(next.url, '/hooks/use-search-params')
-          const html = await res.text()
-          expect(html).toInclude('<html id="__next_error__">')
-        })
 
         it('should bailout to client rendering - with suspense boundary', async () => {
-          const res = await fetchViaHTTP(
+          const browser = await webdriver(
             next.url,
-            '/hooks/use-search-params/with-suspense'
+            '/hooks/use-search-params/with-suspense?first=value&second=other&third'
           )
-          const html = await res.text()
-          expect(html).toInclude('<p>search params suspense</p>')
+
+          expect(await browser.elementByCss('#params-first').text()).toBe(
+            'value'
+          )
+          expect(await browser.elementByCss('#params-second').text()).toBe(
+            'other'
+          )
+          expect(await browser.elementByCss('#params-third').text()).toBe('')
+          expect(await browser.elementByCss('#params-not-real').text()).toBe(
+            'N/A'
+          )
         })
 
         it.skip('should have empty search params on force-static', async () => {
-          const res = await fetchViaHTTP(
+          const browser = await webdriver(
             next.url,
             '/hooks/use-search-params/force-static?first=value&second=other&third'
           )
-          const html = await res.text()
 
-          // Shouild not bail out to client rendering
-          expect(html).not.toInclude('<p>search params suspense</p>')
+          expect(await browser.elementByCss('#params-first').text()).toBe('N/A')
+          expect(await browser.elementByCss('#params-second').text()).toBe(
+            'N/A'
+          )
+          expect(await browser.elementByCss('#params-third').text()).toBe('N/A')
+          expect(await browser.elementByCss('#params-not-real').text()).toBe(
+            'N/A'
+          )
 
-          // Use empty search params instead
-          const $ = cheerio.load(html)
-          expect($('#params-first').text()).toBe('N/A')
-          expect($('#params-second').text()).toBe('N/A')
-          expect($('#params-third').text()).toBe('N/A')
-          expect($('#params-not-real').text()).toBe('N/A')
+          await browser.elementById('to-use-search-params').click()
+          await browser.waitForElementByCss('#hooks-use-search-params')
+
+          // Should not be empty after navigating to another page with useSearchParams
+          expect(await browser.elementByCss('#params-first').text()).toBe('1')
+          expect(await browser.elementByCss('#params-second').text()).toBe('2')
+          expect(await browser.elementByCss('#params-third').text()).toBe('3')
+          expect(await browser.elementByCss('#params-not-real').text()).toBe(
+            'N/A'
+          )
         })
+
+        // TODO-APP: re-enable after investigating rewrite params
+        if (!(global as any).isNextDeploy) {
+          it('should have values from canonical url on rewrite', async () => {
+            const browser = await webdriver(
+              next.url,
+              '/rewritten-use-search-params?first=a&second=b&third=c'
+            )
+
+            expect(await browser.elementByCss('#params-first').text()).toBe('a')
+            expect(await browser.elementByCss('#params-second').text()).toBe(
+              'b'
+            )
+            expect(await browser.elementByCss('#params-third').text()).toBe('c')
+            expect(await browser.elementByCss('#params-not-real').text()).toBe(
+              'N/A'
+            )
+          })
+        }
       })
-    }
-  })
+      // Don't run these tests in dev mode since they won't be statically generated
+      if (!isDev) {
+        describe('server response', () => {
+          it('should bailout to client rendering - without suspense boundary', async () => {
+            const res = await fetchViaHTTP(next.url, '/hooks/use-search-params')
+            const html = await res.text()
+            expect(html).toInclude('<html id="__next_error__">')
+          })
 
-  // TODO: needs updating as usePathname should not bail
-  describe.skip('usePathname', () => {
-    if (isDev) {
-      it('should bail out to client rendering during SSG', async () => {
-        const res = await fetchViaHTTP(next.url, '/hooks/use-pathname/slug')
-        const html = await res.text()
-        expect(html).toInclude('<html id="__next_error__">')
-      })
-    }
+          it('should bailout to client rendering - with suspense boundary', async () => {
+            const res = await fetchViaHTTP(
+              next.url,
+              '/hooks/use-search-params/with-suspense'
+            )
+            const html = await res.text()
+            expect(html).toInclude('<p>search params suspense</p>')
+          })
 
-    it('should have the correct values', async () => {
-      const browser = await webdriver(next.url, '/hooks/use-pathname/slug')
+          it.skip('should have empty search params on force-static', async () => {
+            const res = await fetchViaHTTP(
+              next.url,
+              '/hooks/use-search-params/force-static?first=value&second=other&third'
+            )
+            const html = await res.text()
 
-      expect(await browser.elementByCss('#pathname').text()).toBe(
-        '/hooks/use-pathname/slug'
-      )
+            // Shouild not bail out to client rendering
+            expect(html).not.toInclude('<p>search params suspense</p>')
+
+            // Use empty search params instead
+            const $ = cheerio.load(html)
+            expect($('#params-first').text()).toBe('N/A')
+            expect($('#params-second').text()).toBe('N/A')
+            expect($('#params-third').text()).toBe('N/A')
+            expect($('#params-not-real').text()).toBe('N/A')
+          })
+        })
+      }
     })
 
-    it('should have values from canonical url on rewrite', async () => {
-      const browser = await webdriver(next.url, '/rewritten-use-pathname')
+    // TODO: needs updating as usePathname should not bail
+    describe.skip('usePathname', () => {
+      if (isDev) {
+        it('should bail out to client rendering during SSG', async () => {
+          const res = await fetchViaHTTP(next.url, '/hooks/use-pathname/slug')
+          const html = await res.text()
+          expect(html).toInclude('<html id="__next_error__">')
+        })
+      }
 
-      expect(await browser.elementByCss('#pathname').text()).toBe(
-        '/rewritten-use-pathname'
-      )
+      it('should have the correct values', async () => {
+        const browser = await webdriver(next.url, '/hooks/use-pathname/slug')
+
+        expect(await browser.elementByCss('#pathname').text()).toBe(
+          '/hooks/use-pathname/slug'
+        )
+      })
+
+      it('should have values from canonical url on rewrite', async () => {
+        const browser = await webdriver(next.url, '/rewritten-use-pathname')
+
+        expect(await browser.elementByCss('#pathname').text()).toBe(
+          '/rewritten-use-pathname'
+        )
+      })
     })
-  })
 
-  if (!(global as any).isNextDeploy) {
-    it('should show a message to leave feedback for `appDir`', async () => {
-      expect(next.cliOutput).toContain(
-        `Thank you for testing \`appDir\` please leave your feedback at https://nextjs.link/app-feedback`
-      )
+    if (!(global as any).isNextDeploy) {
+      it('should show a message to leave feedback for `appDir`', async () => {
+        expect(next.cliOutput).toContain(
+          `Thank you for testing \`appDir\` please leave your feedback at https://nextjs.link/app-feedback`
+        )
+      })
+    }
+
+    it('should keep querystring on static page', async () => {
+      const browser = await webdriver(next.url, '/blog/tim?message=hello-world')
+      const checkUrl = async () =>
+        expect(await browser.url()).toBe(
+          next.url + '/blog/tim?message=hello-world'
+        )
+
+      checkUrl()
+      await waitFor(1000)
+      checkUrl()
     })
   }
-
-  it('should keep querystring on static page', async () => {
-    const browser = await webdriver(next.url, '/blog/tim?message=hello-world')
-    const checkUrl = async () =>
-      expect(await browser.url()).toBe(
-        next.url + '/blog/tim?message=hello-world'
-      )
-
-    checkUrl()
-    await waitFor(1000)
-    checkUrl()
-  })
-})
+)

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -3,8 +3,7 @@ import cheerio from 'cheerio'
 import { promisify } from 'util'
 import path, { join } from 'path'
 import { createNextDescribe } from 'e2e-utils'
-import { check, fetchViaHTTP, normalizeRegEx, waitFor } from 'next-test-utils'
-import webdriver from 'next-webdriver'
+import { check, normalizeRegEx, waitFor } from 'next-test-utils'
 
 const glob = promisify(globOrig)
 

--- a/test/e2e/app-dir/asset-prefix.test.ts
+++ b/test/e2e/app-dir/asset-prefix.test.ts
@@ -1,62 +1,47 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 
-describe('app-dir assetPrefix handling', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
-
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'asset-prefix')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
-      skipStart: true,
+createNextDescribe(
+  'app-dir assetPrefix handling',
+  {
+    files: path.join(__dirname, 'asset-prefix'),
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should redirect route when requesting it directly', async () => {
+      const res = await fetchViaHTTP(
+        next.url,
+        '/a/',
+        {},
+        {
+          redirect: 'manual',
+        }
+      )
+      expect(res.status).toBe(308)
+      expect(res.headers.get('location')).toBe(next.url + '/a')
     })
 
-    await next.start()
-  })
-  afterAll(() => next.destroy())
+    it('should render link', async () => {
+      const html = await renderViaHTTP(next.url, '/')
+      const $ = cheerio.load(html)
+      expect($('#to-a-trailing-slash').attr('href')).toBe('/a')
+    })
 
-  it('should redirect route when requesting it directly', async () => {
-    const res = await fetchViaHTTP(
-      next.url,
-      '/a/',
-      {},
-      {
-        redirect: 'manual',
-      }
-    )
-    expect(res.status).toBe(308)
-    expect(res.headers.get('location')).toBe(next.url + '/a')
-  })
+    it('should redirect route when requesting it directly by browser', async () => {
+      const browser = await webdriver(next.url, '/a')
+      expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
+    })
 
-  it('should render link', async () => {
-    const html = await renderViaHTTP(next.url, '/')
-    const $ = cheerio.load(html)
-    expect($('#to-a-trailing-slash').attr('href')).toBe('/a')
-  })
-
-  it('should redirect route when requesting it directly by browser', async () => {
-    const browser = await webdriver(next.url, '/a')
-    expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
-  })
-
-  it('should redirect route when clicking link', async () => {
-    const browser = await webdriver(next.url, '/')
-    await browser
-      .elementByCss('#to-a-trailing-slash')
-      .click()
-      .waitForElementByCss('#a-page')
-    expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
-  })
-})
+    it('should redirect route when clicking link', async () => {
+      const browser = await webdriver(next.url, '/')
+      await browser
+        .elementByCss('#to-a-trailing-slash')
+        .click()
+        .waitForElementByCss('#a-page')
+      expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
+    })
+  }
+)

--- a/test/e2e/app-dir/asset-prefix.test.ts
+++ b/test/e2e/app-dir/asset-prefix.test.ts
@@ -1,8 +1,6 @@
 import { createNextDescribe } from 'e2e-utils'
-import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import cheerio from 'cheerio'
-import webdriver from 'next-webdriver'
 
 createNextDescribe(
   'app-dir assetPrefix handling',
@@ -12,8 +10,7 @@ createNextDescribe(
   },
   ({ next }) => {
     it('should redirect route when requesting it directly', async () => {
-      const res = await fetchViaHTTP(
-        next.url,
+      const res = await next.fetch(
         '/a/',
         {},
         {
@@ -25,18 +22,18 @@ createNextDescribe(
     })
 
     it('should render link', async () => {
-      const html = await renderViaHTTP(next.url, '/')
+      const html = await next.render('/')
       const $ = cheerio.load(html)
       expect($('#to-a-trailing-slash').attr('href')).toBe('/a')
     })
 
     it('should redirect route when requesting it directly by browser', async () => {
-      const browser = await webdriver(next.url, '/a')
+      const browser = await next.browser('/a')
       expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
     })
 
     it('should redirect route when clicking link', async () => {
-      const browser = await webdriver(next.url, '/')
+      const browser = await next.browser('/')
       await browser
         .elementByCss('#to-a-trailing-slash')
         .click()

--- a/test/e2e/app-dir/asset-prefix.test.ts
+++ b/test/e2e/app-dir/asset-prefix.test.ts
@@ -1,6 +1,5 @@
 import { createNextDescribe } from 'e2e-utils'
 import path from 'path'
-import cheerio from 'cheerio'
 
 createNextDescribe(
   'app-dir assetPrefix handling',
@@ -22,8 +21,7 @@ createNextDescribe(
     })
 
     it('should render link', async () => {
-      const html = await next.render('/')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/')
       expect($('#to-a-trailing-slash').attr('href')).toBe('/a')
     })
 

--- a/test/e2e/app-dir/async-component-preload.test.ts
+++ b/test/e2e/app-dir/async-component-preload.test.ts
@@ -1,29 +1,18 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
-import webdriver from 'next-webdriver'
+import { createNextDescribe } from 'e2e-utils'
 import path from 'path'
 
-describe('async-component-preload', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
-
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'async-component-preload')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
+createNextDescribe(
+  'async-component-preload',
+  {
+    files: path.join(__dirname, 'async-component-preload'),
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should handle redirect in an async page', async () => {
+      const browser = await next.browser('/')
+      expect(await browser.waitForElementByCss('#success').text()).toBe(
+        'Success'
+      )
     })
-  })
-  afterAll(() => next.destroy())
-
-  it('should handle redirect in an async page', async () => {
-    const browser = await webdriver(next.url, '/')
-    expect(await browser.waitForElementByCss('#success').text()).toBe('Success')
-  })
-})
+  }
+)

--- a/test/e2e/app-dir/back-button-download-bug.test.ts
+++ b/test/e2e/app-dir/back-button-download-bug.test.ts
@@ -1,42 +1,30 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 import path from 'path'
-import webdriver from 'next-webdriver'
 
 // TODO-APP: fix test as it's failing randomly
 describe.skip('app-dir back button download bug', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
+  createNextDescribe(
+    'app-dir back button download bug',
+    {
+      files: path.join(__dirname, 'back-button-download-bug'),
+      skipDeployment: true,
+    },
+    ({ next }) => {
+      it('should redirect route when clicking link', async () => {
+        const browser = await next.browser('/')
+        const text = await browser
+          .elementByCss('#to-post-1')
+          .click()
+          .waitForElementByCss('#post-page')
+          .text()
+        expect(text).toBe('This is the post page')
 
-  let next: NextInstance
+        await browser.back()
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'back-button-download-bug')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
-      skipStart: true,
-    })
-
-    await next.start()
-  })
-  afterAll(() => next.destroy())
-
-  it('should redirect route when clicking link', async () => {
-    const browser = await webdriver(next.url, '/')
-    const text = await browser
-      .elementByCss('#to-post-1')
-      .click()
-      .waitForElementByCss('#post-page')
-      .text()
-    expect(text).toBe('This is the post page')
-
-    await browser.back()
-
-    expect(await browser.waitForElementByCss('#home-page').text()).toBe('Home!')
-  })
+        expect(await browser.waitForElementByCss('#home-page').text()).toBe(
+          'Home!'
+        )
+      })
+    }
+  )
 })

--- a/test/e2e/app-dir/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout.test.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
-import webdriver from 'next-webdriver'
 import { check } from 'next-test-utils'
 
 describe('app-dir create root layout', () => {
@@ -35,7 +34,7 @@ describe('app-dir create root layout', () => {
 
         it('create root layout', async () => {
           const outputIndex = next.cliOutput.length
-          const browser = await webdriver(next.url, '/route')
+          const browser = await next.browser('/route')
 
           expect(await browser.elementById('page-text').text()).toBe(
             'Hello world!'
@@ -97,7 +96,7 @@ describe('app-dir create root layout', () => {
 
         it('create root layout', async () => {
           const outputIndex = next.cliOutput.length
-          const browser = await webdriver(next.url, '/')
+          const browser = await next.browser('/')
 
           expect(await browser.elementById('page-text').text()).toBe(
             'Hello world'
@@ -164,7 +163,7 @@ describe('app-dir create root layout', () => {
 
         it('create root layout', async () => {
           const outputIndex = next.cliOutput.length
-          const browser = await webdriver(next.url, '/route/second/inner')
+          const browser = await next.browser('/route/second/inner')
 
           expect(await browser.elementById('page-text').text()).toBe(
             'Hello world'
@@ -232,7 +231,7 @@ describe('app-dir create root layout', () => {
 
       it('create root layout', async () => {
         const outputIndex = next.cliOutput.length
-        const browser = await webdriver(next.url, '/')
+        const browser = await next.browser('/')
 
         expect(await browser.elementById('page-text').text()).toBe(
           'Hello world!'

--- a/test/e2e/app-dir/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout.test.ts
@@ -12,10 +12,6 @@ describe('app-dir create root layout', () => {
     return
   }
 
-  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
-    it('should skip for react v17', () => {})
-    return
-  }
   let next: NextInstance
 
   if (isDev) {

--- a/test/e2e/app-dir/dynamic-href.test.ts
+++ b/test/e2e/app-dir/dynamic-href.test.ts
@@ -1,75 +1,63 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 import { getRedboxDescription, hasRedbox } from 'next-test-utils'
 import path from 'path'
-import webdriver from 'next-webdriver'
 
-describe('dynamic-href', () => {
-  const isDev = (global as any).isNextDev
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
+createNextDescribe(
+  'dynamic-href',
+  {
+    files: path.join(__dirname, 'dynamic-href'),
+    skipDeployment: true,
+  },
+  ({ isNextDev: isDev, next }) => {
+    if (isDev) {
+      it('should error when using dynamic href.pathname in app dir', async () => {
+        const browser = await next.browser('/object')
 
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'dynamic-href')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
-    })
-  })
-  afterAll(() => next.destroy())
-
-  if (isDev) {
-    it('should error when using dynamic href.pathname in app dir', async () => {
-      const browser = await webdriver(next.url, '/object')
-
-      // Error should show up
-      expect(await hasRedbox(browser, true)).toBeTrue()
-      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-        `"Error: Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href"`
-      )
-
-      // Fix error
-      const pageContent = await next.readFile('app/object/page.js')
-      await next.patchFile(
-        'app/object/page.js',
-        pageContent.replace(
-          "pathname: '/object/[slug]'",
-          "pathname: '/object/slug'"
+        // Error should show up
+        expect(await hasRedbox(browser, true)).toBeTrue()
+        expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+          `"Error: Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href"`
         )
-      )
-      expect(await browser.waitForElementByCss('#link').text()).toBe('to slug')
 
-      // Navigate to new page
-      await browser.elementByCss('#link').click()
-      expect(await browser.waitForElementByCss('#pathname').text()).toBe(
-        '/object/slug'
-      )
-      expect(await browser.elementByCss('#slug').text()).toBe('1')
-    })
+        // Fix error
+        const pageContent = await next.readFile('app/object/page.js')
+        await next.patchFile(
+          'app/object/page.js',
+          pageContent.replace(
+            "pathname: '/object/[slug]'",
+            "pathname: '/object/slug'"
+          )
+        )
+        expect(await browser.waitForElementByCss('#link').text()).toBe(
+          'to slug'
+        )
 
-    it('should error when using dynamic href in app dir', async () => {
-      const browser = await webdriver(next.url, '/string')
+        // Navigate to new page
+        await browser.elementByCss('#link').click()
+        expect(await browser.waitForElementByCss('#pathname').text()).toBe(
+          '/object/slug'
+        )
+        expect(await browser.elementByCss('#slug').text()).toBe('1')
+      })
 
-      // Error should show up
-      expect(await hasRedbox(browser, true)).toBeTrue()
-      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-        `"Error: Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href"`
-      )
-    })
-  } else {
-    it('should not error on /object in prod', async () => {
-      const browser = await webdriver(next.url, '/object')
-      expect(await browser.elementByCss('#link').text()).toBe('to slug')
-    })
-    it('should not error on /string in prod', async () => {
-      const browser = await webdriver(next.url, '/string')
-      expect(await browser.elementByCss('#link').text()).toBe('to slug')
-    })
+      it('should error when using dynamic href in app dir', async () => {
+        const browser = await next.browser('/string')
+
+        // Error should show up
+        expect(await hasRedbox(browser, true)).toBeTrue()
+        expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+          `"Error: Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href"`
+        )
+      })
+    } else {
+      it('should not error on /object in prod', async () => {
+        const browser = await next.browser('/object')
+        expect(await browser.elementByCss('#link').text()).toBe('to slug')
+      })
+      it('should not error on /string in prod', async () => {
+        const browser = await next.browser('/string')
+        expect(await browser.elementByCss('#link').text()).toBe('to slug')
+      })
+    }
   }
-})
+)

--- a/test/e2e/app-dir/global-error.test.ts
+++ b/test/e2e/app-dir/global-error.test.ts
@@ -1,35 +1,29 @@
 import path from 'path'
 import { getRedboxHeader, hasRedbox } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
-import webdriver from 'next-webdriver'
+import { createNextDescribe } from 'e2e-utils'
 
-describe('app dir - global error', () => {
-  let next: NextInstance
-  const isDev = (global as any).isNextDev
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, './global-error')),
-    })
-  })
-  afterAll(() => next.destroy())
-
-  it('should trigger error component when an error happens during rendering', async () => {
-    const browser = await webdriver(next.url, '/throw')
-    await browser
-      .waitForElementByCss('#error-trigger-button')
-      .elementByCss('#error-trigger-button')
-      .click()
-
-    if (isDev) {
-      expect(await hasRedbox(browser)).toBe(true)
-      expect(await getRedboxHeader(browser)).toMatch(/Error: Client error/)
-    } else {
+createNextDescribe(
+  'app dir - global error',
+  {
+    files: path.join(__dirname, './global-error'),
+  },
+  ({ next, isNextDev }) => {
+    it('should trigger error component when an error happens during rendering', async () => {
+      const browser = await next.browser('/throw')
       await browser
-      expect(await browser.elementByCss('#error').text()).toBe(
-        'Error message: Client error'
-      )
-    }
-  })
-})
+        .waitForElementByCss('#error-trigger-button')
+        .elementByCss('#error-trigger-button')
+        .click()
+
+      if (isNextDev) {
+        expect(await hasRedbox(browser)).toBe(true)
+        expect(await getRedboxHeader(browser)).toMatch(/Error: Client error/)
+      } else {
+        await browser
+        expect(await browser.elementByCss('#error').text()).toBe(
+          'Error message: Client error'
+        )
+      }
+    })
+  }
+)

--- a/test/e2e/app-dir/import.test.ts
+++ b/test/e2e/app-dir/import.test.ts
@@ -5,34 +5,26 @@ import { NextInstance } from 'test/lib/next-modes/base'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('app dir imports', () => {
-  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
-    it('should skip for react v17', () => {})
-    return
-  }
   let next: NextInstance
 
-  function runTests() {
-    beforeAll(async () => {
-      next = await createNext({
-        files: new FileRef(path.join(__dirname, 'import')),
-        dependencies: {
-          react: 'latest',
-          'react-dom': 'latest',
-          typescript: 'latest',
-          '@types/react': 'latest',
-          '@types/node': 'latest',
-        },
-      })
+  beforeAll(async () => {
+    next = await createNext({
+      files: new FileRef(path.join(__dirname, 'import')),
+      dependencies: {
+        react: 'latest',
+        'react-dom': 'latest',
+        typescript: 'latest',
+        '@types/react': 'latest',
+        '@types/node': 'latest',
+      },
     })
-    afterAll(() => next.destroy())
-    ;['js', 'jsx', 'ts', 'tsx'].forEach((ext) => {
-      it(`we can import all components from .${ext}`, async () => {
-        const html = await renderViaHTTP(next.url, `/${ext}`)
-        const $ = cheerio.load(html)
-        expect($('#js').text()).toBe('CompJs')
-      })
+  })
+  afterAll(() => next.destroy())
+  ;['js', 'jsx', 'ts', 'tsx'].forEach((ext) => {
+    it(`we can import all components from .${ext}`, async () => {
+      const html = await renderViaHTTP(next.url, `/${ext}`)
+      const $ = cheerio.load(html)
+      expect($('#js').text()).toBe('CompJs')
     })
-  }
-
-  runTests()
+  })
 })

--- a/test/e2e/app-dir/import.test.ts
+++ b/test/e2e/app-dir/import.test.ts
@@ -1,30 +1,24 @@
 import path from 'path'
-import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
-import { renderViaHTTP } from 'next-test-utils'
+import { createNextDescribe } from 'e2e-utils'
 
-describe('app dir imports', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'import')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-        typescript: 'latest',
-        '@types/react': 'latest',
-        '@types/node': 'latest',
-      },
+createNextDescribe(
+  'app dir imports',
+  {
+    files: path.join(__dirname, 'import'),
+    dependencies: {
+      react: 'latest',
+      'react-dom': 'latest',
+      typescript: 'latest',
+      '@types/react': 'latest',
+      '@types/node': 'latest',
+    },
+  },
+  ({ next }) => {
+    ;['js', 'jsx', 'ts', 'tsx'].forEach((ext) => {
+      it(`we can import all components from .${ext}`, async () => {
+        const $ = await next.render$(`/${ext}`)
+        expect($('#js').text()).toBe('CompJs')
+      })
     })
-  })
-  afterAll(() => next.destroy())
-  ;['js', 'jsx', 'ts', 'tsx'].forEach((ext) => {
-    it(`we can import all components from .${ext}`, async () => {
-      const html = await renderViaHTTP(next.url, `/${ext}`)
-      const $ = cheerio.load(html)
-      expect($('#js').text()).toBe('CompJs')
-    })
-  })
-})
+  }
+)

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1,16 +1,8 @@
 import { createNextDescribe } from 'e2e-utils'
 import crypto from 'crypto'
-import {
-  check,
-  fetchViaHTTP,
-  getRedboxHeader,
-  hasRedbox,
-  renderViaHTTP,
-  waitFor,
-} from 'next-test-utils'
+import { check, getRedboxHeader, hasRedbox, waitFor } from 'next-test-utils'
 import path from 'path'
 import cheerio from 'cheerio'
-import webdriver from 'next-webdriver'
 
 createNextDescribe(
   'app dir',
@@ -28,25 +20,31 @@ createNextDescribe(
       it('should not share edge workers', async () => {
         const controller1 = new AbortController()
         const controller2 = new AbortController()
-        fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
-          signal: controller1.signal,
-        }).catch(() => {})
-        fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
-          signal: controller2.signal,
-        }).catch(() => {})
+        next
+          .fetch('/slow-page-no-loading', undefined, {
+            signal: controller1.signal,
+          })
+          .catch(() => {})
+        next
+          .fetch('/slow-page-no-loading', undefined, {
+            signal: controller2.signal,
+          })
+          .catch(() => {})
 
         await waitFor(1000)
         controller1.abort()
 
         const controller3 = new AbortController()
-        fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
-          signal: controller3.signal,
-        }).catch(() => {})
+        next
+          .fetch('/slow-page-no-loading', undefined, {
+            signal: controller3.signal,
+          })
+          .catch(() => {})
         await waitFor(1000)
         controller2.abort()
         controller3.abort()
 
-        const res = await fetchViaHTTP(next.url, '/slow-page-no-loading')
+        const res = await next.fetch('/slow-page-no-loading')
         expect(res.status).toBe(200)
         expect(await res.text()).toContain('hello from slow page')
         expect(next.cliOutput).not.toContain(
@@ -69,8 +67,7 @@ createNextDescribe(
     }
 
     it('should use application/octet-stream for flight', async () => {
-      const res = await fetchViaHTTP(
-        next.url,
+      const res = await next.fetch(
         '/dashboard/deployments/123',
         {},
         {
@@ -83,8 +80,7 @@ createNextDescribe(
     })
 
     it('should use application/octet-stream for flight with edge runtime', async () => {
-      const res = await fetchViaHTTP(
-        next.url,
+      const res = await next.fetch(
         '/dashboard',
         {},
         {
@@ -97,13 +93,13 @@ createNextDescribe(
     })
 
     it('should pass props from getServerSideProps in root layout', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard')
+      const html = await next.render('/dashboard')
       const $ = cheerio.load(html)
       expect($('title').text()).toBe('hello world')
     })
 
     it('should serve from pages', async () => {
-      const html = await renderViaHTTP(next.url, '/')
+      const html = await next.render('/')
       expect(html).toContain('hello from pages/index')
 
       // esm imports should work fine in pages/
@@ -111,17 +107,17 @@ createNextDescribe(
     })
 
     it('should serve dynamic route from pages', async () => {
-      const html = await renderViaHTTP(next.url, '/blog/first')
+      const html = await next.render('/blog/first')
       expect(html).toContain('hello from pages/blog/[slug]')
     })
 
     it('should serve from public', async () => {
-      const html = await renderViaHTTP(next.url, '/hello.txt')
+      const html = await next.render('/hello.txt')
       expect(html).toContain('hello world')
     })
 
     it('should serve from app', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard')
+      const html = await next.render('/dashboard')
       expect(html).toContain('hello from app/dashboard')
     })
 
@@ -131,7 +127,7 @@ createNextDescribe(
         next.on('stderr', (err) => {
           stderr.push(err)
         })
-        const html = await renderViaHTTP(next.url, '/dashboard/index')
+        const html = await next.render('/dashboard/index')
         expect(html).toContain('hello from app/dashboard/index')
         expect(stderr.some((err) => err.includes('Invalid hook call'))).toBe(
           false
@@ -139,7 +135,7 @@ createNextDescribe(
       })
 
       it('should handle next/dynamic correctly', async () => {
-        const html = await renderViaHTTP(next.url, '/dashboard/dynamic')
+        const html = await next.render('/dashboard/dynamic')
         const $ = cheerio.load(html)
         // filter out the script
         const selector = 'body div'
@@ -161,7 +157,7 @@ createNextDescribe(
         // client component under server component with ssr: false will not be rendered either in flight or SSR
         expect(html).not.toContain('client component under sever no ssr')
 
-        const browser = await webdriver(next.url, '/dashboard/dynamic')
+        const browser = await next.browser('/dashboard/dynamic')
         const clientContent = await browser.elementByCss(selector).text()
         expect(clientContent).toContain('next-dynamic dynamic no ssr on server')
         expect(clientContent).toContain('client component under sever no ssr')
@@ -173,7 +169,7 @@ createNextDescribe(
       })
 
       it('should serve polyfills for browsers that do not support modules', async () => {
-        const html = await renderViaHTTP(next.url, '/dashboard/index')
+        const html = await next.render('/dashboard/index')
         expect(html).toMatch(
           /<script src="\/_next\/static\/chunks\/polyfills(-\w+)?\.js" nomodule="">/
         )
@@ -182,7 +178,7 @@ createNextDescribe(
 
     // TODO-APP: handle css modules fouc in dev
     it.skip('should handle css imports in next/dynamic correctly', async () => {
-      const browser = await webdriver(next.url, '/dashboard/index')
+      const browser = await next.browser('/dashboard/index')
 
       expect(
         await browser.eval(
@@ -197,7 +193,7 @@ createNextDescribe(
     })
 
     it('should include layouts when no direct parent layout', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/integrations')
+      const html = await next.render('/dashboard/integrations')
       const $ = cheerio.load(html)
       // Should not be nested in dashboard
       expect($('h1').text()).toBe('Dashboard')
@@ -207,7 +203,7 @@ createNextDescribe(
 
     // TODO-APP: handle new root layout
     it.skip('should not include parent when not in parent directory with route in directory', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/hello')
+      const html = await next.render('/dashboard/hello')
       const $ = cheerio.load(html)
 
       // new root has to provide it's own custom root layout or the default
@@ -225,7 +221,7 @@ createNextDescribe(
     })
 
     it('should use new root layout when provided', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/another')
+      const html = await next.render('/dashboard/another')
       const $ = cheerio.load(html)
 
       // new root has to provide it's own custom root layout or the default
@@ -241,10 +237,7 @@ createNextDescribe(
     })
 
     it('should not create new root layout when nested (optional)', async () => {
-      const html = await renderViaHTTP(
-        next.url,
-        '/dashboard/deployments/breakdown'
-      )
+      const html = await next.render('/dashboard/deployments/breakdown')
       const $ = cheerio.load(html)
 
       // new root has to provide it's own custom root layout or the default
@@ -263,7 +256,7 @@ createNextDescribe(
     })
 
     it('should include parent document when no direct parent layout', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/integrations')
+      const html = await next.render('/dashboard/integrations')
       const $ = cheerio.load(html)
 
       expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
@@ -271,7 +264,7 @@ createNextDescribe(
     })
 
     it('should not include parent when not in parent directory', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/changelog')
+      const html = await next.render('/dashboard/changelog')
       const $ = cheerio.load(html)
       // Should not be nested in dashboard
       expect($('h1').text()).toBeFalsy()
@@ -280,7 +273,7 @@ createNextDescribe(
     })
 
     it('should serve nested parent', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/deployments/123')
+      const html = await next.render('/dashboard/deployments/123')
       const $ = cheerio.load(html)
       // Should be nested in dashboard
       expect($('h1').text()).toBe('Dashboard')
@@ -289,7 +282,7 @@ createNextDescribe(
     })
 
     it('should serve dynamic parameter', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/deployments/123')
+      const html = await next.render('/dashboard/deployments/123')
       const $ = cheerio.load(html)
       // Should include the page text with the parameter
       expect($('p').text()).toBe(
@@ -300,13 +293,13 @@ createNextDescribe(
     // TODO-APP: fix to ensure behavior matches on deploy
     if (!isNextDeploy) {
       it('should serve page as a segment name correctly', async () => {
-        const html = await renderViaHTTP(next.url, '/dashboard/page')
+        const html = await next.render('/dashboard/page')
         expect(html).toContain('hello dashboard/page!')
       })
     }
 
     it('should include document html and body', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard')
+      const html = await next.render('/dashboard')
       const $ = cheerio.load(html)
 
       expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
@@ -314,7 +307,7 @@ createNextDescribe(
     })
 
     it('should not serve when layout is provided but no folder index', async () => {
-      const res = await fetchViaHTTP(next.url, '/dashboard/deployments')
+      const res = await next.fetch('/dashboard/deployments')
       expect(res.status).toBe(404)
       expect(await res.text()).toContain('This page could not be found')
     })
@@ -322,20 +315,20 @@ createNextDescribe(
     // TODO-APP: do we want to make this only work for /root or is it allowed
     // to work for /pages as well?
     it.skip('should match partial parameters', async () => {
-      const html = await renderViaHTTP(next.url, '/partial-match-123')
+      const html = await next.render('/partial-match-123')
       expect(html).toContain('hello from app/partial-match-[id]. ID is: 123')
     })
 
     describe('rewrites', () => {
       // TODO-APP: rewrite url is broken
       it('should support rewrites on initial load', async () => {
-        const browser = await webdriver(next.url, '/rewritten-to-dashboard')
+        const browser = await next.browser('/rewritten-to-dashboard')
         expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
         expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
       })
 
       it('should support rewrites on client-side navigation from pages to app with existing pages path', async () => {
-        const browser = await webdriver(next.url, '/link-to-rewritten-path')
+        const browser = await next.browser('/link-to-rewritten-path')
 
         try {
           // Click the link.
@@ -356,7 +349,7 @@ createNextDescribe(
       })
 
       it('should support rewrites on client-side navigation', async () => {
-        const browser = await webdriver(next.url, '/rewrites')
+        const browser = await next.browser('/rewrites')
 
         try {
           // Click the link.
@@ -380,7 +373,7 @@ createNextDescribe(
     ;(isDev ? it.skip : it)(
       'should not rerender layout when navigating between routes in the same layout',
       async () => {
-        const browser = await webdriver(next.url, '/same-layout/first')
+        const browser = await next.browser('/same-layout/first')
 
         try {
           // Get the render id from the dom and click the first link.
@@ -406,7 +399,7 @@ createNextDescribe(
     )
 
     it('should handle hash in initial url', async () => {
-      const browser = await webdriver(next.url, '/dashboard#abc')
+      const browser = await next.browser('/dashboard#abc')
 
       try {
         // Check if hash is preserved
@@ -422,7 +415,7 @@ createNextDescribe(
     describe('parallel routes', () => {
       if (!isNextDeploy) {
         it('should match parallel routes', async () => {
-          const html = await renderViaHTTP(next.url, '/parallel/nested')
+          const html = await next.render('/parallel/nested')
           expect(html).toContain('parallel/layout')
           expect(html).toContain('parallel/@foo/nested/layout')
           expect(html).toContain('parallel/@foo/nested/@a/page')
@@ -435,7 +428,7 @@ createNextDescribe(
       }
 
       it('should match parallel routes in route groups', async () => {
-        const html = await renderViaHTTP(next.url, '/parallel/nested-2')
+        const html = await next.render('/parallel/nested-2')
         expect(html).toContain('parallel/layout')
         expect(html).toContain('parallel/(new)/layout')
         expect(html).toContain('parallel/(new)/@baz/nested/page')
@@ -444,7 +437,7 @@ createNextDescribe(
 
     describe('<Link />', () => {
       it('should hard push', async () => {
-        const browser = await webdriver(next.url, '/link-hard-push/123')
+        const browser = await next.browser('/link-hard-push/123')
 
         try {
           // Click the link on the page, and verify that the history entry was
@@ -471,7 +464,7 @@ createNextDescribe(
       })
 
       it('should hard replace', async () => {
-        const browser = await webdriver(next.url, '/link-hard-replace/123')
+        const browser = await next.browser('/link-hard-replace/123')
 
         try {
           // Click the link on the page, and verify that the history entry was NOT
@@ -504,7 +497,7 @@ createNextDescribe(
 
       // TODO-APP: Re-enable this test.
       it('should soft push', async () => {
-        const browser = await webdriver(next.url, '/link-soft-push')
+        const browser = await next.browser('/link-soft-push')
 
         try {
           // Click the link on the page, and verify that the history entry was
@@ -531,7 +524,7 @@ createNextDescribe(
 
       // TODO-APP: investigate this test
       it.skip('should soft replace', async () => {
-        const browser = await webdriver(next.url, '/link-soft-replace')
+        const browser = await next.browser('/link-soft-replace')
 
         try {
           // Get the render ID so we can compare it.
@@ -567,7 +560,7 @@ createNextDescribe(
       })
 
       it('should be soft for back navigation', async () => {
-        const browser = await webdriver(next.url, '/with-id')
+        const browser = await next.browser('/with-id')
 
         try {
           // Get the id on the rendered page.
@@ -587,7 +580,7 @@ createNextDescribe(
       })
 
       it('should be soft for forward navigation', async () => {
-        const browser = await webdriver(next.url, '/with-id')
+        const browser = await next.browser('/with-id')
 
         try {
           // Click the link.
@@ -610,7 +603,7 @@ createNextDescribe(
       })
 
       it('should allow linking from app page to pages page', async () => {
-        const browser = await webdriver(next.url, '/pages-linking')
+        const browser = await next.browser('/pages-linking')
 
         try {
           // Click the link.
@@ -630,10 +623,7 @@ createNextDescribe(
       })
 
       it('should navigate to pages dynamic route from pages page if it overlaps with an app page', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/dynamic-pages-route-app-overlap'
-        )
+        const browser = await next.browser('/dynamic-pages-route-app-overlap')
 
         try {
           // Click the link.
@@ -658,60 +648,45 @@ createNextDescribe(
       // should be? Seems like they both either should be servable or not
       it('should not serve .server.js as a path', async () => {
         // Without .server.js should serve
-        const html = await renderViaHTTP(next.url, '/should-not-serve-server')
+        const html = await next.render('/should-not-serve-server')
         expect(html).toContain('hello from app/should-not-serve-server')
 
         // Should not serve `.server`
-        const res = await fetchViaHTTP(
-          next.url,
-          '/should-not-serve-server.server'
-        )
+        const res = await next.fetch('/should-not-serve-server.server')
         expect(res.status).toBe(404)
         expect(await res.text()).toContain('This page could not be found')
 
         // Should not serve `.server.js`
-        const res2 = await fetchViaHTTP(
-          next.url,
-          '/should-not-serve-server.server.js'
-        )
+        const res2 = await next.fetch('/should-not-serve-server.server.js')
         expect(res2.status).toBe(404)
         expect(await res2.text()).toContain('This page could not be found')
       })
 
       it('should not serve .client.js as a path', async () => {
         // Without .client.js should serve
-        const html = await renderViaHTTP(next.url, '/should-not-serve-client')
+        const html = await next.render('/should-not-serve-client')
         expect(html).toContain('hello from app/should-not-serve-client')
 
         // Should not serve `.client`
-        const res = await fetchViaHTTP(
-          next.url,
-          '/should-not-serve-client.client'
-        )
+        const res = await next.fetch('/should-not-serve-client.client')
         expect(res.status).toBe(404)
         expect(await res.text()).toContain('This page could not be found')
 
         // Should not serve `.client.js`
-        const res2 = await fetchViaHTTP(
-          next.url,
-          '/should-not-serve-client.client.js'
-        )
+        const res2 = await next.fetch('/should-not-serve-client.client.js')
         expect(res2.status).toBe(404)
         expect(await res2.text()).toContain('This page could not be found')
       })
 
       it('should serve shared component', async () => {
         // Without .client.js should serve
-        const html = await renderViaHTTP(next.url, '/shared-component-route')
+        const html = await next.render('/shared-component-route')
         expect(html).toContain('hello from app/shared-component-route')
       })
 
       describe('dynamic routes', () => {
         it('should only pass params that apply to the layout', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/dynamic/books/hello-world'
-          )
+          const html = await next.render('/dynamic/books/hello-world')
           const $ = cheerio.load(html)
 
           expect($('#dynamic-layout-params').text()).toBe('{}')
@@ -731,22 +706,19 @@ createNextDescribe(
         it('should handle optional segments', async () => {
           const params = ['this', 'is', 'a', 'test']
           const route = params.join('/')
-          const html = await renderViaHTTP(
-            next.url,
-            `/catch-all-optional/${route}`
-          )
+          const html = await next.render(`/catch-all-optional/${route}`)
           const $ = cheerio.load(html)
           expect($('#text').attr('data-params')).toBe(route)
         })
 
         it('should handle optional segments root', async () => {
-          const html = await renderViaHTTP(next.url, `/catch-all-optional`)
+          const html = await next.render(`/catch-all-optional`)
           const $ = cheerio.load(html)
           expect($('#text').attr('data-params')).toBe('')
         })
 
         it('should handle optional catch-all segments link', async () => {
-          const browser = await webdriver(next.url, '/catch-all-link')
+          const browser = await next.browser('/catch-all-link')
           expect(
             await browser
               .elementByCss('#to-catch-all-optional')
@@ -759,7 +731,7 @@ createNextDescribe(
         it('should handle required segments', async () => {
           const params = ['this', 'is', 'a', 'test']
           const route = params.join('/')
-          const html = await renderViaHTTP(next.url, `/catch-all/${route}`)
+          const html = await next.render(`/catch-all/${route}`)
           const $ = cheerio.load(html)
           expect($('#text').attr('data-params')).toBe(route)
           expect($('#not-a-page').text()).toBe('Not a page')
@@ -770,13 +742,13 @@ createNextDescribe(
         })
 
         it('should handle required segments root as not found', async () => {
-          const res = await fetchViaHTTP(next.url, `/catch-all`)
+          const res = await next.fetch(`/catch-all`)
           expect(res.status).toBe(404)
           expect(await res.text()).toContain('This page could not be found')
         })
 
         it('should handle catch-all segments link', async () => {
-          const browser = await webdriver(next.url, '/catch-all-link')
+          const browser = await next.browser('/catch-all-link')
           expect(
             await browser
               .elementByCss('#to-catch-all')
@@ -789,7 +761,7 @@ createNextDescribe(
 
       describe('should serve client component', () => {
         it('should serve server-side', async () => {
-          const html = await renderViaHTTP(next.url, '/client-component-route')
+          const html = await next.render('/client-component-route')
           const $ = cheerio.load(html)
           expect($('p').text()).toBe(
             'hello from app/client-component-route. count: 0'
@@ -798,7 +770,7 @@ createNextDescribe(
 
         // TODO-APP: investigate hydration not kicking in on some runs
         it('should serve client-side', async () => {
-          const browser = await webdriver(next.url, '/client-component-route')
+          const browser = await next.browser('/client-component-route')
 
           // After hydration count should be 1
           expect(await browser.elementByCss('p').text()).toBe(
@@ -809,7 +781,7 @@ createNextDescribe(
 
       describe('should include client component layout with server component route', () => {
         it('should include it server-side', async () => {
-          const html = await renderViaHTTP(next.url, '/client-nested')
+          const html = await next.render('/client-nested')
           const $ = cheerio.load(html)
           // Should not be nested in dashboard
           expect($('h1').text()).toBe('Client Nested. Count: 0')
@@ -818,7 +790,7 @@ createNextDescribe(
         })
 
         it('should include it client-side', async () => {
-          const browser = await webdriver(next.url, '/client-nested')
+          const browser = await next.browser('/client-nested')
 
           // After hydration count should be 1
           expect(await browser.elementByCss('h1').text()).toBe(
@@ -834,17 +806,17 @@ createNextDescribe(
 
       describe('Loading', () => {
         it('should render loading.js in initial html for slow page', async () => {
-          const html = await renderViaHTTP(next.url, '/slow-page-with-loading')
+          const html = await next.render('/slow-page-with-loading')
           const $ = cheerio.load(html)
 
           expect($('#loading').text()).toBe('Loading...')
         })
 
         it('should render loading.js in browser for slow page', async () => {
-          const browser = await webdriver(next.url, '/slow-page-with-loading', {
+          const browser = await next.browser('/slow-page-with-loading', {
             waitHydration: false,
           })
-          // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+          // TODO-APP: `await next.browser()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
           // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
 
           expect(await browser.elementByCss('#slow-page-message').text()).toBe(
@@ -853,24 +825,17 @@ createNextDescribe(
         })
 
         it('should render loading.js in initial html for slow layout', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/slow-layout-with-loading/slow'
-          )
+          const html = await next.render('/slow-layout-with-loading/slow')
           const $ = cheerio.load(html)
 
           expect($('#loading').text()).toBe('Loading...')
         })
 
         it('should render loading.js in browser for slow layout', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/slow-layout-with-loading/slow',
-            {
-              waitHydration: false,
-            }
-          )
-          // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+          const browser = await next.browser('/slow-layout-with-loading/slow', {
+            waitHydration: false,
+          })
+          // TODO-APP: `await next.browser()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
           // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
 
           expect(
@@ -883,8 +848,7 @@ createNextDescribe(
         })
 
         it('should render loading.js in initial html for slow layout and page', async () => {
-          const html = await renderViaHTTP(
-            next.url,
+          const html = await next.render(
             '/slow-layout-and-page-with-loading/slow'
           )
           const $ = cheerio.load(html)
@@ -894,14 +858,13 @@ createNextDescribe(
         })
 
         it('should render loading.js in browser for slow layout and page', async () => {
-          const browser = await webdriver(
-            next.url,
+          const browser = await next.browser(
             '/slow-layout-and-page-with-loading/slow',
             {
               waitHydration: false,
             }
           )
-          // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+          // TODO-APP: `await next.browser()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
           // expect(await browser.elementByCss('#loading-layout').text()).toBe('Loading...')
           // expect(await browser.elementByCss('#loading-page').text()).toBe('Loading...')
 
@@ -919,7 +882,7 @@ createNextDescribe(
         it.each(['rewrite', 'redirect'])(
           `should strip internal query parameters from requests to middleware for %s`,
           async (method) => {
-            const browser = await webdriver(next.url, '/internal')
+            const browser = await next.browser('/internal')
 
             try {
               // Wait for and click the navigation element, this should trigger
@@ -943,7 +906,7 @@ createNextDescribe(
 
       describe('next/router', () => {
         it('should support router.back and router.forward', async () => {
-          const browser = await webdriver(next.url, '/back-forward/1')
+          const browser = await next.browser('/back-forward/1')
 
           const firstMessage = 'Hello from 1'
           const secondMessage = 'Hello from 2'
@@ -982,7 +945,7 @@ createNextDescribe(
       describe('hooks', () => {
         describe('cookies function', () => {
           it('should retrieve cookies in a server component', async () => {
-            const browser = await webdriver(next.url, '/hooks/use-cookies')
+            const browser = await next.browser('/hooks/use-cookies')
 
             try {
               await browser.waitForElementByCss('#does-not-have-cookie')
@@ -1000,12 +963,12 @@ createNextDescribe(
           })
 
           it('should retrieve cookies in a server component in the edge runtime', async () => {
-            const res = await fetchViaHTTP(next.url, '/edge-apis/cookies')
+            const res = await next.fetch('/edge-apis/cookies')
             expect(await res.text()).toInclude('Hello')
           })
 
           it('should access cookies on <Link /> navigation', async () => {
-            const browser = await webdriver(next.url, '/navigation')
+            const browser = await next.browser('/navigation')
 
             try {
               // Click the cookies link to verify it can't see the cookie that's
@@ -1041,8 +1004,7 @@ createNextDescribe(
         describe('headers function', () => {
           it('should have access to incoming headers in a server component', async () => {
             // Check to see that we can't see the header when it's not present.
-            let html = await renderViaHTTP(
-              next.url,
+            let html = await next.render(
               '/hooks/use-headers',
               {},
               { headers: {} }
@@ -1052,8 +1014,7 @@ createNextDescribe(
             expect($('#has-header').length).toBe(0)
 
             // Check to see that we can see the header when it's present.
-            html = await renderViaHTTP(
-              next.url,
+            html = await next.render(
               '/hooks/use-headers',
               {},
               { headers: { 'x-use-headers': 'value' } }
@@ -1064,7 +1025,7 @@ createNextDescribe(
           })
 
           it('should access headers on <Link /> navigation', async () => {
-            const browser = await webdriver(next.url, '/navigation')
+            const browser = await next.browser('/navigation')
 
             try {
               await browser.elementById('use-headers').click()
@@ -1077,7 +1038,7 @@ createNextDescribe(
 
         describe('previewData function', () => {
           it('should return no preview data when there is none', async () => {
-            const browser = await webdriver(next.url, '/hooks/use-preview-data')
+            const browser = await next.browser('/hooks/use-preview-data')
 
             try {
               await browser.waitForElementByCss('#does-not-have-preview-data')
@@ -1087,7 +1048,7 @@ createNextDescribe(
           })
 
           it('should return preview data when there is some', async () => {
-            const browser = await webdriver(next.url, '/api/preview')
+            const browser = await next.browser('/api/preview')
 
             try {
               await browser.loadPage(next.url + '/hooks/use-preview-data', {
@@ -1104,7 +1065,7 @@ createNextDescribe(
         describe('useRouter', () => {
           // TODO-APP: should enable when implemented
           it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(next.url, '/hooks/use-router/server')
+            const res = await next.fetch('/hooks/use-router/server')
             expect(res.status).toBe(500)
             expect(await res.text()).toContain('Internal Server Error')
           })
@@ -1113,7 +1074,7 @@ createNextDescribe(
         describe('useParams', () => {
           // TODO-APP: should enable when implemented
           it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(next.url, '/hooks/use-params/server')
+            const res = await next.fetch('/hooks/use-params/server')
             expect(res.status).toBe(500)
             expect(await res.text()).toContain('Internal Server Error')
           })
@@ -1122,10 +1083,7 @@ createNextDescribe(
         describe('useSearchParams', () => {
           // TODO-APP: should enable when implemented
           it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(
-              next.url,
-              '/hooks/use-search-params/server'
-            )
+            const res = await next.fetch('/hooks/use-search-params/server')
             expect(res.status).toBe(500)
             expect(await res.text()).toContain('Internal Server Error')
           })
@@ -1134,10 +1092,7 @@ createNextDescribe(
         describe('usePathname', () => {
           // TODO-APP: should enable when implemented
           it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(
-              next.url,
-              '/hooks/use-pathname/server'
-            )
+            const res = await next.fetch('/hooks/use-pathname/server')
             expect(res.status).toBe(500)
             expect(await res.text()).toContain('Internal Server Error')
           })
@@ -1146,10 +1101,7 @@ createNextDescribe(
         describe('useLayoutSegments', () => {
           // TODO-APP: should enable when implemented
           it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(
-              next.url,
-              '/hooks/use-layout-segments/server'
-            )
+            const res = await next.fetch('/hooks/use-layout-segments/server')
             expect(res.status).toBe(500)
             expect(await res.text()).toContain('Internal Server Error')
           })
@@ -1158,8 +1110,7 @@ createNextDescribe(
         describe('useSelectedLayoutSegment', () => {
           // TODO-APP: should enable when implemented
           it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(
-              next.url,
+            const res = await next.fetch(
               '/hooks/use-selected-layout-segment/server'
             )
             expect(res.status).toBe(500)
@@ -1184,8 +1135,7 @@ createNextDescribe(
           ])(
             'should have the correct hooks',
             async ({ pathname, keyValue = '' }) => {
-              const browser = await webdriver(
-                next.url,
+              const browser = await next.browser(
                 pathname + (keyValue ? `?key=${keyValue}` : '')
               )
 
@@ -1209,7 +1159,7 @@ createNextDescribe(
 
         describe('usePathname', () => {
           it('should have the correct pathname', async () => {
-            const html = await renderViaHTTP(next.url, '/hooks/use-pathname')
+            const html = await next.render('/hooks/use-pathname')
             const $ = cheerio.load(html)
             expect($('#pathname').attr('data-pathname')).toBe(
               '/hooks/use-pathname'
@@ -1217,10 +1167,7 @@ createNextDescribe(
           })
 
           it('should have the canonical url pathname on rewrite', async () => {
-            const html = await renderViaHTTP(
-              next.url,
-              '/rewritten-use-pathname'
-            )
+            const html = await next.render('/rewritten-use-pathname')
             const $ = cheerio.load(html)
             expect($('#pathname').attr('data-pathname')).toBe(
               '/rewritten-use-pathname'
@@ -1230,8 +1177,7 @@ createNextDescribe(
 
         describe('useSearchParams', () => {
           it('should have the correct search params', async () => {
-            const html = await renderViaHTTP(
-              next.url,
+            const html = await next.render(
               '/hooks/use-search-params?first=value&second=other%20value&third'
             )
             const $ = cheerio.load(html)
@@ -1244,8 +1190,7 @@ createNextDescribe(
           // TODO-APP: correct this behavior when deployed
           if (!isNextDeploy) {
             it('should have the canonical url search params on rewrite', async () => {
-              const html = await renderViaHTTP(
-                next.url,
+              const html = await next.render(
                 '/rewritten-use-search-params?first=a&second=b&third=c'
               )
               const $ = cheerio.load(html)
@@ -1259,7 +1204,7 @@ createNextDescribe(
 
         describe('useRouter', () => {
           it('should allow access to the router', async () => {
-            const browser = await webdriver(next.url, '/hooks/use-router')
+            const browser = await next.browser('/hooks/use-router')
 
             try {
               // Wait for the page to load, click the button (which uses a method
@@ -1279,8 +1224,7 @@ createNextDescribe(
 
           if (!isNextDeploy) {
             it('should have consistent query and params handling', async () => {
-              const html = await renderViaHTTP(
-                next.url,
+              const html = await next.render(
                 '/param-and-query/params?slug=query'
               )
               const $ = cheerio.load(html)
@@ -1303,7 +1247,7 @@ createNextDescribe(
           `(
             'should have the correct layout segments at $path',
             async ({ path, outerLayout, innerLayout }) => {
-              const html = await renderViaHTTP(next.url, path)
+              const html = await next.render(path)
               const $ = cheerio.load(html)
 
               expect(JSON.parse($('#outer-layout').text())).toEqual(outerLayout)
@@ -1312,8 +1256,7 @@ createNextDescribe(
           )
 
           it('should return an empty array in pages', async () => {
-            const html = await renderViaHTTP(
-              next.url,
+            const html = await next.render(
               '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
             )
             const $ = cheerio.load(html)
@@ -1331,7 +1274,7 @@ createNextDescribe(
           `(
             'should have the correct layout segment at $path',
             async ({ path, outerLayout, innerLayout }) => {
-              const html = await renderViaHTTP(next.url, path)
+              const html = await next.render(path)
               const $ = cheerio.load(html)
 
               expect(JSON.parse($('#outer-layout-segment').text())).toEqual(
@@ -1344,8 +1287,7 @@ createNextDescribe(
           )
 
           it('should return null in pages', async () => {
-            const html = await renderViaHTTP(
-              next.url,
+            const html = await next.render(
               '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
             )
             const $ = cheerio.load(html)
@@ -1359,7 +1301,7 @@ createNextDescribe(
     describe('css support', () => {
       describe('server layouts', () => {
         it('should support global css inside server layouts', async () => {
-          const browser = await webdriver(next.url, '/dashboard')
+          const browser = await next.browser('/dashboard')
 
           // Should body text in red
           expect(
@@ -1377,7 +1319,7 @@ createNextDescribe(
         })
 
         it('should support css modules inside server layouts', async () => {
-          const browser = await webdriver(next.url, '/css/css-nested')
+          const browser = await next.browser('/css/css-nested')
           expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('#server-cssm')).color`
@@ -1388,7 +1330,7 @@ createNextDescribe(
 
       describe('server pages', () => {
         it('should support global css inside server pages', async () => {
-          const browser = await webdriver(next.url, '/css/css-page')
+          const browser = await next.browser('/css/css-page')
           expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
@@ -1397,7 +1339,7 @@ createNextDescribe(
         })
 
         it('should support css modules inside server pages', async () => {
-          const browser = await webdriver(next.url, '/css/css-page')
+          const browser = await next.browser('/css/css-page')
           expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('#cssm')).color`
@@ -1407,7 +1349,7 @@ createNextDescribe(
 
         if (!isDev) {
           it('should not include unused css modules in the page in prod', async () => {
-            const browser = await webdriver(next.url, '/css/css-page/unused')
+            const browser = await next.browser('/css/css-page/unused')
             expect(
               await browser.eval(
                 `[...document.styleSheets].some(({ rules }) => [...rules].some(rule => rule.selectorText.includes('this_should_not_be_included')))`
@@ -1416,8 +1358,7 @@ createNextDescribe(
           })
 
           it('should not include unused css modules in nested pages in prod', async () => {
-            const browser = await webdriver(
-              next.url,
+            const browser = await next.browser(
               '/css/css-page/unused-nested/inner'
             )
             expect(
@@ -1431,7 +1372,7 @@ createNextDescribe(
 
       describe('client layouts', () => {
         it('should support css modules inside client layouts', async () => {
-          const browser = await webdriver(next.url, '/client-nested')
+          const browser = await next.browser('/client-nested')
 
           // Should render h1 in red
           expect(
@@ -1442,7 +1383,7 @@ createNextDescribe(
         })
 
         it('should support global css inside client layouts', async () => {
-          const browser = await webdriver(next.url, '/client-nested')
+          const browser = await next.browser('/client-nested')
 
           // Should render button in red
           expect(
@@ -1455,7 +1396,7 @@ createNextDescribe(
 
       describe('client pages', () => {
         it('should support css modules inside client pages', async () => {
-          const browser = await webdriver(next.url, '/client-component-route')
+          const browser = await next.browser('/client-component-route')
 
           // Should render p in red
           expect(
@@ -1466,7 +1407,7 @@ createNextDescribe(
         })
 
         it('should support global css inside client pages', async () => {
-          const browser = await webdriver(next.url, '/client-component-route')
+          const browser = await next.browser('/client-component-route')
 
           // Should render `b` in blue
           expect(
@@ -1479,7 +1420,7 @@ createNextDescribe(
 
       describe('client components', () => {
         it('should support css modules inside client page', async () => {
-          const browser = await webdriver(next.url, '/css/css-client')
+          const browser = await next.browser('/css/css-client')
 
           expect(
             await browser.eval(
@@ -1489,7 +1430,7 @@ createNextDescribe(
         })
 
         it('should support css modules inside client components', async () => {
-          const browser = await webdriver(next.url, '/css/css-client/inner')
+          const browser = await next.browser('/css/css-client/inner')
 
           expect(
             await browser.eval(
@@ -1501,7 +1442,7 @@ createNextDescribe(
 
       describe('special entries', () => {
         it('should include css imported in loading.js', async () => {
-          const html = await renderViaHTTP(next.url, '/loading-bug/hi')
+          const html = await next.render('/loading-bug/hi')
           // The link tag should be included together with loading
           expect(html).toMatch(
             /<link rel="stylesheet" href="(.+)\.css"\/><h2>Loading...<\/h2>/
@@ -1509,7 +1450,7 @@ createNextDescribe(
         })
 
         it('should include css imported in client template.js', async () => {
-          const browser = await webdriver(next.url, '/template/clientcomponent')
+          const browser = await next.browser('/template/clientcomponent')
           expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('button')).fontSize`
@@ -1518,7 +1459,7 @@ createNextDescribe(
         })
 
         it('should include css imported in server template.js', async () => {
-          const browser = await webdriver(next.url, '/template/servercomponent')
+          const browser = await next.browser('/template/servercomponent')
           expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
@@ -1527,10 +1468,7 @@ createNextDescribe(
         })
 
         it('should include css imported in client not-found.js', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/not-found/clientcomponent'
-          )
+          const browser = await next.browser('/not-found/clientcomponent')
           expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
@@ -1539,10 +1477,7 @@ createNextDescribe(
         })
 
         it('should include css imported in server not-found.js', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/not-found/servercomponent'
-          )
+          const browser = await next.browser('/not-found/servercomponent')
           expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
@@ -1551,7 +1486,7 @@ createNextDescribe(
         })
 
         it('should include css imported in error.js', async () => {
-          const browser = await webdriver(next.url, '/error/client-component')
+          const browser = await next.browser('/error/client-component')
           await browser.elementByCss('button').click()
 
           // Wait for error page to render and CSS to be loaded
@@ -1573,7 +1508,7 @@ createNextDescribe(
           const origContent = await next.readFile(filePath)
 
           // h1 should be red
-          const browser = await webdriver(next.url, '/css/css-page')
+          const browser = await next.browser('/css/css-page')
           expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
@@ -1601,7 +1536,7 @@ createNextDescribe(
           const origContent = await next.readFile(filePath)
 
           // h1 should be red
-          const browser = await webdriver(next.url, '/css/css-client')
+          const browser = await next.browser('/css/css-client')
           expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
@@ -1628,7 +1563,7 @@ createNextDescribe(
           const origContent = await next.readFile(filePath)
 
           try {
-            const browser = await webdriver(next.url, '/dashboard/index')
+            const browser = await next.browser('/dashboard/index')
             expect(await browser.elementByCss('p').text()).toContain(
               'hello from app/dashboard/index'
             )
@@ -1649,12 +1584,9 @@ createNextDescribe(
           const origContent = await next.readFile(filePath)
 
           try {
-            const browser = await webdriver(next.url, '/client-component-route')
+            const browser = await next.browser('/client-component-route')
 
-            const ssrInitial = await renderViaHTTP(
-              next.url,
-              '/client-component-route'
-            )
+            const ssrInitial = await next.render('/client-component-route')
 
             expect(ssrInitial).toContain(
               'hello from app/client-component-route'
@@ -1671,18 +1603,15 @@ createNextDescribe(
 
             await check(() => browser.elementByCss('p').text(), /swapped from/)
 
-            const ssrUpdated = await renderViaHTTP(
-              next.url,
-              '/client-component-route'
-            )
+            const ssrUpdated = await next.render('/client-component-route')
             expect(ssrUpdated).toContain('swapped from')
 
             await next.patchFile(filePath, origContent)
 
             await check(() => browser.elementByCss('p').text(), /hello from/)
-            expect(
-              await renderViaHTTP(next.url, '/client-component-route')
-            ).toContain('hello from')
+            expect(await next.render('/client-component-route')).toContain(
+              'hello from'
+            )
           } finally {
             await next.patchFile(filePath, origContent)
           }
@@ -1693,7 +1622,7 @@ createNextDescribe(
           const origContent = await next.readFile(filePath)
 
           try {
-            const browser = await webdriver(next.url, '/dashboard/page')
+            const browser = await next.browser('/dashboard/page')
 
             expect(await browser.elementByCss('p').text()).toContain(
               'hello dashboard/page!'
@@ -1764,8 +1693,7 @@ createNextDescribe(
     describe('searchParams prop', () => {
       describe('client component', () => {
         it('should have the correct search params', async () => {
-          const html = await renderViaHTTP(
-            next.url,
+          const html = await next.render(
             '/search-params-prop?first=value&second=other%20value&third'
           )
           const $ = cheerio.load(html)
@@ -1777,10 +1705,7 @@ createNextDescribe(
         })
 
         it('should have the correct search params on rewrite', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/search-params-prop-rewrite'
-          )
+          const html = await next.render('/search-params-prop-rewrite')
           const $ = cheerio.load(html)
           const el = $('#params')
           expect(el.attr('data-param-first')).toBe('value')
@@ -1790,8 +1715,7 @@ createNextDescribe(
         })
 
         it('should have the correct search params on middleware rewrite', async () => {
-          const html = await renderViaHTTP(
-            next.url,
+          const html = await next.render(
             '/search-params-prop-middleware-rewrite'
           )
           const $ = cheerio.load(html)
@@ -1805,8 +1729,7 @@ createNextDescribe(
 
       describe('server component', () => {
         it('should have the correct search params', async () => {
-          const html = await renderViaHTTP(
-            next.url,
+          const html = await next.render(
             '/search-params-prop/server?first=value&second=other%20value&third'
           )
           const $ = cheerio.load(html)
@@ -1818,10 +1741,7 @@ createNextDescribe(
         })
 
         it('should have the correct search params on rewrite', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/search-params-prop-server-rewrite'
-          )
+          const html = await next.render('/search-params-prop-server-rewrite')
           const $ = cheerio.load(html)
           const el = $('#params')
           expect(el.attr('data-param-first')).toBe('value')
@@ -1831,8 +1751,7 @@ createNextDescribe(
         })
 
         it('should have the correct search params on middleware rewrite', async () => {
-          const html = await renderViaHTTP(
-            next.url,
+          const html = await next.render(
             '/search-params-prop-server-middleware-rewrite'
           )
           const $ = cheerio.load(html)
@@ -1848,7 +1767,7 @@ createNextDescribe(
     describe('sass support', () => {
       describe('server layouts', () => {
         it('should support global sass/scss inside server layouts', async () => {
-          const browser = await webdriver(next.url, '/css/sass/inner')
+          const browser = await next.browser('/css/sass/inner')
           // .sass
           expect(
             await browser.eval(
@@ -1864,7 +1783,7 @@ createNextDescribe(
         })
 
         it('should support sass/scss modules inside server layouts', async () => {
-          const browser = await webdriver(next.url, '/css/sass/inner')
+          const browser = await next.browser('/css/sass/inner')
           // .sass
           expect(
             await browser.eval(
@@ -1882,7 +1801,7 @@ createNextDescribe(
 
       describe('server pages', () => {
         it('should support global sass/scss inside server pages', async () => {
-          const browser = await webdriver(next.url, '/css/sass/inner')
+          const browser = await next.browser('/css/sass/inner')
           // .sass
           expect(
             await browser.eval(
@@ -1898,7 +1817,7 @@ createNextDescribe(
         })
 
         it('should support sass/scss modules inside server pages', async () => {
-          const browser = await webdriver(next.url, '/css/sass/inner')
+          const browser = await next.browser('/css/sass/inner')
           // .sass
           expect(
             await browser.eval(
@@ -1916,7 +1835,7 @@ createNextDescribe(
 
       describe('client layouts', () => {
         it('should support global sass/scss inside client layouts', async () => {
-          const browser = await webdriver(next.url, '/css/sass-client/inner')
+          const browser = await next.browser('/css/sass-client/inner')
           // .sass
           expect(
             await browser.eval(
@@ -1932,7 +1851,7 @@ createNextDescribe(
         })
 
         it('should support sass/scss modules inside client layouts', async () => {
-          const browser = await webdriver(next.url, '/css/sass-client/inner')
+          const browser = await next.browser('/css/sass-client/inner')
           // .sass
           expect(
             await browser.eval(
@@ -1951,7 +1870,7 @@ createNextDescribe(
 
     describe('client pages', () => {
       it('should support global sass/scss inside client pages', async () => {
-        const browser = await webdriver(next.url, '/css/sass-client/inner')
+        const browser = await next.browser('/css/sass-client/inner')
 
         // .sass
         await check(
@@ -1972,7 +1891,7 @@ createNextDescribe(
       })
 
       it('should support sass/scss modules inside client pages', async () => {
-        const browser = await webdriver(next.url, '/css/sass-client/inner')
+        const browser = await next.browser('/css/sass-client/inner')
         // .sass
         expect(
           await browser.eval(
@@ -1989,7 +1908,7 @@ createNextDescribe(
     })
     ;(isDev ? describe.skip : describe)('Subresource Integrity', () => {
       function fetchWithPolicy(policy: string | null) {
-        return fetchViaHTTP(next.url, '/dashboard', undefined, {
+        return next.fetch('/dashboard', undefined, {
           headers: policy
             ? {
                 'Content-Security-Policy': policy,
@@ -2058,7 +1977,7 @@ createNextDescribe(
       })
 
       it('includes an integrity attribute on scripts', async () => {
-        const html = await renderViaHTTP(next.url, '/dashboard')
+        const html = await next.render('/dashboard')
 
         const $ = cheerio.load(html)
 
@@ -2087,7 +2006,7 @@ createNextDescribe(
         // For each script tag, ensure that the integrity attribute is the
         // correct hash of the script tag.
         for (const [src, integrity] of files) {
-          const res = await fetchViaHTTP(next.url, src)
+          const res = await next.fetch(src)
           expect(res.status).toBe(200)
           const content = await res.text()
 
@@ -2112,7 +2031,7 @@ createNextDescribe(
 
     describe('template component', () => {
       it('should render the template that holds state in a client component and reset on navigation', async () => {
-        const browser = await webdriver(next.url, '/template/clientcomponent')
+        const browser = await next.browser('/template/clientcomponent')
         expect(await browser.elementByCss('h1').text()).toBe('Template 0')
         await browser.elementByCss('button').click()
         expect(await browser.elementByCss('h1').text()).toBe('Template 1')
@@ -2134,7 +2053,7 @@ createNextDescribe(
       ;(isDev ? it.skip : it)(
         'should render the template that is a server component and rerender on navigation',
         async () => {
-          const browser = await webdriver(next.url, '/template/servercomponent')
+          const browser = await next.browser('/template/servercomponent')
           // eslint-disable-next-line jest/no-standalone-expect
           expect(await browser.elementByCss('h1').text()).toStartWith(
             'Template'
@@ -2171,7 +2090,7 @@ createNextDescribe(
 
     describe('error component', () => {
       it('should trigger error component when an error happens during rendering', async () => {
-        const browser = await webdriver(next.url, '/error/client-component')
+        const browser = await next.browser('/error/client-component')
         await browser.elementByCss('#error-trigger-button').click()
 
         if (isDev) {
@@ -2189,7 +2108,7 @@ createNextDescribe(
       })
 
       it('should trigger error component when an error happens during server components rendering', async () => {
-        const browser = await webdriver(next.url, '/error/server-component')
+        const browser = await next.browser('/error/server-component')
 
         if (isDev) {
           expect(
@@ -2220,8 +2139,7 @@ createNextDescribe(
       })
 
       it('should use default error boundary for prod and overlay for dev when no error component specified', async () => {
-        const browser = await webdriver(
-          next.url,
+        const browser = await next.browser(
           '/error/global-error-boundary/client'
         )
         await browser.elementByCss('#error-trigger-button').click()
@@ -2239,8 +2157,7 @@ createNextDescribe(
       })
 
       it('should display error digest for error in server component with default error boundary', async () => {
-        const browser = await webdriver(
-          next.url,
+        const browser = await next.browser(
           '/error/global-error-boundary/server'
         )
 
@@ -2261,7 +2178,7 @@ createNextDescribe(
 
       if (!isDev) {
         it('should allow resetting error boundary', async () => {
-          const browser = await webdriver(next.url, '/error/client-component')
+          const browser = await next.browser('/error/client-component')
 
           // Try triggering and resetting a few times in a row
           for (let i = 0; i < 5; i++) {
@@ -2286,8 +2203,7 @@ createNextDescribe(
         })
 
         it('should hydrate empty shell to handle server-side rendering errors', async () => {
-          const browser = await webdriver(
-            next.url,
+          const browser = await next.browser(
             '/error/ssr-error-client-component'
           )
           const logs = await browser.log()
@@ -2303,17 +2219,14 @@ createNextDescribe(
     describe('known bugs', () => {
       describe('should support React cache', () => {
         it('server component', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/react-cache/server-component'
-          )
+          const browser = await next.browser('/react-cache/server-component')
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
           expect(val1).toBe(val2)
         })
 
         it('server component client-navigation', async () => {
-          const browser = await webdriver(next.url, '/react-cache')
+          const browser = await next.browser('/react-cache')
 
           await browser
             .elementByCss('#to-server-component')
@@ -2325,17 +2238,14 @@ createNextDescribe(
         })
 
         it('client component', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/react-cache/client-component'
-          )
+          const browser = await next.browser('/react-cache/client-component')
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
           expect(val1).toBe(val2)
         })
 
         it('client component client-navigation', async () => {
-          const browser = await webdriver(next.url, '/react-cache')
+          const browser = await next.browser('/react-cache')
 
           await browser
             .elementByCss('#to-client-component')
@@ -2349,17 +2259,14 @@ createNextDescribe(
 
       describe('should support React fetch instrumentation', () => {
         it('server component', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/react-fetch/server-component'
-          )
+          const browser = await next.browser('/react-fetch/server-component')
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
           expect(val1).toBe(val2)
         })
 
         it('server component client-navigation', async () => {
-          const browser = await webdriver(next.url, '/react-fetch')
+          const browser = await next.browser('/react-fetch')
 
           await browser
             .elementByCss('#to-server-component')
@@ -2372,10 +2279,7 @@ createNextDescribe(
 
         // TODO-APP: React doesn't have fetch deduping for client components yet.
         it.skip('client component', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/react-fetch/client-component'
-          )
+          const browser = await next.browser('/react-fetch/client-component')
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
           expect(val1).toBe(val2)
@@ -2383,7 +2287,7 @@ createNextDescribe(
 
         // TODO-APP: React doesn't have fetch deduping for client components yet.
         it.skip('client component client-navigation', async () => {
-          const browser = await webdriver(next.url, '/react-fetch')
+          const browser = await next.browser('/react-fetch')
 
           await browser
             .elementByCss('#to-client-component')
@@ -2396,9 +2300,7 @@ createNextDescribe(
       })
       it('should not share flight data between requests', async () => {
         const fetches = await Promise.all(
-          [...new Array(5)].map(() =>
-            renderViaHTTP(next.url, '/loading-bug/electronics')
-          )
+          [...new Array(5)].map(() => next.render('/loading-bug/electronics'))
         )
 
         for (const text of fetches) {
@@ -2407,7 +2309,7 @@ createNextDescribe(
         }
       })
       it('should handle as on next/link', async () => {
-        const browser = await webdriver(next.url, '/link-with-as')
+        const browser = await next.browser('/link-with-as')
         expect(
           await browser
             .elementByCss('#link-to-info-123')
@@ -2417,7 +2319,7 @@ createNextDescribe(
         ).toBe(`hello from app/dashboard/deployments/info/[id]. ID is: 123`)
       })
       it('should handle next/link back to initially loaded page', async () => {
-        const browser = await webdriver(next.url, '/linking/about')
+        const browser = await next.browser('/linking/about')
         expect(
           await browser
             .elementByCss('a[href="/linking"]')
@@ -2435,7 +2337,7 @@ createNextDescribe(
         ).toBe(`About page`)
       })
       it('should not do additional pushState when already on the page', async () => {
-        const browser = await webdriver(next.url, '/linking/about')
+        const browser = await next.browser('/linking/about')
         const goToLinkingPage = async () => {
           expect(
             await browser
@@ -2461,7 +2363,7 @@ createNextDescribe(
 
     describe('not-found', () => {
       it('should trigger not-found in a server component', async () => {
-        const browser = await webdriver(next.url, '/not-found/servercomponent')
+        const browser = await next.browser('/not-found/servercomponent')
 
         expect(
           await browser.waitForElementByCss('#not-found-component').text()
@@ -2474,7 +2376,7 @@ createNextDescribe(
       })
 
       it('should trigger not-found in a client component', async () => {
-        const browser = await webdriver(next.url, '/not-found/clientcomponent')
+        const browser = await next.browser('/not-found/clientcomponent')
         expect(
           await browser.waitForElementByCss('#not-found-component').text()
         ).toBe('Not Found!')
@@ -2485,7 +2387,7 @@ createNextDescribe(
         ).toBe('noindex')
       })
       it('should trigger not-found client-side', async () => {
-        const browser = await webdriver(next.url, '/not-found/client-side')
+        const browser = await next.browser('/not-found/client-side')
         await browser
           .elementByCss('button')
           .click()
@@ -2504,16 +2406,11 @@ createNextDescribe(
     describe('bots', () => {
       if (!isNextDeploy) {
         it('should block rendering for bots and return 404 status', async () => {
-          const res = await fetchViaHTTP(
-            next.url,
-            '/not-found/servercomponent',
-            '',
-            {
-              headers: {
-                'User-Agent': 'Googlebot',
-              },
-            }
-          )
+          const res = await next.fetch('/not-found/servercomponent', '', {
+            headers: {
+              'User-Agent': 'Googlebot',
+            },
+          })
 
           expect(res.status).toBe(404)
           expect(await res.text()).toInclude('"noindex"')
@@ -2524,7 +2421,7 @@ createNextDescribe(
     describe('redirect', () => {
       describe('components', () => {
         it('should redirect in a server component', async () => {
-          const browser = await webdriver(next.url, '/redirect/servercomponent')
+          const browser = await next.browser('/redirect/servercomponent')
           await browser.waitForElementByCss('#result-page')
           expect(await browser.elementByCss('#result-page').text()).toBe(
             'Result Page'
@@ -2532,7 +2429,7 @@ createNextDescribe(
         })
 
         it('should redirect in a client component', async () => {
-          const browser = await webdriver(next.url, '/redirect/clientcomponent')
+          const browser = await next.browser('/redirect/clientcomponent')
           await browser.waitForElementByCss('#result-page')
           expect(await browser.elementByCss('#result-page').text()).toBe(
             'Result Page'
@@ -2541,7 +2438,7 @@ createNextDescribe(
 
         // TODO-APP: Enable in development
         it('should redirect client-side', async () => {
-          const browser = await webdriver(next.url, '/redirect/client-side')
+          const browser = await next.browser('/redirect/client-side')
           await browser
             .elementByCss('button')
             .click()
@@ -2555,16 +2452,13 @@ createNextDescribe(
 
       describe('next.config.js redirects', () => {
         it('should redirect from next.config.js', async () => {
-          const browser = await webdriver(next.url, '/redirect/a')
+          const browser = await next.browser('/redirect/a')
           expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
           expect(await browser.url()).toBe(next.url + '/dashboard')
         })
 
         it('should redirect from next.config.js with link navigation', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/redirect/next-config-redirect'
-          )
+          const browser = await next.browser('/redirect/next-config-redirect')
           await browser
             .elementByCss('#redirect-a')
             .click()
@@ -2576,8 +2470,7 @@ createNextDescribe(
 
       describe('middleware redirects', () => {
         it('should redirect from middleware', async () => {
-          const browser = await webdriver(
-            next.url,
+          const browser = await next.browser(
             '/redirect-middleware-to-dashboard'
           )
           expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
@@ -2585,8 +2478,7 @@ createNextDescribe(
         })
 
         it('should redirect from middleware with link navigation', async () => {
-          const browser = await webdriver(
-            next.url,
+          const browser = await next.browser(
             '/redirect/next-middleware-redirect'
           )
           await browser
@@ -2601,7 +2493,7 @@ createNextDescribe(
 
     describe('nested navigation', () => {
       it('should navigate to nested pages', async () => {
-        const browser = await webdriver(next.url, '/nested-navigation')
+        const browser = await next.browser('/nested-navigation')
         expect(await browser.elementByCss('h1').text()).toBe('Home')
 
         const pages = [
@@ -2639,7 +2531,7 @@ createNextDescribe(
     describe('next/script', () => {
       if (!isNextDeploy) {
         it('should support next/script and render in correct order', async () => {
-          const browser = await webdriver(next.url, '/script')
+          const browser = await next.browser('/script')
 
           // Wait for lazyOnload scripts to be ready.
           await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -2657,7 +2549,7 @@ createNextDescribe(
       }
 
       it('should insert preload tags for beforeInteractive and afterInteractive scripts', async () => {
-        const html = await renderViaHTTP(next.url, '/script')
+        const html = await next.render('/script')
         expect(html).toContain(
           '<link href="/test1.js" rel="preload" as="script"/>'
         )
@@ -2677,7 +2569,7 @@ createNextDescribe(
 
     describe('data fetch with response over 16KB with chunked encoding', () => {
       it('should load page when fetching a large amount of data', async () => {
-        const browser = await webdriver(next.url, '/very-large-data-fetch')
+        const browser = await next.browser('/very-large-data-fetch')
         expect(await (await browser.waitForElementByCss('#done')).text()).toBe(
           'Hello world'
         )

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1,6 +1,5 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNextDescribe } from 'e2e-utils'
 import crypto from 'crypto'
-import { NextInstance } from 'test/lib/next-modes/base'
 import {
   check,
   fetchViaHTTP,
@@ -13,1191 +12,928 @@ import path from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 
-describe('app dir', () => {
-  const isDev = (global as any).isNextDev
-  let next: NextInstance
+createNextDescribe(
+  'app dir',
+  {
+    files: path.join(__dirname, 'app'),
+    dependencies: {
+      swr: '2.0.0-rc.0',
+      react: 'latest',
+      'react-dom': 'latest',
+      sass: 'latest',
+    },
+  },
+  ({ next, isNextDev: isDev, isNextStart, isNextDeploy }) => {
+    if (!isNextDeploy) {
+      it('should not share edge workers', async () => {
+        const controller1 = new AbortController()
+        const controller2 = new AbortController()
+        fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
+          signal: controller1.signal,
+        }).catch(() => {})
+        fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
+          signal: controller2.signal,
+        }).catch(() => {})
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'app')),
-      dependencies: {
-        swr: '2.0.0-rc.0',
-        react: 'latest',
-        'react-dom': 'latest',
-        sass: 'latest',
-      },
-    })
-  })
-  afterAll(async () => {
-    await next.destroy()
-  })
+        await waitFor(1000)
+        controller1.abort()
 
-  if (!(global as any).isNextDeploy) {
-    it('should not share edge workers', async () => {
-      const controller1 = new AbortController()
-      const controller2 = new AbortController()
-      fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
-        signal: controller1.signal,
-      }).catch(() => {})
-      fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
-        signal: controller2.signal,
-      }).catch(() => {})
+        const controller3 = new AbortController()
+        fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
+          signal: controller3.signal,
+        }).catch(() => {})
+        await waitFor(1000)
+        controller2.abort()
+        controller3.abort()
 
-      await waitFor(1000)
-      controller1.abort()
-
-      const controller3 = new AbortController()
-      fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
-        signal: controller3.signal,
-      }).catch(() => {})
-      await waitFor(1000)
-      controller2.abort()
-      controller3.abort()
-
-      const res = await fetchViaHTTP(next.url, '/slow-page-no-loading')
-      expect(res.status).toBe(200)
-      expect(await res.text()).toContain('hello from slow page')
-      expect(next.cliOutput).not.toContain(
-        'A separate worker must be used for each render'
-      )
-    })
-  }
-
-  if ((global as any).isNextStart) {
-    it('should generate build traces correctly', async () => {
-      const trace = JSON.parse(
-        await next.readFile(
-          '.next/server/app/dashboard/deployments/[id]/page.js.nft.json'
+        const res = await fetchViaHTTP(next.url, '/slow-page-no-loading')
+        expect(res.status).toBe(200)
+        expect(await res.text()).toContain('hello from slow page')
+        expect(next.cliOutput).not.toContain(
+          'A separate worker must be used for each render'
         )
-      ) as { files: string[] }
-      expect(trace.files.some((file) => file.endsWith('data.json'))).toBe(true)
-    })
-  }
-
-  it('should use application/octet-stream for flight', async () => {
-    const res = await fetchViaHTTP(
-      next.url,
-      '/dashboard/deployments/123',
-      {},
-      {
-        headers: {
-          ['RSC'.toString()]: '1',
-        },
-      }
-    )
-    expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
-  })
-
-  it('should use application/octet-stream for flight with edge runtime', async () => {
-    const res = await fetchViaHTTP(
-      next.url,
-      '/dashboard',
-      {},
-      {
-        headers: {
-          ['RSC'.toString()]: '1',
-        },
-      }
-    )
-    expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
-  })
-
-  it('should pass props from getServerSideProps in root layout', async () => {
-    const html = await renderViaHTTP(next.url, '/dashboard')
-    const $ = cheerio.load(html)
-    expect($('title').text()).toBe('hello world')
-  })
-
-  it('should serve from pages', async () => {
-    const html = await renderViaHTTP(next.url, '/')
-    expect(html).toContain('hello from pages/index')
-
-    // esm imports should work fine in pages/
-    expect(html).toContain('swr-index')
-  })
-
-  it('should serve dynamic route from pages', async () => {
-    const html = await renderViaHTTP(next.url, '/blog/first')
-    expect(html).toContain('hello from pages/blog/[slug]')
-  })
-
-  it('should serve from public', async () => {
-    const html = await renderViaHTTP(next.url, '/hello.txt')
-    expect(html).toContain('hello world')
-  })
-
-  it('should serve from app', async () => {
-    const html = await renderViaHTTP(next.url, '/dashboard')
-    expect(html).toContain('hello from app/dashboard')
-  })
-
-  if (!(global as any).isNextDeploy) {
-    it('should serve /index as separate page', async () => {
-      const stderr = []
-      next.on('stderr', (err) => {
-        stderr.push(err)
-      })
-      const html = await renderViaHTTP(next.url, '/dashboard/index')
-      expect(html).toContain('hello from app/dashboard/index')
-      expect(stderr.some((err) => err.includes('Invalid hook call'))).toBe(
-        false
-      )
-    })
-
-    it('should handle next/dynamic correctly', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/dynamic')
-      const $ = cheerio.load(html)
-      // filter out the script
-      const selector = 'body div'
-      const serverContent = $(selector).text()
-      // should load chunks generated via async import correctly with React.lazy
-      expect(serverContent).toContain('next-dynamic lazy')
-      // should support `dynamic` in both server and client components
-      expect(serverContent).toContain('next-dynamic dynamic on server')
-      expect(serverContent).toContain('next-dynamic dynamic on client')
-      expect(serverContent).toContain('next-dynamic server import client')
-      expect(serverContent).not.toContain(
-        'next-dynamic dynamic no ssr on client'
-      )
-
-      expect(serverContent).not.toContain(
-        'next-dynamic dynamic no ssr on server'
-      )
-
-      // client component under server component with ssr: false will not be rendered either in flight or SSR
-      expect(html).not.toContain('client component under sever no ssr')
-
-      const browser = await webdriver(next.url, '/dashboard/dynamic')
-      const clientContent = await browser.elementByCss(selector).text()
-      expect(clientContent).toContain('next-dynamic dynamic no ssr on server')
-      expect(clientContent).toContain('client component under sever no ssr')
-      await browser.waitForElementByCss('#css-text-dynamic-no-ssr-client')
-
-      expect(
-        await browser.elementByCss('#css-text-dynamic-no-ssr-client').text()
-      ).toBe('next-dynamic dynamic no ssr on client:suffix')
-    })
-
-    it('should serve polyfills for browsers that do not support modules', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/index')
-      expect(html).toMatch(
-        /<script src="\/_next\/static\/chunks\/polyfills(-\w+)?\.js" nomodule="">/
-      )
-    })
-  }
-
-  // TODO-APP: handle css modules fouc in dev
-  it.skip('should handle css imports in next/dynamic correctly', async () => {
-    const browser = await webdriver(next.url, '/dashboard/index')
-
-    expect(
-      await browser.eval(
-        `window.getComputedStyle(document.querySelector('#css-text-dynamic-server')).color`
-      )
-    ).toBe('rgb(0, 0, 255)')
-    expect(
-      await browser.eval(
-        `window.getComputedStyle(document.querySelector('#css-text-lazy')).color`
-      )
-    ).toBe('rgb(128, 0, 128)')
-  })
-
-  it('should include layouts when no direct parent layout', async () => {
-    const html = await renderViaHTTP(next.url, '/dashboard/integrations')
-    const $ = cheerio.load(html)
-    // Should not be nested in dashboard
-    expect($('h1').text()).toBe('Dashboard')
-    // Should include the page text
-    expect($('p').text()).toBe('hello from app/dashboard/integrations')
-  })
-
-  // TODO-APP: handle new root layout
-  it.skip('should not include parent when not in parent directory with route in directory', async () => {
-    const html = await renderViaHTTP(next.url, '/dashboard/hello')
-    const $ = cheerio.load(html)
-
-    // new root has to provide it's own custom root layout or the default
-    // is used instead
-    expect(html).toContain('<html')
-    expect(html).toContain('<body')
-    expect($('html').hasClass('this-is-the-document-html')).toBeFalsy()
-    expect($('body').hasClass('this-is-the-document-body')).toBeFalsy()
-
-    // Should not be nested in dashboard
-    expect($('h1').text()).toBeFalsy()
-
-    // Should render the page text
-    expect($('p').text()).toBe('hello from app/dashboard/rootonly/hello')
-  })
-
-  it('should use new root layout when provided', async () => {
-    const html = await renderViaHTTP(next.url, '/dashboard/another')
-    const $ = cheerio.load(html)
-
-    // new root has to provide it's own custom root layout or the default
-    // is used instead
-    expect($('html').hasClass('this-is-another-document-html')).toBeTruthy()
-    expect($('body').hasClass('this-is-another-document-body')).toBeTruthy()
-
-    // Should not be nested in dashboard
-    expect($('h1').text()).toBeFalsy()
-
-    // Should render the page text
-    expect($('p').text()).toBe('hello from newroot/dashboard/another')
-  })
-
-  it('should not create new root layout when nested (optional)', async () => {
-    const html = await renderViaHTTP(
-      next.url,
-      '/dashboard/deployments/breakdown'
-    )
-    const $ = cheerio.load(html)
-
-    // new root has to provide it's own custom root layout or the default
-    // is used instead
-    expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
-    expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
-
-    // Should be nested in dashboard
-    expect($('h1').text()).toBe('Dashboard')
-    expect($('h2').text()).toBe('Custom dashboard')
-
-    // Should render the page text
-    expect($('p').text()).toBe(
-      'hello from app/dashboard/(custom)/deployments/breakdown'
-    )
-  })
-
-  it('should include parent document when no direct parent layout', async () => {
-    const html = await renderViaHTTP(next.url, '/dashboard/integrations')
-    const $ = cheerio.load(html)
-
-    expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
-    expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
-  })
-
-  it('should not include parent when not in parent directory', async () => {
-    const html = await renderViaHTTP(next.url, '/dashboard/changelog')
-    const $ = cheerio.load(html)
-    // Should not be nested in dashboard
-    expect($('h1').text()).toBeFalsy()
-    // Should include the page text
-    expect($('p').text()).toBe('hello from app/dashboard/changelog')
-  })
-
-  it('should serve nested parent', async () => {
-    const html = await renderViaHTTP(next.url, '/dashboard/deployments/123')
-    const $ = cheerio.load(html)
-    // Should be nested in dashboard
-    expect($('h1').text()).toBe('Dashboard')
-    // Should be nested in deployments
-    expect($('h2').text()).toBe('Deployments hello')
-  })
-
-  it('should serve dynamic parameter', async () => {
-    const html = await renderViaHTTP(next.url, '/dashboard/deployments/123')
-    const $ = cheerio.load(html)
-    // Should include the page text with the parameter
-    expect($('p').text()).toBe(
-      'hello from app/dashboard/deployments/[id]. ID is: 123'
-    )
-  })
-
-  // TODO-APP: fix to ensure behavior matches on deploy
-  if (!(global as any).isNextDeploy) {
-    it('should serve page as a segment name correctly', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/page')
-      expect(html).toContain('hello dashboard/page!')
-    })
-  }
-
-  it('should include document html and body', async () => {
-    const html = await renderViaHTTP(next.url, '/dashboard')
-    const $ = cheerio.load(html)
-
-    expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
-    expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
-  })
-
-  it('should not serve when layout is provided but no folder index', async () => {
-    const res = await fetchViaHTTP(next.url, '/dashboard/deployments')
-    expect(res.status).toBe(404)
-    expect(await res.text()).toContain('This page could not be found')
-  })
-
-  // TODO-APP: do we want to make this only work for /root or is it allowed
-  // to work for /pages as well?
-  it.skip('should match partial parameters', async () => {
-    const html = await renderViaHTTP(next.url, '/partial-match-123')
-    expect(html).toContain('hello from app/partial-match-[id]. ID is: 123')
-  })
-
-  describe('rewrites', () => {
-    // TODO-APP: rewrite url is broken
-    it('should support rewrites on initial load', async () => {
-      const browser = await webdriver(next.url, '/rewritten-to-dashboard')
-      expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
-      expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
-    })
-
-    it('should support rewrites on client-side navigation from pages to app with existing pages path', async () => {
-      const browser = await webdriver(next.url, '/link-to-rewritten-path')
-
-      try {
-        // Click the link.
-        await browser.elementById('link-to-rewritten-path').click()
-        await browser.waitForElementByCss('#from-dashboard')
-
-        // Check to see that we were rewritten and not redirected.
-        // TODO-APP: rewrite url is broken
-        // expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
-
-        // Check to see that the page we navigated to is in fact the dashboard.
-        expect(await browser.elementByCss('#from-dashboard').text()).toBe(
-          'hello from app/dashboard'
-        )
-      } finally {
-        await browser.close()
-      }
-    })
-
-    it('should support rewrites on client-side navigation', async () => {
-      const browser = await webdriver(next.url, '/rewrites')
-
-      try {
-        // Click the link.
-        await browser.elementById('link').click()
-        await browser.waitForElementByCss('#from-dashboard')
-
-        // Check to see that we were rewritten and not redirected.
-        expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
-
-        // Check to see that the page we navigated to is in fact the dashboard.
-        expect(await browser.elementByCss('#from-dashboard').text()).toBe(
-          'hello from app/dashboard'
-        )
-      } finally {
-        await browser.close()
-      }
-    })
-  })
-
-  // TODO-APP: Enable in development
-  ;(isDev ? it.skip : it)(
-    'should not rerender layout when navigating between routes in the same layout',
-    async () => {
-      const browser = await webdriver(next.url, '/same-layout/first')
-
-      try {
-        // Get the render id from the dom and click the first link.
-        const firstRenderID = await browser.elementById('render-id').text()
-        await browser.elementById('link').click()
-        await browser.waitForElementByCss('#second-page')
-
-        // Get the render id from the dom again, it should be the same!
-        const secondRenderID = await browser.elementById('render-id').text()
-        expect(secondRenderID).toBe(firstRenderID)
-
-        // Navigate back to the first page again by clicking the link.
-        await browser.elementById('link').click()
-        await browser.waitForElementByCss('#first-page')
-
-        // Get the render id from the dom again, it should be the same!
-        const thirdRenderID = await browser.elementById('render-id').text()
-        expect(thirdRenderID).toBe(firstRenderID)
-      } finally {
-        await browser.close()
-      }
-    }
-  )
-
-  it('should handle hash in initial url', async () => {
-    const browser = await webdriver(next.url, '/dashboard#abc')
-
-    try {
-      // Check if hash is preserved
-      expect(await browser.eval('window.location.hash')).toBe('#abc')
-      await waitFor(1000)
-      // Check again to be sure as it might be timed different
-      expect(await browser.eval('window.location.hash')).toBe('#abc')
-    } finally {
-      await browser.close()
-    }
-  })
-
-  describe('parallel routes', () => {
-    if (!(global as any).isNextDeploy) {
-      it('should match parallel routes', async () => {
-        const html = await renderViaHTTP(next.url, '/parallel/nested')
-        expect(html).toContain('parallel/layout')
-        expect(html).toContain('parallel/@foo/nested/layout')
-        expect(html).toContain('parallel/@foo/nested/@a/page')
-        expect(html).toContain('parallel/@foo/nested/@b/page')
-        expect(html).toContain('parallel/@bar/nested/layout')
-        expect(html).toContain('parallel/@bar/nested/@a/page')
-        expect(html).toContain('parallel/@bar/nested/@b/page')
-        expect(html).toContain('parallel/nested/page')
       })
     }
 
-    it('should match parallel routes in route groups', async () => {
-      const html = await renderViaHTTP(next.url, '/parallel/nested-2')
-      expect(html).toContain('parallel/layout')
-      expect(html).toContain('parallel/(new)/layout')
-      expect(html).toContain('parallel/(new)/@baz/nested/page')
-    })
-  })
-
-  describe('<Link />', () => {
-    it('should hard push', async () => {
-      const browser = await webdriver(next.url, '/link-hard-push/123')
-
-      try {
-        // Click the link on the page, and verify that the history entry was
-        // added.
-        expect(await browser.eval('window.history.length')).toBe(2)
-        await browser.elementById('link').click()
-        await browser.waitForElementByCss('#render-id-456')
-        expect(await browser.eval('window.history.length')).toBe(3)
-
-        // Get the id on the rendered page.
-        const firstID = await browser.elementById('render-id-456').text()
-
-        // Go back, and redo the navigation by clicking the link.
-        await browser.back()
-        await browser.elementById('link').click()
-        await browser.waitForElementByCss('#render-id-456')
-
-        // Get the id again, and compare, they should not be the same.
-        const secondID = await browser.elementById('render-id-456').text()
-        expect(secondID).not.toBe(firstID)
-      } finally {
-        await browser.close()
-      }
-    })
-
-    it('should hard replace', async () => {
-      const browser = await webdriver(next.url, '/link-hard-replace/123')
-
-      try {
-        // Click the link on the page, and verify that the history entry was NOT
-        // added.
-        expect(await browser.eval('window.history.length')).toBe(2)
-        await browser.elementById('link').click()
-        await browser.waitForElementByCss('#render-id-456')
-        expect(await browser.eval('window.history.length')).toBe(2)
-
-        // Get the date again, and compare, they should not be the same.
-        const firstId = await browser.elementById('render-id-456').text()
-
-        // Navigate to the subpage, verify that the history entry was NOT added.
-        await browser.elementById('link').click()
-        await browser.waitForElementByCss('#render-id-123')
-        expect(await browser.eval('window.history.length')).toBe(2)
-
-        // Navigate back again, verify that the history entry was NOT added.
-        await browser.elementById('link').click()
-        await browser.waitForElementByCss('#render-id-456')
-        expect(await browser.eval('window.history.length')).toBe(2)
-
-        // Get the date again, and compare, they should not be the same.
-        const secondId = await browser.elementById('render-id-456').text()
-        expect(firstId).not.toBe(secondId)
-      } finally {
-        await browser.close()
-      }
-    })
-
-    // TODO-APP: Re-enable this test.
-    it('should soft push', async () => {
-      const browser = await webdriver(next.url, '/link-soft-push')
-
-      try {
-        // Click the link on the page, and verify that the history entry was
-        // added.
-        expect(await browser.eval('window.history.length')).toBe(2)
-        await browser.elementById('link').click()
-        await browser.waitForElementByCss('#render-id')
-        expect(await browser.eval('window.history.length')).toBe(3)
-
-        // Get the id on the rendered page.
-        const firstID = await browser.elementById('render-id').text()
-
-        // Go back, and redo the navigation by clicking the link.
-        await browser.back()
-        await browser.elementById('link').click()
-
-        // Get the date again, and compare, they should be the same.
-        const secondID = await browser.elementById('render-id').text()
-        expect(firstID).toBe(secondID)
-      } finally {
-        await browser.close()
-      }
-    })
-
-    // TODO-APP: investigate this test
-    it.skip('should soft replace', async () => {
-      const browser = await webdriver(next.url, '/link-soft-replace')
-
-      try {
-        // Get the render ID so we can compare it.
-        const firstID = await browser.elementById('render-id').text()
-
-        // Click the link on the page, and verify that the history entry was NOT
-        // added.
-        expect(await browser.eval('window.history.length')).toBe(2)
-        await browser.elementById('self-link').click()
-        await browser.waitForElementByCss('#render-id')
-        expect(await browser.eval('window.history.length')).toBe(2)
-
-        // Get the id on the rendered page.
-        const secondID = await browser.elementById('render-id').text()
-        expect(secondID).toBe(firstID)
-
-        // Navigate to the subpage, verify that the history entry was NOT added.
-        await browser.elementById('subpage-link').click()
-        await browser.waitForElementByCss('#back-link')
-        expect(await browser.eval('window.history.length')).toBe(2)
-
-        // Navigate back again, verify that the history entry was NOT added.
-        await browser.elementById('back-link').click()
-        await browser.waitForElementByCss('#render-id')
-        expect(await browser.eval('window.history.length')).toBe(2)
-
-        // Get the date again, and compare, they should be the same.
-        const thirdID = await browser.elementById('render-id').text()
-        expect(thirdID).toBe(firstID)
-      } finally {
-        await browser.close()
-      }
-    })
-
-    it('should be soft for back navigation', async () => {
-      const browser = await webdriver(next.url, '/with-id')
-
-      try {
-        // Get the id on the rendered page.
-        const firstID = await browser.elementById('render-id').text()
-
-        // Click the link, and go back.
-        await browser.elementById('link').click()
-        await browser.waitForElementByCss('#from-navigation')
-        await browser.back()
-
-        // Get the date again, and compare, they should be the same.
-        const secondID = await browser.elementById('render-id').text()
-        expect(firstID).toBe(secondID)
-      } finally {
-        await browser.close()
-      }
-    })
-
-    it('should be soft for forward navigation', async () => {
-      const browser = await webdriver(next.url, '/with-id')
-
-      try {
-        // Click the link.
-        await browser.elementById('link').click()
-        await browser.waitForElementByCss('#from-navigation')
-
-        // Get the id on the rendered page.
-        const firstID = await browser.elementById('render-id').text()
-
-        // Go back, then forward.
-        await browser.back()
-        await browser.forward()
-
-        // Get the date again, and compare, they should be the same.
-        const secondID = await browser.elementById('render-id').text()
-        expect(firstID).toBe(secondID)
-      } finally {
-        await browser.close()
-      }
-    })
-
-    it('should allow linking from app page to pages page', async () => {
-      const browser = await webdriver(next.url, '/pages-linking')
-
-      try {
-        // Click the link.
-        await browser.elementById('app-link').click()
-        expect(await browser.waitForElementByCss('#pages-link').text()).toBe(
-          'To App Page'
+    if (isNextStart) {
+      it('should generate build traces correctly', async () => {
+        const trace = JSON.parse(
+          await next.readFile(
+            '.next/server/app/dashboard/deployments/[id]/page.js.nft.json'
+          )
+        ) as { files: string[] }
+        expect(trace.files.some((file) => file.endsWith('data.json'))).toBe(
+          true
         )
+      })
+    }
 
-        // Click the other link.
-        await browser.elementById('pages-link').click()
-        expect(await browser.waitForElementByCss('#app-link').text()).toBe(
-          'To Pages Page'
-        )
-      } finally {
-        await browser.close()
-      }
-    })
-
-    it('should navigate to pages dynamic route from pages page if it overlaps with an app page', async () => {
-      const browser = await webdriver(
-        next.url,
-        '/dynamic-pages-route-app-overlap'
-      )
-
-      try {
-        // Click the link.
-        await browser.elementById('pages-link').click()
-        expect(await browser.waitForElementByCss('#pages-text').text()).toBe(
-          'hello from pages/dynamic-pages-route-app-overlap/[slug]'
-        )
-
-        // When refreshing the browser, the app page should be rendered
-        await browser.refresh()
-        expect(await browser.waitForElementByCss('#app-text').text()).toBe(
-          'hello from app/dynamic-pages-route-app-overlap/app-dir/page'
-        )
-      } finally {
-        await browser.close()
-      }
-    })
-  })
-
-  describe('server components', () => {
-    // TODO-APP: why is this not servable but /dashboard+rootonly/hello.server.js
-    // should be? Seems like they both either should be servable or not
-    it('should not serve .server.js as a path', async () => {
-      // Without .server.js should serve
-      const html = await renderViaHTTP(next.url, '/should-not-serve-server')
-      expect(html).toContain('hello from app/should-not-serve-server')
-
-      // Should not serve `.server`
+    it('should use application/octet-stream for flight', async () => {
       const res = await fetchViaHTTP(
         next.url,
-        '/should-not-serve-server.server'
-      )
-      expect(res.status).toBe(404)
-      expect(await res.text()).toContain('This page could not be found')
-
-      // Should not serve `.server.js`
-      const res2 = await fetchViaHTTP(
-        next.url,
-        '/should-not-serve-server.server.js'
-      )
-      expect(res2.status).toBe(404)
-      expect(await res2.text()).toContain('This page could not be found')
-    })
-
-    it('should not serve .client.js as a path', async () => {
-      // Without .client.js should serve
-      const html = await renderViaHTTP(next.url, '/should-not-serve-client')
-      expect(html).toContain('hello from app/should-not-serve-client')
-
-      // Should not serve `.client`
-      const res = await fetchViaHTTP(
-        next.url,
-        '/should-not-serve-client.client'
-      )
-      expect(res.status).toBe(404)
-      expect(await res.text()).toContain('This page could not be found')
-
-      // Should not serve `.client.js`
-      const res2 = await fetchViaHTTP(
-        next.url,
-        '/should-not-serve-client.client.js'
-      )
-      expect(res2.status).toBe(404)
-      expect(await res2.text()).toContain('This page could not be found')
-    })
-
-    it('should serve shared component', async () => {
-      // Without .client.js should serve
-      const html = await renderViaHTTP(next.url, '/shared-component-route')
-      expect(html).toContain('hello from app/shared-component-route')
-    })
-
-    describe('dynamic routes', () => {
-      it('should only pass params that apply to the layout', async () => {
-        const html = await renderViaHTTP(next.url, '/dynamic/books/hello-world')
-        const $ = cheerio.load(html)
-
-        expect($('#dynamic-layout-params').text()).toBe('{}')
-        expect($('#category-layout-params').text()).toBe('{"category":"books"}')
-        expect($('#id-layout-params').text()).toBe(
-          '{"category":"books","id":"hello-world"}'
-        )
-        expect($('#id-page-params').text()).toBe(
-          '{"category":"books","id":"hello-world"}'
-        )
-      })
-    })
-
-    describe('catch-all routes', () => {
-      it('should handle optional segments', async () => {
-        const params = ['this', 'is', 'a', 'test']
-        const route = params.join('/')
-        const html = await renderViaHTTP(
-          next.url,
-          `/catch-all-optional/${route}`
-        )
-        const $ = cheerio.load(html)
-        expect($('#text').attr('data-params')).toBe(route)
-      })
-
-      it('should handle optional segments root', async () => {
-        const html = await renderViaHTTP(next.url, `/catch-all-optional`)
-        const $ = cheerio.load(html)
-        expect($('#text').attr('data-params')).toBe('')
-      })
-
-      it('should handle optional catch-all segments link', async () => {
-        const browser = await webdriver(next.url, '/catch-all-link')
-        expect(
-          await browser
-            .elementByCss('#to-catch-all-optional')
-            .click()
-            .waitForElementByCss('#text')
-            .text()
-        ).toBe(`hello from /catch-all-optional/this/is/a/test`)
-      })
-
-      it('should handle required segments', async () => {
-        const params = ['this', 'is', 'a', 'test']
-        const route = params.join('/')
-        const html = await renderViaHTTP(next.url, `/catch-all/${route}`)
-        const $ = cheerio.load(html)
-        expect($('#text').attr('data-params')).toBe(route)
-        expect($('#not-a-page').text()).toBe('Not a page')
-
-        // Components under catch-all should not be treated as route that errors during build.
-        // They should be rendered properly when imported in page route.
-        expect($('#widget').text()).toBe('widget')
-      })
-
-      it('should handle required segments root as not found', async () => {
-        const res = await fetchViaHTTP(next.url, `/catch-all`)
-        expect(res.status).toBe(404)
-        expect(await res.text()).toContain('This page could not be found')
-      })
-
-      it('should handle catch-all segments link', async () => {
-        const browser = await webdriver(next.url, '/catch-all-link')
-        expect(
-          await browser
-            .elementByCss('#to-catch-all')
-            .click()
-            .waitForElementByCss('#text')
-            .text()
-        ).toBe(`hello from /catch-all/this/is/a/test`)
-      })
-    })
-
-    describe('should serve client component', () => {
-      it('should serve server-side', async () => {
-        const html = await renderViaHTTP(next.url, '/client-component-route')
-        const $ = cheerio.load(html)
-        expect($('p').text()).toBe(
-          'hello from app/client-component-route. count: 0'
-        )
-      })
-
-      // TODO-APP: investigate hydration not kicking in on some runs
-      it('should serve client-side', async () => {
-        const browser = await webdriver(next.url, '/client-component-route')
-
-        // After hydration count should be 1
-        expect(await browser.elementByCss('p').text()).toBe(
-          'hello from app/client-component-route. count: 1'
-        )
-      })
-    })
-
-    describe('should include client component layout with server component route', () => {
-      it('should include it server-side', async () => {
-        const html = await renderViaHTTP(next.url, '/client-nested')
-        const $ = cheerio.load(html)
-        // Should not be nested in dashboard
-        expect($('h1').text()).toBe('Client Nested. Count: 0')
-        // Should include the page text
-        expect($('p').text()).toBe('hello from app/client-nested')
-      })
-
-      it('should include it client-side', async () => {
-        const browser = await webdriver(next.url, '/client-nested')
-
-        // After hydration count should be 1
-        expect(await browser.elementByCss('h1').text()).toBe(
-          'Client Nested. Count: 1'
-        )
-
-        // After hydration count should be 1
-        expect(await browser.elementByCss('p').text()).toBe(
-          'hello from app/client-nested'
-        )
-      })
-    })
-
-    describe('Loading', () => {
-      it('should render loading.js in initial html for slow page', async () => {
-        const html = await renderViaHTTP(next.url, '/slow-page-with-loading')
-        const $ = cheerio.load(html)
-
-        expect($('#loading').text()).toBe('Loading...')
-      })
-
-      it('should render loading.js in browser for slow page', async () => {
-        const browser = await webdriver(next.url, '/slow-page-with-loading', {
-          waitHydration: false,
-        })
-        // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
-        // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
-
-        expect(await browser.elementByCss('#slow-page-message').text()).toBe(
-          'hello from slow page'
-        )
-      })
-
-      it('should render loading.js in initial html for slow layout', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/slow-layout-with-loading/slow'
-        )
-        const $ = cheerio.load(html)
-
-        expect($('#loading').text()).toBe('Loading...')
-      })
-
-      it('should render loading.js in browser for slow layout', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/slow-layout-with-loading/slow',
-          {
-            waitHydration: false,
-          }
-        )
-        // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
-        // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
-
-        expect(await browser.elementByCss('#slow-layout-message').text()).toBe(
-          'hello from slow layout'
-        )
-
-        expect(await browser.elementByCss('#page-message').text()).toBe(
-          'Hello World'
-        )
-      })
-
-      it('should render loading.js in initial html for slow layout and page', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/slow-layout-and-page-with-loading/slow'
-        )
-        const $ = cheerio.load(html)
-
-        expect($('#loading-layout').text()).toBe('Loading layout...')
-        expect($('#loading-page').text()).toBe('Loading page...')
-      })
-
-      it('should render loading.js in browser for slow layout and page', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/slow-layout-and-page-with-loading/slow',
-          {
-            waitHydration: false,
-          }
-        )
-        // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
-        // expect(await browser.elementByCss('#loading-layout').text()).toBe('Loading...')
-        // expect(await browser.elementByCss('#loading-page').text()).toBe('Loading...')
-
-        expect(await browser.elementByCss('#slow-layout-message').text()).toBe(
-          'hello from slow layout'
-        )
-
-        expect(await browser.elementByCss('#slow-page-message').text()).toBe(
-          'hello from slow page'
-        )
-      })
-    })
-
-    describe('middleware', () => {
-      it.each(['rewrite', 'redirect'])(
-        `should strip internal query parameters from requests to middleware for %s`,
-        async (method) => {
-          const browser = await webdriver(next.url, '/internal')
-
-          try {
-            // Wait for and click the navigation element, this should trigger
-            // the flight request that'll be caught by the middleware. If the
-            // middleware sees any flight data on the request it'll redirect to
-            // a page with an element of #failure, otherwise, we'll see the
-            // element for #success.
-            await browser
-              .waitForElementByCss(`#navigate-${method}`)
-              .elementById(`navigate-${method}`)
-              .click()
-            expect(
-              await browser.waitForElementByCss('#success', 3000).text()
-            ).toBe('Success')
-          } finally {
-            await browser.close()
-          }
+        '/dashboard/deployments/123',
+        {},
+        {
+          headers: {
+            ['RSC'.toString()]: '1',
+          },
         }
       )
+      expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
     })
 
-    describe('next/router', () => {
-      it('should support router.back and router.forward', async () => {
-        const browser = await webdriver(next.url, '/back-forward/1')
+    it('should use application/octet-stream for flight with edge runtime', async () => {
+      const res = await fetchViaHTTP(
+        next.url,
+        '/dashboard',
+        {},
+        {
+          headers: {
+            ['RSC'.toString()]: '1',
+          },
+        }
+      )
+      expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
+    })
 
-        const firstMessage = 'Hello from 1'
-        const secondMessage = 'Hello from 2'
+    it('should pass props from getServerSideProps in root layout', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard')
+      const $ = cheerio.load(html)
+      expect($('title').text()).toBe('hello world')
+    })
 
-        expect(await browser.elementByCss('#message-1').text()).toBe(
-          firstMessage
+    it('should serve from pages', async () => {
+      const html = await renderViaHTTP(next.url, '/')
+      expect(html).toContain('hello from pages/index')
+
+      // esm imports should work fine in pages/
+      expect(html).toContain('swr-index')
+    })
+
+    it('should serve dynamic route from pages', async () => {
+      const html = await renderViaHTTP(next.url, '/blog/first')
+      expect(html).toContain('hello from pages/blog/[slug]')
+    })
+
+    it('should serve from public', async () => {
+      const html = await renderViaHTTP(next.url, '/hello.txt')
+      expect(html).toContain('hello world')
+    })
+
+    it('should serve from app', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard')
+      expect(html).toContain('hello from app/dashboard')
+    })
+
+    if (!isNextDeploy) {
+      it('should serve /index as separate page', async () => {
+        const stderr = []
+        next.on('stderr', (err) => {
+          stderr.push(err)
+        })
+        const html = await renderViaHTTP(next.url, '/dashboard/index')
+        expect(html).toContain('hello from app/dashboard/index')
+        expect(stderr.some((err) => err.includes('Invalid hook call'))).toBe(
+          false
+        )
+      })
+
+      it('should handle next/dynamic correctly', async () => {
+        const html = await renderViaHTTP(next.url, '/dashboard/dynamic')
+        const $ = cheerio.load(html)
+        // filter out the script
+        const selector = 'body div'
+        const serverContent = $(selector).text()
+        // should load chunks generated via async import correctly with React.lazy
+        expect(serverContent).toContain('next-dynamic lazy')
+        // should support `dynamic` in both server and client components
+        expect(serverContent).toContain('next-dynamic dynamic on server')
+        expect(serverContent).toContain('next-dynamic dynamic on client')
+        expect(serverContent).toContain('next-dynamic server import client')
+        expect(serverContent).not.toContain(
+          'next-dynamic dynamic no ssr on client'
         )
 
+        expect(serverContent).not.toContain(
+          'next-dynamic dynamic no ssr on server'
+        )
+
+        // client component under server component with ssr: false will not be rendered either in flight or SSR
+        expect(html).not.toContain('client component under sever no ssr')
+
+        const browser = await webdriver(next.url, '/dashboard/dynamic')
+        const clientContent = await browser.elementByCss(selector).text()
+        expect(clientContent).toContain('next-dynamic dynamic no ssr on server')
+        expect(clientContent).toContain('client component under sever no ssr')
+        await browser.waitForElementByCss('#css-text-dynamic-no-ssr-client')
+
+        expect(
+          await browser.elementByCss('#css-text-dynamic-no-ssr-client').text()
+        ).toBe('next-dynamic dynamic no ssr on client:suffix')
+      })
+
+      it('should serve polyfills for browsers that do not support modules', async () => {
+        const html = await renderViaHTTP(next.url, '/dashboard/index')
+        expect(html).toMatch(
+          /<script src="\/_next\/static\/chunks\/polyfills(-\w+)?\.js" nomodule="">/
+        )
+      })
+    }
+
+    // TODO-APP: handle css modules fouc in dev
+    it.skip('should handle css imports in next/dynamic correctly', async () => {
+      const browser = await webdriver(next.url, '/dashboard/index')
+
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.querySelector('#css-text-dynamic-server')).color`
+        )
+      ).toBe('rgb(0, 0, 255)')
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.querySelector('#css-text-lazy')).color`
+        )
+      ).toBe('rgb(128, 0, 128)')
+    })
+
+    it('should include layouts when no direct parent layout', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard/integrations')
+      const $ = cheerio.load(html)
+      // Should not be nested in dashboard
+      expect($('h1').text()).toBe('Dashboard')
+      // Should include the page text
+      expect($('p').text()).toBe('hello from app/dashboard/integrations')
+    })
+
+    // TODO-APP: handle new root layout
+    it.skip('should not include parent when not in parent directory with route in directory', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard/hello')
+      const $ = cheerio.load(html)
+
+      // new root has to provide it's own custom root layout or the default
+      // is used instead
+      expect(html).toContain('<html')
+      expect(html).toContain('<body')
+      expect($('html').hasClass('this-is-the-document-html')).toBeFalsy()
+      expect($('body').hasClass('this-is-the-document-body')).toBeFalsy()
+
+      // Should not be nested in dashboard
+      expect($('h1').text()).toBeFalsy()
+
+      // Should render the page text
+      expect($('p').text()).toBe('hello from app/dashboard/rootonly/hello')
+    })
+
+    it('should use new root layout when provided', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard/another')
+      const $ = cheerio.load(html)
+
+      // new root has to provide it's own custom root layout or the default
+      // is used instead
+      expect($('html').hasClass('this-is-another-document-html')).toBeTruthy()
+      expect($('body').hasClass('this-is-another-document-body')).toBeTruthy()
+
+      // Should not be nested in dashboard
+      expect($('h1').text()).toBeFalsy()
+
+      // Should render the page text
+      expect($('p').text()).toBe('hello from newroot/dashboard/another')
+    })
+
+    it('should not create new root layout when nested (optional)', async () => {
+      const html = await renderViaHTTP(
+        next.url,
+        '/dashboard/deployments/breakdown'
+      )
+      const $ = cheerio.load(html)
+
+      // new root has to provide it's own custom root layout or the default
+      // is used instead
+      expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
+      expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
+
+      // Should be nested in dashboard
+      expect($('h1').text()).toBe('Dashboard')
+      expect($('h2').text()).toBe('Custom dashboard')
+
+      // Should render the page text
+      expect($('p').text()).toBe(
+        'hello from app/dashboard/(custom)/deployments/breakdown'
+      )
+    })
+
+    it('should include parent document when no direct parent layout', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard/integrations')
+      const $ = cheerio.load(html)
+
+      expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
+      expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
+    })
+
+    it('should not include parent when not in parent directory', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard/changelog')
+      const $ = cheerio.load(html)
+      // Should not be nested in dashboard
+      expect($('h1').text()).toBeFalsy()
+      // Should include the page text
+      expect($('p').text()).toBe('hello from app/dashboard/changelog')
+    })
+
+    it('should serve nested parent', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard/deployments/123')
+      const $ = cheerio.load(html)
+      // Should be nested in dashboard
+      expect($('h1').text()).toBe('Dashboard')
+      // Should be nested in deployments
+      expect($('h2').text()).toBe('Deployments hello')
+    })
+
+    it('should serve dynamic parameter', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard/deployments/123')
+      const $ = cheerio.load(html)
+      // Should include the page text with the parameter
+      expect($('p').text()).toBe(
+        'hello from app/dashboard/deployments/[id]. ID is: 123'
+      )
+    })
+
+    // TODO-APP: fix to ensure behavior matches on deploy
+    if (!isNextDeploy) {
+      it('should serve page as a segment name correctly', async () => {
+        const html = await renderViaHTTP(next.url, '/dashboard/page')
+        expect(html).toContain('hello dashboard/page!')
+      })
+    }
+
+    it('should include document html and body', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard')
+      const $ = cheerio.load(html)
+
+      expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
+      expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
+    })
+
+    it('should not serve when layout is provided but no folder index', async () => {
+      const res = await fetchViaHTTP(next.url, '/dashboard/deployments')
+      expect(res.status).toBe(404)
+      expect(await res.text()).toContain('This page could not be found')
+    })
+
+    // TODO-APP: do we want to make this only work for /root or is it allowed
+    // to work for /pages as well?
+    it.skip('should match partial parameters', async () => {
+      const html = await renderViaHTTP(next.url, '/partial-match-123')
+      expect(html).toContain('hello from app/partial-match-[id]. ID is: 123')
+    })
+
+    describe('rewrites', () => {
+      // TODO-APP: rewrite url is broken
+      it('should support rewrites on initial load', async () => {
+        const browser = await webdriver(next.url, '/rewritten-to-dashboard')
+        expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
+        expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
+      })
+
+      it('should support rewrites on client-side navigation from pages to app with existing pages path', async () => {
+        const browser = await webdriver(next.url, '/link-to-rewritten-path')
+
         try {
-          const message2 = await browser
-            .waitForElementByCss('#to-other-page')
-            .click()
-            .waitForElementByCss('#message-2')
-            .text()
-          expect(message2).toBe(secondMessage)
+          // Click the link.
+          await browser.elementById('link-to-rewritten-path').click()
+          await browser.waitForElementByCss('#from-dashboard')
 
-          const message1 = await browser
-            .waitForElementByCss('#back-button')
-            .click()
-            .waitForElementByCss('#message-1')
-            .text()
-          expect(message1).toBe(firstMessage)
+          // Check to see that we were rewritten and not redirected.
+          // TODO-APP: rewrite url is broken
+          // expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
 
-          const message2Again = await browser
-            .waitForElementByCss('#forward-button')
-            .click()
-            .waitForElementByCss('#message-2')
-            .text()
-          expect(message2Again).toBe(secondMessage)
+          // Check to see that the page we navigated to is in fact the dashboard.
+          expect(await browser.elementByCss('#from-dashboard').text()).toBe(
+            'hello from app/dashboard'
+          )
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('should support rewrites on client-side navigation', async () => {
+        const browser = await webdriver(next.url, '/rewrites')
+
+        try {
+          // Click the link.
+          await browser.elementById('link').click()
+          await browser.waitForElementByCss('#from-dashboard')
+
+          // Check to see that we were rewritten and not redirected.
+          expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
+
+          // Check to see that the page we navigated to is in fact the dashboard.
+          expect(await browser.elementByCss('#from-dashboard').text()).toBe(
+            'hello from app/dashboard'
+          )
         } finally {
           await browser.close()
         }
       })
     })
 
-    describe('hooks', () => {
-      describe('cookies function', () => {
-        it('should retrieve cookies in a server component', async () => {
-          const browser = await webdriver(next.url, '/hooks/use-cookies')
+    // TODO-APP: Enable in development
+    ;(isDev ? it.skip : it)(
+      'should not rerender layout when navigating between routes in the same layout',
+      async () => {
+        const browser = await webdriver(next.url, '/same-layout/first')
 
-          try {
-            await browser.waitForElementByCss('#does-not-have-cookie')
-            browser.addCookie({ name: 'use-cookies', value: 'value' })
-            browser.refresh()
+        try {
+          // Get the render id from the dom and click the first link.
+          const firstRenderID = await browser.elementById('render-id').text()
+          await browser.elementById('link').click()
+          await browser.waitForElementByCss('#second-page')
 
-            await browser.waitForElementByCss('#has-cookie')
-            browser.deleteCookies()
-            browser.refresh()
+          // Get the render id from the dom again, it should be the same!
+          const secondRenderID = await browser.elementById('render-id').text()
+          expect(secondRenderID).toBe(firstRenderID)
 
-            await browser.waitForElementByCss('#does-not-have-cookie')
-          } finally {
-            await browser.close()
-          }
+          // Navigate back to the first page again by clicking the link.
+          await browser.elementById('link').click()
+          await browser.waitForElementByCss('#first-page')
+
+          // Get the render id from the dom again, it should be the same!
+          const thirdRenderID = await browser.elementById('render-id').text()
+          expect(thirdRenderID).toBe(firstRenderID)
+        } finally {
+          await browser.close()
+        }
+      }
+    )
+
+    it('should handle hash in initial url', async () => {
+      const browser = await webdriver(next.url, '/dashboard#abc')
+
+      try {
+        // Check if hash is preserved
+        expect(await browser.eval('window.location.hash')).toBe('#abc')
+        await waitFor(1000)
+        // Check again to be sure as it might be timed different
+        expect(await browser.eval('window.location.hash')).toBe('#abc')
+      } finally {
+        await browser.close()
+      }
+    })
+
+    describe('parallel routes', () => {
+      if (!isNextDeploy) {
+        it('should match parallel routes', async () => {
+          const html = await renderViaHTTP(next.url, '/parallel/nested')
+          expect(html).toContain('parallel/layout')
+          expect(html).toContain('parallel/@foo/nested/layout')
+          expect(html).toContain('parallel/@foo/nested/@a/page')
+          expect(html).toContain('parallel/@foo/nested/@b/page')
+          expect(html).toContain('parallel/@bar/nested/layout')
+          expect(html).toContain('parallel/@bar/nested/@a/page')
+          expect(html).toContain('parallel/@bar/nested/@b/page')
+          expect(html).toContain('parallel/nested/page')
         })
+      }
 
-        it('should retrieve cookies in a server component in the edge runtime', async () => {
-          const res = await fetchViaHTTP(next.url, '/edge-apis/cookies')
-          expect(await res.text()).toInclude('Hello')
-        })
-
-        it('should access cookies on <Link /> navigation', async () => {
-          const browser = await webdriver(next.url, '/navigation')
-
-          try {
-            // Click the cookies link to verify it can't see the cookie that's
-            // not there.
-            await browser.elementById('use-cookies').click()
-            await browser.waitForElementByCss('#does-not-have-cookie')
-
-            // Go back and add the cookies.
-            await browser.back()
-            await browser.waitForElementByCss('#from-navigation')
-            browser.addCookie({ name: 'use-cookies', value: 'value' })
-
-            // Click the cookies link again to see that the cookie can be picked
-            // up again.
-            await browser.elementById('use-cookies').click()
-            await browser.waitForElementByCss('#has-cookie')
-
-            // Go back and remove the cookies.
-            await browser.back()
-            await browser.waitForElementByCss('#from-navigation')
-            browser.deleteCookies()
-
-            // Verify for the last time that after clicking the cookie link
-            // again, there are no cookies.
-            await browser.elementById('use-cookies').click()
-            await browser.waitForElementByCss('#does-not-have-cookie')
-          } finally {
-            await browser.close()
-          }
-        })
-      })
-
-      describe('headers function', () => {
-        it('should have access to incoming headers in a server component', async () => {
-          // Check to see that we can't see the header when it's not present.
-          let html = await renderViaHTTP(
-            next.url,
-            '/hooks/use-headers',
-            {},
-            { headers: {} }
-          )
-          let $ = cheerio.load(html)
-          expect($('#does-not-have-header').length).toBe(1)
-          expect($('#has-header').length).toBe(0)
-
-          // Check to see that we can see the header when it's present.
-          html = await renderViaHTTP(
-            next.url,
-            '/hooks/use-headers',
-            {},
-            { headers: { 'x-use-headers': 'value' } }
-          )
-          $ = cheerio.load(html)
-          expect($('#has-header').length).toBe(1)
-          expect($('#does-not-have-header').length).toBe(0)
-        })
-
-        it('should access headers on <Link /> navigation', async () => {
-          const browser = await webdriver(next.url, '/navigation')
-
-          try {
-            await browser.elementById('use-headers').click()
-            await browser.waitForElementByCss('#has-referer')
-          } finally {
-            await browser.close()
-          }
-        })
-      })
-
-      describe('previewData function', () => {
-        it('should return no preview data when there is none', async () => {
-          const browser = await webdriver(next.url, '/hooks/use-preview-data')
-
-          try {
-            await browser.waitForElementByCss('#does-not-have-preview-data')
-          } finally {
-            await browser.close()
-          }
-        })
-
-        it('should return preview data when there is some', async () => {
-          const browser = await webdriver(next.url, '/api/preview')
-
-          try {
-            await browser.loadPage(next.url + '/hooks/use-preview-data', {
-              disableCache: false,
-              beforePageLoad: null,
-            })
-            await browser.waitForElementByCss('#has-preview-data')
-          } finally {
-            await browser.close()
-          }
-        })
-      })
-
-      describe('useRouter', () => {
-        // TODO-APP: should enable when implemented
-        it.skip('should throw an error when imported', async () => {
-          const res = await fetchViaHTTP(next.url, '/hooks/use-router/server')
-          expect(res.status).toBe(500)
-          expect(await res.text()).toContain('Internal Server Error')
-        })
-      })
-
-      describe('useParams', () => {
-        // TODO-APP: should enable when implemented
-        it.skip('should throw an error when imported', async () => {
-          const res = await fetchViaHTTP(next.url, '/hooks/use-params/server')
-          expect(res.status).toBe(500)
-          expect(await res.text()).toContain('Internal Server Error')
-        })
-      })
-
-      describe('useSearchParams', () => {
-        // TODO-APP: should enable when implemented
-        it.skip('should throw an error when imported', async () => {
-          const res = await fetchViaHTTP(
-            next.url,
-            '/hooks/use-search-params/server'
-          )
-          expect(res.status).toBe(500)
-          expect(await res.text()).toContain('Internal Server Error')
-        })
-      })
-
-      describe('usePathname', () => {
-        // TODO-APP: should enable when implemented
-        it.skip('should throw an error when imported', async () => {
-          const res = await fetchViaHTTP(next.url, '/hooks/use-pathname/server')
-          expect(res.status).toBe(500)
-          expect(await res.text()).toContain('Internal Server Error')
-        })
-      })
-
-      describe('useLayoutSegments', () => {
-        // TODO-APP: should enable when implemented
-        it.skip('should throw an error when imported', async () => {
-          const res = await fetchViaHTTP(
-            next.url,
-            '/hooks/use-layout-segments/server'
-          )
-          expect(res.status).toBe(500)
-          expect(await res.text()).toContain('Internal Server Error')
-        })
-      })
-
-      describe('useSelectedLayoutSegment', () => {
-        // TODO-APP: should enable when implemented
-        it.skip('should throw an error when imported', async () => {
-          const res = await fetchViaHTTP(
-            next.url,
-            '/hooks/use-selected-layout-segment/server'
-          )
-          expect(res.status).toBe(500)
-          expect(await res.text()).toContain('Internal Server Error')
-        })
+      it('should match parallel routes in route groups', async () => {
+        const html = await renderViaHTTP(next.url, '/parallel/nested-2')
+        expect(html).toContain('parallel/layout')
+        expect(html).toContain('parallel/(new)/layout')
+        expect(html).toContain('parallel/(new)/@baz/nested/page')
       })
     })
-  })
 
-  describe('client components', () => {
-    describe('hooks', () => {
-      describe('from pages', () => {
-        it.each([
-          { pathname: '/adapter-hooks/static' },
-          { pathname: '/adapter-hooks/1' },
-          { pathname: '/adapter-hooks/2' },
-          { pathname: '/adapter-hooks/1/account' },
-          { pathname: '/adapter-hooks/static', keyValue: 'value' },
-          { pathname: '/adapter-hooks/1', keyValue: 'value' },
-          { pathname: '/adapter-hooks/2', keyValue: 'value' },
-          { pathname: '/adapter-hooks/1/account', keyValue: 'value' },
-        ])(
-          'should have the correct hooks',
-          async ({ pathname, keyValue = '' }) => {
-            const browser = await webdriver(
-              next.url,
-              pathname + (keyValue ? `?key=${keyValue}` : '')
-            )
+    describe('<Link />', () => {
+      it('should hard push', async () => {
+        const browser = await webdriver(next.url, '/link-hard-push/123')
+
+        try {
+          // Click the link on the page, and verify that the history entry was
+          // added.
+          expect(await browser.eval('window.history.length')).toBe(2)
+          await browser.elementById('link').click()
+          await browser.waitForElementByCss('#render-id-456')
+          expect(await browser.eval('window.history.length')).toBe(3)
+
+          // Get the id on the rendered page.
+          const firstID = await browser.elementById('render-id-456').text()
+
+          // Go back, and redo the navigation by clicking the link.
+          await browser.back()
+          await browser.elementById('link').click()
+          await browser.waitForElementByCss('#render-id-456')
+
+          // Get the id again, and compare, they should not be the same.
+          const secondID = await browser.elementById('render-id-456').text()
+          expect(secondID).not.toBe(firstID)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('should hard replace', async () => {
+        const browser = await webdriver(next.url, '/link-hard-replace/123')
+
+        try {
+          // Click the link on the page, and verify that the history entry was NOT
+          // added.
+          expect(await browser.eval('window.history.length')).toBe(2)
+          await browser.elementById('link').click()
+          await browser.waitForElementByCss('#render-id-456')
+          expect(await browser.eval('window.history.length')).toBe(2)
+
+          // Get the date again, and compare, they should not be the same.
+          const firstId = await browser.elementById('render-id-456').text()
+
+          // Navigate to the subpage, verify that the history entry was NOT added.
+          await browser.elementById('link').click()
+          await browser.waitForElementByCss('#render-id-123')
+          expect(await browser.eval('window.history.length')).toBe(2)
+
+          // Navigate back again, verify that the history entry was NOT added.
+          await browser.elementById('link').click()
+          await browser.waitForElementByCss('#render-id-456')
+          expect(await browser.eval('window.history.length')).toBe(2)
+
+          // Get the date again, and compare, they should not be the same.
+          const secondId = await browser.elementById('render-id-456').text()
+          expect(firstId).not.toBe(secondId)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      // TODO-APP: Re-enable this test.
+      it('should soft push', async () => {
+        const browser = await webdriver(next.url, '/link-soft-push')
+
+        try {
+          // Click the link on the page, and verify that the history entry was
+          // added.
+          expect(await browser.eval('window.history.length')).toBe(2)
+          await browser.elementById('link').click()
+          await browser.waitForElementByCss('#render-id')
+          expect(await browser.eval('window.history.length')).toBe(3)
+
+          // Get the id on the rendered page.
+          const firstID = await browser.elementById('render-id').text()
+
+          // Go back, and redo the navigation by clicking the link.
+          await browser.back()
+          await browser.elementById('link').click()
+
+          // Get the date again, and compare, they should be the same.
+          const secondID = await browser.elementById('render-id').text()
+          expect(firstID).toBe(secondID)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      // TODO-APP: investigate this test
+      it.skip('should soft replace', async () => {
+        const browser = await webdriver(next.url, '/link-soft-replace')
+
+        try {
+          // Get the render ID so we can compare it.
+          const firstID = await browser.elementById('render-id').text()
+
+          // Click the link on the page, and verify that the history entry was NOT
+          // added.
+          expect(await browser.eval('window.history.length')).toBe(2)
+          await browser.elementById('self-link').click()
+          await browser.waitForElementByCss('#render-id')
+          expect(await browser.eval('window.history.length')).toBe(2)
+
+          // Get the id on the rendered page.
+          const secondID = await browser.elementById('render-id').text()
+          expect(secondID).toBe(firstID)
+
+          // Navigate to the subpage, verify that the history entry was NOT added.
+          await browser.elementById('subpage-link').click()
+          await browser.waitForElementByCss('#back-link')
+          expect(await browser.eval('window.history.length')).toBe(2)
+
+          // Navigate back again, verify that the history entry was NOT added.
+          await browser.elementById('back-link').click()
+          await browser.waitForElementByCss('#render-id')
+          expect(await browser.eval('window.history.length')).toBe(2)
+
+          // Get the date again, and compare, they should be the same.
+          const thirdID = await browser.elementById('render-id').text()
+          expect(thirdID).toBe(firstID)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('should be soft for back navigation', async () => {
+        const browser = await webdriver(next.url, '/with-id')
+
+        try {
+          // Get the id on the rendered page.
+          const firstID = await browser.elementById('render-id').text()
+
+          // Click the link, and go back.
+          await browser.elementById('link').click()
+          await browser.waitForElementByCss('#from-navigation')
+          await browser.back()
+
+          // Get the date again, and compare, they should be the same.
+          const secondID = await browser.elementById('render-id').text()
+          expect(firstID).toBe(secondID)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('should be soft for forward navigation', async () => {
+        const browser = await webdriver(next.url, '/with-id')
+
+        try {
+          // Click the link.
+          await browser.elementById('link').click()
+          await browser.waitForElementByCss('#from-navigation')
+
+          // Get the id on the rendered page.
+          const firstID = await browser.elementById('render-id').text()
+
+          // Go back, then forward.
+          await browser.back()
+          await browser.forward()
+
+          // Get the date again, and compare, they should be the same.
+          const secondID = await browser.elementById('render-id').text()
+          expect(firstID).toBe(secondID)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('should allow linking from app page to pages page', async () => {
+        const browser = await webdriver(next.url, '/pages-linking')
+
+        try {
+          // Click the link.
+          await browser.elementById('app-link').click()
+          expect(await browser.waitForElementByCss('#pages-link').text()).toBe(
+            'To App Page'
+          )
+
+          // Click the other link.
+          await browser.elementById('pages-link').click()
+          expect(await browser.waitForElementByCss('#app-link').text()).toBe(
+            'To Pages Page'
+          )
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('should navigate to pages dynamic route from pages page if it overlaps with an app page', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/dynamic-pages-route-app-overlap'
+        )
+
+        try {
+          // Click the link.
+          await browser.elementById('pages-link').click()
+          expect(await browser.waitForElementByCss('#pages-text').text()).toBe(
+            'hello from pages/dynamic-pages-route-app-overlap/[slug]'
+          )
+
+          // When refreshing the browser, the app page should be rendered
+          await browser.refresh()
+          expect(await browser.waitForElementByCss('#app-text').text()).toBe(
+            'hello from app/dynamic-pages-route-app-overlap/app-dir/page'
+          )
+        } finally {
+          await browser.close()
+        }
+      })
+    })
+
+    describe('server components', () => {
+      // TODO-APP: why is this not servable but /dashboard+rootonly/hello.server.js
+      // should be? Seems like they both either should be servable or not
+      it('should not serve .server.js as a path', async () => {
+        // Without .server.js should serve
+        const html = await renderViaHTTP(next.url, '/should-not-serve-server')
+        expect(html).toContain('hello from app/should-not-serve-server')
+
+        // Should not serve `.server`
+        const res = await fetchViaHTTP(
+          next.url,
+          '/should-not-serve-server.server'
+        )
+        expect(res.status).toBe(404)
+        expect(await res.text()).toContain('This page could not be found')
+
+        // Should not serve `.server.js`
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/should-not-serve-server.server.js'
+        )
+        expect(res2.status).toBe(404)
+        expect(await res2.text()).toContain('This page could not be found')
+      })
+
+      it('should not serve .client.js as a path', async () => {
+        // Without .client.js should serve
+        const html = await renderViaHTTP(next.url, '/should-not-serve-client')
+        expect(html).toContain('hello from app/should-not-serve-client')
+
+        // Should not serve `.client`
+        const res = await fetchViaHTTP(
+          next.url,
+          '/should-not-serve-client.client'
+        )
+        expect(res.status).toBe(404)
+        expect(await res.text()).toContain('This page could not be found')
+
+        // Should not serve `.client.js`
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/should-not-serve-client.client.js'
+        )
+        expect(res2.status).toBe(404)
+        expect(await res2.text()).toContain('This page could not be found')
+      })
+
+      it('should serve shared component', async () => {
+        // Without .client.js should serve
+        const html = await renderViaHTTP(next.url, '/shared-component-route')
+        expect(html).toContain('hello from app/shared-component-route')
+      })
+
+      describe('dynamic routes', () => {
+        it('should only pass params that apply to the layout', async () => {
+          const html = await renderViaHTTP(
+            next.url,
+            '/dynamic/books/hello-world'
+          )
+          const $ = cheerio.load(html)
+
+          expect($('#dynamic-layout-params').text()).toBe('{}')
+          expect($('#category-layout-params').text()).toBe(
+            '{"category":"books"}'
+          )
+          expect($('#id-layout-params').text()).toBe(
+            '{"category":"books","id":"hello-world"}'
+          )
+          expect($('#id-page-params').text()).toBe(
+            '{"category":"books","id":"hello-world"}'
+          )
+        })
+      })
+
+      describe('catch-all routes', () => {
+        it('should handle optional segments', async () => {
+          const params = ['this', 'is', 'a', 'test']
+          const route = params.join('/')
+          const html = await renderViaHTTP(
+            next.url,
+            `/catch-all-optional/${route}`
+          )
+          const $ = cheerio.load(html)
+          expect($('#text').attr('data-params')).toBe(route)
+        })
+
+        it('should handle optional segments root', async () => {
+          const html = await renderViaHTTP(next.url, `/catch-all-optional`)
+          const $ = cheerio.load(html)
+          expect($('#text').attr('data-params')).toBe('')
+        })
+
+        it('should handle optional catch-all segments link', async () => {
+          const browser = await webdriver(next.url, '/catch-all-link')
+          expect(
+            await browser
+              .elementByCss('#to-catch-all-optional')
+              .click()
+              .waitForElementByCss('#text')
+              .text()
+          ).toBe(`hello from /catch-all-optional/this/is/a/test`)
+        })
+
+        it('should handle required segments', async () => {
+          const params = ['this', 'is', 'a', 'test']
+          const route = params.join('/')
+          const html = await renderViaHTTP(next.url, `/catch-all/${route}`)
+          const $ = cheerio.load(html)
+          expect($('#text').attr('data-params')).toBe(route)
+          expect($('#not-a-page').text()).toBe('Not a page')
+
+          // Components under catch-all should not be treated as route that errors during build.
+          // They should be rendered properly when imported in page route.
+          expect($('#widget').text()).toBe('widget')
+        })
+
+        it('should handle required segments root as not found', async () => {
+          const res = await fetchViaHTTP(next.url, `/catch-all`)
+          expect(res.status).toBe(404)
+          expect(await res.text()).toContain('This page could not be found')
+        })
+
+        it('should handle catch-all segments link', async () => {
+          const browser = await webdriver(next.url, '/catch-all-link')
+          expect(
+            await browser
+              .elementByCss('#to-catch-all')
+              .click()
+              .waitForElementByCss('#text')
+              .text()
+          ).toBe(`hello from /catch-all/this/is/a/test`)
+        })
+      })
+
+      describe('should serve client component', () => {
+        it('should serve server-side', async () => {
+          const html = await renderViaHTTP(next.url, '/client-component-route')
+          const $ = cheerio.load(html)
+          expect($('p').text()).toBe(
+            'hello from app/client-component-route. count: 0'
+          )
+        })
+
+        // TODO-APP: investigate hydration not kicking in on some runs
+        it('should serve client-side', async () => {
+          const browser = await webdriver(next.url, '/client-component-route')
+
+          // After hydration count should be 1
+          expect(await browser.elementByCss('p').text()).toBe(
+            'hello from app/client-component-route. count: 1'
+          )
+        })
+      })
+
+      describe('should include client component layout with server component route', () => {
+        it('should include it server-side', async () => {
+          const html = await renderViaHTTP(next.url, '/client-nested')
+          const $ = cheerio.load(html)
+          // Should not be nested in dashboard
+          expect($('h1').text()).toBe('Client Nested. Count: 0')
+          // Should include the page text
+          expect($('p').text()).toBe('hello from app/client-nested')
+        })
+
+        it('should include it client-side', async () => {
+          const browser = await webdriver(next.url, '/client-nested')
+
+          // After hydration count should be 1
+          expect(await browser.elementByCss('h1').text()).toBe(
+            'Client Nested. Count: 1'
+          )
+
+          // After hydration count should be 1
+          expect(await browser.elementByCss('p').text()).toBe(
+            'hello from app/client-nested'
+          )
+        })
+      })
+
+      describe('Loading', () => {
+        it('should render loading.js in initial html for slow page', async () => {
+          const html = await renderViaHTTP(next.url, '/slow-page-with-loading')
+          const $ = cheerio.load(html)
+
+          expect($('#loading').text()).toBe('Loading...')
+        })
+
+        it('should render loading.js in browser for slow page', async () => {
+          const browser = await webdriver(next.url, '/slow-page-with-loading', {
+            waitHydration: false,
+          })
+          // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+          // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
+
+          expect(await browser.elementByCss('#slow-page-message').text()).toBe(
+            'hello from slow page'
+          )
+        })
+
+        it('should render loading.js in initial html for slow layout', async () => {
+          const html = await renderViaHTTP(
+            next.url,
+            '/slow-layout-with-loading/slow'
+          )
+          const $ = cheerio.load(html)
+
+          expect($('#loading').text()).toBe('Loading...')
+        })
+
+        it('should render loading.js in browser for slow layout', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/slow-layout-with-loading/slow',
+            {
+              waitHydration: false,
+            }
+          )
+          // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+          // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
+
+          expect(
+            await browser.elementByCss('#slow-layout-message').text()
+          ).toBe('hello from slow layout')
+
+          expect(await browser.elementByCss('#page-message').text()).toBe(
+            'Hello World'
+          )
+        })
+
+        it('should render loading.js in initial html for slow layout and page', async () => {
+          const html = await renderViaHTTP(
+            next.url,
+            '/slow-layout-and-page-with-loading/slow'
+          )
+          const $ = cheerio.load(html)
+
+          expect($('#loading-layout').text()).toBe('Loading layout...')
+          expect($('#loading-page').text()).toBe('Loading page...')
+        })
+
+        it('should render loading.js in browser for slow layout and page', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/slow-layout-and-page-with-loading/slow',
+            {
+              waitHydration: false,
+            }
+          )
+          // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+          // expect(await browser.elementByCss('#loading-layout').text()).toBe('Loading...')
+          // expect(await browser.elementByCss('#loading-page').text()).toBe('Loading...')
+
+          expect(
+            await browser.elementByCss('#slow-layout-message').text()
+          ).toBe('hello from slow layout')
+
+          expect(await browser.elementByCss('#slow-page-message').text()).toBe(
+            'hello from slow page'
+          )
+        })
+      })
+
+      describe('middleware', () => {
+        it.each(['rewrite', 'redirect'])(
+          `should strip internal query parameters from requests to middleware for %s`,
+          async (method) => {
+            const browser = await webdriver(next.url, '/internal')
 
             try {
-              await browser.waitForElementByCss('#router-ready')
-              expect(await browser.elementById('key-value').text()).toBe(
-                keyValue
-              )
-              expect(await browser.elementById('pathname').text()).toBe(
-                pathname
-              )
-
-              await browser.elementByCss('button').click()
-              await browser.waitForElementByCss('#pushed')
+              // Wait for and click the navigation element, this should trigger
+              // the flight request that'll be caught by the middleware. If the
+              // middleware sees any flight data on the request it'll redirect to
+              // a page with an element of #failure, otherwise, we'll see the
+              // element for #success.
+              await browser
+                .waitForElementByCss(`#navigate-${method}`)
+                .elementById(`navigate-${method}`)
+                .click()
+              expect(
+                await browser.waitForElementByCss('#success', 3000).text()
+              ).toBe('Success')
             } finally {
               await browser.close()
             }
@@ -1205,1221 +941,1483 @@ describe('app dir', () => {
         )
       })
 
-      describe('usePathname', () => {
-        it('should have the correct pathname', async () => {
-          const html = await renderViaHTTP(next.url, '/hooks/use-pathname')
-          const $ = cheerio.load(html)
-          expect($('#pathname').attr('data-pathname')).toBe(
-            '/hooks/use-pathname'
+      describe('next/router', () => {
+        it('should support router.back and router.forward', async () => {
+          const browser = await webdriver(next.url, '/back-forward/1')
+
+          const firstMessage = 'Hello from 1'
+          const secondMessage = 'Hello from 2'
+
+          expect(await browser.elementByCss('#message-1').text()).toBe(
+            firstMessage
           )
-        })
-
-        it('should have the canonical url pathname on rewrite', async () => {
-          const html = await renderViaHTTP(next.url, '/rewritten-use-pathname')
-          const $ = cheerio.load(html)
-          expect($('#pathname').attr('data-pathname')).toBe(
-            '/rewritten-use-pathname'
-          )
-        })
-      })
-
-      describe('useSearchParams', () => {
-        it('should have the correct search params', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/hooks/use-search-params?first=value&second=other%20value&third'
-          )
-          const $ = cheerio.load(html)
-          expect($('#params-first').text()).toBe('value')
-          expect($('#params-second').text()).toBe('other value')
-          expect($('#params-third').text()).toBe('')
-          expect($('#params-not-real').text()).toBe('N/A')
-        })
-
-        // TODO-APP: correct this behavior when deployed
-        if (!(global as any).isNextDeploy) {
-          it('should have the canonical url search params on rewrite', async () => {
-            const html = await renderViaHTTP(
-              next.url,
-              '/rewritten-use-search-params?first=a&second=b&third=c'
-            )
-            const $ = cheerio.load(html)
-            expect($('#params-first').text()).toBe('a')
-            expect($('#params-second').text()).toBe('b')
-            expect($('#params-third').text()).toBe('c')
-            expect($('#params-not-real').text()).toBe('N/A')
-          })
-        }
-      })
-
-      describe('useRouter', () => {
-        it('should allow access to the router', async () => {
-          const browser = await webdriver(next.url, '/hooks/use-router')
 
           try {
-            // Wait for the page to load, click the button (which uses a method
-            // on the router) and then wait for the correct page to load.
-            await browser.waitForElementByCss('#router')
-            await browser.elementById('button-push').click()
-            await browser.waitForElementByCss('#router-sub-page')
+            const message2 = await browser
+              .waitForElementByCss('#to-other-page')
+              .click()
+              .waitForElementByCss('#message-2')
+              .text()
+            expect(message2).toBe(secondMessage)
 
-            // Go back (confirming we did do a hard push), and wait for the
-            // correct previous page.
-            await browser.back()
-            await browser.waitForElementByCss('#router')
+            const message1 = await browser
+              .waitForElementByCss('#back-button')
+              .click()
+              .waitForElementByCss('#message-1')
+              .text()
+            expect(message1).toBe(firstMessage)
+
+            const message2Again = await browser
+              .waitForElementByCss('#forward-button')
+              .click()
+              .waitForElementByCss('#message-2')
+              .text()
+            expect(message2Again).toBe(secondMessage)
           } finally {
             await browser.close()
           }
         })
+      })
 
-        if (!(global as any).isNextDeploy) {
-          it('should have consistent query and params handling', async () => {
-            const html = await renderViaHTTP(
-              next.url,
-              '/param-and-query/params?slug=query'
-            )
-            const $ = cheerio.load(html)
-            const el = $('#params-and-query')
-            expect(el.attr('data-params')).toBe('params')
-            expect(el.attr('data-query')).toBe('query')
+      describe('hooks', () => {
+        describe('cookies function', () => {
+          it('should retrieve cookies in a server component', async () => {
+            const browser = await webdriver(next.url, '/hooks/use-cookies')
+
+            try {
+              await browser.waitForElementByCss('#does-not-have-cookie')
+              browser.addCookie({ name: 'use-cookies', value: 'value' })
+              browser.refresh()
+
+              await browser.waitForElementByCss('#has-cookie')
+              browser.deleteCookies()
+              browser.refresh()
+
+              await browser.waitForElementByCss('#does-not-have-cookie')
+            } finally {
+              await browser.close()
+            }
           })
-        }
-      })
 
-      describe('useSelectedLayoutSegments', () => {
-        it.each`
-          path                                                           | outerLayout                                             | innerLayout
-          ${'/hooks/use-selected-layout-segment/first'}                  | ${['first']}                                            | ${[]}
-          ${'/hooks/use-selected-layout-segment/first/slug1'}            | ${['first', 'slug1']}                                   | ${['slug1']}
-          ${'/hooks/use-selected-layout-segment/first/slug2/second'}     | ${['first', 'slug2', '(group)', 'second']}              | ${['slug2', '(group)', 'second']}
-          ${'/hooks/use-selected-layout-segment/first/slug2/second/a/b'} | ${['first', 'slug2', '(group)', 'second', 'a/b']}       | ${['slug2', '(group)', 'second', 'a/b']}
-          ${'/hooks/use-selected-layout-segment/rewritten'}              | ${['first', 'slug3', '(group)', 'second', 'catch/all']} | ${['slug3', '(group)', 'second', 'catch/all']}
-          ${'/hooks/use-selected-layout-segment/rewritten-middleware'}   | ${['first', 'slug3', '(group)', 'second', 'catch/all']} | ${['slug3', '(group)', 'second', 'catch/all']}
-        `(
-          'should have the correct layout segments at $path',
-          async ({ path, outerLayout, innerLayout }) => {
-            const html = await renderViaHTTP(next.url, path)
-            const $ = cheerio.load(html)
+          it('should retrieve cookies in a server component in the edge runtime', async () => {
+            const res = await fetchViaHTTP(next.url, '/edge-apis/cookies')
+            expect(await res.text()).toInclude('Hello')
+          })
 
-            expect(JSON.parse($('#outer-layout').text())).toEqual(outerLayout)
-            expect(JSON.parse($('#inner-layout').text())).toEqual(innerLayout)
-          }
-        )
+          it('should access cookies on <Link /> navigation', async () => {
+            const browser = await webdriver(next.url, '/navigation')
 
-        it('should return an empty array in pages', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
-          )
-          const $ = cheerio.load(html)
+            try {
+              // Click the cookies link to verify it can't see the cookie that's
+              // not there.
+              await browser.elementById('use-cookies').click()
+              await browser.waitForElementByCss('#does-not-have-cookie')
 
-          expect(JSON.parse($('#page-layout-segments').text())).toEqual([])
-        })
-      })
+              // Go back and add the cookies.
+              await browser.back()
+              await browser.waitForElementByCss('#from-navigation')
+              browser.addCookie({ name: 'use-cookies', value: 'value' })
 
-      describe('useSelectedLayoutSegment', () => {
-        it.each`
-          path                                                           | outerLayout | innerLayout
-          ${'/hooks/use-selected-layout-segment/first'}                  | ${'first'}  | ${null}
-          ${'/hooks/use-selected-layout-segment/first/slug1'}            | ${'first'}  | ${'slug1'}
-          ${'/hooks/use-selected-layout-segment/first/slug2/second/a/b'} | ${'first'}  | ${'slug2'}
-        `(
-          'should have the correct layout segment at $path',
-          async ({ path, outerLayout, innerLayout }) => {
-            const html = await renderViaHTTP(next.url, path)
-            const $ = cheerio.load(html)
+              // Click the cookies link again to see that the cookie can be picked
+              // up again.
+              await browser.elementById('use-cookies').click()
+              await browser.waitForElementByCss('#has-cookie')
 
-            expect(JSON.parse($('#outer-layout-segment').text())).toEqual(
-              outerLayout
-            )
-            expect(JSON.parse($('#inner-layout-segment').text())).toEqual(
-              innerLayout
-            )
-          }
-        )
+              // Go back and remove the cookies.
+              await browser.back()
+              await browser.waitForElementByCss('#from-navigation')
+              browser.deleteCookies()
 
-        it('should return null in pages', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
-          )
-          const $ = cheerio.load(html)
-
-          expect(JSON.parse($('#page-layout-segment').text())).toEqual(null)
-        })
-      })
-    })
-  })
-
-  describe('css support', () => {
-    describe('server layouts', () => {
-      it('should support global css inside server layouts', async () => {
-        const browser = await webdriver(next.url, '/dashboard')
-
-        // Should body text in red
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('.p')).color`
-          )
-        ).toBe('rgb(255, 0, 0)')
-
-        // Should inject global css for .green selectors
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('.green')).color`
-          )
-        ).toBe('rgb(0, 128, 0)')
-      })
-
-      it('should support css modules inside server layouts', async () => {
-        const browser = await webdriver(next.url, '/css/css-nested')
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#server-cssm')).color`
-          )
-        ).toBe('rgb(0, 128, 0)')
-      })
-    })
-
-    describe('server pages', () => {
-      it('should support global css inside server pages', async () => {
-        const browser = await webdriver(next.url, '/css/css-page')
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('h1')).color`
-          )
-        ).toBe('rgb(255, 0, 0)')
-      })
-
-      it('should support css modules inside server pages', async () => {
-        const browser = await webdriver(next.url, '/css/css-page')
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#cssm')).color`
-          )
-        ).toBe('rgb(0, 0, 255)')
-      })
-
-      if (!isDev) {
-        it('should not include unused css modules in the page in prod', async () => {
-          const browser = await webdriver(next.url, '/css/css-page/unused')
-          expect(
-            await browser.eval(
-              `[...document.styleSheets].some(({ rules }) => [...rules].some(rule => rule.selectorText.includes('this_should_not_be_included')))`
-            )
-          ).toBe(false)
+              // Verify for the last time that after clicking the cookie link
+              // again, there are no cookies.
+              await browser.elementById('use-cookies').click()
+              await browser.waitForElementByCss('#does-not-have-cookie')
+            } finally {
+              await browser.close()
+            }
+          })
         })
 
-        it('should not include unused css modules in nested pages in prod', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/css/css-page/unused-nested/inner'
-          )
-          expect(
-            await browser.eval(
-              `[...document.styleSheets].some(({ rules }) => [...rules].some(rule => rule.selectorText.includes('this_should_not_be_included_in_inner_path')))`
+        describe('headers function', () => {
+          it('should have access to incoming headers in a server component', async () => {
+            // Check to see that we can't see the header when it's not present.
+            let html = await renderViaHTTP(
+              next.url,
+              '/hooks/use-headers',
+              {},
+              { headers: {} }
             )
-          ).toBe(false)
+            let $ = cheerio.load(html)
+            expect($('#does-not-have-header').length).toBe(1)
+            expect($('#has-header').length).toBe(0)
+
+            // Check to see that we can see the header when it's present.
+            html = await renderViaHTTP(
+              next.url,
+              '/hooks/use-headers',
+              {},
+              { headers: { 'x-use-headers': 'value' } }
+            )
+            $ = cheerio.load(html)
+            expect($('#has-header').length).toBe(1)
+            expect($('#does-not-have-header').length).toBe(0)
+          })
+
+          it('should access headers on <Link /> navigation', async () => {
+            const browser = await webdriver(next.url, '/navigation')
+
+            try {
+              await browser.elementById('use-headers').click()
+              await browser.waitForElementByCss('#has-referer')
+            } finally {
+              await browser.close()
+            }
+          })
         })
-      }
-    })
 
-    describe('client layouts', () => {
-      it('should support css modules inside client layouts', async () => {
-        const browser = await webdriver(next.url, '/client-nested')
+        describe('previewData function', () => {
+          it('should return no preview data when there is none', async () => {
+            const browser = await webdriver(next.url, '/hooks/use-preview-data')
 
-        // Should render h1 in red
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('h1')).color`
-          )
-        ).toBe('rgb(255, 0, 0)')
-      })
+            try {
+              await browser.waitForElementByCss('#does-not-have-preview-data')
+            } finally {
+              await browser.close()
+            }
+          })
 
-      it('should support global css inside client layouts', async () => {
-        const browser = await webdriver(next.url, '/client-nested')
+          it('should return preview data when there is some', async () => {
+            const browser = await webdriver(next.url, '/api/preview')
 
-        // Should render button in red
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('button')).color`
-          )
-        ).toBe('rgb(255, 0, 0)')
-      })
-    })
+            try {
+              await browser.loadPage(next.url + '/hooks/use-preview-data', {
+                disableCache: false,
+                beforePageLoad: null,
+              })
+              await browser.waitForElementByCss('#has-preview-data')
+            } finally {
+              await browser.close()
+            }
+          })
+        })
 
-    describe('client pages', () => {
-      it('should support css modules inside client pages', async () => {
-        const browser = await webdriver(next.url, '/client-component-route')
+        describe('useRouter', () => {
+          // TODO-APP: should enable when implemented
+          it.skip('should throw an error when imported', async () => {
+            const res = await fetchViaHTTP(next.url, '/hooks/use-router/server')
+            expect(res.status).toBe(500)
+            expect(await res.text()).toContain('Internal Server Error')
+          })
+        })
 
-        // Should render p in red
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('p')).color`
-          )
-        ).toBe('rgb(255, 0, 0)')
-      })
+        describe('useParams', () => {
+          // TODO-APP: should enable when implemented
+          it.skip('should throw an error when imported', async () => {
+            const res = await fetchViaHTTP(next.url, '/hooks/use-params/server')
+            expect(res.status).toBe(500)
+            expect(await res.text()).toContain('Internal Server Error')
+          })
+        })
 
-      it('should support global css inside client pages', async () => {
-        const browser = await webdriver(next.url, '/client-component-route')
+        describe('useSearchParams', () => {
+          // TODO-APP: should enable when implemented
+          it.skip('should throw an error when imported', async () => {
+            const res = await fetchViaHTTP(
+              next.url,
+              '/hooks/use-search-params/server'
+            )
+            expect(res.status).toBe(500)
+            expect(await res.text()).toContain('Internal Server Error')
+          })
+        })
 
-        // Should render `b` in blue
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('b')).color`
-          )
-        ).toBe('rgb(0, 0, 255)')
+        describe('usePathname', () => {
+          // TODO-APP: should enable when implemented
+          it.skip('should throw an error when imported', async () => {
+            const res = await fetchViaHTTP(
+              next.url,
+              '/hooks/use-pathname/server'
+            )
+            expect(res.status).toBe(500)
+            expect(await res.text()).toContain('Internal Server Error')
+          })
+        })
+
+        describe('useLayoutSegments', () => {
+          // TODO-APP: should enable when implemented
+          it.skip('should throw an error when imported', async () => {
+            const res = await fetchViaHTTP(
+              next.url,
+              '/hooks/use-layout-segments/server'
+            )
+            expect(res.status).toBe(500)
+            expect(await res.text()).toContain('Internal Server Error')
+          })
+        })
+
+        describe('useSelectedLayoutSegment', () => {
+          // TODO-APP: should enable when implemented
+          it.skip('should throw an error when imported', async () => {
+            const res = await fetchViaHTTP(
+              next.url,
+              '/hooks/use-selected-layout-segment/server'
+            )
+            expect(res.status).toBe(500)
+            expect(await res.text()).toContain('Internal Server Error')
+          })
+        })
       })
     })
 
     describe('client components', () => {
-      it('should support css modules inside client page', async () => {
-        const browser = await webdriver(next.url, '/css/css-client')
+      describe('hooks', () => {
+        describe('from pages', () => {
+          it.each([
+            { pathname: '/adapter-hooks/static' },
+            { pathname: '/adapter-hooks/1' },
+            { pathname: '/adapter-hooks/2' },
+            { pathname: '/adapter-hooks/1/account' },
+            { pathname: '/adapter-hooks/static', keyValue: 'value' },
+            { pathname: '/adapter-hooks/1', keyValue: 'value' },
+            { pathname: '/adapter-hooks/2', keyValue: 'value' },
+            { pathname: '/adapter-hooks/1/account', keyValue: 'value' },
+          ])(
+            'should have the correct hooks',
+            async ({ pathname, keyValue = '' }) => {
+              const browser = await webdriver(
+                next.url,
+                pathname + (keyValue ? `?key=${keyValue}` : '')
+              )
 
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#css-modules')).fontSize`
+              try {
+                await browser.waitForElementByCss('#router-ready')
+                expect(await browser.elementById('key-value').text()).toBe(
+                  keyValue
+                )
+                expect(await browser.elementById('pathname').text()).toBe(
+                  pathname
+                )
+
+                await browser.elementByCss('button').click()
+                await browser.waitForElementByCss('#pushed')
+              } finally {
+                await browser.close()
+              }
+            }
           )
-        ).toBe('100px')
-      })
+        })
 
-      it('should support css modules inside client components', async () => {
-        const browser = await webdriver(next.url, '/css/css-client/inner')
+        describe('usePathname', () => {
+          it('should have the correct pathname', async () => {
+            const html = await renderViaHTTP(next.url, '/hooks/use-pathname')
+            const $ = cheerio.load(html)
+            expect($('#pathname').attr('data-pathname')).toBe(
+              '/hooks/use-pathname'
+            )
+          })
 
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#client-component')).fontSize`
+          it('should have the canonical url pathname on rewrite', async () => {
+            const html = await renderViaHTTP(
+              next.url,
+              '/rewritten-use-pathname'
+            )
+            const $ = cheerio.load(html)
+            expect($('#pathname').attr('data-pathname')).toBe(
+              '/rewritten-use-pathname'
+            )
+          })
+        })
+
+        describe('useSearchParams', () => {
+          it('should have the correct search params', async () => {
+            const html = await renderViaHTTP(
+              next.url,
+              '/hooks/use-search-params?first=value&second=other%20value&third'
+            )
+            const $ = cheerio.load(html)
+            expect($('#params-first').text()).toBe('value')
+            expect($('#params-second').text()).toBe('other value')
+            expect($('#params-third').text()).toBe('')
+            expect($('#params-not-real').text()).toBe('N/A')
+          })
+
+          // TODO-APP: correct this behavior when deployed
+          if (!isNextDeploy) {
+            it('should have the canonical url search params on rewrite', async () => {
+              const html = await renderViaHTTP(
+                next.url,
+                '/rewritten-use-search-params?first=a&second=b&third=c'
+              )
+              const $ = cheerio.load(html)
+              expect($('#params-first').text()).toBe('a')
+              expect($('#params-second').text()).toBe('b')
+              expect($('#params-third').text()).toBe('c')
+              expect($('#params-not-real').text()).toBe('N/A')
+            })
+          }
+        })
+
+        describe('useRouter', () => {
+          it('should allow access to the router', async () => {
+            const browser = await webdriver(next.url, '/hooks/use-router')
+
+            try {
+              // Wait for the page to load, click the button (which uses a method
+              // on the router) and then wait for the correct page to load.
+              await browser.waitForElementByCss('#router')
+              await browser.elementById('button-push').click()
+              await browser.waitForElementByCss('#router-sub-page')
+
+              // Go back (confirming we did do a hard push), and wait for the
+              // correct previous page.
+              await browser.back()
+              await browser.waitForElementByCss('#router')
+            } finally {
+              await browser.close()
+            }
+          })
+
+          if (!isNextDeploy) {
+            it('should have consistent query and params handling', async () => {
+              const html = await renderViaHTTP(
+                next.url,
+                '/param-and-query/params?slug=query'
+              )
+              const $ = cheerio.load(html)
+              const el = $('#params-and-query')
+              expect(el.attr('data-params')).toBe('params')
+              expect(el.attr('data-query')).toBe('query')
+            })
+          }
+        })
+
+        describe('useSelectedLayoutSegments', () => {
+          it.each`
+            path                                                           | outerLayout                                             | innerLayout
+            ${'/hooks/use-selected-layout-segment/first'}                  | ${['first']}                                            | ${[]}
+            ${'/hooks/use-selected-layout-segment/first/slug1'}            | ${['first', 'slug1']}                                   | ${['slug1']}
+            ${'/hooks/use-selected-layout-segment/first/slug2/second'}     | ${['first', 'slug2', '(group)', 'second']}              | ${['slug2', '(group)', 'second']}
+            ${'/hooks/use-selected-layout-segment/first/slug2/second/a/b'} | ${['first', 'slug2', '(group)', 'second', 'a/b']}       | ${['slug2', '(group)', 'second', 'a/b']}
+            ${'/hooks/use-selected-layout-segment/rewritten'}              | ${['first', 'slug3', '(group)', 'second', 'catch/all']} | ${['slug3', '(group)', 'second', 'catch/all']}
+            ${'/hooks/use-selected-layout-segment/rewritten-middleware'}   | ${['first', 'slug3', '(group)', 'second', 'catch/all']} | ${['slug3', '(group)', 'second', 'catch/all']}
+          `(
+            'should have the correct layout segments at $path',
+            async ({ path, outerLayout, innerLayout }) => {
+              const html = await renderViaHTTP(next.url, path)
+              const $ = cheerio.load(html)
+
+              expect(JSON.parse($('#outer-layout').text())).toEqual(outerLayout)
+              expect(JSON.parse($('#inner-layout').text())).toEqual(innerLayout)
+            }
           )
-        ).toBe('100px')
+
+          it('should return an empty array in pages', async () => {
+            const html = await renderViaHTTP(
+              next.url,
+              '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
+            )
+            const $ = cheerio.load(html)
+
+            expect(JSON.parse($('#page-layout-segments').text())).toEqual([])
+          })
+        })
+
+        describe('useSelectedLayoutSegment', () => {
+          it.each`
+            path                                                           | outerLayout | innerLayout
+            ${'/hooks/use-selected-layout-segment/first'}                  | ${'first'}  | ${null}
+            ${'/hooks/use-selected-layout-segment/first/slug1'}            | ${'first'}  | ${'slug1'}
+            ${'/hooks/use-selected-layout-segment/first/slug2/second/a/b'} | ${'first'}  | ${'slug2'}
+          `(
+            'should have the correct layout segment at $path',
+            async ({ path, outerLayout, innerLayout }) => {
+              const html = await renderViaHTTP(next.url, path)
+              const $ = cheerio.load(html)
+
+              expect(JSON.parse($('#outer-layout-segment').text())).toEqual(
+                outerLayout
+              )
+              expect(JSON.parse($('#inner-layout-segment').text())).toEqual(
+                innerLayout
+              )
+            }
+          )
+
+          it('should return null in pages', async () => {
+            const html = await renderViaHTTP(
+              next.url,
+              '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
+            )
+            const $ = cheerio.load(html)
+
+            expect(JSON.parse($('#page-layout-segment').text())).toEqual(null)
+          })
+        })
       })
     })
 
-    describe('special entries', () => {
-      it('should include css imported in loading.js', async () => {
-        const html = await renderViaHTTP(next.url, '/loading-bug/hi')
-        // The link tag should be included together with loading
-        expect(html).toMatch(
-          /<link rel="stylesheet" href="(.+)\.css"\/><h2>Loading...<\/h2>/
-        )
+    describe('css support', () => {
+      describe('server layouts', () => {
+        it('should support global css inside server layouts', async () => {
+          const browser = await webdriver(next.url, '/dashboard')
+
+          // Should body text in red
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('.p')).color`
+            )
+          ).toBe('rgb(255, 0, 0)')
+
+          // Should inject global css for .green selectors
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('.green')).color`
+            )
+          ).toBe('rgb(0, 128, 0)')
+        })
+
+        it('should support css modules inside server layouts', async () => {
+          const browser = await webdriver(next.url, '/css/css-nested')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#server-cssm')).color`
+            )
+          ).toBe('rgb(0, 128, 0)')
+        })
       })
 
-      it('should include css imported in client template.js', async () => {
-        const browser = await webdriver(next.url, '/template/clientcomponent')
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('button')).fontSize`
-          )
-        ).toBe('100px')
-      })
+      describe('server pages', () => {
+        it('should support global css inside server pages', async () => {
+          const browser = await webdriver(next.url, '/css/css-page')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('h1')).color`
+            )
+          ).toBe('rgb(255, 0, 0)')
+        })
 
-      it('should include css imported in server template.js', async () => {
-        const browser = await webdriver(next.url, '/template/servercomponent')
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('h1')).color`
-          )
-        ).toBe('rgb(255, 0, 0)')
-      })
+        it('should support css modules inside server pages', async () => {
+          const browser = await webdriver(next.url, '/css/css-page')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#cssm')).color`
+            )
+          ).toBe('rgb(0, 0, 255)')
+        })
 
-      it('should include css imported in client not-found.js', async () => {
-        const browser = await webdriver(next.url, '/not-found/clientcomponent')
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('h1')).color`
-          )
-        ).toBe('rgb(255, 0, 0)')
-      })
+        if (!isDev) {
+          it('should not include unused css modules in the page in prod', async () => {
+            const browser = await webdriver(next.url, '/css/css-page/unused')
+            expect(
+              await browser.eval(
+                `[...document.styleSheets].some(({ rules }) => [...rules].some(rule => rule.selectorText.includes('this_should_not_be_included')))`
+              )
+            ).toBe(false)
+          })
 
-      it('should include css imported in server not-found.js', async () => {
-        const browser = await webdriver(next.url, '/not-found/servercomponent')
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('h1')).color`
-          )
-        ).toBe('rgb(255, 0, 0)')
-      })
-
-      it('should include css imported in error.js', async () => {
-        const browser = await webdriver(next.url, '/error/client-component')
-        await browser.elementByCss('button').click()
-
-        // Wait for error page to render and CSS to be loaded
-        await new Promise((resolve) => setTimeout(resolve, 2000))
-
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('button')).fontSize`
-          )
-        ).toBe('50px')
-      })
-    })
-  })
-
-  if (isDev) {
-    describe('HMR', () => {
-      it('should support HMR for CSS imports in server components', async () => {
-        const filePath = 'app/css/css-page/style.css'
-        const origContent = await next.readFile(filePath)
-
-        // h1 should be red
-        const browser = await webdriver(next.url, '/css/css-page')
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('h1')).color`
-          )
-        ).toBe('rgb(255, 0, 0)')
-
-        try {
-          await next.patchFile(filePath, origContent.replace('red', 'blue'))
-
-          // Wait for HMR to trigger
-          await check(
-            () =>
-              browser.eval(
-                `window.getComputedStyle(document.querySelector('h1')).color`
-              ),
-            'rgb(0, 0, 255)'
-          )
-        } finally {
-          await next.patchFile(filePath, origContent)
+          it('should not include unused css modules in nested pages in prod', async () => {
+            const browser = await webdriver(
+              next.url,
+              '/css/css-page/unused-nested/inner'
+            )
+            expect(
+              await browser.eval(
+                `[...document.styleSheets].some(({ rules }) => [...rules].some(rule => rule.selectorText.includes('this_should_not_be_included_in_inner_path')))`
+              )
+            ).toBe(false)
+          })
         }
       })
 
-      it('should support HMR for CSS imports in client components', async () => {
-        const filePath = 'app/css/css-client/client-page.css'
-        const origContent = await next.readFile(filePath)
+      describe('client layouts', () => {
+        it('should support css modules inside client layouts', async () => {
+          const browser = await webdriver(next.url, '/client-nested')
 
-        // h1 should be red
-        const browser = await webdriver(next.url, '/css/css-client')
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('h1')).color`
-          )
-        ).toBe('rgb(255, 0, 0)')
+          // Should render h1 in red
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('h1')).color`
+            )
+          ).toBe('rgb(255, 0, 0)')
+        })
 
-        try {
-          await next.patchFile(filePath, origContent.replace('red', 'blue'))
+        it('should support global css inside client layouts', async () => {
+          const browser = await webdriver(next.url, '/client-nested')
 
-          await check(
-            () =>
-              browser.eval(
-                `window.getComputedStyle(document.querySelector('h1')).color`
-              ),
-            'rgb(0, 0, 255)'
-          )
-        } finally {
-          await next.patchFile(filePath, origContent)
-        }
+          // Should render button in red
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('button')).color`
+            )
+          ).toBe('rgb(255, 0, 0)')
+        })
       })
 
-      it('should HMR correctly for server component', async () => {
-        const filePath = 'app/dashboard/index/page.js'
-        const origContent = await next.readFile(filePath)
-
-        try {
-          const browser = await webdriver(next.url, '/dashboard/index')
-          expect(await browser.elementByCss('p').text()).toContain(
-            'hello from app/dashboard/index'
-          )
-
-          await next.patchFile(
-            filePath,
-            origContent.replace('hello from', 'swapped from')
-          )
-
-          await check(() => browser.elementByCss('p').text(), /swapped from/)
-        } finally {
-          await next.patchFile(filePath, origContent)
-        }
-      })
-
-      it('should HMR correctly for client component', async () => {
-        const filePath = 'app/client-component-route/page.js'
-        const origContent = await next.readFile(filePath)
-
-        try {
+      describe('client pages', () => {
+        it('should support css modules inside client pages', async () => {
           const browser = await webdriver(next.url, '/client-component-route')
 
-          const ssrInitial = await renderViaHTTP(
-            next.url,
-            '/client-component-route'
-          )
-
-          expect(ssrInitial).toContain('hello from app/client-component-route')
-
-          expect(await browser.elementByCss('p').text()).toContain(
-            'hello from app/client-component-route'
-          )
-
-          await next.patchFile(
-            filePath,
-            origContent.replace('hello from', 'swapped from')
-          )
-
-          await check(() => browser.elementByCss('p').text(), /swapped from/)
-
-          const ssrUpdated = await renderViaHTTP(
-            next.url,
-            '/client-component-route'
-          )
-          expect(ssrUpdated).toContain('swapped from')
-
-          await next.patchFile(filePath, origContent)
-
-          await check(() => browser.elementByCss('p').text(), /hello from/)
+          // Should render p in red
           expect(
-            await renderViaHTTP(next.url, '/client-component-route')
-          ).toContain('hello from')
-        } finally {
-          await next.patchFile(filePath, origContent)
-        }
-      })
-
-      it('should HMR correctly when changing the component type', async () => {
-        const filePath = 'app/dashboard/page/page.jsx'
-        const origContent = await next.readFile(filePath)
-
-        try {
-          const browser = await webdriver(next.url, '/dashboard/page')
-
-          expect(await browser.elementByCss('p').text()).toContain(
-            'hello dashboard/page!'
-          )
-
-          // Test HMR with server component
-          await next.patchFile(
-            filePath,
-            origContent.replace(
-              'hello dashboard/page!',
-              'hello dashboard/page in server component!'
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('p')).color`
             )
-          )
-          await check(
-            () => browser.elementByCss('p').text(),
-            /in server component/
-          )
+          ).toBe('rgb(255, 0, 0)')
+        })
 
-          // Change to client component
-          await next.patchFile(
-            filePath,
-            origContent
-              .replace("// 'use client'", "'use client'")
-              .replace(
-                'hello dashboard/page!',
-                'hello dashboard/page in client component!'
-              )
-          )
-          await check(
-            () => browser.elementByCss('p').text(),
-            /in client component/
-          )
+        it('should support global css inside client pages', async () => {
+          const browser = await webdriver(next.url, '/client-component-route')
 
-          // Change back to server component
-          await next.patchFile(
-            filePath,
-            origContent.replace(
-              'hello dashboard/page!',
-              'hello dashboard/page in server component2!'
+          // Should render `b` in blue
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('b')).color`
             )
-          )
-          await check(
-            () => browser.elementByCss('p').text(),
-            /in server component2/
-          )
+          ).toBe('rgb(0, 0, 255)')
+        })
+      })
 
-          // Change to client component again
-          await next.patchFile(
-            filePath,
-            origContent
-              .replace("// 'use client'", "'use client'")
-              .replace(
+      describe('client components', () => {
+        it('should support css modules inside client page', async () => {
+          const browser = await webdriver(next.url, '/css/css-client')
+
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#css-modules')).fontSize`
+            )
+          ).toBe('100px')
+        })
+
+        it('should support css modules inside client components', async () => {
+          const browser = await webdriver(next.url, '/css/css-client/inner')
+
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#client-component')).fontSize`
+            )
+          ).toBe('100px')
+        })
+      })
+
+      describe('special entries', () => {
+        it('should include css imported in loading.js', async () => {
+          const html = await renderViaHTTP(next.url, '/loading-bug/hi')
+          // The link tag should be included together with loading
+          expect(html).toMatch(
+            /<link rel="stylesheet" href="(.+)\.css"\/><h2>Loading...<\/h2>/
+          )
+        })
+
+        it('should include css imported in client template.js', async () => {
+          const browser = await webdriver(next.url, '/template/clientcomponent')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('button')).fontSize`
+            )
+          ).toBe('100px')
+        })
+
+        it('should include css imported in server template.js', async () => {
+          const browser = await webdriver(next.url, '/template/servercomponent')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('h1')).color`
+            )
+          ).toBe('rgb(255, 0, 0)')
+        })
+
+        it('should include css imported in client not-found.js', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/not-found/clientcomponent'
+          )
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('h1')).color`
+            )
+          ).toBe('rgb(255, 0, 0)')
+        })
+
+        it('should include css imported in server not-found.js', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/not-found/servercomponent'
+          )
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('h1')).color`
+            )
+          ).toBe('rgb(255, 0, 0)')
+        })
+
+        it('should include css imported in error.js', async () => {
+          const browser = await webdriver(next.url, '/error/client-component')
+          await browser.elementByCss('button').click()
+
+          // Wait for error page to render and CSS to be loaded
+          await new Promise((resolve) => setTimeout(resolve, 2000))
+
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('button')).fontSize`
+            )
+          ).toBe('50px')
+        })
+      })
+    })
+
+    if (isDev) {
+      describe('HMR', () => {
+        it('should support HMR for CSS imports in server components', async () => {
+          const filePath = 'app/css/css-page/style.css'
+          const origContent = await next.readFile(filePath)
+
+          // h1 should be red
+          const browser = await webdriver(next.url, '/css/css-page')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('h1')).color`
+            )
+          ).toBe('rgb(255, 0, 0)')
+
+          try {
+            await next.patchFile(filePath, origContent.replace('red', 'blue'))
+
+            // Wait for HMR to trigger
+            await check(
+              () =>
+                browser.eval(
+                  `window.getComputedStyle(document.querySelector('h1')).color`
+                ),
+              'rgb(0, 0, 255)'
+            )
+          } finally {
+            await next.patchFile(filePath, origContent)
+          }
+        })
+
+        it('should support HMR for CSS imports in client components', async () => {
+          const filePath = 'app/css/css-client/client-page.css'
+          const origContent = await next.readFile(filePath)
+
+          // h1 should be red
+          const browser = await webdriver(next.url, '/css/css-client')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('h1')).color`
+            )
+          ).toBe('rgb(255, 0, 0)')
+
+          try {
+            await next.patchFile(filePath, origContent.replace('red', 'blue'))
+
+            await check(
+              () =>
+                browser.eval(
+                  `window.getComputedStyle(document.querySelector('h1')).color`
+                ),
+              'rgb(0, 0, 255)'
+            )
+          } finally {
+            await next.patchFile(filePath, origContent)
+          }
+        })
+
+        it('should HMR correctly for server component', async () => {
+          const filePath = 'app/dashboard/index/page.js'
+          const origContent = await next.readFile(filePath)
+
+          try {
+            const browser = await webdriver(next.url, '/dashboard/index')
+            expect(await browser.elementByCss('p').text()).toContain(
+              'hello from app/dashboard/index'
+            )
+
+            await next.patchFile(
+              filePath,
+              origContent.replace('hello from', 'swapped from')
+            )
+
+            await check(() => browser.elementByCss('p').text(), /swapped from/)
+          } finally {
+            await next.patchFile(filePath, origContent)
+          }
+        })
+
+        it('should HMR correctly for client component', async () => {
+          const filePath = 'app/client-component-route/page.js'
+          const origContent = await next.readFile(filePath)
+
+          try {
+            const browser = await webdriver(next.url, '/client-component-route')
+
+            const ssrInitial = await renderViaHTTP(
+              next.url,
+              '/client-component-route'
+            )
+
+            expect(ssrInitial).toContain(
+              'hello from app/client-component-route'
+            )
+
+            expect(await browser.elementByCss('p').text()).toContain(
+              'hello from app/client-component-route'
+            )
+
+            await next.patchFile(
+              filePath,
+              origContent.replace('hello from', 'swapped from')
+            )
+
+            await check(() => browser.elementByCss('p').text(), /swapped from/)
+
+            const ssrUpdated = await renderViaHTTP(
+              next.url,
+              '/client-component-route'
+            )
+            expect(ssrUpdated).toContain('swapped from')
+
+            await next.patchFile(filePath, origContent)
+
+            await check(() => browser.elementByCss('p').text(), /hello from/)
+            expect(
+              await renderViaHTTP(next.url, '/client-component-route')
+            ).toContain('hello from')
+          } finally {
+            await next.patchFile(filePath, origContent)
+          }
+        })
+
+        it('should HMR correctly when changing the component type', async () => {
+          const filePath = 'app/dashboard/page/page.jsx'
+          const origContent = await next.readFile(filePath)
+
+          try {
+            const browser = await webdriver(next.url, '/dashboard/page')
+
+            expect(await browser.elementByCss('p').text()).toContain(
+              'hello dashboard/page!'
+            )
+
+            // Test HMR with server component
+            await next.patchFile(
+              filePath,
+              origContent.replace(
                 'hello dashboard/page!',
-                'hello dashboard/page in client component2!'
+                'hello dashboard/page in server component!'
               )
+            )
+            await check(
+              () => browser.elementByCss('p').text(),
+              /in server component/
+            )
+
+            // Change to client component
+            await next.patchFile(
+              filePath,
+              origContent
+                .replace("// 'use client'", "'use client'")
+                .replace(
+                  'hello dashboard/page!',
+                  'hello dashboard/page in client component!'
+                )
+            )
+            await check(
+              () => browser.elementByCss('p').text(),
+              /in client component/
+            )
+
+            // Change back to server component
+            await next.patchFile(
+              filePath,
+              origContent.replace(
+                'hello dashboard/page!',
+                'hello dashboard/page in server component2!'
+              )
+            )
+            await check(
+              () => browser.elementByCss('p').text(),
+              /in server component2/
+            )
+
+            // Change to client component again
+            await next.patchFile(
+              filePath,
+              origContent
+                .replace("// 'use client'", "'use client'")
+                .replace(
+                  'hello dashboard/page!',
+                  'hello dashboard/page in client component2!'
+                )
+            )
+            await check(
+              () => browser.elementByCss('p').text(),
+              /in client component2/
+            )
+          } finally {
+            await next.patchFile(filePath, origContent)
+          }
+        })
+      })
+    }
+
+    describe('searchParams prop', () => {
+      describe('client component', () => {
+        it('should have the correct search params', async () => {
+          const html = await renderViaHTTP(
+            next.url,
+            '/search-params-prop?first=value&second=other%20value&third'
           )
-          await check(
-            () => browser.elementByCss('p').text(),
-            /in client component2/
+          const $ = cheerio.load(html)
+          const el = $('#params')
+          expect(el.attr('data-param-first')).toBe('value')
+          expect(el.attr('data-param-second')).toBe('other value')
+          expect(el.attr('data-param-third')).toBe('')
+          expect(el.attr('data-param-not-real')).toBe('N/A')
+        })
+
+        it('should have the correct search params on rewrite', async () => {
+          const html = await renderViaHTTP(
+            next.url,
+            '/search-params-prop-rewrite'
           )
-        } finally {
-          await next.patchFile(filePath, origContent)
-        }
+          const $ = cheerio.load(html)
+          const el = $('#params')
+          expect(el.attr('data-param-first')).toBe('value')
+          expect(el.attr('data-param-second')).toBe('other value')
+          expect(el.attr('data-param-third')).toBe('')
+          expect(el.attr('data-param-not-real')).toBe('N/A')
+        })
+
+        it('should have the correct search params on middleware rewrite', async () => {
+          const html = await renderViaHTTP(
+            next.url,
+            '/search-params-prop-middleware-rewrite'
+          )
+          const $ = cheerio.load(html)
+          const el = $('#params')
+          expect(el.attr('data-param-first')).toBe('value')
+          expect(el.attr('data-param-second')).toBe('other value')
+          expect(el.attr('data-param-third')).toBe('')
+          expect(el.attr('data-param-not-real')).toBe('N/A')
+        })
+      })
+
+      describe('server component', () => {
+        it('should have the correct search params', async () => {
+          const html = await renderViaHTTP(
+            next.url,
+            '/search-params-prop/server?first=value&second=other%20value&third'
+          )
+          const $ = cheerio.load(html)
+          const el = $('#params')
+          expect(el.attr('data-param-first')).toBe('value')
+          expect(el.attr('data-param-second')).toBe('other value')
+          expect(el.attr('data-param-third')).toBe('')
+          expect(el.attr('data-param-not-real')).toBe('N/A')
+        })
+
+        it('should have the correct search params on rewrite', async () => {
+          const html = await renderViaHTTP(
+            next.url,
+            '/search-params-prop-server-rewrite'
+          )
+          const $ = cheerio.load(html)
+          const el = $('#params')
+          expect(el.attr('data-param-first')).toBe('value')
+          expect(el.attr('data-param-second')).toBe('other value')
+          expect(el.attr('data-param-third')).toBe('')
+          expect(el.attr('data-param-not-real')).toBe('N/A')
+        })
+
+        it('should have the correct search params on middleware rewrite', async () => {
+          const html = await renderViaHTTP(
+            next.url,
+            '/search-params-prop-server-middleware-rewrite'
+          )
+          const $ = cheerio.load(html)
+          const el = $('#params')
+          expect(el.attr('data-param-first')).toBe('value')
+          expect(el.attr('data-param-second')).toBe('other value')
+          expect(el.attr('data-param-third')).toBe('')
+          expect(el.attr('data-param-not-real')).toBe('N/A')
+        })
       })
     })
-  }
 
-  describe('searchParams prop', () => {
-    describe('client component', () => {
-      it('should have the correct search params', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/search-params-prop?first=value&second=other%20value&third'
-        )
-        const $ = cheerio.load(html)
-        const el = $('#params')
-        expect(el.attr('data-param-first')).toBe('value')
-        expect(el.attr('data-param-second')).toBe('other value')
-        expect(el.attr('data-param-third')).toBe('')
-        expect(el.attr('data-param-not-real')).toBe('N/A')
+    describe('sass support', () => {
+      describe('server layouts', () => {
+        it('should support global sass/scss inside server layouts', async () => {
+          const browser = await webdriver(next.url, '/css/sass/inner')
+          // .sass
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#sass-server-layout')).color`
+            )
+          ).toBe('rgb(165, 42, 42)')
+          // .scss
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#scss-server-layout')).color`
+            )
+          ).toBe('rgb(222, 184, 135)')
+        })
+
+        it('should support sass/scss modules inside server layouts', async () => {
+          const browser = await webdriver(next.url, '/css/sass/inner')
+          // .sass
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#sass-server-layout')).backgroundColor`
+            )
+          ).toBe('rgb(233, 150, 122)')
+          // .scss
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#scss-server-layout')).backgroundColor`
+            )
+          ).toBe('rgb(139, 0, 0)')
+        })
       })
 
-      it('should have the correct search params on rewrite', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/search-params-prop-rewrite'
-        )
-        const $ = cheerio.load(html)
-        const el = $('#params')
-        expect(el.attr('data-param-first')).toBe('value')
-        expect(el.attr('data-param-second')).toBe('other value')
-        expect(el.attr('data-param-third')).toBe('')
-        expect(el.attr('data-param-not-real')).toBe('N/A')
+      describe('server pages', () => {
+        it('should support global sass/scss inside server pages', async () => {
+          const browser = await webdriver(next.url, '/css/sass/inner')
+          // .sass
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#sass-server-page')).color`
+            )
+          ).toBe('rgb(245, 222, 179)')
+          // .scss
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#scss-server-page')).color`
+            )
+          ).toBe('rgb(255, 99, 71)')
+        })
+
+        it('should support sass/scss modules inside server pages', async () => {
+          const browser = await webdriver(next.url, '/css/sass/inner')
+          // .sass
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#sass-server-page')).backgroundColor`
+            )
+          ).toBe('rgb(75, 0, 130)')
+          // .scss
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#scss-server-page')).backgroundColor`
+            )
+          ).toBe('rgb(0, 255, 255)')
+        })
       })
 
-      it('should have the correct search params on middleware rewrite', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/search-params-prop-middleware-rewrite'
-        )
-        const $ = cheerio.load(html)
-        const el = $('#params')
-        expect(el.attr('data-param-first')).toBe('value')
-        expect(el.attr('data-param-second')).toBe('other value')
-        expect(el.attr('data-param-third')).toBe('')
-        expect(el.attr('data-param-not-real')).toBe('N/A')
+      describe('client layouts', () => {
+        it('should support global sass/scss inside client layouts', async () => {
+          const browser = await webdriver(next.url, '/css/sass-client/inner')
+          // .sass
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#sass-client-layout')).color`
+            )
+          ).toBe('rgb(165, 42, 42)')
+          // .scss
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#scss-client-layout')).color`
+            )
+          ).toBe('rgb(222, 184, 135)')
+        })
+
+        it('should support sass/scss modules inside client layouts', async () => {
+          const browser = await webdriver(next.url, '/css/sass-client/inner')
+          // .sass
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#sass-client-layout')).backgroundColor`
+            )
+          ).toBe('rgb(233, 150, 122)')
+          // .scss
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#scss-client-layout')).backgroundColor`
+            )
+          ).toBe('rgb(139, 0, 0)')
+        })
       })
     })
 
-    describe('server component', () => {
-      it('should have the correct search params', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/search-params-prop/server?first=value&second=other%20value&third'
-        )
-        const $ = cheerio.load(html)
-        const el = $('#params')
-        expect(el.attr('data-param-first')).toBe('value')
-        expect(el.attr('data-param-second')).toBe('other value')
-        expect(el.attr('data-param-third')).toBe('')
-        expect(el.attr('data-param-not-real')).toBe('N/A')
-      })
+    describe('client pages', () => {
+      it('should support global sass/scss inside client pages', async () => {
+        const browser = await webdriver(next.url, '/css/sass-client/inner')
 
-      it('should have the correct search params on rewrite', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/search-params-prop-server-rewrite'
-        )
-        const $ = cheerio.load(html)
-        const el = $('#params')
-        expect(el.attr('data-param-first')).toBe('value')
-        expect(el.attr('data-param-second')).toBe('other value')
-        expect(el.attr('data-param-third')).toBe('')
-        expect(el.attr('data-param-not-real')).toBe('N/A')
-      })
-
-      it('should have the correct search params on middleware rewrite', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/search-params-prop-server-middleware-rewrite'
-        )
-        const $ = cheerio.load(html)
-        const el = $('#params')
-        expect(el.attr('data-param-first')).toBe('value')
-        expect(el.attr('data-param-second')).toBe('other value')
-        expect(el.attr('data-param-third')).toBe('')
-        expect(el.attr('data-param-not-real')).toBe('N/A')
-      })
-    })
-  })
-
-  describe('sass support', () => {
-    describe('server layouts', () => {
-      it('should support global sass/scss inside server layouts', async () => {
-        const browser = await webdriver(next.url, '/css/sass/inner')
         // .sass
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#sass-server-layout')).color`
-          )
-        ).toBe('rgb(165, 42, 42)')
+        await check(
+          () =>
+            browser.eval(
+              `window.getComputedStyle(document.querySelector('#sass-client-page')).color`
+            ),
+          'rgb(245, 222, 179)'
+        )
         // .scss
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#scss-server-layout')).color`
-          )
-        ).toBe('rgb(222, 184, 135)')
+        await check(
+          () =>
+            browser.eval(
+              `window.getComputedStyle(document.querySelector('#scss-client-page')).color`
+            ),
+          'rgb(255, 99, 71)'
+        )
       })
 
-      it('should support sass/scss modules inside server layouts', async () => {
-        const browser = await webdriver(next.url, '/css/sass/inner')
+      it('should support sass/scss modules inside client pages', async () => {
+        const browser = await webdriver(next.url, '/css/sass-client/inner')
         // .sass
         expect(
           await browser.eval(
-            `window.getComputedStyle(document.querySelector('#sass-server-layout')).backgroundColor`
-          )
-        ).toBe('rgb(233, 150, 122)')
-        // .scss
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#scss-server-layout')).backgroundColor`
-          )
-        ).toBe('rgb(139, 0, 0)')
-      })
-    })
-
-    describe('server pages', () => {
-      it('should support global sass/scss inside server pages', async () => {
-        const browser = await webdriver(next.url, '/css/sass/inner')
-        // .sass
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#sass-server-page')).color`
-          )
-        ).toBe('rgb(245, 222, 179)')
-        // .scss
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#scss-server-page')).color`
-          )
-        ).toBe('rgb(255, 99, 71)')
-      })
-
-      it('should support sass/scss modules inside server pages', async () => {
-        const browser = await webdriver(next.url, '/css/sass/inner')
-        // .sass
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#sass-server-page')).backgroundColor`
+            `window.getComputedStyle(document.querySelector('#sass-client-page')).backgroundColor`
           )
         ).toBe('rgb(75, 0, 130)')
         // .scss
         expect(
           await browser.eval(
-            `window.getComputedStyle(document.querySelector('#scss-server-page')).backgroundColor`
+            `window.getComputedStyle(document.querySelector('#scss-client-page')).backgroundColor`
           )
         ).toBe('rgb(0, 255, 255)')
       })
     })
-
-    describe('client layouts', () => {
-      it('should support global sass/scss inside client layouts', async () => {
-        const browser = await webdriver(next.url, '/css/sass-client/inner')
-        // .sass
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#sass-client-layout')).color`
-          )
-        ).toBe('rgb(165, 42, 42)')
-        // .scss
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#scss-client-layout')).color`
-          )
-        ).toBe('rgb(222, 184, 135)')
-      })
-
-      it('should support sass/scss modules inside client layouts', async () => {
-        const browser = await webdriver(next.url, '/css/sass-client/inner')
-        // .sass
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#sass-client-layout')).backgroundColor`
-          )
-        ).toBe('rgb(233, 150, 122)')
-        // .scss
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('#scss-client-layout')).backgroundColor`
-          )
-        ).toBe('rgb(139, 0, 0)')
-      })
-    })
-  })
-
-  describe('client pages', () => {
-    it('should support global sass/scss inside client pages', async () => {
-      const browser = await webdriver(next.url, '/css/sass-client/inner')
-
-      // .sass
-      await check(
-        () =>
-          browser.eval(
-            `window.getComputedStyle(document.querySelector('#sass-client-page')).color`
-          ),
-        'rgb(245, 222, 179)'
-      )
-      // .scss
-      await check(
-        () =>
-          browser.eval(
-            `window.getComputedStyle(document.querySelector('#scss-client-page')).color`
-          ),
-        'rgb(255, 99, 71)'
-      )
-    })
-
-    it('should support sass/scss modules inside client pages', async () => {
-      const browser = await webdriver(next.url, '/css/sass-client/inner')
-      // .sass
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.querySelector('#sass-client-page')).backgroundColor`
-        )
-      ).toBe('rgb(75, 0, 130)')
-      // .scss
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.querySelector('#scss-client-page')).backgroundColor`
-        )
-      ).toBe('rgb(0, 255, 255)')
-    })
-  })
-  ;(isDev ? describe.skip : describe)('Subresource Integrity', () => {
-    function fetchWithPolicy(policy: string | null) {
-      return fetchViaHTTP(next.url, '/dashboard', undefined, {
-        headers: policy
-          ? {
-              'Content-Security-Policy': policy,
-            }
-          : {},
-      })
-    }
-
-    async function renderWithPolicy(policy: string | null) {
-      const res = await fetchWithPolicy(policy)
-
-      expect(res.ok).toBe(true)
-
-      const html = await res.text()
-
-      return cheerio.load(html)
-    }
-
-    it('does not include nonce when not enabled', async () => {
-      const policies = [
-        `script-src 'nonce-'`, // invalid nonce
-        'style-src "nonce-cmFuZG9tCg=="', // no script or default src
-        '', // empty string
-      ]
-
-      for (const policy of policies) {
-        const $ = await renderWithPolicy(policy)
-
-        // Find all the script tags without src attributes and with nonce
-        // attributes.
-        const elements = $('script[nonce]:not([src])')
-
-        // Expect there to be none.
-        expect(elements.length).toBe(0)
-      }
-    })
-
-    it('includes a nonce value with inline scripts when Content-Security-Policy header is defined', async () => {
-      // A random nonce value, base64 encoded.
-      const nonce = 'cmFuZG9tCg=='
-
-      // Validate all the cases where we could parse the nonce.
-      const policies = [
-        `script-src 'nonce-${nonce}'`, // base case
-        `   script-src   'nonce-${nonce}' `, // extra space added around sources and directive
-        `style-src 'self'; script-src 'nonce-${nonce}'`, // extra directives
-        `script-src 'self' 'nonce-${nonce}' 'nonce-othernonce'`, // extra nonces
-        `default-src 'nonce-othernonce'; script-src 'nonce-${nonce}';`, // script and then fallback case
-        `default-src 'nonce-${nonce}'`, // fallback case
-      ]
-
-      for (const policy of policies) {
-        const $ = await renderWithPolicy(policy)
-
-        // Find all the script tags without src attributes.
-        const elements = $('script:not([src])')
-
-        // Expect there to be at least 1 script tag without a src attribute.
-        expect(elements.length).toBeGreaterThan(0)
-
-        // Expect all inline scripts to have the nonce value.
-        elements.each((i, el) => {
-          expect(el.attribs['nonce']).toBe(nonce)
+    ;(isDev ? describe.skip : describe)('Subresource Integrity', () => {
+      function fetchWithPolicy(policy: string | null) {
+        return fetchViaHTTP(next.url, '/dashboard', undefined, {
+          headers: policy
+            ? {
+                'Content-Security-Policy': policy,
+              }
+            : {},
         })
       }
-    })
 
-    it('includes an integrity attribute on scripts', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard')
+      async function renderWithPolicy(policy: string | null) {
+        const res = await fetchWithPolicy(policy)
 
-      const $ = cheerio.load(html)
+        expect(res.ok).toBe(true)
 
-      // Find all the script tags with src attributes.
-      const elements = $('script[src]')
+        const html = await res.text()
 
-      // Expect there to be at least 1 script tag with a src attribute.
-      expect(elements.length).toBeGreaterThan(0)
+        return cheerio.load(html)
+      }
 
-      // Collect all the scripts with integrity hashes so we can verify them.
-      const files: [string, string][] = []
+      it('does not include nonce when not enabled', async () => {
+        const policies = [
+          `script-src 'nonce-'`, // invalid nonce
+          'style-src "nonce-cmFuZG9tCg=="', // no script or default src
+          '', // empty string
+        ]
 
-      // For each of these attributes, ensure that there's an integrity
-      // attribute and starts with the correct integrity hash prefix.
-      elements.each((i, el) => {
-        const integrity = el.attribs['integrity']
-        expect(integrity).toBeDefined()
-        expect(integrity).toStartWith('sha256-')
+        for (const policy of policies) {
+          const $ = await renderWithPolicy(policy)
 
-        const src = el.attribs['src']
-        expect(src).toBeDefined()
+          // Find all the script tags without src attributes and with nonce
+          // attributes.
+          const elements = $('script[nonce]:not([src])')
 
-        files.push([src, integrity])
+          // Expect there to be none.
+          expect(elements.length).toBe(0)
+        }
       })
 
-      // For each script tag, ensure that the integrity attribute is the
-      // correct hash of the script tag.
-      for (const [src, integrity] of files) {
-        const res = await fetchViaHTTP(next.url, src)
-        expect(res.status).toBe(200)
-        const content = await res.text()
+      it('includes a nonce value with inline scripts when Content-Security-Policy header is defined', async () => {
+        // A random nonce value, base64 encoded.
+        const nonce = 'cmFuZG9tCg=='
 
-        const hash = crypto
-          .createHash('sha256')
-          .update(content)
-          .digest()
-          .toString('base64')
+        // Validate all the cases where we could parse the nonce.
+        const policies = [
+          `script-src 'nonce-${nonce}'`, // base case
+          `   script-src   'nonce-${nonce}' `, // extra space added around sources and directive
+          `style-src 'self'; script-src 'nonce-${nonce}'`, // extra directives
+          `script-src 'self' 'nonce-${nonce}' 'nonce-othernonce'`, // extra nonces
+          `default-src 'nonce-othernonce'; script-src 'nonce-${nonce}';`, // script and then fallback case
+          `default-src 'nonce-${nonce}'`, // fallback case
+        ]
 
-        expect(integrity).toEndWith(hash)
-      }
+        for (const policy of policies) {
+          const $ = await renderWithPolicy(policy)
+
+          // Find all the script tags without src attributes.
+          const elements = $('script:not([src])')
+
+          // Expect there to be at least 1 script tag without a src attribute.
+          expect(elements.length).toBeGreaterThan(0)
+
+          // Expect all inline scripts to have the nonce value.
+          elements.each((i, el) => {
+            expect(el.attribs['nonce']).toBe(nonce)
+          })
+        }
+      })
+
+      it('includes an integrity attribute on scripts', async () => {
+        const html = await renderViaHTTP(next.url, '/dashboard')
+
+        const $ = cheerio.load(html)
+
+        // Find all the script tags with src attributes.
+        const elements = $('script[src]')
+
+        // Expect there to be at least 1 script tag with a src attribute.
+        expect(elements.length).toBeGreaterThan(0)
+
+        // Collect all the scripts with integrity hashes so we can verify them.
+        const files: [string, string][] = []
+
+        // For each of these attributes, ensure that there's an integrity
+        // attribute and starts with the correct integrity hash prefix.
+        elements.each((i, el) => {
+          const integrity = el.attribs['integrity']
+          expect(integrity).toBeDefined()
+          expect(integrity).toStartWith('sha256-')
+
+          const src = el.attribs['src']
+          expect(src).toBeDefined()
+
+          files.push([src, integrity])
+        })
+
+        // For each script tag, ensure that the integrity attribute is the
+        // correct hash of the script tag.
+        for (const [src, integrity] of files) {
+          const res = await fetchViaHTTP(next.url, src)
+          expect(res.status).toBe(200)
+          const content = await res.text()
+
+          const hash = crypto
+            .createHash('sha256')
+            .update(content)
+            .digest()
+            .toString('base64')
+
+          expect(integrity).toEndWith(hash)
+        }
+      })
+
+      it('throws when escape characters are included in nonce', async () => {
+        const res = await fetchWithPolicy(
+          `script-src 'nonce-"><script></script>"'`
+        )
+
+        expect(res.status).toBe(500)
+      })
     })
 
-    it('throws when escape characters are included in nonce', async () => {
-      const res = await fetchWithPolicy(
-        `script-src 'nonce-"><script></script>"'`
-      )
-
-      expect(res.status).toBe(500)
-    })
-  })
-
-  describe('template component', () => {
-    it('should render the template that holds state in a client component and reset on navigation', async () => {
-      const browser = await webdriver(next.url, '/template/clientcomponent')
-      expect(await browser.elementByCss('h1').text()).toBe('Template 0')
-      await browser.elementByCss('button').click()
-      expect(await browser.elementByCss('h1').text()).toBe('Template 1')
-
-      await browser.elementByCss('#link').click()
-      await browser.waitForElementByCss('#other-page')
-
-      expect(await browser.elementByCss('h1').text()).toBe('Template 0')
-      await browser.elementByCss('button').click()
-      expect(await browser.elementByCss('h1').text()).toBe('Template 1')
-
-      await browser.elementByCss('#link').click()
-      await browser.waitForElementByCss('#page')
-
-      expect(await browser.elementByCss('h1').text()).toBe('Template 0')
-    })
-
-    // TODO-APP: disable failing test and investigate later
-    ;(isDev ? it.skip : it)(
-      'should render the template that is a server component and rerender on navigation',
-      async () => {
-        const browser = await webdriver(next.url, '/template/servercomponent')
-        // eslint-disable-next-line jest/no-standalone-expect
-        expect(await browser.elementByCss('h1').text()).toStartWith('Template')
-
-        const currentTime = await browser
-          .elementByCss('#performance-now')
-          .text()
+    describe('template component', () => {
+      it('should render the template that holds state in a client component and reset on navigation', async () => {
+        const browser = await webdriver(next.url, '/template/clientcomponent')
+        expect(await browser.elementByCss('h1').text()).toBe('Template 0')
+        await browser.elementByCss('button').click()
+        expect(await browser.elementByCss('h1').text()).toBe('Template 1')
 
         await browser.elementByCss('#link').click()
         await browser.waitForElementByCss('#other-page')
 
-        // eslint-disable-next-line jest/no-standalone-expect
-        expect(await browser.elementByCss('h1').text()).toStartWith('Template')
-
-        // template should rerender on navigation even when it's a server component
-        // eslint-disable-next-line jest/no-standalone-expect
-        expect(await browser.elementByCss('#performance-now').text()).toBe(
-          currentTime
-        )
+        expect(await browser.elementByCss('h1').text()).toBe('Template 0')
+        await browser.elementByCss('button').click()
+        expect(await browser.elementByCss('h1').text()).toBe('Template 1')
 
         await browser.elementByCss('#link').click()
         await browser.waitForElementByCss('#page')
 
-        // eslint-disable-next-line jest/no-standalone-expect
-        expect(await browser.elementByCss('#performance-now').text()).toBe(
-          currentTime
-        )
-      }
-    )
-  })
+        expect(await browser.elementByCss('h1').text()).toBe('Template 0')
+      })
 
-  describe('error component', () => {
-    it('should trigger error component when an error happens during rendering', async () => {
-      const browser = await webdriver(next.url, '/error/client-component')
-      await browser.elementByCss('#error-trigger-button').click()
+      // TODO-APP: disable failing test and investigate later
+      ;(isDev ? it.skip : it)(
+        'should render the template that is a server component and rerender on navigation',
+        async () => {
+          const browser = await webdriver(next.url, '/template/servercomponent')
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(await browser.elementByCss('h1').text()).toStartWith(
+            'Template'
+          )
 
-      if (isDev) {
-        expect(await hasRedbox(browser)).toBe(true)
-        expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
-      } else {
-        await browser
-        expect(
-          await browser
-            .waitForElementByCss('#error-boundary-message')
-            .elementByCss('#error-boundary-message')
+          const currentTime = await browser
+            .elementByCss('#performance-now')
             .text()
-        ).toBe('An error occurred: this is a test')
-      }
-    })
 
-    it('should trigger error component when an error happens during server components rendering', async () => {
-      const browser = await webdriver(next.url, '/error/server-component')
+          await browser.elementByCss('#link').click()
+          await browser.waitForElementByCss('#other-page')
 
-      if (isDev) {
-        expect(
-          await browser
-            .waitForElementByCss('#error-boundary-message')
-            .elementByCss('#error-boundary-message')
-            .text()
-        ).toBe('this is a test')
-        expect(
-          await browser.waitForElementByCss('#error-boundary-digest').text()
-          // Digest of the error message should be stable.
-        ).not.toBe('')
-        // TODO-APP: ensure error overlay is shown for errors that happened before/during hydration
-        // expect(await hasRedbox(browser)).toBe(true)
-        // expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
-      } else {
-        await browser
-        expect(
-          await browser.waitForElementByCss('#error-boundary-message').text()
-        ).toBe(
-          'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
-        )
-        expect(
-          await browser.waitForElementByCss('#error-boundary-digest').text()
-          // Digest of the error message should be stable.
-        ).not.toBe('')
-      }
-    })
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(await browser.elementByCss('h1').text()).toStartWith(
+            'Template'
+          )
 
-    it('should use default error boundary for prod and overlay for dev when no error component specified', async () => {
-      const browser = await webdriver(
-        next.url,
-        '/error/global-error-boundary/client'
+          // template should rerender on navigation even when it's a server component
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(await browser.elementByCss('#performance-now').text()).toBe(
+            currentTime
+          )
+
+          await browser.elementByCss('#link').click()
+          await browser.waitForElementByCss('#page')
+
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(await browser.elementByCss('#performance-now').text()).toBe(
+            currentTime
+          )
+        }
       )
-      await browser.elementByCss('#error-trigger-button').click()
-
-      if (isDev) {
-        expect(await hasRedbox(browser)).toBe(true)
-        expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
-      } else {
-        expect(
-          await browser.waitForElementByCss('body').elementByCss('h2').text()
-        ).toBe(
-          'Application error: a client-side exception has occurred (see the browser console for more information).'
-        )
-      }
     })
 
-    it('should display error digest for error in server component with default error boundary', async () => {
-      const browser = await webdriver(
-        next.url,
-        '/error/global-error-boundary/server'
-      )
-
-      if (isDev) {
-        expect(await hasRedbox(browser)).toBe(true)
-        expect(await getRedboxHeader(browser)).toMatch(/custom server error/)
-      } else {
-        expect(
-          await browser.waitForElementByCss('body').elementByCss('h2').text()
-        ).toBe(
-          'Application error: a client-side exception has occurred (see the browser console for more information).'
-        )
-        expect(
-          await browser.waitForElementByCss('body').elementByCss('p').text()
-        ).toMatch(/Digest: \w+/)
-      }
-    })
-
-    if (!isDev) {
-      it('should allow resetting error boundary', async () => {
+    describe('error component', () => {
+      it('should trigger error component when an error happens during rendering', async () => {
         const browser = await webdriver(next.url, '/error/client-component')
+        await browser.elementByCss('#error-trigger-button').click()
 
-        // Try triggering and resetting a few times in a row
-        for (let i = 0; i < 5; i++) {
+        if (isDev) {
+          expect(await hasRedbox(browser)).toBe(true)
+          expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
+        } else {
           await browser
-            .elementByCss('#error-trigger-button')
-            .click()
-            .waitForElementByCss('#error-boundary-message')
-
           expect(
-            await browser.elementByCss('#error-boundary-message').text()
+            await browser
+              .waitForElementByCss('#error-boundary-message')
+              .elementByCss('#error-boundary-message')
+              .text()
           ).toBe('An error occurred: this is a test')
-
-          await browser
-            .elementByCss('#reset')
-            .click()
-            .waitForElementByCss('#error-trigger-button')
-
-          expect(
-            await browser.elementByCss('#error-trigger-button').text()
-          ).toBe('Trigger Error!')
         }
       })
 
-      it('should hydrate empty shell to handle server-side rendering errors', async () => {
+      it('should trigger error component when an error happens during server components rendering', async () => {
+        const browser = await webdriver(next.url, '/error/server-component')
+
+        if (isDev) {
+          expect(
+            await browser
+              .waitForElementByCss('#error-boundary-message')
+              .elementByCss('#error-boundary-message')
+              .text()
+          ).toBe('this is a test')
+          expect(
+            await browser.waitForElementByCss('#error-boundary-digest').text()
+            // Digest of the error message should be stable.
+          ).not.toBe('')
+          // TODO-APP: ensure error overlay is shown for errors that happened before/during hydration
+          // expect(await hasRedbox(browser)).toBe(true)
+          // expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
+        } else {
+          await browser
+          expect(
+            await browser.waitForElementByCss('#error-boundary-message').text()
+          ).toBe(
+            'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
+          )
+          expect(
+            await browser.waitForElementByCss('#error-boundary-digest').text()
+            // Digest of the error message should be stable.
+          ).not.toBe('')
+        }
+      })
+
+      it('should use default error boundary for prod and overlay for dev when no error component specified', async () => {
         const browser = await webdriver(
           next.url,
-          '/error/ssr-error-client-component'
+          '/error/global-error-boundary/client'
         )
-        const logs = await browser.log()
-        const errors = logs
-          .filter((x) => x.source === 'error')
-          .map((x) => x.message)
-          .join('\n')
-        expect(errors).toInclude('Error during SSR')
-      })
-    }
-  })
+        await browser.elementByCss('#error-trigger-button').click()
 
-  describe('known bugs', () => {
-    describe('should support React cache', () => {
-      it('server component', async () => {
+        if (isDev) {
+          expect(await hasRedbox(browser)).toBe(true)
+          expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
+        } else {
+          expect(
+            await browser.waitForElementByCss('body').elementByCss('h2').text()
+          ).toBe(
+            'Application error: a client-side exception has occurred (see the browser console for more information).'
+          )
+        }
+      })
+
+      it('should display error digest for error in server component with default error boundary', async () => {
         const browser = await webdriver(
           next.url,
-          '/react-cache/server-component'
+          '/error/global-error-boundary/server'
         )
-        const val1 = await browser.elementByCss('#value-1').text()
-        const val2 = await browser.elementByCss('#value-2').text()
-        expect(val1).toBe(val2)
+
+        if (isDev) {
+          expect(await hasRedbox(browser)).toBe(true)
+          expect(await getRedboxHeader(browser)).toMatch(/custom server error/)
+        } else {
+          expect(
+            await browser.waitForElementByCss('body').elementByCss('h2').text()
+          ).toBe(
+            'Application error: a client-side exception has occurred (see the browser console for more information).'
+          )
+          expect(
+            await browser.waitForElementByCss('body').elementByCss('p').text()
+          ).toMatch(/Digest: \w+/)
+        }
       })
 
-      it('server component client-navigation', async () => {
-        const browser = await webdriver(next.url, '/react-cache')
+      if (!isDev) {
+        it('should allow resetting error boundary', async () => {
+          const browser = await webdriver(next.url, '/error/client-component')
 
-        await browser
-          .elementByCss('#to-server-component')
-          .click()
-          .waitForElementByCss('#value-1', 10000)
-        const val1 = await browser.elementByCss('#value-1').text()
-        const val2 = await browser.elementByCss('#value-2').text()
-        expect(val1).toBe(val2)
-      })
+          // Try triggering and resetting a few times in a row
+          for (let i = 0; i < 5; i++) {
+            await browser
+              .elementByCss('#error-trigger-button')
+              .click()
+              .waitForElementByCss('#error-boundary-message')
 
-      it('client component', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/react-cache/client-component'
-        )
-        const val1 = await browser.elementByCss('#value-1').text()
-        const val2 = await browser.elementByCss('#value-2').text()
-        expect(val1).toBe(val2)
-      })
+            expect(
+              await browser.elementByCss('#error-boundary-message').text()
+            ).toBe('An error occurred: this is a test')
 
-      it('client component client-navigation', async () => {
-        const browser = await webdriver(next.url, '/react-cache')
+            await browser
+              .elementByCss('#reset')
+              .click()
+              .waitForElementByCss('#error-trigger-button')
 
-        await browser
-          .elementByCss('#to-client-component')
-          .click()
-          .waitForElementByCss('#value-1', 10000)
-        const val1 = await browser.elementByCss('#value-1').text()
-        const val2 = await browser.elementByCss('#value-2').text()
-        expect(val1).toBe(val2)
-      })
-    })
+            expect(
+              await browser.elementByCss('#error-trigger-button').text()
+            ).toBe('Trigger Error!')
+          }
+        })
 
-    describe('should support React fetch instrumentation', () => {
-      it('server component', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/react-fetch/server-component'
-        )
-        const val1 = await browser.elementByCss('#value-1').text()
-        const val2 = await browser.elementByCss('#value-2').text()
-        expect(val1).toBe(val2)
-      })
-
-      it('server component client-navigation', async () => {
-        const browser = await webdriver(next.url, '/react-fetch')
-
-        await browser
-          .elementByCss('#to-server-component')
-          .click()
-          .waitForElementByCss('#value-1', 10000)
-        const val1 = await browser.elementByCss('#value-1').text()
-        const val2 = await browser.elementByCss('#value-2').text()
-        expect(val1).toBe(val2)
-      })
-
-      // TODO-APP: React doesn't have fetch deduping for client components yet.
-      it.skip('client component', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/react-fetch/client-component'
-        )
-        const val1 = await browser.elementByCss('#value-1').text()
-        const val2 = await browser.elementByCss('#value-2').text()
-        expect(val1).toBe(val2)
-      })
-
-      // TODO-APP: React doesn't have fetch deduping for client components yet.
-      it.skip('client component client-navigation', async () => {
-        const browser = await webdriver(next.url, '/react-fetch')
-
-        await browser
-          .elementByCss('#to-client-component')
-          .click()
-          .waitForElementByCss('#value-1', 10000)
-        const val1 = await browser.elementByCss('#value-1').text()
-        const val2 = await browser.elementByCss('#value-2').text()
-        expect(val1).toBe(val2)
-      })
-    })
-    it('should not share flight data between requests', async () => {
-      const fetches = await Promise.all(
-        [...new Array(5)].map(() =>
-          renderViaHTTP(next.url, '/loading-bug/electronics')
-        )
-      )
-
-      for (const text of fetches) {
-        const $ = cheerio.load(text)
-        expect($('#category-id').text()).toBe('electronicsabc')
+        it('should hydrate empty shell to handle server-side rendering errors', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/error/ssr-error-client-component'
+          )
+          const logs = await browser.log()
+          const errors = logs
+            .filter((x) => x.source === 'error')
+            .map((x) => x.message)
+            .join('\n')
+          expect(errors).toInclude('Error during SSR')
+        })
       }
     })
-    it('should handle as on next/link', async () => {
-      const browser = await webdriver(next.url, '/link-with-as')
-      expect(
-        await browser
-          .elementByCss('#link-to-info-123')
-          .click()
-          .waitForElementByCss('#message')
-          .text()
-      ).toBe(`hello from app/dashboard/deployments/info/[id]. ID is: 123`)
-    })
-    it('should handle next/link back to initially loaded page', async () => {
-      const browser = await webdriver(next.url, '/linking/about')
-      expect(
-        await browser
-          .elementByCss('a[href="/linking"]')
-          .click()
-          .waitForElementByCss('#home-page')
-          .text()
-      ).toBe(`Home page`)
 
-      expect(
-        await browser
-          .elementByCss('a[href="/linking/about"]')
-          .click()
-          .waitForElementByCss('#about-page')
-          .text()
-      ).toBe(`About page`)
-    })
-    it('should not do additional pushState when already on the page', async () => {
-      const browser = await webdriver(next.url, '/linking/about')
-      const goToLinkingPage = async () => {
+    describe('known bugs', () => {
+      describe('should support React cache', () => {
+        it('server component', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/react-cache/server-component'
+          )
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        it('server component client-navigation', async () => {
+          const browser = await webdriver(next.url, '/react-cache')
+
+          await browser
+            .elementByCss('#to-server-component')
+            .click()
+            .waitForElementByCss('#value-1', 10000)
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        it('client component', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/react-cache/client-component'
+          )
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        it('client component client-navigation', async () => {
+          const browser = await webdriver(next.url, '/react-cache')
+
+          await browser
+            .elementByCss('#to-client-component')
+            .click()
+            .waitForElementByCss('#value-1', 10000)
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+      })
+
+      describe('should support React fetch instrumentation', () => {
+        it('server component', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/react-fetch/server-component'
+          )
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        it('server component client-navigation', async () => {
+          const browser = await webdriver(next.url, '/react-fetch')
+
+          await browser
+            .elementByCss('#to-server-component')
+            .click()
+            .waitForElementByCss('#value-1', 10000)
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        // TODO-APP: React doesn't have fetch deduping for client components yet.
+        it.skip('client component', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/react-fetch/client-component'
+          )
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+
+        // TODO-APP: React doesn't have fetch deduping for client components yet.
+        it.skip('client component client-navigation', async () => {
+          const browser = await webdriver(next.url, '/react-fetch')
+
+          await browser
+            .elementByCss('#to-client-component')
+            .click()
+            .waitForElementByCss('#value-1', 10000)
+          const val1 = await browser.elementByCss('#value-1').text()
+          const val2 = await browser.elementByCss('#value-2').text()
+          expect(val1).toBe(val2)
+        })
+      })
+      it('should not share flight data between requests', async () => {
+        const fetches = await Promise.all(
+          [...new Array(5)].map(() =>
+            renderViaHTTP(next.url, '/loading-bug/electronics')
+          )
+        )
+
+        for (const text of fetches) {
+          const $ = cheerio.load(text)
+          expect($('#category-id').text()).toBe('electronicsabc')
+        }
+      })
+      it('should handle as on next/link', async () => {
+        const browser = await webdriver(next.url, '/link-with-as')
+        expect(
+          await browser
+            .elementByCss('#link-to-info-123')
+            .click()
+            .waitForElementByCss('#message')
+            .text()
+        ).toBe(`hello from app/dashboard/deployments/info/[id]. ID is: 123`)
+      })
+      it('should handle next/link back to initially loaded page', async () => {
+        const browser = await webdriver(next.url, '/linking/about')
         expect(
           await browser
             .elementByCss('a[href="/linking"]')
@@ -2427,244 +2425,264 @@ describe('app dir', () => {
             .waitForElementByCss('#home-page')
             .text()
         ).toBe(`Home page`)
-      }
 
-      await goToLinkingPage()
-      await waitFor(1000)
-      await goToLinkingPage()
-      await waitFor(1000)
-      await goToLinkingPage()
-      await waitFor(1000)
-
-      expect(
-        await browser.back().waitForElementByCss('#about-page', 2000).text()
-      ).toBe(`About page`)
-    })
-  })
-
-  describe('not-found', () => {
-    it('should trigger not-found in a server component', async () => {
-      const browser = await webdriver(next.url, '/not-found/servercomponent')
-
-      expect(
-        await browser.waitForElementByCss('#not-found-component').text()
-      ).toBe('Not Found!')
-      expect(
-        await browser
-          .waitForElementByCss('meta[name="robots"]')
-          .getAttribute('content')
-      ).toBe('noindex')
-    })
-
-    it('should trigger not-found in a client component', async () => {
-      const browser = await webdriver(next.url, '/not-found/clientcomponent')
-      expect(
-        await browser.waitForElementByCss('#not-found-component').text()
-      ).toBe('Not Found!')
-      expect(
-        await browser
-          .waitForElementByCss('meta[name="robots"]')
-          .getAttribute('content')
-      ).toBe('noindex')
-    })
-    it('should trigger not-found client-side', async () => {
-      const browser = await webdriver(next.url, '/not-found/client-side')
-      await browser
-        .elementByCss('button')
-        .click()
-        .waitForElementByCss('#not-found-component')
-      expect(await browser.elementByCss('#not-found-component').text()).toBe(
-        'Not Found!'
-      )
-      expect(
-        await browser
-          .waitForElementByCss('meta[name="robots"]')
-          .getAttribute('content')
-      ).toBe('noindex')
-    })
-  })
-
-  describe('bots', () => {
-    if (!(global as any).isNextDeploy) {
-      it('should block rendering for bots and return 404 status', async () => {
-        const res = await fetchViaHTTP(
-          next.url,
-          '/not-found/servercomponent',
-          '',
-          {
-            headers: {
-              'User-Agent': 'Googlebot',
-            },
-          }
-        )
-
-        expect(res.status).toBe(404)
-        expect(await res.text()).toInclude('"noindex"')
+        expect(
+          await browser
+            .elementByCss('a[href="/linking/about"]')
+            .click()
+            .waitForElementByCss('#about-page')
+            .text()
+        ).toBe(`About page`)
       })
-    }
-  })
+      it('should not do additional pushState when already on the page', async () => {
+        const browser = await webdriver(next.url, '/linking/about')
+        const goToLinkingPage = async () => {
+          expect(
+            await browser
+              .elementByCss('a[href="/linking"]')
+              .click()
+              .waitForElementByCss('#home-page')
+              .text()
+          ).toBe(`Home page`)
+        }
 
-  describe('redirect', () => {
-    describe('components', () => {
-      it('should redirect in a server component', async () => {
-        const browser = await webdriver(next.url, '/redirect/servercomponent')
-        await browser.waitForElementByCss('#result-page')
-        expect(await browser.elementByCss('#result-page').text()).toBe(
-          'Result Page'
-        )
+        await goToLinkingPage()
+        await waitFor(1000)
+        await goToLinkingPage()
+        await waitFor(1000)
+        await goToLinkingPage()
+        await waitFor(1000)
+
+        expect(
+          await browser.back().waitForElementByCss('#about-page', 2000).text()
+        ).toBe(`About page`)
+      })
+    })
+
+    describe('not-found', () => {
+      it('should trigger not-found in a server component', async () => {
+        const browser = await webdriver(next.url, '/not-found/servercomponent')
+
+        expect(
+          await browser.waitForElementByCss('#not-found-component').text()
+        ).toBe('Not Found!')
+        expect(
+          await browser
+            .waitForElementByCss('meta[name="robots"]')
+            .getAttribute('content')
+        ).toBe('noindex')
       })
 
-      it('should redirect in a client component', async () => {
-        const browser = await webdriver(next.url, '/redirect/clientcomponent')
-        await browser.waitForElementByCss('#result-page')
-        expect(await browser.elementByCss('#result-page').text()).toBe(
-          'Result Page'
-        )
+      it('should trigger not-found in a client component', async () => {
+        const browser = await webdriver(next.url, '/not-found/clientcomponent')
+        expect(
+          await browser.waitForElementByCss('#not-found-component').text()
+        ).toBe('Not Found!')
+        expect(
+          await browser
+            .waitForElementByCss('meta[name="robots"]')
+            .getAttribute('content')
+        ).toBe('noindex')
       })
-
-      // TODO-APP: Enable in development
-      it('should redirect client-side', async () => {
-        const browser = await webdriver(next.url, '/redirect/client-side')
+      it('should trigger not-found client-side', async () => {
+        const browser = await webdriver(next.url, '/not-found/client-side')
         await browser
           .elementByCss('button')
           .click()
-          .waitForElementByCss('#result-page')
-        // eslint-disable-next-line jest/no-standalone-expect
-        expect(await browser.elementByCss('#result-page').text()).toBe(
-          'Result Page'
+          .waitForElementByCss('#not-found-component')
+        expect(await browser.elementByCss('#not-found-component').text()).toBe(
+          'Not Found!'
         )
-      })
-    })
-
-    describe('next.config.js redirects', () => {
-      it('should redirect from next.config.js', async () => {
-        const browser = await webdriver(next.url, '/redirect/a')
-        expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
-        expect(await browser.url()).toBe(next.url + '/dashboard')
-      })
-
-      it('should redirect from next.config.js with link navigation', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/redirect/next-config-redirect'
-        )
-        await browser
-          .elementByCss('#redirect-a')
-          .click()
-          .waitForElementByCss('h1')
-        expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
-        expect(await browser.url()).toBe(next.url + '/dashboard')
-      })
-    })
-
-    describe('middleware redirects', () => {
-      it('should redirect from middleware', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/redirect-middleware-to-dashboard'
-        )
-        expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
-        expect(await browser.url()).toBe(next.url + '/dashboard')
-      })
-
-      it('should redirect from middleware with link navigation', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/redirect/next-middleware-redirect'
-        )
-        await browser
-          .elementByCss('#redirect-middleware')
-          .click()
-          .waitForElementByCss('h1')
-        expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
-        expect(await browser.url()).toBe(next.url + '/dashboard')
-      })
-    })
-  })
-
-  describe('nested navigation', () => {
-    it('should navigate to nested pages', async () => {
-      const browser = await webdriver(next.url, '/nested-navigation')
-      expect(await browser.elementByCss('h1').text()).toBe('Home')
-
-      const pages = [
-        ['Electronics', ['Phones', 'Tablets', 'Laptops']],
-        ['Clothing', ['Tops', 'Shorts', 'Shoes']],
-        ['Books', ['Fiction', 'Biography', 'Education']],
-      ] as const
-
-      for (const [category, subCategories] of pages) {
         expect(
           await browser
-            .elementByCss(
-              `a[href="/nested-navigation/${category.toLowerCase()}"]`
-            )
-            .click()
-            .waitForElementByCss(`#all-${category.toLowerCase()}`)
-            .text()
-        ).toBe(`All ${category}`)
+            .waitForElementByCss('meta[name="robots"]')
+            .getAttribute('content')
+        ).toBe('noindex')
+      })
+    })
 
-        for (const subcategory of subCategories) {
+    describe('bots', () => {
+      if (!isNextDeploy) {
+        it('should block rendering for bots and return 404 status', async () => {
+          const res = await fetchViaHTTP(
+            next.url,
+            '/not-found/servercomponent',
+            '',
+            {
+              headers: {
+                'User-Agent': 'Googlebot',
+              },
+            }
+          )
+
+          expect(res.status).toBe(404)
+          expect(await res.text()).toInclude('"noindex"')
+        })
+      }
+    })
+
+    describe('redirect', () => {
+      describe('components', () => {
+        it('should redirect in a server component', async () => {
+          const browser = await webdriver(next.url, '/redirect/servercomponent')
+          await browser.waitForElementByCss('#result-page')
+          expect(await browser.elementByCss('#result-page').text()).toBe(
+            'Result Page'
+          )
+        })
+
+        it('should redirect in a client component', async () => {
+          const browser = await webdriver(next.url, '/redirect/clientcomponent')
+          await browser.waitForElementByCss('#result-page')
+          expect(await browser.elementByCss('#result-page').text()).toBe(
+            'Result Page'
+          )
+        })
+
+        // TODO-APP: Enable in development
+        it('should redirect client-side', async () => {
+          const browser = await webdriver(next.url, '/redirect/client-side')
+          await browser
+            .elementByCss('button')
+            .click()
+            .waitForElementByCss('#result-page')
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(await browser.elementByCss('#result-page').text()).toBe(
+            'Result Page'
+          )
+        })
+      })
+
+      describe('next.config.js redirects', () => {
+        it('should redirect from next.config.js', async () => {
+          const browser = await webdriver(next.url, '/redirect/a')
+          expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
+          expect(await browser.url()).toBe(next.url + '/dashboard')
+        })
+
+        it('should redirect from next.config.js with link navigation', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/redirect/next-config-redirect'
+          )
+          await browser
+            .elementByCss('#redirect-a')
+            .click()
+            .waitForElementByCss('h1')
+          expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
+          expect(await browser.url()).toBe(next.url + '/dashboard')
+        })
+      })
+
+      describe('middleware redirects', () => {
+        it('should redirect from middleware', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/redirect-middleware-to-dashboard'
+          )
+          expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
+          expect(await browser.url()).toBe(next.url + '/dashboard')
+        })
+
+        it('should redirect from middleware with link navigation', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/redirect/next-middleware-redirect'
+          )
+          await browser
+            .elementByCss('#redirect-middleware')
+            .click()
+            .waitForElementByCss('h1')
+          expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
+          expect(await browser.url()).toBe(next.url + '/dashboard')
+        })
+      })
+    })
+
+    describe('nested navigation', () => {
+      it('should navigate to nested pages', async () => {
+        const browser = await webdriver(next.url, '/nested-navigation')
+        expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+        const pages = [
+          ['Electronics', ['Phones', 'Tablets', 'Laptops']],
+          ['Clothing', ['Tops', 'Shorts', 'Shoes']],
+          ['Books', ['Fiction', 'Biography', 'Education']],
+        ] as const
+
+        for (const [category, subCategories] of pages) {
           expect(
             await browser
               .elementByCss(
-                `a[href="/nested-navigation/${category.toLowerCase()}/${subcategory.toLowerCase()}"]`
+                `a[href="/nested-navigation/${category.toLowerCase()}"]`
               )
               .click()
-              .waitForElementByCss(`#${subcategory.toLowerCase()}`)
+              .waitForElementByCss(`#all-${category.toLowerCase()}`)
               .text()
-          ).toBe(`${subcategory}`)
+          ).toBe(`All ${category}`)
+
+          for (const subcategory of subCategories) {
+            expect(
+              await browser
+                .elementByCss(
+                  `a[href="/nested-navigation/${category.toLowerCase()}/${subcategory.toLowerCase()}"]`
+                )
+                .click()
+                .waitForElementByCss(`#${subcategory.toLowerCase()}`)
+                .text()
+            ).toBe(`${subcategory}`)
+          }
         }
-      }
-    })
-  })
-
-  describe('next/script', () => {
-    if (!(global as any).isNextDeploy) {
-      it('should support next/script and render in correct order', async () => {
-        const browser = await webdriver(next.url, '/script')
-
-        // Wait for lazyOnload scripts to be ready.
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-
-        expect(await browser.eval(`window._script_order`)).toStrictEqual([
-          1,
-          1.5,
-          2,
-          2.5,
-          'render',
-          3,
-          4,
-        ])
       })
-    }
-
-    it('should insert preload tags for beforeInteractive and afterInteractive scripts', async () => {
-      const html = await renderViaHTTP(next.url, '/script')
-      expect(html).toContain(
-        '<link href="/test1.js" rel="preload" as="script"/>'
-      )
-      expect(html).toContain(
-        '<link href="/test2.js" rel="preload" as="script"/>'
-      )
-      expect(html).toContain(
-        '<link href="/test3.js" rel="preload" as="script"/>'
-      )
-
-      // test4.js has lazyOnload which doesn't need to be preloaded
-      expect(html).not.toContain(
-        '<script src="/test4.js" rel="preload" as="script"/>'
-      )
     })
-  })
 
-  describe('data fetch with response over 16KB with chunked encoding', () => {
-    it('should load page when fetching a large amount of data', async () => {
-      const browser = await webdriver(next.url, '/very-large-data-fetch')
-      expect(await (await browser.waitForElementByCss('#done')).text()).toBe(
-        'Hello world'
-      )
-      expect(await browser.elementByCss('p').text()).toBe('item count 128000')
+    describe('next/script', () => {
+      if (!isNextDeploy) {
+        it('should support next/script and render in correct order', async () => {
+          const browser = await webdriver(next.url, '/script')
+
+          // Wait for lazyOnload scripts to be ready.
+          await new Promise((resolve) => setTimeout(resolve, 1000))
+
+          expect(await browser.eval(`window._script_order`)).toStrictEqual([
+            1,
+            1.5,
+            2,
+            2.5,
+            'render',
+            3,
+            4,
+          ])
+        })
+      }
+
+      it('should insert preload tags for beforeInteractive and afterInteractive scripts', async () => {
+        const html = await renderViaHTTP(next.url, '/script')
+        expect(html).toContain(
+          '<link href="/test1.js" rel="preload" as="script"/>'
+        )
+        expect(html).toContain(
+          '<link href="/test2.js" rel="preload" as="script"/>'
+        )
+        expect(html).toContain(
+          '<link href="/test3.js" rel="preload" as="script"/>'
+        )
+
+        // test4.js has lazyOnload which doesn't need to be preloaded
+        expect(html).not.toContain(
+          '<script src="/test4.js" rel="preload" as="script"/>'
+        )
+      })
     })
-  })
-})
+
+    describe('data fetch with response over 16KB with chunked encoding', () => {
+      it('should load page when fetching a large amount of data', async () => {
+        const browser = await webdriver(next.url, '/very-large-data-fetch')
+        expect(await (await browser.waitForElementByCss('#done')).text()).toBe(
+          'Hello world'
+        )
+        expect(await browser.elementByCss('p').text()).toBe('item count 128000')
+      })
+    })
+  }
+)

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -153,7 +153,7 @@ createNextDescribe(
         )
 
         // client component under server component with ssr: false will not be rendered either in flight or SSR
-        expect(html).not.toContain('client component under sever no ssr')
+        expect($.html()).not.toContain('client component under sever no ssr')
 
         const browser = await next.browser('/dashboard/dynamic')
         const clientContent = await browser.elementByCss(selector).text()

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -93,8 +93,7 @@ createNextDescribe(
     })
 
     it('should pass props from getServerSideProps in root layout', async () => {
-      const html = await next.render('/dashboard')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/dashboard')
       expect($('title').text()).toBe('hello world')
     })
 
@@ -135,8 +134,7 @@ createNextDescribe(
       })
 
       it('should handle next/dynamic correctly', async () => {
-        const html = await next.render('/dashboard/dynamic')
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/dashboard/dynamic')
         // filter out the script
         const selector = 'body div'
         const serverContent = $(selector).text()
@@ -193,8 +191,7 @@ createNextDescribe(
     })
 
     it('should include layouts when no direct parent layout', async () => {
-      const html = await next.render('/dashboard/integrations')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/dashboard/integrations')
       // Should not be nested in dashboard
       expect($('h1').text()).toBe('Dashboard')
       // Should include the page text
@@ -203,8 +200,8 @@ createNextDescribe(
 
     // TODO-APP: handle new root layout
     it.skip('should not include parent when not in parent directory with route in directory', async () => {
-      const html = await next.render('/dashboard/hello')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/dashboard/hello')
+      const html = $.html()
 
       // new root has to provide it's own custom root layout or the default
       // is used instead
@@ -221,8 +218,7 @@ createNextDescribe(
     })
 
     it('should use new root layout when provided', async () => {
-      const html = await next.render('/dashboard/another')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/dashboard/another')
 
       // new root has to provide it's own custom root layout or the default
       // is used instead
@@ -237,8 +233,7 @@ createNextDescribe(
     })
 
     it('should not create new root layout when nested (optional)', async () => {
-      const html = await next.render('/dashboard/deployments/breakdown')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/dashboard/deployments/breakdown')
 
       // new root has to provide it's own custom root layout or the default
       // is used instead
@@ -256,16 +251,14 @@ createNextDescribe(
     })
 
     it('should include parent document when no direct parent layout', async () => {
-      const html = await next.render('/dashboard/integrations')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/dashboard/integrations')
 
       expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
       expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
     })
 
     it('should not include parent when not in parent directory', async () => {
-      const html = await next.render('/dashboard/changelog')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/dashboard/changelog')
       // Should not be nested in dashboard
       expect($('h1').text()).toBeFalsy()
       // Should include the page text
@@ -273,8 +266,7 @@ createNextDescribe(
     })
 
     it('should serve nested parent', async () => {
-      const html = await next.render('/dashboard/deployments/123')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/dashboard/deployments/123')
       // Should be nested in dashboard
       expect($('h1').text()).toBe('Dashboard')
       // Should be nested in deployments
@@ -282,8 +274,7 @@ createNextDescribe(
     })
 
     it('should serve dynamic parameter', async () => {
-      const html = await next.render('/dashboard/deployments/123')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/dashboard/deployments/123')
       // Should include the page text with the parameter
       expect($('p').text()).toBe(
         'hello from app/dashboard/deployments/[id]. ID is: 123'
@@ -299,8 +290,7 @@ createNextDescribe(
     }
 
     it('should include document html and body', async () => {
-      const html = await next.render('/dashboard')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/dashboard')
 
       expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
       expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
@@ -686,8 +676,7 @@ createNextDescribe(
 
       describe('dynamic routes', () => {
         it('should only pass params that apply to the layout', async () => {
-          const html = await next.render('/dynamic/books/hello-world')
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/dynamic/books/hello-world')
 
           expect($('#dynamic-layout-params').text()).toBe('{}')
           expect($('#category-layout-params').text()).toBe(
@@ -706,14 +695,12 @@ createNextDescribe(
         it('should handle optional segments', async () => {
           const params = ['this', 'is', 'a', 'test']
           const route = params.join('/')
-          const html = await next.render(`/catch-all-optional/${route}`)
-          const $ = cheerio.load(html)
+          const $ = await next.render$(`/catch-all-optional/${route}`)
           expect($('#text').attr('data-params')).toBe(route)
         })
 
         it('should handle optional segments root', async () => {
-          const html = await next.render(`/catch-all-optional`)
-          const $ = cheerio.load(html)
+          const $ = await next.render$(`/catch-all-optional`)
           expect($('#text').attr('data-params')).toBe('')
         })
 
@@ -731,8 +718,7 @@ createNextDescribe(
         it('should handle required segments', async () => {
           const params = ['this', 'is', 'a', 'test']
           const route = params.join('/')
-          const html = await next.render(`/catch-all/${route}`)
-          const $ = cheerio.load(html)
+          const $ = await next.render$(`/catch-all/${route}`)
           expect($('#text').attr('data-params')).toBe(route)
           expect($('#not-a-page').text()).toBe('Not a page')
 
@@ -761,8 +747,7 @@ createNextDescribe(
 
       describe('should serve client component', () => {
         it('should serve server-side', async () => {
-          const html = await next.render('/client-component-route')
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/client-component-route')
           expect($('p').text()).toBe(
             'hello from app/client-component-route. count: 0'
           )
@@ -781,8 +766,7 @@ createNextDescribe(
 
       describe('should include client component layout with server component route', () => {
         it('should include it server-side', async () => {
-          const html = await next.render('/client-nested')
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/client-nested')
           // Should not be nested in dashboard
           expect($('h1').text()).toBe('Client Nested. Count: 0')
           // Should include the page text
@@ -806,8 +790,7 @@ createNextDescribe(
 
       describe('Loading', () => {
         it('should render loading.js in initial html for slow page', async () => {
-          const html = await next.render('/slow-page-with-loading')
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/slow-page-with-loading')
 
           expect($('#loading').text()).toBe('Loading...')
         })
@@ -825,8 +808,7 @@ createNextDescribe(
         })
 
         it('should render loading.js in initial html for slow layout', async () => {
-          const html = await next.render('/slow-layout-with-loading/slow')
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/slow-layout-with-loading/slow')
 
           expect($('#loading').text()).toBe('Loading...')
         })
@@ -848,10 +830,9 @@ createNextDescribe(
         })
 
         it('should render loading.js in initial html for slow layout and page', async () => {
-          const html = await next.render(
+          const $ = await next.render$(
             '/slow-layout-and-page-with-loading/slow'
           )
-          const $ = cheerio.load(html)
 
           expect($('#loading-layout').text()).toBe('Loading layout...')
           expect($('#loading-page').text()).toBe('Loading page...')
@@ -1004,22 +985,20 @@ createNextDescribe(
         describe('headers function', () => {
           it('should have access to incoming headers in a server component', async () => {
             // Check to see that we can't see the header when it's not present.
-            let html = await next.render(
+            let $ = await next.render$(
               '/hooks/use-headers',
               {},
               { headers: {} }
             )
-            let $ = cheerio.load(html)
             expect($('#does-not-have-header').length).toBe(1)
             expect($('#has-header').length).toBe(0)
 
             // Check to see that we can see the header when it's present.
-            html = await next.render(
+            $ = await next.render$(
               '/hooks/use-headers',
               {},
               { headers: { 'x-use-headers': 'value' } }
             )
-            $ = cheerio.load(html)
             expect($('#has-header').length).toBe(1)
             expect($('#does-not-have-header').length).toBe(0)
           })
@@ -1159,16 +1138,14 @@ createNextDescribe(
 
         describe('usePathname', () => {
           it('should have the correct pathname', async () => {
-            const html = await next.render('/hooks/use-pathname')
-            const $ = cheerio.load(html)
+            const $ = await next.render$('/hooks/use-pathname')
             expect($('#pathname').attr('data-pathname')).toBe(
               '/hooks/use-pathname'
             )
           })
 
           it('should have the canonical url pathname on rewrite', async () => {
-            const html = await next.render('/rewritten-use-pathname')
-            const $ = cheerio.load(html)
+            const $ = await next.render$('/rewritten-use-pathname')
             expect($('#pathname').attr('data-pathname')).toBe(
               '/rewritten-use-pathname'
             )
@@ -1177,10 +1154,9 @@ createNextDescribe(
 
         describe('useSearchParams', () => {
           it('should have the correct search params', async () => {
-            const html = await next.render(
+            const $ = await next.render$(
               '/hooks/use-search-params?first=value&second=other%20value&third'
             )
-            const $ = cheerio.load(html)
             expect($('#params-first').text()).toBe('value')
             expect($('#params-second').text()).toBe('other value')
             expect($('#params-third').text()).toBe('')
@@ -1190,10 +1166,9 @@ createNextDescribe(
           // TODO-APP: correct this behavior when deployed
           if (!isNextDeploy) {
             it('should have the canonical url search params on rewrite', async () => {
-              const html = await next.render(
+              const $ = await next.render$(
                 '/rewritten-use-search-params?first=a&second=b&third=c'
               )
-              const $ = cheerio.load(html)
               expect($('#params-first').text()).toBe('a')
               expect($('#params-second').text()).toBe('b')
               expect($('#params-third').text()).toBe('c')
@@ -1224,10 +1199,7 @@ createNextDescribe(
 
           if (!isNextDeploy) {
             it('should have consistent query and params handling', async () => {
-              const html = await next.render(
-                '/param-and-query/params?slug=query'
-              )
-              const $ = cheerio.load(html)
+              const $ = await next.render$('/param-and-query/params?slug=query')
               const el = $('#params-and-query')
               expect(el.attr('data-params')).toBe('params')
               expect(el.attr('data-query')).toBe('query')
@@ -1247,8 +1219,7 @@ createNextDescribe(
           `(
             'should have the correct layout segments at $path',
             async ({ path, outerLayout, innerLayout }) => {
-              const html = await next.render(path)
-              const $ = cheerio.load(html)
+              const $ = await next.render$(path)
 
               expect(JSON.parse($('#outer-layout').text())).toEqual(outerLayout)
               expect(JSON.parse($('#inner-layout').text())).toEqual(innerLayout)
@@ -1256,10 +1227,9 @@ createNextDescribe(
           )
 
           it('should return an empty array in pages', async () => {
-            const html = await next.render(
+            const $ = await next.render$(
               '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
             )
-            const $ = cheerio.load(html)
 
             expect(JSON.parse($('#page-layout-segments').text())).toEqual([])
           })
@@ -1274,8 +1244,7 @@ createNextDescribe(
           `(
             'should have the correct layout segment at $path',
             async ({ path, outerLayout, innerLayout }) => {
-              const html = await next.render(path)
-              const $ = cheerio.load(html)
+              const $ = await next.render$(path)
 
               expect(JSON.parse($('#outer-layout-segment').text())).toEqual(
                 outerLayout
@@ -1287,10 +1256,9 @@ createNextDescribe(
           )
 
           it('should return null in pages', async () => {
-            const html = await next.render(
+            const $ = await next.render$(
               '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
             )
-            const $ = cheerio.load(html)
 
             expect(JSON.parse($('#page-layout-segment').text())).toEqual(null)
           })
@@ -1693,10 +1661,9 @@ createNextDescribe(
     describe('searchParams prop', () => {
       describe('client component', () => {
         it('should have the correct search params', async () => {
-          const html = await next.render(
+          const $ = await next.render$(
             '/search-params-prop?first=value&second=other%20value&third'
           )
-          const $ = cheerio.load(html)
           const el = $('#params')
           expect(el.attr('data-param-first')).toBe('value')
           expect(el.attr('data-param-second')).toBe('other value')
@@ -1705,8 +1672,7 @@ createNextDescribe(
         })
 
         it('should have the correct search params on rewrite', async () => {
-          const html = await next.render('/search-params-prop-rewrite')
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/search-params-prop-rewrite')
           const el = $('#params')
           expect(el.attr('data-param-first')).toBe('value')
           expect(el.attr('data-param-second')).toBe('other value')
@@ -1715,10 +1681,7 @@ createNextDescribe(
         })
 
         it('should have the correct search params on middleware rewrite', async () => {
-          const html = await next.render(
-            '/search-params-prop-middleware-rewrite'
-          )
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/search-params-prop-middleware-rewrite')
           const el = $('#params')
           expect(el.attr('data-param-first')).toBe('value')
           expect(el.attr('data-param-second')).toBe('other value')
@@ -1729,10 +1692,9 @@ createNextDescribe(
 
       describe('server component', () => {
         it('should have the correct search params', async () => {
-          const html = await next.render(
+          const $ = await next.render$(
             '/search-params-prop/server?first=value&second=other%20value&third'
           )
-          const $ = cheerio.load(html)
           const el = $('#params')
           expect(el.attr('data-param-first')).toBe('value')
           expect(el.attr('data-param-second')).toBe('other value')
@@ -1741,8 +1703,7 @@ createNextDescribe(
         })
 
         it('should have the correct search params on rewrite', async () => {
-          const html = await next.render('/search-params-prop-server-rewrite')
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/search-params-prop-server-rewrite')
           const el = $('#params')
           expect(el.attr('data-param-first')).toBe('value')
           expect(el.attr('data-param-second')).toBe('other value')
@@ -1751,10 +1712,9 @@ createNextDescribe(
         })
 
         it('should have the correct search params on middleware rewrite', async () => {
-          const html = await next.render(
+          const $ = await next.render$(
             '/search-params-prop-server-middleware-rewrite'
           )
-          const $ = cheerio.load(html)
           const el = $('#params')
           expect(el.attr('data-param-first')).toBe('value')
           expect(el.attr('data-param-second')).toBe('other value')
@@ -1977,9 +1937,7 @@ createNextDescribe(
       })
 
       it('includes an integrity attribute on scripts', async () => {
-        const html = await next.render('/dashboard')
-
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/dashboard')
 
         // Find all the script tags with src attributes.
         const elements = $('script[src]')

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -17,2416 +17,2409 @@ describe('app dir', () => {
   const isDev = (global as any).isNextDev
   let next: NextInstance
 
-  function runTests() {
-    beforeAll(async () => {
-      next = await createNext({
-        files: new FileRef(path.join(__dirname, 'app')),
-        dependencies: {
-          swr: '2.0.0-rc.0',
-          react: 'latest',
-          'react-dom': 'latest',
-          sass: 'latest',
+  beforeAll(async () => {
+    next = await createNext({
+      files: new FileRef(path.join(__dirname, 'app')),
+      dependencies: {
+        swr: '2.0.0-rc.0',
+        react: 'latest',
+        'react-dom': 'latest',
+        sass: 'latest',
+      },
+    })
+  })
+  afterAll(async () => {
+    await next.destroy()
+  })
+
+  if (!(global as any).isNextDeploy) {
+    it('should not share edge workers', async () => {
+      const controller1 = new AbortController()
+      const controller2 = new AbortController()
+      fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
+        signal: controller1.signal,
+      }).catch(() => {})
+      fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
+        signal: controller2.signal,
+      }).catch(() => {})
+
+      await waitFor(1000)
+      controller1.abort()
+
+      const controller3 = new AbortController()
+      fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
+        signal: controller3.signal,
+      }).catch(() => {})
+      await waitFor(1000)
+      controller2.abort()
+      controller3.abort()
+
+      const res = await fetchViaHTTP(next.url, '/slow-page-no-loading')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('hello from slow page')
+      expect(next.cliOutput).not.toContain(
+        'A separate worker must be used for each render'
+      )
+    })
+  }
+
+  if ((global as any).isNextStart) {
+    it('should generate build traces correctly', async () => {
+      const trace = JSON.parse(
+        await next.readFile(
+          '.next/server/app/dashboard/deployments/[id]/page.js.nft.json'
+        )
+      ) as { files: string[] }
+      expect(trace.files.some((file) => file.endsWith('data.json'))).toBe(true)
+    })
+  }
+
+  it('should use application/octet-stream for flight', async () => {
+    const res = await fetchViaHTTP(
+      next.url,
+      '/dashboard/deployments/123',
+      {},
+      {
+        headers: {
+          ['RSC'.toString()]: '1',
         },
-      })
-    })
-    afterAll(async () => {
-      await next.destroy()
-    })
-
-    if (!(global as any).isNextDeploy) {
-      it('should not share edge workers', async () => {
-        const controller1 = new AbortController()
-        const controller2 = new AbortController()
-        fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
-          signal: controller1.signal,
-        }).catch(() => {})
-        fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
-          signal: controller2.signal,
-        }).catch(() => {})
-
-        await waitFor(1000)
-        controller1.abort()
-
-        const controller3 = new AbortController()
-        fetchViaHTTP(next.url, '/slow-page-no-loading', undefined, {
-          signal: controller3.signal,
-        }).catch(() => {})
-        await waitFor(1000)
-        controller2.abort()
-        controller3.abort()
-
-        const res = await fetchViaHTTP(next.url, '/slow-page-no-loading')
-        expect(res.status).toBe(200)
-        expect(await res.text()).toContain('hello from slow page')
-        expect(next.cliOutput).not.toContain(
-          'A separate worker must be used for each render'
-        )
-      })
-    }
-
-    if ((global as any).isNextStart) {
-      it('should generate build traces correctly', async () => {
-        const trace = JSON.parse(
-          await next.readFile(
-            '.next/server/app/dashboard/deployments/[id]/page.js.nft.json'
-          )
-        ) as { files: string[] }
-        expect(trace.files.some((file) => file.endsWith('data.json'))).toBe(
-          true
-        )
-      })
-    }
-
-    it('should use application/octet-stream for flight', async () => {
-      const res = await fetchViaHTTP(
-        next.url,
-        '/dashboard/deployments/123',
-        {},
-        {
-          headers: {
-            ['RSC'.toString()]: '1',
-          },
-        }
-      )
-      expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
-    })
-
-    it('should use application/octet-stream for flight with edge runtime', async () => {
-      const res = await fetchViaHTTP(
-        next.url,
-        '/dashboard',
-        {},
-        {
-          headers: {
-            ['RSC'.toString()]: '1',
-          },
-        }
-      )
-      expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
-    })
-
-    it('should pass props from getServerSideProps in root layout', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard')
-      const $ = cheerio.load(html)
-      expect($('title').text()).toBe('hello world')
-    })
-
-    it('should serve from pages', async () => {
-      const html = await renderViaHTTP(next.url, '/')
-      expect(html).toContain('hello from pages/index')
-
-      // esm imports should work fine in pages/
-      expect(html).toContain('swr-index')
-    })
-
-    it('should serve dynamic route from pages', async () => {
-      const html = await renderViaHTTP(next.url, '/blog/first')
-      expect(html).toContain('hello from pages/blog/[slug]')
-    })
-
-    it('should serve from public', async () => {
-      const html = await renderViaHTTP(next.url, '/hello.txt')
-      expect(html).toContain('hello world')
-    })
-
-    it('should serve from app', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard')
-      expect(html).toContain('hello from app/dashboard')
-    })
-
-    if (!(global as any).isNextDeploy) {
-      it('should serve /index as separate page', async () => {
-        const stderr = []
-        next.on('stderr', (err) => {
-          stderr.push(err)
-        })
-        const html = await renderViaHTTP(next.url, '/dashboard/index')
-        expect(html).toContain('hello from app/dashboard/index')
-        expect(stderr.some((err) => err.includes('Invalid hook call'))).toBe(
-          false
-        )
-      })
-
-      it('should handle next/dynamic correctly', async () => {
-        const html = await renderViaHTTP(next.url, '/dashboard/dynamic')
-        const $ = cheerio.load(html)
-        // filter out the script
-        const selector = 'body div'
-        const serverContent = $(selector).text()
-        // should load chunks generated via async import correctly with React.lazy
-        expect(serverContent).toContain('next-dynamic lazy')
-        // should support `dynamic` in both server and client components
-        expect(serverContent).toContain('next-dynamic dynamic on server')
-        expect(serverContent).toContain('next-dynamic dynamic on client')
-        expect(serverContent).toContain('next-dynamic server import client')
-        expect(serverContent).not.toContain(
-          'next-dynamic dynamic no ssr on client'
-        )
-
-        expect(serverContent).not.toContain(
-          'next-dynamic dynamic no ssr on server'
-        )
-
-        // client component under server component with ssr: false will not be rendered either in flight or SSR
-        expect(html).not.toContain('client component under sever no ssr')
-
-        const browser = await webdriver(next.url, '/dashboard/dynamic')
-        const clientContent = await browser.elementByCss(selector).text()
-        expect(clientContent).toContain('next-dynamic dynamic no ssr on server')
-        expect(clientContent).toContain('client component under sever no ssr')
-        await browser.waitForElementByCss('#css-text-dynamic-no-ssr-client')
-
-        expect(
-          await browser.elementByCss('#css-text-dynamic-no-ssr-client').text()
-        ).toBe('next-dynamic dynamic no ssr on client:suffix')
-      })
-
-      it('should serve polyfills for browsers that do not support modules', async () => {
-        const html = await renderViaHTTP(next.url, '/dashboard/index')
-        expect(html).toMatch(
-          /<script src="\/_next\/static\/chunks\/polyfills(-\w+)?\.js" nomodule="">/
-        )
-      })
-    }
-
-    // TODO-APP: handle css modules fouc in dev
-    it.skip('should handle css imports in next/dynamic correctly', async () => {
-      const browser = await webdriver(next.url, '/dashboard/index')
-
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.querySelector('#css-text-dynamic-server')).color`
-        )
-      ).toBe('rgb(0, 0, 255)')
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.querySelector('#css-text-lazy')).color`
-        )
-      ).toBe('rgb(128, 0, 128)')
-    })
-
-    it('should include layouts when no direct parent layout', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/integrations')
-      const $ = cheerio.load(html)
-      // Should not be nested in dashboard
-      expect($('h1').text()).toBe('Dashboard')
-      // Should include the page text
-      expect($('p').text()).toBe('hello from app/dashboard/integrations')
-    })
-
-    // TODO-APP: handle new root layout
-    it.skip('should not include parent when not in parent directory with route in directory', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/hello')
-      const $ = cheerio.load(html)
-
-      // new root has to provide it's own custom root layout or the default
-      // is used instead
-      expect(html).toContain('<html')
-      expect(html).toContain('<body')
-      expect($('html').hasClass('this-is-the-document-html')).toBeFalsy()
-      expect($('body').hasClass('this-is-the-document-body')).toBeFalsy()
-
-      // Should not be nested in dashboard
-      expect($('h1').text()).toBeFalsy()
-
-      // Should render the page text
-      expect($('p').text()).toBe('hello from app/dashboard/rootonly/hello')
-    })
-
-    it('should use new root layout when provided', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/another')
-      const $ = cheerio.load(html)
-
-      // new root has to provide it's own custom root layout or the default
-      // is used instead
-      expect($('html').hasClass('this-is-another-document-html')).toBeTruthy()
-      expect($('body').hasClass('this-is-another-document-body')).toBeTruthy()
-
-      // Should not be nested in dashboard
-      expect($('h1').text()).toBeFalsy()
-
-      // Should render the page text
-      expect($('p').text()).toBe('hello from newroot/dashboard/another')
-    })
-
-    it('should not create new root layout when nested (optional)', async () => {
-      const html = await renderViaHTTP(
-        next.url,
-        '/dashboard/deployments/breakdown'
-      )
-      const $ = cheerio.load(html)
-
-      // new root has to provide it's own custom root layout or the default
-      // is used instead
-      expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
-      expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
-
-      // Should be nested in dashboard
-      expect($('h1').text()).toBe('Dashboard')
-      expect($('h2').text()).toBe('Custom dashboard')
-
-      // Should render the page text
-      expect($('p').text()).toBe(
-        'hello from app/dashboard/(custom)/deployments/breakdown'
-      )
-    })
-
-    it('should include parent document when no direct parent layout', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/integrations')
-      const $ = cheerio.load(html)
-
-      expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
-      expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
-    })
-
-    it('should not include parent when not in parent directory', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/changelog')
-      const $ = cheerio.load(html)
-      // Should not be nested in dashboard
-      expect($('h1').text()).toBeFalsy()
-      // Should include the page text
-      expect($('p').text()).toBe('hello from app/dashboard/changelog')
-    })
-
-    it('should serve nested parent', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/deployments/123')
-      const $ = cheerio.load(html)
-      // Should be nested in dashboard
-      expect($('h1').text()).toBe('Dashboard')
-      // Should be nested in deployments
-      expect($('h2').text()).toBe('Deployments hello')
-    })
-
-    it('should serve dynamic parameter', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard/deployments/123')
-      const $ = cheerio.load(html)
-      // Should include the page text with the parameter
-      expect($('p').text()).toBe(
-        'hello from app/dashboard/deployments/[id]. ID is: 123'
-      )
-    })
-
-    // TODO-APP: fix to ensure behavior matches on deploy
-    if (!(global as any).isNextDeploy) {
-      it('should serve page as a segment name correctly', async () => {
-        const html = await renderViaHTTP(next.url, '/dashboard/page')
-        expect(html).toContain('hello dashboard/page!')
-      })
-    }
-
-    it('should include document html and body', async () => {
-      const html = await renderViaHTTP(next.url, '/dashboard')
-      const $ = cheerio.load(html)
-
-      expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
-      expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
-    })
-
-    it('should not serve when layout is provided but no folder index', async () => {
-      const res = await fetchViaHTTP(next.url, '/dashboard/deployments')
-      expect(res.status).toBe(404)
-      expect(await res.text()).toContain('This page could not be found')
-    })
-
-    // TODO-APP: do we want to make this only work for /root or is it allowed
-    // to work for /pages as well?
-    it.skip('should match partial parameters', async () => {
-      const html = await renderViaHTTP(next.url, '/partial-match-123')
-      expect(html).toContain('hello from app/partial-match-[id]. ID is: 123')
-    })
-
-    describe('rewrites', () => {
-      // TODO-APP: rewrite url is broken
-      it('should support rewrites on initial load', async () => {
-        const browser = await webdriver(next.url, '/rewritten-to-dashboard')
-        expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
-        expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
-      })
-
-      it('should support rewrites on client-side navigation from pages to app with existing pages path', async () => {
-        const browser = await webdriver(next.url, '/link-to-rewritten-path')
-
-        try {
-          // Click the link.
-          await browser.elementById('link-to-rewritten-path').click()
-          await browser.waitForElementByCss('#from-dashboard')
-
-          // Check to see that we were rewritten and not redirected.
-          // TODO-APP: rewrite url is broken
-          // expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
-
-          // Check to see that the page we navigated to is in fact the dashboard.
-          expect(await browser.elementByCss('#from-dashboard').text()).toBe(
-            'hello from app/dashboard'
-          )
-        } finally {
-          await browser.close()
-        }
-      })
-
-      it('should support rewrites on client-side navigation', async () => {
-        const browser = await webdriver(next.url, '/rewrites')
-
-        try {
-          // Click the link.
-          await browser.elementById('link').click()
-          await browser.waitForElementByCss('#from-dashboard')
-
-          // Check to see that we were rewritten and not redirected.
-          expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
-
-          // Check to see that the page we navigated to is in fact the dashboard.
-          expect(await browser.elementByCss('#from-dashboard').text()).toBe(
-            'hello from app/dashboard'
-          )
-        } finally {
-          await browser.close()
-        }
-      })
-    })
-
-    // TODO-APP: Enable in development
-    ;(isDev ? it.skip : it)(
-      'should not rerender layout when navigating between routes in the same layout',
-      async () => {
-        const browser = await webdriver(next.url, '/same-layout/first')
-
-        try {
-          // Get the render id from the dom and click the first link.
-          const firstRenderID = await browser.elementById('render-id').text()
-          await browser.elementById('link').click()
-          await browser.waitForElementByCss('#second-page')
-
-          // Get the render id from the dom again, it should be the same!
-          const secondRenderID = await browser.elementById('render-id').text()
-          expect(secondRenderID).toBe(firstRenderID)
-
-          // Navigate back to the first page again by clicking the link.
-          await browser.elementById('link').click()
-          await browser.waitForElementByCss('#first-page')
-
-          // Get the render id from the dom again, it should be the same!
-          const thirdRenderID = await browser.elementById('render-id').text()
-          expect(thirdRenderID).toBe(firstRenderID)
-        } finally {
-          await browser.close()
-        }
       }
     )
+    expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
+  })
 
-    it('should handle hash in initial url', async () => {
-      const browser = await webdriver(next.url, '/dashboard#abc')
+  it('should use application/octet-stream for flight with edge runtime', async () => {
+    const res = await fetchViaHTTP(
+      next.url,
+      '/dashboard',
+      {},
+      {
+        headers: {
+          ['RSC'.toString()]: '1',
+        },
+      }
+    )
+    expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
+  })
+
+  it('should pass props from getServerSideProps in root layout', async () => {
+    const html = await renderViaHTTP(next.url, '/dashboard')
+    const $ = cheerio.load(html)
+    expect($('title').text()).toBe('hello world')
+  })
+
+  it('should serve from pages', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    expect(html).toContain('hello from pages/index')
+
+    // esm imports should work fine in pages/
+    expect(html).toContain('swr-index')
+  })
+
+  it('should serve dynamic route from pages', async () => {
+    const html = await renderViaHTTP(next.url, '/blog/first')
+    expect(html).toContain('hello from pages/blog/[slug]')
+  })
+
+  it('should serve from public', async () => {
+    const html = await renderViaHTTP(next.url, '/hello.txt')
+    expect(html).toContain('hello world')
+  })
+
+  it('should serve from app', async () => {
+    const html = await renderViaHTTP(next.url, '/dashboard')
+    expect(html).toContain('hello from app/dashboard')
+  })
+
+  if (!(global as any).isNextDeploy) {
+    it('should serve /index as separate page', async () => {
+      const stderr = []
+      next.on('stderr', (err) => {
+        stderr.push(err)
+      })
+      const html = await renderViaHTTP(next.url, '/dashboard/index')
+      expect(html).toContain('hello from app/dashboard/index')
+      expect(stderr.some((err) => err.includes('Invalid hook call'))).toBe(
+        false
+      )
+    })
+
+    it('should handle next/dynamic correctly', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard/dynamic')
+      const $ = cheerio.load(html)
+      // filter out the script
+      const selector = 'body div'
+      const serverContent = $(selector).text()
+      // should load chunks generated via async import correctly with React.lazy
+      expect(serverContent).toContain('next-dynamic lazy')
+      // should support `dynamic` in both server and client components
+      expect(serverContent).toContain('next-dynamic dynamic on server')
+      expect(serverContent).toContain('next-dynamic dynamic on client')
+      expect(serverContent).toContain('next-dynamic server import client')
+      expect(serverContent).not.toContain(
+        'next-dynamic dynamic no ssr on client'
+      )
+
+      expect(serverContent).not.toContain(
+        'next-dynamic dynamic no ssr on server'
+      )
+
+      // client component under server component with ssr: false will not be rendered either in flight or SSR
+      expect(html).not.toContain('client component under sever no ssr')
+
+      const browser = await webdriver(next.url, '/dashboard/dynamic')
+      const clientContent = await browser.elementByCss(selector).text()
+      expect(clientContent).toContain('next-dynamic dynamic no ssr on server')
+      expect(clientContent).toContain('client component under sever no ssr')
+      await browser.waitForElementByCss('#css-text-dynamic-no-ssr-client')
+
+      expect(
+        await browser.elementByCss('#css-text-dynamic-no-ssr-client').text()
+      ).toBe('next-dynamic dynamic no ssr on client:suffix')
+    })
+
+    it('should serve polyfills for browsers that do not support modules', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard/index')
+      expect(html).toMatch(
+        /<script src="\/_next\/static\/chunks\/polyfills(-\w+)?\.js" nomodule="">/
+      )
+    })
+  }
+
+  // TODO-APP: handle css modules fouc in dev
+  it.skip('should handle css imports in next/dynamic correctly', async () => {
+    const browser = await webdriver(next.url, '/dashboard/index')
+
+    expect(
+      await browser.eval(
+        `window.getComputedStyle(document.querySelector('#css-text-dynamic-server')).color`
+      )
+    ).toBe('rgb(0, 0, 255)')
+    expect(
+      await browser.eval(
+        `window.getComputedStyle(document.querySelector('#css-text-lazy')).color`
+      )
+    ).toBe('rgb(128, 0, 128)')
+  })
+
+  it('should include layouts when no direct parent layout', async () => {
+    const html = await renderViaHTTP(next.url, '/dashboard/integrations')
+    const $ = cheerio.load(html)
+    // Should not be nested in dashboard
+    expect($('h1').text()).toBe('Dashboard')
+    // Should include the page text
+    expect($('p').text()).toBe('hello from app/dashboard/integrations')
+  })
+
+  // TODO-APP: handle new root layout
+  it.skip('should not include parent when not in parent directory with route in directory', async () => {
+    const html = await renderViaHTTP(next.url, '/dashboard/hello')
+    const $ = cheerio.load(html)
+
+    // new root has to provide it's own custom root layout or the default
+    // is used instead
+    expect(html).toContain('<html')
+    expect(html).toContain('<body')
+    expect($('html').hasClass('this-is-the-document-html')).toBeFalsy()
+    expect($('body').hasClass('this-is-the-document-body')).toBeFalsy()
+
+    // Should not be nested in dashboard
+    expect($('h1').text()).toBeFalsy()
+
+    // Should render the page text
+    expect($('p').text()).toBe('hello from app/dashboard/rootonly/hello')
+  })
+
+  it('should use new root layout when provided', async () => {
+    const html = await renderViaHTTP(next.url, '/dashboard/another')
+    const $ = cheerio.load(html)
+
+    // new root has to provide it's own custom root layout or the default
+    // is used instead
+    expect($('html').hasClass('this-is-another-document-html')).toBeTruthy()
+    expect($('body').hasClass('this-is-another-document-body')).toBeTruthy()
+
+    // Should not be nested in dashboard
+    expect($('h1').text()).toBeFalsy()
+
+    // Should render the page text
+    expect($('p').text()).toBe('hello from newroot/dashboard/another')
+  })
+
+  it('should not create new root layout when nested (optional)', async () => {
+    const html = await renderViaHTTP(
+      next.url,
+      '/dashboard/deployments/breakdown'
+    )
+    const $ = cheerio.load(html)
+
+    // new root has to provide it's own custom root layout or the default
+    // is used instead
+    expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
+    expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
+
+    // Should be nested in dashboard
+    expect($('h1').text()).toBe('Dashboard')
+    expect($('h2').text()).toBe('Custom dashboard')
+
+    // Should render the page text
+    expect($('p').text()).toBe(
+      'hello from app/dashboard/(custom)/deployments/breakdown'
+    )
+  })
+
+  it('should include parent document when no direct parent layout', async () => {
+    const html = await renderViaHTTP(next.url, '/dashboard/integrations')
+    const $ = cheerio.load(html)
+
+    expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
+    expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
+  })
+
+  it('should not include parent when not in parent directory', async () => {
+    const html = await renderViaHTTP(next.url, '/dashboard/changelog')
+    const $ = cheerio.load(html)
+    // Should not be nested in dashboard
+    expect($('h1').text()).toBeFalsy()
+    // Should include the page text
+    expect($('p').text()).toBe('hello from app/dashboard/changelog')
+  })
+
+  it('should serve nested parent', async () => {
+    const html = await renderViaHTTP(next.url, '/dashboard/deployments/123')
+    const $ = cheerio.load(html)
+    // Should be nested in dashboard
+    expect($('h1').text()).toBe('Dashboard')
+    // Should be nested in deployments
+    expect($('h2').text()).toBe('Deployments hello')
+  })
+
+  it('should serve dynamic parameter', async () => {
+    const html = await renderViaHTTP(next.url, '/dashboard/deployments/123')
+    const $ = cheerio.load(html)
+    // Should include the page text with the parameter
+    expect($('p').text()).toBe(
+      'hello from app/dashboard/deployments/[id]. ID is: 123'
+    )
+  })
+
+  // TODO-APP: fix to ensure behavior matches on deploy
+  if (!(global as any).isNextDeploy) {
+    it('should serve page as a segment name correctly', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard/page')
+      expect(html).toContain('hello dashboard/page!')
+    })
+  }
+
+  it('should include document html and body', async () => {
+    const html = await renderViaHTTP(next.url, '/dashboard')
+    const $ = cheerio.load(html)
+
+    expect($('html').hasClass('this-is-the-document-html')).toBeTruthy()
+    expect($('body').hasClass('this-is-the-document-body')).toBeTruthy()
+  })
+
+  it('should not serve when layout is provided but no folder index', async () => {
+    const res = await fetchViaHTTP(next.url, '/dashboard/deployments')
+    expect(res.status).toBe(404)
+    expect(await res.text()).toContain('This page could not be found')
+  })
+
+  // TODO-APP: do we want to make this only work for /root or is it allowed
+  // to work for /pages as well?
+  it.skip('should match partial parameters', async () => {
+    const html = await renderViaHTTP(next.url, '/partial-match-123')
+    expect(html).toContain('hello from app/partial-match-[id]. ID is: 123')
+  })
+
+  describe('rewrites', () => {
+    // TODO-APP: rewrite url is broken
+    it('should support rewrites on initial load', async () => {
+      const browser = await webdriver(next.url, '/rewritten-to-dashboard')
+      expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
+      expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
+    })
+
+    it('should support rewrites on client-side navigation from pages to app with existing pages path', async () => {
+      const browser = await webdriver(next.url, '/link-to-rewritten-path')
 
       try {
-        // Check if hash is preserved
-        expect(await browser.eval('window.location.hash')).toBe('#abc')
-        await waitFor(1000)
-        // Check again to be sure as it might be timed different
-        expect(await browser.eval('window.location.hash')).toBe('#abc')
+        // Click the link.
+        await browser.elementById('link-to-rewritten-path').click()
+        await browser.waitForElementByCss('#from-dashboard')
+
+        // Check to see that we were rewritten and not redirected.
+        // TODO-APP: rewrite url is broken
+        // expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
+
+        // Check to see that the page we navigated to is in fact the dashboard.
+        expect(await browser.elementByCss('#from-dashboard').text()).toBe(
+          'hello from app/dashboard'
+        )
       } finally {
         await browser.close()
       }
     })
 
-    describe('parallel routes', () => {
-      if (!(global as any).isNextDeploy) {
-        it('should match parallel routes', async () => {
-          const html = await renderViaHTTP(next.url, '/parallel/nested')
-          expect(html).toContain('parallel/layout')
-          expect(html).toContain('parallel/@foo/nested/layout')
-          expect(html).toContain('parallel/@foo/nested/@a/page')
-          expect(html).toContain('parallel/@foo/nested/@b/page')
-          expect(html).toContain('parallel/@bar/nested/layout')
-          expect(html).toContain('parallel/@bar/nested/@a/page')
-          expect(html).toContain('parallel/@bar/nested/@b/page')
-          expect(html).toContain('parallel/nested/page')
-        })
-      }
+    it('should support rewrites on client-side navigation', async () => {
+      const browser = await webdriver(next.url, '/rewrites')
 
-      it('should match parallel routes in route groups', async () => {
-        const html = await renderViaHTTP(next.url, '/parallel/nested-2')
+      try {
+        // Click the link.
+        await browser.elementById('link').click()
+        await browser.waitForElementByCss('#from-dashboard')
+
+        // Check to see that we were rewritten and not redirected.
+        expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
+
+        // Check to see that the page we navigated to is in fact the dashboard.
+        expect(await browser.elementByCss('#from-dashboard').text()).toBe(
+          'hello from app/dashboard'
+        )
+      } finally {
+        await browser.close()
+      }
+    })
+  })
+
+  // TODO-APP: Enable in development
+  ;(isDev ? it.skip : it)(
+    'should not rerender layout when navigating between routes in the same layout',
+    async () => {
+      const browser = await webdriver(next.url, '/same-layout/first')
+
+      try {
+        // Get the render id from the dom and click the first link.
+        const firstRenderID = await browser.elementById('render-id').text()
+        await browser.elementById('link').click()
+        await browser.waitForElementByCss('#second-page')
+
+        // Get the render id from the dom again, it should be the same!
+        const secondRenderID = await browser.elementById('render-id').text()
+        expect(secondRenderID).toBe(firstRenderID)
+
+        // Navigate back to the first page again by clicking the link.
+        await browser.elementById('link').click()
+        await browser.waitForElementByCss('#first-page')
+
+        // Get the render id from the dom again, it should be the same!
+        const thirdRenderID = await browser.elementById('render-id').text()
+        expect(thirdRenderID).toBe(firstRenderID)
+      } finally {
+        await browser.close()
+      }
+    }
+  )
+
+  it('should handle hash in initial url', async () => {
+    const browser = await webdriver(next.url, '/dashboard#abc')
+
+    try {
+      // Check if hash is preserved
+      expect(await browser.eval('window.location.hash')).toBe('#abc')
+      await waitFor(1000)
+      // Check again to be sure as it might be timed different
+      expect(await browser.eval('window.location.hash')).toBe('#abc')
+    } finally {
+      await browser.close()
+    }
+  })
+
+  describe('parallel routes', () => {
+    if (!(global as any).isNextDeploy) {
+      it('should match parallel routes', async () => {
+        const html = await renderViaHTTP(next.url, '/parallel/nested')
         expect(html).toContain('parallel/layout')
-        expect(html).toContain('parallel/(new)/layout')
-        expect(html).toContain('parallel/(new)/@baz/nested/page')
+        expect(html).toContain('parallel/@foo/nested/layout')
+        expect(html).toContain('parallel/@foo/nested/@a/page')
+        expect(html).toContain('parallel/@foo/nested/@b/page')
+        expect(html).toContain('parallel/@bar/nested/layout')
+        expect(html).toContain('parallel/@bar/nested/@a/page')
+        expect(html).toContain('parallel/@bar/nested/@b/page')
+        expect(html).toContain('parallel/nested/page')
+      })
+    }
+
+    it('should match parallel routes in route groups', async () => {
+      const html = await renderViaHTTP(next.url, '/parallel/nested-2')
+      expect(html).toContain('parallel/layout')
+      expect(html).toContain('parallel/(new)/layout')
+      expect(html).toContain('parallel/(new)/@baz/nested/page')
+    })
+  })
+
+  describe('<Link />', () => {
+    it('should hard push', async () => {
+      const browser = await webdriver(next.url, '/link-hard-push/123')
+
+      try {
+        // Click the link on the page, and verify that the history entry was
+        // added.
+        expect(await browser.eval('window.history.length')).toBe(2)
+        await browser.elementById('link').click()
+        await browser.waitForElementByCss('#render-id-456')
+        expect(await browser.eval('window.history.length')).toBe(3)
+
+        // Get the id on the rendered page.
+        const firstID = await browser.elementById('render-id-456').text()
+
+        // Go back, and redo the navigation by clicking the link.
+        await browser.back()
+        await browser.elementById('link').click()
+        await browser.waitForElementByCss('#render-id-456')
+
+        // Get the id again, and compare, they should not be the same.
+        const secondID = await browser.elementById('render-id-456').text()
+        expect(secondID).not.toBe(firstID)
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should hard replace', async () => {
+      const browser = await webdriver(next.url, '/link-hard-replace/123')
+
+      try {
+        // Click the link on the page, and verify that the history entry was NOT
+        // added.
+        expect(await browser.eval('window.history.length')).toBe(2)
+        await browser.elementById('link').click()
+        await browser.waitForElementByCss('#render-id-456')
+        expect(await browser.eval('window.history.length')).toBe(2)
+
+        // Get the date again, and compare, they should not be the same.
+        const firstId = await browser.elementById('render-id-456').text()
+
+        // Navigate to the subpage, verify that the history entry was NOT added.
+        await browser.elementById('link').click()
+        await browser.waitForElementByCss('#render-id-123')
+        expect(await browser.eval('window.history.length')).toBe(2)
+
+        // Navigate back again, verify that the history entry was NOT added.
+        await browser.elementById('link').click()
+        await browser.waitForElementByCss('#render-id-456')
+        expect(await browser.eval('window.history.length')).toBe(2)
+
+        // Get the date again, and compare, they should not be the same.
+        const secondId = await browser.elementById('render-id-456').text()
+        expect(firstId).not.toBe(secondId)
+      } finally {
+        await browser.close()
+      }
+    })
+
+    // TODO-APP: Re-enable this test.
+    it('should soft push', async () => {
+      const browser = await webdriver(next.url, '/link-soft-push')
+
+      try {
+        // Click the link on the page, and verify that the history entry was
+        // added.
+        expect(await browser.eval('window.history.length')).toBe(2)
+        await browser.elementById('link').click()
+        await browser.waitForElementByCss('#render-id')
+        expect(await browser.eval('window.history.length')).toBe(3)
+
+        // Get the id on the rendered page.
+        const firstID = await browser.elementById('render-id').text()
+
+        // Go back, and redo the navigation by clicking the link.
+        await browser.back()
+        await browser.elementById('link').click()
+
+        // Get the date again, and compare, they should be the same.
+        const secondID = await browser.elementById('render-id').text()
+        expect(firstID).toBe(secondID)
+      } finally {
+        await browser.close()
+      }
+    })
+
+    // TODO-APP: investigate this test
+    it.skip('should soft replace', async () => {
+      const browser = await webdriver(next.url, '/link-soft-replace')
+
+      try {
+        // Get the render ID so we can compare it.
+        const firstID = await browser.elementById('render-id').text()
+
+        // Click the link on the page, and verify that the history entry was NOT
+        // added.
+        expect(await browser.eval('window.history.length')).toBe(2)
+        await browser.elementById('self-link').click()
+        await browser.waitForElementByCss('#render-id')
+        expect(await browser.eval('window.history.length')).toBe(2)
+
+        // Get the id on the rendered page.
+        const secondID = await browser.elementById('render-id').text()
+        expect(secondID).toBe(firstID)
+
+        // Navigate to the subpage, verify that the history entry was NOT added.
+        await browser.elementById('subpage-link').click()
+        await browser.waitForElementByCss('#back-link')
+        expect(await browser.eval('window.history.length')).toBe(2)
+
+        // Navigate back again, verify that the history entry was NOT added.
+        await browser.elementById('back-link').click()
+        await browser.waitForElementByCss('#render-id')
+        expect(await browser.eval('window.history.length')).toBe(2)
+
+        // Get the date again, and compare, they should be the same.
+        const thirdID = await browser.elementById('render-id').text()
+        expect(thirdID).toBe(firstID)
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should be soft for back navigation', async () => {
+      const browser = await webdriver(next.url, '/with-id')
+
+      try {
+        // Get the id on the rendered page.
+        const firstID = await browser.elementById('render-id').text()
+
+        // Click the link, and go back.
+        await browser.elementById('link').click()
+        await browser.waitForElementByCss('#from-navigation')
+        await browser.back()
+
+        // Get the date again, and compare, they should be the same.
+        const secondID = await browser.elementById('render-id').text()
+        expect(firstID).toBe(secondID)
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should be soft for forward navigation', async () => {
+      const browser = await webdriver(next.url, '/with-id')
+
+      try {
+        // Click the link.
+        await browser.elementById('link').click()
+        await browser.waitForElementByCss('#from-navigation')
+
+        // Get the id on the rendered page.
+        const firstID = await browser.elementById('render-id').text()
+
+        // Go back, then forward.
+        await browser.back()
+        await browser.forward()
+
+        // Get the date again, and compare, they should be the same.
+        const secondID = await browser.elementById('render-id').text()
+        expect(firstID).toBe(secondID)
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should allow linking from app page to pages page', async () => {
+      const browser = await webdriver(next.url, '/pages-linking')
+
+      try {
+        // Click the link.
+        await browser.elementById('app-link').click()
+        expect(await browser.waitForElementByCss('#pages-link').text()).toBe(
+          'To App Page'
+        )
+
+        // Click the other link.
+        await browser.elementById('pages-link').click()
+        expect(await browser.waitForElementByCss('#app-link').text()).toBe(
+          'To Pages Page'
+        )
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should navigate to pages dynamic route from pages page if it overlaps with an app page', async () => {
+      const browser = await webdriver(
+        next.url,
+        '/dynamic-pages-route-app-overlap'
+      )
+
+      try {
+        // Click the link.
+        await browser.elementById('pages-link').click()
+        expect(await browser.waitForElementByCss('#pages-text').text()).toBe(
+          'hello from pages/dynamic-pages-route-app-overlap/[slug]'
+        )
+
+        // When refreshing the browser, the app page should be rendered
+        await browser.refresh()
+        expect(await browser.waitForElementByCss('#app-text').text()).toBe(
+          'hello from app/dynamic-pages-route-app-overlap/app-dir/page'
+        )
+      } finally {
+        await browser.close()
+      }
+    })
+  })
+
+  describe('server components', () => {
+    // TODO-APP: why is this not servable but /dashboard+rootonly/hello.server.js
+    // should be? Seems like they both either should be servable or not
+    it('should not serve .server.js as a path', async () => {
+      // Without .server.js should serve
+      const html = await renderViaHTTP(next.url, '/should-not-serve-server')
+      expect(html).toContain('hello from app/should-not-serve-server')
+
+      // Should not serve `.server`
+      const res = await fetchViaHTTP(
+        next.url,
+        '/should-not-serve-server.server'
+      )
+      expect(res.status).toBe(404)
+      expect(await res.text()).toContain('This page could not be found')
+
+      // Should not serve `.server.js`
+      const res2 = await fetchViaHTTP(
+        next.url,
+        '/should-not-serve-server.server.js'
+      )
+      expect(res2.status).toBe(404)
+      expect(await res2.text()).toContain('This page could not be found')
+    })
+
+    it('should not serve .client.js as a path', async () => {
+      // Without .client.js should serve
+      const html = await renderViaHTTP(next.url, '/should-not-serve-client')
+      expect(html).toContain('hello from app/should-not-serve-client')
+
+      // Should not serve `.client`
+      const res = await fetchViaHTTP(
+        next.url,
+        '/should-not-serve-client.client'
+      )
+      expect(res.status).toBe(404)
+      expect(await res.text()).toContain('This page could not be found')
+
+      // Should not serve `.client.js`
+      const res2 = await fetchViaHTTP(
+        next.url,
+        '/should-not-serve-client.client.js'
+      )
+      expect(res2.status).toBe(404)
+      expect(await res2.text()).toContain('This page could not be found')
+    })
+
+    it('should serve shared component', async () => {
+      // Without .client.js should serve
+      const html = await renderViaHTTP(next.url, '/shared-component-route')
+      expect(html).toContain('hello from app/shared-component-route')
+    })
+
+    describe('dynamic routes', () => {
+      it('should only pass params that apply to the layout', async () => {
+        const html = await renderViaHTTP(next.url, '/dynamic/books/hello-world')
+        const $ = cheerio.load(html)
+
+        expect($('#dynamic-layout-params').text()).toBe('{}')
+        expect($('#category-layout-params').text()).toBe('{"category":"books"}')
+        expect($('#id-layout-params').text()).toBe(
+          '{"category":"books","id":"hello-world"}'
+        )
+        expect($('#id-page-params').text()).toBe(
+          '{"category":"books","id":"hello-world"}'
+        )
       })
     })
 
-    describe('<Link />', () => {
-      it('should hard push', async () => {
-        const browser = await webdriver(next.url, '/link-hard-push/123')
-
-        try {
-          // Click the link on the page, and verify that the history entry was
-          // added.
-          expect(await browser.eval('window.history.length')).toBe(2)
-          await browser.elementById('link').click()
-          await browser.waitForElementByCss('#render-id-456')
-          expect(await browser.eval('window.history.length')).toBe(3)
-
-          // Get the id on the rendered page.
-          const firstID = await browser.elementById('render-id-456').text()
-
-          // Go back, and redo the navigation by clicking the link.
-          await browser.back()
-          await browser.elementById('link').click()
-          await browser.waitForElementByCss('#render-id-456')
-
-          // Get the id again, and compare, they should not be the same.
-          const secondID = await browser.elementById('render-id-456').text()
-          expect(secondID).not.toBe(firstID)
-        } finally {
-          await browser.close()
-        }
+    describe('catch-all routes', () => {
+      it('should handle optional segments', async () => {
+        const params = ['this', 'is', 'a', 'test']
+        const route = params.join('/')
+        const html = await renderViaHTTP(
+          next.url,
+          `/catch-all-optional/${route}`
+        )
+        const $ = cheerio.load(html)
+        expect($('#text').attr('data-params')).toBe(route)
       })
 
-      it('should hard replace', async () => {
-        const browser = await webdriver(next.url, '/link-hard-replace/123')
-
-        try {
-          // Click the link on the page, and verify that the history entry was NOT
-          // added.
-          expect(await browser.eval('window.history.length')).toBe(2)
-          await browser.elementById('link').click()
-          await browser.waitForElementByCss('#render-id-456')
-          expect(await browser.eval('window.history.length')).toBe(2)
-
-          // Get the date again, and compare, they should not be the same.
-          const firstId = await browser.elementById('render-id-456').text()
-
-          // Navigate to the subpage, verify that the history entry was NOT added.
-          await browser.elementById('link').click()
-          await browser.waitForElementByCss('#render-id-123')
-          expect(await browser.eval('window.history.length')).toBe(2)
-
-          // Navigate back again, verify that the history entry was NOT added.
-          await browser.elementById('link').click()
-          await browser.waitForElementByCss('#render-id-456')
-          expect(await browser.eval('window.history.length')).toBe(2)
-
-          // Get the date again, and compare, they should not be the same.
-          const secondId = await browser.elementById('render-id-456').text()
-          expect(firstId).not.toBe(secondId)
-        } finally {
-          await browser.close()
-        }
+      it('should handle optional segments root', async () => {
+        const html = await renderViaHTTP(next.url, `/catch-all-optional`)
+        const $ = cheerio.load(html)
+        expect($('#text').attr('data-params')).toBe('')
       })
 
-      // TODO-APP: Re-enable this test.
-      it('should soft push', async () => {
-        const browser = await webdriver(next.url, '/link-soft-push')
-
-        try {
-          // Click the link on the page, and verify that the history entry was
-          // added.
-          expect(await browser.eval('window.history.length')).toBe(2)
-          await browser.elementById('link').click()
-          await browser.waitForElementByCss('#render-id')
-          expect(await browser.eval('window.history.length')).toBe(3)
-
-          // Get the id on the rendered page.
-          const firstID = await browser.elementById('render-id').text()
-
-          // Go back, and redo the navigation by clicking the link.
-          await browser.back()
-          await browser.elementById('link').click()
-
-          // Get the date again, and compare, they should be the same.
-          const secondID = await browser.elementById('render-id').text()
-          expect(firstID).toBe(secondID)
-        } finally {
-          await browser.close()
-        }
+      it('should handle optional catch-all segments link', async () => {
+        const browser = await webdriver(next.url, '/catch-all-link')
+        expect(
+          await browser
+            .elementByCss('#to-catch-all-optional')
+            .click()
+            .waitForElementByCss('#text')
+            .text()
+        ).toBe(`hello from /catch-all-optional/this/is/a/test`)
       })
 
-      // TODO-APP: investigate this test
-      it.skip('should soft replace', async () => {
-        const browser = await webdriver(next.url, '/link-soft-replace')
+      it('should handle required segments', async () => {
+        const params = ['this', 'is', 'a', 'test']
+        const route = params.join('/')
+        const html = await renderViaHTTP(next.url, `/catch-all/${route}`)
+        const $ = cheerio.load(html)
+        expect($('#text').attr('data-params')).toBe(route)
+        expect($('#not-a-page').text()).toBe('Not a page')
 
-        try {
-          // Get the render ID so we can compare it.
-          const firstID = await browser.elementById('render-id').text()
-
-          // Click the link on the page, and verify that the history entry was NOT
-          // added.
-          expect(await browser.eval('window.history.length')).toBe(2)
-          await browser.elementById('self-link').click()
-          await browser.waitForElementByCss('#render-id')
-          expect(await browser.eval('window.history.length')).toBe(2)
-
-          // Get the id on the rendered page.
-          const secondID = await browser.elementById('render-id').text()
-          expect(secondID).toBe(firstID)
-
-          // Navigate to the subpage, verify that the history entry was NOT added.
-          await browser.elementById('subpage-link').click()
-          await browser.waitForElementByCss('#back-link')
-          expect(await browser.eval('window.history.length')).toBe(2)
-
-          // Navigate back again, verify that the history entry was NOT added.
-          await browser.elementById('back-link').click()
-          await browser.waitForElementByCss('#render-id')
-          expect(await browser.eval('window.history.length')).toBe(2)
-
-          // Get the date again, and compare, they should be the same.
-          const thirdID = await browser.elementById('render-id').text()
-          expect(thirdID).toBe(firstID)
-        } finally {
-          await browser.close()
-        }
+        // Components under catch-all should not be treated as route that errors during build.
+        // They should be rendered properly when imported in page route.
+        expect($('#widget').text()).toBe('widget')
       })
 
-      it('should be soft for back navigation', async () => {
-        const browser = await webdriver(next.url, '/with-id')
-
-        try {
-          // Get the id on the rendered page.
-          const firstID = await browser.elementById('render-id').text()
-
-          // Click the link, and go back.
-          await browser.elementById('link').click()
-          await browser.waitForElementByCss('#from-navigation')
-          await browser.back()
-
-          // Get the date again, and compare, they should be the same.
-          const secondID = await browser.elementById('render-id').text()
-          expect(firstID).toBe(secondID)
-        } finally {
-          await browser.close()
-        }
+      it('should handle required segments root as not found', async () => {
+        const res = await fetchViaHTTP(next.url, `/catch-all`)
+        expect(res.status).toBe(404)
+        expect(await res.text()).toContain('This page could not be found')
       })
 
-      it('should be soft for forward navigation', async () => {
-        const browser = await webdriver(next.url, '/with-id')
+      it('should handle catch-all segments link', async () => {
+        const browser = await webdriver(next.url, '/catch-all-link')
+        expect(
+          await browser
+            .elementByCss('#to-catch-all')
+            .click()
+            .waitForElementByCss('#text')
+            .text()
+        ).toBe(`hello from /catch-all/this/is/a/test`)
+      })
+    })
 
-        try {
-          // Click the link.
-          await browser.elementById('link').click()
-          await browser.waitForElementByCss('#from-navigation')
-
-          // Get the id on the rendered page.
-          const firstID = await browser.elementById('render-id').text()
-
-          // Go back, then forward.
-          await browser.back()
-          await browser.forward()
-
-          // Get the date again, and compare, they should be the same.
-          const secondID = await browser.elementById('render-id').text()
-          expect(firstID).toBe(secondID)
-        } finally {
-          await browser.close()
-        }
+    describe('should serve client component', () => {
+      it('should serve server-side', async () => {
+        const html = await renderViaHTTP(next.url, '/client-component-route')
+        const $ = cheerio.load(html)
+        expect($('p').text()).toBe(
+          'hello from app/client-component-route. count: 0'
+        )
       })
 
-      it('should allow linking from app page to pages page', async () => {
-        const browser = await webdriver(next.url, '/pages-linking')
+      // TODO-APP: investigate hydration not kicking in on some runs
+      it('should serve client-side', async () => {
+        const browser = await webdriver(next.url, '/client-component-route')
 
-        try {
-          // Click the link.
-          await browser.elementById('app-link').click()
-          expect(await browser.waitForElementByCss('#pages-link').text()).toBe(
-            'To App Page'
-          )
+        // After hydration count should be 1
+        expect(await browser.elementByCss('p').text()).toBe(
+          'hello from app/client-component-route. count: 1'
+        )
+      })
+    })
 
-          // Click the other link.
-          await browser.elementById('pages-link').click()
-          expect(await browser.waitForElementByCss('#app-link').text()).toBe(
-            'To Pages Page'
-          )
-        } finally {
-          await browser.close()
-        }
+    describe('should include client component layout with server component route', () => {
+      it('should include it server-side', async () => {
+        const html = await renderViaHTTP(next.url, '/client-nested')
+        const $ = cheerio.load(html)
+        // Should not be nested in dashboard
+        expect($('h1').text()).toBe('Client Nested. Count: 0')
+        // Should include the page text
+        expect($('p').text()).toBe('hello from app/client-nested')
       })
 
-      it('should navigate to pages dynamic route from pages page if it overlaps with an app page', async () => {
+      it('should include it client-side', async () => {
+        const browser = await webdriver(next.url, '/client-nested')
+
+        // After hydration count should be 1
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'Client Nested. Count: 1'
+        )
+
+        // After hydration count should be 1
+        expect(await browser.elementByCss('p').text()).toBe(
+          'hello from app/client-nested'
+        )
+      })
+    })
+
+    describe('Loading', () => {
+      it('should render loading.js in initial html for slow page', async () => {
+        const html = await renderViaHTTP(next.url, '/slow-page-with-loading')
+        const $ = cheerio.load(html)
+
+        expect($('#loading').text()).toBe('Loading...')
+      })
+
+      it('should render loading.js in browser for slow page', async () => {
+        const browser = await webdriver(next.url, '/slow-page-with-loading', {
+          waitHydration: false,
+        })
+        // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+        // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
+
+        expect(await browser.elementByCss('#slow-page-message').text()).toBe(
+          'hello from slow page'
+        )
+      })
+
+      it('should render loading.js in initial html for slow layout', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/slow-layout-with-loading/slow'
+        )
+        const $ = cheerio.load(html)
+
+        expect($('#loading').text()).toBe('Loading...')
+      })
+
+      it('should render loading.js in browser for slow layout', async () => {
         const browser = await webdriver(
           next.url,
-          '/dynamic-pages-route-app-overlap'
+          '/slow-layout-with-loading/slow',
+          {
+            waitHydration: false,
+          }
+        )
+        // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+        // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
+
+        expect(await browser.elementByCss('#slow-layout-message').text()).toBe(
+          'hello from slow layout'
+        )
+
+        expect(await browser.elementByCss('#page-message').text()).toBe(
+          'Hello World'
+        )
+      })
+
+      it('should render loading.js in initial html for slow layout and page', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/slow-layout-and-page-with-loading/slow'
+        )
+        const $ = cheerio.load(html)
+
+        expect($('#loading-layout').text()).toBe('Loading layout...')
+        expect($('#loading-page').text()).toBe('Loading page...')
+      })
+
+      it('should render loading.js in browser for slow layout and page', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/slow-layout-and-page-with-loading/slow',
+          {
+            waitHydration: false,
+          }
+        )
+        // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+        // expect(await browser.elementByCss('#loading-layout').text()).toBe('Loading...')
+        // expect(await browser.elementByCss('#loading-page').text()).toBe('Loading...')
+
+        expect(await browser.elementByCss('#slow-layout-message').text()).toBe(
+          'hello from slow layout'
+        )
+
+        expect(await browser.elementByCss('#slow-page-message').text()).toBe(
+          'hello from slow page'
+        )
+      })
+    })
+
+    describe('middleware', () => {
+      it.each(['rewrite', 'redirect'])(
+        `should strip internal query parameters from requests to middleware for %s`,
+        async (method) => {
+          const browser = await webdriver(next.url, '/internal')
+
+          try {
+            // Wait for and click the navigation element, this should trigger
+            // the flight request that'll be caught by the middleware. If the
+            // middleware sees any flight data on the request it'll redirect to
+            // a page with an element of #failure, otherwise, we'll see the
+            // element for #success.
+            await browser
+              .waitForElementByCss(`#navigate-${method}`)
+              .elementById(`navigate-${method}`)
+              .click()
+            expect(
+              await browser.waitForElementByCss('#success', 3000).text()
+            ).toBe('Success')
+          } finally {
+            await browser.close()
+          }
+        }
+      )
+    })
+
+    describe('next/router', () => {
+      it('should support router.back and router.forward', async () => {
+        const browser = await webdriver(next.url, '/back-forward/1')
+
+        const firstMessage = 'Hello from 1'
+        const secondMessage = 'Hello from 2'
+
+        expect(await browser.elementByCss('#message-1').text()).toBe(
+          firstMessage
         )
 
         try {
-          // Click the link.
-          await browser.elementById('pages-link').click()
-          expect(await browser.waitForElementByCss('#pages-text').text()).toBe(
-            'hello from pages/dynamic-pages-route-app-overlap/[slug]'
-          )
+          const message2 = await browser
+            .waitForElementByCss('#to-other-page')
+            .click()
+            .waitForElementByCss('#message-2')
+            .text()
+          expect(message2).toBe(secondMessage)
 
-          // When refreshing the browser, the app page should be rendered
-          await browser.refresh()
-          expect(await browser.waitForElementByCss('#app-text').text()).toBe(
-            'hello from app/dynamic-pages-route-app-overlap/app-dir/page'
-          )
+          const message1 = await browser
+            .waitForElementByCss('#back-button')
+            .click()
+            .waitForElementByCss('#message-1')
+            .text()
+          expect(message1).toBe(firstMessage)
+
+          const message2Again = await browser
+            .waitForElementByCss('#forward-button')
+            .click()
+            .waitForElementByCss('#message-2')
+            .text()
+          expect(message2Again).toBe(secondMessage)
         } finally {
           await browser.close()
         }
       })
     })
 
-    describe('server components', () => {
-      // TODO-APP: why is this not servable but /dashboard+rootonly/hello.server.js
-      // should be? Seems like they both either should be servable or not
-      it('should not serve .server.js as a path', async () => {
-        // Without .server.js should serve
-        const html = await renderViaHTTP(next.url, '/should-not-serve-server')
-        expect(html).toContain('hello from app/should-not-serve-server')
-
-        // Should not serve `.server`
-        const res = await fetchViaHTTP(
-          next.url,
-          '/should-not-serve-server.server'
-        )
-        expect(res.status).toBe(404)
-        expect(await res.text()).toContain('This page could not be found')
-
-        // Should not serve `.server.js`
-        const res2 = await fetchViaHTTP(
-          next.url,
-          '/should-not-serve-server.server.js'
-        )
-        expect(res2.status).toBe(404)
-        expect(await res2.text()).toContain('This page could not be found')
-      })
-
-      it('should not serve .client.js as a path', async () => {
-        // Without .client.js should serve
-        const html = await renderViaHTTP(next.url, '/should-not-serve-client')
-        expect(html).toContain('hello from app/should-not-serve-client')
-
-        // Should not serve `.client`
-        const res = await fetchViaHTTP(
-          next.url,
-          '/should-not-serve-client.client'
-        )
-        expect(res.status).toBe(404)
-        expect(await res.text()).toContain('This page could not be found')
-
-        // Should not serve `.client.js`
-        const res2 = await fetchViaHTTP(
-          next.url,
-          '/should-not-serve-client.client.js'
-        )
-        expect(res2.status).toBe(404)
-        expect(await res2.text()).toContain('This page could not be found')
-      })
-
-      it('should serve shared component', async () => {
-        // Without .client.js should serve
-        const html = await renderViaHTTP(next.url, '/shared-component-route')
-        expect(html).toContain('hello from app/shared-component-route')
-      })
-
-      describe('dynamic routes', () => {
-        it('should only pass params that apply to the layout', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/dynamic/books/hello-world'
-          )
-          const $ = cheerio.load(html)
-
-          expect($('#dynamic-layout-params').text()).toBe('{}')
-          expect($('#category-layout-params').text()).toBe(
-            '{"category":"books"}'
-          )
-          expect($('#id-layout-params').text()).toBe(
-            '{"category":"books","id":"hello-world"}'
-          )
-          expect($('#id-page-params').text()).toBe(
-            '{"category":"books","id":"hello-world"}'
-          )
-        })
-      })
-
-      describe('catch-all routes', () => {
-        it('should handle optional segments', async () => {
-          const params = ['this', 'is', 'a', 'test']
-          const route = params.join('/')
-          const html = await renderViaHTTP(
-            next.url,
-            `/catch-all-optional/${route}`
-          )
-          const $ = cheerio.load(html)
-          expect($('#text').attr('data-params')).toBe(route)
-        })
-
-        it('should handle optional segments root', async () => {
-          const html = await renderViaHTTP(next.url, `/catch-all-optional`)
-          const $ = cheerio.load(html)
-          expect($('#text').attr('data-params')).toBe('')
-        })
-
-        it('should handle optional catch-all segments link', async () => {
-          const browser = await webdriver(next.url, '/catch-all-link')
-          expect(
-            await browser
-              .elementByCss('#to-catch-all-optional')
-              .click()
-              .waitForElementByCss('#text')
-              .text()
-          ).toBe(`hello from /catch-all-optional/this/is/a/test`)
-        })
-
-        it('should handle required segments', async () => {
-          const params = ['this', 'is', 'a', 'test']
-          const route = params.join('/')
-          const html = await renderViaHTTP(next.url, `/catch-all/${route}`)
-          const $ = cheerio.load(html)
-          expect($('#text').attr('data-params')).toBe(route)
-          expect($('#not-a-page').text()).toBe('Not a page')
-
-          // Components under catch-all should not be treated as route that errors during build.
-          // They should be rendered properly when imported in page route.
-          expect($('#widget').text()).toBe('widget')
-        })
-
-        it('should handle required segments root as not found', async () => {
-          const res = await fetchViaHTTP(next.url, `/catch-all`)
-          expect(res.status).toBe(404)
-          expect(await res.text()).toContain('This page could not be found')
-        })
-
-        it('should handle catch-all segments link', async () => {
-          const browser = await webdriver(next.url, '/catch-all-link')
-          expect(
-            await browser
-              .elementByCss('#to-catch-all')
-              .click()
-              .waitForElementByCss('#text')
-              .text()
-          ).toBe(`hello from /catch-all/this/is/a/test`)
-        })
-      })
-
-      describe('should serve client component', () => {
-        it('should serve server-side', async () => {
-          const html = await renderViaHTTP(next.url, '/client-component-route')
-          const $ = cheerio.load(html)
-          expect($('p').text()).toBe(
-            'hello from app/client-component-route. count: 0'
-          )
-        })
-
-        // TODO-APP: investigate hydration not kicking in on some runs
-        it('should serve client-side', async () => {
-          const browser = await webdriver(next.url, '/client-component-route')
-
-          // After hydration count should be 1
-          expect(await browser.elementByCss('p').text()).toBe(
-            'hello from app/client-component-route. count: 1'
-          )
-        })
-      })
-
-      describe('should include client component layout with server component route', () => {
-        it('should include it server-side', async () => {
-          const html = await renderViaHTTP(next.url, '/client-nested')
-          const $ = cheerio.load(html)
-          // Should not be nested in dashboard
-          expect($('h1').text()).toBe('Client Nested. Count: 0')
-          // Should include the page text
-          expect($('p').text()).toBe('hello from app/client-nested')
-        })
-
-        it('should include it client-side', async () => {
-          const browser = await webdriver(next.url, '/client-nested')
-
-          // After hydration count should be 1
-          expect(await browser.elementByCss('h1').text()).toBe(
-            'Client Nested. Count: 1'
-          )
-
-          // After hydration count should be 1
-          expect(await browser.elementByCss('p').text()).toBe(
-            'hello from app/client-nested'
-          )
-        })
-      })
-
-      describe('Loading', () => {
-        it('should render loading.js in initial html for slow page', async () => {
-          const html = await renderViaHTTP(next.url, '/slow-page-with-loading')
-          const $ = cheerio.load(html)
-
-          expect($('#loading').text()).toBe('Loading...')
-        })
-
-        it('should render loading.js in browser for slow page', async () => {
-          const browser = await webdriver(next.url, '/slow-page-with-loading', {
-            waitHydration: false,
-          })
-          // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
-          // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
-
-          expect(await browser.elementByCss('#slow-page-message').text()).toBe(
-            'hello from slow page'
-          )
-        })
-
-        it('should render loading.js in initial html for slow layout', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/slow-layout-with-loading/slow'
-          )
-          const $ = cheerio.load(html)
-
-          expect($('#loading').text()).toBe('Loading...')
-        })
-
-        it('should render loading.js in browser for slow layout', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/slow-layout-with-loading/slow',
-            {
-              waitHydration: false,
-            }
-          )
-          // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
-          // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
-
-          expect(
-            await browser.elementByCss('#slow-layout-message').text()
-          ).toBe('hello from slow layout')
-
-          expect(await browser.elementByCss('#page-message').text()).toBe(
-            'Hello World'
-          )
-        })
-
-        it('should render loading.js in initial html for slow layout and page', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/slow-layout-and-page-with-loading/slow'
-          )
-          const $ = cheerio.load(html)
-
-          expect($('#loading-layout').text()).toBe('Loading layout...')
-          expect($('#loading-page').text()).toBe('Loading page...')
-        })
-
-        it('should render loading.js in browser for slow layout and page', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/slow-layout-and-page-with-loading/slow',
-            {
-              waitHydration: false,
-            }
-          )
-          // TODO-APP: `await webdriver()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
-          // expect(await browser.elementByCss('#loading-layout').text()).toBe('Loading...')
-          // expect(await browser.elementByCss('#loading-page').text()).toBe('Loading...')
-
-          expect(
-            await browser.elementByCss('#slow-layout-message').text()
-          ).toBe('hello from slow layout')
-
-          expect(await browser.elementByCss('#slow-page-message').text()).toBe(
-            'hello from slow page'
-          )
-        })
-      })
-
-      describe('middleware', () => {
-        it.each(['rewrite', 'redirect'])(
-          `should strip internal query parameters from requests to middleware for %s`,
-          async (method) => {
-            const browser = await webdriver(next.url, '/internal')
-
-            try {
-              // Wait for and click the navigation element, this should trigger
-              // the flight request that'll be caught by the middleware. If the
-              // middleware sees any flight data on the request it'll redirect to
-              // a page with an element of #failure, otherwise, we'll see the
-              // element for #success.
-              await browser
-                .waitForElementByCss(`#navigate-${method}`)
-                .elementById(`navigate-${method}`)
-                .click()
-              expect(
-                await browser.waitForElementByCss('#success', 3000).text()
-              ).toBe('Success')
-            } finally {
-              await browser.close()
-            }
-          }
-        )
-      })
-
-      describe('next/router', () => {
-        it('should support router.back and router.forward', async () => {
-          const browser = await webdriver(next.url, '/back-forward/1')
-
-          const firstMessage = 'Hello from 1'
-          const secondMessage = 'Hello from 2'
-
-          expect(await browser.elementByCss('#message-1').text()).toBe(
-            firstMessage
-          )
+    describe('hooks', () => {
+      describe('cookies function', () => {
+        it('should retrieve cookies in a server component', async () => {
+          const browser = await webdriver(next.url, '/hooks/use-cookies')
 
           try {
-            const message2 = await browser
-              .waitForElementByCss('#to-other-page')
-              .click()
-              .waitForElementByCss('#message-2')
-              .text()
-            expect(message2).toBe(secondMessage)
+            await browser.waitForElementByCss('#does-not-have-cookie')
+            browser.addCookie({ name: 'use-cookies', value: 'value' })
+            browser.refresh()
 
-            const message1 = await browser
-              .waitForElementByCss('#back-button')
-              .click()
-              .waitForElementByCss('#message-1')
-              .text()
-            expect(message1).toBe(firstMessage)
+            await browser.waitForElementByCss('#has-cookie')
+            browser.deleteCookies()
+            browser.refresh()
 
-            const message2Again = await browser
-              .waitForElementByCss('#forward-button')
-              .click()
-              .waitForElementByCss('#message-2')
-              .text()
-            expect(message2Again).toBe(secondMessage)
+            await browser.waitForElementByCss('#does-not-have-cookie')
+          } finally {
+            await browser.close()
+          }
+        })
+
+        it('should retrieve cookies in a server component in the edge runtime', async () => {
+          const res = await fetchViaHTTP(next.url, '/edge-apis/cookies')
+          expect(await res.text()).toInclude('Hello')
+        })
+
+        it('should access cookies on <Link /> navigation', async () => {
+          const browser = await webdriver(next.url, '/navigation')
+
+          try {
+            // Click the cookies link to verify it can't see the cookie that's
+            // not there.
+            await browser.elementById('use-cookies').click()
+            await browser.waitForElementByCss('#does-not-have-cookie')
+
+            // Go back and add the cookies.
+            await browser.back()
+            await browser.waitForElementByCss('#from-navigation')
+            browser.addCookie({ name: 'use-cookies', value: 'value' })
+
+            // Click the cookies link again to see that the cookie can be picked
+            // up again.
+            await browser.elementById('use-cookies').click()
+            await browser.waitForElementByCss('#has-cookie')
+
+            // Go back and remove the cookies.
+            await browser.back()
+            await browser.waitForElementByCss('#from-navigation')
+            browser.deleteCookies()
+
+            // Verify for the last time that after clicking the cookie link
+            // again, there are no cookies.
+            await browser.elementById('use-cookies').click()
+            await browser.waitForElementByCss('#does-not-have-cookie')
           } finally {
             await browser.close()
           }
         })
       })
 
-      describe('hooks', () => {
-        describe('cookies function', () => {
-          it('should retrieve cookies in a server component', async () => {
-            const browser = await webdriver(next.url, '/hooks/use-cookies')
+      describe('headers function', () => {
+        it('should have access to incoming headers in a server component', async () => {
+          // Check to see that we can't see the header when it's not present.
+          let html = await renderViaHTTP(
+            next.url,
+            '/hooks/use-headers',
+            {},
+            { headers: {} }
+          )
+          let $ = cheerio.load(html)
+          expect($('#does-not-have-header').length).toBe(1)
+          expect($('#has-header').length).toBe(0)
 
-            try {
-              await browser.waitForElementByCss('#does-not-have-cookie')
-              browser.addCookie({ name: 'use-cookies', value: 'value' })
-              browser.refresh()
-
-              await browser.waitForElementByCss('#has-cookie')
-              browser.deleteCookies()
-              browser.refresh()
-
-              await browser.waitForElementByCss('#does-not-have-cookie')
-            } finally {
-              await browser.close()
-            }
-          })
-
-          it('should retrieve cookies in a server component in the edge runtime', async () => {
-            const res = await fetchViaHTTP(next.url, '/edge-apis/cookies')
-            expect(await res.text()).toInclude('Hello')
-          })
-
-          it('should access cookies on <Link /> navigation', async () => {
-            const browser = await webdriver(next.url, '/navigation')
-
-            try {
-              // Click the cookies link to verify it can't see the cookie that's
-              // not there.
-              await browser.elementById('use-cookies').click()
-              await browser.waitForElementByCss('#does-not-have-cookie')
-
-              // Go back and add the cookies.
-              await browser.back()
-              await browser.waitForElementByCss('#from-navigation')
-              browser.addCookie({ name: 'use-cookies', value: 'value' })
-
-              // Click the cookies link again to see that the cookie can be picked
-              // up again.
-              await browser.elementById('use-cookies').click()
-              await browser.waitForElementByCss('#has-cookie')
-
-              // Go back and remove the cookies.
-              await browser.back()
-              await browser.waitForElementByCss('#from-navigation')
-              browser.deleteCookies()
-
-              // Verify for the last time that after clicking the cookie link
-              // again, there are no cookies.
-              await browser.elementById('use-cookies').click()
-              await browser.waitForElementByCss('#does-not-have-cookie')
-            } finally {
-              await browser.close()
-            }
-          })
+          // Check to see that we can see the header when it's present.
+          html = await renderViaHTTP(
+            next.url,
+            '/hooks/use-headers',
+            {},
+            { headers: { 'x-use-headers': 'value' } }
+          )
+          $ = cheerio.load(html)
+          expect($('#has-header').length).toBe(1)
+          expect($('#does-not-have-header').length).toBe(0)
         })
 
-        describe('headers function', () => {
-          it('should have access to incoming headers in a server component', async () => {
-            // Check to see that we can't see the header when it's not present.
-            let html = await renderViaHTTP(
-              next.url,
-              '/hooks/use-headers',
-              {},
-              { headers: {} }
-            )
-            let $ = cheerio.load(html)
-            expect($('#does-not-have-header').length).toBe(1)
-            expect($('#has-header').length).toBe(0)
+        it('should access headers on <Link /> navigation', async () => {
+          const browser = await webdriver(next.url, '/navigation')
 
-            // Check to see that we can see the header when it's present.
-            html = await renderViaHTTP(
-              next.url,
-              '/hooks/use-headers',
-              {},
-              { headers: { 'x-use-headers': 'value' } }
-            )
-            $ = cheerio.load(html)
-            expect($('#has-header').length).toBe(1)
-            expect($('#does-not-have-header').length).toBe(0)
-          })
-
-          it('should access headers on <Link /> navigation', async () => {
-            const browser = await webdriver(next.url, '/navigation')
-
-            try {
-              await browser.elementById('use-headers').click()
-              await browser.waitForElementByCss('#has-referer')
-            } finally {
-              await browser.close()
-            }
-          })
-        })
-
-        describe('previewData function', () => {
-          it('should return no preview data when there is none', async () => {
-            const browser = await webdriver(next.url, '/hooks/use-preview-data')
-
-            try {
-              await browser.waitForElementByCss('#does-not-have-preview-data')
-            } finally {
-              await browser.close()
-            }
-          })
-
-          it('should return preview data when there is some', async () => {
-            const browser = await webdriver(next.url, '/api/preview')
-
-            try {
-              await browser.loadPage(next.url + '/hooks/use-preview-data', {
-                disableCache: false,
-                beforePageLoad: null,
-              })
-              await browser.waitForElementByCss('#has-preview-data')
-            } finally {
-              await browser.close()
-            }
-          })
-        })
-
-        describe('useRouter', () => {
-          // TODO-APP: should enable when implemented
-          it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(next.url, '/hooks/use-router/server')
-            expect(res.status).toBe(500)
-            expect(await res.text()).toContain('Internal Server Error')
-          })
-        })
-
-        describe('useParams', () => {
-          // TODO-APP: should enable when implemented
-          it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(next.url, '/hooks/use-params/server')
-            expect(res.status).toBe(500)
-            expect(await res.text()).toContain('Internal Server Error')
-          })
-        })
-
-        describe('useSearchParams', () => {
-          // TODO-APP: should enable when implemented
-          it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(
-              next.url,
-              '/hooks/use-search-params/server'
-            )
-            expect(res.status).toBe(500)
-            expect(await res.text()).toContain('Internal Server Error')
-          })
-        })
-
-        describe('usePathname', () => {
-          // TODO-APP: should enable when implemented
-          it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(
-              next.url,
-              '/hooks/use-pathname/server'
-            )
-            expect(res.status).toBe(500)
-            expect(await res.text()).toContain('Internal Server Error')
-          })
-        })
-
-        describe('useLayoutSegments', () => {
-          // TODO-APP: should enable when implemented
-          it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(
-              next.url,
-              '/hooks/use-layout-segments/server'
-            )
-            expect(res.status).toBe(500)
-            expect(await res.text()).toContain('Internal Server Error')
-          })
-        })
-
-        describe('useSelectedLayoutSegment', () => {
-          // TODO-APP: should enable when implemented
-          it.skip('should throw an error when imported', async () => {
-            const res = await fetchViaHTTP(
-              next.url,
-              '/hooks/use-selected-layout-segment/server'
-            )
-            expect(res.status).toBe(500)
-            expect(await res.text()).toContain('Internal Server Error')
-          })
+          try {
+            await browser.elementById('use-headers').click()
+            await browser.waitForElementByCss('#has-referer')
+          } finally {
+            await browser.close()
+          }
         })
       })
-    })
 
-    describe('client components', () => {
-      describe('hooks', () => {
-        describe('from pages', () => {
-          it.each([
-            { pathname: '/adapter-hooks/static' },
-            { pathname: '/adapter-hooks/1' },
-            { pathname: '/adapter-hooks/2' },
-            { pathname: '/adapter-hooks/1/account' },
-            { pathname: '/adapter-hooks/static', keyValue: 'value' },
-            { pathname: '/adapter-hooks/1', keyValue: 'value' },
-            { pathname: '/adapter-hooks/2', keyValue: 'value' },
-            { pathname: '/adapter-hooks/1/account', keyValue: 'value' },
-          ])(
-            'should have the correct hooks',
-            async ({ pathname, keyValue = '' }) => {
-              const browser = await webdriver(
-                next.url,
-                pathname + (keyValue ? `?key=${keyValue}` : '')
-              )
+      describe('previewData function', () => {
+        it('should return no preview data when there is none', async () => {
+          const browser = await webdriver(next.url, '/hooks/use-preview-data')
 
-              try {
-                await browser.waitForElementByCss('#router-ready')
-                expect(await browser.elementById('key-value').text()).toBe(
-                  keyValue
-                )
-                expect(await browser.elementById('pathname').text()).toBe(
-                  pathname
-                )
-
-                await browser.elementByCss('button').click()
-                await browser.waitForElementByCss('#pushed')
-              } finally {
-                await browser.close()
-              }
-            }
-          )
-        })
-
-        describe('usePathname', () => {
-          it('should have the correct pathname', async () => {
-            const html = await renderViaHTTP(next.url, '/hooks/use-pathname')
-            const $ = cheerio.load(html)
-            expect($('#pathname').attr('data-pathname')).toBe(
-              '/hooks/use-pathname'
-            )
-          })
-
-          it('should have the canonical url pathname on rewrite', async () => {
-            const html = await renderViaHTTP(
-              next.url,
-              '/rewritten-use-pathname'
-            )
-            const $ = cheerio.load(html)
-            expect($('#pathname').attr('data-pathname')).toBe(
-              '/rewritten-use-pathname'
-            )
-          })
-        })
-
-        describe('useSearchParams', () => {
-          it('should have the correct search params', async () => {
-            const html = await renderViaHTTP(
-              next.url,
-              '/hooks/use-search-params?first=value&second=other%20value&third'
-            )
-            const $ = cheerio.load(html)
-            expect($('#params-first').text()).toBe('value')
-            expect($('#params-second').text()).toBe('other value')
-            expect($('#params-third').text()).toBe('')
-            expect($('#params-not-real').text()).toBe('N/A')
-          })
-
-          // TODO-APP: correct this behavior when deployed
-          if (!(global as any).isNextDeploy) {
-            it('should have the canonical url search params on rewrite', async () => {
-              const html = await renderViaHTTP(
-                next.url,
-                '/rewritten-use-search-params?first=a&second=b&third=c'
-              )
-              const $ = cheerio.load(html)
-              expect($('#params-first').text()).toBe('a')
-              expect($('#params-second').text()).toBe('b')
-              expect($('#params-third').text()).toBe('c')
-              expect($('#params-not-real').text()).toBe('N/A')
-            })
+          try {
+            await browser.waitForElementByCss('#does-not-have-preview-data')
+          } finally {
+            await browser.close()
           }
         })
 
-        describe('useRouter', () => {
-          it('should allow access to the router', async () => {
-            const browser = await webdriver(next.url, '/hooks/use-router')
+        it('should return preview data when there is some', async () => {
+          const browser = await webdriver(next.url, '/api/preview')
 
-            try {
-              // Wait for the page to load, click the button (which uses a method
-              // on the router) and then wait for the correct page to load.
-              await browser.waitForElementByCss('#router')
-              await browser.elementById('button-push').click()
-              await browser.waitForElementByCss('#router-sub-page')
-
-              // Go back (confirming we did do a hard push), and wait for the
-              // correct previous page.
-              await browser.back()
-              await browser.waitForElementByCss('#router')
-            } finally {
-              await browser.close()
-            }
-          })
-
-          if (!(global as any).isNextDeploy) {
-            it('should have consistent query and params handling', async () => {
-              const html = await renderViaHTTP(
-                next.url,
-                '/param-and-query/params?slug=query'
-              )
-              const $ = cheerio.load(html)
-              const el = $('#params-and-query')
-              expect(el.attr('data-params')).toBe('params')
-              expect(el.attr('data-query')).toBe('query')
+          try {
+            await browser.loadPage(next.url + '/hooks/use-preview-data', {
+              disableCache: false,
+              beforePageLoad: null,
             })
+            await browser.waitForElementByCss('#has-preview-data')
+          } finally {
+            await browser.close()
           }
         })
+      })
 
-        describe('useSelectedLayoutSegments', () => {
-          it.each`
-            path                                                           | outerLayout                                             | innerLayout
-            ${'/hooks/use-selected-layout-segment/first'}                  | ${['first']}                                            | ${[]}
-            ${'/hooks/use-selected-layout-segment/first/slug1'}            | ${['first', 'slug1']}                                   | ${['slug1']}
-            ${'/hooks/use-selected-layout-segment/first/slug2/second'}     | ${['first', 'slug2', '(group)', 'second']}              | ${['slug2', '(group)', 'second']}
-            ${'/hooks/use-selected-layout-segment/first/slug2/second/a/b'} | ${['first', 'slug2', '(group)', 'second', 'a/b']}       | ${['slug2', '(group)', 'second', 'a/b']}
-            ${'/hooks/use-selected-layout-segment/rewritten'}              | ${['first', 'slug3', '(group)', 'second', 'catch/all']} | ${['slug3', '(group)', 'second', 'catch/all']}
-            ${'/hooks/use-selected-layout-segment/rewritten-middleware'}   | ${['first', 'slug3', '(group)', 'second', 'catch/all']} | ${['slug3', '(group)', 'second', 'catch/all']}
-          `(
-            'should have the correct layout segments at $path',
-            async ({ path, outerLayout, innerLayout }) => {
-              const html = await renderViaHTTP(next.url, path)
-              const $ = cheerio.load(html)
-
-              expect(JSON.parse($('#outer-layout').text())).toEqual(outerLayout)
-              expect(JSON.parse($('#inner-layout').text())).toEqual(innerLayout)
-            }
-          )
-
-          it('should return an empty array in pages', async () => {
-            const html = await renderViaHTTP(
-              next.url,
-              '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
-            )
-            const $ = cheerio.load(html)
-
-            expect(JSON.parse($('#page-layout-segments').text())).toEqual([])
-          })
+      describe('useRouter', () => {
+        // TODO-APP: should enable when implemented
+        it.skip('should throw an error when imported', async () => {
+          const res = await fetchViaHTTP(next.url, '/hooks/use-router/server')
+          expect(res.status).toBe(500)
+          expect(await res.text()).toContain('Internal Server Error')
         })
+      })
 
-        describe('useSelectedLayoutSegment', () => {
-          it.each`
-            path                                                           | outerLayout | innerLayout
-            ${'/hooks/use-selected-layout-segment/first'}                  | ${'first'}  | ${null}
-            ${'/hooks/use-selected-layout-segment/first/slug1'}            | ${'first'}  | ${'slug1'}
-            ${'/hooks/use-selected-layout-segment/first/slug2/second/a/b'} | ${'first'}  | ${'slug2'}
-          `(
-            'should have the correct layout segment at $path',
-            async ({ path, outerLayout, innerLayout }) => {
-              const html = await renderViaHTTP(next.url, path)
-              const $ = cheerio.load(html)
+      describe('useParams', () => {
+        // TODO-APP: should enable when implemented
+        it.skip('should throw an error when imported', async () => {
+          const res = await fetchViaHTTP(next.url, '/hooks/use-params/server')
+          expect(res.status).toBe(500)
+          expect(await res.text()).toContain('Internal Server Error')
+        })
+      })
 
-              expect(JSON.parse($('#outer-layout-segment').text())).toEqual(
-                outerLayout
-              )
-              expect(JSON.parse($('#inner-layout-segment').text())).toEqual(
-                innerLayout
-              )
-            }
+      describe('useSearchParams', () => {
+        // TODO-APP: should enable when implemented
+        it.skip('should throw an error when imported', async () => {
+          const res = await fetchViaHTTP(
+            next.url,
+            '/hooks/use-search-params/server'
           )
+          expect(res.status).toBe(500)
+          expect(await res.text()).toContain('Internal Server Error')
+        })
+      })
 
-          it('should return null in pages', async () => {
-            const html = await renderViaHTTP(
-              next.url,
-              '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
-            )
-            const $ = cheerio.load(html)
+      describe('usePathname', () => {
+        // TODO-APP: should enable when implemented
+        it.skip('should throw an error when imported', async () => {
+          const res = await fetchViaHTTP(next.url, '/hooks/use-pathname/server')
+          expect(res.status).toBe(500)
+          expect(await res.text()).toContain('Internal Server Error')
+        })
+      })
 
-            expect(JSON.parse($('#page-layout-segment').text())).toEqual(null)
-          })
+      describe('useLayoutSegments', () => {
+        // TODO-APP: should enable when implemented
+        it.skip('should throw an error when imported', async () => {
+          const res = await fetchViaHTTP(
+            next.url,
+            '/hooks/use-layout-segments/server'
+          )
+          expect(res.status).toBe(500)
+          expect(await res.text()).toContain('Internal Server Error')
+        })
+      })
+
+      describe('useSelectedLayoutSegment', () => {
+        // TODO-APP: should enable when implemented
+        it.skip('should throw an error when imported', async () => {
+          const res = await fetchViaHTTP(
+            next.url,
+            '/hooks/use-selected-layout-segment/server'
+          )
+          expect(res.status).toBe(500)
+          expect(await res.text()).toContain('Internal Server Error')
         })
       })
     })
+  })
 
-    describe('css support', () => {
-      describe('server layouts', () => {
-        it('should support global css inside server layouts', async () => {
-          const browser = await webdriver(next.url, '/dashboard')
-
-          // Should body text in red
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('.p')).color`
-            )
-          ).toBe('rgb(255, 0, 0)')
-
-          // Should inject global css for .green selectors
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('.green')).color`
-            )
-          ).toBe('rgb(0, 128, 0)')
-        })
-
-        it('should support css modules inside server layouts', async () => {
-          const browser = await webdriver(next.url, '/css/css-nested')
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#server-cssm')).color`
-            )
-          ).toBe('rgb(0, 128, 0)')
-        })
-      })
-
-      describe('server pages', () => {
-        it('should support global css inside server pages', async () => {
-          const browser = await webdriver(next.url, '/css/css-page')
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('h1')).color`
-            )
-          ).toBe('rgb(255, 0, 0)')
-        })
-
-        it('should support css modules inside server pages', async () => {
-          const browser = await webdriver(next.url, '/css/css-page')
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#cssm')).color`
-            )
-          ).toBe('rgb(0, 0, 255)')
-        })
-
-        if (!isDev) {
-          it('should not include unused css modules in the page in prod', async () => {
-            const browser = await webdriver(next.url, '/css/css-page/unused')
-            expect(
-              await browser.eval(
-                `[...document.styleSheets].some(({ rules }) => [...rules].some(rule => rule.selectorText.includes('this_should_not_be_included')))`
-              )
-            ).toBe(false)
-          })
-
-          it('should not include unused css modules in nested pages in prod', async () => {
+  describe('client components', () => {
+    describe('hooks', () => {
+      describe('from pages', () => {
+        it.each([
+          { pathname: '/adapter-hooks/static' },
+          { pathname: '/adapter-hooks/1' },
+          { pathname: '/adapter-hooks/2' },
+          { pathname: '/adapter-hooks/1/account' },
+          { pathname: '/adapter-hooks/static', keyValue: 'value' },
+          { pathname: '/adapter-hooks/1', keyValue: 'value' },
+          { pathname: '/adapter-hooks/2', keyValue: 'value' },
+          { pathname: '/adapter-hooks/1/account', keyValue: 'value' },
+        ])(
+          'should have the correct hooks',
+          async ({ pathname, keyValue = '' }) => {
             const browser = await webdriver(
               next.url,
-              '/css/css-page/unused-nested/inner'
+              pathname + (keyValue ? `?key=${keyValue}` : '')
             )
-            expect(
-              await browser.eval(
-                `[...document.styleSheets].some(({ rules }) => [...rules].some(rule => rule.selectorText.includes('this_should_not_be_included_in_inner_path')))`
+
+            try {
+              await browser.waitForElementByCss('#router-ready')
+              expect(await browser.elementById('key-value').text()).toBe(
+                keyValue
               )
-            ).toBe(false)
+              expect(await browser.elementById('pathname').text()).toBe(
+                pathname
+              )
+
+              await browser.elementByCss('button').click()
+              await browser.waitForElementByCss('#pushed')
+            } finally {
+              await browser.close()
+            }
+          }
+        )
+      })
+
+      describe('usePathname', () => {
+        it('should have the correct pathname', async () => {
+          const html = await renderViaHTTP(next.url, '/hooks/use-pathname')
+          const $ = cheerio.load(html)
+          expect($('#pathname').attr('data-pathname')).toBe(
+            '/hooks/use-pathname'
+          )
+        })
+
+        it('should have the canonical url pathname on rewrite', async () => {
+          const html = await renderViaHTTP(next.url, '/rewritten-use-pathname')
+          const $ = cheerio.load(html)
+          expect($('#pathname').attr('data-pathname')).toBe(
+            '/rewritten-use-pathname'
+          )
+        })
+      })
+
+      describe('useSearchParams', () => {
+        it('should have the correct search params', async () => {
+          const html = await renderViaHTTP(
+            next.url,
+            '/hooks/use-search-params?first=value&second=other%20value&third'
+          )
+          const $ = cheerio.load(html)
+          expect($('#params-first').text()).toBe('value')
+          expect($('#params-second').text()).toBe('other value')
+          expect($('#params-third').text()).toBe('')
+          expect($('#params-not-real').text()).toBe('N/A')
+        })
+
+        // TODO-APP: correct this behavior when deployed
+        if (!(global as any).isNextDeploy) {
+          it('should have the canonical url search params on rewrite', async () => {
+            const html = await renderViaHTTP(
+              next.url,
+              '/rewritten-use-search-params?first=a&second=b&third=c'
+            )
+            const $ = cheerio.load(html)
+            expect($('#params-first').text()).toBe('a')
+            expect($('#params-second').text()).toBe('b')
+            expect($('#params-third').text()).toBe('c')
+            expect($('#params-not-real').text()).toBe('N/A')
           })
         }
       })
 
-      describe('client layouts', () => {
-        it('should support css modules inside client layouts', async () => {
-          const browser = await webdriver(next.url, '/client-nested')
+      describe('useRouter', () => {
+        it('should allow access to the router', async () => {
+          const browser = await webdriver(next.url, '/hooks/use-router')
 
-          // Should render h1 in red
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('h1')).color`
-            )
-          ).toBe('rgb(255, 0, 0)')
+          try {
+            // Wait for the page to load, click the button (which uses a method
+            // on the router) and then wait for the correct page to load.
+            await browser.waitForElementByCss('#router')
+            await browser.elementById('button-push').click()
+            await browser.waitForElementByCss('#router-sub-page')
+
+            // Go back (confirming we did do a hard push), and wait for the
+            // correct previous page.
+            await browser.back()
+            await browser.waitForElementByCss('#router')
+          } finally {
+            await browser.close()
+          }
         })
 
-        it('should support global css inside client layouts', async () => {
-          const browser = await webdriver(next.url, '/client-nested')
-
-          // Should render button in red
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('button')).color`
+        if (!(global as any).isNextDeploy) {
+          it('should have consistent query and params handling', async () => {
+            const html = await renderViaHTTP(
+              next.url,
+              '/param-and-query/params?slug=query'
             )
-          ).toBe('rgb(255, 0, 0)')
-        })
+            const $ = cheerio.load(html)
+            const el = $('#params-and-query')
+            expect(el.attr('data-params')).toBe('params')
+            expect(el.attr('data-query')).toBe('query')
+          })
+        }
       })
 
-      describe('client pages', () => {
-        it('should support css modules inside client pages', async () => {
-          const browser = await webdriver(next.url, '/client-component-route')
+      describe('useSelectedLayoutSegments', () => {
+        it.each`
+          path                                                           | outerLayout                                             | innerLayout
+          ${'/hooks/use-selected-layout-segment/first'}                  | ${['first']}                                            | ${[]}
+          ${'/hooks/use-selected-layout-segment/first/slug1'}            | ${['first', 'slug1']}                                   | ${['slug1']}
+          ${'/hooks/use-selected-layout-segment/first/slug2/second'}     | ${['first', 'slug2', '(group)', 'second']}              | ${['slug2', '(group)', 'second']}
+          ${'/hooks/use-selected-layout-segment/first/slug2/second/a/b'} | ${['first', 'slug2', '(group)', 'second', 'a/b']}       | ${['slug2', '(group)', 'second', 'a/b']}
+          ${'/hooks/use-selected-layout-segment/rewritten'}              | ${['first', 'slug3', '(group)', 'second', 'catch/all']} | ${['slug3', '(group)', 'second', 'catch/all']}
+          ${'/hooks/use-selected-layout-segment/rewritten-middleware'}   | ${['first', 'slug3', '(group)', 'second', 'catch/all']} | ${['slug3', '(group)', 'second', 'catch/all']}
+        `(
+          'should have the correct layout segments at $path',
+          async ({ path, outerLayout, innerLayout }) => {
+            const html = await renderViaHTTP(next.url, path)
+            const $ = cheerio.load(html)
 
-          // Should render p in red
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('p')).color`
-            )
-          ).toBe('rgb(255, 0, 0)')
-        })
+            expect(JSON.parse($('#outer-layout').text())).toEqual(outerLayout)
+            expect(JSON.parse($('#inner-layout').text())).toEqual(innerLayout)
+          }
+        )
 
-        it('should support global css inside client pages', async () => {
-          const browser = await webdriver(next.url, '/client-component-route')
-
-          // Should render `b` in blue
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('b')).color`
-            )
-          ).toBe('rgb(0, 0, 255)')
-        })
-      })
-
-      describe('client components', () => {
-        it('should support css modules inside client page', async () => {
-          const browser = await webdriver(next.url, '/css/css-client')
-
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#css-modules')).fontSize`
-            )
-          ).toBe('100px')
-        })
-
-        it('should support css modules inside client components', async () => {
-          const browser = await webdriver(next.url, '/css/css-client/inner')
-
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#client-component')).fontSize`
-            )
-          ).toBe('100px')
-        })
-      })
-
-      describe('special entries', () => {
-        it('should include css imported in loading.js', async () => {
-          const html = await renderViaHTTP(next.url, '/loading-bug/hi')
-          // The link tag should be included together with loading
-          expect(html).toMatch(
-            /<link rel="stylesheet" href="(.+)\.css"\/><h2>Loading...<\/h2>/
-          )
-        })
-
-        it('should include css imported in client template.js', async () => {
-          const browser = await webdriver(next.url, '/template/clientcomponent')
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('button')).fontSize`
-            )
-          ).toBe('100px')
-        })
-
-        it('should include css imported in server template.js', async () => {
-          const browser = await webdriver(next.url, '/template/servercomponent')
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('h1')).color`
-            )
-          ).toBe('rgb(255, 0, 0)')
-        })
-
-        it('should include css imported in client not-found.js', async () => {
-          const browser = await webdriver(
+        it('should return an empty array in pages', async () => {
+          const html = await renderViaHTTP(
             next.url,
-            '/not-found/clientcomponent'
+            '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
           )
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('h1')).color`
-            )
-          ).toBe('rgb(255, 0, 0)')
-        })
+          const $ = cheerio.load(html)
 
-        it('should include css imported in server not-found.js', async () => {
-          const browser = await webdriver(
+          expect(JSON.parse($('#page-layout-segments').text())).toEqual([])
+        })
+      })
+
+      describe('useSelectedLayoutSegment', () => {
+        it.each`
+          path                                                           | outerLayout | innerLayout
+          ${'/hooks/use-selected-layout-segment/first'}                  | ${'first'}  | ${null}
+          ${'/hooks/use-selected-layout-segment/first/slug1'}            | ${'first'}  | ${'slug1'}
+          ${'/hooks/use-selected-layout-segment/first/slug2/second/a/b'} | ${'first'}  | ${'slug2'}
+        `(
+          'should have the correct layout segment at $path',
+          async ({ path, outerLayout, innerLayout }) => {
+            const html = await renderViaHTTP(next.url, path)
+            const $ = cheerio.load(html)
+
+            expect(JSON.parse($('#outer-layout-segment').text())).toEqual(
+              outerLayout
+            )
+            expect(JSON.parse($('#inner-layout-segment').text())).toEqual(
+              innerLayout
+            )
+          }
+        )
+
+        it('should return null in pages', async () => {
+          const html = await renderViaHTTP(
             next.url,
-            '/not-found/servercomponent'
+            '/hooks/use-selected-layout-segment/first/slug2/second/a/b'
           )
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('h1')).color`
-            )
-          ).toBe('rgb(255, 0, 0)')
-        })
+          const $ = cheerio.load(html)
 
-        it('should include css imported in error.js', async () => {
-          const browser = await webdriver(next.url, '/error/client-component')
-          await browser.elementByCss('button').click()
-
-          // Wait for error page to render and CSS to be loaded
-          await new Promise((resolve) => setTimeout(resolve, 2000))
-
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('button')).fontSize`
-            )
-          ).toBe('50px')
+          expect(JSON.parse($('#page-layout-segment').text())).toEqual(null)
         })
       })
     })
+  })
 
-    if (isDev) {
-      describe('HMR', () => {
-        it('should support HMR for CSS imports in server components', async () => {
-          const filePath = 'app/css/css-page/style.css'
-          const origContent = await next.readFile(filePath)
+  describe('css support', () => {
+    describe('server layouts', () => {
+      it('should support global css inside server layouts', async () => {
+        const browser = await webdriver(next.url, '/dashboard')
 
-          // h1 should be red
-          const browser = await webdriver(next.url, '/css/css-page')
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('h1')).color`
-            )
-          ).toBe('rgb(255, 0, 0)')
-
-          try {
-            await next.patchFile(filePath, origContent.replace('red', 'blue'))
-
-            // Wait for HMR to trigger
-            await check(
-              () =>
-                browser.eval(
-                  `window.getComputedStyle(document.querySelector('h1')).color`
-                ),
-              'rgb(0, 0, 255)'
-            )
-          } finally {
-            await next.patchFile(filePath, origContent)
-          }
-        })
-
-        it('should support HMR for CSS imports in client components', async () => {
-          const filePath = 'app/css/css-client/client-page.css'
-          const origContent = await next.readFile(filePath)
-
-          // h1 should be red
-          const browser = await webdriver(next.url, '/css/css-client')
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('h1')).color`
-            )
-          ).toBe('rgb(255, 0, 0)')
-
-          try {
-            await next.patchFile(filePath, origContent.replace('red', 'blue'))
-
-            await check(
-              () =>
-                browser.eval(
-                  `window.getComputedStyle(document.querySelector('h1')).color`
-                ),
-              'rgb(0, 0, 255)'
-            )
-          } finally {
-            await next.patchFile(filePath, origContent)
-          }
-        })
-
-        it('should HMR correctly for server component', async () => {
-          const filePath = 'app/dashboard/index/page.js'
-          const origContent = await next.readFile(filePath)
-
-          try {
-            const browser = await webdriver(next.url, '/dashboard/index')
-            expect(await browser.elementByCss('p').text()).toContain(
-              'hello from app/dashboard/index'
-            )
-
-            await next.patchFile(
-              filePath,
-              origContent.replace('hello from', 'swapped from')
-            )
-
-            await check(() => browser.elementByCss('p').text(), /swapped from/)
-          } finally {
-            await next.patchFile(filePath, origContent)
-          }
-        })
-
-        it('should HMR correctly for client component', async () => {
-          const filePath = 'app/client-component-route/page.js'
-          const origContent = await next.readFile(filePath)
-
-          try {
-            const browser = await webdriver(next.url, '/client-component-route')
-
-            const ssrInitial = await renderViaHTTP(
-              next.url,
-              '/client-component-route'
-            )
-
-            expect(ssrInitial).toContain(
-              'hello from app/client-component-route'
-            )
-
-            expect(await browser.elementByCss('p').text()).toContain(
-              'hello from app/client-component-route'
-            )
-
-            await next.patchFile(
-              filePath,
-              origContent.replace('hello from', 'swapped from')
-            )
-
-            await check(() => browser.elementByCss('p').text(), /swapped from/)
-
-            const ssrUpdated = await renderViaHTTP(
-              next.url,
-              '/client-component-route'
-            )
-            expect(ssrUpdated).toContain('swapped from')
-
-            await next.patchFile(filePath, origContent)
-
-            await check(() => browser.elementByCss('p').text(), /hello from/)
-            expect(
-              await renderViaHTTP(next.url, '/client-component-route')
-            ).toContain('hello from')
-          } finally {
-            await next.patchFile(filePath, origContent)
-          }
-        })
-
-        it('should HMR correctly when changing the component type', async () => {
-          const filePath = 'app/dashboard/page/page.jsx'
-          const origContent = await next.readFile(filePath)
-
-          try {
-            const browser = await webdriver(next.url, '/dashboard/page')
-
-            expect(await browser.elementByCss('p').text()).toContain(
-              'hello dashboard/page!'
-            )
-
-            // Test HMR with server component
-            await next.patchFile(
-              filePath,
-              origContent.replace(
-                'hello dashboard/page!',
-                'hello dashboard/page in server component!'
-              )
-            )
-            await check(
-              () => browser.elementByCss('p').text(),
-              /in server component/
-            )
-
-            // Change to client component
-            await next.patchFile(
-              filePath,
-              origContent
-                .replace("// 'use client'", "'use client'")
-                .replace(
-                  'hello dashboard/page!',
-                  'hello dashboard/page in client component!'
-                )
-            )
-            await check(
-              () => browser.elementByCss('p').text(),
-              /in client component/
-            )
-
-            // Change back to server component
-            await next.patchFile(
-              filePath,
-              origContent.replace(
-                'hello dashboard/page!',
-                'hello dashboard/page in server component2!'
-              )
-            )
-            await check(
-              () => browser.elementByCss('p').text(),
-              /in server component2/
-            )
-
-            // Change to client component again
-            await next.patchFile(
-              filePath,
-              origContent
-                .replace("// 'use client'", "'use client'")
-                .replace(
-                  'hello dashboard/page!',
-                  'hello dashboard/page in client component2!'
-                )
-            )
-            await check(
-              () => browser.elementByCss('p').text(),
-              /in client component2/
-            )
-          } finally {
-            await next.patchFile(filePath, origContent)
-          }
-        })
-      })
-    }
-
-    describe('searchParams prop', () => {
-      describe('client component', () => {
-        it('should have the correct search params', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/search-params-prop?first=value&second=other%20value&third'
+        // Should body text in red
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('.p')).color`
           )
-          const $ = cheerio.load(html)
-          const el = $('#params')
-          expect(el.attr('data-param-first')).toBe('value')
-          expect(el.attr('data-param-second')).toBe('other value')
-          expect(el.attr('data-param-third')).toBe('')
-          expect(el.attr('data-param-not-real')).toBe('N/A')
-        })
+        ).toBe('rgb(255, 0, 0)')
 
-        it('should have the correct search params on rewrite', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/search-params-prop-rewrite'
+        // Should inject global css for .green selectors
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('.green')).color`
           )
-          const $ = cheerio.load(html)
-          const el = $('#params')
-          expect(el.attr('data-param-first')).toBe('value')
-          expect(el.attr('data-param-second')).toBe('other value')
-          expect(el.attr('data-param-third')).toBe('')
-          expect(el.attr('data-param-not-real')).toBe('N/A')
-        })
-
-        it('should have the correct search params on middleware rewrite', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/search-params-prop-middleware-rewrite'
-          )
-          const $ = cheerio.load(html)
-          const el = $('#params')
-          expect(el.attr('data-param-first')).toBe('value')
-          expect(el.attr('data-param-second')).toBe('other value')
-          expect(el.attr('data-param-third')).toBe('')
-          expect(el.attr('data-param-not-real')).toBe('N/A')
-        })
+        ).toBe('rgb(0, 128, 0)')
       })
 
-      describe('server component', () => {
-        it('should have the correct search params', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/search-params-prop/server?first=value&second=other%20value&third'
+      it('should support css modules inside server layouts', async () => {
+        const browser = await webdriver(next.url, '/css/css-nested')
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#server-cssm')).color`
           )
-          const $ = cheerio.load(html)
-          const el = $('#params')
-          expect(el.attr('data-param-first')).toBe('value')
-          expect(el.attr('data-param-second')).toBe('other value')
-          expect(el.attr('data-param-third')).toBe('')
-          expect(el.attr('data-param-not-real')).toBe('N/A')
-        })
-
-        it('should have the correct search params on rewrite', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/search-params-prop-server-rewrite'
-          )
-          const $ = cheerio.load(html)
-          const el = $('#params')
-          expect(el.attr('data-param-first')).toBe('value')
-          expect(el.attr('data-param-second')).toBe('other value')
-          expect(el.attr('data-param-third')).toBe('')
-          expect(el.attr('data-param-not-real')).toBe('N/A')
-        })
-
-        it('should have the correct search params on middleware rewrite', async () => {
-          const html = await renderViaHTTP(
-            next.url,
-            '/search-params-prop-server-middleware-rewrite'
-          )
-          const $ = cheerio.load(html)
-          const el = $('#params')
-          expect(el.attr('data-param-first')).toBe('value')
-          expect(el.attr('data-param-second')).toBe('other value')
-          expect(el.attr('data-param-third')).toBe('')
-          expect(el.attr('data-param-not-real')).toBe('N/A')
-        })
+        ).toBe('rgb(0, 128, 0)')
       })
     })
 
-    describe('sass support', () => {
-      describe('server layouts', () => {
-        it('should support global sass/scss inside server layouts', async () => {
-          const browser = await webdriver(next.url, '/css/sass/inner')
-          // .sass
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#sass-server-layout')).color`
-            )
-          ).toBe('rgb(165, 42, 42)')
-          // .scss
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#scss-server-layout')).color`
-            )
-          ).toBe('rgb(222, 184, 135)')
-        })
-
-        it('should support sass/scss modules inside server layouts', async () => {
-          const browser = await webdriver(next.url, '/css/sass/inner')
-          // .sass
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#sass-server-layout')).backgroundColor`
-            )
-          ).toBe('rgb(233, 150, 122)')
-          // .scss
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#scss-server-layout')).backgroundColor`
-            )
-          ).toBe('rgb(139, 0, 0)')
-        })
+    describe('server pages', () => {
+      it('should support global css inside server pages', async () => {
+        const browser = await webdriver(next.url, '/css/css-page')
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('h1')).color`
+          )
+        ).toBe('rgb(255, 0, 0)')
       })
 
-      describe('server pages', () => {
-        it('should support global sass/scss inside server pages', async () => {
-          const browser = await webdriver(next.url, '/css/sass/inner')
-          // .sass
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#sass-server-page')).color`
-            )
-          ).toBe('rgb(245, 222, 179)')
-          // .scss
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#scss-server-page')).color`
-            )
-          ).toBe('rgb(255, 99, 71)')
-        })
-
-        it('should support sass/scss modules inside server pages', async () => {
-          const browser = await webdriver(next.url, '/css/sass/inner')
-          // .sass
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#sass-server-page')).backgroundColor`
-            )
-          ).toBe('rgb(75, 0, 130)')
-          // .scss
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#scss-server-page')).backgroundColor`
-            )
-          ).toBe('rgb(0, 255, 255)')
-        })
+      it('should support css modules inside server pages', async () => {
+        const browser = await webdriver(next.url, '/css/css-page')
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#cssm')).color`
+          )
+        ).toBe('rgb(0, 0, 255)')
       })
 
-      describe('client layouts', () => {
-        it('should support global sass/scss inside client layouts', async () => {
-          const browser = await webdriver(next.url, '/css/sass-client/inner')
-          // .sass
+      if (!isDev) {
+        it('should not include unused css modules in the page in prod', async () => {
+          const browser = await webdriver(next.url, '/css/css-page/unused')
           expect(
             await browser.eval(
-              `window.getComputedStyle(document.querySelector('#sass-client-layout')).color`
+              `[...document.styleSheets].some(({ rules }) => [...rules].some(rule => rule.selectorText.includes('this_should_not_be_included')))`
             )
-          ).toBe('rgb(165, 42, 42)')
-          // .scss
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#scss-client-layout')).color`
-            )
-          ).toBe('rgb(222, 184, 135)')
+          ).toBe(false)
         })
 
-        it('should support sass/scss modules inside client layouts', async () => {
-          const browser = await webdriver(next.url, '/css/sass-client/inner')
-          // .sass
+        it('should not include unused css modules in nested pages in prod', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/css/css-page/unused-nested/inner'
+          )
           expect(
             await browser.eval(
-              `window.getComputedStyle(document.querySelector('#sass-client-layout')).backgroundColor`
+              `[...document.styleSheets].some(({ rules }) => [...rules].some(rule => rule.selectorText.includes('this_should_not_be_included_in_inner_path')))`
             )
-          ).toBe('rgb(233, 150, 122)')
-          // .scss
-          expect(
-            await browser.eval(
-              `window.getComputedStyle(document.querySelector('#scss-client-layout')).backgroundColor`
-            )
-          ).toBe('rgb(139, 0, 0)')
+          ).toBe(false)
         })
+      }
+    })
+
+    describe('client layouts', () => {
+      it('should support css modules inside client layouts', async () => {
+        const browser = await webdriver(next.url, '/client-nested')
+
+        // Should render h1 in red
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('h1')).color`
+          )
+        ).toBe('rgb(255, 0, 0)')
+      })
+
+      it('should support global css inside client layouts', async () => {
+        const browser = await webdriver(next.url, '/client-nested')
+
+        // Should render button in red
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('button')).color`
+          )
+        ).toBe('rgb(255, 0, 0)')
       })
     })
 
     describe('client pages', () => {
-      it('should support global sass/scss inside client pages', async () => {
-        const browser = await webdriver(next.url, '/css/sass-client/inner')
+      it('should support css modules inside client pages', async () => {
+        const browser = await webdriver(next.url, '/client-component-route')
 
-        // .sass
-        await check(
-          () =>
-            browser.eval(
-              `window.getComputedStyle(document.querySelector('#sass-client-page')).color`
-            ),
-          'rgb(245, 222, 179)'
-        )
-        // .scss
-        await check(
-          () =>
-            browser.eval(
-              `window.getComputedStyle(document.querySelector('#scss-client-page')).color`
-            ),
-          'rgb(255, 99, 71)'
+        // Should render p in red
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('p')).color`
+          )
+        ).toBe('rgb(255, 0, 0)')
+      })
+
+      it('should support global css inside client pages', async () => {
+        const browser = await webdriver(next.url, '/client-component-route')
+
+        // Should render `b` in blue
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('b')).color`
+          )
+        ).toBe('rgb(0, 0, 255)')
+      })
+    })
+
+    describe('client components', () => {
+      it('should support css modules inside client page', async () => {
+        const browser = await webdriver(next.url, '/css/css-client')
+
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#css-modules')).fontSize`
+          )
+        ).toBe('100px')
+      })
+
+      it('should support css modules inside client components', async () => {
+        const browser = await webdriver(next.url, '/css/css-client/inner')
+
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#client-component')).fontSize`
+          )
+        ).toBe('100px')
+      })
+    })
+
+    describe('special entries', () => {
+      it('should include css imported in loading.js', async () => {
+        const html = await renderViaHTTP(next.url, '/loading-bug/hi')
+        // The link tag should be included together with loading
+        expect(html).toMatch(
+          /<link rel="stylesheet" href="(.+)\.css"\/><h2>Loading...<\/h2>/
         )
       })
 
-      it('should support sass/scss modules inside client pages', async () => {
-        const browser = await webdriver(next.url, '/css/sass-client/inner')
+      it('should include css imported in client template.js', async () => {
+        const browser = await webdriver(next.url, '/template/clientcomponent')
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('button')).fontSize`
+          )
+        ).toBe('100px')
+      })
+
+      it('should include css imported in server template.js', async () => {
+        const browser = await webdriver(next.url, '/template/servercomponent')
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('h1')).color`
+          )
+        ).toBe('rgb(255, 0, 0)')
+      })
+
+      it('should include css imported in client not-found.js', async () => {
+        const browser = await webdriver(next.url, '/not-found/clientcomponent')
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('h1')).color`
+          )
+        ).toBe('rgb(255, 0, 0)')
+      })
+
+      it('should include css imported in server not-found.js', async () => {
+        const browser = await webdriver(next.url, '/not-found/servercomponent')
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('h1')).color`
+          )
+        ).toBe('rgb(255, 0, 0)')
+      })
+
+      it('should include css imported in error.js', async () => {
+        const browser = await webdriver(next.url, '/error/client-component')
+        await browser.elementByCss('button').click()
+
+        // Wait for error page to render and CSS to be loaded
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('button')).fontSize`
+          )
+        ).toBe('50px')
+      })
+    })
+  })
+
+  if (isDev) {
+    describe('HMR', () => {
+      it('should support HMR for CSS imports in server components', async () => {
+        const filePath = 'app/css/css-page/style.css'
+        const origContent = await next.readFile(filePath)
+
+        // h1 should be red
+        const browser = await webdriver(next.url, '/css/css-page')
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('h1')).color`
+          )
+        ).toBe('rgb(255, 0, 0)')
+
+        try {
+          await next.patchFile(filePath, origContent.replace('red', 'blue'))
+
+          // Wait for HMR to trigger
+          await check(
+            () =>
+              browser.eval(
+                `window.getComputedStyle(document.querySelector('h1')).color`
+              ),
+            'rgb(0, 0, 255)'
+          )
+        } finally {
+          await next.patchFile(filePath, origContent)
+        }
+      })
+
+      it('should support HMR for CSS imports in client components', async () => {
+        const filePath = 'app/css/css-client/client-page.css'
+        const origContent = await next.readFile(filePath)
+
+        // h1 should be red
+        const browser = await webdriver(next.url, '/css/css-client')
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('h1')).color`
+          )
+        ).toBe('rgb(255, 0, 0)')
+
+        try {
+          await next.patchFile(filePath, origContent.replace('red', 'blue'))
+
+          await check(
+            () =>
+              browser.eval(
+                `window.getComputedStyle(document.querySelector('h1')).color`
+              ),
+            'rgb(0, 0, 255)'
+          )
+        } finally {
+          await next.patchFile(filePath, origContent)
+        }
+      })
+
+      it('should HMR correctly for server component', async () => {
+        const filePath = 'app/dashboard/index/page.js'
+        const origContent = await next.readFile(filePath)
+
+        try {
+          const browser = await webdriver(next.url, '/dashboard/index')
+          expect(await browser.elementByCss('p').text()).toContain(
+            'hello from app/dashboard/index'
+          )
+
+          await next.patchFile(
+            filePath,
+            origContent.replace('hello from', 'swapped from')
+          )
+
+          await check(() => browser.elementByCss('p').text(), /swapped from/)
+        } finally {
+          await next.patchFile(filePath, origContent)
+        }
+      })
+
+      it('should HMR correctly for client component', async () => {
+        const filePath = 'app/client-component-route/page.js'
+        const origContent = await next.readFile(filePath)
+
+        try {
+          const browser = await webdriver(next.url, '/client-component-route')
+
+          const ssrInitial = await renderViaHTTP(
+            next.url,
+            '/client-component-route'
+          )
+
+          expect(ssrInitial).toContain('hello from app/client-component-route')
+
+          expect(await browser.elementByCss('p').text()).toContain(
+            'hello from app/client-component-route'
+          )
+
+          await next.patchFile(
+            filePath,
+            origContent.replace('hello from', 'swapped from')
+          )
+
+          await check(() => browser.elementByCss('p').text(), /swapped from/)
+
+          const ssrUpdated = await renderViaHTTP(
+            next.url,
+            '/client-component-route'
+          )
+          expect(ssrUpdated).toContain('swapped from')
+
+          await next.patchFile(filePath, origContent)
+
+          await check(() => browser.elementByCss('p').text(), /hello from/)
+          expect(
+            await renderViaHTTP(next.url, '/client-component-route')
+          ).toContain('hello from')
+        } finally {
+          await next.patchFile(filePath, origContent)
+        }
+      })
+
+      it('should HMR correctly when changing the component type', async () => {
+        const filePath = 'app/dashboard/page/page.jsx'
+        const origContent = await next.readFile(filePath)
+
+        try {
+          const browser = await webdriver(next.url, '/dashboard/page')
+
+          expect(await browser.elementByCss('p').text()).toContain(
+            'hello dashboard/page!'
+          )
+
+          // Test HMR with server component
+          await next.patchFile(
+            filePath,
+            origContent.replace(
+              'hello dashboard/page!',
+              'hello dashboard/page in server component!'
+            )
+          )
+          await check(
+            () => browser.elementByCss('p').text(),
+            /in server component/
+          )
+
+          // Change to client component
+          await next.patchFile(
+            filePath,
+            origContent
+              .replace("// 'use client'", "'use client'")
+              .replace(
+                'hello dashboard/page!',
+                'hello dashboard/page in client component!'
+              )
+          )
+          await check(
+            () => browser.elementByCss('p').text(),
+            /in client component/
+          )
+
+          // Change back to server component
+          await next.patchFile(
+            filePath,
+            origContent.replace(
+              'hello dashboard/page!',
+              'hello dashboard/page in server component2!'
+            )
+          )
+          await check(
+            () => browser.elementByCss('p').text(),
+            /in server component2/
+          )
+
+          // Change to client component again
+          await next.patchFile(
+            filePath,
+            origContent
+              .replace("// 'use client'", "'use client'")
+              .replace(
+                'hello dashboard/page!',
+                'hello dashboard/page in client component2!'
+              )
+          )
+          await check(
+            () => browser.elementByCss('p').text(),
+            /in client component2/
+          )
+        } finally {
+          await next.patchFile(filePath, origContent)
+        }
+      })
+    })
+  }
+
+  describe('searchParams prop', () => {
+    describe('client component', () => {
+      it('should have the correct search params', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/search-params-prop?first=value&second=other%20value&third'
+        )
+        const $ = cheerio.load(html)
+        const el = $('#params')
+        expect(el.attr('data-param-first')).toBe('value')
+        expect(el.attr('data-param-second')).toBe('other value')
+        expect(el.attr('data-param-third')).toBe('')
+        expect(el.attr('data-param-not-real')).toBe('N/A')
+      })
+
+      it('should have the correct search params on rewrite', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/search-params-prop-rewrite'
+        )
+        const $ = cheerio.load(html)
+        const el = $('#params')
+        expect(el.attr('data-param-first')).toBe('value')
+        expect(el.attr('data-param-second')).toBe('other value')
+        expect(el.attr('data-param-third')).toBe('')
+        expect(el.attr('data-param-not-real')).toBe('N/A')
+      })
+
+      it('should have the correct search params on middleware rewrite', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/search-params-prop-middleware-rewrite'
+        )
+        const $ = cheerio.load(html)
+        const el = $('#params')
+        expect(el.attr('data-param-first')).toBe('value')
+        expect(el.attr('data-param-second')).toBe('other value')
+        expect(el.attr('data-param-third')).toBe('')
+        expect(el.attr('data-param-not-real')).toBe('N/A')
+      })
+    })
+
+    describe('server component', () => {
+      it('should have the correct search params', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/search-params-prop/server?first=value&second=other%20value&third'
+        )
+        const $ = cheerio.load(html)
+        const el = $('#params')
+        expect(el.attr('data-param-first')).toBe('value')
+        expect(el.attr('data-param-second')).toBe('other value')
+        expect(el.attr('data-param-third')).toBe('')
+        expect(el.attr('data-param-not-real')).toBe('N/A')
+      })
+
+      it('should have the correct search params on rewrite', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/search-params-prop-server-rewrite'
+        )
+        const $ = cheerio.load(html)
+        const el = $('#params')
+        expect(el.attr('data-param-first')).toBe('value')
+        expect(el.attr('data-param-second')).toBe('other value')
+        expect(el.attr('data-param-third')).toBe('')
+        expect(el.attr('data-param-not-real')).toBe('N/A')
+      })
+
+      it('should have the correct search params on middleware rewrite', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/search-params-prop-server-middleware-rewrite'
+        )
+        const $ = cheerio.load(html)
+        const el = $('#params')
+        expect(el.attr('data-param-first')).toBe('value')
+        expect(el.attr('data-param-second')).toBe('other value')
+        expect(el.attr('data-param-third')).toBe('')
+        expect(el.attr('data-param-not-real')).toBe('N/A')
+      })
+    })
+  })
+
+  describe('sass support', () => {
+    describe('server layouts', () => {
+      it('should support global sass/scss inside server layouts', async () => {
+        const browser = await webdriver(next.url, '/css/sass/inner')
         // .sass
         expect(
           await browser.eval(
-            `window.getComputedStyle(document.querySelector('#sass-client-page')).backgroundColor`
+            `window.getComputedStyle(document.querySelector('#sass-server-layout')).color`
+          )
+        ).toBe('rgb(165, 42, 42)')
+        // .scss
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#scss-server-layout')).color`
+          )
+        ).toBe('rgb(222, 184, 135)')
+      })
+
+      it('should support sass/scss modules inside server layouts', async () => {
+        const browser = await webdriver(next.url, '/css/sass/inner')
+        // .sass
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#sass-server-layout')).backgroundColor`
+          )
+        ).toBe('rgb(233, 150, 122)')
+        // .scss
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#scss-server-layout')).backgroundColor`
+          )
+        ).toBe('rgb(139, 0, 0)')
+      })
+    })
+
+    describe('server pages', () => {
+      it('should support global sass/scss inside server pages', async () => {
+        const browser = await webdriver(next.url, '/css/sass/inner')
+        // .sass
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#sass-server-page')).color`
+          )
+        ).toBe('rgb(245, 222, 179)')
+        // .scss
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#scss-server-page')).color`
+          )
+        ).toBe('rgb(255, 99, 71)')
+      })
+
+      it('should support sass/scss modules inside server pages', async () => {
+        const browser = await webdriver(next.url, '/css/sass/inner')
+        // .sass
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#sass-server-page')).backgroundColor`
           )
         ).toBe('rgb(75, 0, 130)')
         // .scss
         expect(
           await browser.eval(
-            `window.getComputedStyle(document.querySelector('#scss-client-page')).backgroundColor`
+            `window.getComputedStyle(document.querySelector('#scss-server-page')).backgroundColor`
           )
         ).toBe('rgb(0, 255, 255)')
       })
     })
-    ;(isDev ? describe.skip : describe)('Subresource Integrity', () => {
-      function fetchWithPolicy(policy: string | null) {
-        return fetchViaHTTP(next.url, '/dashboard', undefined, {
-          headers: policy
-            ? {
-                'Content-Security-Policy': policy,
-              }
-            : {},
-        })
-      }
 
-      async function renderWithPolicy(policy: string | null) {
-        const res = await fetchWithPolicy(policy)
-
-        expect(res.ok).toBe(true)
-
-        const html = await res.text()
-
-        return cheerio.load(html)
-      }
-
-      it('does not include nonce when not enabled', async () => {
-        const policies = [
-          `script-src 'nonce-'`, // invalid nonce
-          'style-src "nonce-cmFuZG9tCg=="', // no script or default src
-          '', // empty string
-        ]
-
-        for (const policy of policies) {
-          const $ = await renderWithPolicy(policy)
-
-          // Find all the script tags without src attributes and with nonce
-          // attributes.
-          const elements = $('script[nonce]:not([src])')
-
-          // Expect there to be none.
-          expect(elements.length).toBe(0)
-        }
+    describe('client layouts', () => {
+      it('should support global sass/scss inside client layouts', async () => {
+        const browser = await webdriver(next.url, '/css/sass-client/inner')
+        // .sass
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#sass-client-layout')).color`
+          )
+        ).toBe('rgb(165, 42, 42)')
+        // .scss
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#scss-client-layout')).color`
+          )
+        ).toBe('rgb(222, 184, 135)')
       })
 
-      it('includes a nonce value with inline scripts when Content-Security-Policy header is defined', async () => {
-        // A random nonce value, base64 encoded.
-        const nonce = 'cmFuZG9tCg=='
-
-        // Validate all the cases where we could parse the nonce.
-        const policies = [
-          `script-src 'nonce-${nonce}'`, // base case
-          `   script-src   'nonce-${nonce}' `, // extra space added around sources and directive
-          `style-src 'self'; script-src 'nonce-${nonce}'`, // extra directives
-          `script-src 'self' 'nonce-${nonce}' 'nonce-othernonce'`, // extra nonces
-          `default-src 'nonce-othernonce'; script-src 'nonce-${nonce}';`, // script and then fallback case
-          `default-src 'nonce-${nonce}'`, // fallback case
-        ]
-
-        for (const policy of policies) {
-          const $ = await renderWithPolicy(policy)
-
-          // Find all the script tags without src attributes.
-          const elements = $('script:not([src])')
-
-          // Expect there to be at least 1 script tag without a src attribute.
-          expect(elements.length).toBeGreaterThan(0)
-
-          // Expect all inline scripts to have the nonce value.
-          elements.each((i, el) => {
-            expect(el.attribs['nonce']).toBe(nonce)
-          })
-        }
-      })
-
-      it('includes an integrity attribute on scripts', async () => {
-        const html = await renderViaHTTP(next.url, '/dashboard')
-
-        const $ = cheerio.load(html)
-
-        // Find all the script tags with src attributes.
-        const elements = $('script[src]')
-
-        // Expect there to be at least 1 script tag with a src attribute.
-        expect(elements.length).toBeGreaterThan(0)
-
-        // Collect all the scripts with integrity hashes so we can verify them.
-        const files: [string, string][] = []
-
-        // For each of these attributes, ensure that there's an integrity
-        // attribute and starts with the correct integrity hash prefix.
-        elements.each((i, el) => {
-          const integrity = el.attribs['integrity']
-          expect(integrity).toBeDefined()
-          expect(integrity).toStartWith('sha256-')
-
-          const src = el.attribs['src']
-          expect(src).toBeDefined()
-
-          files.push([src, integrity])
-        })
-
-        // For each script tag, ensure that the integrity attribute is the
-        // correct hash of the script tag.
-        for (const [src, integrity] of files) {
-          const res = await fetchViaHTTP(next.url, src)
-          expect(res.status).toBe(200)
-          const content = await res.text()
-
-          const hash = crypto
-            .createHash('sha256')
-            .update(content)
-            .digest()
-            .toString('base64')
-
-          expect(integrity).toEndWith(hash)
-        }
-      })
-
-      it('throws when escape characters are included in nonce', async () => {
-        const res = await fetchWithPolicy(
-          `script-src 'nonce-"><script></script>"'`
-        )
-
-        expect(res.status).toBe(500)
+      it('should support sass/scss modules inside client layouts', async () => {
+        const browser = await webdriver(next.url, '/css/sass-client/inner')
+        // .sass
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#sass-client-layout')).backgroundColor`
+          )
+        ).toBe('rgb(233, 150, 122)')
+        // .scss
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('#scss-client-layout')).backgroundColor`
+          )
+        ).toBe('rgb(139, 0, 0)')
       })
     })
+  })
 
-    describe('template component', () => {
-      it('should render the template that holds state in a client component and reset on navigation', async () => {
-        const browser = await webdriver(next.url, '/template/clientcomponent')
-        expect(await browser.elementByCss('h1').text()).toBe('Template 0')
-        await browser.elementByCss('button').click()
-        expect(await browser.elementByCss('h1').text()).toBe('Template 1')
+  describe('client pages', () => {
+    it('should support global sass/scss inside client pages', async () => {
+      const browser = await webdriver(next.url, '/css/sass-client/inner')
+
+      // .sass
+      await check(
+        () =>
+          browser.eval(
+            `window.getComputedStyle(document.querySelector('#sass-client-page')).color`
+          ),
+        'rgb(245, 222, 179)'
+      )
+      // .scss
+      await check(
+        () =>
+          browser.eval(
+            `window.getComputedStyle(document.querySelector('#scss-client-page')).color`
+          ),
+        'rgb(255, 99, 71)'
+      )
+    })
+
+    it('should support sass/scss modules inside client pages', async () => {
+      const browser = await webdriver(next.url, '/css/sass-client/inner')
+      // .sass
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.querySelector('#sass-client-page')).backgroundColor`
+        )
+      ).toBe('rgb(75, 0, 130)')
+      // .scss
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.querySelector('#scss-client-page')).backgroundColor`
+        )
+      ).toBe('rgb(0, 255, 255)')
+    })
+  })
+  ;(isDev ? describe.skip : describe)('Subresource Integrity', () => {
+    function fetchWithPolicy(policy: string | null) {
+      return fetchViaHTTP(next.url, '/dashboard', undefined, {
+        headers: policy
+          ? {
+              'Content-Security-Policy': policy,
+            }
+          : {},
+      })
+    }
+
+    async function renderWithPolicy(policy: string | null) {
+      const res = await fetchWithPolicy(policy)
+
+      expect(res.ok).toBe(true)
+
+      const html = await res.text()
+
+      return cheerio.load(html)
+    }
+
+    it('does not include nonce when not enabled', async () => {
+      const policies = [
+        `script-src 'nonce-'`, // invalid nonce
+        'style-src "nonce-cmFuZG9tCg=="', // no script or default src
+        '', // empty string
+      ]
+
+      for (const policy of policies) {
+        const $ = await renderWithPolicy(policy)
+
+        // Find all the script tags without src attributes and with nonce
+        // attributes.
+        const elements = $('script[nonce]:not([src])')
+
+        // Expect there to be none.
+        expect(elements.length).toBe(0)
+      }
+    })
+
+    it('includes a nonce value with inline scripts when Content-Security-Policy header is defined', async () => {
+      // A random nonce value, base64 encoded.
+      const nonce = 'cmFuZG9tCg=='
+
+      // Validate all the cases where we could parse the nonce.
+      const policies = [
+        `script-src 'nonce-${nonce}'`, // base case
+        `   script-src   'nonce-${nonce}' `, // extra space added around sources and directive
+        `style-src 'self'; script-src 'nonce-${nonce}'`, // extra directives
+        `script-src 'self' 'nonce-${nonce}' 'nonce-othernonce'`, // extra nonces
+        `default-src 'nonce-othernonce'; script-src 'nonce-${nonce}';`, // script and then fallback case
+        `default-src 'nonce-${nonce}'`, // fallback case
+      ]
+
+      for (const policy of policies) {
+        const $ = await renderWithPolicy(policy)
+
+        // Find all the script tags without src attributes.
+        const elements = $('script:not([src])')
+
+        // Expect there to be at least 1 script tag without a src attribute.
+        expect(elements.length).toBeGreaterThan(0)
+
+        // Expect all inline scripts to have the nonce value.
+        elements.each((i, el) => {
+          expect(el.attribs['nonce']).toBe(nonce)
+        })
+      }
+    })
+
+    it('includes an integrity attribute on scripts', async () => {
+      const html = await renderViaHTTP(next.url, '/dashboard')
+
+      const $ = cheerio.load(html)
+
+      // Find all the script tags with src attributes.
+      const elements = $('script[src]')
+
+      // Expect there to be at least 1 script tag with a src attribute.
+      expect(elements.length).toBeGreaterThan(0)
+
+      // Collect all the scripts with integrity hashes so we can verify them.
+      const files: [string, string][] = []
+
+      // For each of these attributes, ensure that there's an integrity
+      // attribute and starts with the correct integrity hash prefix.
+      elements.each((i, el) => {
+        const integrity = el.attribs['integrity']
+        expect(integrity).toBeDefined()
+        expect(integrity).toStartWith('sha256-')
+
+        const src = el.attribs['src']
+        expect(src).toBeDefined()
+
+        files.push([src, integrity])
+      })
+
+      // For each script tag, ensure that the integrity attribute is the
+      // correct hash of the script tag.
+      for (const [src, integrity] of files) {
+        const res = await fetchViaHTTP(next.url, src)
+        expect(res.status).toBe(200)
+        const content = await res.text()
+
+        const hash = crypto
+          .createHash('sha256')
+          .update(content)
+          .digest()
+          .toString('base64')
+
+        expect(integrity).toEndWith(hash)
+      }
+    })
+
+    it('throws when escape characters are included in nonce', async () => {
+      const res = await fetchWithPolicy(
+        `script-src 'nonce-"><script></script>"'`
+      )
+
+      expect(res.status).toBe(500)
+    })
+  })
+
+  describe('template component', () => {
+    it('should render the template that holds state in a client component and reset on navigation', async () => {
+      const browser = await webdriver(next.url, '/template/clientcomponent')
+      expect(await browser.elementByCss('h1').text()).toBe('Template 0')
+      await browser.elementByCss('button').click()
+      expect(await browser.elementByCss('h1').text()).toBe('Template 1')
+
+      await browser.elementByCss('#link').click()
+      await browser.waitForElementByCss('#other-page')
+
+      expect(await browser.elementByCss('h1').text()).toBe('Template 0')
+      await browser.elementByCss('button').click()
+      expect(await browser.elementByCss('h1').text()).toBe('Template 1')
+
+      await browser.elementByCss('#link').click()
+      await browser.waitForElementByCss('#page')
+
+      expect(await browser.elementByCss('h1').text()).toBe('Template 0')
+    })
+
+    // TODO-APP: disable failing test and investigate later
+    ;(isDev ? it.skip : it)(
+      'should render the template that is a server component and rerender on navigation',
+      async () => {
+        const browser = await webdriver(next.url, '/template/servercomponent')
+        // eslint-disable-next-line jest/no-standalone-expect
+        expect(await browser.elementByCss('h1').text()).toStartWith('Template')
+
+        const currentTime = await browser
+          .elementByCss('#performance-now')
+          .text()
 
         await browser.elementByCss('#link').click()
         await browser.waitForElementByCss('#other-page')
 
-        expect(await browser.elementByCss('h1').text()).toBe('Template 0')
-        await browser.elementByCss('button').click()
-        expect(await browser.elementByCss('h1').text()).toBe('Template 1')
+        // eslint-disable-next-line jest/no-standalone-expect
+        expect(await browser.elementByCss('h1').text()).toStartWith('Template')
+
+        // template should rerender on navigation even when it's a server component
+        // eslint-disable-next-line jest/no-standalone-expect
+        expect(await browser.elementByCss('#performance-now').text()).toBe(
+          currentTime
+        )
 
         await browser.elementByCss('#link').click()
         await browser.waitForElementByCss('#page')
 
-        expect(await browser.elementByCss('h1').text()).toBe('Template 0')
-      })
+        // eslint-disable-next-line jest/no-standalone-expect
+        expect(await browser.elementByCss('#performance-now').text()).toBe(
+          currentTime
+        )
+      }
+    )
+  })
 
-      // TODO-APP: disable failing test and investigate later
-      ;(isDev ? it.skip : it)(
-        'should render the template that is a server component and rerender on navigation',
-        async () => {
-          const browser = await webdriver(next.url, '/template/servercomponent')
-          // eslint-disable-next-line jest/no-standalone-expect
-          expect(await browser.elementByCss('h1').text()).toStartWith(
-            'Template'
-          )
+  describe('error component', () => {
+    it('should trigger error component when an error happens during rendering', async () => {
+      const browser = await webdriver(next.url, '/error/client-component')
+      await browser.elementByCss('#error-trigger-button').click()
 
-          const currentTime = await browser
-            .elementByCss('#performance-now')
+      if (isDev) {
+        expect(await hasRedbox(browser)).toBe(true)
+        expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
+      } else {
+        await browser
+        expect(
+          await browser
+            .waitForElementByCss('#error-boundary-message')
+            .elementByCss('#error-boundary-message')
             .text()
-
-          await browser.elementByCss('#link').click()
-          await browser.waitForElementByCss('#other-page')
-
-          // eslint-disable-next-line jest/no-standalone-expect
-          expect(await browser.elementByCss('h1').text()).toStartWith(
-            'Template'
-          )
-
-          // template should rerender on navigation even when it's a server component
-          // eslint-disable-next-line jest/no-standalone-expect
-          expect(await browser.elementByCss('#performance-now').text()).toBe(
-            currentTime
-          )
-
-          await browser.elementByCss('#link').click()
-          await browser.waitForElementByCss('#page')
-
-          // eslint-disable-next-line jest/no-standalone-expect
-          expect(await browser.elementByCss('#performance-now').text()).toBe(
-            currentTime
-          )
-        }
-      )
-    })
-
-    describe('error component', () => {
-      it('should trigger error component when an error happens during rendering', async () => {
-        const browser = await webdriver(next.url, '/error/client-component')
-        await browser.elementByCss('#error-trigger-button').click()
-
-        if (isDev) {
-          expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
-        } else {
-          await browser
-          expect(
-            await browser
-              .waitForElementByCss('#error-boundary-message')
-              .elementByCss('#error-boundary-message')
-              .text()
-          ).toBe('An error occurred: this is a test')
-        }
-      })
-
-      it('should trigger error component when an error happens during server components rendering', async () => {
-        const browser = await webdriver(next.url, '/error/server-component')
-
-        if (isDev) {
-          expect(
-            await browser
-              .waitForElementByCss('#error-boundary-message')
-              .elementByCss('#error-boundary-message')
-              .text()
-          ).toBe('this is a test')
-          expect(
-            await browser.waitForElementByCss('#error-boundary-digest').text()
-            // Digest of the error message should be stable.
-          ).not.toBe('')
-          // TODO-APP: ensure error overlay is shown for errors that happened before/during hydration
-          // expect(await hasRedbox(browser)).toBe(true)
-          // expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
-        } else {
-          await browser
-          expect(
-            await browser.waitForElementByCss('#error-boundary-message').text()
-          ).toBe(
-            'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
-          )
-          expect(
-            await browser.waitForElementByCss('#error-boundary-digest').text()
-            // Digest of the error message should be stable.
-          ).not.toBe('')
-        }
-      })
-
-      it('should use default error boundary for prod and overlay for dev when no error component specified', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/error/global-error-boundary/client'
-        )
-        await browser.elementByCss('#error-trigger-button').click()
-
-        if (isDev) {
-          expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
-        } else {
-          expect(
-            await browser.waitForElementByCss('body').elementByCss('h2').text()
-          ).toBe(
-            'Application error: a client-side exception has occurred (see the browser console for more information).'
-          )
-        }
-      })
-
-      it('should display error digest for error in server component with default error boundary', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/error/global-error-boundary/server'
-        )
-
-        if (isDev) {
-          expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxHeader(browser)).toMatch(/custom server error/)
-        } else {
-          expect(
-            await browser.waitForElementByCss('body').elementByCss('h2').text()
-          ).toBe(
-            'Application error: a client-side exception has occurred (see the browser console for more information).'
-          )
-          expect(
-            await browser.waitForElementByCss('body').elementByCss('p').text()
-          ).toMatch(/Digest: \w+/)
-        }
-      })
-
-      if (!isDev) {
-        it('should allow resetting error boundary', async () => {
-          const browser = await webdriver(next.url, '/error/client-component')
-
-          // Try triggering and resetting a few times in a row
-          for (let i = 0; i < 5; i++) {
-            await browser
-              .elementByCss('#error-trigger-button')
-              .click()
-              .waitForElementByCss('#error-boundary-message')
-
-            expect(
-              await browser.elementByCss('#error-boundary-message').text()
-            ).toBe('An error occurred: this is a test')
-
-            await browser
-              .elementByCss('#reset')
-              .click()
-              .waitForElementByCss('#error-trigger-button')
-
-            expect(
-              await browser.elementByCss('#error-trigger-button').text()
-            ).toBe('Trigger Error!')
-          }
-        })
-
-        it('should hydrate empty shell to handle server-side rendering errors', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/error/ssr-error-client-component'
-          )
-          const logs = await browser.log()
-          const errors = logs
-            .filter((x) => x.source === 'error')
-            .map((x) => x.message)
-            .join('\n')
-          expect(errors).toInclude('Error during SSR')
-        })
+        ).toBe('An error occurred: this is a test')
       }
     })
 
-    describe('known bugs', () => {
-      describe('should support React cache', () => {
-        it('server component', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/react-cache/server-component'
-          )
-          const val1 = await browser.elementByCss('#value-1').text()
-          const val2 = await browser.elementByCss('#value-2').text()
-          expect(val1).toBe(val2)
-        })
+    it('should trigger error component when an error happens during server components rendering', async () => {
+      const browser = await webdriver(next.url, '/error/server-component')
 
-        it('server component client-navigation', async () => {
-          const browser = await webdriver(next.url, '/react-cache')
-
-          await browser
-            .elementByCss('#to-server-component')
-            .click()
-            .waitForElementByCss('#value-1', 10000)
-          const val1 = await browser.elementByCss('#value-1').text()
-          const val2 = await browser.elementByCss('#value-2').text()
-          expect(val1).toBe(val2)
-        })
-
-        it('client component', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/react-cache/client-component'
-          )
-          const val1 = await browser.elementByCss('#value-1').text()
-          const val2 = await browser.elementByCss('#value-2').text()
-          expect(val1).toBe(val2)
-        })
-
-        it('client component client-navigation', async () => {
-          const browser = await webdriver(next.url, '/react-cache')
-
-          await browser
-            .elementByCss('#to-client-component')
-            .click()
-            .waitForElementByCss('#value-1', 10000)
-          const val1 = await browser.elementByCss('#value-1').text()
-          const val2 = await browser.elementByCss('#value-2').text()
-          expect(val1).toBe(val2)
-        })
-      })
-
-      describe('should support React fetch instrumentation', () => {
-        it('server component', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/react-fetch/server-component'
-          )
-          const val1 = await browser.elementByCss('#value-1').text()
-          const val2 = await browser.elementByCss('#value-2').text()
-          expect(val1).toBe(val2)
-        })
-
-        it('server component client-navigation', async () => {
-          const browser = await webdriver(next.url, '/react-fetch')
-
-          await browser
-            .elementByCss('#to-server-component')
-            .click()
-            .waitForElementByCss('#value-1', 10000)
-          const val1 = await browser.elementByCss('#value-1').text()
-          const val2 = await browser.elementByCss('#value-2').text()
-          expect(val1).toBe(val2)
-        })
-
-        // TODO-APP: React doesn't have fetch deduping for client components yet.
-        it.skip('client component', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/react-fetch/client-component'
-          )
-          const val1 = await browser.elementByCss('#value-1').text()
-          const val2 = await browser.elementByCss('#value-2').text()
-          expect(val1).toBe(val2)
-        })
-
-        // TODO-APP: React doesn't have fetch deduping for client components yet.
-        it.skip('client component client-navigation', async () => {
-          const browser = await webdriver(next.url, '/react-fetch')
-
-          await browser
-            .elementByCss('#to-client-component')
-            .click()
-            .waitForElementByCss('#value-1', 10000)
-          const val1 = await browser.elementByCss('#value-1').text()
-          const val2 = await browser.elementByCss('#value-2').text()
-          expect(val1).toBe(val2)
-        })
-      })
-      it('should not share flight data between requests', async () => {
-        const fetches = await Promise.all(
-          [...new Array(5)].map(() =>
-            renderViaHTTP(next.url, '/loading-bug/electronics')
-          )
-        )
-
-        for (const text of fetches) {
-          const $ = cheerio.load(text)
-          expect($('#category-id').text()).toBe('electronicsabc')
-        }
-      })
-      it('should handle as on next/link', async () => {
-        const browser = await webdriver(next.url, '/link-with-as')
+      if (isDev) {
         expect(
           await browser
-            .elementByCss('#link-to-info-123')
-            .click()
-            .waitForElementByCss('#message')
+            .waitForElementByCss('#error-boundary-message')
+            .elementByCss('#error-boundary-message')
             .text()
-        ).toBe(`hello from app/dashboard/deployments/info/[id]. ID is: 123`)
+        ).toBe('this is a test')
+        expect(
+          await browser.waitForElementByCss('#error-boundary-digest').text()
+          // Digest of the error message should be stable.
+        ).not.toBe('')
+        // TODO-APP: ensure error overlay is shown for errors that happened before/during hydration
+        // expect(await hasRedbox(browser)).toBe(true)
+        // expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
+      } else {
+        await browser
+        expect(
+          await browser.waitForElementByCss('#error-boundary-message').text()
+        ).toBe(
+          'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
+        )
+        expect(
+          await browser.waitForElementByCss('#error-boundary-digest').text()
+          // Digest of the error message should be stable.
+        ).not.toBe('')
+      }
+    })
+
+    it('should use default error boundary for prod and overlay for dev when no error component specified', async () => {
+      const browser = await webdriver(
+        next.url,
+        '/error/global-error-boundary/client'
+      )
+      await browser.elementByCss('#error-trigger-button').click()
+
+      if (isDev) {
+        expect(await hasRedbox(browser)).toBe(true)
+        expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
+      } else {
+        expect(
+          await browser.waitForElementByCss('body').elementByCss('h2').text()
+        ).toBe(
+          'Application error: a client-side exception has occurred (see the browser console for more information).'
+        )
+      }
+    })
+
+    it('should display error digest for error in server component with default error boundary', async () => {
+      const browser = await webdriver(
+        next.url,
+        '/error/global-error-boundary/server'
+      )
+
+      if (isDev) {
+        expect(await hasRedbox(browser)).toBe(true)
+        expect(await getRedboxHeader(browser)).toMatch(/custom server error/)
+      } else {
+        expect(
+          await browser.waitForElementByCss('body').elementByCss('h2').text()
+        ).toBe(
+          'Application error: a client-side exception has occurred (see the browser console for more information).'
+        )
+        expect(
+          await browser.waitForElementByCss('body').elementByCss('p').text()
+        ).toMatch(/Digest: \w+/)
+      }
+    })
+
+    if (!isDev) {
+      it('should allow resetting error boundary', async () => {
+        const browser = await webdriver(next.url, '/error/client-component')
+
+        // Try triggering and resetting a few times in a row
+        for (let i = 0; i < 5; i++) {
+          await browser
+            .elementByCss('#error-trigger-button')
+            .click()
+            .waitForElementByCss('#error-boundary-message')
+
+          expect(
+            await browser.elementByCss('#error-boundary-message').text()
+          ).toBe('An error occurred: this is a test')
+
+          await browser
+            .elementByCss('#reset')
+            .click()
+            .waitForElementByCss('#error-trigger-button')
+
+          expect(
+            await browser.elementByCss('#error-trigger-button').text()
+          ).toBe('Trigger Error!')
+        }
       })
-      it('should handle next/link back to initially loaded page', async () => {
-        const browser = await webdriver(next.url, '/linking/about')
+
+      it('should hydrate empty shell to handle server-side rendering errors', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/error/ssr-error-client-component'
+        )
+        const logs = await browser.log()
+        const errors = logs
+          .filter((x) => x.source === 'error')
+          .map((x) => x.message)
+          .join('\n')
+        expect(errors).toInclude('Error during SSR')
+      })
+    }
+  })
+
+  describe('known bugs', () => {
+    describe('should support React cache', () => {
+      it('server component', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/react-cache/server-component'
+        )
+        const val1 = await browser.elementByCss('#value-1').text()
+        const val2 = await browser.elementByCss('#value-2').text()
+        expect(val1).toBe(val2)
+      })
+
+      it('server component client-navigation', async () => {
+        const browser = await webdriver(next.url, '/react-cache')
+
+        await browser
+          .elementByCss('#to-server-component')
+          .click()
+          .waitForElementByCss('#value-1', 10000)
+        const val1 = await browser.elementByCss('#value-1').text()
+        const val2 = await browser.elementByCss('#value-2').text()
+        expect(val1).toBe(val2)
+      })
+
+      it('client component', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/react-cache/client-component'
+        )
+        const val1 = await browser.elementByCss('#value-1').text()
+        const val2 = await browser.elementByCss('#value-2').text()
+        expect(val1).toBe(val2)
+      })
+
+      it('client component client-navigation', async () => {
+        const browser = await webdriver(next.url, '/react-cache')
+
+        await browser
+          .elementByCss('#to-client-component')
+          .click()
+          .waitForElementByCss('#value-1', 10000)
+        const val1 = await browser.elementByCss('#value-1').text()
+        const val2 = await browser.elementByCss('#value-2').text()
+        expect(val1).toBe(val2)
+      })
+    })
+
+    describe('should support React fetch instrumentation', () => {
+      it('server component', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/react-fetch/server-component'
+        )
+        const val1 = await browser.elementByCss('#value-1').text()
+        const val2 = await browser.elementByCss('#value-2').text()
+        expect(val1).toBe(val2)
+      })
+
+      it('server component client-navigation', async () => {
+        const browser = await webdriver(next.url, '/react-fetch')
+
+        await browser
+          .elementByCss('#to-server-component')
+          .click()
+          .waitForElementByCss('#value-1', 10000)
+        const val1 = await browser.elementByCss('#value-1').text()
+        const val2 = await browser.elementByCss('#value-2').text()
+        expect(val1).toBe(val2)
+      })
+
+      // TODO-APP: React doesn't have fetch deduping for client components yet.
+      it.skip('client component', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/react-fetch/client-component'
+        )
+        const val1 = await browser.elementByCss('#value-1').text()
+        const val2 = await browser.elementByCss('#value-2').text()
+        expect(val1).toBe(val2)
+      })
+
+      // TODO-APP: React doesn't have fetch deduping for client components yet.
+      it.skip('client component client-navigation', async () => {
+        const browser = await webdriver(next.url, '/react-fetch')
+
+        await browser
+          .elementByCss('#to-client-component')
+          .click()
+          .waitForElementByCss('#value-1', 10000)
+        const val1 = await browser.elementByCss('#value-1').text()
+        const val2 = await browser.elementByCss('#value-2').text()
+        expect(val1).toBe(val2)
+      })
+    })
+    it('should not share flight data between requests', async () => {
+      const fetches = await Promise.all(
+        [...new Array(5)].map(() =>
+          renderViaHTTP(next.url, '/loading-bug/electronics')
+        )
+      )
+
+      for (const text of fetches) {
+        const $ = cheerio.load(text)
+        expect($('#category-id').text()).toBe('electronicsabc')
+      }
+    })
+    it('should handle as on next/link', async () => {
+      const browser = await webdriver(next.url, '/link-with-as')
+      expect(
+        await browser
+          .elementByCss('#link-to-info-123')
+          .click()
+          .waitForElementByCss('#message')
+          .text()
+      ).toBe(`hello from app/dashboard/deployments/info/[id]. ID is: 123`)
+    })
+    it('should handle next/link back to initially loaded page', async () => {
+      const browser = await webdriver(next.url, '/linking/about')
+      expect(
+        await browser
+          .elementByCss('a[href="/linking"]')
+          .click()
+          .waitForElementByCss('#home-page')
+          .text()
+      ).toBe(`Home page`)
+
+      expect(
+        await browser
+          .elementByCss('a[href="/linking/about"]')
+          .click()
+          .waitForElementByCss('#about-page')
+          .text()
+      ).toBe(`About page`)
+    })
+    it('should not do additional pushState when already on the page', async () => {
+      const browser = await webdriver(next.url, '/linking/about')
+      const goToLinkingPage = async () => {
         expect(
           await browser
             .elementByCss('a[href="/linking"]')
@@ -2434,266 +2427,244 @@ describe('app dir', () => {
             .waitForElementByCss('#home-page')
             .text()
         ).toBe(`Home page`)
+      }
 
-        expect(
-          await browser
-            .elementByCss('a[href="/linking/about"]')
-            .click()
-            .waitForElementByCss('#about-page')
-            .text()
-        ).toBe(`About page`)
-      })
-      it('should not do additional pushState when already on the page', async () => {
-        const browser = await webdriver(next.url, '/linking/about')
-        const goToLinkingPage = async () => {
-          expect(
-            await browser
-              .elementByCss('a[href="/linking"]')
-              .click()
-              .waitForElementByCss('#home-page')
-              .text()
-          ).toBe(`Home page`)
-        }
+      await goToLinkingPage()
+      await waitFor(1000)
+      await goToLinkingPage()
+      await waitFor(1000)
+      await goToLinkingPage()
+      await waitFor(1000)
 
-        await goToLinkingPage()
-        await waitFor(1000)
-        await goToLinkingPage()
-        await waitFor(1000)
-        await goToLinkingPage()
-        await waitFor(1000)
+      expect(
+        await browser.back().waitForElementByCss('#about-page', 2000).text()
+      ).toBe(`About page`)
+    })
+  })
 
-        expect(
-          await browser.back().waitForElementByCss('#about-page', 2000).text()
-        ).toBe(`About page`)
-      })
+  describe('not-found', () => {
+    it('should trigger not-found in a server component', async () => {
+      const browser = await webdriver(next.url, '/not-found/servercomponent')
+
+      expect(
+        await browser.waitForElementByCss('#not-found-component').text()
+      ).toBe('Not Found!')
+      expect(
+        await browser
+          .waitForElementByCss('meta[name="robots"]')
+          .getAttribute('content')
+      ).toBe('noindex')
     })
 
-    describe('not-found', () => {
-      it('should trigger not-found in a server component', async () => {
-        const browser = await webdriver(next.url, '/not-found/servercomponent')
+    it('should trigger not-found in a client component', async () => {
+      const browser = await webdriver(next.url, '/not-found/clientcomponent')
+      expect(
+        await browser.waitForElementByCss('#not-found-component').text()
+      ).toBe('Not Found!')
+      expect(
+        await browser
+          .waitForElementByCss('meta[name="robots"]')
+          .getAttribute('content')
+      ).toBe('noindex')
+    })
+    it('should trigger not-found client-side', async () => {
+      const browser = await webdriver(next.url, '/not-found/client-side')
+      await browser
+        .elementByCss('button')
+        .click()
+        .waitForElementByCss('#not-found-component')
+      expect(await browser.elementByCss('#not-found-component').text()).toBe(
+        'Not Found!'
+      )
+      expect(
+        await browser
+          .waitForElementByCss('meta[name="robots"]')
+          .getAttribute('content')
+      ).toBe('noindex')
+    })
+  })
 
-        expect(
-          await browser.waitForElementByCss('#not-found-component').text()
-        ).toBe('Not Found!')
-        expect(
-          await browser
-            .waitForElementByCss('meta[name="robots"]')
-            .getAttribute('content')
-        ).toBe('noindex')
+  describe('bots', () => {
+    if (!(global as any).isNextDeploy) {
+      it('should block rendering for bots and return 404 status', async () => {
+        const res = await fetchViaHTTP(
+          next.url,
+          '/not-found/servercomponent',
+          '',
+          {
+            headers: {
+              'User-Agent': 'Googlebot',
+            },
+          }
+        )
+
+        expect(res.status).toBe(404)
+        expect(await res.text()).toInclude('"noindex"')
+      })
+    }
+  })
+
+  describe('redirect', () => {
+    describe('components', () => {
+      it('should redirect in a server component', async () => {
+        const browser = await webdriver(next.url, '/redirect/servercomponent')
+        await browser.waitForElementByCss('#result-page')
+        expect(await browser.elementByCss('#result-page').text()).toBe(
+          'Result Page'
+        )
       })
 
-      it('should trigger not-found in a client component', async () => {
-        const browser = await webdriver(next.url, '/not-found/clientcomponent')
-        expect(
-          await browser.waitForElementByCss('#not-found-component').text()
-        ).toBe('Not Found!')
-        expect(
-          await browser
-            .waitForElementByCss('meta[name="robots"]')
-            .getAttribute('content')
-        ).toBe('noindex')
+      it('should redirect in a client component', async () => {
+        const browser = await webdriver(next.url, '/redirect/clientcomponent')
+        await browser.waitForElementByCss('#result-page')
+        expect(await browser.elementByCss('#result-page').text()).toBe(
+          'Result Page'
+        )
       })
-      it('should trigger not-found client-side', async () => {
-        const browser = await webdriver(next.url, '/not-found/client-side')
+
+      // TODO-APP: Enable in development
+      it('should redirect client-side', async () => {
+        const browser = await webdriver(next.url, '/redirect/client-side')
         await browser
           .elementByCss('button')
           .click()
-          .waitForElementByCss('#not-found-component')
-        expect(await browser.elementByCss('#not-found-component').text()).toBe(
-          'Not Found!'
+          .waitForElementByCss('#result-page')
+        // eslint-disable-next-line jest/no-standalone-expect
+        expect(await browser.elementByCss('#result-page').text()).toBe(
+          'Result Page'
         )
+      })
+    })
+
+    describe('next.config.js redirects', () => {
+      it('should redirect from next.config.js', async () => {
+        const browser = await webdriver(next.url, '/redirect/a')
+        expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
+        expect(await browser.url()).toBe(next.url + '/dashboard')
+      })
+
+      it('should redirect from next.config.js with link navigation', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/redirect/next-config-redirect'
+        )
+        await browser
+          .elementByCss('#redirect-a')
+          .click()
+          .waitForElementByCss('h1')
+        expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
+        expect(await browser.url()).toBe(next.url + '/dashboard')
+      })
+    })
+
+    describe('middleware redirects', () => {
+      it('should redirect from middleware', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/redirect-middleware-to-dashboard'
+        )
+        expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
+        expect(await browser.url()).toBe(next.url + '/dashboard')
+      })
+
+      it('should redirect from middleware with link navigation', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/redirect/next-middleware-redirect'
+        )
+        await browser
+          .elementByCss('#redirect-middleware')
+          .click()
+          .waitForElementByCss('h1')
+        expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
+        expect(await browser.url()).toBe(next.url + '/dashboard')
+      })
+    })
+  })
+
+  describe('nested navigation', () => {
+    it('should navigate to nested pages', async () => {
+      const browser = await webdriver(next.url, '/nested-navigation')
+      expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+      const pages = [
+        ['Electronics', ['Phones', 'Tablets', 'Laptops']],
+        ['Clothing', ['Tops', 'Shorts', 'Shoes']],
+        ['Books', ['Fiction', 'Biography', 'Education']],
+      ] as const
+
+      for (const [category, subCategories] of pages) {
         expect(
           await browser
-            .waitForElementByCss('meta[name="robots"]')
-            .getAttribute('content')
-        ).toBe('noindex')
-      })
-    })
-
-    describe('bots', () => {
-      if (!(global as any).isNextDeploy) {
-        it('should block rendering for bots and return 404 status', async () => {
-          const res = await fetchViaHTTP(
-            next.url,
-            '/not-found/servercomponent',
-            '',
-            {
-              headers: {
-                'User-Agent': 'Googlebot',
-              },
-            }
-          )
-
-          expect(res.status).toBe(404)
-          expect(await res.text()).toInclude('"noindex"')
-        })
-      }
-    })
-
-    describe('redirect', () => {
-      describe('components', () => {
-        it('should redirect in a server component', async () => {
-          const browser = await webdriver(next.url, '/redirect/servercomponent')
-          await browser.waitForElementByCss('#result-page')
-          expect(await browser.elementByCss('#result-page').text()).toBe(
-            'Result Page'
-          )
-        })
-
-        it('should redirect in a client component', async () => {
-          const browser = await webdriver(next.url, '/redirect/clientcomponent')
-          await browser.waitForElementByCss('#result-page')
-          expect(await browser.elementByCss('#result-page').text()).toBe(
-            'Result Page'
-          )
-        })
-
-        // TODO-APP: Enable in development
-        it('should redirect client-side', async () => {
-          const browser = await webdriver(next.url, '/redirect/client-side')
-          await browser
-            .elementByCss('button')
+            .elementByCss(
+              `a[href="/nested-navigation/${category.toLowerCase()}"]`
+            )
             .click()
-            .waitForElementByCss('#result-page')
-          // eslint-disable-next-line jest/no-standalone-expect
-          expect(await browser.elementByCss('#result-page').text()).toBe(
-            'Result Page'
-          )
-        })
-      })
+            .waitForElementByCss(`#all-${category.toLowerCase()}`)
+            .text()
+        ).toBe(`All ${category}`)
 
-      describe('next.config.js redirects', () => {
-        it('should redirect from next.config.js', async () => {
-          const browser = await webdriver(next.url, '/redirect/a')
-          expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
-          expect(await browser.url()).toBe(next.url + '/dashboard')
-        })
-
-        it('should redirect from next.config.js with link navigation', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/redirect/next-config-redirect'
-          )
-          await browser
-            .elementByCss('#redirect-a')
-            .click()
-            .waitForElementByCss('h1')
-          expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
-          expect(await browser.url()).toBe(next.url + '/dashboard')
-        })
-      })
-
-      describe('middleware redirects', () => {
-        it('should redirect from middleware', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/redirect-middleware-to-dashboard'
-          )
-          expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
-          expect(await browser.url()).toBe(next.url + '/dashboard')
-        })
-
-        it('should redirect from middleware with link navigation', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/redirect/next-middleware-redirect'
-          )
-          await browser
-            .elementByCss('#redirect-middleware')
-            .click()
-            .waitForElementByCss('h1')
-          expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
-          expect(await browser.url()).toBe(next.url + '/dashboard')
-        })
-      })
-    })
-
-    describe('nested navigation', () => {
-      it('should navigate to nested pages', async () => {
-        const browser = await webdriver(next.url, '/nested-navigation')
-        expect(await browser.elementByCss('h1').text()).toBe('Home')
-
-        const pages = [
-          ['Electronics', ['Phones', 'Tablets', 'Laptops']],
-          ['Clothing', ['Tops', 'Shorts', 'Shoes']],
-          ['Books', ['Fiction', 'Biography', 'Education']],
-        ] as const
-
-        for (const [category, subCategories] of pages) {
+        for (const subcategory of subCategories) {
           expect(
             await browser
               .elementByCss(
-                `a[href="/nested-navigation/${category.toLowerCase()}"]`
+                `a[href="/nested-navigation/${category.toLowerCase()}/${subcategory.toLowerCase()}"]`
               )
               .click()
-              .waitForElementByCss(`#all-${category.toLowerCase()}`)
+              .waitForElementByCss(`#${subcategory.toLowerCase()}`)
               .text()
-          ).toBe(`All ${category}`)
-
-          for (const subcategory of subCategories) {
-            expect(
-              await browser
-                .elementByCss(
-                  `a[href="/nested-navigation/${category.toLowerCase()}/${subcategory.toLowerCase()}"]`
-                )
-                .click()
-                .waitForElementByCss(`#${subcategory.toLowerCase()}`)
-                .text()
-            ).toBe(`${subcategory}`)
-          }
+          ).toBe(`${subcategory}`)
         }
-      })
-    })
-
-    describe('next/script', () => {
-      if (!(global as any).isNextDeploy) {
-        it('should support next/script and render in correct order', async () => {
-          const browser = await webdriver(next.url, '/script')
-
-          // Wait for lazyOnload scripts to be ready.
-          await new Promise((resolve) => setTimeout(resolve, 1000))
-
-          expect(await browser.eval(`window._script_order`)).toStrictEqual([
-            1,
-            1.5,
-            2,
-            2.5,
-            'render',
-            3,
-            4,
-          ])
-        })
       }
-
-      it('should insert preload tags for beforeInteractive and afterInteractive scripts', async () => {
-        const html = await renderViaHTTP(next.url, '/script')
-        expect(html).toContain(
-          '<link href="/test1.js" rel="preload" as="script"/>'
-        )
-        expect(html).toContain(
-          '<link href="/test2.js" rel="preload" as="script"/>'
-        )
-        expect(html).toContain(
-          '<link href="/test3.js" rel="preload" as="script"/>'
-        )
-
-        // test4.js has lazyOnload which doesn't need to be preloaded
-        expect(html).not.toContain(
-          '<script src="/test4.js" rel="preload" as="script"/>'
-        )
-      })
     })
+  })
 
-    describe('data fetch with response over 16KB with chunked encoding', () => {
-      it('should load page when fetching a large amount of data', async () => {
-        const browser = await webdriver(next.url, '/very-large-data-fetch')
-        expect(await (await browser.waitForElementByCss('#done')).text()).toBe(
-          'Hello world'
-        )
-        expect(await browser.elementByCss('p').text()).toBe('item count 128000')
+  describe('next/script', () => {
+    if (!(global as any).isNextDeploy) {
+      it('should support next/script and render in correct order', async () => {
+        const browser = await webdriver(next.url, '/script')
+
+        // Wait for lazyOnload scripts to be ready.
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+
+        expect(await browser.eval(`window._script_order`)).toStrictEqual([
+          1,
+          1.5,
+          2,
+          2.5,
+          'render',
+          3,
+          4,
+        ])
       })
-    })
-  }
+    }
 
-  runTests()
+    it('should insert preload tags for beforeInteractive and afterInteractive scripts', async () => {
+      const html = await renderViaHTTP(next.url, '/script')
+      expect(html).toContain(
+        '<link href="/test1.js" rel="preload" as="script"/>'
+      )
+      expect(html).toContain(
+        '<link href="/test2.js" rel="preload" as="script"/>'
+      )
+      expect(html).toContain(
+        '<link href="/test3.js" rel="preload" as="script"/>'
+      )
+
+      // test4.js has lazyOnload which doesn't need to be preloaded
+      expect(html).not.toContain(
+        '<script src="/test4.js" rel="preload" as="script"/>'
+      )
+    })
+  })
+
+  describe('data fetch with response over 16KB with chunked encoding', () => {
+    it('should load page when fetching a large amount of data', async () => {
+      const browser = await webdriver(next.url, '/very-large-data-fetch')
+      expect(await (await browser.waitForElementByCss('#done')).text()).toBe(
+        'Hello world'
+      )
+      expect(await browser.elementByCss('p').text()).toBe('item count 128000')
+    })
+  })
 })

--- a/test/e2e/app-dir/layout-params.test.ts
+++ b/test/e2e/app-dir/layout-params.test.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import { renderViaHTTP } from 'next-test-utils'
-import { createNextDescribe, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 import cheerio from 'cheerio'
 
 createNextDescribe(

--- a/test/e2e/app-dir/layout-params.test.ts
+++ b/test/e2e/app-dir/layout-params.test.ts
@@ -1,92 +1,92 @@
 import path from 'path'
 import { renderViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNextDescribe, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import cheerio from 'cheerio'
 
-describe('app dir - layout params', () => {
-  let next: NextInstance
+createNextDescribe(
+  'app dir - layout params',
+  {
+    files: path.join(__dirname, './layout-params'),
+    dependencies: {
+      react: 'latest',
+      'react-dom': 'latest',
+      typescript: 'latest',
+      '@types/react': 'latest',
+      '@types/node': 'latest',
+    },
+  },
+  ({ next }) => {
+    describe('basic params', () => {
+      it('check layout without params get no params', async () => {
+        const html = await renderViaHTTP(next.url, '/base/something/another')
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, './layout-params')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-        typescript: 'latest',
-        '@types/react': 'latest',
-        '@types/node': 'latest',
-      },
-    })
-  })
-  afterAll(() => next.destroy())
+        const $ = cheerio.load(html)
 
-  describe('basic params', () => {
-    it('check layout without params get no params', async () => {
-      const html = await renderViaHTTP(next.url, '/base/something/another')
+        const ids = ['#root-layout', '#lvl1-layout']
+        ids.forEach((divId) => {
+          const params = $(`${divId} > div`)
+          expect(params.length).toBe(0)
+        })
+      })
 
-      const $ = cheerio.load(html)
+      it("check layout renders just it's params", async () => {
+        const html = await renderViaHTTP(next.url, '/base/something/another')
 
-      const ids = ['#root-layout', '#lvl1-layout']
-      ids.forEach((divId) => {
-        const params = $(`${divId} > div`)
-        expect(params.length).toBe(0)
+        const $ = cheerio.load(html)
+
+        expect($('#lvl2-layout > div').length).toBe(1)
+        expect($('#lvl2-param1').text()).toBe('"something"')
+      })
+
+      it('check topmost layout renders all params', async () => {
+        const html = await renderViaHTTP(next.url, '/base/something/another')
+
+        const $ = cheerio.load(html)
+
+        expect($('#lvl3-layout > div').length).toBe(2)
+        expect($('#lvl3-param1').text()).toBe('"something"')
+        expect($('#lvl3-param2').text()).toBe('"another"')
       })
     })
 
-    it("check layout renders just it's params", async () => {
-      const html = await renderViaHTTP(next.url, '/base/something/another')
+    describe('catchall params', () => {
+      it('should give catchall params just to last layout', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/catchall/something/another'
+        )
 
-      const $ = cheerio.load(html)
+        const $ = cheerio.load(html)
 
-      expect($('#lvl2-layout > div').length).toBe(1)
-      expect($('#lvl2-param1').text()).toBe('"something"')
+        expect($(`#root-layout > div`).length).toBe(0)
+
+        expect($('#lvl2-layout > div').length).toBe(1)
+        expect($('#lvl2-params').text()).toBe('["something","another"]')
+      })
+
+      it('should give optional catchall params just to last layout', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/optional-catchall/something/another'
+        )
+
+        const $ = cheerio.load(html)
+
+        expect($(`#root-layout > div`).length).toBe(0)
+
+        expect($('#lvl2-layout > div').length).toBe(1)
+        expect($('#lvl2-params').text()).toBe('["something","another"]')
+      })
+
+      it("should give empty optional catchall params won't give params to any layout", async () => {
+        const html = await renderViaHTTP(next.url, '/optional-catchall')
+
+        const $ = cheerio.load(html)
+
+        expect($(`#root-layout > div`).length).toBe(0)
+        expect($('#lvl2-layout > div').length).toBe(0)
+      })
     })
-
-    it('check topmost layout renders all params', async () => {
-      const html = await renderViaHTTP(next.url, '/base/something/another')
-
-      const $ = cheerio.load(html)
-
-      expect($('#lvl3-layout > div').length).toBe(2)
-      expect($('#lvl3-param1').text()).toBe('"something"')
-      expect($('#lvl3-param2').text()).toBe('"another"')
-    })
-  })
-
-  describe('catchall params', () => {
-    it('should give catchall params just to last layout', async () => {
-      const html = await renderViaHTTP(next.url, '/catchall/something/another')
-
-      const $ = cheerio.load(html)
-
-      expect($(`#root-layout > div`).length).toBe(0)
-
-      expect($('#lvl2-layout > div').length).toBe(1)
-      expect($('#lvl2-params').text()).toBe('["something","another"]')
-    })
-
-    it('should give optional catchall params just to last layout', async () => {
-      const html = await renderViaHTTP(
-        next.url,
-        '/optional-catchall/something/another'
-      )
-
-      const $ = cheerio.load(html)
-
-      expect($(`#root-layout > div`).length).toBe(0)
-
-      expect($('#lvl2-layout > div').length).toBe(1)
-      expect($('#lvl2-params').text()).toBe('["something","another"]')
-    })
-
-    it("should give empty optional catchall params won't give params to any layout", async () => {
-      const html = await renderViaHTTP(next.url, '/optional-catchall')
-
-      const $ = cheerio.load(html)
-
-      expect($(`#root-layout > div`).length).toBe(0)
-      expect($('#lvl2-layout > div').length).toBe(0)
-    })
-  })
-})
+  }
+)

--- a/test/e2e/app-dir/layout-params.test.ts
+++ b/test/e2e/app-dir/layout-params.test.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import { renderViaHTTP } from 'next-test-utils'
 import { createNextDescribe } from 'e2e-utils'
 import cheerio from 'cheerio'
 
@@ -18,7 +17,7 @@ createNextDescribe(
   ({ next }) => {
     describe('basic params', () => {
       it('check layout without params get no params', async () => {
-        const html = await renderViaHTTP(next.url, '/base/something/another')
+        const html = await next.render('/base/something/another')
 
         const $ = cheerio.load(html)
 
@@ -30,7 +29,7 @@ createNextDescribe(
       })
 
       it("check layout renders just it's params", async () => {
-        const html = await renderViaHTTP(next.url, '/base/something/another')
+        const html = await next.render('/base/something/another')
 
         const $ = cheerio.load(html)
 
@@ -39,7 +38,7 @@ createNextDescribe(
       })
 
       it('check topmost layout renders all params', async () => {
-        const html = await renderViaHTTP(next.url, '/base/something/another')
+        const html = await next.render('/base/something/another')
 
         const $ = cheerio.load(html)
 
@@ -51,10 +50,7 @@ createNextDescribe(
 
     describe('catchall params', () => {
       it('should give catchall params just to last layout', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/catchall/something/another'
-        )
+        const html = await next.render('/catchall/something/another')
 
         const $ = cheerio.load(html)
 
@@ -65,10 +61,7 @@ createNextDescribe(
       })
 
       it('should give optional catchall params just to last layout', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/optional-catchall/something/another'
-        )
+        const html = await next.render('/optional-catchall/something/another')
 
         const $ = cheerio.load(html)
 
@@ -79,7 +72,7 @@ createNextDescribe(
       })
 
       it("should give empty optional catchall params won't give params to any layout", async () => {
-        const html = await renderViaHTTP(next.url, '/optional-catchall')
+        const html = await next.render('/optional-catchall')
 
         const $ = cheerio.load(html)
 

--- a/test/e2e/app-dir/layout-params.test.ts
+++ b/test/e2e/app-dir/layout-params.test.ts
@@ -21,13 +21,6 @@ describe('app dir - layout params', () => {
   })
   afterAll(() => next.destroy())
 
-  const isReact17 = process.env.NEXT_TEST_REACT_VERSION === '^17'
-
-  if (isReact17) {
-    it('should skip tests for react 17', () => {})
-    return
-  }
-
   describe('basic params', () => {
     it('check layout without params get no params', async () => {
       const html = await renderViaHTTP(next.url, '/base/something/another')

--- a/test/e2e/app-dir/layout-params.test.ts
+++ b/test/e2e/app-dir/layout-params.test.ts
@@ -1,6 +1,5 @@
 import path from 'path'
 import { createNextDescribe } from 'e2e-utils'
-import cheerio from 'cheerio'
 
 createNextDescribe(
   'app dir - layout params',
@@ -17,10 +16,7 @@ createNextDescribe(
   ({ next }) => {
     describe('basic params', () => {
       it('check layout without params get no params', async () => {
-        const html = await next.render('/base/something/another')
-
-        const $ = cheerio.load(html)
-
+        const $ = await next.render$('/base/something/another')
         const ids = ['#root-layout', '#lvl1-layout']
         ids.forEach((divId) => {
           const params = $(`${divId} > div`)
@@ -29,18 +25,14 @@ createNextDescribe(
       })
 
       it("check layout renders just it's params", async () => {
-        const html = await next.render('/base/something/another')
-
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/base/something/another')
 
         expect($('#lvl2-layout > div').length).toBe(1)
         expect($('#lvl2-param1').text()).toBe('"something"')
       })
 
       it('check topmost layout renders all params', async () => {
-        const html = await next.render('/base/something/another')
-
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/base/something/another')
 
         expect($('#lvl3-layout > div').length).toBe(2)
         expect($('#lvl3-param1').text()).toBe('"something"')
@@ -50,20 +42,15 @@ createNextDescribe(
 
     describe('catchall params', () => {
       it('should give catchall params just to last layout', async () => {
-        const html = await next.render('/catchall/something/another')
-
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/catchall/something/another')
 
         expect($(`#root-layout > div`).length).toBe(0)
-
         expect($('#lvl2-layout > div').length).toBe(1)
         expect($('#lvl2-params').text()).toBe('["something","another"]')
       })
 
       it('should give optional catchall params just to last layout', async () => {
-        const html = await next.render('/optional-catchall/something/another')
-
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/optional-catchall/something/another')
 
         expect($(`#root-layout > div`).length).toBe(0)
 
@@ -72,9 +59,7 @@ createNextDescribe(
       })
 
       it("should give empty optional catchall params won't give params to any layout", async () => {
-        const html = await next.render('/optional-catchall')
-
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/optional-catchall')
 
         expect($(`#root-layout > div`).length).toBe(0)
         expect($('#lvl2-layout > div').length).toBe(0)

--- a/test/e2e/app-dir/next-font.test.ts
+++ b/test/e2e/app-dir/next-font.test.ts
@@ -1,8 +1,7 @@
 import { createNextDescribe } from 'e2e-utils'
-import { getRedboxSource, hasRedbox, renderViaHTTP } from 'next-test-utils'
+import { getRedboxSource, hasRedbox } from 'next-test-utils'
 import cheerio from 'cheerio'
 import path from 'path'
-import webdriver from 'next-webdriver'
 
 createNextDescribe(
   'app dir next-font',
@@ -18,7 +17,7 @@ createNextDescribe(
   ({ next, isNextDev: isDev }) => {
     describe('import values', () => {
       it('should have correct values at /', async () => {
-        const html = await renderViaHTTP(next.url, '/')
+        const html = await next.render('/')
         const $ = cheerio.load(html)
 
         // layout
@@ -49,7 +48,7 @@ createNextDescribe(
       })
 
       it('should have correct values at /client', async () => {
-        const html = await renderViaHTTP(next.url, '/client')
+        const html = await next.render('/client')
         const $ = cheerio.load(html)
 
         // root layout
@@ -89,7 +88,7 @@ createNextDescribe(
 
     describe('computed styles', () => {
       it('should have correct styles at /', async () => {
-        const browser = await webdriver(next.url, '/')
+        const browser = await next.browser('/')
 
         // layout
         expect(
@@ -144,7 +143,7 @@ createNextDescribe(
       })
 
       it('should have correct styles at /client', async () => {
-        const browser = await webdriver(next.url, '/client')
+        const browser = await next.browser('/client')
 
         // root layout
         expect(
@@ -219,7 +218,7 @@ createNextDescribe(
     if (!isDev) {
       describe('preload', () => {
         it('should preload correctly with server components', async () => {
-          const html = await renderViaHTTP(next.url, '/')
+          const html = await next.render('/')
           const $ = cheerio.load(html)
 
           // Preconnect
@@ -250,7 +249,7 @@ createNextDescribe(
         })
 
         it('should preload correctly with client components', async () => {
-          const html = await renderViaHTTP(next.url, '/client')
+          const html = await next.render('/client')
           const $ = cheerio.load(html)
 
           // Preconnect
@@ -283,7 +282,7 @@ createNextDescribe(
         })
 
         it('should preload correctly with layout using fonts', async () => {
-          const html = await renderViaHTTP(next.url, '/layout-with-fonts')
+          const html = await next.render('/layout-with-fonts')
           const $ = cheerio.load(html)
 
           // Preconnect
@@ -309,7 +308,7 @@ createNextDescribe(
         })
 
         it('should preload correctly with page using fonts', async () => {
-          const html = await renderViaHTTP(next.url, '/page-with-fonts')
+          const html = await next.render('/page-with-fonts')
           const $ = cheerio.load(html)
 
           // Preconnect
@@ -339,7 +338,7 @@ createNextDescribe(
     if (isDev) {
       describe('Dev errors', () => {
         it('should recover on font loader error', async () => {
-          const browser = await webdriver(next.url, '/')
+          const browser = await next.browser('/')
           const font1Content = await next.readFile('fonts/index.js')
 
           // Break file

--- a/test/e2e/app-dir/next-font.test.ts
+++ b/test/e2e/app-dir/next-font.test.ts
@@ -1,373 +1,362 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 import { getRedboxSource, hasRedbox, renderViaHTTP } from 'next-test-utils'
 import cheerio from 'cheerio'
 import path from 'path'
 import webdriver from 'next-webdriver'
 
-describe('app dir next-font', () => {
-  const isDev = (global as any).isNextDev
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
-
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'next-font')),
-      dependencies: {
-        '@next/font': 'canary',
-        react: 'latest',
-        'react-dom': 'latest',
-      },
-      skipStart: true,
-    })
-    await next.start()
-  })
-  afterAll(() => next.destroy())
-
-  describe('import values', () => {
-    it('should have correct values at /', async () => {
-      const html = await renderViaHTTP(next.url, '/')
-      const $ = cheerio.load(html)
-
-      // layout
-      expect(JSON.parse($('#root-layout').text())).toEqual({
-        className: expect.stringMatching(/^__className_.{6}$/),
-        variable: expect.stringMatching(/^__variable_.{6}$/),
-        style: {
-          fontFamily: expect.stringMatching(/^'__font1_.{6}'$/),
-        },
-      })
-      // page
-      expect(JSON.parse($('#root-page').text())).toEqual({
-        className: expect.stringMatching(/^__className_.{6}$/),
-        variable: expect.stringMatching(/^__variable_.{6}$/),
-        style: {
-          fontFamily: expect.stringMatching(/^'__font2_.{6}'$/),
-        },
-      })
-      // Comp
-      expect(JSON.parse($('#root-comp').text())).toEqual({
-        className: expect.stringMatching(/^__className_.{6}$/),
-        style: {
-          fontFamily: expect.stringMatching(/^'__font3_.{6}'$/),
-          fontStyle: 'italic',
-          fontWeight: 900,
-        },
-      })
-    })
-
-    it('should have correct values at /client', async () => {
-      const html = await renderViaHTTP(next.url, '/client')
-      const $ = cheerio.load(html)
-
-      // root layout
-      expect(JSON.parse($('#root-layout').text())).toEqual({
-        className: expect.stringMatching(/^__className_.{6}$/),
-        variable: expect.stringMatching(/^__variable_.{6}$/),
-        style: {
-          fontFamily: expect.stringMatching(/^'__font1_.{6}'$/),
-        },
-      })
-
-      // layout
-      expect(JSON.parse($('#client-layout').text())).toEqual({
-        className: expect.stringMatching(/^__className_.{6}$/),
-        style: {
-          fontFamily: expect.stringMatching(/^'__font4_.{6}'$/),
-          fontWeight: 100,
-        },
-      })
-      // page
-      expect(JSON.parse($('#client-page').text())).toEqual({
-        className: expect.stringMatching(/^__className_.{6}$/),
-        style: {
-          fontFamily: expect.stringMatching(/^'__font5_.{6}'$/),
-          fontStyle: 'italic',
-        },
-      })
-      // Comp
-      expect(JSON.parse($('#client-comp').text())).toEqual({
-        className: expect.stringMatching(/^__className_.{6}$/),
-        style: {
-          fontFamily: expect.stringMatching(/^'__font6_.{6}'$/),
-        },
-      })
-    })
-  })
-
-  describe('computed styles', () => {
-    it('should have correct styles at /', async () => {
-      const browser = await webdriver(next.url, '/')
-
-      // layout
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-layout")).fontFamily'
-        )
-      ).toMatch(/^__font1_.{6}$/)
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-layout")).fontWeight'
-        )
-      ).toBe('400')
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-layout")).fontStyle'
-        )
-      ).toBe('normal')
-
-      // page
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-page")).fontFamily'
-        )
-      ).toMatch(/^__font2_.{6}$/)
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-page")).fontWeight'
-        )
-      ).toBe('400')
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-page")).fontStyle'
-        )
-      ).toBe('normal')
-
-      // Comp
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-comp")).fontFamily'
-        )
-      ).toMatch(/^__font3_.{6}$/)
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-comp")).fontWeight'
-        )
-      ).toBe('900')
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-comp")).fontStyle'
-        )
-      ).toBe('italic')
-    })
-
-    it('should have correct styles at /client', async () => {
-      const browser = await webdriver(next.url, '/client')
-
-      // root layout
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-layout")).fontFamily'
-        )
-      ).toMatch(/^__font1_.{6}$/)
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-layout")).fontWeight'
-        )
-      ).toBe('400')
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#root-layout")).fontStyle'
-        )
-      ).toBe('normal')
-
-      // layout
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#client-layout")).fontFamily'
-        )
-      ).toMatch(/^__font4_.{6}$/)
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#client-layout")).fontWeight'
-        )
-      ).toBe('100')
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#client-layout")).fontStyle'
-        )
-      ).toBe('normal')
-
-      // page
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#client-page")).fontFamily'
-        )
-      ).toMatch(/^__font5_.{6}$/)
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#client-page")).fontWeight'
-        )
-      ).toBe('400')
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#client-page")).fontStyle'
-        )
-      ).toBe('italic')
-
-      // Comp
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#client-comp")).fontFamily'
-        )
-      ).toMatch(/^__font6_.{6}$/)
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#client-comp")).fontWeight'
-        )
-      ).toBe('400')
-      expect(
-        await browser.eval(
-          'getComputedStyle(document.querySelector("#client-comp")).fontStyle'
-        )
-      ).toBe('normal')
-    })
-  })
-
-  if (!isDev) {
-    describe('preload', () => {
-      it('should preload correctly with server components', async () => {
+createNextDescribe(
+  'app dir next-font',
+  {
+    files: path.join(__dirname, 'next-font'),
+    dependencies: {
+      '@next/font': 'canary',
+      react: 'latest',
+      'react-dom': 'latest',
+    },
+    skipDeployment: true,
+  },
+  ({ next, isNextDev: isDev }) => {
+    describe('import values', () => {
+      it('should have correct values at /', async () => {
         const html = await renderViaHTTP(next.url, '/')
         const $ = cheerio.load(html)
 
-        // Preconnect
-        expect($('link[rel="preconnect"]').length).toBe(0)
-
-        expect($('link[as="font"]').length).toBe(3)
-        expect($('link[as="font"]').get(0).attribs).toEqual({
-          as: 'font',
-          crossorigin: '',
-          href: '/_next/static/media/e9b9dc0d8ba35f48.p.woff2',
-          rel: 'preload',
-          type: 'font/woff2',
+        // layout
+        expect(JSON.parse($('#root-layout').text())).toEqual({
+          className: expect.stringMatching(/^__className_.{6}$/),
+          variable: expect.stringMatching(/^__variable_.{6}$/),
+          style: {
+            fontFamily: expect.stringMatching(/^'__font1_.{6}'$/),
+          },
         })
-        expect($('link[as="font"]').get(1).attribs).toEqual({
-          as: 'font',
-          crossorigin: '',
-          href: '/_next/static/media/b61859a50be14c53.p.woff2',
-          rel: 'preload',
-          type: 'font/woff2',
+        // page
+        expect(JSON.parse($('#root-page').text())).toEqual({
+          className: expect.stringMatching(/^__className_.{6}$/),
+          variable: expect.stringMatching(/^__variable_.{6}$/),
+          style: {
+            fontFamily: expect.stringMatching(/^'__font2_.{6}'$/),
+          },
         })
-        expect($('link[as="font"]').get(2).attribs).toEqual({
-          as: 'font',
-          crossorigin: '',
-          href: '/_next/static/media/b2104791981359ae.p.woff2',
-          rel: 'preload',
-          type: 'font/woff2',
+        // Comp
+        expect(JSON.parse($('#root-comp').text())).toEqual({
+          className: expect.stringMatching(/^__className_.{6}$/),
+          style: {
+            fontFamily: expect.stringMatching(/^'__font3_.{6}'$/),
+            fontStyle: 'italic',
+            fontWeight: 900,
+          },
         })
       })
 
-      it('should preload correctly with client components', async () => {
+      it('should have correct values at /client', async () => {
         const html = await renderViaHTTP(next.url, '/client')
         const $ = cheerio.load(html)
 
-        // Preconnect
-        expect($('link[rel="preconnect"]').length).toBe(0)
-
-        expect($('link[as="font"]').length).toBe(3)
-        // From root layout
-        expect($('link[as="font"]').get(0).attribs).toEqual({
-          as: 'font',
-          crossorigin: '',
-          href: '/_next/static/media/e9b9dc0d8ba35f48.p.woff2',
-          rel: 'preload',
-          type: 'font/woff2',
+        // root layout
+        expect(JSON.parse($('#root-layout').text())).toEqual({
+          className: expect.stringMatching(/^__className_.{6}$/),
+          variable: expect.stringMatching(/^__variable_.{6}$/),
+          style: {
+            fontFamily: expect.stringMatching(/^'__font1_.{6}'$/),
+          },
         })
 
-        expect($('link[as="font"]').get(1).attribs).toEqual({
-          as: 'font',
-          crossorigin: '',
-          href: '/_next/static/media/e1053f04babc7571.p.woff2',
-          rel: 'preload',
-          type: 'font/woff2',
+        // layout
+        expect(JSON.parse($('#client-layout').text())).toEqual({
+          className: expect.stringMatching(/^__className_.{6}$/),
+          style: {
+            fontFamily: expect.stringMatching(/^'__font4_.{6}'$/),
+            fontWeight: 100,
+          },
         })
-        expect($('link[as="font"]').get(2).attribs).toEqual({
-          as: 'font',
-          crossorigin: '',
-          href: '/_next/static/media/feab2c68f2a8e9a4.p.woff2',
-          rel: 'preload',
-          type: 'font/woff2',
+        // page
+        expect(JSON.parse($('#client-page').text())).toEqual({
+          className: expect.stringMatching(/^__className_.{6}$/),
+          style: {
+            fontFamily: expect.stringMatching(/^'__font5_.{6}'$/),
+            fontStyle: 'italic',
+          },
         })
-      })
-
-      it('should preload correctly with layout using fonts', async () => {
-        const html = await renderViaHTTP(next.url, '/layout-with-fonts')
-        const $ = cheerio.load(html)
-
-        // Preconnect
-        expect($('link[rel="preconnect"]').length).toBe(0)
-
-        expect($('link[as="font"]').length).toBe(2)
-        // From root layout
-        expect($('link[as="font"]').get(0).attribs).toEqual({
-          as: 'font',
-          crossorigin: '',
-          href: '/_next/static/media/e9b9dc0d8ba35f48.p.woff2',
-          rel: 'preload',
-          type: 'font/woff2',
-        })
-
-        expect($('link[as="font"]').get(1).attribs).toEqual({
-          as: 'font',
-          crossorigin: '',
-          href: '/_next/static/media/75c5faeeb9c86969.p.woff2',
-          rel: 'preload',
-          type: 'font/woff2',
-        })
-      })
-
-      it('should preload correctly with page using fonts', async () => {
-        const html = await renderViaHTTP(next.url, '/page-with-fonts')
-        const $ = cheerio.load(html)
-
-        // Preconnect
-        expect($('link[rel="preconnect"]').length).toBe(0)
-
-        expect($('link[as="font"]').length).toBe(2)
-        // From root layout
-        expect($('link[as="font"]').get(0).attribs).toEqual({
-          as: 'font',
-          crossorigin: '',
-          href: '/_next/static/media/e9b9dc0d8ba35f48.p.woff2',
-          rel: 'preload',
-          type: 'font/woff2',
-        })
-
-        expect($('link[as="font"]').get(1).attribs).toEqual({
-          as: 'font',
-          crossorigin: '',
-          href: '/_next/static/media/568e4c6d8123c4d6.p.woff2',
-          rel: 'preload',
-          type: 'font/woff2',
+        // Comp
+        expect(JSON.parse($('#client-comp').text())).toEqual({
+          className: expect.stringMatching(/^__className_.{6}$/),
+          style: {
+            fontFamily: expect.stringMatching(/^'__font6_.{6}'$/),
+          },
         })
       })
     })
-  }
 
-  if (isDev) {
-    describe('Dev errors', () => {
-      it('should recover on font loader error', async () => {
+    describe('computed styles', () => {
+      it('should have correct styles at /', async () => {
         const browser = await webdriver(next.url, '/')
-        const font1Content = await next.readFile('fonts/index.js')
 
-        // Break file
-        await next.patchFile(
-          'fonts/index.js',
-          font1Content.replace('./font1.woff2', './does-not-exist.woff2')
-        )
-        expect(await hasRedbox(browser, true)).toBeTrue()
-        expect(await getRedboxSource(browser)).toInclude(
-          "Can't resolve './does-not-exist.woff2'"
-        )
+        // layout
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-layout")).fontFamily'
+          )
+        ).toMatch(/^__font1_.{6}$/)
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-layout")).fontWeight'
+          )
+        ).toBe('400')
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-layout")).fontStyle'
+          )
+        ).toBe('normal')
 
-        // Fix file
-        await next.patchFile('fonts/index.js', font1Content)
-        await browser.waitForElementByCss('#root-page')
+        // page
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-page")).fontFamily'
+          )
+        ).toMatch(/^__font2_.{6}$/)
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-page")).fontWeight'
+          )
+        ).toBe('400')
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-page")).fontStyle'
+          )
+        ).toBe('normal')
+
+        // Comp
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-comp")).fontFamily'
+          )
+        ).toMatch(/^__font3_.{6}$/)
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-comp")).fontWeight'
+          )
+        ).toBe('900')
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-comp")).fontStyle'
+          )
+        ).toBe('italic')
+      })
+
+      it('should have correct styles at /client', async () => {
+        const browser = await webdriver(next.url, '/client')
+
+        // root layout
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-layout")).fontFamily'
+          )
+        ).toMatch(/^__font1_.{6}$/)
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-layout")).fontWeight'
+          )
+        ).toBe('400')
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#root-layout")).fontStyle'
+          )
+        ).toBe('normal')
+
+        // layout
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#client-layout")).fontFamily'
+          )
+        ).toMatch(/^__font4_.{6}$/)
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#client-layout")).fontWeight'
+          )
+        ).toBe('100')
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#client-layout")).fontStyle'
+          )
+        ).toBe('normal')
+
+        // page
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#client-page")).fontFamily'
+          )
+        ).toMatch(/^__font5_.{6}$/)
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#client-page")).fontWeight'
+          )
+        ).toBe('400')
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#client-page")).fontStyle'
+          )
+        ).toBe('italic')
+
+        // Comp
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#client-comp")).fontFamily'
+          )
+        ).toMatch(/^__font6_.{6}$/)
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#client-comp")).fontWeight'
+          )
+        ).toBe('400')
+        expect(
+          await browser.eval(
+            'getComputedStyle(document.querySelector("#client-comp")).fontStyle'
+          )
+        ).toBe('normal')
       })
     })
+
+    if (!isDev) {
+      describe('preload', () => {
+        it('should preload correctly with server components', async () => {
+          const html = await renderViaHTTP(next.url, '/')
+          const $ = cheerio.load(html)
+
+          // Preconnect
+          expect($('link[rel="preconnect"]').length).toBe(0)
+
+          expect($('link[as="font"]').length).toBe(3)
+          expect($('link[as="font"]').get(0).attribs).toEqual({
+            as: 'font',
+            crossorigin: '',
+            href: '/_next/static/media/e9b9dc0d8ba35f48.p.woff2',
+            rel: 'preload',
+            type: 'font/woff2',
+          })
+          expect($('link[as="font"]').get(1).attribs).toEqual({
+            as: 'font',
+            crossorigin: '',
+            href: '/_next/static/media/b61859a50be14c53.p.woff2',
+            rel: 'preload',
+            type: 'font/woff2',
+          })
+          expect($('link[as="font"]').get(2).attribs).toEqual({
+            as: 'font',
+            crossorigin: '',
+            href: '/_next/static/media/b2104791981359ae.p.woff2',
+            rel: 'preload',
+            type: 'font/woff2',
+          })
+        })
+
+        it('should preload correctly with client components', async () => {
+          const html = await renderViaHTTP(next.url, '/client')
+          const $ = cheerio.load(html)
+
+          // Preconnect
+          expect($('link[rel="preconnect"]').length).toBe(0)
+
+          expect($('link[as="font"]').length).toBe(3)
+          // From root layout
+          expect($('link[as="font"]').get(0).attribs).toEqual({
+            as: 'font',
+            crossorigin: '',
+            href: '/_next/static/media/e9b9dc0d8ba35f48.p.woff2',
+            rel: 'preload',
+            type: 'font/woff2',
+          })
+
+          expect($('link[as="font"]').get(1).attribs).toEqual({
+            as: 'font',
+            crossorigin: '',
+            href: '/_next/static/media/e1053f04babc7571.p.woff2',
+            rel: 'preload',
+            type: 'font/woff2',
+          })
+          expect($('link[as="font"]').get(2).attribs).toEqual({
+            as: 'font',
+            crossorigin: '',
+            href: '/_next/static/media/feab2c68f2a8e9a4.p.woff2',
+            rel: 'preload',
+            type: 'font/woff2',
+          })
+        })
+
+        it('should preload correctly with layout using fonts', async () => {
+          const html = await renderViaHTTP(next.url, '/layout-with-fonts')
+          const $ = cheerio.load(html)
+
+          // Preconnect
+          expect($('link[rel="preconnect"]').length).toBe(0)
+
+          expect($('link[as="font"]').length).toBe(2)
+          // From root layout
+          expect($('link[as="font"]').get(0).attribs).toEqual({
+            as: 'font',
+            crossorigin: '',
+            href: '/_next/static/media/e9b9dc0d8ba35f48.p.woff2',
+            rel: 'preload',
+            type: 'font/woff2',
+          })
+
+          expect($('link[as="font"]').get(1).attribs).toEqual({
+            as: 'font',
+            crossorigin: '',
+            href: '/_next/static/media/75c5faeeb9c86969.p.woff2',
+            rel: 'preload',
+            type: 'font/woff2',
+          })
+        })
+
+        it('should preload correctly with page using fonts', async () => {
+          const html = await renderViaHTTP(next.url, '/page-with-fonts')
+          const $ = cheerio.load(html)
+
+          // Preconnect
+          expect($('link[rel="preconnect"]').length).toBe(0)
+
+          expect($('link[as="font"]').length).toBe(2)
+          // From root layout
+          expect($('link[as="font"]').get(0).attribs).toEqual({
+            as: 'font',
+            crossorigin: '',
+            href: '/_next/static/media/e9b9dc0d8ba35f48.p.woff2',
+            rel: 'preload',
+            type: 'font/woff2',
+          })
+
+          expect($('link[as="font"]').get(1).attribs).toEqual({
+            as: 'font',
+            crossorigin: '',
+            href: '/_next/static/media/568e4c6d8123c4d6.p.woff2',
+            rel: 'preload',
+            type: 'font/woff2',
+          })
+        })
+      })
+    }
+
+    if (isDev) {
+      describe('Dev errors', () => {
+        it('should recover on font loader error', async () => {
+          const browser = await webdriver(next.url, '/')
+          const font1Content = await next.readFile('fonts/index.js')
+
+          // Break file
+          await next.patchFile(
+            'fonts/index.js',
+            font1Content.replace('./font1.woff2', './does-not-exist.woff2')
+          )
+          expect(await hasRedbox(browser, true)).toBeTrue()
+          expect(await getRedboxSource(browser)).toInclude(
+            "Can't resolve './does-not-exist.woff2'"
+          )
+
+          // Fix file
+          await next.patchFile('fonts/index.js', font1Content)
+          await browser.waitForElementByCss('#root-page')
+        })
+      })
+    }
   }
-})
+)

--- a/test/e2e/app-dir/next-font.test.ts
+++ b/test/e2e/app-dir/next-font.test.ts
@@ -1,6 +1,5 @@
 import { createNextDescribe } from 'e2e-utils'
 import { getRedboxSource, hasRedbox } from 'next-test-utils'
-import cheerio from 'cheerio'
 import path from 'path'
 
 createNextDescribe(
@@ -17,8 +16,7 @@ createNextDescribe(
   ({ next, isNextDev: isDev }) => {
     describe('import values', () => {
       it('should have correct values at /', async () => {
-        const html = await next.render('/')
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/')
 
         // layout
         expect(JSON.parse($('#root-layout').text())).toEqual({
@@ -48,8 +46,7 @@ createNextDescribe(
       })
 
       it('should have correct values at /client', async () => {
-        const html = await next.render('/client')
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/client')
 
         // root layout
         expect(JSON.parse($('#root-layout').text())).toEqual({
@@ -218,8 +215,7 @@ createNextDescribe(
     if (!isDev) {
       describe('preload', () => {
         it('should preload correctly with server components', async () => {
-          const html = await next.render('/')
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/')
 
           // Preconnect
           expect($('link[rel="preconnect"]').length).toBe(0)
@@ -249,8 +245,7 @@ createNextDescribe(
         })
 
         it('should preload correctly with client components', async () => {
-          const html = await next.render('/client')
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/client')
 
           // Preconnect
           expect($('link[rel="preconnect"]').length).toBe(0)
@@ -282,8 +277,7 @@ createNextDescribe(
         })
 
         it('should preload correctly with layout using fonts', async () => {
-          const html = await next.render('/layout-with-fonts')
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/layout-with-fonts')
 
           // Preconnect
           expect($('link[rel="preconnect"]').length).toBe(0)
@@ -308,8 +302,7 @@ createNextDescribe(
         })
 
         it('should preload correctly with page using fonts', async () => {
-          const html = await next.render('/page-with-fonts')
-          const $ = cheerio.load(html)
+          const $ = await next.render$('/page-with-fonts')
 
           // Preconnect
           expect($('link[rel="preconnect"]').length).toBe(0)

--- a/test/e2e/app-dir/next-image.test.ts
+++ b/test/e2e/app-dir/next-image.test.ts
@@ -1,5 +1,4 @@
 import { createNextDescribe } from 'e2e-utils'
-import cheerio from 'cheerio'
 import path from 'path'
 
 createNextDescribe(
@@ -11,8 +10,7 @@ createNextDescribe(
   ({ next }) => {
     describe('ssr content', () => {
       it('should render images on / route', async () => {
-        const html = await next.render('/')
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/')
 
         const layout = $('#app-layout')
         expect(layout.attr('src')).toBe(
@@ -40,8 +38,7 @@ createNextDescribe(
       })
 
       it('should render images on /client route', async () => {
-        const html = await next.render('/client')
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/client')
 
         const root = $('#app-layout')
         expect(root.attr('src')).toBe(
@@ -77,8 +74,7 @@ createNextDescribe(
       })
 
       it('should render images nested under page dir on /nested route', async () => {
-        const html = await next.render('/nested')
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/nested')
 
         const root = $('#app-layout')
         expect(root.attr('src')).toBe(
@@ -218,8 +214,7 @@ createNextDescribe(
 
     describe('image content', () => {
       it('should render images on / route', async () => {
-        const html = await next.render('/')
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/')
 
         const res1 = await next.fetch($('#app-layout').attr('src'))
         expect(res1.status).toBe(200)
@@ -235,8 +230,7 @@ createNextDescribe(
       })
 
       it('should render images on /client route', async () => {
-        const html = await next.render('/client')
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/client')
 
         const res1 = await next.fetch($('#app-layout').attr('src'))
         expect(res1.status).toBe(200)
@@ -256,8 +250,7 @@ createNextDescribe(
       })
 
       it('should render images nested under page dir on /nested route', async () => {
-        const html = await next.render('/nested')
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/nested')
 
         const res1 = await next.fetch($('#app-layout').attr('src'))
         expect(res1.status).toBe(200)

--- a/test/e2e/app-dir/next-image.test.ts
+++ b/test/e2e/app-dir/next-image.test.ts
@@ -1,8 +1,6 @@
 import { createNextDescribe } from 'e2e-utils'
-import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import cheerio from 'cheerio'
 import path from 'path'
-import webdriver from 'next-webdriver'
 
 createNextDescribe(
   'app dir next-image',
@@ -13,7 +11,7 @@ createNextDescribe(
   ({ next }) => {
     describe('ssr content', () => {
       it('should render images on / route', async () => {
-        const html = await renderViaHTTP(next.url, '/')
+        const html = await next.render('/')
         const $ = cheerio.load(html)
 
         const layout = $('#app-layout')
@@ -42,7 +40,7 @@ createNextDescribe(
       })
 
       it('should render images on /client route', async () => {
-        const html = await renderViaHTTP(next.url, '/client')
+        const html = await next.render('/client')
         const $ = cheerio.load(html)
 
         const root = $('#app-layout')
@@ -79,7 +77,7 @@ createNextDescribe(
       })
 
       it('should render images nested under page dir on /nested route', async () => {
-        const html = await renderViaHTTP(next.url, '/nested')
+        const html = await next.render('/nested')
         const $ = cheerio.load(html)
 
         const root = $('#app-layout')
@@ -118,7 +116,7 @@ createNextDescribe(
 
     describe('browser content', () => {
       it('should render images on / route', async () => {
-        const browser = await webdriver(next.url, '/')
+        const browser = await next.browser('/')
 
         const layout = await browser.elementById('app-layout')
         expect(await layout.getAttribute('src')).toBe(
@@ -146,7 +144,7 @@ createNextDescribe(
       })
 
       it('should render images on /client route', async () => {
-        const browser = await webdriver(next.url, '/client')
+        const browser = await next.browser('/client')
 
         const root = await browser.elementById('app-layout')
         expect(await root.getAttribute('src')).toBe(
@@ -182,7 +180,7 @@ createNextDescribe(
       })
 
       it('should render images nested under page dir on /nested route', async () => {
-        const browser = await webdriver(next.url, '/nested')
+        const browser = await next.browser('/nested')
 
         const root = await browser.elementById('app-layout')
         expect(await root.getAttribute('src')).toBe(
@@ -220,78 +218,60 @@ createNextDescribe(
 
     describe('image content', () => {
       it('should render images on / route', async () => {
-        const html = await renderViaHTTP(next.url, '/')
+        const html = await next.render('/')
         const $ = cheerio.load(html)
 
-        const res1 = await fetchViaHTTP(next.url, $('#app-layout').attr('src'))
+        const res1 = await next.fetch($('#app-layout').attr('src'))
         expect(res1.status).toBe(200)
         expect(res1.headers.get('content-type')).toBe('image/png')
 
-        const res2 = await fetchViaHTTP(next.url, $('#app-page').attr('src'))
+        const res2 = await next.fetch($('#app-page').attr('src'))
         expect(res2.status).toBe(200)
         expect(res2.headers.get('content-type')).toBe('image/png')
 
-        const res3 = await fetchViaHTTP(next.url, $('#app-comp').attr('src'))
+        const res3 = await next.fetch($('#app-comp').attr('src'))
         expect(res3.status).toBe(200)
         expect(res3.headers.get('content-type')).toBe('image/png')
       })
 
       it('should render images on /client route', async () => {
-        const html = await renderViaHTTP(next.url, '/client')
+        const html = await next.render('/client')
         const $ = cheerio.load(html)
 
-        const res1 = await fetchViaHTTP(next.url, $('#app-layout').attr('src'))
+        const res1 = await next.fetch($('#app-layout').attr('src'))
         expect(res1.status).toBe(200)
         expect(res1.headers.get('content-type')).toBe('image/png')
 
-        const res2 = await fetchViaHTTP(
-          next.url,
-          $('#app-client-layout').attr('src')
-        )
+        const res2 = await next.fetch($('#app-client-layout').attr('src'))
         expect(res2.status).toBe(200)
         expect(res2.headers.get('content-type')).toBe('image/png')
 
-        const res3 = await fetchViaHTTP(
-          next.url,
-          $('#app-client-page').attr('src')
-        )
+        const res3 = await next.fetch($('#app-client-page').attr('src'))
         expect(res3.status).toBe(200)
         expect(res3.headers.get('content-type')).toBe('image/png')
 
-        const res4 = await fetchViaHTTP(
-          next.url,
-          $('#app-client-comp').attr('src')
-        )
+        const res4 = await next.fetch($('#app-client-comp').attr('src'))
         expect(res4.status).toBe(200)
         expect(res4.headers.get('content-type')).toBe('image/png')
       })
 
       it('should render images nested under page dir on /nested route', async () => {
-        const html = await renderViaHTTP(next.url, '/nested')
+        const html = await next.render('/nested')
         const $ = cheerio.load(html)
 
-        const res1 = await fetchViaHTTP(next.url, $('#app-layout').attr('src'))
+        const res1 = await next.fetch($('#app-layout').attr('src'))
         expect(res1.status).toBe(200)
         expect(res1.headers.get('content-type')).toBe('image/png')
 
-        const res2 = await fetchViaHTTP(
-          next.url,
-          $('#app-nested-layout').attr('src')
-        )
+        const res2 = await next.fetch($('#app-nested-layout').attr('src'))
         expect(res2.status).toBe(200)
         expect(res2.headers.get('content-type')).toBe('image/jpeg')
 
-        const res3 = await fetchViaHTTP(
-          next.url,
-          $('#app-nested-page').attr('src')
-        )
+        const res3 = await next.fetch($('#app-nested-page').attr('src'))
         expect(res3.status).toBe(200)
         expect(res3.headers.get('content-type')).toBe('image/jpeg')
 
-        const res4 = await fetchViaHTTP(
-          next.url,
-          $('#app-nested-comp').attr('src')
-        )
+        const res4 = await next.fetch($('#app-nested-comp').attr('src'))
         expect(res4.status).toBe(200)
         expect(res4.headers.get('content-type')).toBe('image/jpeg')
       })

--- a/test/e2e/app-dir/next-image.test.ts
+++ b/test/e2e/app-dir/next-image.test.ts
@@ -1,314 +1,300 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import cheerio from 'cheerio'
 import path from 'path'
 import webdriver from 'next-webdriver'
 
-describe('app dir next-image', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
+createNextDescribe(
+  'app dir next-image',
+  {
+    files: path.join(__dirname, 'next-image'),
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    describe('ssr content', () => {
+      it('should render images on / route', async () => {
+        const html = await renderViaHTTP(next.url, '/')
+        const $ = cheerio.load(html)
+
+        const layout = $('#app-layout')
+        expect(layout.attr('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
+        )
+        expect(layout.attr('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
+        )
+
+        const page = $('#app-page')
+        expect(page.attr('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90'
+        )
+        expect(page.attr('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=90 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90 2x'
+        )
+
+        const comp = $('#app-comp')
+        expect(comp.attr('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80'
+        )
+        expect(comp.attr('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=80 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80 2x'
+        )
+      })
+
+      it('should render images on /client route', async () => {
+        const html = await renderViaHTTP(next.url, '/client')
+        const $ = cheerio.load(html)
+
+        const root = $('#app-layout')
+        expect(root.attr('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
+        )
+        expect(root.attr('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
+        )
+
+        const layout = $('#app-client-layout')
+        expect(layout.attr('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=55'
+        )
+        expect(layout.attr('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=55 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=55 2x'
+        )
+
+        const page = $('#app-client-page')
+        expect(page.attr('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=60'
+        )
+        expect(page.attr('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=60 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=60 2x'
+        )
+
+        const comp = $('#app-client-comp')
+        expect(comp.attr('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=50'
+        )
+        expect(comp.attr('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=50 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=50 2x'
+        )
+      })
+
+      it('should render images nested under page dir on /nested route', async () => {
+        const html = await renderViaHTTP(next.url, '/nested')
+        const $ = cheerio.load(html)
+
+        const root = $('#app-layout')
+        expect(root.attr('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
+        )
+        expect(root.attr('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
+        )
+
+        const layout = $('#app-nested-layout')
+        expect(layout.attr('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=70'
+        )
+        expect(layout.attr('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=70 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=70 2x'
+        )
+
+        const page = $('#app-nested-page')
+        expect(page.attr('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=75'
+        )
+        expect(page.attr('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=75 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=75 2x'
+        )
+
+        const comp = $('#app-nested-comp')
+        expect(comp.attr('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=65'
+        )
+        expect(comp.attr('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=65 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=65 2x'
+        )
+      })
+    })
+
+    describe('browser content', () => {
+      it('should render images on / route', async () => {
+        const browser = await webdriver(next.url, '/')
+
+        const layout = await browser.elementById('app-layout')
+        expect(await layout.getAttribute('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
+        )
+        expect(await layout.getAttribute('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
+        )
+
+        const page = await browser.elementById('app-page')
+        expect(await page.getAttribute('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90'
+        )
+        expect(await page.getAttribute('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=90 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90 2x'
+        )
+
+        const comp = await browser.elementById('app-comp')
+        expect(await comp.getAttribute('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80'
+        )
+        expect(await comp.getAttribute('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=80 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80 2x'
+        )
+      })
+
+      it('should render images on /client route', async () => {
+        const browser = await webdriver(next.url, '/client')
+
+        const root = await browser.elementById('app-layout')
+        expect(await root.getAttribute('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
+        )
+        expect(await root.getAttribute('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
+        )
+
+        const layout = await browser.elementById('app-client-layout')
+        expect(await layout.getAttribute('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=55'
+        )
+        expect(await layout.getAttribute('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=55 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=55 2x'
+        )
+
+        const page = await browser.elementById('app-client-page')
+        expect(await page.getAttribute('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=60'
+        )
+        expect(await page.getAttribute('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=60 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=60 2x'
+        )
+
+        const comp = await browser.elementById('app-client-comp')
+        expect(await comp.getAttribute('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=50'
+        )
+        expect(await comp.getAttribute('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=50 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=50 2x'
+        )
+      })
+
+      it('should render images nested under page dir on /nested route', async () => {
+        const browser = await webdriver(next.url, '/nested')
+
+        const root = await browser.elementById('app-layout')
+        expect(await root.getAttribute('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
+        )
+        expect(await root.getAttribute('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
+        )
+
+        const layout = await browser.elementById('app-nested-layout')
+        expect(await layout.getAttribute('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=70'
+        )
+        expect(await layout.getAttribute('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=70 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=70 2x'
+        )
+
+        const page = await browser.elementById('app-nested-page')
+        expect(await page.getAttribute('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=75'
+        )
+        expect(await page.getAttribute('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=75 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=75 2x'
+        )
+
+        const comp = await browser.elementById('app-nested-comp')
+        expect(await comp.getAttribute('src')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=65'
+        )
+        expect(await comp.getAttribute('srcset')).toBe(
+          '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=65 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=65 2x'
+        )
+      })
+    })
+
+    describe('image content', () => {
+      it('should render images on / route', async () => {
+        const html = await renderViaHTTP(next.url, '/')
+        const $ = cheerio.load(html)
+
+        const res1 = await fetchViaHTTP(next.url, $('#app-layout').attr('src'))
+        expect(res1.status).toBe(200)
+        expect(res1.headers.get('content-type')).toBe('image/png')
+
+        const res2 = await fetchViaHTTP(next.url, $('#app-page').attr('src'))
+        expect(res2.status).toBe(200)
+        expect(res2.headers.get('content-type')).toBe('image/png')
+
+        const res3 = await fetchViaHTTP(next.url, $('#app-comp').attr('src'))
+        expect(res3.status).toBe(200)
+        expect(res3.headers.get('content-type')).toBe('image/png')
+      })
+
+      it('should render images on /client route', async () => {
+        const html = await renderViaHTTP(next.url, '/client')
+        const $ = cheerio.load(html)
+
+        const res1 = await fetchViaHTTP(next.url, $('#app-layout').attr('src'))
+        expect(res1.status).toBe(200)
+        expect(res1.headers.get('content-type')).toBe('image/png')
+
+        const res2 = await fetchViaHTTP(
+          next.url,
+          $('#app-client-layout').attr('src')
+        )
+        expect(res2.status).toBe(200)
+        expect(res2.headers.get('content-type')).toBe('image/png')
+
+        const res3 = await fetchViaHTTP(
+          next.url,
+          $('#app-client-page').attr('src')
+        )
+        expect(res3.status).toBe(200)
+        expect(res3.headers.get('content-type')).toBe('image/png')
+
+        const res4 = await fetchViaHTTP(
+          next.url,
+          $('#app-client-comp').attr('src')
+        )
+        expect(res4.status).toBe(200)
+        expect(res4.headers.get('content-type')).toBe('image/png')
+      })
+
+      it('should render images nested under page dir on /nested route', async () => {
+        const html = await renderViaHTTP(next.url, '/nested')
+        const $ = cheerio.load(html)
+
+        const res1 = await fetchViaHTTP(next.url, $('#app-layout').attr('src'))
+        expect(res1.status).toBe(200)
+        expect(res1.headers.get('content-type')).toBe('image/png')
+
+        const res2 = await fetchViaHTTP(
+          next.url,
+          $('#app-nested-layout').attr('src')
+        )
+        expect(res2.status).toBe(200)
+        expect(res2.headers.get('content-type')).toBe('image/jpeg')
+
+        const res3 = await fetchViaHTTP(
+          next.url,
+          $('#app-nested-page').attr('src')
+        )
+        expect(res3.status).toBe(200)
+        expect(res3.headers.get('content-type')).toBe('image/jpeg')
+
+        const res4 = await fetchViaHTTP(
+          next.url,
+          $('#app-nested-comp').attr('src')
+        )
+        expect(res4.status).toBe(200)
+        expect(res4.headers.get('content-type')).toBe('image/jpeg')
+      })
+    })
   }
-
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'next-image')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
-      skipStart: true,
-    })
-    await next.start()
-  })
-  afterAll(() => next.destroy())
-
-  describe('ssr content', () => {
-    it('should render images on / route', async () => {
-      const html = await renderViaHTTP(next.url, '/')
-      const $ = cheerio.load(html)
-
-      const layout = $('#app-layout')
-      expect(layout.attr('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
-      )
-      expect(layout.attr('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
-      )
-
-      const page = $('#app-page')
-      expect(page.attr('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90'
-      )
-      expect(page.attr('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=90 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90 2x'
-      )
-
-      const comp = $('#app-comp')
-      expect(comp.attr('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80'
-      )
-      expect(comp.attr('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=80 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80 2x'
-      )
-    })
-
-    it('should render images on /client route', async () => {
-      const html = await renderViaHTTP(next.url, '/client')
-      const $ = cheerio.load(html)
-
-      const root = $('#app-layout')
-      expect(root.attr('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
-      )
-      expect(root.attr('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
-      )
-
-      const layout = $('#app-client-layout')
-      expect(layout.attr('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=55'
-      )
-      expect(layout.attr('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=55 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=55 2x'
-      )
-
-      const page = $('#app-client-page')
-      expect(page.attr('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=60'
-      )
-      expect(page.attr('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=60 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=60 2x'
-      )
-
-      const comp = $('#app-client-comp')
-      expect(comp.attr('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=50'
-      )
-      expect(comp.attr('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=50 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=50 2x'
-      )
-    })
-
-    it('should render images nested under page dir on /nested route', async () => {
-      const html = await renderViaHTTP(next.url, '/nested')
-      const $ = cheerio.load(html)
-
-      const root = $('#app-layout')
-      expect(root.attr('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
-      )
-      expect(root.attr('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
-      )
-
-      const layout = $('#app-nested-layout')
-      expect(layout.attr('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=70'
-      )
-      expect(layout.attr('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=70 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=70 2x'
-      )
-
-      const page = $('#app-nested-page')
-      expect(page.attr('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=75'
-      )
-      expect(page.attr('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=75 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=75 2x'
-      )
-
-      const comp = $('#app-nested-comp')
-      expect(comp.attr('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=65'
-      )
-      expect(comp.attr('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=65 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=65 2x'
-      )
-    })
-  })
-
-  describe('browser content', () => {
-    it('should render images on / route', async () => {
-      const browser = await webdriver(next.url, '/')
-
-      const layout = await browser.elementById('app-layout')
-      expect(await layout.getAttribute('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
-      )
-      expect(await layout.getAttribute('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
-      )
-
-      const page = await browser.elementById('app-page')
-      expect(await page.getAttribute('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90'
-      )
-      expect(await page.getAttribute('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=90 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90 2x'
-      )
-
-      const comp = await browser.elementById('app-comp')
-      expect(await comp.getAttribute('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80'
-      )
-      expect(await comp.getAttribute('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=80 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80 2x'
-      )
-    })
-
-    it('should render images on /client route', async () => {
-      const browser = await webdriver(next.url, '/client')
-
-      const root = await browser.elementById('app-layout')
-      expect(await root.getAttribute('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
-      )
-      expect(await root.getAttribute('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
-      )
-
-      const layout = await browser.elementById('app-client-layout')
-      expect(await layout.getAttribute('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=55'
-      )
-      expect(await layout.getAttribute('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=55 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=55 2x'
-      )
-
-      const page = await browser.elementById('app-client-page')
-      expect(await page.getAttribute('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=60'
-      )
-      expect(await page.getAttribute('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=60 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=60 2x'
-      )
-
-      const comp = await browser.elementById('app-client-comp')
-      expect(await comp.getAttribute('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=50'
-      )
-      expect(await comp.getAttribute('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=50 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=50 2x'
-      )
-    })
-
-    it('should render images nested under page dir on /nested route', async () => {
-      const browser = await webdriver(next.url, '/nested')
-
-      const root = await browser.elementById('app-layout')
-      expect(await root.getAttribute('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85'
-      )
-      expect(await root.getAttribute('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x'
-      )
-
-      const layout = await browser.elementById('app-nested-layout')
-      expect(await layout.getAttribute('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=70'
-      )
-      expect(await layout.getAttribute('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=70 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=70 2x'
-      )
-
-      const page = await browser.elementById('app-nested-page')
-      expect(await page.getAttribute('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=75'
-      )
-      expect(await page.getAttribute('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=75 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=75 2x'
-      )
-
-      const comp = await browser.elementById('app-nested-comp')
-      expect(await comp.getAttribute('src')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=65'
-      )
-      expect(await comp.getAttribute('srcset')).toBe(
-        '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=640&q=65 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.fab2915d.jpg&w=828&q=65 2x'
-      )
-    })
-  })
-
-  describe('image content', () => {
-    it('should render images on / route', async () => {
-      const html = await renderViaHTTP(next.url, '/')
-      const $ = cheerio.load(html)
-
-      const res1 = await fetchViaHTTP(next.url, $('#app-layout').attr('src'))
-      expect(res1.status).toBe(200)
-      expect(res1.headers.get('content-type')).toBe('image/png')
-
-      const res2 = await fetchViaHTTP(next.url, $('#app-page').attr('src'))
-      expect(res2.status).toBe(200)
-      expect(res2.headers.get('content-type')).toBe('image/png')
-
-      const res3 = await fetchViaHTTP(next.url, $('#app-comp').attr('src'))
-      expect(res3.status).toBe(200)
-      expect(res3.headers.get('content-type')).toBe('image/png')
-    })
-
-    it('should render images on /client route', async () => {
-      const html = await renderViaHTTP(next.url, '/client')
-      const $ = cheerio.load(html)
-
-      const res1 = await fetchViaHTTP(next.url, $('#app-layout').attr('src'))
-      expect(res1.status).toBe(200)
-      expect(res1.headers.get('content-type')).toBe('image/png')
-
-      const res2 = await fetchViaHTTP(
-        next.url,
-        $('#app-client-layout').attr('src')
-      )
-      expect(res2.status).toBe(200)
-      expect(res2.headers.get('content-type')).toBe('image/png')
-
-      const res3 = await fetchViaHTTP(
-        next.url,
-        $('#app-client-page').attr('src')
-      )
-      expect(res3.status).toBe(200)
-      expect(res3.headers.get('content-type')).toBe('image/png')
-
-      const res4 = await fetchViaHTTP(
-        next.url,
-        $('#app-client-comp').attr('src')
-      )
-      expect(res4.status).toBe(200)
-      expect(res4.headers.get('content-type')).toBe('image/png')
-    })
-
-    it('should render images nested under page dir on /nested route', async () => {
-      const html = await renderViaHTTP(next.url, '/nested')
-      const $ = cheerio.load(html)
-
-      const res1 = await fetchViaHTTP(next.url, $('#app-layout').attr('src'))
-      expect(res1.status).toBe(200)
-      expect(res1.headers.get('content-type')).toBe('image/png')
-
-      const res2 = await fetchViaHTTP(
-        next.url,
-        $('#app-nested-layout').attr('src')
-      )
-      expect(res2.status).toBe(200)
-      expect(res2.headers.get('content-type')).toBe('image/jpeg')
-
-      const res3 = await fetchViaHTTP(
-        next.url,
-        $('#app-nested-page').attr('src')
-      )
-      expect(res3.status).toBe(200)
-      expect(res3.headers.get('content-type')).toBe('image/jpeg')
-
-      const res4 = await fetchViaHTTP(
-        next.url,
-        $('#app-nested-comp').attr('src')
-      )
-      expect(res4.status).toBe(200)
-      expect(res4.headers.get('content-type')).toBe('image/jpeg')
-    })
-  })
-})
+)

--- a/test/e2e/app-dir/prefetching.test.ts
+++ b/test/e2e/app-dir/prefetching.test.ts
@@ -1,63 +1,55 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNextDescribe, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { waitFor } from 'next-test-utils'
 import path from 'path'
 import webdriver from 'next-webdriver'
 
-describe('app dir prefetching', () => {
-  // TODO: re-enable for dev after https://vercel.slack.com/archives/C035J346QQL/p1663822388387959 is resolved (Sep 22nd 2022)
-  if ((global as any).isNextDeploy || (global as any).isNextDev) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
+createNextDescribe(
+  'app dir prefetching',
+  {
+    files: path.join(__dirname, 'app-prefetch'),
+    skipDeployment: true,
+  },
+  ({ next, isNextDev }) => {
+    // TODO: re-enable for dev after https://vercel.slack.com/archives/C035J346QQL/p1663822388387959 is resolved (Sep 22nd 2022)
+    if (isNextDev) {
+      it('should skip next deploy for now', () => {})
+      return
+    }
 
-  let next: NextInstance
+    it('should show layout eagerly when prefetched with loading one level down', async () => {
+      const browser = await next.browser('/')
+      // Ensure the page is prefetched
+      await waitFor(1000)
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'app-prefetch')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
-      skipStart: true,
+      const before = Date.now()
+      await browser
+        .elementByCss('#to-dashboard')
+        .click()
+        .waitForElementByCss('#dashboard-layout')
+      const after = Date.now()
+      const timeToComplete = after - before
+
+      expect(timeToComplete < 1000).toBe(true)
+
+      expect(await browser.elementByCss('#dashboard-layout').text()).toBe(
+        'Dashboard Hello World'
+      )
+
+      await browser.waitForElementByCss('#dashboard-page')
+
+      expect(await browser.waitForElementByCss('#dashboard-page').text()).toBe(
+        'Welcome to the dashboard'
+      )
     })
-    await next.start()
-  })
-  afterAll(() => next.destroy())
 
-  it('should show layout eagerly when prefetched with loading one level down', async () => {
-    const browser = await webdriver(next.url, '/')
-    // Ensure the page is prefetched
-    await waitFor(1000)
-
-    const before = Date.now()
-    await browser
-      .elementByCss('#to-dashboard')
-      .click()
-      .waitForElementByCss('#dashboard-layout')
-    const after = Date.now()
-    const timeToComplete = after - before
-
-    expect(timeToComplete < 1000).toBe(true)
-
-    expect(await browser.elementByCss('#dashboard-layout').text()).toBe(
-      'Dashboard Hello World'
-    )
-
-    await browser.waitForElementByCss('#dashboard-page')
-
-    expect(await browser.waitForElementByCss('#dashboard-page').text()).toBe(
-      'Welcome to the dashboard'
-    )
-  })
-
-  it('should not have prefetch error for static path', async () => {
-    const browser = await webdriver(next.url, '/')
-    await browser.eval('window.nd.router.prefetch("/dashboard/123")')
-    await waitFor(3000)
-    await browser.eval('window.nd.router.push("/dashboard/123")')
-    expect(next.cliOutput).not.toContain('ReferenceError')
-    expect(next.cliOutput).not.toContain('is not defined')
-  })
-})
+    it('should not have prefetch error for static path', async () => {
+      const browser = await next.browser('/')
+      await browser.eval('window.nd.router.prefetch("/dashboard/123")')
+      await waitFor(3000)
+      await browser.eval('window.nd.router.push("/dashboard/123")')
+      expect(next.cliOutput).not.toContain('ReferenceError')
+      expect(next.cliOutput).not.toContain('is not defined')
+    })
+  }
+)

--- a/test/e2e/app-dir/prefetching.test.ts
+++ b/test/e2e/app-dir/prefetching.test.ts
@@ -1,8 +1,6 @@
-import { createNextDescribe, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import path from 'path'
-import webdriver from 'next-webdriver'
 
 createNextDescribe(
   'app dir prefetching',

--- a/test/e2e/app-dir/rendering.test.ts
+++ b/test/e2e/app-dir/rendering.test.ts
@@ -17,21 +17,19 @@ createNextDescribe(
 
     describe('SSR only', () => {
       it('should run data in layout and page', async () => {
-        const html = await next.render('/ssr-only/nested')
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/ssr-only/nested')
         expect($('#layout-message').text()).toBe('hello from layout')
         expect($('#page-message').text()).toBe('hello from page')
       })
 
       it('should run data fetch in parallel', async () => {
         const startTime = Date.now()
-        const html = await next.render('/ssr-only/slow')
+        const $ = await next.render$('/ssr-only/slow')
         const endTime = Date.now()
         const duration = endTime - startTime
         // Each part takes 5 seconds so it should be below 10 seconds
         // Using 7 seconds to ensure external factors causing slight slowness don't fail the tests
         expect(duration < 7000).toBe(true)
-        const $ = cheerio.load(html)
         expect($('#slow-layout-message').text()).toBe('hello from slow layout')
         expect($('#slow-page-message').text()).toBe('hello from slow page')
       })
@@ -39,8 +37,7 @@ createNextDescribe(
 
     describe('static only', () => {
       it('should run data in layout and page', async () => {
-        const html = await next.render('/static-only/nested')
-        const $ = cheerio.load(html)
+        const $ = await next.render$('/static-only/nested')
         expect($('#layout-message').text()).toBe('hello from layout')
         expect($('#page-message').text()).toBe('hello from page')
       })
@@ -49,7 +46,7 @@ createNextDescribe(
         isDev ? 'during development' : 'and use cached version for production'
       }`, async () => {
         // const startTime = Date.now()
-        const html = await next.render('/static-only/slow')
+        const $ = await next.render$('/static-only/slow')
         // const endTime = Date.now()
         // const duration = endTime - startTime
         // Each part takes 5 seconds so it should be below 10 seconds
@@ -57,7 +54,6 @@ createNextDescribe(
         // TODO: cache static props in prod
         // expect(duration < (isDev ? 7000 : 2000)).toBe(true)
         // expect(duration < 7000).toBe(true)
-        const $ = cheerio.load(html)
         expect($('#slow-layout-message').text()).toBe('hello from slow layout')
         expect($('#slow-page-message').text()).toBe('hello from slow page')
       })
@@ -106,10 +102,10 @@ createNextDescribe(
     describe.skip('mixed static and dynamic', () => {
       it('should generate static data during build and use it', async () => {
         const getPage = async () => {
-          const html = await next.render('isr-ssr-combined/nested')
+          const $ = await next.render$('isr-ssr-combined/nested')
 
           return {
-            $: cheerio.load(html),
+            $,
           }
         }
         const { $ } = await getPage()

--- a/test/e2e/app-dir/rendering.test.ts
+++ b/test/e2e/app-dir/rendering.test.ts
@@ -1,5 +1,5 @@
 import { createNextDescribe } from 'e2e-utils'
-import { renderViaHTTP, fetchViaHTTP, waitFor } from 'next-test-utils'
+import { waitFor } from 'next-test-utils'
 import path from 'path'
 import cheerio from 'cheerio'
 
@@ -11,13 +11,13 @@ createNextDescribe(
   },
   ({ next, isNextDev: isDev }) => {
     it('should serve app/page.server.js at /', async () => {
-      const html = await renderViaHTTP(next.url, '/')
+      const html = await next.render('/')
       expect(html).toContain('app/page.server.js')
     })
 
     describe('SSR only', () => {
       it('should run data in layout and page', async () => {
-        const html = await renderViaHTTP(next.url, '/ssr-only/nested')
+        const html = await next.render('/ssr-only/nested')
         const $ = cheerio.load(html)
         expect($('#layout-message').text()).toBe('hello from layout')
         expect($('#page-message').text()).toBe('hello from page')
@@ -25,7 +25,7 @@ createNextDescribe(
 
       it('should run data fetch in parallel', async () => {
         const startTime = Date.now()
-        const html = await renderViaHTTP(next.url, '/ssr-only/slow')
+        const html = await next.render('/ssr-only/slow')
         const endTime = Date.now()
         const duration = endTime - startTime
         // Each part takes 5 seconds so it should be below 10 seconds
@@ -39,7 +39,7 @@ createNextDescribe(
 
     describe('static only', () => {
       it('should run data in layout and page', async () => {
-        const html = await renderViaHTTP(next.url, '/static-only/nested')
+        const html = await next.render('/static-only/nested')
         const $ = cheerio.load(html)
         expect($('#layout-message').text()).toBe('hello from layout')
         expect($('#page-message').text()).toBe('hello from page')
@@ -49,7 +49,7 @@ createNextDescribe(
         isDev ? 'during development' : 'and use cached version for production'
       }`, async () => {
         // const startTime = Date.now()
-        const html = await renderViaHTTP(next.url, '/static-only/slow')
+        const html = await next.render('/static-only/slow')
         // const endTime = Date.now()
         // const duration = endTime - startTime
         // Each part takes 5 seconds so it should be below 10 seconds
@@ -66,7 +66,7 @@ createNextDescribe(
     describe('ISR', () => {
       it('should revalidate the page when revalidate is configured', async () => {
         const getPage = async () => {
-          const res = await fetchViaHTTP(next.url, 'isr-multiple/nested')
+          const res = await next.fetch('isr-multiple/nested')
           const html = await res.text()
 
           return {
@@ -106,7 +106,7 @@ createNextDescribe(
     describe.skip('mixed static and dynamic', () => {
       it('should generate static data during build and use it', async () => {
         const getPage = async () => {
-          const html = await renderViaHTTP(next.url, 'isr-ssr-combined/nested')
+          const html = await next.render('isr-ssr-combined/nested')
 
           return {
             $: cheerio.load(html),

--- a/test/e2e/app-dir/rendering.test.ts
+++ b/test/e2e/app-dir/rendering.test.ts
@@ -1,147 +1,134 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 import { renderViaHTTP, fetchViaHTTP, waitFor } from 'next-test-utils'
 import path from 'path'
 import cheerio from 'cheerio'
 
-describe('app dir rendering', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
+createNextDescribe(
+  'app dir rendering',
+  {
+    files: path.join(__dirname, 'app-rendering'),
+    skipDeployment: true,
+  },
+  ({ next, isNextDev: isDev }) => {
+    it('should serve app/page.server.js at /', async () => {
+      const html = await renderViaHTTP(next.url, '/')
+      expect(html).toContain('app/page.server.js')
+    })
+
+    describe('SSR only', () => {
+      it('should run data in layout and page', async () => {
+        const html = await renderViaHTTP(next.url, '/ssr-only/nested')
+        const $ = cheerio.load(html)
+        expect($('#layout-message').text()).toBe('hello from layout')
+        expect($('#page-message').text()).toBe('hello from page')
+      })
+
+      it('should run data fetch in parallel', async () => {
+        const startTime = Date.now()
+        const html = await renderViaHTTP(next.url, '/ssr-only/slow')
+        const endTime = Date.now()
+        const duration = endTime - startTime
+        // Each part takes 5 seconds so it should be below 10 seconds
+        // Using 7 seconds to ensure external factors causing slight slowness don't fail the tests
+        expect(duration < 7000).toBe(true)
+        const $ = cheerio.load(html)
+        expect($('#slow-layout-message').text()).toBe('hello from slow layout')
+        expect($('#slow-page-message').text()).toBe('hello from slow page')
+      })
+    })
+
+    describe('static only', () => {
+      it('should run data in layout and page', async () => {
+        const html = await renderViaHTTP(next.url, '/static-only/nested')
+        const $ = cheerio.load(html)
+        expect($('#layout-message').text()).toBe('hello from layout')
+        expect($('#page-message').text()).toBe('hello from page')
+      })
+
+      it(`should run data in parallel ${
+        isDev ? 'during development' : 'and use cached version for production'
+      }`, async () => {
+        // const startTime = Date.now()
+        const html = await renderViaHTTP(next.url, '/static-only/slow')
+        // const endTime = Date.now()
+        // const duration = endTime - startTime
+        // Each part takes 5 seconds so it should be below 10 seconds
+        // Using 7 seconds to ensure external factors causing slight slowness don't fail the tests
+        // TODO: cache static props in prod
+        // expect(duration < (isDev ? 7000 : 2000)).toBe(true)
+        // expect(duration < 7000).toBe(true)
+        const $ = cheerio.load(html)
+        expect($('#slow-layout-message').text()).toBe('hello from slow layout')
+        expect($('#slow-page-message').text()).toBe('hello from slow page')
+      })
+    })
+
+    describe('ISR', () => {
+      it('should revalidate the page when revalidate is configured', async () => {
+        const getPage = async () => {
+          const res = await fetchViaHTTP(next.url, 'isr-multiple/nested')
+          const html = await res.text()
+
+          return {
+            $: cheerio.load(html),
+            cacheHeader: res.headers['x-nextjs-cache'],
+          }
+        }
+        const { $ } = await getPage()
+        expect($('#layout-message').text()).toBe('hello from layout')
+        expect($('#page-message').text()).toBe('hello from page')
+
+        const layoutNow = $('#layout-now').text()
+        const pageNow = $('#page-now').text()
+
+        await waitFor(2000)
+
+        // TODO: implement
+        // Trigger revalidate
+        // const { cacheHeader: revalidateCacheHeader } = await getPage()
+        // expect(revalidateCacheHeader).toBe('STALE')
+
+        // TODO: implement
+        const { $: $revalidated /* cacheHeader: revalidatedCacheHeader */ } =
+          await getPage()
+        // expect(revalidatedCacheHeader).toBe('REVALIDATED')
+
+        const layoutNowRevalidated = $revalidated('#layout-now').text()
+        const pageNowRevalidated = $revalidated('#page-now').text()
+
+        // Expect that the `Date.now()` is different as the page have been regenerated
+        expect(layoutNow).not.toBe(layoutNowRevalidated)
+        expect(pageNow).not.toBe(pageNowRevalidated)
+      })
+    })
+
+    // TODO: implement
+    describe.skip('mixed static and dynamic', () => {
+      it('should generate static data during build and use it', async () => {
+        const getPage = async () => {
+          const html = await renderViaHTTP(next.url, 'isr-ssr-combined/nested')
+
+          return {
+            $: cheerio.load(html),
+          }
+        }
+        const { $ } = await getPage()
+        expect($('#layout-message').text()).toBe('hello from layout')
+        expect($('#page-message').text()).toBe('hello from page')
+
+        const layoutNow = $('#layout-now').text()
+        const pageNow = $('#page-now').text()
+
+        const { $: $second } = await getPage()
+
+        const layoutNowSecond = $second('#layout-now').text()
+        const pageNowSecond = $second('#page-now').text()
+
+        // Expect that the `Date.now()` is different as it came from getServerSideProps
+        expect(layoutNow).not.toBe(layoutNowSecond)
+        // Expect that the `Date.now()` is the same as it came from getStaticProps
+        expect(pageNow).toBe(pageNowSecond)
+      })
+    })
   }
-
-  const isDev = (global as any).isNextDev
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'app-rendering')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
-    })
-  })
-  afterAll(() => next.destroy())
-
-  it('should serve app/page.server.js at /', async () => {
-    const html = await renderViaHTTP(next.url, '/')
-    expect(html).toContain('app/page.server.js')
-  })
-
-  describe('SSR only', () => {
-    it('should run data in layout and page', async () => {
-      const html = await renderViaHTTP(next.url, '/ssr-only/nested')
-      const $ = cheerio.load(html)
-      expect($('#layout-message').text()).toBe('hello from layout')
-      expect($('#page-message').text()).toBe('hello from page')
-    })
-
-    it('should run data fetch in parallel', async () => {
-      const startTime = Date.now()
-      const html = await renderViaHTTP(next.url, '/ssr-only/slow')
-      const endTime = Date.now()
-      const duration = endTime - startTime
-      // Each part takes 5 seconds so it should be below 10 seconds
-      // Using 7 seconds to ensure external factors causing slight slowness don't fail the tests
-      expect(duration < 7000).toBe(true)
-      const $ = cheerio.load(html)
-      expect($('#slow-layout-message').text()).toBe('hello from slow layout')
-      expect($('#slow-page-message').text()).toBe('hello from slow page')
-    })
-  })
-
-  describe('static only', () => {
-    it('should run data in layout and page', async () => {
-      const html = await renderViaHTTP(next.url, '/static-only/nested')
-      const $ = cheerio.load(html)
-      expect($('#layout-message').text()).toBe('hello from layout')
-      expect($('#page-message').text()).toBe('hello from page')
-    })
-
-    it(`should run data in parallel ${
-      isDev ? 'during development' : 'and use cached version for production'
-    }`, async () => {
-      // const startTime = Date.now()
-      const html = await renderViaHTTP(next.url, '/static-only/slow')
-      // const endTime = Date.now()
-      // const duration = endTime - startTime
-      // Each part takes 5 seconds so it should be below 10 seconds
-      // Using 7 seconds to ensure external factors causing slight slowness don't fail the tests
-      // TODO: cache static props in prod
-      // expect(duration < (isDev ? 7000 : 2000)).toBe(true)
-      // expect(duration < 7000).toBe(true)
-      const $ = cheerio.load(html)
-      expect($('#slow-layout-message').text()).toBe('hello from slow layout')
-      expect($('#slow-page-message').text()).toBe('hello from slow page')
-    })
-  })
-
-  describe('ISR', () => {
-    it('should revalidate the page when revalidate is configured', async () => {
-      const getPage = async () => {
-        const res = await fetchViaHTTP(next.url, 'isr-multiple/nested')
-        const html = await res.text()
-
-        return {
-          $: cheerio.load(html),
-          cacheHeader: res.headers['x-nextjs-cache'],
-        }
-      }
-      const { $ } = await getPage()
-      expect($('#layout-message').text()).toBe('hello from layout')
-      expect($('#page-message').text()).toBe('hello from page')
-
-      const layoutNow = $('#layout-now').text()
-      const pageNow = $('#page-now').text()
-
-      await waitFor(2000)
-
-      // TODO: implement
-      // Trigger revalidate
-      // const { cacheHeader: revalidateCacheHeader } = await getPage()
-      // expect(revalidateCacheHeader).toBe('STALE')
-
-      // TODO: implement
-      const { $: $revalidated /* cacheHeader: revalidatedCacheHeader */ } =
-        await getPage()
-      // expect(revalidatedCacheHeader).toBe('REVALIDATED')
-
-      const layoutNowRevalidated = $revalidated('#layout-now').text()
-      const pageNowRevalidated = $revalidated('#page-now').text()
-
-      // Expect that the `Date.now()` is different as the page have been regenerated
-      expect(layoutNow).not.toBe(layoutNowRevalidated)
-      expect(pageNow).not.toBe(pageNowRevalidated)
-    })
-  })
-
-  // TODO: implement
-  describe.skip('mixed static and dynamic', () => {
-    it('should generate static data during build and use it', async () => {
-      const getPage = async () => {
-        const html = await renderViaHTTP(next.url, 'isr-ssr-combined/nested')
-
-        return {
-          $: cheerio.load(html),
-        }
-      }
-      const { $ } = await getPage()
-      expect($('#layout-message').text()).toBe('hello from layout')
-      expect($('#page-message').text()).toBe('hello from page')
-
-      const layoutNow = $('#layout-now').text()
-      const pageNow = $('#page-now').text()
-
-      const { $: $second } = await getPage()
-
-      const layoutNowSecond = $second('#layout-now').text()
-      const pageNowSecond = $second('#page-now').text()
-
-      // Expect that the `Date.now()` is different as it came from getServerSideProps
-      expect(layoutNow).not.toBe(layoutNowSecond)
-      // Expect that the `Date.now()` is the same as it came from getStaticProps
-      expect(pageNow).toBe(pageNowSecond)
-    })
-  })
-})
+)

--- a/test/e2e/app-dir/root-layout.test.ts
+++ b/test/e2e/app-dir/root-layout.test.ts
@@ -1,219 +1,207 @@
 import path from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import { getRedboxSource, hasRedbox } from 'next-test-utils'
 
-describe('app-dir root layout', () => {
-  const isDev = (global as any).isNextDev
+createNextDescribe(
+  'app-dir root layout',
+  {
+    files: path.join(__dirname, 'root-layout'),
+    skipDeployment: true,
+  },
+  ({ next, isNextDev: isDev }) => {
+    if (isDev) {
+      // TODO-APP: re-enable after reworking the error overlay.
+      describe.skip('Missing required tags', () => {
+        it('should error on page load', async () => {
+          const browser = await webdriver(next.url, '/missing-tags', {
+            waitHydration: false,
+          })
 
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
-
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        app: new FileRef(path.join(__dirname, 'root-layout/app')),
-        'next.config.js': new FileRef(
-          path.join(__dirname, 'root-layout/next.config.js')
-        ),
-      },
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
-    })
-  })
-  afterAll(() => next.destroy())
-
-  if (isDev) {
-    // TODO-APP: re-enable after reworking the error overlay.
-    describe.skip('Missing required tags', () => {
-      it('should error on page load', async () => {
-        const browser = await webdriver(next.url, '/missing-tags', {
-          waitHydration: false,
-        })
-
-        expect(await hasRedbox(browser, true)).toBe(true)
-        expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+          expect(await hasRedbox(browser, true)).toBe(true)
+          expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
           "Please make sure to include the following tags in your root layout: <html>, <body>.
 
           Missing required root layout tags: html, body"
         `)
-      })
-
-      it('should error on page navigation', async () => {
-        const browser = await webdriver(next.url, '/has-tags', {
-          waitHydration: false,
         })
+
+        it('should error on page navigation', async () => {
+          const browser = await webdriver(next.url, '/has-tags', {
+            waitHydration: false,
+          })
+          await browser.elementByCss('a').click()
+
+          expect(await hasRedbox(browser, true)).toBe(true)
+          expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+          "Please make sure to include the following tags in your root layout: <html>, <body>.
+
+          Missing required root layout tags: html, body"
+        `)
+        })
+
+        it('should error on page load on static generation', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/static-missing-tags/slug',
+            {
+              waitHydration: false,
+            }
+          )
+
+          expect(await hasRedbox(browser, true)).toBe(true)
+          expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+          "Please make sure to include the following tags in your root layout: <html>, <body>.
+
+          Missing required root layout tags: html, body"
+        `)
+        })
+      })
+    }
+
+    describe('Should do a mpa navigation when switching root layout', () => {
+      it('should work with basic routes', async () => {
+        const browser = await webdriver(next.url, '/basic-route')
+
+        expect(await browser.elementById('basic-route').text()).toBe(
+          'Basic route'
+        )
+        await browser.eval('window.__TEST_NO_RELOAD = true')
+
+        // Navigate to page with same root layout
         await browser.elementByCss('a').click()
+        expect(
+          await browser.waitForElementByCss('#inner-basic-route').text()
+        ).toBe('Inner basic route')
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
 
-        expect(await hasRedbox(browser, true)).toBe(true)
-        expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-          "Please make sure to include the following tags in your root layout: <html>, <body>.
-
-          Missing required root layout tags: html, body"
-        `)
+        // Navigate to page with different root layout
+        await browser.elementByCss('a').click()
+        expect(await browser.waitForElementByCss('#route-group').text()).toBe(
+          'Route group'
+        )
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
       })
 
-      it('should error on page load on static generation', async () => {
-        const browser = await webdriver(next.url, '/static-missing-tags/slug', {
-          waitHydration: false,
-        })
+      it('should work with route groups', async () => {
+        const browser = await webdriver(next.url, '/route-group')
 
-        expect(await hasRedbox(browser, true)).toBe(true)
-        expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-          "Please make sure to include the following tags in your root layout: <html>, <body>.
+        expect(await browser.elementById('route-group').text()).toBe(
+          'Route group'
+        )
+        await browser.eval('window.__TEST_NO_RELOAD = true')
 
-          Missing required root layout tags: html, body"
-        `)
+        // Navigate to page with same root layout
+        await browser.elementByCss('a').click()
+        expect(
+          await browser.waitForElementByCss('#nested-route-group').text()
+        ).toBe('Nested route group')
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
+
+        // Navigate to page with different root layout
+        await browser.elementByCss('a').click()
+        expect(await browser.waitForElementByCss('#parallel-one').text()).toBe(
+          'One'
+        )
+        expect(await browser.waitForElementByCss('#parallel-two').text()).toBe(
+          'Two'
+        )
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
+      })
+
+      it('should work with parallel routes', async () => {
+        const browser = await webdriver(next.url, '/with-parallel-routes')
+
+        expect(await browser.elementById('parallel-one').text()).toBe('One')
+        expect(await browser.elementById('parallel-two').text()).toBe('Two')
+        await browser.eval('window.__TEST_NO_RELOAD = true')
+
+        // Navigate to page with same root layout
+        await browser.elementByCss('a').click()
+        expect(
+          await browser.waitForElementByCss('#parallel-one-inner').text()
+        ).toBe('One inner')
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
+
+        // Navigate to page with different root layout
+        await browser.elementByCss('a').click()
+        expect(await browser.waitForElementByCss('#dynamic-hello').text()).toBe(
+          'dynamic hello'
+        )
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
+      })
+
+      it('should work with dynamic routes', async () => {
+        const browser = await webdriver(next.url, '/dynamic/first')
+
+        expect(await browser.elementById('dynamic-first').text()).toBe(
+          'dynamic first'
+        )
+        await browser.eval('window.__TEST_NO_RELOAD = true')
+
+        // Navigate to page with same root layout
+        await browser.elementByCss('a').click()
+        expect(
+          await browser.waitForElementByCss('#dynamic-first-second').text()
+        ).toBe('dynamic first second')
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
+
+        // Navigate to page with different root layout
+        await browser.elementByCss('a').click()
+        expect(
+          await browser.waitForElementByCss('#inner-basic-route').text()
+        ).toBe('Inner basic route')
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
+      })
+
+      it('should work with dynamic catchall routes', async () => {
+        const browser = await webdriver(next.url, '/dynamic-catchall/slug')
+
+        expect(await browser.elementById('catchall-slug').text()).toBe(
+          'catchall slug'
+        )
+        await browser.eval('window.__TEST_NO_RELOAD = true')
+
+        // Navigate to page with same root layout
+        await browser.elementById('to-next-url').click()
+        expect(
+          await browser.waitForElementByCss('#catchall-slug-slug').text()
+        ).toBe('catchall slug slug')
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
+
+        // Navigate to page with different root layout
+        await browser.elementById('to-dynamic-first').click()
+        expect(await browser.elementById('dynamic-first').text()).toBe(
+          'dynamic first'
+        )
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
+      })
+
+      it('should work with static routes', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/static-mpa-navigation/slug1'
+        )
+
+        expect(await browser.elementById('static-slug1').text()).toBe(
+          'static slug1'
+        )
+        await browser.eval('window.__TEST_NO_RELOAD = true')
+
+        // Navigate to page with same root layout
+        await browser.elementByCss('a').click()
+        expect(await browser.waitForElementByCss('#static-slug2').text()).toBe(
+          'static slug2'
+        )
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
+
+        // Navigate to page with different root layout
+        await browser.elementByCss('a').click()
+        expect(await browser.elementById('basic-route').text()).toBe(
+          'Basic route'
+        )
+        expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
       })
     })
   }
-
-  describe('Should do a mpa navigation when switching root layout', () => {
-    it('should work with basic routes', async () => {
-      const browser = await webdriver(next.url, '/basic-route')
-
-      expect(await browser.elementById('basic-route').text()).toBe(
-        'Basic route'
-      )
-      await browser.eval('window.__TEST_NO_RELOAD = true')
-
-      // Navigate to page with same root layout
-      await browser.elementByCss('a').click()
-      expect(
-        await browser.waitForElementByCss('#inner-basic-route').text()
-      ).toBe('Inner basic route')
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
-
-      // Navigate to page with different root layout
-      await browser.elementByCss('a').click()
-      expect(await browser.waitForElementByCss('#route-group').text()).toBe(
-        'Route group'
-      )
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
-    })
-
-    it('should work with route groups', async () => {
-      const browser = await webdriver(next.url, '/route-group')
-
-      expect(await browser.elementById('route-group').text()).toBe(
-        'Route group'
-      )
-      await browser.eval('window.__TEST_NO_RELOAD = true')
-
-      // Navigate to page with same root layout
-      await browser.elementByCss('a').click()
-      expect(
-        await browser.waitForElementByCss('#nested-route-group').text()
-      ).toBe('Nested route group')
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
-
-      // Navigate to page with different root layout
-      await browser.elementByCss('a').click()
-      expect(await browser.waitForElementByCss('#parallel-one').text()).toBe(
-        'One'
-      )
-      expect(await browser.waitForElementByCss('#parallel-two').text()).toBe(
-        'Two'
-      )
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
-    })
-
-    it('should work with parallel routes', async () => {
-      const browser = await webdriver(next.url, '/with-parallel-routes')
-
-      expect(await browser.elementById('parallel-one').text()).toBe('One')
-      expect(await browser.elementById('parallel-two').text()).toBe('Two')
-      await browser.eval('window.__TEST_NO_RELOAD = true')
-
-      // Navigate to page with same root layout
-      await browser.elementByCss('a').click()
-      expect(
-        await browser.waitForElementByCss('#parallel-one-inner').text()
-      ).toBe('One inner')
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
-
-      // Navigate to page with different root layout
-      await browser.elementByCss('a').click()
-      expect(await browser.waitForElementByCss('#dynamic-hello').text()).toBe(
-        'dynamic hello'
-      )
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
-    })
-
-    it('should work with dynamic routes', async () => {
-      const browser = await webdriver(next.url, '/dynamic/first')
-
-      expect(await browser.elementById('dynamic-first').text()).toBe(
-        'dynamic first'
-      )
-      await browser.eval('window.__TEST_NO_RELOAD = true')
-
-      // Navigate to page with same root layout
-      await browser.elementByCss('a').click()
-      expect(
-        await browser.waitForElementByCss('#dynamic-first-second').text()
-      ).toBe('dynamic first second')
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
-
-      // Navigate to page with different root layout
-      await browser.elementByCss('a').click()
-      expect(
-        await browser.waitForElementByCss('#inner-basic-route').text()
-      ).toBe('Inner basic route')
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
-    })
-
-    it('should work with dynamic catchall routes', async () => {
-      const browser = await webdriver(next.url, '/dynamic-catchall/slug')
-
-      expect(await browser.elementById('catchall-slug').text()).toBe(
-        'catchall slug'
-      )
-      await browser.eval('window.__TEST_NO_RELOAD = true')
-
-      // Navigate to page with same root layout
-      await browser.elementById('to-next-url').click()
-      expect(
-        await browser.waitForElementByCss('#catchall-slug-slug').text()
-      ).toBe('catchall slug slug')
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
-
-      // Navigate to page with different root layout
-      await browser.elementById('to-dynamic-first').click()
-      expect(await browser.elementById('dynamic-first').text()).toBe(
-        'dynamic first'
-      )
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
-    })
-
-    it('should work with static routes', async () => {
-      const browser = await webdriver(next.url, '/static-mpa-navigation/slug1')
-
-      expect(await browser.elementById('static-slug1').text()).toBe(
-        'static slug1'
-      )
-      await browser.eval('window.__TEST_NO_RELOAD = true')
-
-      // Navigate to page with same root layout
-      await browser.elementByCss('a').click()
-      expect(await browser.waitForElementByCss('#static-slug2').text()).toBe(
-        'static slug2'
-      )
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
-
-      // Navigate to page with different root layout
-      await browser.elementByCss('a').click()
-      expect(await browser.elementById('basic-route').text()).toBe(
-        'Basic route'
-      )
-      expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
-    })
-  })
-})
+)

--- a/test/e2e/app-dir/root-layout.test.ts
+++ b/test/e2e/app-dir/root-layout.test.ts
@@ -1,6 +1,5 @@
 import path from 'path'
 import { createNextDescribe } from 'e2e-utils'
-import webdriver from 'next-webdriver'
 import { getRedboxSource, hasRedbox } from 'next-test-utils'
 
 createNextDescribe(
@@ -14,7 +13,7 @@ createNextDescribe(
       // TODO-APP: re-enable after reworking the error overlay.
       describe.skip('Missing required tags', () => {
         it('should error on page load', async () => {
-          const browser = await webdriver(next.url, '/missing-tags', {
+          const browser = await next.browser('/missing-tags', {
             waitHydration: false,
           })
 
@@ -27,7 +26,7 @@ createNextDescribe(
         })
 
         it('should error on page navigation', async () => {
-          const browser = await webdriver(next.url, '/has-tags', {
+          const browser = await next.browser('/has-tags', {
             waitHydration: false,
           })
           await browser.elementByCss('a').click()
@@ -41,13 +40,9 @@ createNextDescribe(
         })
 
         it('should error on page load on static generation', async () => {
-          const browser = await webdriver(
-            next.url,
-            '/static-missing-tags/slug',
-            {
-              waitHydration: false,
-            }
-          )
+          const browser = await next.browser('/static-missing-tags/slug', {
+            waitHydration: false,
+          })
 
           expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
@@ -61,7 +56,7 @@ createNextDescribe(
 
     describe('Should do a mpa navigation when switching root layout', () => {
       it('should work with basic routes', async () => {
-        const browser = await webdriver(next.url, '/basic-route')
+        const browser = await next.browser('/basic-route')
 
         expect(await browser.elementById('basic-route').text()).toBe(
           'Basic route'
@@ -84,7 +79,7 @@ createNextDescribe(
       })
 
       it('should work with route groups', async () => {
-        const browser = await webdriver(next.url, '/route-group')
+        const browser = await next.browser('/route-group')
 
         expect(await browser.elementById('route-group').text()).toBe(
           'Route group'
@@ -110,7 +105,7 @@ createNextDescribe(
       })
 
       it('should work with parallel routes', async () => {
-        const browser = await webdriver(next.url, '/with-parallel-routes')
+        const browser = await next.browser('/with-parallel-routes')
 
         expect(await browser.elementById('parallel-one').text()).toBe('One')
         expect(await browser.elementById('parallel-two').text()).toBe('Two')
@@ -132,7 +127,7 @@ createNextDescribe(
       })
 
       it('should work with dynamic routes', async () => {
-        const browser = await webdriver(next.url, '/dynamic/first')
+        const browser = await next.browser('/dynamic/first')
 
         expect(await browser.elementById('dynamic-first').text()).toBe(
           'dynamic first'
@@ -155,7 +150,7 @@ createNextDescribe(
       })
 
       it('should work with dynamic catchall routes', async () => {
-        const browser = await webdriver(next.url, '/dynamic-catchall/slug')
+        const browser = await next.browser('/dynamic-catchall/slug')
 
         expect(await browser.elementById('catchall-slug').text()).toBe(
           'catchall slug'
@@ -178,10 +173,7 @@ createNextDescribe(
       })
 
       it('should work with static routes', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/static-mpa-navigation/slug1'
-        )
+        const browser = await next.browser('/static-mpa-navigation/slug1')
 
         expect(await browser.elementById('static-slug1').text()).toBe(
           'static slug1'

--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -5,11 +5,6 @@ import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import cheerio from 'cheerio'
 
-function getNodeBySelector(html, selector) {
-  const $ = cheerio.load(html)
-  return $(selector)
-}
-
 async function resolveStreamResponse(response: any, onData?: any) {
   let result = ''
   onData = onData || (() => {})
@@ -195,8 +190,8 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should support next/link in server components', async () => {
-    const linkHTML = await next.render('/next-api/link')
-    const linkText = getNodeBySelector(linkHTML, 'body a[href="/root"]').text()
+    const $ = await next.render$('/next-api/link')
+    const linkText = $('body a[href="/root"]').text()
 
     expect(linkText).toContain('home')
 
@@ -249,22 +244,22 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should suspense next/legacy/image in server components', async () => {
-    const imageHTML = await next.render('/next-api/image-legacy')
-    const imageTag = getNodeBySelector(imageHTML, '#myimg')
+    const $ = await next.render$('/next-api/image-legacy')
+    const imageTag = $('#myimg')
 
     expect(imageTag.attr('src')).toContain('data:image')
   })
 
   it('should suspense next/image in server components', async () => {
-    const imageHTML = await next.render('/next-api/image-new')
-    const imageTag = getNodeBySelector(imageHTML, '#myimg')
+    const $ = await next.render$('/next-api/image-new')
+    const imageTag = $('#myimg')
 
     expect(imageTag.attr('src')).toMatch(/test.+jpg/)
   })
 
   it('should handle various kinds of exports correctly', async () => {
-    const html = await next.render('/various-exports')
-    const content = getNodeBySelector(html, 'body').text()
+    const $ = await next.render$('/various-exports')
+    const content = $('body').text()
 
     expect(content).toContain('abcde')
     expect(content).toContain('default-export-arrow.client')
@@ -282,17 +277,17 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should support native modules in server component', async () => {
-    const html = await next.render('/native-module')
-    const content = getNodeBySelector(html, 'body').text()
+    const $ = await next.render$('/native-module')
+    const content = $('body').text()
 
     expect(content).toContain('fs: function')
     expect(content).toContain('foo.client')
   })
 
   it('should resolve different kinds of components correctly', async () => {
-    const html = await next.render('/shared')
-    const main = getNodeBySelector(html, '#main').html()
-    const content = getNodeBySelector(html, '#bar').text()
+    const $ = await next.render$('/shared')
+    const main = $('#main').html()
+    const content = $('#bar').text()
 
     // Should have 5 occurrences of "client_component".
     expect(Array.from(main.matchAll(/client_component/g)).length).toBe(5)
@@ -312,8 +307,8 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should render initial styles of css-in-js in nodejs SSR correctly', async () => {
-    const html = await next.render('/css-in-js')
-    const head = getNodeBySelector(html, 'head').html()
+    const $ = await next.render$('/css-in-js')
+    const head = $('head').html()
 
     // from styled-jsx
     expect(head).toMatch(/{color:(\s*)purple;?}/) // styled-jsx/style
@@ -324,8 +319,8 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should render initial styles of css-in-js in edge SSR correctly', async () => {
-    const html = await next.render('/css-in-js/edge')
-    const head = getNodeBySelector(html, 'head').html()
+    const $ = await next.render$('/css-in-js/edge')
+    const head = $('head').html()
 
     // from styled-jsx
     expect(head).toMatch(/{color:(\s*)purple;?}/) // styled-jsx/style

--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import fs from 'fs-extra'
-import webdriver from 'next-webdriver'
-import { renderViaHTTP, fetchViaHTTP, check } from 'next-test-utils'
+import { check } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import cheerio from 'cheerio'
@@ -64,46 +63,43 @@ describe('app dir - rsc basics', () => {
   }
 
   it('should correctly render page returning null', async () => {
-    const homeHTML = await renderViaHTTP(next.url, '/return-null/page')
+    const homeHTML = await next.render('/return-null/page')
     const $ = cheerio.load(homeHTML)
     expect($('#return-null-layout').html()).toBeEmpty()
   })
 
   it('should correctly render component returning null', async () => {
-    const homeHTML = await renderViaHTTP(next.url, '/return-null/component')
+    const homeHTML = await next.render('/return-null/component')
     const $ = cheerio.load(homeHTML)
     expect($('#return-null-layout').html()).toBeEmpty()
   })
 
   it('should correctly render layout returning null', async () => {
-    const homeHTML = await renderViaHTTP(next.url, '/return-null/layout')
+    const homeHTML = await next.render('/return-null/layout')
     const $ = cheerio.load(homeHTML)
     expect($('#return-null-layout').html()).toBeEmpty()
   })
 
   it('should correctly render page returning undefined', async () => {
-    const homeHTML = await renderViaHTTP(next.url, '/return-undefined/page')
+    const homeHTML = await next.render('/return-undefined/page')
     const $ = cheerio.load(homeHTML)
     expect($('#return-undefined-layout').html()).toBeEmpty()
   })
 
   it('should correctly render component returning undefined', async () => {
-    const homeHTML = await renderViaHTTP(
-      next.url,
-      '/return-undefined/component'
-    )
+    const homeHTML = await next.render('/return-undefined/component')
     const $ = cheerio.load(homeHTML)
     expect($('#return-undefined-layout').html()).toBeEmpty()
   })
 
   it('should correctly render layout returning undefined', async () => {
-    const homeHTML = await renderViaHTTP(next.url, '/return-undefined/layout')
+    const homeHTML = await next.render('/return-undefined/layout')
     const $ = cheerio.load(homeHTML)
     expect($('#return-undefined-layout').html()).toBeEmpty()
   })
 
   it('should render server components correctly', async () => {
-    const homeHTML = await renderViaHTTP(next.url, '/', null, {
+    const homeHTML = await next.render('/', null, {
       headers: {
         'x-next-test-client': 'test-util',
       },
@@ -141,7 +137,7 @@ describe('app dir - rsc basics', () => {
   it('should reuse the inline flight response without sending extra requests', async () => {
     let hasFlightRequest = false
     let requestsCount = 0
-    await webdriver(next.url, '/root', {
+    await next.browser('/root', {
       beforePageLoad(page) {
         page.on('request', (request) => {
           requestsCount++
@@ -163,13 +159,13 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should support multi-level server component imports', async () => {
-    const html = await renderViaHTTP(next.url, '/multi')
+    const html = await next.render('/multi')
     expect(html).toContain('bar.server.js:')
     expect(html).toContain('foo.client')
   })
 
   it('should be able to navigate between rsc routes', async () => {
-    const browser = await webdriver(next.url, '/root')
+    const browser = await next.browser('/root')
 
     await browser.waitForElementByCss('#goto-next-link').click()
     await new Promise((res) => setTimeout(res, 1000))
@@ -191,7 +187,7 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should handle streaming server components correctly', async () => {
-    const browser = await webdriver(next.url, '/streaming-rsc')
+    const browser = await next.browser('/streaming-rsc')
     const content = await browser.eval(
       `document.querySelector('#content').innerText`
     )
@@ -199,12 +195,12 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should support next/link in server components', async () => {
-    const linkHTML = await renderViaHTTP(next.url, '/next-api/link')
+    const linkHTML = await next.render('/next-api/link')
     const linkText = getNodeBySelector(linkHTML, 'body a[href="/root"]').text()
 
     expect(linkText).toContain('home')
 
-    const browser = await webdriver(next.url, '/next-api/link')
+    const browser = await next.browser('/next-api/link')
 
     // We need to make sure the app is fully hydrated before clicking, otherwise
     // it will be a full redirection instead of being taken over by the next
@@ -227,7 +223,7 @@ describe('app dir - rsc basics', () => {
   it('should link correctly with next/link without mpa navigation to the page', async () => {
     // Select the button which is not hidden but rendered
     const selector = '#goto-next-link'
-    const browser = await webdriver(next.url, '/root', {})
+    const browser = await next.browser('/root', {})
 
     await browser.eval('window.didNotReloadPage = true')
     await browser.elementByCss(selector).click().waitForElementByCss('#query')
@@ -239,13 +235,13 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should escape streaming data correctly', async () => {
-    const browser = await webdriver(next.url, '/escaping-rsc')
+    const browser = await next.browser('/escaping-rsc')
     const manipulated = await browser.eval(`window.__manipulated_by_injection`)
     expect(manipulated).toBe(undefined)
   })
 
   it('should render built-in 404 page for missing route if pagesDir is not presented', async () => {
-    const res = await fetchViaHTTP(next.url, '/does-not-exist')
+    const res = await next.fetch('/does-not-exist')
 
     expect(res.status).toBe(404)
     const html = await res.text()
@@ -253,28 +249,28 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should suspense next/legacy/image in server components', async () => {
-    const imageHTML = await renderViaHTTP(next.url, '/next-api/image-legacy')
+    const imageHTML = await next.render('/next-api/image-legacy')
     const imageTag = getNodeBySelector(imageHTML, '#myimg')
 
     expect(imageTag.attr('src')).toContain('data:image')
   })
 
   it('should suspense next/image in server components', async () => {
-    const imageHTML = await renderViaHTTP(next.url, '/next-api/image-new')
+    const imageHTML = await next.render('/next-api/image-new')
     const imageTag = getNodeBySelector(imageHTML, '#myimg')
 
     expect(imageTag.attr('src')).toMatch(/test.+jpg/)
   })
 
   it('should handle various kinds of exports correctly', async () => {
-    const html = await renderViaHTTP(next.url, '/various-exports')
+    const html = await next.render('/various-exports')
     const content = getNodeBySelector(html, 'body').text()
 
     expect(content).toContain('abcde')
     expect(content).toContain('default-export-arrow.client')
     expect(content).toContain('named.client')
 
-    const browser = await webdriver(next.url, '/various-exports')
+    const browser = await next.browser('/various-exports')
     const hydratedContent = await browser.waitForElementByCss('body').text()
 
     expect(hydratedContent).toContain('abcde')
@@ -286,7 +282,7 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should support native modules in server component', async () => {
-    const html = await renderViaHTTP(next.url, '/native-module')
+    const html = await next.render('/native-module')
     const content = getNodeBySelector(html, 'body').text()
 
     expect(content).toContain('fs: function')
@@ -294,7 +290,7 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should resolve different kinds of components correctly', async () => {
-    const html = await renderViaHTTP(next.url, '/shared')
+    const html = await next.render('/shared')
     const main = getNodeBySelector(html, '#main').html()
     const content = getNodeBySelector(html, '#bar').text()
 
@@ -316,7 +312,7 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should render initial styles of css-in-js in nodejs SSR correctly', async () => {
-    const html = await renderViaHTTP(next.url, '/css-in-js')
+    const html = await next.render('/css-in-js')
     const head = getNodeBySelector(html, 'head').html()
 
     // from styled-jsx
@@ -328,7 +324,7 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should render initial styles of css-in-js in edge SSR correctly', async () => {
-    const html = await renderViaHTTP(next.url, '/css-in-js/edge')
+    const html = await next.render('/css-in-js/edge')
     const head = getNodeBySelector(html, 'head').html()
 
     // from styled-jsx
@@ -340,28 +336,26 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should render css-in-js suspense boundary correctly', async () => {
-    await fetchViaHTTP(next.url, '/css-in-js/suspense', null, {}).then(
-      async (response) => {
-        const results = []
+    await next.fetch('/css-in-js/suspense', null, {}).then(async (response) => {
+      const results = []
 
-        await resolveStreamResponse(response, (chunk: string) => {
-          // check if rsc refresh script for suspense show up, the test content could change with react version
-          const hasRCScript = /\$RC=function/.test(chunk)
-          if (hasRCScript) results.push('refresh-script')
+      await resolveStreamResponse(response, (chunk: string) => {
+        // check if rsc refresh script for suspense show up, the test content could change with react version
+        const hasRCScript = /\$RC=function/.test(chunk)
+        if (hasRCScript) results.push('refresh-script')
 
-          const isSuspenseyDataResolved =
-            /<style[^<>]*>(\s)*.+{padding:2px;(\s)*color:orange;}/.test(chunk)
-          if (isSuspenseyDataResolved) results.push('data')
+        const isSuspenseyDataResolved =
+          /<style[^<>]*>(\s)*.+{padding:2px;(\s)*color:orange;}/.test(chunk)
+        if (isSuspenseyDataResolved) results.push('data')
 
-          const isFallbackResolved = chunk.includes('fallback')
-          if (isFallbackResolved) results.push('fallback')
-        })
+        const isFallbackResolved = chunk.includes('fallback')
+        if (isFallbackResolved) results.push('fallback')
+      })
 
-        expect(results).toEqual(['fallback', 'data', 'refresh-script'])
-      }
-    )
+      expect(results).toEqual(['fallback', 'data', 'refresh-script'])
+    })
     // // TODO-APP: fix streaming/suspense within browser for test suite
-    // const browser = await webdriver(next.url, '/css-in-js', { waitHydration: false })
+    // const browser = await next.browser( '/css-in-js', { waitHydration: false })
     // const footer = await browser.elementByCss('#footer')
     // expect(await footer.text()).toBe('wait for fallback')
     // expect(
@@ -389,7 +383,7 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should stick to the url without trailing /page suffix', async () => {
-    const browser = await webdriver(next.url, '/edge/dynamic')
+    const browser = await next.browser('/edge/dynamic')
     const indexUrl = await browser.url()
 
     await browser.loadPage(`${next.url}/edge/dynamic/123`, {
@@ -403,51 +397,50 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should support streaming for flight response', async () => {
-    await fetchViaHTTP(
-      next.url,
-      '/',
-      {},
-      {
-        headers: {
-          ['RSC'.toString()]: '1',
-        },
-      }
-    ).then(async (response) => {
-      const result = await resolveStreamResponse(response)
-      expect(result).toContain('component:index.server')
-    })
+    await next
+      .fetch(
+        '/',
+        {},
+        {
+          headers: {
+            ['RSC'.toString()]: '1',
+          },
+        }
+      )
+      .then(async (response) => {
+        const result = await resolveStreamResponse(response)
+        expect(result).toContain('component:index.server')
+      })
   })
 
   it('should support partial hydration with inlined server data', async () => {
-    await fetchViaHTTP(next.url, '/partial-hydration', null, {}).then(
-      async (response) => {
-        let gotFallback = false
-        let gotData = false
-        let gotInlinedData = false
+    await next.fetch('/partial-hydration', null, {}).then(async (response) => {
+      let gotFallback = false
+      let gotData = false
+      let gotInlinedData = false
 
-        await resolveStreamResponse(response, (_, result) => {
-          gotInlinedData = result.includes('self.__next_f=')
-          gotData = result.includes('next_streaming_data')
-          if (!gotFallback) {
-            gotFallback = result.includes('next_streaming_fallback')
-            if (gotFallback) {
-              expect(gotData).toBe(false)
-              expect(gotInlinedData).toBe(false)
-            }
+      await resolveStreamResponse(response, (_, result) => {
+        gotInlinedData = result.includes('self.__next_f=')
+        gotData = result.includes('next_streaming_data')
+        if (!gotFallback) {
+          gotFallback = result.includes('next_streaming_fallback')
+          if (gotFallback) {
+            expect(gotData).toBe(false)
+            expect(gotInlinedData).toBe(false)
           }
-        })
+        }
+      })
 
-        expect(gotFallback).toBe(true)
-        expect(gotData).toBe(true)
-        expect(gotInlinedData).toBe(true)
-      }
-    )
+      expect(gotFallback).toBe(true)
+      expect(gotData).toBe(true)
+      expect(gotInlinedData).toBe(true)
+    })
   })
 
   // disable this flaky test
   it.skip('should support partial hydration with inlined server data in browser', async () => {
     // Should end up with "next_streaming_data".
-    const browser = await webdriver(next.url, '/partial-hydration', {
+    const browser = await next.browser('/partial-hydration', {
       waitHydration: false,
     })
     const content = await browser.eval(`window.document.body.innerText`)

--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -58,8 +58,7 @@ describe('app dir - rsc basics', () => {
   afterAll(() => next.destroy())
 
   const { isNextDeploy, isNextDev } = global as any
-  const isReact17 = process.env.NEXT_TEST_REACT_VERSION === '^17'
-  if (isNextDeploy || isReact17) {
+  if (isNextDeploy) {
     it('should skip tests for next-deploy and react 17', () => {})
     return
   }

--- a/test/e2e/app-dir/rsc-errors.test.ts
+++ b/test/e2e/app-dir/rsc-errors.test.ts
@@ -1,112 +1,110 @@
 import path from 'path'
 import { check, fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
-import { createNextDescribe, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 
-createNextDescribe(
-  'app dir - rsc errors',
-  {
-    files: path.join(__dirname, './rsc-errors'),
-    skipDeployment: true,
-  },
-  ({ next, isNextDev }) => {
-    if (!isNextDev) {
-      it('should skip tests for next-start', () => {})
-      return
-    }
-
-    it('should throw an error when getServerSideProps is used', async () => {
-      const pageFile = 'app/client-with-errors/get-server-side-props/page.js'
-      const content = await next.readFile(pageFile)
-      const uncomment = content.replace(
-        '// export function getServerSideProps',
-        'export function getServerSideProps'
-      )
-      await next.patchFile(pageFile, uncomment)
-      const res = await fetchViaHTTP(
-        next.url,
-        '/client-with-errors/get-server-side-props'
-      )
-      await next.patchFile(pageFile, content)
-
-      await check(async () => {
-        const { status } = await fetchViaHTTP(
+if (!(globalThis as any).isNextDev) {
+  it('should skip tests for next-start', () => {})
+} else {
+  createNextDescribe(
+    'app dir - rsc errors',
+    {
+      files: path.join(__dirname, './rsc-errors'),
+      skipDeployment: true,
+    },
+    ({ next }) => {
+      it('should throw an error when getServerSideProps is used', async () => {
+        const pageFile = 'app/client-with-errors/get-server-side-props/page.js'
+        const content = await next.readFile(pageFile)
+        const uncomment = content.replace(
+          '// export function getServerSideProps',
+          'export function getServerSideProps'
+        )
+        await next.patchFile(pageFile, uncomment)
+        const res = await fetchViaHTTP(
           next.url,
           '/client-with-errors/get-server-side-props'
         )
-        return status
-      }, /200/)
+        await next.patchFile(pageFile, content)
 
-      expect(res.status).toBe(500)
-      expect(await res.text()).toContain(
-        '"getServerSideProps\\" is not supported in app/'
-      )
-    })
+        await check(async () => {
+          const { status } = await fetchViaHTTP(
+            next.url,
+            '/client-with-errors/get-server-side-props'
+          )
+          return status
+        }, /200/)
 
-    it('should throw an error when getStaticProps is used', async () => {
-      const pageFile = 'app/client-with-errors/get-static-props/page.js'
-      const content = await next.readFile(pageFile)
-      const uncomment = content.replace(
-        '// export function getStaticProps',
-        'export function getStaticProps'
-      )
-      await next.patchFile(pageFile, uncomment)
-      const res = await fetchViaHTTP(
-        next.url,
-        '/client-with-errors/get-static-props'
-      )
-      await next.patchFile(pageFile, content)
-      await check(async () => {
-        const { status } = await fetchViaHTTP(
+        expect(res.status).toBe(500)
+        expect(await res.text()).toContain(
+          '"getServerSideProps\\" is not supported in app/'
+        )
+      })
+
+      it('should throw an error when getStaticProps is used', async () => {
+        const pageFile = 'app/client-with-errors/get-static-props/page.js'
+        const content = await next.readFile(pageFile)
+        const uncomment = content.replace(
+          '// export function getStaticProps',
+          'export function getStaticProps'
+        )
+        await next.patchFile(pageFile, uncomment)
+        const res = await fetchViaHTTP(
           next.url,
           '/client-with-errors/get-static-props'
         )
-        return status
-      }, /200/)
+        await next.patchFile(pageFile, content)
+        await check(async () => {
+          const { status } = await fetchViaHTTP(
+            next.url,
+            '/client-with-errors/get-static-props'
+          )
+          return status
+        }, /200/)
 
-      expect(res.status).toBe(500)
-      expect(await res.text()).toContain(
-        '"getStaticProps\\" is not supported in app/'
-      )
-    })
+        expect(res.status).toBe(500)
+        expect(await res.text()).toContain(
+          '"getStaticProps\\" is not supported in app/'
+        )
+      })
 
-    it('should error for styled-jsx imports on server side', async () => {
-      const html = await renderViaHTTP(
-        next.url,
-        '/server-with-errors/styled-jsx'
-      )
-      expect(html).toContain(
-        'This module cannot be imported from a Server Component module. It should only be used from a Client Component.'
-      )
-    })
+      it('should error for styled-jsx imports on server side', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/server-with-errors/styled-jsx'
+        )
+        expect(html).toContain(
+          'This module cannot be imported from a Server Component module. It should only be used from a Client Component.'
+        )
+      })
 
-    it('should error when page component export is not valid', async () => {
-      const html = await renderViaHTTP(
-        next.url,
-        '/server-with-errors/page-export'
-      )
-      expect(html).toContain(
-        'The default export is not a React Component in page:'
-      )
-    })
+      it('should error when page component export is not valid', async () => {
+        const html = await renderViaHTTP(
+          next.url,
+          '/server-with-errors/page-export'
+        )
+        expect(html).toContain(
+          'The default export is not a React Component in page:'
+        )
+      })
 
-    it('should throw an error when "use client" is on the top level but after other expressions', async () => {
-      const pageFile = 'app/swc/use-client/page.js'
-      const content = await next.readFile(pageFile)
-      const uncomment = content.replace("// 'use client'", "'use client'")
-      await next.patchFile(pageFile, uncomment)
-      const res = await fetchViaHTTP(next.url, '/swc/use-client')
-      await next.patchFile(pageFile, content)
+      it('should throw an error when "use client" is on the top level but after other expressions', async () => {
+        const pageFile = 'app/swc/use-client/page.js'
+        const content = await next.readFile(pageFile)
+        const uncomment = content.replace("// 'use client'", "'use client'")
+        await next.patchFile(pageFile, uncomment)
+        const res = await fetchViaHTTP(next.url, '/swc/use-client')
+        await next.patchFile(pageFile, content)
 
-      await check(async () => {
-        const { status } = await fetchViaHTTP(next.url, '/swc/use-client')
-        return status
-      }, /200/)
+        await check(async () => {
+          const { status } = await fetchViaHTTP(next.url, '/swc/use-client')
+          return status
+        }, /200/)
 
-      expect(res.status).toBe(500)
-      expect(await res.text()).toContain(
-        'directive must be placed before other expressions'
-      )
-    })
-  }
-)
+        expect(res.status).toBe(500)
+        expect(await res.text()).toContain(
+          'directive must be placed before other expressions'
+        )
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir/rsc-errors.test.ts
+++ b/test/e2e/app-dir/rsc-errors.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { check, fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
+import { check } from 'next-test-utils'
 import { createNextDescribe } from 'e2e-utils'
 
 if (!(globalThis as any).isNextDev) {
@@ -20,15 +20,13 @@ if (!(globalThis as any).isNextDev) {
           'export function getServerSideProps'
         )
         await next.patchFile(pageFile, uncomment)
-        const res = await fetchViaHTTP(
-          next.url,
+        const res = await next.fetch(
           '/client-with-errors/get-server-side-props'
         )
         await next.patchFile(pageFile, content)
 
         await check(async () => {
-          const { status } = await fetchViaHTTP(
-            next.url,
+          const { status } = await next.fetch(
             '/client-with-errors/get-server-side-props'
           )
           return status
@@ -48,14 +46,10 @@ if (!(globalThis as any).isNextDev) {
           'export function getStaticProps'
         )
         await next.patchFile(pageFile, uncomment)
-        const res = await fetchViaHTTP(
-          next.url,
-          '/client-with-errors/get-static-props'
-        )
+        const res = await next.fetch('/client-with-errors/get-static-props')
         await next.patchFile(pageFile, content)
         await check(async () => {
-          const { status } = await fetchViaHTTP(
-            next.url,
+          const { status } = await next.fetch(
             '/client-with-errors/get-static-props'
           )
           return status
@@ -68,20 +62,14 @@ if (!(globalThis as any).isNextDev) {
       })
 
       it('should error for styled-jsx imports on server side', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/server-with-errors/styled-jsx'
-        )
+        const html = await next.render('/server-with-errors/styled-jsx')
         expect(html).toContain(
           'This module cannot be imported from a Server Component module. It should only be used from a Client Component.'
         )
       })
 
       it('should error when page component export is not valid', async () => {
-        const html = await renderViaHTTP(
-          next.url,
-          '/server-with-errors/page-export'
-        )
+        const html = await next.render('/server-with-errors/page-export')
         expect(html).toContain(
           'The default export is not a React Component in page:'
         )
@@ -92,11 +80,11 @@ if (!(globalThis as any).isNextDev) {
         const content = await next.readFile(pageFile)
         const uncomment = content.replace("// 'use client'", "'use client'")
         await next.patchFile(pageFile, uncomment)
-        const res = await fetchViaHTTP(next.url, '/swc/use-client')
+        const res = await next.fetch('/swc/use-client')
         await next.patchFile(pageFile, content)
 
         await check(async () => {
-          const { status } = await fetchViaHTTP(next.url, '/swc/use-client')
+          const { status } = await next.fetch('/swc/use-client')
           return status
         }, /200/)
 

--- a/test/e2e/app-dir/rsc-errors.test.ts
+++ b/test/e2e/app-dir/rsc-errors.test.ts
@@ -1,120 +1,112 @@
 import path from 'path'
 import { check, fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNextDescribe, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 
-describe('app dir - rsc errors', () => {
-  let next: NextInstance
+createNextDescribe(
+  'app dir - rsc errors',
+  {
+    files: path.join(__dirname, './rsc-errors'),
+    skipDeployment: true,
+  },
+  ({ next, isNextDev }) => {
+    if (!isNextDev) {
+      it('should skip tests for next-start', () => {})
+      return
+    }
 
-  const { isNextDeploy, isNextDev } = global as any
-  if (isNextDeploy) {
-    it('should skip tests for next-deploy and react 17', () => {})
-    return
-  }
-  if (!isNextDev) {
-    it('should skip tests for next-start', () => {})
-    return
-  }
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, './rsc-errors')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
-    })
-  })
-  afterAll(() => next.destroy())
-
-  it('should throw an error when getServerSideProps is used', async () => {
-    const pageFile = 'app/client-with-errors/get-server-side-props/page.js'
-    const content = await next.readFile(pageFile)
-    const uncomment = content.replace(
-      '// export function getServerSideProps',
-      'export function getServerSideProps'
-    )
-    await next.patchFile(pageFile, uncomment)
-    const res = await fetchViaHTTP(
-      next.url,
-      '/client-with-errors/get-server-side-props'
-    )
-    await next.patchFile(pageFile, content)
-
-    await check(async () => {
-      const { status } = await fetchViaHTTP(
+    it('should throw an error when getServerSideProps is used', async () => {
+      const pageFile = 'app/client-with-errors/get-server-side-props/page.js'
+      const content = await next.readFile(pageFile)
+      const uncomment = content.replace(
+        '// export function getServerSideProps',
+        'export function getServerSideProps'
+      )
+      await next.patchFile(pageFile, uncomment)
+      const res = await fetchViaHTTP(
         next.url,
         '/client-with-errors/get-server-side-props'
       )
-      return status
-    }, /200/)
+      await next.patchFile(pageFile, content)
 
-    expect(res.status).toBe(500)
-    expect(await res.text()).toContain(
-      '"getServerSideProps\\" is not supported in app/'
-    )
-  })
+      await check(async () => {
+        const { status } = await fetchViaHTTP(
+          next.url,
+          '/client-with-errors/get-server-side-props'
+        )
+        return status
+      }, /200/)
 
-  it('should throw an error when getStaticProps is used', async () => {
-    const pageFile = 'app/client-with-errors/get-static-props/page.js'
-    const content = await next.readFile(pageFile)
-    const uncomment = content.replace(
-      '// export function getStaticProps',
-      'export function getStaticProps'
-    )
-    await next.patchFile(pageFile, uncomment)
-    const res = await fetchViaHTTP(
-      next.url,
-      '/client-with-errors/get-static-props'
-    )
-    await next.patchFile(pageFile, content)
-    await check(async () => {
-      const { status } = await fetchViaHTTP(
+      expect(res.status).toBe(500)
+      expect(await res.text()).toContain(
+        '"getServerSideProps\\" is not supported in app/'
+      )
+    })
+
+    it('should throw an error when getStaticProps is used', async () => {
+      const pageFile = 'app/client-with-errors/get-static-props/page.js'
+      const content = await next.readFile(pageFile)
+      const uncomment = content.replace(
+        '// export function getStaticProps',
+        'export function getStaticProps'
+      )
+      await next.patchFile(pageFile, uncomment)
+      const res = await fetchViaHTTP(
         next.url,
         '/client-with-errors/get-static-props'
       )
-      return status
-    }, /200/)
+      await next.patchFile(pageFile, content)
+      await check(async () => {
+        const { status } = await fetchViaHTTP(
+          next.url,
+          '/client-with-errors/get-static-props'
+        )
+        return status
+      }, /200/)
 
-    expect(res.status).toBe(500)
-    expect(await res.text()).toContain(
-      '"getStaticProps\\" is not supported in app/'
-    )
-  })
+      expect(res.status).toBe(500)
+      expect(await res.text()).toContain(
+        '"getStaticProps\\" is not supported in app/'
+      )
+    })
 
-  it('should error for styled-jsx imports on server side', async () => {
-    const html = await renderViaHTTP(next.url, '/server-with-errors/styled-jsx')
-    expect(html).toContain(
-      'This module cannot be imported from a Server Component module. It should only be used from a Client Component.'
-    )
-  })
+    it('should error for styled-jsx imports on server side', async () => {
+      const html = await renderViaHTTP(
+        next.url,
+        '/server-with-errors/styled-jsx'
+      )
+      expect(html).toContain(
+        'This module cannot be imported from a Server Component module. It should only be used from a Client Component.'
+      )
+    })
 
-  it('should error when page component export is not valid', async () => {
-    const html = await renderViaHTTP(
-      next.url,
-      '/server-with-errors/page-export'
-    )
-    expect(html).toContain(
-      'The default export is not a React Component in page:'
-    )
-  })
+    it('should error when page component export is not valid', async () => {
+      const html = await renderViaHTTP(
+        next.url,
+        '/server-with-errors/page-export'
+      )
+      expect(html).toContain(
+        'The default export is not a React Component in page:'
+      )
+    })
 
-  it('should throw an error when "use client" is on the top level but after other expressions', async () => {
-    const pageFile = 'app/swc/use-client/page.js'
-    const content = await next.readFile(pageFile)
-    const uncomment = content.replace("// 'use client'", "'use client'")
-    await next.patchFile(pageFile, uncomment)
-    const res = await fetchViaHTTP(next.url, '/swc/use-client')
-    await next.patchFile(pageFile, content)
+    it('should throw an error when "use client" is on the top level but after other expressions', async () => {
+      const pageFile = 'app/swc/use-client/page.js'
+      const content = await next.readFile(pageFile)
+      const uncomment = content.replace("// 'use client'", "'use client'")
+      await next.patchFile(pageFile, uncomment)
+      const res = await fetchViaHTTP(next.url, '/swc/use-client')
+      await next.patchFile(pageFile, content)
 
-    await check(async () => {
-      const { status } = await fetchViaHTTP(next.url, '/swc/use-client')
-      return status
-    }, /200/)
+      await check(async () => {
+        const { status } = await fetchViaHTTP(next.url, '/swc/use-client')
+        return status
+      }, /200/)
 
-    expect(res.status).toBe(500)
-    expect(await res.text()).toContain(
-      'directive must be placed before other expressions'
-    )
-  })
-})
+      expect(res.status).toBe(500)
+      expect(await res.text()).toContain(
+        'directive must be placed before other expressions'
+      )
+    })
+  }
+)

--- a/test/e2e/app-dir/standalone.test.ts
+++ b/test/e2e/app-dir/standalone.test.ts
@@ -1,5 +1,4 @@
 import { createNextDescribe, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
 import fs from 'fs-extra'
 import os from 'os'
 import path from 'path'
@@ -10,100 +9,102 @@ import {
   killApp,
 } from 'next-test-utils'
 
-createNextDescribe(
-  'output: standalone with app dir',
-  {
-    files: new FileRef(path.join(__dirname, 'app')),
-    dependencies: {
-      swr: '2.0.0-rc.0',
-      react: 'latest',
-      'react-dom': 'latest',
-      sass: 'latest',
+if (!(globalThis as any).isNextStart) {
+  it('should skip for non-next start', () => {})
+} else {
+  createNextDescribe(
+    'output: standalone with app dir',
+    {
+      files: new FileRef(path.join(__dirname, 'app')),
+      dependencies: {
+        swr: '2.0.0-rc.0',
+        react: 'latest',
+        'react-dom': 'latest',
+        sass: 'latest',
+      },
+      skipStart: true,
     },
-    skipStart: true,
-  },
-  ({ next, isNextStart }) => {
-    if (!isNextStart) {
-      it('should skip for non-next start', () => {})
-      return
-    }
-
-    beforeAll(async () => {
-      await next.patchFile(
-        'next.config.js',
-        (await next.readFile('next.config.js')).replace('// output', 'output')
-      )
-      await next.start()
-    })
-
-    it('should handle trace files correctly for route groups (nodejs only)', async () => {
-      expect(next.cliOutput).not.toContain('Failed to copy traced files')
-      const serverDirPath = path.join(
-        next.testDir,
-        '.next/standalone/.next/server'
-      )
-      for (const page of [
-        '(newroot)/dashboard/another',
-        '(newroot)/dashboard/project/[projectId]',
-        '(rootonly)/dashboard/changelog',
-      ]) {
-        const pagePath = path.join(serverDirPath, 'app', page)
-
-        expect(
-          await fs.pathExists(path.join(pagePath, 'page.js.nft.json'))
-        ).toBe(true)
-
-        const files = (
-          await fs.readJSON(path.join(pagePath, 'page.js.nft.json'))
-        ).files as string[]
-
-        for (const file of files) {
-          expect(await fs.pathExists(path.join(pagePath, file))).toBe(true)
-        }
-      }
-    })
-
-    it('should work correctly with output standalone', async () => {
-      const tmpFolder = path.join(os.tmpdir(), 'next-standalone-' + Date.now())
-      await fs.move(path.join(next.testDir, '.next/standalone'), tmpFolder)
-      let server: any
-
-      try {
-        const testServer = path.join(tmpFolder, 'server.js')
-        const appPort = await findPort()
-        server = await initNextServerScript(
-          testServer,
-          /Listening on/,
-          {
-            ...process.env,
-            PORT: appPort,
-          },
-          undefined,
-          {
-            cwd: tmpFolder,
-          }
+    ({ next }) => {
+      beforeAll(async () => {
+        await next.patchFile(
+          'next.config.js',
+          (await next.readFile('next.config.js')).replace('// output', 'output')
         )
+        await next.start()
+      })
 
-        for (const testPath of [
-          '/',
-          '/api/hello',
-          '/blog/first',
-          '/dashboard',
-          '/dashboard/another',
-          '/dashboard/changelog',
-          '/dashboard/deployments/breakdown',
-          '/dashboard/deployments/123',
-          '/dashboard/hello',
-          '/dashboard/project/123',
-          '/catch-all/first',
+      it('should handle trace files correctly for route groups (nodejs only)', async () => {
+        expect(next.cliOutput).not.toContain('Failed to copy traced files')
+        const serverDirPath = path.join(
+          next.testDir,
+          '.next/standalone/.next/server'
+        )
+        for (const page of [
+          '(newroot)/dashboard/another',
+          '(newroot)/dashboard/project/[projectId]',
+          '(rootonly)/dashboard/changelog',
         ]) {
-          const res = await fetchViaHTTP(appPort, testPath)
-          expect(res.status).toBe(200)
+          const pagePath = path.join(serverDirPath, 'app', page)
+
+          expect(
+            await fs.pathExists(path.join(pagePath, 'page.js.nft.json'))
+          ).toBe(true)
+
+          const files = (
+            await fs.readJSON(path.join(pagePath, 'page.js.nft.json'))
+          ).files as string[]
+
+          for (const file of files) {
+            expect(await fs.pathExists(path.join(pagePath, file))).toBe(true)
+          }
         }
-      } finally {
-        if (server) await killApp(server)
-        await fs.remove(tmpFolder)
-      }
-    })
-  }
-)
+      })
+
+      it('should work correctly with output standalone', async () => {
+        const tmpFolder = path.join(
+          os.tmpdir(),
+          'next-standalone-' + Date.now()
+        )
+        await fs.move(path.join(next.testDir, '.next/standalone'), tmpFolder)
+        let server: any
+
+        try {
+          const testServer = path.join(tmpFolder, 'server.js')
+          const appPort = await findPort()
+          server = await initNextServerScript(
+            testServer,
+            /Listening on/,
+            {
+              ...process.env,
+              PORT: appPort,
+            },
+            undefined,
+            {
+              cwd: tmpFolder,
+            }
+          )
+
+          for (const testPath of [
+            '/',
+            '/api/hello',
+            '/blog/first',
+            '/dashboard',
+            '/dashboard/another',
+            '/dashboard/changelog',
+            '/dashboard/deployments/breakdown',
+            '/dashboard/deployments/123',
+            '/dashboard/hello',
+            '/dashboard/project/123',
+            '/catch-all/first',
+          ]) {
+            const res = await fetchViaHTTP(appPort, testPath)
+            expect(res.status).toBe(200)
+          }
+        } finally {
+          if (server) await killApp(server)
+          await fs.remove(tmpFolder)
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir/standalone.test.ts
+++ b/test/e2e/app-dir/standalone.test.ts
@@ -1,4 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNextDescribe, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import fs from 'fs-extra'
 import os from 'os'
@@ -10,37 +10,32 @@ import {
   killApp,
 } from 'next-test-utils'
 
-describe('output: standalone with app dir', () => {
-  let next: NextInstance
+createNextDescribe(
+  'output: standalone with app dir',
+  {
+    files: new FileRef(path.join(__dirname, 'app')),
+    dependencies: {
+      swr: '2.0.0-rc.0',
+      react: 'latest',
+      'react-dom': 'latest',
+      sass: 'latest',
+    },
+    skipStart: true,
+  },
+  ({ next, isNextStart }) => {
+    if (!isNextStart) {
+      it('should skip for non-next start', () => {})
+      return
+    }
 
-  if (!(global as any).isNextStart) {
-    it('should skip for non-next start', () => {})
-    return
-  }
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'app')),
-      dependencies: {
-        swr: '2.0.0-rc.0',
-        react: 'latest',
-        'react-dom': 'latest',
-        sass: 'latest',
-      },
-      skipStart: true,
+    beforeAll(async () => {
+      await next.patchFile(
+        'next.config.js',
+        (await next.readFile('next.config.js')).replace('// output', 'output')
+      )
+      await next.start()
     })
 
-    await next.patchFile(
-      'next.config.js',
-      (await next.readFile('next.config.js')).replace('// output', 'output')
-    )
-    await next.start()
-  })
-  afterAll(async () => {
-    await next.destroy()
-  })
-
-  if ((global as any).isNextStart) {
     it('should handle trace files correctly for route groups (nodejs only)', async () => {
       expect(next.cliOutput).not.toContain('Failed to copy traced files')
       const serverDirPath = path.join(
@@ -67,48 +62,48 @@ describe('output: standalone with app dir', () => {
         }
       }
     })
-  }
 
-  it('should work correctly with output standalone', async () => {
-    const tmpFolder = path.join(os.tmpdir(), 'next-standalone-' + Date.now())
-    await fs.move(path.join(next.testDir, '.next/standalone'), tmpFolder)
-    let server: any
+    it('should work correctly with output standalone', async () => {
+      const tmpFolder = path.join(os.tmpdir(), 'next-standalone-' + Date.now())
+      await fs.move(path.join(next.testDir, '.next/standalone'), tmpFolder)
+      let server: any
 
-    try {
-      const testServer = path.join(tmpFolder, 'server.js')
-      const appPort = await findPort()
-      server = await initNextServerScript(
-        testServer,
-        /Listening on/,
-        {
-          ...process.env,
-          PORT: appPort,
-        },
-        undefined,
-        {
-          cwd: tmpFolder,
+      try {
+        const testServer = path.join(tmpFolder, 'server.js')
+        const appPort = await findPort()
+        server = await initNextServerScript(
+          testServer,
+          /Listening on/,
+          {
+            ...process.env,
+            PORT: appPort,
+          },
+          undefined,
+          {
+            cwd: tmpFolder,
+          }
+        )
+
+        for (const testPath of [
+          '/',
+          '/api/hello',
+          '/blog/first',
+          '/dashboard',
+          '/dashboard/another',
+          '/dashboard/changelog',
+          '/dashboard/deployments/breakdown',
+          '/dashboard/deployments/123',
+          '/dashboard/hello',
+          '/dashboard/project/123',
+          '/catch-all/first',
+        ]) {
+          const res = await fetchViaHTTP(appPort, testPath)
+          expect(res.status).toBe(200)
         }
-      )
-
-      for (const testPath of [
-        '/',
-        '/api/hello',
-        '/blog/first',
-        '/dashboard',
-        '/dashboard/another',
-        '/dashboard/changelog',
-        '/dashboard/deployments/breakdown',
-        '/dashboard/deployments/123',
-        '/dashboard/hello',
-        '/dashboard/project/123',
-        '/catch-all/first',
-      ]) {
-        const res = await fetchViaHTTP(appPort, testPath)
-        expect(res.status).toBe(200)
+      } finally {
+        if (server) await killApp(server)
+        await fs.remove(tmpFolder)
       }
-    } finally {
-      if (server) await killApp(server)
-      await fs.remove(tmpFolder)
-    }
-  })
-})
+    })
+  }
+)

--- a/test/e2e/app-dir/standalone.test.ts
+++ b/test/e2e/app-dir/standalone.test.ts
@@ -3,10 +3,10 @@ import fs from 'fs-extra'
 import os from 'os'
 import path from 'path'
 import {
-  fetchViaHTTP,
   findPort,
   initNextServerScript,
   killApp,
+  fetchViaHTTP,
 } from 'next-test-utils'
 
 if (!(globalThis as any).isNextStart) {

--- a/test/e2e/app-dir/trailingslash.test.ts
+++ b/test/e2e/app-dir/trailingslash.test.ts
@@ -1,8 +1,6 @@
 import { createNextDescribe } from 'e2e-utils'
-import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import cheerio from 'cheerio'
-import webdriver from 'next-webdriver'
 
 createNextDescribe(
   'app-dir trailingSlash handling',
@@ -12,8 +10,7 @@ createNextDescribe(
   },
   ({ next }) => {
     it('should redirect route when requesting it directly', async () => {
-      const res = await fetchViaHTTP(
-        next.url,
+      const res = await next.fetch(
         '/a',
         {},
         {
@@ -25,18 +22,18 @@ createNextDescribe(
     })
 
     it('should render link with trailing slash', async () => {
-      const html = await renderViaHTTP(next.url, '/')
+      const html = await next.render('/')
       const $ = cheerio.load(html)
       expect($('#to-a-trailing-slash').attr('href')).toBe('/a/')
     })
 
     it('should redirect route when requesting it directly by browser', async () => {
-      const browser = await webdriver(next.url, '/a')
+      const browser = await next.browser('/a')
       expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
     })
 
     it('should redirect route when clicking link', async () => {
-      const browser = await webdriver(next.url, '/')
+      const browser = await next.browser('/')
       await browser
         .elementByCss('#to-a-trailing-slash')
         .click()

--- a/test/e2e/app-dir/trailingslash.test.ts
+++ b/test/e2e/app-dir/trailingslash.test.ts
@@ -1,6 +1,5 @@
 import { createNextDescribe } from 'e2e-utils'
 import path from 'path'
-import cheerio from 'cheerio'
 
 createNextDescribe(
   'app-dir trailingSlash handling',
@@ -22,8 +21,7 @@ createNextDescribe(
     })
 
     it('should render link with trailing slash', async () => {
-      const html = await next.render('/')
-      const $ = cheerio.load(html)
+      const $ = await next.render$('/')
       expect($('#to-a-trailing-slash').attr('href')).toBe('/a/')
     })
 

--- a/test/e2e/app-dir/trailingslash.test.ts
+++ b/test/e2e/app-dir/trailingslash.test.ts
@@ -1,62 +1,47 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { createNextDescribe } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 
-describe('app-dir trailingSlash handling', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
-
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'trailingslash')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
-      skipStart: true,
+createNextDescribe(
+  'app-dir trailingSlash handling',
+  {
+    files: path.join(__dirname, 'trailingslash'),
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should redirect route when requesting it directly', async () => {
+      const res = await fetchViaHTTP(
+        next.url,
+        '/a',
+        {},
+        {
+          redirect: 'manual',
+        }
+      )
+      expect(res.status).toBe(308)
+      expect(res.headers.get('location')).toBe(next.url + '/a/')
     })
 
-    await next.start()
-  })
-  afterAll(() => next.destroy())
+    it('should render link with trailing slash', async () => {
+      const html = await renderViaHTTP(next.url, '/')
+      const $ = cheerio.load(html)
+      expect($('#to-a-trailing-slash').attr('href')).toBe('/a/')
+    })
 
-  it('should redirect route when requesting it directly', async () => {
-    const res = await fetchViaHTTP(
-      next.url,
-      '/a',
-      {},
-      {
-        redirect: 'manual',
-      }
-    )
-    expect(res.status).toBe(308)
-    expect(res.headers.get('location')).toBe(next.url + '/a/')
-  })
+    it('should redirect route when requesting it directly by browser', async () => {
+      const browser = await webdriver(next.url, '/a')
+      expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
+    })
 
-  it('should render link with trailing slash', async () => {
-    const html = await renderViaHTTP(next.url, '/')
-    const $ = cheerio.load(html)
-    expect($('#to-a-trailing-slash').attr('href')).toBe('/a/')
-  })
-
-  it('should redirect route when requesting it directly by browser', async () => {
-    const browser = await webdriver(next.url, '/a')
-    expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
-  })
-
-  it('should redirect route when clicking link', async () => {
-    const browser = await webdriver(next.url, '/')
-    await browser
-      .elementByCss('#to-a-trailing-slash')
-      .click()
-      .waitForElementByCss('#a-page')
-    expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
-  })
-})
+    it('should redirect route when clicking link', async () => {
+      const browser = await webdriver(next.url, '/')
+      await browser
+        .elementByCss('#to-a-trailing-slash')
+        .click()
+        .waitForElementByCss('#a-page')
+      expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
+    })
+  }
+)

--- a/test/e2e/app-dir/vercel-analytics.test.ts
+++ b/test/e2e/app-dir/vercel-analytics.test.ts
@@ -2,7 +2,6 @@ import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { check } from 'next-test-utils'
 import path from 'path'
-import webdriver from 'next-webdriver'
 
 describe('vercel analytics', () => {
   const isDev = (global as any).isNextDev
@@ -48,7 +47,7 @@ describe('vercel analytics', () => {
       it('should send web vitals to Vercel analytics', async () => {
         let eventsCount = 0
         let countEvents = false
-        const browser = await webdriver(next.url, '/client-nested', {
+        const browser = await next.browser('/client-nested', {
           beforePageLoad(page) {
             page.route(
               'https://vitals.vercel-insights.com/v1/vitals',

--- a/test/e2e/app-dir/with-babel.test.ts
+++ b/test/e2e/app-dir/with-babel.test.ts
@@ -1,31 +1,16 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
-import { renderViaHTTP } from 'next-test-utils'
+import { createNextDescribe } from 'e2e-utils'
 import path from 'path'
-import cheerio from 'cheerio'
 
-describe('with babel', () => {
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
-
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'with-babel')),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-      },
+createNextDescribe(
+  'with babel',
+  {
+    files: path.join(__dirname, 'with-babel'),
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should support babel in app dir', async () => {
+      const $ = await next.render$('/')
+      expect($('h1').text()).toBe('hello')
     })
-  })
-  afterAll(() => next.destroy())
-
-  it('should support babel in app dir', async () => {
-    const html = await renderViaHTTP(next.url, '/')
-    const $ = cheerio.load(html)
-    expect($('h1').text()).toBe('hello')
-  })
-})
+  }
+)

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -35,8 +35,7 @@ describe('transpile packages', () => {
   afterAll(() => next.destroy())
 
   const { isNextDeploy } = global as any
-  const isReact17 = process.env.NEXT_TEST_REACT_VERSION === '^17'
-  if (isNextDeploy || isReact17) {
+  if (isNextDeploy) {
     it('should skip tests for next-deploy and react 17', () => {})
     return
   }

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -221,7 +221,8 @@ export function createNextDescribe(
 
     const nextProxy = new Proxy<NextInstance>({} as NextInstance, {
       get: function (_target, property) {
-        return next[property]
+        const prop = next[property]
+        return typeof prop === 'function' ? prop.bind(next) : prop
       },
     })
     fn({

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -364,6 +364,9 @@ export class NextInstance {
   public async readFile(filename: string) {
     return fs.readFile(path.join(this.testDir, filename), 'utf8')
   }
+  public async readJSON(filename: string) {
+    return fs.readJSON(path.join(this.testDir, filename))
+  }
   public async patchFile(filename: string, content: string) {
     const outputPath = path.join(this.testDir, filename)
     await fs.ensureDir(path.dirname(outputPath))


### PR DESCRIPTION
- Remove React 17 test opt-outs
- Remove runTests wrapper
- Remove runTests wrapper
- Refactor import.test.ts to use createNextDescribe
- Refactor app-alias.test.ts to use createNextDescribe

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
