### PR TITLE
Use the stable GraphQL Yoga v3 in the GraphQL example

### DIFF
--- a/examples/api-routes-graphql/package.json
+++ b/examples/api-routes-graphql/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "graphql-yoga": "three",
+    "graphql-yoga": "^3.2.1",
     "graphql": "^16.5.0",
     "next": "latest",
     "react": "^18.2.0",

--- a/examples/api-routes-graphql/pages/api/graphql.ts
+++ b/examples/api-routes-graphql/pages/api/graphql.ts
@@ -22,6 +22,13 @@ const schema = createSchema({
   resolvers,
 })
 
+export const config = {
+  api: {
+    // Disable body parsing (required for file uploads)
+    bodyParser: false
+  }
+}
+
 export default createYoga({
   schema,
   // Needed to be defined explicitly because our endpoint lives at a different path other than `/graphql`

--- a/examples/api-routes-graphql/pages/api/graphql.ts
+++ b/examples/api-routes-graphql/pages/api/graphql.ts
@@ -25,8 +25,8 @@ const schema = createSchema({
 export const config = {
   api: {
     // Disable body parsing (required for file uploads)
-    bodyParser: false
-  }
+    bodyParser: false,
+  },
 }
 
 export default createYoga({


### PR DESCRIPTION
Use the stable GraphQL Yoga v3 in the GraphQL example, and also disable body parser for fully functionality as in GraphQL Yoga's recipe for Next.js;
https://the-guild.dev/graphql/yoga-server/docs/integrations/integration-with-nextjs#example
