### PR TITLE
docs: clarify default `basePath` value

### DIFF
--- a/docs/api-reference/next.config.js/basepath.md
+++ b/docs/api-reference/next.config.js/basepath.md
@@ -15,7 +15,7 @@ description: Learn more about setting a base path in Next.js
 
 To deploy a Next.js application under a sub-path of a domain you can use the `basePath` config option.
 
-`basePath` allows you to set a path prefix for the application. For example, to use `/docs` instead of ``(an empty string, the default), open`next.config.js`and add the`basePath` config:
+`basePath` allows you to set a path prefix for the application. For example, to use `/docs` instead of `''` (an empty string, the default), open `next.config.js`and add the`basePath` config:
 
 ```js
 module.exports = {

--- a/docs/api-reference/next.config.js/basepath.md
+++ b/docs/api-reference/next.config.js/basepath.md
@@ -15,7 +15,7 @@ description: Learn more about setting a base path in Next.js
 
 To deploy a Next.js application under a sub-path of a domain you can use the `basePath` config option.
 
-`basePath` allows you to set a path prefix for the application. For example, to use `/docs` instead of `''` (an empty string, the default), open `next.config.js`and add the`basePath` config:
+`basePath` allows you to set a path prefix for the application. For example, to use `/docs` instead of `''` (an empty string, the default), open `next.config.js` and add the `basePath` config:
 
 ```js
 module.exports = {

--- a/docs/api-reference/next.config.js/basepath.md
+++ b/docs/api-reference/next.config.js/basepath.md
@@ -15,7 +15,7 @@ description: Learn more about setting a base path in Next.js
 
 To deploy a Next.js application under a sub-path of a domain you can use the `basePath` config option.
 
-`basePath` allows you to set a path prefix for the application. For example, to use `/docs` instead of `/` (the default), open `next.config.js` and add the `basePath` config:
+`basePath` allows you to set a path prefix for the application. For example, to use `/docs` instead of ``(an empty string, the default), open`next.config.js`and add the`basePath` config:
 
 ```js
 module.exports = {


### PR DESCRIPTION
Closes #43946

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
