### PR TITLE
Temporarily disable Azure e2e tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,74 +109,74 @@ stages:
             condition: eq(variables['isDocsOnly'], 'No')
             displayName: 'Run tests'
 
-      - job: test_e2e_dev
-        pool:
-          vmImage: 'windows-2019'
-        steps:
-          - task: NodeTool@0
-            inputs:
-              versionSpec: $(node_16_version)
-            displayName: 'Install Node.js'
+      # - job: test_e2e_dev
+      #   pool:
+      #     vmImage: 'windows-2019'
+      #   steps:
+      #     - task: NodeTool@0
+      #       inputs:
+      #         versionSpec: $(node_16_version)
+      #       displayName: 'Install Node.js'
 
-          - bash: |
-              node scripts/run-for-change.js --not --type docs --exec echo "##vso[task.setvariable variable=isDocsOnly]No"
-            displayName: 'Check Docs Only Change'
+      #     - bash: |
+      #         node scripts/run-for-change.js --not --type docs --exec echo "##vso[task.setvariable variable=isDocsOnly]No"
+      #       displayName: 'Check Docs Only Change'
 
-          - script: npm i -g pnpm@$(PNPM_VERSION)
-            condition: eq(variables['isDocsOnly'], 'No')
+      #     - script: npm i -g pnpm@$(PNPM_VERSION)
+      #       condition: eq(variables['isDocsOnly'], 'No')
 
-          - script: pnpm config set store-dir $(PNPM_CACHE_FOLDER)
-            condition: eq(variables['isDocsOnly'], 'No')
+      #     - script: pnpm config set store-dir $(PNPM_CACHE_FOLDER)
+      #       condition: eq(variables['isDocsOnly'], 'No')
 
-          - script: pnpm store path
-            condition: eq(variables['isDocsOnly'], 'No')
+      #     - script: pnpm store path
+      #       condition: eq(variables['isDocsOnly'], 'No')
 
-          - script: pnpm install && pnpm run build
-            condition: eq(variables['isDocsOnly'], 'No')
-            displayName: 'Install and build'
+      #     - script: pnpm install && pnpm run build
+      #       condition: eq(variables['isDocsOnly'], 'No')
+      #       displayName: 'Install and build'
 
-          - script: npx playwright install chromium
-            condition: eq(variables['isDocsOnly'], 'No')
+      #     - script: npx playwright install chromium
+      #       condition: eq(variables['isDocsOnly'], 'No')
 
-          - script: |
-              node run-tests.js -c 1 --debug test/e2e/app-dir/app/index.test.ts
-            condition: eq(variables['isDocsOnly'], 'No')
-            displayName: 'Run tests (E2E Development)'
-            env:
-              NEXT_TEST_MODE: 'dev'
+      #     - script: |
+      #         node run-tests.js -c 1 --debug test/e2e/app-dir/app/index.test.ts
+      #       condition: eq(variables['isDocsOnly'], 'No')
+      #       displayName: 'Run tests (E2E Development)'
+      #       env:
+      #         NEXT_TEST_MODE: 'dev'
 
-      - job: test_e2e_prod
-        pool:
-          vmImage: 'windows-2019'
-        steps:
-          - task: NodeTool@0
-            inputs:
-              versionSpec: $(node_16_version)
-            displayName: 'Install Node.js'
+      # - job: test_e2e_prod
+      #   pool:
+      #     vmImage: 'windows-2019'
+      #   steps:
+      #     - task: NodeTool@0
+      #       inputs:
+      #         versionSpec: $(node_16_version)
+      #       displayName: 'Install Node.js'
 
-          - bash: |
-              node scripts/run-for-change.js --not --type docs --exec echo "##vso[task.setvariable variable=isDocsOnly]No"
-            displayName: 'Check Docs Only Change'
+      #     - bash: |
+      #         node scripts/run-for-change.js --not --type docs --exec echo "##vso[task.setvariable variable=isDocsOnly]No"
+      #       displayName: 'Check Docs Only Change'
 
-          - script: npm i -g pnpm@$(PNPM_VERSION)
-            condition: eq(variables['isDocsOnly'], 'No')
+      #     - script: npm i -g pnpm@$(PNPM_VERSION)
+      #       condition: eq(variables['isDocsOnly'], 'No')
 
-          - script: pnpm config set store-dir $(PNPM_CACHE_FOLDER)
-            condition: eq(variables['isDocsOnly'], 'No')
+      #     - script: pnpm config set store-dir $(PNPM_CACHE_FOLDER)
+      #       condition: eq(variables['isDocsOnly'], 'No')
 
-          - script: pnpm store path
-            condition: eq(variables['isDocsOnly'], 'No')
+      #     - script: pnpm store path
+      #       condition: eq(variables['isDocsOnly'], 'No')
 
-          - script: pnpm install && pnpm run build
-            condition: eq(variables['isDocsOnly'], 'No')
-            displayName: 'Install and build'
+      #     - script: pnpm install && pnpm run build
+      #       condition: eq(variables['isDocsOnly'], 'No')
+      #       displayName: 'Install and build'
 
-          - script: npx playwright install chromium
-            condition: eq(variables['isDocsOnly'], 'No')
+      #     - script: npx playwright install chromium
+      #       condition: eq(variables['isDocsOnly'], 'No')
 
-          - script: |
-              node run-tests.js -c 1 --debug test/e2e/app-dir/app/index.test.ts
-            condition: eq(variables['isDocsOnly'], 'No')
-            displayName: 'Run tests (E2E Production)'
-            env:
-              NEXT_TEST_MODE: 'start'
+      #     - script: |
+      #         node run-tests.js -c 1 --debug test/e2e/app-dir/app/index.test.ts
+      #       condition: eq(variables['isDocsOnly'], 'No')
+      #       displayName: 'Run tests (E2E Production)'
+      #       env:
+      #         NEXT_TEST_MODE: 'start'


### PR DESCRIPTION
This temporarily disables the Azure e2e tests that are currently stalling and backing up the test queue due to known failures on windows, we should re-enable these after they are patched. 