### PR TITLE
Revert "Use turbo for packing files in test setup (#44074)"

### DIFF
--- a/.github/actions/next-stats-action/package.json
+++ b/.github/actions/next-stats-action/package.json
@@ -1,9 +1,6 @@
 {
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "turbo": "turbo"
-  },
   "dependencies": {
     "async-sema": "^3.1.0",
     "fs-extra": "^8.1.0",
@@ -15,7 +12,6 @@
     "prettier": "^1.18.2",
     "pretty-bytes": "^5.3.0",
     "pretty-ms": "^5.0.0",
-    "semver": "7.3.4",
-    "turbo": "1.6.3"
+    "semver": "7.3.4"
   }
 }

--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -10,18 +10,6 @@ const mockTrace = () => ({
   traceChild: () => mockTrace(),
 })
 
-let turboRepoRoot = path.join(__dirname, '..', '..', '..', '..', '..')
-
-// stats-action runs this code without access to the original repo.
-// In that case we just use the temporary directory (everything is temporary anyway in CI)
-if (turboRepoRoot === '/') {
-  turboRepoRoot = path.join(__dirname, '..', '..')
-}
-
-/** Save turbo cache to persistent storage */
-const turboCacheLocation = path.join(turboRepoRoot, 'node_modules/.cache/turbo')
-const packedPkgsDir = path.join(turboRepoRoot, 'test/tmp/packedPkgs')
-
 module.exports = (actionInfo) => {
   return {
     async cloneRepo(repoPath = '', dest = '') {
@@ -93,15 +81,9 @@ module.exports = (actionInfo) => {
         await rootSpan
           .traceChild('prepare packages for packing')
           .traceAsyncFn(async () => {
-            await fs.ensureDir(packedPkgsDir)
-            const repoData = require(path.join(repoDir, 'package.json'))
-
             for (const pkg of pkgs) {
               const pkgPath = path.join(repoDir, 'packages', pkg)
-              const packedPkgPath = path.join(
-                packedPkgsDir,
-                `${pkg}-packed.tgz`
-              )
+              const packedPkgPath = path.join(pkgPath, `${pkg}-packed.tgz`)
 
               const pkgDataPath = path.join(pkgPath, 'package.json')
               if (!fs.existsSync(pkgDataPath)) {
@@ -121,8 +103,7 @@ module.exports = (actionInfo) => {
             }
 
             for (const pkg of pkgDatas.keys()) {
-              const { pkgDataPath, pkgData, pkgPath, packedPkgPath } =
-                pkgDatas.get(pkg)
+              const { pkgDataPath, pkgData } = pkgDatas.get(pkg)
 
               for (const pkg of pkgDatas.keys()) {
                 const { packedPkgPath } = pkgDatas.get(pkg)
@@ -158,27 +139,6 @@ module.exports = (actionInfo) => {
                 }
               }
 
-              // Turbo requires package manager specification
-              pkgData.packageManager =
-                pkgData.packageManager || repoData.packageManager
-
-              pkgData.scripts = {
-                ...pkgData.scripts,
-                'test-pack': `yarn pack -f ${packedPkgPath}`,
-              }
-
-              await fs.writeJSON(path.join(pkgPath, 'turbo.json'), {
-                pipeline: {
-                  'test-pack': {
-                    outputs: [packedPkgPath],
-                    inputs: ['*', '!node_modules/', '!.turbo/'],
-                  },
-                },
-              })
-
-              // Turbo requires pnpm-lock.yaml that is not empty
-              await fs.writeFile(path.join(pkgPath, 'pnpm-lock.yaml'), '')
-
               await fs.writeFile(
                 pkgDataPath,
                 JSON.stringify(pkgData, null, 2),
@@ -197,9 +157,9 @@ module.exports = (actionInfo) => {
                 await packingSpan
                   .traceChild(`pack ${pkgName}`)
                   .traceAsyncFn(async () => {
-                    const { pkgPath } = pkgDatas.get(pkgName)
+                    const { pkg, pkgPath } = pkgDatas.get(pkgName)
                     await exec(
-                      `pnpm run --dir="${turboRepoRoot}" turbo run test-pack --cache-dir="${turboCacheLocation}" --cwd="${pkgPath}"`,
+                      `cd ${pkgPath} && yarn pack -f '${pkg}-packed.tgz'`,
                       true
                     )
                   })

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "build": "turbo run build",
     "lerna": "lerna",
     "dev": "turbo run dev --parallel",
-    "turbo": "turbo",
     "test-types": "pnpm tsc",
     "test-unit": "pnpm jest test/unit/",
     "test-dev": "cross-env NEXT_TEST_MODE=dev pnpm testheadless",

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -183,7 +183,8 @@ async function createNextInstall({
               const cachedFiles = [
                 // We can't cache node-modules because .pnpm store must be on the same mount - we can't move it between mountpoints
                 // 'node_modules',
-                'pnpm-lock.yaml',
+                // FIXME: caching lock file caused itssues and It's not possible when we don't use turbo which we had to disable temporarily
+                // 'pnpm-lock.yaml',
               ]
 
               if (


### PR DESCRIPTION
This reverts commit fd9ec646acc26e746822cff903981ca7d7d366e1.

It seems that there is an issue with caching of inputs which uses stale files.

We also had to disable caching of `pnpm-lock.yaml` because it requires stable package locations chich we removed.