### PR TITLE
Improve errors caused by Class Component rendered in a server component.

### DIFF
--- a/errors/class-component-in-server-component.md
+++ b/errors/class-component-in-server-component.md
@@ -1,0 +1,54 @@
+# React Class component rendered in a Server Component
+
+#### Why This Error Occurred
+
+You are rendering a React Class Component in a Server Component, `React.Component` and `React.PureComponent` only works in Client Components.
+
+#### Possible Ways to Fix It
+
+Use a Function Component.
+
+##### Before
+
+```jsx
+export default class Page extends React.Component {
+  render() {
+    return <p>Hello world</p>
+  }
+}
+```
+
+##### After
+
+```jsx
+export default function Page() {
+  return <p>Hello world</p>
+}
+```
+
+Mark the component rendering the React Class Component as a Client Component by adding `'use client'` at the top of the file.
+
+##### Before
+
+```jsx
+export default class Page extends React.Component {
+  render() {
+    return <p>Hello world</p>
+  }
+}
+```
+
+##### After
+
+```jsx
+'use client'
+export default class Page extends React.Component {
+  render() {
+    return <p>Hello world</p>
+  }
+}
+```
+
+### Useful Links
+
+[Server and Client Components](https://beta.nextjs.org/docs/rendering/server-and-client-components)

--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -781,6 +781,10 @@
         {
           "title": "react-client-hook-in-server-component",
           "path": "/errors/react-client-hook-in-server-component.md"
+        },
+        {
+          "title": "class-component-in-server-component",
+          "path": "/errors/class-component-in-server-component.md"
         }
       ]
     }

