### PR TITLE
Update mdx docs example to show merging config

### DIFF
--- a/docs/advanced-features/using-mdx.md
+++ b/docs/advanced-features/using-mdx.md
@@ -53,10 +53,17 @@ The following steps outline how to setup `@next/mdx` in your Next.js project:
        // providerImportSource: "@mdx-js/react",
      },
    })
-   module.exports = withMDX({
-     // Append the default value with md extensions
+
+   /** @type {import('next').NextConfig} */
+   const nextConfig = {
+     // Configure pageExtensions to include md and mdx
      pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
-   })
+     // Optionally, add any other Next.js config below
+     reactStrictMode: true,
+   }
+
+   // Merge MDX config with Next.js config
+   module.exports = withMDX(nextConfig)
    ```
 
 3. Create a new MDX page within the `/pages` directory:


### PR DESCRIPTION
This PR updates the `@next/mdx` docs example code snippet to show merging config inside next.config.js

Related to comment https://github.com/vercel/next.js/pull/44205#issuecomment-1373714608