### PR TITLE
fix link to index page in Image Component Example

### DIFF
--- a/examples/image-component/README.md
+++ b/examples/image-component/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to use the [Image Component in Next.js](https://nextjs.org/docs/api-reference/next/image) serve optimized, responsive images.
 
-The index page ([`pages/index.js`](pages/index.js)) has a couple images, one internal image and one external image. In [`next.config.js`](next.config.js), the `domains` property is used to enable external images. The other pages demonstrate the different layouts. Run or deploy the app to see how it works!
+The index page ([`pages/index.tsx`](pages/index.tsx)) has a couple images, one internal image and one external image. In [`next.config.js`](next.config.js), the `domains` property is used to enable external images. The other pages demonstrate the different layouts. Run or deploy the app to see how it works!
 
 ## Live demo
 


### PR DESCRIPTION

## Documentation / Examples
On [Image Component Example README](https://github.com/vercel/next.js/tree/canary/examples/image-component) was a old link to index.js file, instead of index.tsx, changed old link to a new, now page exist, insteadof 404.

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc]