### PR TITLE
Update redirects.md to fix a typo.

### DIFF
--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -167,7 +167,7 @@ module.exports = {
         destination: '/another-page',
       },
       // if the header `x-dont-redirect` is present,
-      // this redirect will be applied
+      // this redirect will NOT be applied
       {
         source: '/:path((?!another-page$).*)',
         missing: [


### PR DESCRIPTION
This will fix a typo where it says that the redirect will happen if the `missing` has matched. Which is not true.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
