### PR TITLE
Wrap CSS variable in var

### DIFF
--- a/packages/create-next-app/templates/app/js/app/globals.css
+++ b/packages/create-next-app/templates/app/js/app/globals.css
@@ -86,7 +86,7 @@ body {
 }
 
 body {
-  color: rbg(--foreground-rgb);
+  color: rbg(var(--foreground-rgb));
   background: linear-gradient(
       to bottom,
       transparent,

--- a/packages/create-next-app/templates/app/js/app/globals.css
+++ b/packages/create-next-app/templates/app/js/app/globals.css
@@ -86,7 +86,7 @@ body {
 }
 
 body {
-  color: rbg(var(--foreground-rgb));
+  color: rgb(var(--foreground-rgb));
   background: linear-gradient(
       to bottom,
       transparent,

--- a/packages/create-next-app/templates/app/ts/app/globals.css
+++ b/packages/create-next-app/templates/app/ts/app/globals.css
@@ -86,7 +86,7 @@ body {
 }
 
 body {
-  color: rbg(--foreground-rgb);
+  color: rbg(var(--foreground-rgb));
   background: linear-gradient(
       to bottom,
       transparent,

--- a/packages/create-next-app/templates/app/ts/app/globals.css
+++ b/packages/create-next-app/templates/app/ts/app/globals.css
@@ -86,7 +86,7 @@ body {
 }
 
 body {
-  color: rbg(var(--foreground-rgb));
+  color: rgb(var(--foreground-rgb));
   background: linear-gradient(
       to bottom,
       transparent,

--- a/packages/create-next-app/templates/default/js/styles/globals.css
+++ b/packages/create-next-app/templates/default/js/styles/globals.css
@@ -86,7 +86,7 @@ body {
 }
 
 body {
-  color: rbg(--foreground-rgb);
+  color: rbg(var(--foreground-rgb));
   background: linear-gradient(
       to bottom,
       transparent,

--- a/packages/create-next-app/templates/default/js/styles/globals.css
+++ b/packages/create-next-app/templates/default/js/styles/globals.css
@@ -86,7 +86,7 @@ body {
 }
 
 body {
-  color: rbg(var(--foreground-rgb));
+  color: rgb(var(--foreground-rgb));
   background: linear-gradient(
       to bottom,
       transparent,

--- a/packages/create-next-app/templates/default/ts/styles/globals.css
+++ b/packages/create-next-app/templates/default/ts/styles/globals.css
@@ -86,7 +86,7 @@ body {
 }
 
 body {
-  color: rbg(--foreground-rgb);
+  color: rbg(var(--foreground-rgb));
   background: linear-gradient(
       to bottom,
       transparent,

--- a/packages/create-next-app/templates/default/ts/styles/globals.css
+++ b/packages/create-next-app/templates/default/ts/styles/globals.css
@@ -86,7 +86,7 @@ body {
 }
 
 body {
-  color: rbg(var(--foreground-rgb));
+  color: rgb(var(--foreground-rgb));
   background: linear-gradient(
       to bottom,
       transparent,


### PR DESCRIPTION
Adds missing CSS var() wrapper + spelling error, caught in [Discussion #9094](https://github.com/vercel/vercel/discussions/9094). 

Closes: #44126
Closes: https://github.com/vercel/next.js/pull/44127 

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
