### PR TITLE
Minor performance improvement on `next export` 🏎

### DIFF
--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -707,14 +707,18 @@ export default async function exportApp(
           )
           const jsonDest = join(pagesDataDir, `${route}.json`)
 
-          await promises.mkdir(dirname(htmlDest), { recursive: true })
-          await promises.mkdir(dirname(jsonDest), { recursive: true })
+          await Promise.all([
+            promises.mkdir(dirname(htmlDest), { recursive: true }),
+            promises.mkdir(dirname(jsonDest), { recursive: true })
+          ])
 
           const htmlSrc = `${orig}.html`
           const jsonSrc = `${orig}.json`
 
-          await promises.copyFile(htmlSrc, htmlDest)
-          await promises.copyFile(jsonSrc, jsonDest)
+          await Promise.all([
+            promises.copyFile(htmlSrc, htmlDest),
+            promises.copyFile(jsonSrc, jsonDest)
+          ])
 
           if (await exists(`${orig}.amp.html`)) {
             await promises.mkdir(dirname(ampHtmlDest), { recursive: true })

--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -357,11 +357,13 @@ export default async function exportPage({
           results.fromBuildExportRevalidate = revalidate
 
           if (revalidate !== 0) {
-            await promises.writeFile(htmlFilepath, html ?? '', 'utf8')
-            await promises.writeFile(
-              htmlFilepath.replace(/\.html$/, '.rsc'),
-              flightData
-            )
+            await Promise.all([
+              promises.writeFile(htmlFilepath, html ?? '', 'utf8'),
+              promises.writeFile(
+                htmlFilepath.replace(/\.html$/, '.rsc'),
+                flightData
+              )
+            ])
           } else if (isDynamicError) {
             throw new Error(
               `Page with dynamic = "error" encountered dynamic data method ${path}.`
@@ -513,19 +515,19 @@ export default async function exportPage({
         )
 
         await promises.mkdir(dirname(dataFile), { recursive: true })
-        await promises.writeFile(
-          dataFile,
-          JSON.stringify((curRenderOpts as any).pageData),
-          'utf8'
-        )
-
-        if (hybridAmp) {
-          await promises.writeFile(
+       
+        await Promise.all([
+          promises.writeFile(
+            dataFile,
+            JSON.stringify((curRenderOpts as any).pageData),
+            'utf8'
+          ),
+          hybridAmp && promises.writeFile(
             dataFile.replace(/\.json$/, '.amp.json'),
             JSON.stringify((curRenderOpts as any).pageData),
             'utf8'
           )
-        }
+        ])
       }
       results.fromBuildExportRevalidate = (curRenderOpts as any).revalidate
 


### PR DESCRIPTION
Improving the performance of `next export` by running certain independent async functions concurrently/parallel.
I thought this would improve the build process of _Incremental Static Regeneration_ too.

_Extremely sorry if I made any mistakes :(_