--- a/packages/next/src/lib/format-server-error.ts
+++ b/packages/next/src/lib/format-server-error.ts
@@ -21,6 +21,20 @@ function setMessage(error: Error, message: string): void {
 }
 
 export function formatServerError(error: Error): void {
+  if (
+    error.message.includes(
+      'Class extends value undefined is not a constructor or null'
+    )
+  ) {
+    setMessage(
+      error,
+      `${error.message}
+
+This might be caused by a React Class component being rendered in a server component, React Class components only works in client components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component`
+    )
+    return
+  }
+
   if (error.message.includes('createContext is not a function')) {
     setMessage(
       error,

--- a/packages/next/src/lib/format-server-error.ts
+++ b/packages/next/src/lib/format-server-error.ts
@@ -30,7 +30,7 @@ export function formatServerError(error: Error): void {
       error,
       `${error.message}
 
-This might be caused by a React Class component being rendered in a server component, React Class components only works in client components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component`
+This might be caused by a React Class component being rendered in a server component, React Class components only works in Client Components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component`
     )
     return
   }

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -17,7 +17,7 @@ createNextDescribe(
   ({ next }) => {
     describe('createContext called in Server Component', () => {
       it('should show error when React.createContext is called', async () => {
-        const { session, cleanup } = await sandbox(
+        const { browser, cleanup } = await sandbox(
           next,
           new Map([
             [
@@ -38,22 +38,26 @@ createNextDescribe(
           ])
         )
 
-        expect(await session.hasRedbox(true)).toBe(true)
         await check(async () => {
-          expect(await session.getRedboxSource(true)).toContain(
-            `TypeError: createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component`
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
           )
           return 'success'
         }, 'success')
+
         expect(next.cliOutput).toContain(
-          'createContext only works in Client Components'
+          'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
         )
 
         await cleanup()
       })
 
       it('should show error when React.createContext is called in external package', async () => {
-        const { session, cleanup } = await sandbox(
+        const { browser, cleanup } = await sandbox(
           next,
           new Map([
             [
@@ -89,24 +93,26 @@ createNextDescribe(
           ])
         )
 
-        expect(await session.hasRedbox(true)).toBe(true)
-
         await check(async () => {
-          expect(await session.getRedboxSource(true)).toContain(
-            `TypeError: createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component`
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
           )
           return 'success'
         }, 'success')
 
         expect(next.cliOutput).toContain(
-          'createContext only works in Client Components'
+          'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
         )
 
         await cleanup()
       })
 
       it('should show error when createContext is called in external package', async () => {
-        const { session, cleanup } = await sandbox(
+        const { browser, cleanup } = await sandbox(
           next,
           new Map([
             [
@@ -141,26 +147,28 @@ createNextDescribe(
             ],
           ])
         )
-
-        expect(await session.hasRedbox(true)).toBe(true)
-
         await check(async () => {
-          expect(await session.getRedboxSource(true)).toContain(
-            `TypeError: createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component`
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
           )
           return 'success'
         }, 'success')
 
         expect(next.cliOutput).toContain(
-          'createContext only works in Client Components'
+          'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
         )
+
         await cleanup()
       })
     })
 
     describe('React component hooks called in Server Component', () => {
       it('should show error when React.<client-hook> is called', async () => {
-        const { session, cleanup } = await sandbox(
+        const { browser, cleanup } = await sandbox(
           next,
           new Map([
             [
@@ -175,24 +183,26 @@ createNextDescribe(
           ])
         )
 
-        expect(await session.hasRedbox(true)).toBe(true)
-
         await check(async () => {
-          expect(await session.getRedboxSource(true)).toContain(
-            `Error: useRef only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component`
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'useRef only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
           )
           return 'success'
         }, 'success')
 
         expect(next.cliOutput).toContain(
-          'useRef only works in Client Components'
+          'useRef only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
         )
 
         await cleanup()
       })
 
       it('should show error when React.<client-hook> is called in external package', async () => {
-        const { session, cleanup } = await sandbox(
+        const { browser, cleanup } = await sandbox(
           next,
           new Map([
             [
@@ -225,24 +235,26 @@ createNextDescribe(
           ])
         )
 
-        expect(await session.hasRedbox(true)).toBe(true)
-
         await check(async () => {
-          expect(await session.getRedboxSource(true)).toContain(
-            `Error: useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component`
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
           )
           return 'success'
         }, 'success')
 
         expect(next.cliOutput).toContain(
-          'useState only works in Client Components'
+          'useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
         )
 
         await cleanup()
       })
 
       it('should show error when React client hook is called in external package', async () => {
-        const { session, cleanup } = await sandbox(
+        const { browser, cleanup } = await sandbox(
           next,
           new Map([
             [
@@ -275,17 +287,19 @@ createNextDescribe(
           ])
         )
 
-        expect(await session.hasRedbox(true)).toBe(true)
-
         await check(async () => {
-          expect(await session.getRedboxSource(true)).toContain(
-            `Error: useEffect only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component`
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'useEffect only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
           )
           return 'success'
         }, 'success')
 
         expect(next.cliOutput).toContain(
-          'useEffect only works in Client Components'
+          'useEffect only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
         )
 
         await cleanup()
@@ -294,7 +308,7 @@ createNextDescribe(
 
     describe('Class component used in Server Component', () => {
       it('should show error when Class Component is used', async () => {
-        const { session, cleanup } = await sandbox(
+        const { browser, cleanup } = await sandbox(
           next,
           new Map([
             [
@@ -311,11 +325,13 @@ createNextDescribe(
           ])
         )
 
-        expect(await session.hasRedbox(true)).toBe(true)
-
         await check(async () => {
-          expect(await session.getRedboxSource(true)).toContain(
-            'This might be caused by a React Class component being rendered in a server component, React Class components only works in Client Components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component'
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'This might be caused by a React Class component being rendered in a server component'
           )
           return 'success'
         }, 'success')
@@ -328,7 +344,7 @@ createNextDescribe(
       })
 
       it('should show error when React.PureComponent is rendered in external package', async () => {
-        const { session, cleanup } = await sandbox(
+        const { browser, cleanup } = await sandbox(
           next,
           new Map([
             [
@@ -362,11 +378,13 @@ createNextDescribe(
           ])
         )
 
-        expect(await session.hasRedbox(true)).toBe(true)
-
         await check(async () => {
-          expect(await session.getRedboxSource(true)).toContain(
-            'This might be caused by a React Class component being rendered in a server component, React Class components only works in Client Components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component'
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'This might be caused by a React Class component being rendered in a server component'
           )
           return 'success'
         }, 'success')
@@ -379,7 +397,7 @@ createNextDescribe(
       })
 
       it('should show error when Component is rendered in external package', async () => {
-        const { session, cleanup } = await sandbox(
+        const { browser, cleanup } = await sandbox(
           next,
           new Map([
             [
@@ -413,11 +431,13 @@ createNextDescribe(
           ])
         )
 
-        expect(await session.hasRedbox(true)).toBe(true)
-
         await check(async () => {
-          expect(await session.getRedboxSource(true)).toContain(
-            'This might be caused by a React Class component being rendered in a server component, React Class components only works in client components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component'
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'This might be caused by a React Class component being rendered in a server component'
           )
           return 'success'
         }, 'success')
@@ -440,7 +460,7 @@ createNextDescribe(
         ['useSelectedLayoutSegments'],
         ['usePathname'],
       ])('should show error when %s is called', async (hook: string) => {
-        const { session, cleanup } = await sandbox(
+        const { browser, cleanup } = await sandbox(
           next,
           new Map([
             [
@@ -455,17 +475,19 @@ createNextDescribe(
           ])
         )
 
-        expect(await session.hasRedbox(true)).toBe(true)
-
         await check(async () => {
-          expect(await session.getRedboxSource(true)).toContain(
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
             `Error: ${hook} only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component`
           )
           return 'success'
         }, 'success')
 
         expect(next.cliOutput).toContain(
-          `${hook} only works in Client Components`
+          `Error: ${hook} only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component`
         )
 
         await cleanup()

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -292,6 +292,144 @@ createNextDescribe(
       })
     })
 
+    describe('Class component used in Server Component', () => {
+      it('should show error when Class Component is used', async () => {
+        const { session, cleanup } = await sandbox(
+          next,
+          new Map([
+            [
+              'app/page.js',
+              `
+        import React from 'react'
+        export default class Page extends React.Component {
+          render() {
+            return <p>Hello world</p>
+          }
+        }
+        `,
+            ],
+          ])
+        )
+
+        expect(await session.hasRedbox(true)).toBe(true)
+
+        await check(async () => {
+          expect(await session.getRedboxSource(true)).toContain(
+            'This might be caused by a React Class component being rendered in a server component, React Class components only works in client components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component'
+          )
+          return 'success'
+        }, 'success')
+
+        expect(next.cliOutput).toContain(
+          'This might be caused by a React Class component being rendered in a server component'
+        )
+
+        await cleanup()
+      })
+
+      it('should show error when React.Component is rendered in external package', async () => {
+        const { session, cleanup } = await sandbox(
+          next,
+          new Map([
+            [
+              'node_modules/my-package/index.js',
+              `
+          const React = require('react')
+          module.exports = class extends React.Component {
+            render() {
+              return "Hello world"
+            } 
+          }
+        `,
+            ],
+            [
+              'node_modules/my-package/package.json',
+              `
+          {
+            "name": "my-package",
+            "version": "0.0.1"
+          }
+        `,
+            ],
+            [
+              'app/page.js',
+              `
+        import Component from 'my-package'
+        export default function Page() {
+          return <Component />
+        }`,
+            ],
+          ])
+        )
+
+        expect(await session.hasRedbox(true)).toBe(true)
+
+        await check(async () => {
+          expect(await session.getRedboxSource(true)).toContain(
+            'This might be caused by a React Class component being rendered in a server component, React Class components only works in client components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component'
+          )
+          return 'success'
+        }, 'success')
+
+        expect(next.cliOutput).toContain(
+          'This might be caused by a React Class component being rendered in a server component'
+        )
+
+        await cleanup()
+      })
+
+      it('should show error when Component is rendered in external package', async () => {
+        const { session, cleanup } = await sandbox(
+          next,
+          new Map([
+            [
+              'node_modules/my-package/index.js',
+              `
+          const { Component } = require('react')
+          module.exports = class extends Component {
+            render() {
+              return "Hello world"
+            }
+          }
+        `,
+            ],
+            [
+              'node_modules/my-package/package.json',
+              `
+          {
+            "name": "my-package",
+            "version": "0.0.1"
+          }
+        `,
+            ],
+            [
+              'app/page.js',
+              `
+            import Component from 'my-package'
+            export default function Page() {
+              return <Component />
+            }`,
+            ],
+          ])
+        )
+
+        expect(await session.hasRedbox(true)).toBe(true)
+
+        await check(async () => {
+          expect(await session.getRedboxSource(true)).toContain(
+            'This might be caused by a React Class component being rendered in a server component, React Class components only works in client components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component'
+          )
+          return 'success'
+        }, 'success')
+
+        expect(next.cliOutput).toContain(
+          'This might be caused by a React Class component being rendered in a server component'
+        )
+
+        await cleanup()
+      })
+    })
+
     describe('Next.js component hooks called in Server Component', () => {
       it.each([
         // TODO-APP: add test for useParams

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -327,7 +327,7 @@ createNextDescribe(
         await cleanup()
       })
 
-      it('should show error when React.Component is rendered in external package', async () => {
+      it('should show error when React.PureComponent is rendered in external package', async () => {
         const { session, cleanup } = await sandbox(
           next,
           new Map([
@@ -335,7 +335,7 @@ createNextDescribe(
               'node_modules/my-package/index.js',
               `
           const React = require('react')
-          module.exports = class extends React.Component {
+          module.exports = class extends React.PureComponent {
             render() {
               return "Hello world"
             } 

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -315,7 +315,7 @@ createNextDescribe(
 
         await check(async () => {
           expect(await session.getRedboxSource(true)).toContain(
-            'This might be caused by a React Class component being rendered in a server component, React Class components only works in client components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component'
+            'This might be caused by a React Class component being rendered in a server component, React Class components only works in Client Components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component'
           )
           return 'success'
         }, 'success')

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -366,7 +366,7 @@ createNextDescribe(
 
         await check(async () => {
           expect(await session.getRedboxSource(true)).toContain(
-            'This might be caused by a React Class component being rendered in a server component, React Class components only works in client components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component'
+            'This might be caused by a React Class component being rendered in a server component, React Class components only works in Client Components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component'
           )
           return 'success'
         }, 'success')


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/25056922/211333854-bc2b70d4-c2e0-4686-b2bb-205e828077cf.png)


After
![image](https://user-images.githubusercontent.com/25056922/211333605-42d094eb-26c1-4a2d-af39-8c7c2aab7dc5.png)

Fixes NEXT-353

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
