### PR TITLE
Fix styled-components setup in turbo example

### DIFF
--- a/examples/with-turbopack/lib/styling.tsx
+++ b/examples/with-turbopack/lib/styling.tsx
@@ -9,11 +9,12 @@ export function useStyledComponentsRegistry() {
 
   const styledComponentsFlushEffect = () => {
     const styles = styledComponentsStyleSheet.getStyleElement();
-    styledComponentsStyleSheet.seal();
+    styledComponentsStyleSheet.instance.clearTag();
     return <>{styles}</>;
   };
 
   function StyledComponentsRegistry({ children }: ChildProps) {
+    if (typeof window !== 'undefined') return <>{children}</>;
     return (
       <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
         {children as React.ReactChild}

--- a/test/e2e/app-dir/rsc-basic/app/root-style-registry.js
+++ b/test/e2e/app-dir/rsc-basic/app/root-style-registry.js
@@ -29,9 +29,15 @@ export default function RootStyleRegistry({ children }) {
     return <>{styledComponentsFlushEffect()}</>
   })
 
-  return (
-    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
-      <StyleRegistry registry={jsxStyleRegistry}>{children}</StyleRegistry>
-    </StyleSheetManager>
+  const child = (
+    <StyleRegistry registry={jsxStyleRegistry}>{children}</StyleRegistry>
   )
+  if (typeof window === 'undefined') {
+    return (
+      <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
+        {child}
+      </StyleSheetManager>
+    )
+  }
+  return child
 }


### PR DESCRIPTION
Closes: #44164

Sync to the latest setup doc on https://beta.nextjs.org/docs/styling/css-in-js#styled-components

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
