### PR TITLE
Ensure next.url is used instead of next.appPort

### DIFF
--- a/test/development/acceptance-app/helpers.ts
+++ b/test/development/acceptance-app/helpers.ts
@@ -20,7 +20,7 @@ export async function sandbox(
     }
   }
   await next.start()
-  const browser = await webdriver(next.appPort, '/')
+  const browser = await webdriver(next.url, '/')
   return {
     browser,
     session: {

--- a/test/development/acceptance/helpers.ts
+++ b/test/development/acceptance/helpers.ts
@@ -29,7 +29,7 @@ export async function sandbox(
     }
   }
   await next.start()
-  const browser = await webdriver(next.appPort, '/')
+  const browser = await webdriver(next.url, '/')
   return {
     session: {
       async write(filename, content) {

--- a/test/development/basic-basepath/hmr.test.ts
+++ b/test/development/basic-basepath/hmr.test.ts
@@ -36,7 +36,7 @@ describe('basic HMR', () => {
         const newContactPagePath = join('pages', 'hmr', '_contact.js')
         let browser
         try {
-          browser = await webdriver(next.appPort, '/docs/hmr/contact')
+          browser = await webdriver(next.url, '/docs/hmr/contact')
           const text = await browser.elementByCss('p').text()
           expect(text).toBe('This is the contact page.')
 
@@ -71,7 +71,7 @@ describe('basic HMR', () => {
       it('should detect the changes and display it', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/docs/hmr/about')
+          browser = await webdriver(next.url, '/docs/hmr/about')
           const text = await browser.elementByCss('p').text()
           expect(text).toBe('This is the about page.')
 
@@ -106,7 +106,7 @@ describe('basic HMR', () => {
       it('should not reload unrelated pages', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/docs/hmr/counter')
+          browser = await webdriver(next.url, '/docs/hmr/counter')
           const text = await browser
             .elementByCss('button')
             .click()
@@ -146,7 +146,7 @@ describe('basic HMR', () => {
       it('should update styles correctly', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/docs/hmr/style')
+          browser = await webdriver(next.url, '/docs/hmr/style')
           const pTag = await browser.elementByCss('.hmr-style-page p')
           const initialFontSize = await pTag.getComputedCss('font-size')
 
@@ -186,7 +186,7 @@ describe('basic HMR', () => {
         const originalContent = await next.readFile(pagePath)
         try {
           browser = await webdriver(
-            next.appPort,
+            next.url,
             '/docs/hmr/style-stateful-component'
           )
           const pTag = await browser.elementByCss('.hmr-style-page p')
@@ -220,7 +220,7 @@ describe('basic HMR', () => {
         const originalContent = await next.readFile(pagePath)
         try {
           browser = await webdriver(
-            next.appPort,
+            next.url,
             '/docs/hmr/style-dynamic-component'
           )
           const div = await browser.elementByCss('#dynamic-component')
@@ -230,7 +230,7 @@ describe('basic HMR', () => {
           expect(initialFontSize).toBe('100px')
 
           const initialHtml = await renderViaHTTP(
-            next.appPort,
+            next.url,
             '/docs/hmr/style-dynamic-component'
           )
           expect(initialHtml.includes('100px')).toBeTruthy()
@@ -250,7 +250,7 @@ describe('basic HMR', () => {
           await waitFor(5000)
 
           secondBrowser = await webdriver(
-            next.appPort,
+            next.url,
             '/docs/hmr/style-dynamic-component'
           )
           // Check whether the this page has reloaded or not.
@@ -268,7 +268,7 @@ describe('basic HMR', () => {
           expect(browserHtml.includes('font-size:100px')).toBe(false)
 
           const editedHtml = await renderViaHTTP(
-            next.appPort,
+            next.url,
             '/docs/hmr/style-dynamic-component'
           )
           expect(editedHtml.includes('200px')).toBeTruthy()
@@ -300,7 +300,7 @@ describe('basic HMR', () => {
       const newPage = join('pages', 'hmr', 'new-page.js')
 
       try {
-        browser = await webdriver(next.appPort, '/docs/hmr/new-page')
+        browser = await webdriver(next.url, '/docs/hmr/new-page')
 
         expect(await browser.elementByCss('body').text()).toMatch(
           /This page could not be found/
@@ -335,7 +335,7 @@ describe('basic HMR', () => {
       const aboutPage = join('pages', 'hmr', 'about2.js')
       const aboutContent = await next.readFile(aboutPage)
       try {
-        browser = await webdriver(next.appPort, '/docs/hmr/about2')
+        browser = await webdriver(next.url, '/docs/hmr/about2')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(aboutPage, aboutContent.replace('</div>', 'div'))
@@ -368,14 +368,14 @@ describe('basic HMR', () => {
       const aboutContent = await next.readFile(aboutPage)
       let browser
       try {
-        await renderViaHTTP(next.appPort, '/docs/hmr/about2')
+        await renderViaHTTP(next.url, '/docs/hmr/about2')
 
         await next.patchFile(aboutPage, aboutContent.replace('</div>', 'div'))
 
         // Ensure dev server has time to break:
         await new Promise((resolve) => setTimeout(resolve, 2000))
 
-        browser = await webdriver(next.appPort, '/docs/hmr/contact')
+        browser = await webdriver(next.url, '/docs/hmr/contact')
 
         expect(await hasRedbox(browser)).toBe(true)
         expect(await getRedboxSource(browser)).toMatch(/Unexpected eof/)
@@ -408,7 +408,7 @@ describe('basic HMR', () => {
       const aboutPage = join('pages', 'hmr', 'about3.js')
       const aboutContent = await next.readFile(aboutPage)
       try {
-        browser = await webdriver(next.appPort, '/docs/hmr/about3')
+        browser = await webdriver(next.url, '/docs/hmr/about3')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(
@@ -435,7 +435,7 @@ describe('basic HMR', () => {
       const aboutPage = join('pages', 'hmr', 'about4.js')
       const aboutContent = await next.readFile(aboutPage)
       try {
-        browser = await webdriver(next.appPort, '/docs/hmr/about4')
+        browser = await webdriver(next.url, '/docs/hmr/about4')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(
@@ -474,7 +474,7 @@ describe('basic HMR', () => {
       const aboutPage = join('pages', 'hmr', 'about5.js')
       const aboutContent = await next.readFile(aboutPage)
       try {
-        browser = await webdriver(next.appPort, '/docs/hmr/about5')
+        browser = await webdriver(next.url, '/docs/hmr/about5')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(
@@ -521,7 +521,7 @@ describe('basic HMR', () => {
       const aboutPage = join('pages', 'hmr', 'about6.js')
       const aboutContent = await next.readFile(aboutPage)
       try {
-        browser = await webdriver(next.appPort, '/docs/hmr/about6')
+        browser = await webdriver(next.url, '/docs/hmr/about6')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(
@@ -565,7 +565,7 @@ describe('basic HMR', () => {
 
       const aboutContent = await next.readFile(aboutPage)
       try {
-        browser = await webdriver(next.appPort, '/docs/hmr/about7')
+        browser = await webdriver(next.url, '/docs/hmr/about7')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(
@@ -613,7 +613,7 @@ describe('basic HMR', () => {
       const erroredPage = join('pages', 'hmr', 'error-in-gip.js')
       const errorContent = await next.readFile(erroredPage)
       try {
-        browser = await webdriver(next.appPort, '/docs/hmr')
+        browser = await webdriver(next.url, '/docs/hmr')
         await browser.elementByCss('#error-in-gip-link').click()
 
         expect(await hasRedbox(browser)).toBe(true)
@@ -658,7 +658,7 @@ describe('basic HMR', () => {
       const erroredPage = join('pages', 'hmr', 'error-in-gip.js')
       const errorContent = await next.readFile(erroredPage)
       try {
-        browser = await webdriver(next.appPort, '/docs/hmr/error-in-gip')
+        browser = await webdriver(next.url, '/docs/hmr/error-in-gip')
 
         expect(await hasRedbox(browser)).toBe(true)
         expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`

--- a/test/development/basic-basepath/misc.test.ts
+++ b/test/development/basic-basepath/misc.test.ts
@@ -22,17 +22,17 @@ describe('misc basic dev tests', () => {
   afterAll(() => next.destroy())
 
   it('should set process.env.NODE_ENV in development', async () => {
-    const browser = await webdriver(next.appPort, '/docs/process-env')
+    const browser = await webdriver(next.url, '/docs/process-env')
     const nodeEnv = await browser.elementByCss('#node-env').text()
     expect(nodeEnv).toBe('development')
     await browser.close()
   })
 
   it('should allow access to public files', async () => {
-    const data = await renderViaHTTP(next.appPort, '/docs/data/data.txt')
+    const data = await renderViaHTTP(next.url, '/docs/data/data.txt')
     expect(data).toBe('data')
 
-    const legacy = await renderViaHTTP(next.appPort, '/docs/static/legacy.txt')
+    const legacy = await renderViaHTTP(next.url, '/docs/static/legacy.txt')
     expect(legacy).toMatch(`new static folder`)
   })
 
@@ -43,7 +43,7 @@ describe('misc basic dev tests', () => {
         `/docs/_next/static/../routes-manifest.json`,
       ]
       for (const path of pathsToCheck) {
-        const res = await fetchViaHTTP(next.appPort, path)
+        const res = await fetchViaHTTP(next.url, path)
         const text = await res.text()
         try {
           expect(res.status).toBe(404)
@@ -56,7 +56,7 @@ describe('misc basic dev tests', () => {
 
     it('should handle encoded / value for trailing slash correctly', async () => {
       const res = await fetchViaHTTP(
-        next.appPort,
+        next.url,
         '/docs/%2fexample.com/',
         undefined,
         { redirect: 'manual' }
@@ -77,7 +77,7 @@ describe('misc basic dev tests', () => {
     let foundLog = false
     let browser
     try {
-      browser = await webdriver(next.appPort, path)
+      browser = await webdriver(next.url, path)
       const browserLogs = await browser.log('browser')
 
       browserLogs.forEach((log) => {

--- a/test/development/basic-basepath/next-dynamic.test.ts
+++ b/test/development/basic-basepath/next-dynamic.test.ts
@@ -22,7 +22,7 @@ describe('basic next/dynamic usage', () => {
   afterAll(() => next.destroy())
 
   async function get$(path, query?: any) {
-    const html = await renderViaHTTP(next.appPort, path, query)
+    const html = await renderViaHTTP(next.url, path, query)
     return cheerio.load(html)
   }
 
@@ -49,7 +49,7 @@ describe('basic next/dynamic usage', () => {
       it('should render even there are no physical chunk exists', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/docs/dynamic/no-chunk')
+          browser = await webdriver(next.url, '/docs/dynamic/no-chunk')
           await check(
             () => browser.elementByCss('body').text(),
             /Welcome, normal/
@@ -68,7 +68,7 @@ describe('basic next/dynamic usage', () => {
       it('should hydrate nested chunks', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/docs/dynamic/nested')
+          browser = await webdriver(next.url, '/docs/dynamic/nested')
           await check(() => browser.elementByCss('body').text(), /Nested 1/)
           await check(() => browser.elementByCss('body').text(), /Nested 2/)
           await check(
@@ -95,7 +95,7 @@ describe('basic next/dynamic usage', () => {
       it('should render the component Head content', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/docs/dynamic/head')
+          browser = await webdriver(next.url, '/docs/dynamic/head')
           await check(() => browser.elementByCss('body').text(), /test/)
           const backgroundColor = await browser
             .elementByCss('.dynamic-style')
@@ -122,7 +122,7 @@ describe('basic next/dynamic usage', () => {
       it('should render the component on client side', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/docs/dynamic/no-ssr')
+          browser = await webdriver(next.url, '/docs/dynamic/no-ssr')
           await check(
             () => browser.elementByCss('body').text(),
             /Hello World 1/
@@ -154,7 +154,7 @@ describe('basic next/dynamic usage', () => {
       it('should render the component on client side', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/docs/dynamic/ssr-true')
+          browser = await webdriver(next.url, '/docs/dynamic/ssr-true')
           await check(
             () => browser.elementByCss('body').text(),
             /Hello World 1/
@@ -177,7 +177,7 @@ describe('basic next/dynamic usage', () => {
       it('should render the component on client side', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/docs/dynamic/chunkfilename')
+          browser = await webdriver(next.url, '/docs/dynamic/chunkfilename')
           await check(
             () => browser.elementByCss('body').text(),
             /test chunkfilename/
@@ -200,7 +200,7 @@ describe('basic next/dynamic usage', () => {
         let browser
         try {
           browser = await webdriver(
-            next.appPort,
+            next.url,
             '/docs/dynamic/no-ssr-custom-loading'
           )
           await check(
@@ -226,10 +226,7 @@ describe('basic next/dynamic usage', () => {
       it('should only load the rendered module in the browser', async () => {
         let browser
         try {
-          browser = await webdriver(
-            next.appPort,
-            '/docs/dynamic/multiple-modules'
-          )
+          browser = await webdriver(next.url, '/docs/dynamic/multiple-modules')
           const html = await browser.eval('document.documentElement.innerHTML')
           expect(html).toMatch(/hello1\.js/)
           expect(html).not.toMatch(/hello2\.js/)

--- a/test/development/basic/define-class-fields.test.ts
+++ b/test/development/basic/define-class-fields.test.ts
@@ -30,7 +30,7 @@ describe('useDefineForClassFields SWC option', () => {
   it('tsx should compile with useDefineForClassFields enabled', async () => {
     let browser
     try {
-      browser = await webdriver(next.appPort, '/')
+      browser = await webdriver(next.url, '/')
       await browser.elementByCss('#action').click()
       await check(
         () => browser.elementByCss('#name').text(),
@@ -46,7 +46,7 @@ describe('useDefineForClassFields SWC option', () => {
   it("Initializes resident to undefined after the call to 'super()' when with useDefineForClassFields enabled", async () => {
     let browser
     try {
-      browser = await webdriver(next.appPort, '/animal')
+      browser = await webdriver(next.url, '/animal')
       expect(await browser.elementByCss('#dog').text()).toBe('')
       expect(await browser.elementByCss('#dogDecl').text()).toBe('dog')
     } finally {
@@ -76,7 +76,7 @@ describe('useDefineForClassFields SWC option', () => {
   it('set accessors from base classes won’t get triggered with useDefineForClassFields enabled', async () => {
     let browser
     try {
-      browser = await webdriver(next.appPort, '/derived')
+      browser = await webdriver(next.url, '/derived')
       await matchLogs$(browser).then(([data_foundLog, name_foundLog]) => {
         expect(data_foundLog).toBe(true)
         expect(name_foundLog).toBe(false)

--- a/test/development/basic/emotion-swc.test.ts
+++ b/test/development/basic/emotion-swc.test.ts
@@ -29,7 +29,7 @@ describe('emotion SWC option', () => {
   it('should have styling from the css prop', async () => {
     let browser
     try {
-      browser = await webdriver(next.appPort, '/')
+      browser = await webdriver(next.url, '/')
       const color = await browser
         .elementByCss('#test-element')
         .getComputedCss('background-color')

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -78,7 +78,7 @@ describe('basic HMR', () => {
         let browser
         try {
           const start = next.cliOutput.length
-          browser = await webdriver(next.appPort, '/hmr/contact')
+          browser = await webdriver(next.url, '/hmr/contact')
           const text = await browser.elementByCss('p').text()
           expect(text).toBe('This is the contact page.')
 
@@ -121,7 +121,7 @@ describe('basic HMR', () => {
       it('should detect the changes and display it', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/hmr/about')
+          browser = await webdriver(next.url, '/hmr/about')
           const text = await browser.elementByCss('p').text()
           expect(text).toBe('This is the about page.')
 
@@ -156,7 +156,7 @@ describe('basic HMR', () => {
       it('should not reload unrelated pages', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/hmr/counter')
+          browser = await webdriver(next.url, '/hmr/counter')
           const text = await browser
             .elementByCss('button')
             .click()
@@ -196,7 +196,7 @@ describe('basic HMR', () => {
       it('should update styles correctly', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/hmr/style')
+          browser = await webdriver(next.url, '/hmr/style')
           const pTag = await browser.elementByCss('.hmr-style-page p')
           const initialFontSize = await pTag.getComputedCss('font-size')
 
@@ -235,10 +235,7 @@ describe('basic HMR', () => {
         const pagePath = join('pages', 'hmr', 'style-stateful-component.js')
         const originalContent = await next.readFile(pagePath)
         try {
-          browser = await webdriver(
-            next.appPort,
-            '/hmr/style-stateful-component'
-          )
+          browser = await webdriver(next.url, '/hmr/style-stateful-component')
           const pTag = await browser.elementByCss('.hmr-style-page p')
           const initialFontSize = await pTag.getComputedCss('font-size')
 
@@ -269,10 +266,7 @@ describe('basic HMR', () => {
         const pagePath = join('components', 'hmr', 'dynamic.js')
         const originalContent = await next.readFile(pagePath)
         try {
-          browser = await webdriver(
-            next.appPort,
-            '/hmr/style-dynamic-component'
-          )
+          browser = await webdriver(next.url, '/hmr/style-dynamic-component')
           const div = await browser.elementByCss('#dynamic-component')
           const initialClientClassName = await div.getAttribute('class')
           const initialFontSize = await div.getComputedCss('font-size')
@@ -280,7 +274,7 @@ describe('basic HMR', () => {
           expect(initialFontSize).toBe('100px')
 
           const initialHtml = await renderViaHTTP(
-            next.appPort,
+            next.url,
             '/hmr/style-dynamic-component'
           )
           expect(initialHtml.includes('100px')).toBeTruthy()
@@ -300,7 +294,7 @@ describe('basic HMR', () => {
           await waitFor(5000)
 
           secondBrowser = await webdriver(
-            next.appPort,
+            next.url,
             '/hmr/style-dynamic-component'
           )
           // Check whether the this page has reloaded or not.
@@ -318,7 +312,7 @@ describe('basic HMR', () => {
           expect(browserHtml.includes('font-size:100px')).toBe(false)
 
           const editedHtml = await renderViaHTTP(
-            next.appPort,
+            next.url,
             '/hmr/style-dynamic-component'
           )
           expect(editedHtml.includes('200px')).toBeTruthy()
@@ -351,7 +345,7 @@ describe('basic HMR', () => {
 
       try {
         const start = next.cliOutput.length
-        browser = await webdriver(next.appPort, '/hmr/new-page')
+        browser = await webdriver(next.url, '/hmr/new-page')
 
         expect(await browser.elementByCss('body').text()).toMatch(
           /This page could not be found/
@@ -394,7 +388,7 @@ describe('basic HMR', () => {
       const aboutContent = await next.readFile(aboutPage)
       try {
         const start = next.cliOutput.length
-        browser = await webdriver(next.appPort, '/hmr/about2')
+        browser = await webdriver(next.url, '/hmr/about2')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(aboutPage, aboutContent.replace('</div>', 'div'))
@@ -433,14 +427,14 @@ describe('basic HMR', () => {
       const aboutContent = await next.readFile(aboutPage)
       let browser
       try {
-        await renderViaHTTP(next.appPort, '/hmr/about2')
+        await renderViaHTTP(next.url, '/hmr/about2')
 
         await next.patchFile(aboutPage, aboutContent.replace('</div>', 'div'))
 
         // Ensure dev server has time to break:
         await new Promise((resolve) => setTimeout(resolve, 2000))
 
-        browser = await webdriver(next.appPort, '/hmr/contact')
+        browser = await webdriver(next.url, '/hmr/contact')
 
         expect(await hasRedbox(browser)).toBe(true)
         expect(await getRedboxSource(browser)).toMatch(/Unexpected eof/)
@@ -473,7 +467,7 @@ describe('basic HMR', () => {
       const aboutPage = join('pages', 'hmr', 'about3.js')
       const aboutContent = await next.readFile(aboutPage)
       try {
-        browser = await webdriver(next.appPort, '/hmr/about3')
+        browser = await webdriver(next.url, '/hmr/about3')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(
@@ -500,7 +494,7 @@ describe('basic HMR', () => {
       const aboutPage = join('pages', 'hmr', 'about4.js')
       const aboutContent = await next.readFile(aboutPage)
       try {
-        browser = await webdriver(next.appPort, '/hmr/about4')
+        browser = await webdriver(next.url, '/hmr/about4')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(
@@ -539,7 +533,7 @@ describe('basic HMR', () => {
       const aboutPage = join('pages', 'hmr', 'about5.js')
       const aboutContent = await next.readFile(aboutPage)
       try {
-        browser = await webdriver(next.appPort, '/hmr/about5')
+        browser = await webdriver(next.url, '/hmr/about5')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(
@@ -586,7 +580,7 @@ describe('basic HMR', () => {
       const aboutPage = join('pages', 'hmr', 'about6.js')
       const aboutContent = await next.readFile(aboutPage)
       try {
-        browser = await webdriver(next.appPort, '/hmr/about6')
+        browser = await webdriver(next.url, '/hmr/about6')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(
@@ -630,7 +624,7 @@ describe('basic HMR', () => {
 
       const aboutContent = await next.readFile(aboutPage)
       try {
-        browser = await webdriver(next.appPort, '/hmr/about7')
+        browser = await webdriver(next.url, '/hmr/about7')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
         await next.patchFile(
@@ -678,7 +672,7 @@ describe('basic HMR', () => {
       const erroredPage = join('pages', 'hmr', 'error-in-gip.js')
       const errorContent = await next.readFile(erroredPage)
       try {
-        browser = await webdriver(next.appPort, '/hmr')
+        browser = await webdriver(next.url, '/hmr')
         await browser.elementByCss('#error-in-gip-link').click()
 
         expect(await hasRedbox(browser)).toBe(true)
@@ -723,7 +717,7 @@ describe('basic HMR', () => {
       const erroredPage = join('pages', 'hmr', 'error-in-gip.js')
       const errorContent = await next.readFile(erroredPage)
       try {
-        browser = await webdriver(next.appPort, '/hmr/error-in-gip')
+        browser = await webdriver(next.url, '/hmr/error-in-gip')
 
         expect(await hasRedbox(browser)).toBe(true)
         expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
@@ -770,10 +764,7 @@ describe('basic HMR', () => {
   describe('Full reload', () => {
     it('should warn about full reload in cli output - anonymous page function', async () => {
       const start = next.cliOutput.length
-      const browser = await webdriver(
-        next.appPort,
-        `/hmr/anonymous-page-function`
-      )
+      const browser = await webdriver(next.url, `/hmr/anonymous-page-function`)
       const cliWarning =
         'Fast Refresh had to perform a full reload when ./pages/hmr/anonymous-page-function.js changed. Read more: https://nextjs.org/docs/messages/fast-refresh-reload'
 
@@ -812,7 +803,7 @@ describe('basic HMR', () => {
 
     it('should warn about full reload in cli output - runtime-error', async () => {
       const start = next.cliOutput.length
-      const browser = await webdriver(next.appPort, `/hmr/runtime-error`)
+      const browser = await webdriver(next.url, `/hmr/runtime-error`)
       const cliWarning =
         'Fast Refresh had to perform a full reload due to a runtime error.'
 

--- a/test/development/basic/legacy-decorators.test.ts
+++ b/test/development/basic/legacy-decorators.test.ts
@@ -26,7 +26,7 @@ describe('Legacy decorators SWC option', () => {
   it('should compile with legacy decorators enabled', async () => {
     let browser
     try {
-      browser = await webdriver(next.appPort, '/')
+      browser = await webdriver(next.url, '/')
       const text = await browser.elementByCss('#count').text()
       expect(text).toBe('Current number: 0')
       await browser.elementByCss('#increase').click()

--- a/test/development/basic/misc.test.ts
+++ b/test/development/basic/misc.test.ts
@@ -19,17 +19,17 @@ describe('misc basic dev tests', () => {
   afterAll(() => next.destroy())
 
   it('should set process.env.NODE_ENV in development', async () => {
-    const browser = await webdriver(next.appPort, '/process-env')
+    const browser = await webdriver(next.url, '/process-env')
     const nodeEnv = await browser.elementByCss('#node-env').text()
     expect(nodeEnv).toBe('development')
     await browser.close()
   })
 
   it('should allow access to public files', async () => {
-    const data = await renderViaHTTP(next.appPort, '/data/data.txt')
+    const data = await renderViaHTTP(next.url, '/data/data.txt')
     expect(data).toBe('data')
 
-    const legacy = await renderViaHTTP(next.appPort, '/static/legacy.txt')
+    const legacy = await renderViaHTTP(next.url, '/static/legacy.txt')
     expect(legacy).toMatch(`new static folder`)
   })
 
@@ -40,7 +40,7 @@ describe('misc basic dev tests', () => {
         `/_next/static/../routes-manifest.json`,
       ]
       for (const path of pathsToCheck) {
-        const res = await fetchViaHTTP(next.appPort, path)
+        const res = await fetchViaHTTP(next.url, path)
         const text = await res.text()
         try {
           expect(res.status).toBe(404)
@@ -52,12 +52,9 @@ describe('misc basic dev tests', () => {
     })
 
     it('should handle encoded / value for trailing slash correctly', async () => {
-      const res = await fetchViaHTTP(
-        next.appPort,
-        '/%2fexample.com/',
-        undefined,
-        { redirect: 'manual' }
-      )
+      const res = await fetchViaHTTP(next.url, '/%2fexample.com/', undefined, {
+        redirect: 'manual',
+      })
 
       const { pathname, hostname } = url.parse(
         res.headers.get('location') || ''
@@ -74,7 +71,7 @@ describe('misc basic dev tests', () => {
     let foundLog = false
     let browser
     try {
-      browser = await webdriver(next.appPort, path)
+      browser = await webdriver(next.url, path)
       const browserLogs = await browser.log('browser')
 
       browserLogs.forEach((log) => {

--- a/test/development/basic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic.test.ts
@@ -19,7 +19,7 @@ describe('basic next/dynamic usage', () => {
   afterAll(() => next.destroy())
 
   async function get$(path, query?: any) {
-    const html = await renderViaHTTP(next.appPort, path, query)
+    const html = await renderViaHTTP(next.url, path, query)
     return cheerio.load(html)
   }
 
@@ -46,7 +46,7 @@ describe('basic next/dynamic usage', () => {
       it('should render even there are no physical chunk exists', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/dynamic/no-chunk')
+          browser = await webdriver(next.url, '/dynamic/no-chunk')
           await check(
             () => browser.elementByCss('body').text(),
             /Welcome, normal/
@@ -65,7 +65,7 @@ describe('basic next/dynamic usage', () => {
       it('should hydrate nested chunks', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/dynamic/nested')
+          browser = await webdriver(next.url, '/dynamic/nested')
           await check(() => browser.elementByCss('body').text(), /Nested 1/)
           await check(() => browser.elementByCss('body').text(), /Nested 2/)
           await check(
@@ -92,7 +92,7 @@ describe('basic next/dynamic usage', () => {
       it('should render the component Head content', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/dynamic/head')
+          browser = await webdriver(next.url, '/dynamic/head')
           await check(() => browser.elementByCss('body').text(), /test/)
           const backgroundColor = await browser
             .elementByCss('.dynamic-style')
@@ -119,7 +119,7 @@ describe('basic next/dynamic usage', () => {
       it('should render the component on client side', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/dynamic/no-ssr')
+          browser = await webdriver(next.url, '/dynamic/no-ssr')
           await check(
             () => browser.elementByCss('body').text(),
             /Hello World 1/
@@ -142,7 +142,7 @@ describe('basic next/dynamic usage', () => {
       it('should render the component on client side', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/dynamic/ssr-true')
+          browser = await webdriver(next.url, '/dynamic/ssr-true')
           await check(
             () => browser.elementByCss('body').text(),
             /Hello World 1/
@@ -174,7 +174,7 @@ describe('basic next/dynamic usage', () => {
       it('should render the component on client side', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/dynamic/chunkfilename')
+          browser = await webdriver(next.url, '/dynamic/chunkfilename')
           await check(
             () => browser.elementByCss('body').text(),
             /test chunkfilename/
@@ -196,10 +196,7 @@ describe('basic next/dynamic usage', () => {
       it('should render the component on client side', async () => {
         let browser
         try {
-          browser = await webdriver(
-            next.appPort,
-            '/dynamic/no-ssr-custom-loading'
-          )
+          browser = await webdriver(next.url, '/dynamic/no-ssr-custom-loading')
           await check(
             () => browser.elementByCss('body').text(),
             /Hello World 1/
@@ -223,7 +220,7 @@ describe('basic next/dynamic usage', () => {
       it('should only load the rendered module in the browser', async () => {
         let browser
         try {
-          browser = await webdriver(next.appPort, '/dynamic/multiple-modules')
+          browser = await webdriver(next.url, '/dynamic/multiple-modules')
           const html = await browser.eval('document.documentElement.innerHTML')
           expect(html).toMatch(/hello1\.js/)
           expect(html).not.toMatch(/hello2\.js/)

--- a/test/development/basic/styled-components-disabled.test.ts
+++ b/test/development/basic/styled-components-disabled.test.ts
@@ -41,10 +41,10 @@ describe.each([
   it('should have hydration mismatch with styled-components transform disabled', async () => {
     let browser
     try {
-      browser = await webdriver(next.appPort, '/')
+      browser = await webdriver(next.url, '/')
 
       // Compile /_error
-      await fetchViaHTTP(next.appPort, '/404')
+      await fetchViaHTTP(next.url, '/404')
 
       try {
         // Try 4 times to be sure there is no mismatch

--- a/test/development/basic/styled-components.test.ts
+++ b/test/development/basic/styled-components.test.ts
@@ -38,10 +38,10 @@ describe('styled-components SWC transform', () => {
   it('should not have hydration mismatch with styled-components transform enabled', async () => {
     let browser
     try {
-      browser = await webdriver(next.appPort, '/')
+      browser = await webdriver(next.url, '/')
 
       // Compile /_error
-      await fetchViaHTTP(next.appPort, '/404')
+      await fetchViaHTTP(next.url, '/404')
 
       // Try 4 times to be sure there is no mismatch
       expect(await matchLogs$(browser)).toBe(false)
@@ -59,7 +59,7 @@ describe('styled-components SWC transform', () => {
   })
 
   it('should render the page with correct styles', async () => {
-    const browser = await webdriver(next.appPort, '/')
+    const browser = await webdriver(next.url, '/')
 
     expect(
       await browser.eval(
@@ -75,7 +75,7 @@ describe('styled-components SWC transform', () => {
 
   it('should enable the display name transform by default', async () => {
     // make sure the index chunk gets generated
-    await webdriver(next.appPort, '/')
+    await webdriver(next.url, '/')
 
     const chunk = await next.readFile('.next/static/chunks/pages/index.js')
     expect(chunk).toContain('displayName: \\"pages__Button\\"')

--- a/test/development/basic/tailwind-jit.test.ts
+++ b/test/development/basic/tailwind-jit.test.ts
@@ -29,7 +29,7 @@ describe('TailwindCSS JIT', () => {
   it('works with JIT enabled', async () => {
     let browser
     try {
-      browser = await webdriver(next.appPort, '/')
+      browser = await webdriver(next.url, '/')
       const text = await browser.elementByCss('.text-6xl').text()
       expect(text).toMatch(/Welcome to/)
       const cssBlue = await browser

--- a/test/development/basic/theme-ui.test.ts
+++ b/test/development/basic/theme-ui.test.ts
@@ -23,7 +23,7 @@ describe('theme-ui SWC option', () => {
   it('should have theme provided styling', async () => {
     let browser
     try {
-      browser = await webdriver(next.appPort, '/')
+      browser = await webdriver(next.url, '/')
       const color = await browser.elementByCss('#hello').getComputedCss('color')
       expect(color).toBe('rgb(51, 51, 238)')
     } finally {

--- a/test/development/dotenv-default-expansion/index.test.ts
+++ b/test/development/dotenv-default-expansion/index.test.ts
@@ -23,7 +23,7 @@ describe('Dotenv default expansion', () => {
   afterAll(() => next.destroy())
 
   it('should work', async () => {
-    const browser = await webdriver(next.appPort, '/')
+    const browser = await webdriver(next.url, '/')
     const text = await browser.elementByCss('p').text()
     expect(text).toBe('default')
 

--- a/test/development/gssp-notfound/index.test.ts
+++ b/test/development/gssp-notfound/index.test.ts
@@ -25,7 +25,7 @@ describe('getServerSideProps returns notFound: true', () => {
   afterAll(() => next.destroy())
 
   it('should not poll indefinitely', async () => {
-    const browser = await webdriver(next.appPort, '/')
+    const browser = await webdriver(next.url, '/')
     await waitFor(3000)
     await browser.close()
     const logOccurrences = next.cliOutput.split('gssp called').length - 1

--- a/test/development/next-font/font-loader-in-document-error.test.ts
+++ b/test/development/next-font/font-loader-in-document-error.test.ts
@@ -20,7 +20,7 @@ describe('font-loader-in-document-error', () => {
   afterAll(() => next.destroy())
 
   test('@next/font inside _document', async () => {
-    const browser = await webdriver(next.appPort, '/')
+    const browser = await webdriver(next.url, '/')
     expect(await hasRedbox(browser, true)).toBeTrue()
     expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
       "pages/_document.js

--- a/test/e2e/basepath.test.ts
+++ b/test/e2e/basepath.test.ts
@@ -617,7 +617,7 @@ describe('basePath', () => {
       it('should navigate an absolute local url with basePath', async () => {
         const browser = await webdriver(
           next.url,
-          `${basePath}/absolute-url-basepath?port=${next.url}`
+          `${basePath}/absolute-url-basepath?port=${next.appPort}`
         )
         await browser.eval('window._didNotNavigate = true')
         await browser.waitForElementByCss('#absolute-link').click()
@@ -632,7 +632,7 @@ describe('basePath', () => {
       it('should navigate an absolute local url without basePath', async () => {
         const browser = await webdriver(
           next.url,
-          `${basePath}/absolute-url-no-basepath?port=${next.url}`
+          `${basePath}/absolute-url-no-basepath?port=${next.appPort}`
         )
         await browser.waitForElementByCss('#absolute-link').click()
         await check(

--- a/test/e2e/basepath.test.ts
+++ b/test/e2e/basepath.test.ts
@@ -617,7 +617,7 @@ describe('basePath', () => {
       it('should navigate an absolute local url with basePath', async () => {
         const browser = await webdriver(
           next.url,
-          `${basePath}/absolute-url-basepath?port=${next.appPort}`
+          `${basePath}/absolute-url-basepath?port=${next.url}`
         )
         await browser.eval('window._didNotNavigate = true')
         await browser.waitForElementByCss('#absolute-link').click()
@@ -632,7 +632,7 @@ describe('basePath', () => {
       it('should navigate an absolute local url without basePath', async () => {
         const browser = await webdriver(
           next.url,
-          `${basePath}/absolute-url-no-basepath?port=${next.appPort}`
+          `${basePath}/absolute-url-no-basepath?port=${next.url}`
         )
         await browser.waitForElementByCss('#absolute-link').click()
         await check(

--- a/test/production/app-dir-prefetch-non-iso-url/index.test.ts
+++ b/test/production/app-dir-prefetch-non-iso-url/index.test.ts
@@ -22,7 +22,7 @@ describe('app-dir-prefetch-non-iso-url', () => {
     let browser: BrowserInterface
 
     try {
-      browser = await webdriver(next.appPort, '/')
+      browser = await webdriver(next.url, '/')
       await browser.elementByCss('#to-iso').click()
       await check(() => browser.elementByCss('#page').text(), '/[slug]')
     } finally {
@@ -36,7 +36,7 @@ describe('app-dir-prefetch-non-iso-url', () => {
     let browser: BrowserInterface
 
     try {
-      browser = await webdriver(next.appPort, '/')
+      browser = await webdriver(next.url, '/')
       await browser.elementByCss('#to-non-iso').click()
       await check(() => browser.elementByCss('#page').text(), '/[slug]')
     } finally {

--- a/test/production/emit-decorator-metadata/index.test.ts
+++ b/test/production/emit-decorator-metadata/index.test.ts
@@ -28,7 +28,7 @@ describe('emitDecoratorMetadata SWC option', () => {
   it('should compile with emitDecoratorMetadata enabled', async () => {
     let browser: BrowserInterface
     try {
-      browser = await webdriver(next.appPort, '/')
+      browser = await webdriver(next.url, '/')
       const message = await browser.elementByCss('#message').text()
 
       expect(message).toBe('Hello, world!')

--- a/test/production/jest/remove-react-properties/remove-react-properties-jest.test.ts
+++ b/test/production/jest/remove-react-properties/remove-react-properties-jest.test.ts
@@ -49,7 +49,7 @@ describe('next/jest', () => {
   afterAll(() => next.destroy())
 
   it('data-testid should be removed in production', async () => {
-    const html = await renderViaHTTP(next.appPort, '/')
+    const html = await renderViaHTTP(next.url, '/')
 
     expect(html).not.toContain('data-testid')
   })


### PR DESCRIPTION
`appPort` shouldn't be used unless absolutely necessary as `next.url` is more specific and allows more control. 

x-ref: https://github.com/vercel/next.js/actions/runs/3734223762/jobs/6336069606
