### PR TITLE
Remove devcontainer network host argument

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,8 +32,6 @@
     // Github latest can't be installed due to GPG issues: https://github.com/cli/cli/discussions/6222
     // "github-cli": "latest",
   },
-  // This is needed for forwarding X11: https://github.com/microsoft/vscode-remote-release/issues/3841
-  "runArgs": ["--net=host"],
   "remoteEnv": {
     "DISPLAY": ":0"
   }


### PR DESCRIPTION
This removes the `--net=host` argument passed to the devcontainer. Originally introduced for X11 forwarding, devcontainer already passes `--network host` argument doing the same [thing](https://stackoverflow.com/q/50644889/8429267)?
Check the build logs
```
Start: Run: docker run --sig-proxy=false -a STDOUT -a STDERR --mount type=bind,src=/var/lib/docker/codespacemount/workspace,dst=/workspaces --mount source=/root/.codespaces/shared,target=/workspaces/.codespaces/shared,type=bind --mount source=/var/lib/docker/codespacemount/.persistedshare,target=/workspaces/.codespaces/.persistedshare,type=bind --mount source=/.codespaces/agent/mount,target=/.codespaces/bin,type=bind --mount source=/mnt/containerTmp,target=/tmp,type=bind --mount type=bind,src=/.codespaces/agent/mount/cache,dst=/vscode -l Type=codespaces -e CODESPACES=true -e ContainerVersion=12 -e RepositoryName=next.js --label ContainerVersion=12 --hostname codespaces-9b31fb --add-host codespaces-9b31fb:127.0.0.1 --cap-add sys_nice --network host --cap-add SYS_PTRACE --security-opt seccomp=unconfined --entrypoint /bin/sh vsc-next.js-e4966344b9ebb252cd82cad8e4b143f1 -c echo Container started
```
[Refer](https://github.com/vercel/next.js/pull/43138#issuecomment-1328026282) for original issue with the current configuration. Closes #43451

P.S. Why do we have X11 support in devcontainers in the first place? Its not something *most* people will use, especially if it comes with the cost of codespaces not working. Need someone to verify if X11 forwarding still works with this configuration as it probably should.