### PR TITLE
Remove extra pnp test

### DIFF
--- a/test/e2e/yarn-pnp/test/pwa-example.test.ts
+++ b/test/e2e/yarn-pnp/test/pwa-example.test.ts
@@ -1,5 +1,0 @@
-import { runTests } from './utils'
-
-describe('yarn PnP', () => {
-  runTests('progressive-web-app')
-})


### PR DESCRIPTION
This removes an extra Yarn PnP test that is failing from a nested dependency change. We have three other examples being tested against PnP which should be sufficient. 

x-ref: https://github.com/vercel/next.js/actions/runs/3840569532/jobs/6542443736
x-ref: https://github.com/vercel/next.js/actions/runs/3840569532/jobs/6542444509
x-ref: https://github.com/vercel/next.js/actions/runs/3840569532/jobs/6542448724
x-ref: https://github.com/vercel/next.js/actions/runs/3840569532/jobs/6542449653