### PR TITLE
Fix pnpm install on Azure

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24000,7 +24000,7 @@ packages:
     dev: true
 
   github.com/watson/ci-info/f43f6a1cefff47fb361c88cf4b943fdbcaafe540:
-    resolution: {commit: f43f6a1cefff47fb361c88cf4b943fdbcaafe540, repo: git+ssh://git@github.com/watson/ci-info.git, type: git}
+    resolution: {tarball: https://codeload.github.com/watson/ci-info/tar.gz/f43f6a1cefff47fb361c88cf4b943fdbcaafe540}
     name: ci-info
     version: 2.0.0
     dev: true


### PR DESCRIPTION
Seems Azure fails to install due to the git URL being used in the lockfile so this corrects it. 

Fixes: https://dev.azure.com/nextjs/next.js/_build/results?buildId=45436&view=logs&jobId=59111904-15f9-56fe-00af-da61f595b979&j=59111904-15f9-56fe-00af-da61f595b979&t=5a27f6c6-b109-58f5-7373-fdf51f21d023


