### PR TITLE
Update prompts for CNA and add default @/* alias

### DIFF
--- a/docs/api-reference/create-next-app.md
+++ b/docs/api-reference/create-next-app.md
@@ -33,7 +33,7 @@ You can also pass command line arguments to set up a new project
 non-interactively. See `create-next-app --help`:
 
 ```bash
-create-next-app <project-directory> [options]
+Usage: create-next-app <project-directory> [options]
 
 Options:
   -V, --version                      output the version number
@@ -49,13 +49,13 @@ Options:
 
     Initialize with eslint config.
 
-  --no-eslint
-
-    Initialize without eslint config.
-
   --experimental-app
 
     Initialize as a `app/` directory project.
+
+  --src-dir
+
+    Initialize inside a `src/` directory.
 
   --use-npm
 
@@ -77,6 +77,8 @@ Options:
     a slash (e.g. bug/fix-1) and the path to the example (e.g. foo/bar).
     In this case, you must specify the path to the example separately:
     --example-path foo/bar
+
+  -h, --help                         output usage information
 ```
 
 ### Why use Create Next App?

--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -36,6 +36,7 @@ export async function createApp({
   typescript,
   eslint,
   experimentalApp,
+  srcDir,
 }: {
   appPath: string
   packageManager: PackageManager
@@ -44,6 +45,7 @@ export async function createApp({
   typescript: boolean
   eslint: boolean
   experimentalApp: boolean
+  srcDir: boolean
 }): Promise<void> {
   let repoInfo: RepoInfo | undefined
   const mode: TemplateMode = typescript ? 'ts' : 'js'
@@ -219,6 +221,7 @@ export async function createApp({
       packageManager,
       isOnline,
       eslint,
+      srcDir,
     })
   }
 

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -49,6 +49,13 @@ const program = new Commander.Command(packageJson.name)
 `
   )
   .option(
+    '--src-dir',
+    `
+
+  Initialize inside a \`src/\` directory.
+`
+  )
+  .option(
     '--use-npm',
     `
 
@@ -212,6 +219,48 @@ async function run(): Promise<void> {
         program.eslint = Boolean(eslint)
       }
     }
+
+    if (
+      !process.argv.includes('--src-dir') &&
+      !process.argv.includes('--no-src-dir')
+    ) {
+      if (ciInfo.isCI) {
+        program.srcDir = false
+      } else {
+        const styledSrcDir = chalk.hex('#007acc')('`src/` directory')
+        const { srcDir } = await prompts({
+          type: 'toggle',
+          name: 'srcDir',
+          message: `Would you like to use ${styledSrcDir} with this project?`,
+          initial: false,
+          active: 'Yes',
+          inactive: 'No',
+        })
+        program.srcDir = Boolean(srcDir)
+      }
+    }
+
+    if (
+      !process.argv.includes('--experimental-app') &&
+      !process.argv.includes('--no-experimental-app')
+    ) {
+      if (ciInfo.isCI) {
+        program.experimentalAll = false
+      } else {
+        const styledAppDir = chalk.hex('#007acc')(
+          'experimental `app/` directory'
+        )
+        const { appDir } = await prompts({
+          type: 'toggle',
+          name: 'appDir',
+          message: `Would you like to use ${styledAppDir} with this project?`,
+          initial: false,
+          active: 'Yes',
+          inactive: 'No',
+        })
+        program.experimentalApp = Boolean(appDir)
+      }
+    }
   }
 
   try {
@@ -223,6 +272,7 @@ async function run(): Promise<void> {
       typescript: program.typescript,
       eslint: program.eslint,
       experimentalApp: program.experimentalApp,
+      srcDir: program.srcDir,
     })
   } catch (reason) {
     if (!(reason instanceof DownloadError)) {
@@ -247,6 +297,7 @@ async function run(): Promise<void> {
       typescript: program.typescript,
       eslint: program.eslint,
       experimentalApp: program.experimentalApp,
+      srcDir: program.srcDir,
     })
   }
 }

--- a/packages/create-next-app/templates/app/js/jsconfig.json
+++ b/packages/create-next-app/templates/app/js/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/packages/create-next-app/templates/app/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app/ts/tsconfig.json
@@ -18,7 +18,11 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/packages/create-next-app/templates/default/js/jsconfig.json
+++ b/packages/create-next-app/templates/default/js/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/packages/create-next-app/templates/default/js/pages/_app.js
+++ b/packages/create-next-app/templates/default/js/pages/_app.js
@@ -1,4 +1,4 @@
-import '../styles/globals.css'
+import '@/styles/globals.css'
 
 export default function App({ Component, pageProps }) {
   return <Component {...pageProps} />

--- a/packages/create-next-app/templates/default/js/pages/index.js
+++ b/packages/create-next-app/templates/default/js/pages/index.js
@@ -1,7 +1,7 @@
 import Head from 'next/head'
 import Image from 'next/image'
 import { Inter } from '@next/font/google'
-import styles from '../styles/Home.module.css'
+import styles from '@/styles/Home.module.css'
 
 const inter = Inter({ subsets: ['latin'] })
 

--- a/packages/create-next-app/templates/default/ts/pages/_app.tsx
+++ b/packages/create-next-app/templates/default/ts/pages/_app.tsx
@@ -1,4 +1,4 @@
-import '../styles/globals.css'
+import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 
 export default function App({ Component, pageProps }: AppProps) {

--- a/packages/create-next-app/templates/default/ts/pages/index.tsx
+++ b/packages/create-next-app/templates/default/ts/pages/index.tsx
@@ -1,7 +1,7 @@
 import Head from 'next/head'
 import Image from 'next/image'
 import { Inter } from '@next/font/google'
-import styles from '../styles/Home.module.css'
+import styles from '@/styles/Home.module.css'
 
 const inter = Inter({ subsets: ['latin'] })
 

--- a/packages/create-next-app/templates/default/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default/ts/tsconfig.json
@@ -13,7 +13,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]

--- a/packages/create-next-app/templates/types.ts
+++ b/packages/create-next-app/templates/types.ts
@@ -18,4 +18,5 @@ export interface InstallTemplateArgs {
   template: TemplateType
   mode: TemplateMode
   eslint: boolean
+  srcDir: boolean
 }

--- a/test/integration/create-next-app/index.test.ts
+++ b/test/integration/create-next-app/index.test.ts
@@ -29,7 +29,7 @@ const run = (args: string[], options: execa.Options) =>
   execa('node', [cli].concat(args), options)
 
 describe('create next app', () => {
-  if (!process.env.NEXT_TEST_CNA && process.env.CI) {
+  if (!process.env.NEXT_TEST_CNA && process.env.NEXT_TEST_JOB) {
     it('should skip when env is not set', () => {})
     return
   }

--- a/test/integration/create-next-app/index.test.ts
+++ b/test/integration/create-next-app/index.test.ts
@@ -29,7 +29,7 @@ const run = (args: string[], options: execa.Options) =>
   execa('node', [cli].concat(args), options)
 
 describe('create next app', () => {
-  if (!process.env.NEXT_TEST_CNA) {
+  if (!process.env.NEXT_TEST_CNA && process.env.CI) {
     it('should skip when env is not set', () => {})
     return
   }
@@ -41,10 +41,19 @@ describe('create next app', () => {
       const pkg = path.join(cwd, projectName, 'package.json')
       fs.writeFileSync(pkg, '{ "foo": "bar" }')
 
-      const res = await run([projectName, '--js', '--eslint'], {
-        cwd,
-        reject: false,
-      })
+      const res = await run(
+        [
+          projectName,
+          '--js',
+          '--eslint',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
+        {
+          cwd,
+          reject: false,
+        }
+      )
       expect(res.exitCode).toBe(1)
       expect(res.stdout).toMatch(/contains files that could conflict/)
     })
@@ -56,7 +65,16 @@ describe('create next app', () => {
     it('empty directory', async () => {
       await useTempDir(async (cwd) => {
         const projectName = 'empty-directory'
-        const res = await run([projectName, '--js', '--eslint'], { cwd })
+        const res = await run(
+          [
+            projectName,
+            '--js',
+            '--eslint',
+            '--no-src-dir',
+            '--no-experimental-app',
+          ],
+          { cwd }
+        )
 
         expect(res.exitCode).toBe(0)
         shouldBeJavascriptProject({ cwd, projectName, template: 'default' })
@@ -294,10 +312,20 @@ describe('create next app', () => {
   it('should exit if example flag is empty', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'no-example-provided'
-      const res = await run([projectName, '--js', '--eslint', '--example'], {
-        cwd,
-        reject: false,
-      })
+      const res = await run(
+        [
+          projectName,
+          '--js',
+          '--eslint',
+          '--example',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
+        {
+          cwd,
+          reject: false,
+        }
+      )
 
       expect(res.exitCode).toBe(1)
     })
@@ -320,10 +348,19 @@ describe('create next app', () => {
         )
         return
       }
-      const res = await run([projectName, '--js', '--eslint'], {
-        cwd,
-        reject: false,
-      })
+      const res = await run(
+        [
+          projectName,
+          '--js',
+          '--eslint',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
+        {
+          cwd,
+          reject: false,
+        }
+      )
 
       expect(res.stderr).toMatch(
         /you do not have write permissions for this folder/
@@ -350,12 +387,15 @@ describe('create next app', () => {
         delete env.npm_config_user_agent
       }
 
-      const res = await run(['.', '--js', '--eslint'], {
-        cwd,
-        env,
-        extendEnv: false,
-        stdio: 'inherit',
-      })
+      const res = await run(
+        ['.', '--js', '--eslint', '--no-src-dir', '--no-experimental-app'],
+        {
+          cwd,
+          env,
+          extendEnv: false,
+          stdio: 'inherit',
+        }
+      )
       await fs.remove(tmpBin)
 
       expect(res.exitCode).toBe(0)
@@ -366,10 +406,13 @@ describe('create next app', () => {
   it('should ask the user for a name for the project if none supplied', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'test-project'
-      const res = await run(['--js', '--eslint'], {
-        cwd,
-        input: `${projectName}\n`,
-      })
+      const res = await run(
+        ['--js', '--eslint', '--no-src-dir', '--no-experimental-app'],
+        {
+          cwd,
+          input: `${projectName}\n`,
+        }
+      )
 
       expect(res.exitCode).toBe(0)
       shouldBeJavascriptProject({ cwd, projectName, template: 'default' })
@@ -379,9 +422,19 @@ describe('create next app', () => {
   it('should use npm as the package manager on supplying --use-npm', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-npm'
-      const res = await run([projectName, '--js', '--eslint', '--use-npm'], {
-        cwd,
-      })
+      const res = await run(
+        [
+          projectName,
+          '--js',
+          '--eslint',
+          '--use-npm',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
+        {
+          cwd,
+        }
+      )
 
       expect(res.exitCode).toBe(0)
       shouldBeJavascriptProject({ cwd, projectName, template: 'default' })
@@ -421,9 +474,19 @@ describe('create next app', () => {
   it('should use pnpm as the package manager on supplying --use-pnpm', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-pnpm'
-      const res = await run([projectName, '--js', '--eslint', '--use-pnpm'], {
-        cwd,
-      })
+      const res = await run(
+        [
+          projectName,
+          '--js',
+          '--eslint',
+          '--use-pnpm',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
+        {
+          cwd,
+        }
+      )
 
       expect(res.exitCode).toBe(0)
       projectFilesShouldExist({
@@ -481,10 +544,19 @@ describe('create next app', () => {
   it('should infer npm as the package manager', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'infer-package-manager-npm'
-      const res = await run([projectName, '--js', '--eslint'], {
-        cwd,
-        env: { ...process.env, npm_config_user_agent: 'npm' },
-      })
+      const res = await run(
+        [
+          projectName,
+          '--js',
+          '--eslint',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
+        {
+          cwd,
+          env: { ...process.env, npm_config_user_agent: 'npm' },
+        }
+      )
 
       const files = [
         'package.json',
@@ -537,10 +609,19 @@ describe('create next app', () => {
 
     await useTempDir(async (cwd) => {
       const projectName = 'infer-package-manager-yarn'
-      const res = await run([projectName, '--js', '--eslint'], {
-        cwd,
-        env: { ...process.env, npm_config_user_agent: 'yarn' },
-      })
+      const res = await run(
+        [
+          projectName,
+          '--js',
+          '--eslint',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
+        {
+          cwd,
+          env: { ...process.env, npm_config_user_agent: 'yarn' },
+        }
+      )
 
       const files = [
         'package.json',
@@ -600,10 +681,19 @@ describe('create next app', () => {
 
     await useTempDir(async (cwd) => {
       const projectName = 'infer-package-manager'
-      const res = await run([projectName, '--js', '--eslint'], {
-        cwd,
-        env: { ...process.env, npm_config_user_agent: 'pnpm' },
-      })
+      const res = await run(
+        [
+          projectName,
+          '--js',
+          '--eslint',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
+        {
+          cwd,
+          env: { ...process.env, npm_config_user_agent: 'pnpm' },
+        }
+      )
 
       const files = [
         'package.json',

--- a/test/integration/create-next-app/lib/specification.ts
+++ b/test/integration/create-next-app/lib/specification.ts
@@ -1,4 +1,6 @@
+import path from 'path'
 import {
+  SRC_DIR_NAMES,
   TemplateMode,
   TemplateType,
 } from '../../../../packages/create-next-app/templates'
@@ -40,7 +42,12 @@ export const projectSpecification: ProjectSpecification = {
   },
   default: {
     js: {
-      files: ['pages/index.js', 'pages/_app.js', 'pages/api/hello.js'],
+      files: [
+        'pages/index.js',
+        'pages/_app.js',
+        'pages/api/hello.js',
+        'jsconfig.json',
+      ],
       deps: [],
       devDeps: [],
     },
@@ -65,6 +72,7 @@ export const projectSpecification: ProjectSpecification = {
         'app/head.jsx',
         'app/layout.jsx',
         'pages/api/hello.js',
+        'jsconfig.json',
       ],
     },
     ts: {
@@ -86,15 +94,24 @@ export type GetProjectSettingsArgs = {
   template: TemplateType
   mode: TemplateMode
   setting: keyof ProjectSettings
+  srcDir?: boolean
 }
+
+export const mapSrcFiles = (files: string[], srcDir?: boolean) =>
+  files.map((file) =>
+    srcDir && SRC_DIR_NAMES.some((name) => file.startsWith(name))
+      ? path.join('src', file)
+      : file
+  )
 
 export const getProjectSetting = ({
   template,
   mode,
   setting,
+  srcDir,
 }: GetProjectSettingsArgs) => {
   return [
     ...projectSpecification.global[setting],
-    ...projectSpecification[template][mode][setting],
+    ...mapSrcFiles(projectSpecification[template][mode][setting], srcDir),
   ]
 }

--- a/test/integration/create-next-app/lib/types.ts
+++ b/test/integration/create-next-app/lib/types.ts
@@ -11,6 +11,7 @@ export interface DefaultTemplateOptions {
 export interface CustomTemplateOptions extends DefaultTemplateOptions {
   mode: TemplateMode
   template: TemplateType
+  srcDir?: boolean
 }
 
 export interface ProjectFiles extends DefaultTemplateOptions {

--- a/test/integration/create-next-app/lib/utils.ts
+++ b/test/integration/create-next-app/lib/utils.ts
@@ -9,7 +9,11 @@ import { existsSync } from 'fs'
 import { resolve } from 'path'
 import glob from 'glob'
 
-import { getProjectSetting, projectSpecification } from './specification'
+import {
+  getProjectSetting,
+  mapSrcFiles,
+  projectSpecification,
+} from './specification'
 import { CustomTemplateOptions, ProjectDeps, ProjectFiles } from './types'
 
 const cli = require.resolve('create-next-app/dist/index.js')
@@ -110,17 +114,21 @@ export const shouldBeTemplateProject = ({
   projectName,
   template,
   mode,
+  srcDir,
 }: CustomTemplateOptions) => {
   projectFilesShouldExist({
     cwd,
     projectName,
-    files: getProjectSetting({ template, mode, setting: 'files' }),
+    files: getProjectSetting({ template, mode, setting: 'files', srcDir }),
   })
 
   projectFilesShouldNotExist({
     cwd,
     projectName,
-    files: projectSpecification[template][mode === 'js' ? 'ts' : 'js'].files,
+    files: mapSrcFiles(
+      projectSpecification[template][mode === 'js' ? 'ts' : 'js'].files,
+      srcDir
+    ),
   })
 
   projectDepsShouldBe({
@@ -142,14 +150,16 @@ export const shouldBeJavascriptProject = ({
   cwd,
   projectName,
   template,
+  srcDir,
 }: Omit<CustomTemplateOptions, 'mode'>) => {
-  shouldBeTemplateProject({ cwd, projectName, template, mode: 'js' })
+  shouldBeTemplateProject({ cwd, projectName, template, mode: 'js', srcDir })
 }
 
 export const shouldBeTypescriptProject = ({
   cwd,
   projectName,
   template,
+  srcDir,
 }: Omit<CustomTemplateOptions, 'mode'>) => {
-  shouldBeTemplateProject({ cwd, projectName, template, mode: 'ts' })
+  shouldBeTemplateProject({ cwd, projectName, template, mode: 'ts', srcDir })
 }

--- a/test/integration/create-next-app/templates.test.ts
+++ b/test/integration/create-next-app/templates.test.ts
@@ -18,7 +18,7 @@ import {
 import { useTempDir } from '../../../test/lib/use-temp-dir'
 
 describe('create-next-app templates', () => {
-  if (!process.env.NEXT_TEST_CNA && process.env.CI) {
+  if (!process.env.NEXT_TEST_CNA && process.env.NEXT_TEST_JOB) {
     it('should skip when env is not set', () => {})
     return
   }
@@ -168,7 +168,7 @@ describe('create-next-app templates', () => {
 })
 
 describe('create-next-app --experimental-app-dir', () => {
-  if (!process.env.NEXT_TEST_CNA && process.env.CI) {
+  if (!process.env.NEXT_TEST_CNA && process.env.NEXT_TEST_JOB) {
     it('should skip when env is not set', () => {})
     return
   }

--- a/test/integration/create-next-app/templates.test.ts
+++ b/test/integration/create-next-app/templates.test.ts
@@ -18,7 +18,7 @@ import {
 import { useTempDir } from '../../../test/lib/use-temp-dir'
 
 describe('create-next-app templates', () => {
-  if (!process.env.NEXT_TEST_CNA) {
+  if (!process.env.NEXT_TEST_CNA && process.env.CI) {
     it('should skip when env is not set', () => {})
     return
   }
@@ -30,7 +30,10 @@ describe('create-next-app templates', () => {
       /**
        * Start the create-next-app call.
        */
