### PR TITLE
Fix next-bundle-analyzer output file paths

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -4,6 +4,12 @@ module.exports =
     return Object.assign({}, nextConfig, {
       webpack(config, options) {
         if (enabled) {
+          const nextRuntimeOutputPath = options.dev
+            ? `../analyze/${options.nextRuntime}.html`
+            : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${
+                options.nextRuntime
+              }.html`
+
           const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
           config.plugins.push(
             new BundleAnalyzerPlugin({
@@ -11,9 +17,7 @@ module.exports =
               openAnalyzer,
               reportFilename: !options.nextRuntime
                 ? `./analyze/client.html`
-                : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${
-                    options.nextRuntime
-                  }.html`,
+                : nextRuntimeOutputPath,
             })
           )
         }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

When you run `next dev`, latest next-bundle-analyzer outputs as the following . And this PR fixes that.

- `.next/analyze/client.html`
- `.next/analyze/edge.html`
- `analyze/nodejs.html`
  - ↑ I guess this one is a bug

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
