### PR TITLE
docs(middleware): add _next/image to match ignore

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -97,9 +97,10 @@ export const config = {
      * Match all request paths except for the ones starting with:
      * - api (API routes)
      * - _next/static (static files)
+     * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      */
-    '/((?!api|_next/static|favicon.ico).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico).*)',
   ],
 }
 ```


### PR DESCRIPTION
I copied the middleware example from the docs to ignore a few matches but the optimized images stopped working. I figure that it was missing adding in the Regex of my middleware.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