-      const childProcess = createNextApp([projectName, '--eslint'], { cwd })
+      const childProcess = createNextApp(
+        [projectName, '--eslint', '--no-src-dir', '--no-experimental-app'],
+        { cwd }
+      )
       /**
        * Wait for the prompt to display.
        */
@@ -62,13 +65,43 @@ describe('create-next-app templates', () => {
   it('should create TS projects with --ts, --typescript', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'typescript-test'
-      const childProcess = createNextApp([projectName, '--ts', '--eslint'], {
-        cwd,
-      })
+      const childProcess = createNextApp(
+        [
+          projectName,
+          '--ts',
+          '--eslint',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
+        {
+          cwd,
+        }
+      )
       const exitCode = await spawnExitPromise(childProcess)
 
       expect(exitCode).toBe(0)
       shouldBeTypescriptProject({ cwd, projectName, template: 'default' })
+    })
+  })
+
+  it('should create TS projects with --ts, --typescript --src-dir', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'typescript-test'
+      const childProcess = createNextApp(
+        [projectName, '--ts', '--eslint', '--src-dir', '--no-experimental-app'],
+        {
+          cwd,
+        }
+      )
+      const exitCode = await spawnExitPromise(childProcess)
+
+      expect(exitCode).toBe(0)
+      shouldBeTypescriptProject({
+        cwd,
+        projectName,
+        template: 'default',
+        srcDir: true,
+      })
     })
   })
 
