### PR TITLE
docs: update JSDoc in config introduction

### DIFF
--- a/docs/api-reference/next.config.js/introduction.md
+++ b/docs/api-reference/next.config.js/introduction.md
@@ -37,28 +37,42 @@ export default nextConfig
 You can also use a function:
 
 ```js
+/**
+ * @typedef NextConfig
+ * @type {import('next').NextConfig}
+ */
+
+/**
+ * @param {string} phase
+ * @param {object} options
+ * @param {NextConfig} options.defaultConfig
+ * @returns {NextConfig}
+ */
 module.exports = (phase, { defaultConfig }) => {
-  /**
-   * @type {import('next').NextConfig}
-   */
-  const nextConfig = {
+  return {
     /* config options here */
   }
-  return nextConfig
 }
 ```
 
 Since Next.js 12.1.0, you can use an async function:
 
 ```js
+/**
+ * @typedef NextConfig
+ * @type {import('next').NextConfig}
+ */
+
+/**
+ * @param {string} phase
+ * @param {object} options
+ * @param {NextConfig} options.defaultConfig
+ * @returns {Promise<NextConfig>}
+ */
 module.exports = async (phase, { defaultConfig }) => {
-  /**
-   * @type {import('next').NextConfig}
-   */
-  const nextConfig = {
+  return {
     /* config options here */
   }
-  return nextConfig
 }
 ```
 


### PR DESCRIPTION
When configuring NextJS using a function, type safety on the parameters can be achieved through JSDoc definition.

Technically, these could be expressed without an explicit `return`, but I thought leaving those in place was clearer.

I took out the assignment to `const` as that removes type safety on the returned object.

## Documentation / Examples

- [ ] ~~Make sure the linting passes by running `pnpm build && pnpm lint`~~
- [ ] ~~The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)~~
