### PR TITLE
Fix FreeBSD next-swc build

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1346,7 +1346,7 @@ jobs:
             whoami
             env
             freebsd-version
-            pnpm --filter=@next/swc run build-native-no-plugin --platform --release --target x86_64-unknown-freebsd
+            GITHUB_EVENT_PATH='' pnpm --filter=@next/swc run build-native-no-plugin --platform --release --target x86_64-unknown-freebsd
             rm -rf node_modules
             rm -rf packages/next-swc/target
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1178,7 +1178,7 @@ jobs:
             build: |
               npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" "turbo@${TURBO_VERSION}" "pnpm@${PNPM_VERSION}"
               turbo run build-native-no-plugin-woa -- --release --target aarch64-pc-windows-msvc --cargo-flags=--no-default-features
-    if: ${{ needs.build.outputs.isRelease == 'true' || (needs.build.outputs.swcChange == 'yup' && needs.build.outputs.turboToken != 'empty') }}
+    if: ${{ needs.build.outputs.isRelease == 'true' || (needs.build.outputs.turboToken != 'empty') }}
     needs: build
     name: stable - ${{ matrix.settings.target }} - node@16
     runs-on: ${{ matrix.settings.host }}
@@ -1271,7 +1271,7 @@ jobs:
           path: packages/next-swc/native/next-swc.*.node
 
   build-native-freebsd:
-    if: ${{ needs.build.outputs.isRelease == 'true' || (needs.build.outputs.swcChange == 'yup' && needs.build.outputs.turboToken != 'empty') }}
+    if: ${{ needs.build.outputs.isRelease == 'true' || (needs.build.outputs.turboToken != 'empty') }}
     needs: build
     name: stable - x86_64-unknown-freebsd - node@16
     runs-on: macos-12
@@ -1352,7 +1352,7 @@ jobs:
 
       - name: cache build
         if: ${{ steps.build-exists.outputs.BUILD_EXISTS == 'no' }}
-        run: pnpm turbo run cache-build-native -- --platform --release --target x86_64-unknown-freebsd
+        run: pnpm turbo run --force cache-build-native -- --platform --release --target x86_64-unknown-freebsd
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1363,7 +1363,7 @@ jobs:
 
   build-wasm:
     needs: build
-    if: ${{ needs.build.outputs.isRelease == 'true' || (needs.build.outputs.swcChange == 'yup' && needs.build.outputs.turboToken != 'empty') }}
+    if: ${{ needs.build.outputs.isRelease == 'true' || (needs.build.outputs.turboToken != 'empty') }}
     strategy:
       matrix:
         target: [web, nodejs]


### PR DESCRIPTION
Seems the FreeBSD build failed as pnpm internals attempt to load the `GITHUB_EVENT` file which isn't copied to the vm the binary is built in https://github.com/yarnpkg/berry/blob/c1919d3c1e0cd7e45a8bea090658b239384b846e/packages/yarnpkg-core/sources/Configuration.ts#L32-L34

There also appears to be an unexpected cache miss in turbo from one of these commits https://github.com/vercel/next.js/compare/v13.1.2-canary.6...v13.1.2-canary.7 which can be investigated separately. 

Fixes: https://github.com/vercel/next.js/actions/runs/3904744068/jobs/6671300649
