### PR TITLE
Replace usage of example.com in gssp-redirect tests

### DIFF
--- a/test/integration/gssp-redirect-base-path/pages/gsp-blog/[post].js
+++ b/test/integration/gssp-redirect-base-path/pages/gsp-blog/[post].js
@@ -29,7 +29,7 @@ export const getStaticProps = ({ params }) => {
     let destination = '/404'
 
     if (params.post.includes('dest-external')) {
-      destination = 'https://example.com'
+      destination = 'https://example.vercel.sh'
     } else if (params.post.includes('dest-')) {
       destination = params.post.split('dest-').pop().replace(/_/g, '/')
     }

--- a/test/integration/gssp-redirect-base-path/pages/gssp-blog/[post].js
+++ b/test/integration/gssp-redirect-base-path/pages/gssp-blog/[post].js
@@ -23,7 +23,7 @@ export const getServerSideProps = ({ params }) => {
     let destination = '/404'
 
     if (params.post.includes('dest-external')) {
-      destination = 'https://example.com'
+      destination = 'https://example.vercel.sh'
     } else if (params.post.includes('dest-')) {
       destination = params.post.split('dest-').pop().replace(/_/g, '/')
     }

--- a/test/integration/gssp-redirect-base-path/test/index.test.js
+++ b/test/integration/gssp-redirect-base-path/test/index.test.js
@@ -240,7 +240,7 @@ const runTests = (isDev) => {
 
     await check(
       () => browser.eval(() => document.location.hostname),
-      'example.com'
+      'example.vercel.sh'
     )
 
     const initialHref = await browser.eval(() => window.initialHref)
@@ -258,7 +258,7 @@ const runTests = (isDev) => {
 
     await check(
       () => browser.eval(() => document.location.hostname),
-      'example.com'
+      'example.vercel.sh'
     )
 
     const initialHref = await browser.eval(() => window.initialHref)
@@ -275,7 +275,7 @@ const runTests = (isDev) => {
     expect(res.status).toBe(307)
 
     const parsed = url.parse(res.headers.get('location'))
-    expect(parsed.hostname).toBe('example.com')
+    expect(parsed.hostname).toBe('example.vercel.sh')
     expect(parsed.pathname).toBe('/')
   })
 

--- a/test/integration/gssp-redirect/pages/gsp-blog-blocking/[post].js
+++ b/test/integration/gssp-redirect/pages/gsp-blog-blocking/[post].js
@@ -29,7 +29,7 @@ export const getStaticProps = ({ params }) => {
     let destination = '/404'
 
     if (params.post.includes('dest-external')) {
-      destination = 'https://example.com'
+      destination = 'https://example.vercel.sh'
     } else if (params.post.includes('dest-')) {
       destination = params.post.split('dest-').pop().replace(/_/g, '/')
     }

--- a/test/integration/gssp-redirect/pages/gsp-blog/[post].js
+++ b/test/integration/gssp-redirect/pages/gsp-blog/[post].js
@@ -29,7 +29,7 @@ export const getStaticProps = ({ params }) => {
     let destination = '/404'
 
     if (params.post.includes('dest-external')) {
-      destination = 'https://example.com'
+      destination = 'https://example.vercel.sh'
     } else if (params.post.includes('dest-')) {
       destination = params.post.split('dest-').pop().replace(/_/g, '/')
     }

--- a/test/integration/gssp-redirect/pages/gssp-blog/[post].js
+++ b/test/integration/gssp-redirect/pages/gssp-blog/[post].js
@@ -23,7 +23,7 @@ export const getServerSideProps = ({ params }) => {
     let destination = '/404'
 
     if (params.post.includes('dest-external')) {
-      destination = 'https://example.com'
+      destination = 'https://example.vercel.sh'
     } else if (params.post.includes('dest-')) {
       destination = params.post.split('dest-').pop().replace(/_/g, '/')
     }

--- a/test/integration/gssp-redirect/test/index.test.js
+++ b/test/integration/gssp-redirect/test/index.test.js
@@ -281,7 +281,7 @@ const runTests = (isDev) => {
 
     await check(
       () => browser.eval(() => document.location.hostname),
-      'example.com'
+      'example.vercel.sh'
     )
 
     const initialHref = await browser.eval(() => window.initialHref)
@@ -299,7 +299,7 @@ const runTests = (isDev) => {
 
     await check(
       () => browser.eval(() => document.location.hostname),
-      'example.com'
+      'example.vercel.sh'
     )
 
     const initialHref = await browser.eval(() => window.initialHref)
@@ -316,7 +316,7 @@ const runTests = (isDev) => {
     expect(res.status).toBe(307)
 
     const parsed = url.parse(res.headers.get('location'))
-    expect(parsed.hostname).toBe('example.com')
+    expect(parsed.hostname).toBe('example.vercel.sh')
     expect(parsed.pathname).toBe('/')
   })
 


### PR DESCRIPTION
Uses example.vercel.sh as example.com flakes quite a bit. 

Fixes: https://github.com/vercel/next.js/actions/runs/3857935438/jobs/6576287232