### PR TITLE
Move options to stable

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -797,8 +797,7 @@ export default async function build(
             header: RSC,
             varyHeader: RSC_VARY_HEADER,
           },
-          skipMiddlewareUrlNormalize:
-            config.experimental.skipMiddlewareUrlNormalize,
+          skipMiddlewareUrlNormalize: config.skipMiddlewareUrlNormalize,
         }
       })
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -305,7 +305,7 @@ export function getDefineEnv({
       config.allowMiddlewareResponseBody
     ),
     'process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE': JSON.stringify(
-      config.experimental.skipMiddlewareUrlNormalize
+      config.skipMiddlewareUrlNormalize
     ),
     'process.env.__NEXT_MANUAL_TRAILING_SLASH': JSON.stringify(
       config.experimental?.skipTrailingSlashRedirect

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -308,7 +308,7 @@ export function getDefineEnv({
       config.skipMiddlewareUrlNormalize
     ),
     'process.env.__NEXT_MANUAL_TRAILING_SLASH': JSON.stringify(
-      config.experimental?.skipTrailingSlashRedirect
+      config.skipTrailingSlashRedirect
     ),
     'process.env.__NEXT_HAS_WEB_VITALS_ATTRIBUTION': JSON.stringify(
       config.experimental.webVitalsAttribution &&

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -302,7 +302,7 @@ export function getDefineEnv({
     'process.env.__NEXT_I18N_DOMAINS': JSON.stringify(config.i18n?.domains),
     'process.env.__NEXT_ANALYTICS_ID': JSON.stringify(config.analyticsId),
     'process.env.__NEXT_ALLOW_MIDDLEWARE_RESPONSE_BODY': JSON.stringify(
-      config.experimental.allowMiddlewareResponseBody
+      config.allowMiddlewareResponseBody
     ),
     'process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE': JSON.stringify(
       config.experimental.skipMiddlewareUrlNormalize
@@ -2062,8 +2062,7 @@ export default async function getBaseWebpackConfig(
           dev,
           sriEnabled: !dev && !!config.experimental.sri?.algorithm,
           hasFontLoaders: !!config.experimental.fontLoaders,
-          allowMiddlewareResponseBody:
-            !!config.experimental.allowMiddlewareResponseBody,
+          allowMiddlewareResponseBody: !!config.allowMiddlewareResponseBody,
         }),
       isClient &&
         new BuildManifestPlugin({

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -659,7 +659,7 @@ export default async function loadCustomRoutes(
     )
   }
 
-  if (!config.experimental?.skipTrailingSlashRedirect) {
+  if (!config.skipTrailingSlashRedirect) {
     if (config.trailingSlash) {
       redirects.unshift(
         {

--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -375,9 +375,6 @@ const configSchema = {
         sharedPool: {
           type: 'boolean',
         },
-        skipTrailingSlashRedirect: {
-          type: 'boolean',
-        },
         sri: {
           properties: {
             algorithm: {
@@ -695,6 +692,9 @@ const configSchema = {
       type: 'object',
     },
     skipMiddlewareUrlNormalize: {
+      type: 'boolean',
+    },
+    skipTrailingSlashRedirect: {
       type: 'boolean',
     },
     staticPageGenerationTimeout: {

--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -7,6 +7,9 @@ const configSchema = {
   type: 'object',
   additionalProperties: false,
   properties: {
+    allowMiddlewareResponseBody: {
+      type: 'boolean',
+    },
     amp: {
       additionalProperties: false,
       properties: {
@@ -267,9 +270,6 @@ const configSchema = {
           ] as any,
         },
         appDir: {
-          type: 'boolean',
-        },
-        allowMiddlewareResponseBody: {
           type: 'boolean',
         },
         externalDir: {

--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -375,9 +375,6 @@ const configSchema = {
         sharedPool: {
           type: 'boolean',
         },
-        skipMiddlewareUrlNormalize: {
-          type: 'boolean',
-        },
         skipTrailingSlashRedirect: {
           type: 'boolean',
         },
@@ -696,6 +693,9 @@ const configSchema = {
     },
     serverRuntimeConfig: {
       type: 'object',
+    },
+    skipMiddlewareUrlNormalize: {
+      type: 'boolean',
     },
     staticPageGenerationTimeout: {
       type: 'number',

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -80,7 +80,6 @@ export interface NextJsWebpackConfig {
 
 export interface ExperimentalConfig {
   fetchCache?: boolean
-  skipTrailingSlashRedirect?: boolean
   optimisticClientCache?: boolean
   middlewarePrefetch?: 'strict' | 'flexible'
   legacyBrowsers?: boolean
@@ -508,6 +507,8 @@ export interface NextConfig extends Record<string, any> {
   allowMiddlewareResponseBody?: boolean
 
   skipMiddlewareUrlNormalize?: boolean
+
+  skipTrailingSlashRedirect?: boolean
 
   /**
    * Enable experimental features. Note that all experimental features are subject to breaking changes in the future.

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -80,7 +80,6 @@ export interface NextJsWebpackConfig {
 
 export interface ExperimentalConfig {
   fetchCache?: boolean
-  allowMiddlewareResponseBody?: boolean
   skipMiddlewareUrlNormalize?: boolean
   skipTrailingSlashRedirect?: boolean
   optimisticClientCache?: boolean
@@ -506,6 +505,8 @@ export interface NextConfig extends Record<string, any> {
   }
 
   output?: 'standalone'
+
+  allowMiddlewareResponseBody?: boolean
 
   /**
    * Enable experimental features. Note that all experimental features are subject to breaking changes in the future.

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -80,7 +80,6 @@ export interface NextJsWebpackConfig {
 
 export interface ExperimentalConfig {
   fetchCache?: boolean
-  skipMiddlewareUrlNormalize?: boolean
   skipTrailingSlashRedirect?: boolean
   optimisticClientCache?: boolean
   middlewarePrefetch?: 'strict' | 'flexible'
@@ -507,6 +506,8 @@ export interface NextConfig extends Record<string, any> {
   output?: 'standalone'
 
   allowMiddlewareResponseBody?: boolean
+
+  skipMiddlewareUrlNormalize?: boolean
 
   /**
    * Enable experimental features. Note that all experimental features are subject to breaking changes in the future.

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1716,7 +1716,7 @@ export default class NextNodeServer extends BaseServer {
 
     let url: string
 
-    if (this.nextConfig.experimental.skipMiddlewareUrlNormalize) {
+    if (this.nextConfig.skipMiddlewareUrlNormalize) {
       url = getRequestMeta(params.request, '__NEXT_INIT_URL')!
     } else {
       // For middleware to "fetch" we must always provide an absolute URL

--- a/test/e2e/app-dir/app-middleware/next.config.js
+++ b/test/e2e/app-dir/app-middleware/next.config.js
@@ -1,6 +1,6 @@
 module.exports = {
+  allowMiddlewareResponseBody: true,
   experimental: {
     appDir: true,
-    allowMiddlewareResponseBody: true,
   },
 }

--- a/test/e2e/skip-trailing-slash-redirect/app/next.config.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/next.config.js
@@ -1,9 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  allowMiddlewareResponseBody: true,
   experimental: {
     skipTrailingSlashRedirect: true,
     skipMiddlewareUrlNormalize: true,
-    allowMiddlewareResponseBody: true,
   },
   async redirects() {
     return [

--- a/test/e2e/skip-trailing-slash-redirect/app/next.config.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/next.config.js
@@ -1,9 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   allowMiddlewareResponseBody: true,
+  skipMiddlewareUrlNormalize: true,
   experimental: {
     skipTrailingSlashRedirect: true,
-    skipMiddlewareUrlNormalize: true,
   },
   async redirects() {
     return [

--- a/test/e2e/skip-trailing-slash-redirect/app/next.config.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/next.config.js
@@ -2,9 +2,7 @@
 const nextConfig = {
   allowMiddlewareResponseBody: true,
   skipMiddlewareUrlNormalize: true,
-  experimental: {
-    skipTrailingSlashRedirect: true,
-  },
+  skipTrailingSlashRedirect: true,
   async redirects() {
     return [
       {


### PR DESCRIPTION
This PR moves `allowMiddlewareResponseBody`, `skipMiddlewareUrlNormalize` and `skipTrailingSlashRedirect` to stable.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
