### PR TITLE
docs: clarify middleware file name when using custom page extension

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -33,7 +33,9 @@ To begin using Middleware, follow the steps below:
 npm install next@latest
 ```
 
-2. Create a `middleware.ts` (or `.js`) file at the root or in the `src` directory (same level as your `pages`)
+2. Create a `middleware.ts` (or `.js`) file at the root or in the `src` directory (same level as your `pages`). 
+> **Note:** if you are using a custom `pageExtensions` in `next.config.js` (e.g. `page.ts`) you will need to conform the middleware file name to contain the page extension (e.g. `middleware.page.ts`).
+
 3. Export a middleware function from the `middleware.ts` file:
 
 ```typescript


### PR DESCRIPTION
## Description
It's not very clear from the docs that `middleware.ts` needs to be altered when using custom page extensions. The only place I found that helped was here https://github.com/vercel/next.js/discussions/38546 so it makes sense to include this in the docs.

## Work Done
Added explanation for changing `middleware.ts` when using custom page extensions

