### PR TITLE
Remove browser.refresh in app tests

### DIFF
--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -145,8 +145,7 @@ describe('ReactRefreshRegression app', () => {
   })
 
   // https://github.com/vercel/next.js/issues/13978
-  // TODO-APP: fix case where server component is moved to a client component
-  test.skip('can fast refresh a page with dynamic rendering', async () => {
+  test('can fast refresh a page with dynamic rendering', async () => {
     const { session, cleanup } = await sandbox(next)
 
     await session.patch(
@@ -216,8 +215,7 @@ describe('ReactRefreshRegression app', () => {
   })
 
   // https://github.com/vercel/next.js/issues/13978
-  // TODO-APP: fix case where server component is moved to a client component
-  test.skip('can fast refresh a page with config', async () => {
+  test('can fast refresh a page with config', async () => {
     const { session, cleanup } = await sandbox(next)
 
     await session.patch(
@@ -264,16 +262,13 @@ describe('ReactRefreshRegression app', () => {
   })
 
   // https://github.com/vercel/next.js/issues/11504
-  // TODO-APP: fix case where error is not resolved to source correctly.
   test('shows an overlay for anonymous function server-side error', async () => {
-    const { session, browser, cleanup } = await sandbox(next)
+    const { session, cleanup } = await sandbox(next)
 
     await session.patch(
       'app/page.js',
       `export default function () { throw new Error('boom'); }`
     )
-
-    await browser.refresh()
 
     expect(await session.hasRedbox(true)).toBe(true)
 
@@ -287,14 +282,12 @@ describe('ReactRefreshRegression app', () => {
   })
 
   test('shows an overlay for server-side error in server component', async () => {
-    const { session, browser, cleanup } = await sandbox(next)
+    const { session, cleanup } = await sandbox(next)
 
     await session.patch(
       'app/page.js',
       `export default function Page() { throw new Error('boom'); }`
     )
-
-    await browser.refresh()
 
     expect(await session.hasRedbox(true)).toBe(true)
 
@@ -308,15 +301,13 @@ describe('ReactRefreshRegression app', () => {
   })
 
   test('shows an overlay for server-side error in client component', async () => {
-    const { session, browser, cleanup } = await sandbox(next)
+    const { session, cleanup } = await sandbox(next)
 
     await session.patch(
       'app/page.js',
       `'use client'
       export default function Page() { throw new Error('boom'); }`
     )
-
-    await browser.refresh()
 
     expect(await session.hasRedbox(true)).toBe(true)
 

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -22,7 +22,7 @@ describe('Error Overlay for server components', () => {
 
   describe('createContext called in Server Component', () => {
     it('should show error when React.createContext is called', async () => {
-      const { session, browser, cleanup } = await sandbox(
+      const { session, cleanup } = await sandbox(
         next,
         new Map([
           [
@@ -58,7 +58,7 @@ describe('Error Overlay for server components', () => {
     })
 
     it('should show error when React.createContext is called in external package', async () => {
-      const { session, browser, cleanup } = await sandbox(
+      const { session, cleanup } = await sandbox(
         next,
         new Map([
           [
@@ -111,7 +111,7 @@ describe('Error Overlay for server components', () => {
     })
 
     it('should show error when createContext is called in external package', async () => {
-      const { session, browser, cleanup } = await sandbox(
+      const { session, cleanup } = await sandbox(
         next,
         new Map([
           [

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -43,9 +43,6 @@ describe('Error Overlay for server components', () => {
         ])
       )
 
-      // TODO-APP: currently requires a full reload because moving from a client component to a server component isn't causing a Fast Refresh yet.
-      await browser.refresh()
-
       expect(await session.hasRedbox(true)).toBe(true)
       await check(async () => {
         expect(await session.getRedboxSource(true)).toContain(
@@ -96,9 +93,6 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
-      // TODO-APP: currently requires a full reload because moving from a client component to a server component isn't causing a Fast Refresh yet.
-      await browser.refresh()
 
       expect(await session.hasRedbox(true)).toBe(true)
 
@@ -152,9 +146,6 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
-      // TODO-APP: currently requires a full reload because moving from a client component to a server component isn't causing a Fast Refresh yet.
-      await browser.refresh()
 
       expect(await session.hasRedbox(true)).toBe(true)
 


### PR DESCRIPTION
Remove `browser.refresh` and enable tests. These now work because HMR works when moving from client/server -> server/client component.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
