### PR TITLE
Allow nested fragments on Head

### DIFF
--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -41,6 +41,9 @@ function onlyReactElement(
           ) {
             return fragmentList
           }
+          if (fragmentChild.type === React.Fragment) {
+            return onlyReactElement(fragmentList, fragmentChild)
+          }
           return fragmentList.concat(fragmentChild)
         },
         []


### PR DESCRIPTION
Not sure about this change does what I expect as haven't tested it, but I think it would be great to support nested fragments on Head component. Also, it's very problematic that due to the current implementation, when there's a nested fragment it fails silently, and if you mocking the Head component in your unit tests it will work as expected but not in the real world

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
