### PR TITLE
Add telemetry for stable features

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -2146,6 +2146,16 @@ export default async function getBaseWebpackConfig(
               ['swcImportSource', !!jsConfig?.compilerOptions?.jsxImportSource],
               ['swcEmotion', !!config.compiler?.emotion],
               ['turbotrace', !!config.experimental.turbotrace],
+              ['transpilePackages', !!config.transpilePackages],
+              [
+                'allowMiddlewareResponseBody',
+                !!config.allowMiddlewareResponseBody,
+              ],
+              [
+                'skipMiddlewareUrlNormalize',
+                !!config.skipMiddlewareUrlNormalize,
+              ],
+              ['skipTrailingSlashRedirect', !!config.skipTrailingSlashRedirect],
               SWCBinaryTarget,
             ].filter<[Feature, boolean]>(Boolean as any)
           )

--- a/packages/next/build/webpack/plugins/telemetry-plugin.ts
+++ b/packages/next/build/webpack/plugins/telemetry-plugin.ts
@@ -37,6 +37,10 @@ export type Feature =
   | 'swcEmotion'
   | `swc/target/${SWC_TARGET_TRIPLE}`
   | 'turbotrace'
+  | 'transpilePackages'
+  | 'allowMiddlewareResponseBody'
+  | 'skipMiddlewareUrlNormalize'
+  | 'skipTrailingSlashRedirect'
 
 interface FeatureUsage {
   featureName: Feature
@@ -96,6 +100,10 @@ const BUILD_FEATURES: Array<Feature> = [
   'swc/target/aarch64-unknown-linux-musl',
   'swc/target/aarch64-pc-windows-msvc',
   'turbotrace',
+  'transpilePackages',
+  'allowMiddlewareResponseBody',
+  'skipMiddlewareUrlNormalize',
+  'skipTrailingSlashRedirect',
 ]
 
 const ELIMINATED_PACKAGES = new Set<string>()

--- a/packages/next/telemetry/events/build.ts
+++ b/packages/next/telemetry/events/build.ts
@@ -166,6 +166,10 @@ export type EventBuildFeatureUsage = {
     | 'turbotrace'
     | 'build-lint'
     | 'vercelImageGeneration'
+    | 'transpilePackages'
+    | 'allowMiddlewareResponseBody'
+    | 'skipMiddlewareUrlNormalize'
+    | 'skipTrailingSlashRedirect'
   invocationCount: number
 }
 export function eventBuildFeatureUsage(

--- a/test/integration/telemetry/next.config.middleware-options
+++ b/test/integration/telemetry/next.config.middleware-options
@@ -1,0 +1,5 @@
+module.exports = {
+  allowMiddlewareResponseBody: true,
+  skipMiddlewareUrlNormalize: true,
+  skipTrailingSlashRedirect: true,
+}

--- a/test/integration/telemetry/next.config.transpile-packages
+++ b/test/integration/telemetry/next.config.transpile-packages
@@ -1,0 +1,3 @@
+module.exports = {
+  transpilePackages: ["foo"]
+}

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -1090,4 +1090,64 @@ describe('Telemetry CLI', () => {
       invocationCount: 1,
     })
   })
+
+  it('emits telemetry for transpilePackages', async () => {
+    await fs.rename(
+      path.join(appDir, 'next.config.transpile-packages'),
+      path.join(appDir, 'next.config.js')
+    )
+
+    const { stderr } = await nextBuild(appDir, [], {
+      stderr: true,
+      env: { NEXT_TELEMETRY_DEBUG: 1 },
+    })
+
+    await fs.rename(
+      path.join(appDir, 'next.config.js'),
+      path.join(appDir, 'next.config.transpile-packages')
+    )
+
+    const featureUsageEvents = findAllTelemetryEvents(
+      stderr,
+      'NEXT_BUILD_FEATURE_USAGE'
+    )
+    expect(featureUsageEvents).toContainEqual({
+      featureName: 'transpilePackages',
+      invocationCount: 1,
+    })
+  })
+
+  it('emits telemetry for middleware related options', async () => {
+    await fs.rename(
+      path.join(appDir, 'next.config.middleware-options'),
+      path.join(appDir, 'next.config.js')
+    )
+
+    const { stderr } = await nextBuild(appDir, [], {
+      stderr: true,
+      env: { NEXT_TELEMETRY_DEBUG: 1 },
+    })
+
+    await fs.rename(
+      path.join(appDir, 'next.config.js'),
+      path.join(appDir, 'next.config.middleware-options')
+    )
+
+    const featureUsageEvents = findAllTelemetryEvents(
+      stderr,
+      'NEXT_BUILD_FEATURE_USAGE'
+    )
+    expect(featureUsageEvents).toContainEqual({
+      featureName: 'allowMiddlewareResponseBody',
+      invocationCount: 1,
+    })
+    expect(featureUsageEvents).toContainEqual({
+      featureName: 'skipMiddlewareUrlNormalize',
+      invocationCount: 1,
+    })
+    expect(featureUsageEvents).toContainEqual({
+      featureName: 'skipTrailingSlashRedirect',
+      invocationCount: 1,
+    })
+  })
 })


### PR DESCRIPTION
Follow up to #44195 #44194.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [x] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
