### PR TITLE
land(Fix: Add trailing slash to locale redirect based on next config)

### DIFF
--- a/packages/next/src/shared/lib/i18n/get-locale-redirect.ts
+++ b/packages/next/src/shared/lib/i18n/get-locale-redirect.ts
@@ -108,7 +108,9 @@ export function getLocaleRedirect({
     if (detectedLocale.toLowerCase() !== defaultLocale.toLowerCase()) {
       return formatUrl({
         ...urlParsed,
-        pathname: `${nextConfig.basePath || ''}/${detectedLocale}${nextConfig.trailingSlash ? '/' : ''}`,
+        pathname: `${nextConfig.basePath || ''}/${detectedLocale}${
+          nextConfig.trailingSlash ? '/' : ''
+        }`,
       })
     }
   }

--- a/packages/next/src/shared/lib/i18n/get-locale-redirect.ts
+++ b/packages/next/src/shared/lib/i18n/get-locale-redirect.ts
@@ -108,7 +108,7 @@ export function getLocaleRedirect({
     if (detectedLocale.toLowerCase() !== defaultLocale.toLowerCase()) {
       return formatUrl({
         ...urlParsed,
-        pathname: `${nextConfig.basePath || ''}/${detectedLocale}`,
+        pathname: `${nextConfig.basePath || ''}/${detectedLocale}${nextConfig.trailingSlash ? '/' : ''}`,
       })
     }
   }


### PR DESCRIPTION
Lands https://github.com/vercel/next.js/pull/44562 with lint fixes

Closes: https://github.com/vercel/next.js/pull/44562

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
