### PR TITLE
Add lang, generateStaticParams, and server-only for i18n example

### DIFF
--- a/examples/app-dir-i18n-routing/app/[lang]/layout.tsx
+++ b/examples/app-dir-i18n-routing/app/[lang]/layout.tsx
@@ -1,0 +1,19 @@
+import { i18n } from '../../i18n-config'
+
+export async function generateStaticParams() {
+  return i18n.locales.map((locale) => ({ lang: locale }))
+}
+
+export default function Root({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: { lang: string }
+}) {
+  return (
+    <html lang={params.lang}>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/examples/app-dir-i18n-routing/app/layout.tsx
+++ b/examples/app-dir-i18n-routing/app/layout.tsx
@@ -1,7 +1,0 @@
-export default function Root({ children }: { children: React.ReactNode }) {
-  return (
-    <html>
-      <body>{children}</body>
-    </html>
-  )
-}

--- a/examples/app-dir-i18n-routing/get-dictionary.ts
+++ b/examples/app-dir-i18n-routing/get-dictionary.ts
@@ -1,3 +1,4 @@
+import 'server-only'
 import type { Locale } from './i18n-config'
 
 // We enumerate all dictionaries here for better linting and typescript support


### PR DESCRIPTION
Ensures static generation is used and the dictionary is not accidentally used in client components

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
