### PR TITLE
fix(ts): Make App props type include 'pageProps' explicitly

### DIFF
--- a/packages/next/src/pages/_app.tsx
+++ b/packages/next/src/pages/_app.tsx
@@ -17,7 +17,8 @@ export { NextWebVitalsMetric }
 
 export type AppContext = AppContextType<Router>
 
-export type AppProps<P = any> = AppPropsType<Router, P>
+export type AppProps<P extends AppInitialProps = AppInitialProps> =
+  AppPropsType<Router, P>
 
 /**
  * `App` component is used for initialize of pages. It allows for overwriting and full control of the `page` initialization.
@@ -31,15 +32,15 @@ async function appGetInitialProps({
   return { pageProps }
 }
 
-export default class App<P = any, CP = {}, S = {}> extends React.Component<
-  P & AppProps<CP>,
-  S
-> {
+export default class App<
+  P extends AppInitialProps = AppInitialProps,
+  S = {}
+> extends React.Component<AppProps<P>, S> {
   static origGetInitialProps = appGetInitialProps
   static getInitialProps = appGetInitialProps
 
   render() {
-    const { Component, pageProps } = this.props as AppProps<CP>
+    const { Component, pageProps } = this.props
 
     return <Component {...pageProps} />
   }

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -27,11 +27,8 @@ export type DocumentType = NextComponentType<
   DocumentProps
 >
 
-export type AppType<P = {}> = NextComponentType<
-  AppContextType,
-  P,
-  AppPropsType<any, P>
->
+export type AppType<P extends AppInitialProps = AppInitialProps> =
+  NextComponentType<AppContextType, P, AppPropsType<any, P>>
 
 export type AppTreeType = ComponentType<
   AppInitialProps & { [name: string]: any }


### PR DESCRIPTION
Fixes #42846

Here's a previously merged PR on this topic - #38867

I saw there's one PR already opened (#42981) but it's a draft and has no activity for ~1.5 months, so i decided it's ok to try and post a new PR.
I've also provided an alternative solution.


### The issue
Before:
![Before](https://user-images.githubusercontent.com/34479008/209995161-e451e72a-db2e-44b2-8729-69576120d6ed.PNG)

Mark, in his PR, merges generic props type with AppInitialProps to make `pageProps` optional, but I instead thought that it's more clear to make you specify `pageProps` explicitly, if you decide to pass a custom App props type. It makes it obvious which types go where and simplifies some things in the code too. Without a type error, when users just pass some properties to the type, they may still falsely expect them to be applied to the wrong place. An error would clear things out.

As @balazsorban44 mentioned in the issue, `pageProps` being a property of `props` is better than having a separate generic type. `App` class component had a separate generic type, so i had to remove it to make it compatible and consistent. 


### Current solution
After:
![After](https://user-images.githubusercontent.com/34479008/209995478-ad79fdf2-008f-4505-bf63-989e5d67f7a4.PNG)

After, with class components:
![After with Class](https://user-images.githubusercontent.com/34479008/209995533-8154c26a-b075-4f02-95cc-79b3fc236e60.PNG)

Example repo - https://github.com/mkayander/next-app-type-issue


### Trade-off
Some users may encounter type errors after such update. For example, they would now need to explicitly specify that their types need to go to the `pageProps` property. Some app class component users would also need to remove a redundant generic type if they use it, and combine 2 types into one. Fixing those errors should be fairly simple overall.

<img width="519" alt="image" src="https://user-images.githubusercontent.com/34479008/210004271-0ef951e5-858f-4276-b129-90836da33479.png">

As i see, it's either this or we can also instead introduce a new Props generic type for the functional app component, like it was in a class component, and leave class component types as they were before (with 2 props types).
I'll gladly provide this solution too if it would seem better after all.

Thanks!

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