@@ -93,19 +126,49 @@ describe('create-next-app templates', () => {
   it('should create JS projects with --js, --javascript', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'javascript-test'
-      const childProcess = createNextApp([projectName, '--js', '--eslint'], {
-        cwd,
-      })
+      const childProcess = createNextApp(
+        [
+          projectName,
+          '--js',
+          '--eslint',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
+        {
+          cwd,
+        }
+      )
       const exitCode = await spawnExitPromise(childProcess)
 
       expect(exitCode).toBe(0)
       shouldBeJavascriptProject({ cwd, projectName, template: 'default' })
     })
   })
+
+  it('should create JS projects with --js, --javascript --src-dir', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'javascript-test'
+      const childProcess = createNextApp(
+        [projectName, '--js', '--eslint', '--src-dir', '--no-experimental-app'],
+        {
+          cwd,
+        }
+      )
+      const exitCode = await spawnExitPromise(childProcess)
+
+      expect(exitCode).toBe(0)
+      shouldBeJavascriptProject({
+        cwd,
+        projectName,
+        template: 'default',
+        srcDir: true,
+      })
+    })
+  })
 })
 
 describe('create-next-app --experimental-app-dir', () => {
-  if (!process.env.NEXT_TEST_CNA) {
+  if (!process.env.NEXT_TEST_CNA && process.env.CI) {
     it('should skip when env is not set', () => {})
     return
   }
@@ -114,7 +177,14 @@ describe('create-next-app --experimental-app-dir', () => {
     await useTempDir(async (cwd) => {
       const projectName = 'appdir-test'
       const childProcess = createNextApp(
-        [projectName, '--ts', '--experimental-app', '--eslint'],
+        [
+          projectName,
+          '--ts',
+          '--experimental-app',
+          '--eslint',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
         {
           cwd,
         }
@@ -130,7 +200,14 @@ describe('create-next-app --experimental-app-dir', () => {
     await useTempDir(async (cwd) => {
       const projectName = 'appdir-test'
       const childProcess = createNextApp(
-        [projectName, '--js', '--experimental-app', '--eslint'],
+        [
+          projectName,
+          '--js',
+          '--experimental-app',
+          '--eslint',
+          '--no-src-dir',
+          '--no-experimental-app',
+        ],
         {
           cwd,
         }
@@ -139,6 +216,29 @@ describe('create-next-app --experimental-app-dir', () => {
       const exitCode = await spawnExitPromise(childProcess)
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({ cwd, projectName, template: 'app', mode: 'js' })
+    })
+  })
+
+  it('should create JS appDir projects with --js --src-dir', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'appdir-test'
+      const childProcess = createNextApp(
+        [projectName, '--js', '--experimental-app', '--eslint', '--src-dir'],
+        {
+          cwd,
+          stdio: 'inherit',
+        }
+      )
+
+      const exitCode = await spawnExitPromise(childProcess)
+      expect(exitCode).toBe(0)
+      shouldBeTemplateProject({
+        cwd,
+        projectName,
+        template: 'app',
+        mode: 'js',
+        srcDir: true,
+      })
     })
   })
 })


### PR DESCRIPTION
This adds prompts for using a `src/` directory and experimental `app/` directory with create-next-app. Also adds `jsconfig` and `tsconfig` options to alias `@/*` by default.  

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1672856097701429)


## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

