### PR TITLE
Fix: Add trailing slash to locale redirect based on next config

### DIFF
--- a/packages/next/src/shared/lib/i18n/get-locale-redirect.ts
+++ b/packages/next/src/shared/lib/i18n/get-locale-redirect.ts
@@ -108,7 +108,7 @@ export function getLocaleRedirect({
     if (detectedLocale.toLowerCase() !== defaultLocale.toLowerCase()) {
       return formatUrl({
         ...urlParsed,
-        pathname: `${nextConfig.basePath || ''}/${detectedLocale}`,
+        pathname: `${nextConfig.basePath || ''}/${detectedLocale}${nextConfig.trailingSlash ? '/' : ''}`,
       })
     }
   }


### PR DESCRIPTION
## Changes

When you have enabled `trailingSlash: true` in `next.config.js`, instead of redirecting an user to the detected locale with trailing slash, next redirects to locale without trailings slash. So now Next needs to redirect the user again from e.g. `/en` to `/en/`. This additional redirect is useless and takes some time to be done.

With that change, Next.js will redirect user to path with or without trailing slash depending on the set value in trailingSlash`` in `next.config.js` file.

**Before:**

![image](https://user-images.githubusercontent.com/28862367/210533640-81a39fe1-187d-4a50-a40f-84de244b6ec4.png)

**After:** 

![image](https://user-images.githubusercontent.com/28862367/210533202-1b2e2f5a-1ec2-440c-823e-18e45451f4ea.png)

