### PR TITLE
@next/font/google unknown font error

### DIFF
--- a/packages/font/src/google/utils.ts
+++ b/packages/font/src/google/utils.ts
@@ -44,6 +44,9 @@ export function validateData(
 
   const fontFamily = functionName.replace(/_/g, ' ')
   const fontFamilyData = (fontData as any)[fontFamily]
+  if (!fontFamilyData) {
+    nextFontError(`Unknown font \`${fontFamily}\``)
+  }
 
   if (preload && !callSubsets && !config?.subsets) {
     nextFontError(
@@ -63,9 +66,6 @@ export function validateData(
   })
 
   const fontWeights = fontFamilyData.weights
-  if (!fontWeights) {
-    nextFontError(`Unknown font \`${fontFamily}\``)
-  }
   const fontStyles = fontFamilyData.styles
 
   const weights = !weight

--- a/test/unit/google-font-loader.test.ts
+++ b/test/unit/google-font-loader.test.ts
@@ -166,9 +166,7 @@ describe('@next/font/google loader', () => {
           variableName: 'myFont',
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        process.version.startsWith('v14')
-          ? `"Cannot read property 'subsets' of undefined"`
-          : `"Cannot read properties of undefined (reading 'subsets')"`
+        `"Unknown font \`Unknown Font\`"`
       )
     })
 


### PR DESCRIPTION
I messed up the unknown font error in https://github.com/vercel/next.js/pull/44594. Restore the original error.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
