### PR TITLE
Added type annotation for 'body' to NextApiRequest

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -197,7 +197,7 @@ export type DocumentProps = DocumentInitialProps & HtmlProps
 /**
  * Next `API` route request
  */
-export interface NextApiRequest extends IncomingMessage {
+export interface NextApiRequest<BodyType = any> extends IncomingMessage {
   /**
    * Object of `query` values from url
    */
@@ -211,7 +211,7 @@ export interface NextApiRequest extends IncomingMessage {
     [key: string]: string
   }>
 
-  body: any
+  body: BodyType
 
   env: Env
 


### PR DESCRIPTION
Not sure what else I should do, but it's a simple fix. It's pretty annoying, even in Express, having `req.body` be any. This way, we can create an interface for our request and simply annotate the handler with it.