### PR TITLE
Fix experimental edge runtime error on API routes in `next dev` when the project is using the src directory.

### DIFF
--- a/packages/next/build/analysis/get-page-static-info.ts
+++ b/packages/next/build/analysis/get-page-static-info.ts
@@ -343,7 +343,7 @@ export async function getPageStaticInfo(params: {
       resolvedRuntime === SERVER_RUNTIME.edge &&
       pageType === 'pages' &&
       page &&
-      !isAPIRoute(page.replace(/^\/pages\//, '/'))
+      !isAPIRoute(page.replace(/^\/(src\/)?pages\//, '/'))
     ) {
       const message = `Page ${page} provided runtime 'edge', the edge runtime for rendering is currently experimental. Use runtime 'experimental-edge' instead.`
       Log.error(message)


### PR DESCRIPTION
fixes #44382

When running `next dev` `page` includes the `/src` prefix (e.g., `/src/pages/api/foo`), causing the `isAPIRoute` check to fail to detect the page as an API route. When running `next build` `page` does not include the `/src` prefix (e.g., `/pages/api/foo`).

Updating this regex resolves the issue in `next dev`. However, the difference in the page path at this point seems like a potential source of environmental differences; I'm unsure if this inconsistency is indicative of a larger failure to normalize the page path at a higher level.