### PR TITLE
Move `modularizeImports` out of experimental

### DIFF
--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -115,7 +115,7 @@ function getBaseSWCOptions({
     reactRemoveProperties: jest
       ? false
       : nextConfig?.compiler?.reactRemoveProperties,
-    modularizeImports: nextConfig?.experimental?.modularizeImports,
+    modularizeImports: nextConfig?.modularizeImports,
     relay: nextConfig?.compiler?.relay,
     // Always transform styled-jsx and error when `client-only` condition is triggered
     styledJsx: true,

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -2304,7 +2304,7 @@ export default async function getBaseWebpackConfig(
     styledComponents: config.compiler?.styledComponents,
     relay: config.compiler?.relay,
     emotion: config.compiler?.emotion,
-    modularizeImports: config.experimental?.modularizeImports,
+    modularizeImports: config.modularizeImports,
     legacyBrowsers: config.experimental?.legacyBrowsers,
     imageLoaderFile: config.images.loaderFile,
   })

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -2155,6 +2155,7 @@ export default async function getBaseWebpackConfig(
                 !!config.skipMiddlewareUrlNormalize,
               ],
               ['skipTrailingSlashRedirect', !!config.skipTrailingSlashRedirect],
+              ['modularizeImports', !!config.modularizeImports],
               SWCBinaryTarget,
             ].filter<[Feature, boolean]>(Boolean as any)
           )

--- a/packages/next/build/webpack/plugins/telemetry-plugin.ts
+++ b/packages/next/build/webpack/plugins/telemetry-plugin.ts
@@ -40,6 +40,7 @@ export type Feature =
   | 'transpilePackages'
   | 'skipMiddlewareUrlNormalize'
   | 'skipTrailingSlashRedirect'
+  | 'modularizeImports'
 
 interface FeatureUsage {
   featureName: Feature
@@ -102,6 +103,7 @@ const BUILD_FEATURES: Array<Feature> = [
   'transpilePackages',
   'skipMiddlewareUrlNormalize',
   'skipTrailingSlashRedirect',
+  'modularizeImports',
 ]
 
 const ELIMINATED_PACKAGES = new Set<string>()

--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -310,9 +310,6 @@ const configSchema = {
           enum: ['strict', 'flexible'] as any,
           type: 'string',
         },
-        modularizeImports: {
-          type: 'object',
-        },
         newNextLinkBehavior: {
           type: 'boolean',
         },
@@ -627,6 +624,9 @@ const configSchema = {
           type: 'string',
         },
       },
+      type: 'object',
+    },
+    modularizeImports: {
       type: 'object',
     },
     onDemandEntries: {

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -120,14 +120,6 @@ export interface ExperimentalConfig {
   urlImports?: NonNullable<webpack.Configuration['experiments']>['buildHttp']
   outputFileTracingRoot?: string
   outputFileTracingIgnores?: string[]
-  modularizeImports?: Record<
-    string,
-    {
-      transform: string
-      preventFullImport?: boolean
-      skipDefaultConversion?: boolean
-    }
-  >
   swcTraceProfiling?: boolean
   forceSwcTransforms?: boolean
 
@@ -508,6 +500,15 @@ export interface NextConfig extends Record<string, any> {
 
   skipTrailingSlashRedirect?: boolean
 
+  modularizeImports?: Record<
+    string,
+    {
+      transform: string
+      preventFullImport?: boolean
+      skipDefaultConversion?: boolean
+    }
+  >
+
   /**
    * Enable experimental features. Note that all experimental features are subject to breaking changes in the future.
    */
@@ -566,6 +567,7 @@ export const defaultConfig: NextConfig = {
   staticPageGenerationTimeout: 60,
   swcMinify: true,
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
+  modularizeImports: undefined,
   experimental: {
     fetchCache: false,
     middlewarePrefetch: 'flexible',
@@ -608,7 +610,6 @@ export const defaultConfig: NextConfig = {
     disablePostcssPresetEnv: undefined,
     amp: undefined,
     urlImports: undefined,
-    modularizeImports: undefined,
     enableUndici: false,
     adjustFontFallbacks: false,
     adjustFontFallbacksWithSizeAdjust: false,

--- a/packages/next/telemetry/events/build.ts
+++ b/packages/next/telemetry/events/build.ts
@@ -169,6 +169,7 @@ export type EventBuildFeatureUsage = {
     | 'transpilePackages'
     | 'skipMiddlewareUrlNormalize'
     | 'skipTrailingSlashRedirect'
+    | 'modularizeImports'
   invocationCount: number
 }
 export function eventBuildFeatureUsage(


### PR DESCRIPTION
CC @timneutkens 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
