### PR TITLE
Add types as a default dependency into tests

### DIFF
--- a/test/e2e/app-dir/app-alias.test.ts
+++ b/test/e2e/app-dir/app-alias.test.ts
@@ -5,13 +5,6 @@ createNextDescribe(
   'app-dir alias handling',
   {
     files: path.join(__dirname, 'app-alias'),
-    dependencies: {
-      react: 'latest',
-      'react-dom': 'latest',
-      typescript: 'latest',
-      '@types/react': 'latest',
-      '@types/node': 'latest',
-    },
     packageJson: {
       type: 'module',
     },

--- a/test/e2e/app-dir/app-edge-global.test.ts
+++ b/test/e2e/app-dir/app-edge-global.test.ts
@@ -5,13 +5,6 @@ createNextDescribe(
   'app-dir global edge configuration',
   {
     files: path.join(__dirname, 'app-edge-global'),
-    dependencies: {
-      react: 'latest',
-      'react-dom': 'latest',
-      typescript: 'latest',
-      '@types/react': 'latest',
-      '@types/node': 'latest',
-    },
     skipDeployment: true,
   },
   ({ next }) => {

--- a/test/e2e/app-dir/app-edge.test.ts
+++ b/test/e2e/app-dir/app-edge.test.ts
@@ -6,13 +6,6 @@ createNextDescribe(
   'app-dir edge SSR',
   {
     files: path.join(__dirname, 'app-edge'),
-    dependencies: {
-      react: 'latest',
-      'react-dom': 'latest',
-      typescript: 'latest',
-      '@types/react': 'latest',
-      '@types/node': 'latest',
-    },
     skipDeployment: true,
   },
   ({ next }) => {

--- a/test/e2e/app-dir/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout.test.ts
@@ -218,13 +218,6 @@ describe('app-dir create root layout', () => {
               path.join(__dirname, 'create-root-layout/next.config.js')
             ),
           },
-          dependencies: {
-            react: 'latest',
-            'react-dom': 'latest',
-            typescript: 'latest',
-            '@types/react': 'latest',
-            '@types/node': 'latest',
-          },
         })
       })
       afterAll(() => next.destroy())

--- a/test/e2e/app-dir/import.test.ts
+++ b/test/e2e/app-dir/import.test.ts
@@ -5,13 +5,6 @@ createNextDescribe(
   'app dir imports',
   {
     files: path.join(__dirname, 'import'),
-    dependencies: {
-      react: 'latest',
-      'react-dom': 'latest',
-      typescript: 'latest',
-      '@types/react': 'latest',
-      '@types/node': 'latest',
-    },
   },
   ({ next }) => {
     ;['js', 'jsx', 'ts', 'tsx'].forEach((ext) => {

--- a/test/e2e/app-dir/layout-params.test.ts
+++ b/test/e2e/app-dir/layout-params.test.ts
@@ -5,13 +5,6 @@ createNextDescribe(
   'app dir - layout params',
   {
     files: path.join(__dirname, './layout-params'),
-    dependencies: {
-      react: 'latest',
-      'react-dom': 'latest',
-      typescript: 'latest',
-      '@types/react': 'latest',
-      '@types/node': 'latest',
-    },
   },
   ({ next }) => {
     describe('basic params', () => {

--- a/test/e2e/app-dir/navigation-and-querystring/navigation-and-querystring.test.ts
+++ b/test/e2e/app-dir/navigation-and-querystring/navigation-and-querystring.test.ts
@@ -9,13 +9,6 @@ describe('app-dir navigation and querystring', () => {
   beforeAll(async () => {
     next = await createNext({
       files: new FileRef(__dirname),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-        typescript: 'latest',
-        '@types/react': 'latest',
-        '@types/node': 'latest',
-      },
     })
   })
   afterAll(() => next.destroy())

--- a/test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts
+++ b/test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts
@@ -9,13 +9,6 @@ describe('useSelectedLayoutSegment(s)', () => {
   beforeAll(async () => {
     next = await createNext({
       files: new FileRef(__dirname),
-      dependencies: {
-        react: 'latest',
-        'react-dom': 'latest',
-        typescript: 'latest',
-        '@types/react': 'latest',
-        '@types/node': 'latest',
-      },
     })
   })
   afterAll(() => next.destroy())

--- a/test/e2e/new-link-behavior/typescript.test.ts
+++ b/test/e2e/new-link-behavior/typescript.test.ts
@@ -17,11 +17,6 @@ describe('New Link Behavior', () => {
         'tsconfig.json': new FileRef(path.join(appDir, 'tsconfig.json')),
         'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
       },
-      dependencies: {
-        typescript: '*',
-        '@types/react': '*',
-        '@types/node': '*',
-      },
     })
   })
   afterAll(() => next.destroy())

--- a/test/e2e/test-utils-tests/basic/basic.test.ts
+++ b/test/e2e/test-utils-tests/basic/basic.test.ts
@@ -1,4 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { fetchViaHTTP } from 'next-test-utils'
 

--- a/test/e2e/test-utils-tests/basic/basic.test.ts
+++ b/test/e2e/test-utils-tests/basic/basic.test.ts
@@ -7,12 +7,7 @@ describe('createNext', () => {
 
   beforeAll(async () => {
     next = await createNext({
-      files: new FileRef(__dirname),
-      dependencies: {
-        typescript: 'latest',
-        '@types/react': 'latest',
-        '@types/node': 'latest',
-      },
+      files: __dirname,
     })
   })
   afterAll(() => next.destroy())

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -129,6 +129,9 @@ export class NextInstance {
         const finalDependencies = {
           react: reactVersion,
           'react-dom': reactVersion,
+          '@types/react': reactVersion,
+          typescript: 'latest',
+          '@types/node': 'latest',
           ...this.dependencies,
           ...this.packageJson?.dependencies,
         }

--- a/test/production/ci-missing-typescript-deps/index.test.ts
+++ b/test/production/ci-missing-typescript-deps/index.test.ts
@@ -14,6 +14,9 @@ describe('ci-missing-typescript-deps', () => {
         CI: '1',
       },
       skipStart: true,
+      dependencies: {
+        typescript: undefined,
+      },
     })
     try {
       let error


### PR DESCRIPTION
We want to make tests primarily in Typescript.
currently, we need to specify custom dependencies in `createNextDescribe`.
This change would allow TS to be used in the default configuration.