### PR TITLE
fix: support runtime value when using multiple declarations per export

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -70,9 +70,10 @@ function checkExports(swcAST: any): {
           node.type === 'ExportDeclaration' &&
           node.declaration?.type === 'VariableDeclaration'
         ) {
-          const id = node.declaration?.declarations[0]?.id.value
-          if (id === 'runtime') {
-            runtime = node.declaration?.declarations[0]?.init.value
+          for (const declaration of node.declaration?.declarations) {
+            if (declaration.id.value === 'runtime') {
+              runtime = declaration.init.value
+            }
           }
         }
 

--- a/test/e2e/switchable-runtime/app/app-valid-runtime/page.js
+++ b/test/e2e/switchable-runtime/app/app-valid-runtime/page.js
@@ -1,0 +1,17 @@
+import Time from '../../utils/time'
+import Runtime from '../../utils/runtime'
+
+export default function Page() {
+  return (
+    <div>
+      This is a SSR RSC page.
+      <br />
+      <Runtime />
+      <br />
+      <Time />
+    </div>
+  )
+}
+
+export const foo = 'bar',
+  runtime = 'edge'

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -530,6 +530,13 @@ describe('Switchable runtime', () => {
         })
       })
 
+      it('should build /app-valid-runtime as a dynamic page with the edge runtime', async () => {
+        await testRoute(context.appPort, '/app-valid-runtime', {
+          isStatic: false,
+          isEdge: true,
+        })
+      })
+
       // FIXME: rsc hydration
       it.skip('should build /node-rsc-ssr as a dynamic page with the nodejs runtime', async () => {
         await testRoute(context.appPort, '/node-rsc-ssr', {


### PR DESCRIPTION
Fixes a bug where the export syntax with multiple declarations didn't work. I.e. this now works:

```
export const foo = 'bar', runtime = 'edge'
```

[x-slack-ref](https://vercel.slack.com/archives/C03LF48T3B7/p1673152323630709) 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
