### PR TITLE
Add warning for experimental flags that have moved

### DIFF
--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -616,6 +616,42 @@ function assignDefaults(dir: string, userConfig: { [key: string]: any }) {
   }
 
   if (
+    result.experimental &&
+    'allowMiddlewareResponseBody' in (result.experimental as any)
+  ) {
+    Log.warn(
+      `\`allowMiddlewareResponseBody\` has been moved out of \`experimental\`. Please update your ${configFileName} file accordingly.`
+    )
+    result.allowMiddlewareResponseBody = (
+      result.experimental as any
+    ).allowMiddlewareResponseBody
+  }
+
+  if (
+    result.experimental &&
+    'skipMiddlewareUrlNormalize' in (result.experimental as any)
+  ) {
+    Log.warn(
+      `\`skipMiddlewareUrlNormalize\` has been moved out of \`experimental\`. Please update your ${configFileName} file accordingly.`
+    )
+    result.skipMiddlewareUrlNormalize = (
+      result.experimental as any
+    ).skipMiddlewareUrlNormalize
+  }
+
+  if (
+    result.experimental &&
+    'skipTrailingSlashRedirect' in (result.experimental as any)
+  ) {
+    Log.warn(
+      `\`skipTrailingSlashRedirect\` has been moved out of \`experimental\`. Please update your ${configFileName} file accordingly.`
+    )
+    result.skipTrailingSlashRedirect = (
+      result.experimental as any
+    ).skipTrailingSlashRedirect
+  }
+
+  if (
     result.experimental?.outputFileTracingRoot &&
     !isAbsolute(result.experimental.outputFileTracingRoot)
   ) {


### PR DESCRIPTION
These options have been moved out of `experimental`.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
