### PR TITLE
test: fix import of cross-spawn

### DIFF
--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -1,5 +1,5 @@
-import { spawn } from 'cross-spawn'
-import { Span } from 'next/trace'
+import spawn from 'cross-spawn'
+import type { Span } from 'next/trace'
 import { NextInstance } from './base'
 
 export class NextDevInstance extends NextInstance {

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -1,8 +1,9 @@
-import path from 'path'
-import fs from 'fs-extra'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import type { SpawnOptions } from 'node:child_process'
+import spawn from 'cross-spawn'
 import { NextInstance } from './base'
-import { spawn, SpawnOptions } from 'cross-spawn'
-import { Span } from 'next/trace'
+import type { Span } from 'next/trace'
 
 export class NextStartInstance extends NextInstance {
   private _buildId: string
@@ -88,13 +89,13 @@ export class NextStartInstance extends NextInstance {
     })
 
     this._buildId = (
-      await fs.readFile(
+      await readFile(
         path.join(
           this.testDir,
           this.nextConfig?.distDir || '.next',
           'BUILD_ID'
         ),
-        'utf8'
+        { encoding: 'utf8' }
       )
     ).trim()
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
**cross-spawn** is a CJS module and should be imported using its default export.

- replace fs-extra.readFile with native promisified version

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
