### PR TITLE
Fix new-error command

### DIFF
--- a/plopfile.js
+++ b/plopfile.js
@@ -1,5 +1,7 @@
 module.exports = function (plop) {
-  plop.setHelper('toFileName', (str) => str.toLowerCase().replace(/ /g, '-'))
+  function getFileName(str) {
+    return str.toLowerCase().replace(/ /g, '-')
+  }
 
   plop.setGenerator('test', {
     description: 'Create a new test',
@@ -76,10 +78,11 @@ module.exports = function (plop) {
       },
     ],
     actions: function (data) {
+      const fileName = getFileName(data.urlPath)
       return [
         {
           type: 'add',
-          path: `errors/{{ toFileName name }}.md`,
+          path: `errors/${fileName}.md`,
           templateFile: `errors/template.txt`,
         },
         {
@@ -88,13 +91,13 @@ module.exports = function (plop) {
           transform(fileContents, data) {
             const manifestData = JSON.parse(fileContents)
             manifestData.routes[0].routes.push({
-              title: '{{ toFileName name }}',
-              path: `/errors/{{ toFileName name }}.md`,
+              title: fileName,
+              path: `/errors/${fileName}.md`,
             })
             return JSON.stringify(manifestData, null, 2)
           },
         },
-        `Url for the error: https://nextjs.org/docs/messages/{{ toFileName name }}`,
+        `Url for the error: https://nextjs.org/docs/messages/${fileName}`,
       ]
     },
   })


### PR DESCRIPTION
Seems like `pnpm new-error` stopped working after https://github.com/vercel/next.js/pull/44227. I've reverted the changes that caused an error when it tried to run the `toFileName` helper.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
