### PR TITLE
Fix support for custom asset/inline rules

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -2222,7 +2222,10 @@ export default async function getBaseWebpackConfig(
     },
   }
   webpack5Config.module!.generator = {
-    asset: {
+    'asset/resource': {
+      filename: 'static/media/[name].[hash:8][ext]',
+    },
+    'asset/source': {
       filename: 'static/media/[name].[hash:8][ext]',
     },
   }


### PR DESCRIPTION
As described in https://github.com/vercel/next.js/discussions/36981#discussioncomment-3167331 and explained by webpack maintainers https://github.com/webpack/webpack/issues/16063#issuecomment-1191263942, setting `module.generators.asset` is problematic, because it will cause a build failure when adding a custom `asset/inline` rule.

This change is as backwards-compatible as possible since the `filename` will continued to be set for all next.js and custom `asset/resource` and `asset/source` rules.

A cleaner fix would be to set `generator` in all asset rules explicitly as explained by webpack maintainers in the link above. This has more potential to break existing custom rules though.

fixes #36981

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
