### PR TITLE
fix(git): use git config for branch name

### DIFF
--- a/packages/create-next-app/helpers/git.ts
+++ b/packages/create-next-app/helpers/git.ts
@@ -30,8 +30,6 @@ export function tryGitInit(root: string): boolean {
     execSync('git init', { stdio: 'ignore' })
     didInit = true
 
-    execSync('git checkout -b main', { stdio: 'ignore' })
-
     execSync('git add -A', { stdio: 'ignore' })
     execSync('git commit -m "Initial commit from Create Next App"', {
       stdio: 'ignore',


### PR DESCRIPTION
This removes the explicit branch name 'main' in favour of delegating to the local git configuration for branch naming policy.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x Related issues linked using `fixes #number`
