### PR TITLE
Fix test template example

### DIFF
--- a/test/e2e/example.txt
+++ b/test/e2e/example.txt
@@ -15,7 +15,7 @@ createNextDescribe(
     // Recommended for tests that need a full browser
     it('should work using browser', async () => {
       const browser = await next.browser('/')
-      expect(await browser.getElementByCss('p').text()).toBe('hello world')
+      expect(await browser.elementByCss('p').text()).toBe('hello world')
     })
 
     // In case you need the full HTML. Can also use $.html() with cheerio.


### PR DESCRIPTION
- Fixes typo from #44147 

`getElementByCss` => `elementByCss`