### PR TITLE
Fix font unit test on Azure

### DIFF
--- a/test/unit/google-font-loader.test.ts
+++ b/test/unit/google-font-loader.test.ts
@@ -166,7 +166,9 @@ describe('@next/font/google loader', () => {
           variableName: 'myFont',
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Cannot read properties of undefined (reading 'subsets')"`
+        process.version.startsWith('v14')
+          ? `"Cannot read property 'subsets' of undefined"`
+          : `"Cannot read properties of undefined (reading 'subsets')"`
       )
     })
 


### PR DESCRIPTION
The error message differs slightly based on the Node.js version so this special cases it. 

Fixes: https://dev.azure.com/nextjs/next.js/_build/results?buildId=45839&view=logs&j=8af7cf9c-43a1-584d-6f5c-57bad8880974&t=7ae70e63-3625-50f4-6764-5b3e72b4bd7a