### PR TITLE
Fix CSS resource path not matched in `__entry_css_files__`

### DIFF
--- a/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
@@ -7,7 +7,7 @@
 
 import { webpack, sources } from 'next/dist/compiled/webpack/webpack'
 import { FLIGHT_MANIFEST } from '../../../shared/lib/constants'
-import { relative } from 'path'
+import { relative, sep } from 'path'
 import { isClientComponentModule, regexCSS } from '../loaders/utils'
 
 import {
@@ -349,7 +349,9 @@ export class FlightManifestPlugin {
         entryName: string | undefined | null
       ) => {
         if (entryName?.startsWith('app/')) {
-          const key = this.appDir + entryName.slice(3)
+          // The `key` here should be the absolute file path but without extension.
+          // We need to replace the separator in the entry name to match the system separator.
+          const key = this.appDir + entryName.slice(3).replace(/\//g, sep)
           entryCSSFiles[key] = files.concat(entryCSSFiles[key] || [])
         }
       }


### PR DESCRIPTION
Currently we use `this.appDir + entryName` as the key of app entries. The `appDir` part is an absolute path which contains `\` in Windows, but `entryName` is a general entry name for Webpack, like `app/page`. A quick fix is to replace all `/` in the entry name with the current system separator.

Confirmed that it fixed the problem in Windows.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
