### PR TITLE
Update custom-app.md

### DIFF
--- a/docs/advanced-features/custom-app.md
+++ b/docs/advanced-features/custom-app.md
@@ -12,7 +12,6 @@ Next.js uses the `App` component to initialize pages. You can override it and co
 
 - Persist layouts between page changes
 - Keeping state when navigating pages
-- Custom error handling using `componentDidCatch`
 - Inject additional data into pages
 - [Add global CSS](/docs/basic-features/built-in-css-support.md#adding-a-global-stylesheet)
 


### PR DESCRIPTION
According to [Upgrade Guide](https://nextjs.org/docs/upgrading#remove-supercomponentdidcatch-from-pages_appjs), `componentDidCatch` has been deprecated and is no longer needed. So I propose that this line get deleted in [Custom App](https://nextjs.org/docs/advanced-features/custom-app) of docs.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
