### PR TITLE
Recommend next-with-deps for running examples

### DIFF
--- a/contributing/examples/run-example-apps.md
+++ b/contributing/examples/run-example-apps.md
@@ -3,7 +3,7 @@
 Running examples can be done with:
 
 ```sh
-pnpm next ./examples/basic-css/
+pnpm next-with-deps ./examples/basic-css/
 ```
 
 To figure out which pages are available for the given example, you can run:


### PR DESCRIPTION
Depends on https://github.com/vercel/next.js/pull/44666

This will install `package.json` dependencies in examples before running them.
