### PR TITLE
Fix paths for check-examples script

### DIFF
--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -2,14 +2,14 @@
 
 for folder in examples/* ; do
   if [ -f "$folder/package.json" ]; then
-    cp -n packages/create-next-app/templates/default/gitignore $folder/.gitignore;
+    cp -n packages/create-next-app/templates/default/js/gitignore $folder/.gitignore;
     cat $folder/package.json | jq '
       .private = true |
       del(.license, .version, .name, .author, .description)
     ' | sponge $folder/package.json
   fi
   if [ -f "$folder/tsconfig.json" ]; then
-    cp packages/create-next-app/templates/typescript/next-env.d.ts $folder/next-env.d.ts
+    cp packages/create-next-app/templates/default/ts/next-env.d.ts $folder/next-env.d.ts
   fi
 done;
 


### PR DESCRIPTION
These paths needed updating from the new template paths. 

Fixes: https://github.com/vercel/next.js/actions/runs/3855317263/jobs/6570244567