### PR TITLE
Fix app ISR handling with no generateStaticParams

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1494,7 +1494,8 @@ export default async function build(
                           isSsg = true
                         }
                         if (
-                          !isDynamicRoute(page) &&
+                          (!isDynamicRoute(page) ||
+                            !workerResult.prerenderRoutes?.length) &&
                           workerResult.appConfig?.revalidate !== 0
                         ) {
                           appStaticPaths.set(originalAppPath, [page])
@@ -2360,6 +2361,8 @@ export default async function build(
             let hasDynamicData = appConfig.revalidate === 0
 
             routes.forEach((route) => {
+              if (isDynamicRoute(page) && route === page) return
+
               let revalidate = exportConfig.initialPageRevalidationMap[route]
 
               if (typeof revalidate === 'undefined') {

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1191,7 +1191,10 @@ export async function buildAppStaticPaths({
     if (!hadGenerateParams) {
       return {
         paths: undefined,
-        fallback: undefined,
+        fallback:
+          process.env.NODE_ENV === 'production' && isDynamicRoute(page)
+            ? true
+            : undefined,
         encodedPaths: undefined,
       }
     }

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -43,6 +43,8 @@ createNextDescribe(
           'dynamic-error.rsc',
           'dynamic-error/page.js',
           'dynamic-no-gen-params-ssr/[slug]/page.js',
+          'dynamic-no-gen-params/[slug].html',
+          'dynamic-no-gen-params/[slug].rsc',
           'dynamic-no-gen-params/[slug]/page.js',
           'force-static/[slug]/page.js',
           'force-static/first.html',
@@ -200,6 +202,16 @@ createNextDescribe(
             dataRouteRegex: normalizeRegEx('^\\/blog\\/([^\\/]+?)\\.rsc$'),
             fallback: false,
             routeRegex: normalizeRegEx('^\\/blog\\/([^\\/]+?)(?:\\/)?$'),
+          },
+          '/dynamic-no-gen-params/[slug]': {
+            dataRoute: '/dynamic-no-gen-params/[slug].rsc',
+            dataRouteRegex: normalizeRegEx(
+              '^\\/dynamic\\-no\\-gen\\-params\\/([^\\/]+?)\\.rsc$'
+            ),
+            fallback: null,
+            routeRegex: normalizeRegEx(
+              '^\\/dynamic\\-no\\-gen\\-params\\/([^\\/]+?)(?:\\/)?$'
+            ),
           },
           '/hooks/use-pathname/[slug]': {
             dataRoute: '/hooks/use-pathname/[slug].rsc',


### PR DESCRIPTION
This ensures we properly detect/treat pages as ISR even when `generateStaticParams` is not defined.

Test deployment with patch can be seen here https://vtest314-e2e-tests-fcaryu4ju-vtest314-next-e2e-tests.vercel.app/dynamic-no-gen-params/first

x-ref: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1673473561292119)
x-ref: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1671680414168329?thread_ts=1671676310.086279&cid=C035J346QQL)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

