### PR TITLE
Clarify middleware.ts location in docs

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -33,7 +33,7 @@ To begin using Middleware, follow the steps below:
 npm install next@latest
 ```
 
-2. Create a `middleware.ts` (or `.js`) file at the root or in the `src` directory (same level as your `pages`)
+2. Create a `middleware.ts` (or `.js`) file at the same level as your `pages` (in the root or `src` directory)
 3. Export a middleware function from the `middleware.ts` file:
 
 ```typescript


### PR DESCRIPTION
I had an issue where middleware stopped running. It turns out that because I had moved the `pages` directory from `/pages` to `/src/pages`, I also needed to move `/middleware.ts` to `/src/middleware.ts`.

While double checking the docs to figure out this problem, I interpreted the docs as saying `middleware.ts` could go in **either** the root or `src`. I thought swapping the sentence around would more clearly indicate `middleware.ts` must be alongside `pages`, wherever that is.