### PR TITLE
Exclude development from static html/json render on data request

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "name": "Launch app development",
+      "name": "Launch development",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",
@@ -29,7 +29,7 @@
       }
     },
     {
-      "name": "Launch app build",
+      "name": "Launch build",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",
@@ -41,7 +41,7 @@
       }
     },
     {
-      "name": "Launch app production",
+      "name": "Launch production",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -1057,7 +1057,8 @@ export async function renderToHTML(
 
   // Avoid rendering page un-necessarily for getServerSideProps data request
   // and getServerSideProps/getStaticProps redirects
-  if ((isDataReq && !isSSG) || (renderOpts as any).isRedirect) {
+  // In development the incrementalCache is not used so we short-circuit bypassing the html rendering.
+  if ((isDataReq && (!isSSG || dev)) || (renderOpts as any).isRedirect) {
     return RenderResult.fromStatic(JSON.stringify(props))
   }
 


### PR DESCRIPTION
As found by @alexkirsz this caused the HTML rendering to happen in development even for data requests of static pages, which is not needed because the incremental cache doesn't apply in development.

Additional updated the launch.json to not say `launch app` given that it might be confused with the `app` directory.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
