### PR TITLE
Ensure yarn is used for next-with-deps

### DIFF
--- a/scripts/next-with-deps.sh
+++ b/scripts/next-with-deps.sh
@@ -29,7 +29,7 @@ done
 
 if [ ! -z $HAS_CONFLICTING_DEP ] || [ ! -d "$PROJECT_DIR/node_modules" ];then
   cd $PROJECT_DIR
-  pnpm install
+  yarn install
   for dep in ${CONFLICTING_DEPS[@]};do 
     rm -rf node_modules/$dep
   done


### PR DESCRIPTION
We aren't able to use `pnpm` for this script as it will no-op inside of the Next.js repo so we need to use a different package manager instead. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1673040998334369?thread_ts=1673034003.245089&cid=C04DUD7EB1B)