### PR TITLE
Only once for the next/head usage in app dir

### DIFF
--- a/packages/next/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-flight-loader/index.ts
@@ -1,6 +1,9 @@
 import { RSC_MODULE_TYPES } from '../../../../shared/lib/constants'
+import { warnOnce } from '../../../../shared/lib/utils/warn-once'
 import { getRSCModuleType } from '../../../analysis/get-page-static-info'
 import { getModuleBuildInfo } from '../get-module-build-info'
+
+const noopHeadPath = require.resolve('next/dist/client/components/noop-head')
 
 export default async function transformSource(
   this: any,
@@ -24,5 +27,10 @@ export default async function transformSource(
     return callback(null, source, sourceMap)
   }
 
+  if (noopHeadPath === this.resourcePath) {
+    warnOnce(
+      `Warning: You're using \`next/head\` inside app directory, please migrate to \`head.js\`. Checkout https://beta.nextjs.org/docs/api-reference/file-conventions/head for details.`
+    )
+  }
   return callback(null, source, sourceMap)
 }

--- a/packages/next/client/components/noop-head.tsx
+++ b/packages/next/client/components/noop-head.tsx
@@ -1,11 +1,3 @@
-import { warnOnce } from '../../shared/lib/utils/warn-once'
-
-if (process.env.NODE_ENV !== 'production') {
-  warnOnce(
-    `You're using \`next/head\` inside app directory, please migrate to \`head.js\`. Checkout https://beta.nextjs.org/docs/api-reference/file-conventions/head for details.`
-  )
-}
-
 export default function NoopHead() {
   return null
 }

--- a/test/e2e/app-dir/head/head.test.ts
+++ b/test/e2e/app-dir/head/head.test.ts
@@ -102,12 +102,12 @@ createNextDescribe(
 
       if (globalThis.isNextDev) {
         expect(
-          errors.some(
+          errors.filter(
             (output) =>
               output ===
-              `You're using \`next/head\` inside app directory, please migrate to \`head.js\`. Checkout https://beta.nextjs.org/docs/api-reference/file-conventions/head for details.\n`
-          )
-        ).toBe(true)
+              `Warning: You're using \`next/head\` inside app directory, please migrate to \`head.js\`. Checkout https://beta.nextjs.org/docs/api-reference/file-conventions/head for details.\n`
+          ).length
+        ).toBe(1)
 
         const dynamicChunkPath = path.join(
           next.testDir,


### PR DESCRIPTION
Follow up for #43885

* only warn once for `next/head` usage in the loader
* add `Warning:` prefix