### PR TITLE
Update `next/head` docs.

### DIFF
--- a/docs/api-reference/next/head.md
+++ b/docs/api-reference/next/head.md
@@ -22,7 +22,6 @@ function IndexPage() {
     <div>
       <Head>
         <title>My page title</title>
-        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
       <p>Hello world!</p>
     </div>


### PR DESCRIPTION
`<meta name="viewport" content="initial-scale=1.0, width=device-width" />` is added by default in `pages`.