### PR TITLE
Add required default value for the ids parameter

### DIFF
--- a/packages/next/src/shared/lib/loadable.ts
+++ b/packages/next/src/shared/lib/loadable.ts
@@ -259,7 +259,7 @@ Loadable.preloadAll = () => {
   })
 }
 
-Loadable.preloadReady = (ids?: (string | number)[]): Promise<void> => {
+Loadable.preloadReady = (ids: (string | number)[] = []): Promise<void> => {
   return new Promise<void>((resolvePreload) => {
     const res = () => {
       initialized = true


### PR DESCRIPTION
Before migrating "loadable" the from js to ts, the reload-ready function initialized its "ids" parameter with an empty array. The migration step added the parameter type but removed the initialization.

Providing an empty array as the default value for the ids parameter is necessary; otherwise, the ids variable in the createLoadableComponent function, line 102, gets undefined, and the loading of components fails.

fixes #44695