### PR TITLE
Improve Security with ContextIsolation for Electron Typescript Example

### DIFF
--- a/examples/with-electron-typescript/electron-src/index.ts
+++ b/examples/with-electron-typescript/electron-src/index.ts
@@ -16,7 +16,7 @@ app.on('ready', async () => {
     height: 600,
     webPreferences: {
       nodeIntegration: false,
-      contextIsolation: false,
+      contextIsolation: true,
       preload: join(__dirname, 'preload.js'),
     },
   })

--- a/examples/with-electron-typescript/electron-src/preload.ts
+++ b/examples/with-electron-typescript/electron-src/preload.ts
@@ -4,10 +4,13 @@ import { contextBridge, ipcRenderer } from 'electron'
 import { IpcRendererEvent } from 'electron/main'
 
 // We are using the context bridge to securely expose NodeAPIs.
-// Please note that many Node APIs grant access to local system resources. 
+// Please note that many Node APIs grant access to local system resources.
 // Be very cautious about which globals and APIs you expose to untrusted remote content.
-contextBridge.exposeInMainWorld("electron", {
-  sayHello: () => ipcRenderer.send("message", "hi from next"),
-  receiveHello: (handler: (event: IpcRendererEvent, ...args: any[]) => void) => ipcRenderer.on("message", handler),
-  stopReceivingHello: (handler: (event: IpcRendererEvent, ...args: any[]) => void) => ipcRenderer.removeListener("message", handler),
+contextBridge.exposeInMainWorld('electron', {
+  sayHello: () => ipcRenderer.send('message', 'hi from next'),
+  receiveHello: (handler: (event: IpcRendererEvent, ...args: any[]) => void) =>
+    ipcRenderer.on('message', handler),
+  stopReceivingHello: (
+    handler: (event: IpcRendererEvent, ...args: any[]) => void
+  ) => ipcRenderer.removeListener('message', handler),
 })

--- a/examples/with-electron-typescript/electron-src/preload.ts
+++ b/examples/with-electron-typescript/electron-src/preload.ts
@@ -1,17 +1,13 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { ipcRenderer, IpcRenderer } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
+import { IpcRendererEvent } from 'electron/main'
 
-declare global {
-  namespace NodeJS {
-    interface Global {
-      ipcRenderer: IpcRenderer
-    }
-  }
-}
-
-// Since we disabled nodeIntegration we can reintroduce
-// needed node functionality here
-process.once('loaded', () => {
-  global.ipcRenderer = ipcRenderer
+// We are using the context bridge to securely expose NodeAPIs.
+// Please note that many Node APIs grant access to local system resources. 
+// Be very cautious about which globals and APIs you expose to untrusted remote content.
+contextBridge.exposeInMainWorld("electron", {
+  sayHello: () => ipcRenderer.send("message", "hi from next"),
+  receiveHello: (handler: (event: IpcRendererEvent, ...args: any[]) => void) => ipcRenderer.on("message", handler),
+  stopReceivingHello: (handler: (event: IpcRendererEvent, ...args: any[]) => void) => ipcRenderer.removeListener("message", handler),
 })

--- a/examples/with-electron-typescript/renderer/interfaces/index.ts
+++ b/examples/with-electron-typescript/renderer/interfaces/index.ts
@@ -8,11 +8,11 @@
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   interface Window {
-      electron: {
-        sayHello: () => void
-        receiveHello: (handler: (event, args) => void) => void;
-        stopReceivingHello: (handler: (event, args) => void) => void;
-      }
+    electron: {
+      sayHello: () => void
+      receiveHello: (handler: (event, args) => void) => void
+      stopReceivingHello: (handler: (event, args) => void) => void
+    }
   }
 }
 

--- a/examples/with-electron-typescript/renderer/interfaces/index.ts
+++ b/examples/with-electron-typescript/renderer/interfaces/index.ts
@@ -4,14 +4,15 @@
 //
 // import User from 'path/to/interfaces';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { IpcRenderer } from 'electron'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace NodeJS {
-    interface Global {
-      ipcRenderer: IpcRenderer
-    }
+  interface Window {
+      electron: {
+        sayHello: () => void
+        receiveHello: (handler: (event, args) => void) => void;
+        stopReceivingHello: (handler: (event, args) => void) => void;
+      }
   }
 }
 

--- a/examples/with-electron-typescript/renderer/pages/index.tsx
+++ b/examples/with-electron-typescript/renderer/pages/index.tsx
@@ -7,15 +7,15 @@ const IndexPage = () => {
     const handleMessage = (_event, args) => alert(args)
 
     // listen to the 'message' channel
-    window.electron.receiveHello(handleMessage);
+    window.electron.receiveHello(handleMessage)
 
     return () => {
-      window.electron.stopReceivingHello(handleMessage);
+      window.electron.stopReceivingHello(handleMessage)
     }
   }, [])
 
   const onSayHiClick = () => {
-    window.electron.sayHello();
+    window.electron.sayHello()
   }
 
   return (

--- a/examples/with-electron-typescript/renderer/pages/index.tsx
+++ b/examples/with-electron-typescript/renderer/pages/index.tsx
@@ -6,16 +6,16 @@ const IndexPage = () => {
   useEffect(() => {
     const handleMessage = (_event, args) => alert(args)
 
-    // add a listener to 'message' channel
-    global.ipcRenderer.addListener('message', handleMessage)
+    // listen to the 'message' channel
+    window.electron.receiveHello(handleMessage);
 
     return () => {
-      global.ipcRenderer.removeListener('message', handleMessage)
+      window.electron.stopReceivingHello(handleMessage);
     }
   }, [])
 
   const onSayHiClick = () => {
-    global.ipcRenderer.send('message', 'hi from next')
+    window.electron.sayHello();
   }
 
   return (

--- a/examples/with-electron-typescript/renderer/tsconfig.json
+++ b/examples/with-electron-typescript/renderer/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -12,8 +16,15 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/examples/with-electron-typescript/renderer/tsconfig.json
+++ b/examples/with-electron-typescript/renderer/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -19,12 +15,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
# Checklist

## Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

# Reason
The [Electron documentation](https://www.electronjs.org/docs/latest/tutorial/context-isolation) outlines that the IpcRenderer API should not be exposed directly to the renderer process. This has now been removed from the example because:
> This would allow any website to send arbitrary IPC messages, which you do not want to be possible. The correct way to expose IPC-based APIs would instead be to provide one method per IPC message.

Additionally, Context Isolation has been enable to ensure the renderer process follows the principle of least privilege. According to the documentation for Electron: 
> This is important for security purposes as it helps prevent the website from accessing Electron internals or the powerful APIs your preload script has access to.

You'll notice that the IpcRenderer API is no longer directly exposed and this will ensure anyone using the template will be setup with a higher level of security from the start.