### PR TITLE
Remove unused `target: es5` from `tsconfig.json`

### DIFF
--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -23,7 +23,6 @@ function getDesiredCompilerOptions(
   const o: DesiredCompilerOptionsShape = {
     // These are suggested values and will be set when not present in the
     // tsconfig.json
-    target: { suggested: 'es5' },
     lib: { suggested: ['dom', 'dom.iterable', 'esnext'] },
     allowJs: { suggested: true },
     skipLibCheck: { suggested: true },

--- a/test/integration/tsconfig-verifier/test/index.test.js
+++ b/test/integration/tsconfig-verifier/test/index.test.js
@@ -312,6 +312,53 @@ describe('tsconfig.json verifier', () => {
     `)
   })
 
+  it('allows you to set target mode', async () => {
+    expect(await exists(tsConfig)).toBe(false)
+
+    await writeFile(tsConfig, `{ "compilerOptions": { "target": "es2022" } }`)
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
+      stderr: true,
+      stdout: true,
+    })
+    expect(stderr + stdout).not.toContain('target')
+    expect(code).toBe(0)
+
+    expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
+      "{
+        \\"compilerOptions\\": {
+          \\"target\\": \\"es2022\\",
+          \\"lib\\": [
+            \\"dom\\",
+            \\"dom.iterable\\",
+            \\"esnext\\"
+          ],
+          \\"allowJs\\": true,
+          \\"skipLibCheck\\": true,
+          \\"strict\\": false,
+          \\"forceConsistentCasingInFileNames\\": true,
+          \\"noEmit\\": true,
+          \\"incremental\\": true,
+          \\"esModuleInterop\\": true,
+          \\"module\\": \\"esnext\\",
+          \\"moduleResolution\\": \\"node\\",
+          \\"resolveJsonModule\\": true,
+          \\"isolatedModules\\": true,
+          \\"jsx\\": \\"preserve\\"
+        },
+        \\"include\\": [
+          \\"next-env.d.ts\\",
+          \\"**/*.ts\\",
+          \\"**/*.tsx\\"
+        ],
+        \\"exclude\\": [
+          \\"node_modules\\"
+        ]
+      }
+      "
+    `)
+  })
+
   it('allows you to extend another configuration file', async () => {
     expect(await exists(tsConfig)).toBe(false)
     expect(await exists(tsConfigBase)).toBe(false)

--- a/test/integration/tsconfig-verifier/test/index.test.js
+++ b/test/integration/tsconfig-verifier/test/index.test.js
@@ -26,7 +26,6 @@ describe('tsconfig.json verifier', () => {
     expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
       "{
         \\"compilerOptions\\": {
-          \\"target\\": \\"es5\\",
           \\"lib\\": [
             \\"dom\\",
             \\"dom.iterable\\",
@@ -75,7 +74,6 @@ describe('tsconfig.json verifier', () => {
     expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
       "{
         \\"compilerOptions\\": {
-          \\"target\\": \\"es5\\",
           \\"lib\\": [
             \\"dom\\",
             \\"dom.iterable\\",
@@ -143,7 +141,6 @@ describe('tsconfig.json verifier', () => {
           \\"module\\": \\"esnext\\" // should not be umd
           // end-object comment
           ,
-          \\"target\\": \\"es5\\",
           \\"lib\\": [
             \\"dom\\",
             \\"dom.iterable\\",
@@ -192,7 +189,6 @@ describe('tsconfig.json verifier', () => {
         \\"compilerOptions\\": {
           \\"esModuleInterop\\": true,
           \\"module\\": \\"commonjs\\",
-          \\"target\\": \\"es5\\",
           \\"lib\\": [
             \\"dom\\",
             \\"dom.iterable\\",
@@ -238,7 +234,6 @@ describe('tsconfig.json verifier', () => {
         \\"compilerOptions\\": {
           \\"esModuleInterop\\": true,
           \\"module\\": \\"es2020\\",
-          \\"target\\": \\"es5\\",
           \\"lib\\": [
             \\"dom\\",
             \\"dom.iterable\\",
@@ -288,7 +283,6 @@ describe('tsconfig.json verifier', () => {
         \\"compilerOptions\\": {
           \\"esModuleInterop\\": true,
           \\"moduleResolution\\": \\"node16\\",
-          \\"target\\": \\"es5\\",
           \\"lib\\": [
             \\"dom\\",
             \\"dom.iterable\\",
@@ -327,7 +321,6 @@ describe('tsconfig.json verifier', () => {
       `
       {
         "compilerOptions": {
-          "target": "es5",
           "lib": [
             "dom",
             "dom.iterable",
@@ -383,7 +376,6 @@ describe('tsconfig.json verifier', () => {
       `
       {
         "compilerOptions": {
-          "target": "es5",
           "lib": [
             "dom",
             "dom.iterable",


### PR DESCRIPTION
There is [some confusion](https://twitter.com/samselikoff/status/1608840153963057152) over why `"target": "es5"` is in `tsconfig.json` and whether or not it should be changed.

The `target` property is not used by Next.js, so this PR removes it.

- Closes: #37271 
- Closes: #43582 