### PR TITLE
[examples] add @types/testing-library__jest-dom package

### DIFF
--- a/examples/with-jest-babel/package.json
+++ b/examples/with-jest-babel/package.json
@@ -17,6 +17,7 @@
     "@testing-library/react": "13.2.0",
     "@testing-library/user-event": "14.2.0",
     "@types/react": "18.0.9",
+    "@types/testing-library__jest-dom": "5.14.5",
     "babel-jest": "28.1.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "28.1.0",

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -17,6 +17,7 @@
     "@testing-library/react": "13.2.0",
     "@testing-library/user-event": "14.2.0",
     "@types/react": "18.0.9",
+    "@types/testing-library__jest-dom": "5.14.5",
     "jest": "28.1.0",
     "jest-environment-jsdom": "28.1.0",
     "typescript": "4.6.4"


### PR DESCRIPTION
## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

The https://www.npmjs.com/package/@testing-library/jest-dom is included in the `with-jest` and `with-jest-babel` examples, but that package has DT types which are not included and may cause TS errors. This PR adds them