### PR TITLE
Add PageConfig type to docs

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -38,7 +38,7 @@ npm install next@latest
 
 ```typescript
 // middleware.ts
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
@@ -76,7 +76,7 @@ There are two ways to define which paths Middleware will run on:
 `matcher` allows you to filter Middleware to run on specific paths.
 
 ```ts
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 
 export const config: PageConfig = {
   matcher: '/about/:path*',
@@ -86,7 +86,7 @@ export const config: PageConfig = {
 You can match a single path or multiple paths with an array syntax:
 
 ```ts
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 
 export const config: PageConfig = {
   matcher: ['/about/:path*', '/dashboard/:path*'],
@@ -96,7 +96,7 @@ export const config: PageConfig = {
 The `matcher` config allows full regex so matching like negative lookaheads or character matching is supported. An example of a negative lookahead to match all except specific paths can be seen here:
 
 ```ts
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 
 export const config: PageConfig = {
   matcher: [
@@ -234,7 +234,7 @@ Once enabled, you can provide a response from middleware using the `Response` or
 
 ```ts
 // middleware.ts
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 import { NextRequest, NextResponse } from 'next/server'
 import { isAuthenticated } from '@lib/auth'
 

--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -38,6 +38,7 @@ npm install next@latest
 
 ```typescript
 // middleware.ts
+import { PageConfig } from "next"
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
@@ -47,7 +48,7 @@ export function middleware(request: NextRequest) {
 }
 
 // See "Matching Paths" below to learn more
-export const config = {
+export const config: PageConfig = {
   matcher: '/about/:path*',
 }
 ```
@@ -74,24 +75,30 @@ There are two ways to define which paths Middleware will run on:
 
 `matcher` allows you to filter Middleware to run on specific paths.
 
-```js
-export const config = {
+```ts
+import { PageConfig } from "next"
+
+export const config: PageConfig = {
   matcher: '/about/:path*',
 }
 ```
 
 You can match a single path or multiple paths with an array syntax:
 
-```js
-export const config = {
+```ts
+import { PageConfig } from "next"
+
+export const config: PageConfig = {
   matcher: ['/about/:path*', '/dashboard/:path*'],
 }
 ```
 
 The `matcher` config allows full regex so matching like negative lookaheads or character matching is supported. An example of a negative lookahead to match all except specific paths can be seen here:
 
-```js
-export const config = {
+```ts
+import { PageConfig } from "next"
+
+export const config: PageConfig = {
   matcher: [
     /*
      * Match all request paths except for the ones starting with:
@@ -227,11 +234,12 @@ Once enabled, you can provide a response from middleware using the `Response` or
 
 ```ts
 // middleware.ts
+import { PageConfig } from "next"
 import { NextRequest, NextResponse } from 'next/server'
 import { isAuthenticated } from '@lib/auth'
 
 // Limit the middleware to paths starting with `/api/`
-export const config = {
+export const config: PageConfig = {
   matcher: '/api/:function*',
 }
 

--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -38,7 +38,7 @@ npm install next@latest
 
 ```typescript
 // middleware.ts
-import { PageConfig } from 'next'
+import { MiddlewareConfig } from 'next'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
@@ -48,7 +48,7 @@ export function middleware(request: NextRequest) {
 }
 
 // See "Matching Paths" below to learn more
-export const config: PageConfig = {
+export const config: MiddlewareConfig = {
   matcher: '/about/:path*',
 }
 ```
@@ -76,9 +76,9 @@ There are two ways to define which paths Middleware will run on:
 `matcher` allows you to filter Middleware to run on specific paths.
 
 ```ts
-import { PageConfig } from 'next'
+import { MiddlewareConfig } from 'next'
 
-export const config: PageConfig = {
+export const config: MiddlewareConfig = {
   matcher: '/about/:path*',
 }
 ```
@@ -86,9 +86,9 @@ export const config: PageConfig = {
 You can match a single path or multiple paths with an array syntax:
 
 ```ts
-import { PageConfig } from 'next'
+import { MiddlewareConfig } from 'next'
 
-export const config: PageConfig = {
+export const config: MiddlewareConfig = {
   matcher: ['/about/:path*', '/dashboard/:path*'],
 }
 ```
@@ -96,9 +96,9 @@ export const config: PageConfig = {
 The `matcher` config allows full regex so matching like negative lookaheads or character matching is supported. An example of a negative lookahead to match all except specific paths can be seen here:
 
 ```ts
-import { PageConfig } from 'next'
+import { MiddlewareConfig } from 'next'
 
-export const config: PageConfig = {
+export const config: MiddlewareConfig = {
   matcher: [
     /*
      * Match all request paths except for the ones starting with:
@@ -234,12 +234,12 @@ Once enabled, you can provide a response from middleware using the `Response` or
 
 ```ts
 // middleware.ts
-import { PageConfig } from 'next'
+import { MiddlewareConfig } from 'next'
 import { NextRequest, NextResponse } from 'next/server'
 import { isAuthenticated } from '@lib/auth'
 
 // Limit the middleware to paths starting with `/api/`
-export const config: PageConfig = {
+export const config: MiddlewareConfig = {
   matcher: '/api/:function*',
 }
 

--- a/docs/api-routes/edge-api-routes.md
+++ b/docs/api-routes/edge-api-routes.md
@@ -23,7 +23,7 @@ export default (req) => new Response('Hello world!')
 ### JSON Response
 
 ```typescript
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 import type { NextRequest } from 'next/server'
 
 export const config: PageConfig = {
@@ -48,7 +48,7 @@ export default async function handler(req: NextRequest) {
 ### Cache-Control
 
 ```typescript
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 import type { NextRequest } from 'next/server'
 
 export const config: PageConfig = {
@@ -74,7 +74,7 @@ export default async function handler(req: NextRequest) {
 ### Query Parameters
 
 ```typescript
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 import type { NextRequest } from 'next/server'
 
 export const config: PageConfig = {
@@ -91,7 +91,7 @@ export default async function handler(req: NextRequest) {
 ### Forwarding Headers
 
 ```typescript
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 import { type NextRequest } from 'next/server'
 
 export const config: PageConfig = {
@@ -117,7 +117,7 @@ You may want to restrict your edge function to specific regions when deploying s
 Note: this config is available in `v12.3.2` of Next.js and up.
 
 ```typescript
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 import { NextResponse } from 'next/server'
 
 export const config: PageConfig = {

--- a/docs/api-routes/edge-api-routes.md
+++ b/docs/api-routes/edge-api-routes.md
@@ -23,9 +23,10 @@ export default (req) => new Response('Hello world!')
 ### JSON Response
 
 ```typescript
+import { PageConfig } from "next"
 import type { NextRequest } from 'next/server'
 
-export const config = {
+export const config: PageConfig = {
   runtime: 'edge',
 }
 
@@ -47,9 +48,10 @@ export default async function handler(req: NextRequest) {
 ### Cache-Control
 
 ```typescript
+import { PageConfig } from "next"
 import type { NextRequest } from 'next/server'
 
-export const config = {
+export const config: PageConfig = {
   runtime: 'edge',
 }
 
@@ -72,9 +74,10 @@ export default async function handler(req: NextRequest) {
 ### Query Parameters
 
 ```typescript
+import { PageConfig } from "next"
 import type { NextRequest } from 'next/server'
 
-export const config = {
+export const config: PageConfig = {
   runtime: 'edge',
 }
 
@@ -88,9 +91,10 @@ export default async function handler(req: NextRequest) {
 ### Forwarding Headers
 
 ```typescript
+import { PageConfig } from "next"
 import { type NextRequest } from 'next/server'
 
-export const config = {
+export const config: PageConfig = {
   runtime: 'edge',
 }
 
@@ -112,10 +116,11 @@ You may want to restrict your edge function to specific regions when deploying s
 
 Note: this config is available in `v12.3.2` of Next.js and up.
 
-```js
+```typescript
+import { PageConfig } from "next"
 import { NextResponse } from 'next/server'
 
-export const config = {
+export const config: PageConfig = {
   regions: ['sfo1', 'iad1'], // defaults to 'all'
 }
 

--- a/docs/api-routes/request-helpers.md
+++ b/docs/api-routes/request-helpers.md
@@ -22,8 +22,10 @@ API Routes provide built-in request helpers which parse the incoming req
 
 Every API Route can export a `config` object to change the default configuration, which is the following:
 
-```js
-export const config = {
+```ts
+import { PageConfig } from "next"
+
+export const config: PageConfig = {
   api: {
     bodyParser: {
       sizeLimit: '1mb',
@@ -38,8 +40,10 @@ The `api` object includes all config options available for API Routes.
 
 One use case for disabling the automatic `bodyParsing` is to allow you to verify the raw body of a **webhook** request, for example [from GitHub](https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github).
 
-```js
-export const config = {
+```ts
+import { PageConfig } from "next"
+
+export const config: PageConfig = {
   api: {
     bodyParser: false,
   },
@@ -48,8 +52,10 @@ export const config = {
 
 `bodyParser.sizeLimit` is the maximum size allowed for the parsed body, in any format supported by [bytes](https://github.com/visionmedia/bytes.js), like so:
 
-```js
-export const config = {
+```ts
+import { PageConfig } from "next"
+
+export const config: PageConfig = {
   api: {
     bodyParser: {
       sizeLimit: '500kb',
@@ -60,8 +66,10 @@ export const config = {
 
 `externalResolver` is an explicit flag that tells the server that this route is being handled by an external resolver like _express_ or _connect_. Enabling this option disables warnings for unresolved requests.
 
-```js
-export const config = {
+```ts
+import { PageConfig } from "next"
+
+export const config: PageConfig = {
   api: {
     externalResolver: true,
   },
@@ -72,8 +80,10 @@ export const config = {
 
 If you are not using Next.js in a serverless environment, and understand the performance implications of not using a CDN or dedicated media host, you can set this limit to `false`.
 
-```js
-export const config = {
+```ts
+import { PageConfig } from "next"
+
+export const config: PageConfig = {
   api: {
     responseLimit: false,
   },
@@ -83,8 +93,10 @@ export const config = {
 `responseLimit` can also take the number of bytes or any string format supported by `bytes`, for example `1000`, `'500kb'` or `'3mb'`.
 This value will be the maximum response size before a warning is displayed. Default is 4MB. (see above)
 
-```js
-export const config = {
+```ts
+import { PageConfig } from "next"
+
+export const config: PageConfig = {
   api: {
     responseLimit: '8mb',
   },

--- a/docs/api-routes/request-helpers.md
+++ b/docs/api-routes/request-helpers.md
@@ -23,7 +23,7 @@ API Routes provide built-in request helpers which parse the incoming req
 Every API Route can export a `config` object to change the default configuration, which is the following:
 
 ```ts
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 
 export const config: PageConfig = {
   api: {
@@ -41,7 +41,7 @@ The `api` object includes all config options available for API Routes.
 One use case for disabling the automatic `bodyParsing` is to allow you to verify the raw body of a **webhook** request, for example [from GitHub](https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github).
 
 ```ts
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 
 export const config: PageConfig = {
   api: {
@@ -53,7 +53,7 @@ export const config: PageConfig = {
 `bodyParser.sizeLimit` is the maximum size allowed for the parsed body, in any format supported by [bytes](https://github.com/visionmedia/bytes.js), like so:
 
 ```ts
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 
 export const config: PageConfig = {
   api: {
@@ -67,7 +67,7 @@ export const config: PageConfig = {
 `externalResolver` is an explicit flag that tells the server that this route is being handled by an external resolver like _express_ or _connect_. Enabling this option disables warnings for unresolved requests.
 
 ```ts
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 
 export const config: PageConfig = {
   api: {
@@ -81,7 +81,7 @@ export const config: PageConfig = {
 If you are not using Next.js in a serverless environment, and understand the performance implications of not using a CDN or dedicated media host, you can set this limit to `false`.
 
 ```ts
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 
 export const config: PageConfig = {
   api: {
@@ -94,7 +94,7 @@ export const config: PageConfig = {
 This value will be the maximum response size before a warning is displayed. Default is 4MB. (see above)
 
 ```ts
-import { PageConfig } from "next"
+import { PageConfig } from 'next'
 
 export const config: PageConfig = {
   api: {

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -4,7 +4,7 @@ import type { EdgeSSRLoaderQuery } from './webpack/loaders/next-edge-ssr-loader'
 import type { NextConfigComplete } from '../server/config-shared'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type {
-  MiddlewareConfig,
+  InternalMiddlewareConfig,
   MiddlewareMatcher,
 } from './analysis/get-page-static-info'
 import type { LoadedEnvFiles } from '@next/env'
@@ -158,7 +158,7 @@ export function getEdgeServerEntry(opts: {
   isServerComponent: boolean
   page: string
   pages: { [page: string]: string }
-  middleware?: Partial<MiddlewareConfig>
+  middleware?: Partial<InternalMiddlewareConfig>
   pagesType: 'app' | 'pages' | 'root'
   appDirLoader?: string
 }) {

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../shared/lib/constants'
 import {
   getPageStaticInfo,
-  MiddlewareConfig,
+  InternalMiddlewareConfig,
 } from '../../analysis/get-page-static-info'
 import { Telemetry } from '../../../telemetry/storage'
 import { traceGlobals } from '../../../trace/shared'
@@ -249,7 +249,7 @@ function isNodeJsModule(moduleName: string) {
 
 function isDynamicCodeEvaluationAllowed(
   fileName: string,
-  edgeFunctionConfig?: Partial<MiddlewareConfig>,
+  edgeFunctionConfig?: Partial<InternalMiddlewareConfig>,
   rootDir?: string
 ) {
   const name = fileName.replace(rootDir ?? '', '')

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -22,6 +22,7 @@ import {
 
 // @ts-ignore This path is generated at build time and conflicts otherwise
 import next from '../dist/server/next'
+import { Middleware } from '../src/lib/load-custom-routes'
 
 export type ServerRuntime = 'nodejs' | 'experimental-edge' | 'edge' | undefined
 
@@ -112,6 +113,28 @@ export type PageConfig = {
   unstable_includeFiles?: string[]
   unstable_excludeFiles?: string[]
 }
+
+/**
+ * `Config` type, use it for export const config in middleware file
+ */
+export type MiddlewareConfig = {
+  /**
+   * Path matchers which allows to filter out routes on which middleware should run
+   *
+   * A single matcher or array of matchers is acceptable, but each one must start with a `/`.
+   * You can include named parameters with `:` as a prefix, to match any sequence of characters in a single path component.
+   * The parameter suffix `?` makes that component optional, `+` requires at least one component and `*` allows for any number of path components.
+   * Regular Expressions are also permitted.
+   */
+  matcher?: MiddlewareConfigMatcher | MiddlewareConfigMatcher[]
+  /**
+   * Restricts middleware to only specific geolocations after deployment
+   */
+  regions?: string[] | string
+  unstable_allowDynamic?: string | string[]
+}
+
+export type MiddlewareConfigMatcher = string | Middleware
 
 export {
   NextPageContext,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
I have added [PageConfig](https://github.com/vercel/next.js/blob/98df70e233e536188a303eacdf27ca2d1f4cfb19/packages/next/types/index.d.ts#L83) type to various pages in the documentation. Some examples are written in JS, while others are written in TS, so I have added this type only to a few examples that felt right.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
