### PR TITLE
Add option to read .env before starting server

### DIFF
--- a/packages/next-env/index.ts
+++ b/packages/next-env/index.ts
@@ -100,6 +100,23 @@ export function processEnv(
   return Object.assign(process.env, parsed)
 }
 
+/**
+ * Array of .env filenames to be loaded, in order of precedence
+ * @param mode Node.js environment mode (development, production, test)
+ */
+export function getDotEnvFilenames(
+  mode: 'development' | 'production' | 'test'
+) {
+  return [
+    `.env.${mode}.local`,
+    // Don't include `.env.local` for `test` environment since normally
+    // you expect tests to produce the same results for everyone
+    ...(mode !== 'test' ? ['.env.local'] : []),
+    `.env.${mode}`,
+    '.env',
+  ]
+}
+
 export function resetEnv() {
   if (initialEnv) {
     replaceProcessEnv(initialEnv)
@@ -129,15 +146,7 @@ export function loadEnvConfig(
 
   const isTest = process.env.NODE_ENV === 'test'
   const mode = isTest ? 'test' : dev ? 'development' : 'production'
-  const dotenvFiles = [
-    `.env.${mode}.local`,
-    // Don't include `.env.local` for `test` environment
-    // since normally you expect tests to produce the same
-    // results for everyone
-    mode !== 'test' && `.env.local`,
-    `.env.${mode}`,
-    '.env',
-  ].filter(Boolean) as string[]
+  const dotenvFiles = getDotEnvFilenames(mode)
 
   for (const envFile of dotenvFiles) {
     // only load .env if the user provided has an env config file

--- a/packages/next/src/cli/next-dev-args.ts
+++ b/packages/next/src/cli/next-dev-args.ts
@@ -6,6 +6,7 @@ export const validArgs: arg.Spec = {
   '--port': Number,
   '--hostname': String,
   '--turbo': Boolean,
+  '--readDotEnv': Boolean,
   '--experimental-https': Boolean,
   '--experimental-https-key': String,
   '--experimental-https-cert': String,

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -120,6 +120,7 @@ const nextDev: CliCommand = async (args) => {
       Options
         --port, -p      A port number on which to start the application
         --hostname, -H  Hostname on which to start the application (default: 0.0.0.0)
+        --readDotEnv    Read .env file before starting the application
         --experimental-upload-trace=<trace-url>  [EXPERIMENTAL] Report a subset of the debugging trace to a remote http url. Includes sensitive data. Disabled by default and url must be provided.
         --help, -h      Displays this message
     `)
@@ -170,7 +171,7 @@ const nextDev: CliCommand = async (args) => {
     }
   }
 
-  const port = getPort(args)
+  const port = getPort(args, { dir })
 
   if (isPortIsReserved(port)) {
     printAndExit(getReservedPortExplanation(port), 1)

--- a/packages/next/src/cli/next-start-args.ts
+++ b/packages/next/src/cli/next-start-args.ts
@@ -6,6 +6,7 @@ export const validArgs: arg.Spec = {
   '--port': Number,
   '--hostname': String,
   '--keepAliveTimeout': Number,
+  '--readDotEnv': Boolean,
   '--experimental-test-proxy': Boolean,
 
   // Aliases

--- a/packages/next/src/cli/next-start.ts
+++ b/packages/next/src/cli/next-start.ts
@@ -26,6 +26,7 @@ const nextStart: CliCommand = async (args) => {
         --port, -p          A port number on which to start the application
         --hostname, -H      Hostname on which to start the application (default: 0.0.0.0)
         --keepAliveTimeout  Max milliseconds to wait before closing inactive connections
+        --readDotEnv        Read .env file before starting the application
         --help, -h          Displays this message
     `)
     process.exit(0)
@@ -33,7 +34,7 @@ const nextStart: CliCommand = async (args) => {
 
   const dir = getProjectDir(args._[0])
   const host = args['--hostname']
-  const port = getPort(args)
+  const port = getPort(args, { dir })
 
   if (isPortIsReserved(port)) {
     printAndExit(getReservedPortExplanation(port), 1)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
fixes #32603
fixes #29464
fixes #10338

### Overview
Checks for `.env` files:
- `.env.${mode}.local`
- `.env.local` (if mode !== test)
- `.env.${mode}`
- `.env`

in the current working directory or parent directories.

### Performance impact

if enabled, adds ~5 ms to start up time:
```typescript
const start = performance.now()
if (args['--readDotEnv']) {
    const { dir, log } = options
    const isDev = process.env.NODE_ENV === 'development'
    const isTest = process.env.NODE_ENV === 'test'
    const mode = isTest ? 'test' : isDev ? 'development' : 'production'
    const { getDotEnvFilenames, loadEnvConfig } =
        require('@next/env') as typeof import('@next/env')
    const findUp =
        require('next/dist/compiled/find-up') as typeof import('next/dist/compiled/find-up')
    const dotenvFiles = getDotEnvFilenames(mode)
    const envPath = findUp.sync(dotenvFiles, { cwd: dir })
    if (envPath) {
        const { dirname } = require('path') as typeof import('path')
        loadEnvConfig(dirname(envPath), isDev, log)
    }
}
const end = performance.now()
console.log(`reading .env took ${end - start}`)

//=> reading .env took 5.047451019287109
```

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
