### PR TITLE
Also check error.message as digest for recoverable errors in pages

### DIFF
--- a/packages/next/client/on-recoverable-error.ts
+++ b/packages/next/client/on-recoverable-error.ts
@@ -1,9 +1,10 @@
 import { NEXT_DYNAMIC_NO_SSR_CODE } from '../shared/lib/no-ssr-error'
 
-export default function onRecoverableError(err: any) {
+export default function onRecoverableError(err: any, errorInfo: any) {
+  const digest = err.digest || errorInfo.digest
+
   // Using default react onRecoverableError
   // x-ref: https://github.com/facebook/react/blob/d4bc16a7d69eb2ea38a88c8ac0b461d5f72cdcab/packages/react-dom/src/client/ReactDOMRoot.js#L83
-  const digest = err.digest || err.message
   const defaultOnRecoverableError =
     typeof reportError === 'function'
       ? // In modern browsers, reportError will dispatch an error event,

--- a/packages/next/client/on-recoverable-error.ts
+++ b/packages/next/client/on-recoverable-error.ts
@@ -3,6 +3,7 @@ import { NEXT_DYNAMIC_NO_SSR_CODE } from '../shared/lib/no-ssr-error'
 export default function onRecoverableError(err: any) {
   // Using default react onRecoverableError
   // x-ref: https://github.com/facebook/react/blob/d4bc16a7d69eb2ea38a88c8ac0b461d5f72cdcab/packages/react-dom/src/client/ReactDOMRoot.js#L83
+  const digest = err.digest || err.message
   const defaultOnRecoverableError =
     typeof reportError === 'function'
       ? // In modern browsers, reportError will dispatch an error event,
@@ -13,6 +14,6 @@ export default function onRecoverableError(err: any) {
         }
 
   // Skip certain custom errors which are not expected to be reported on client
-  if (err.digest === NEXT_DYNAMIC_NO_SSR_CODE) return
+  if (digest === NEXT_DYNAMIC_NO_SSR_CODE) return
   defaultOnRecoverableError(err)
 }

--- a/test/development/basic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { renderViaHTTP, check } from 'next-test-utils'
+import { renderViaHTTP, check, hasRedbox } from 'next-test-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 
 describe('basic next/dynamic usage', () => {
@@ -124,6 +124,7 @@ describe('basic next/dynamic usage', () => {
             () => browser.elementByCss('body').text(),
             /Hello World 1/
           )
+          expect(await hasRedbox(browser)).toBe(false)
         } finally {
           if (browser) {
             await browser.close()


### PR DESCRIPTION
Follow up for #44161

According to https://github.com/facebook/react/pull/25313, the `errorInfo.digest` will be moved to `error.digest`, but for now we use it as a fallback for pages. we can remove it later once the migration is done in required react version for nextjs

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
