### PR TITLE
Handle empty module from the next dynamic loader

### DIFF
--- a/packages/next/src/shared/lib/dynamic.tsx
+++ b/packages/next/src/shared/lib/dynamic.tsx
@@ -30,7 +30,7 @@ export type DynamicOptionsLoadingProps = {
 // Also for backward compatible since next/dynamic allows to resolve a component directly with loader
 // Client component reference proxy need to be converted to a module.
 function convertModule<P>(mod: React.ComponentType<P> | ComponentModule<P>) {
-  return { default: (mod as ComponentModule<P>).default || mod }
+  return { default: (mod as ComponentModule<P>)?.default || mod }
 }
 
 export type DynamicOptions<P = {}> = LoadableGeneratedOptions & {

--- a/test/e2e/app-dir/rsc-errors/rsc-errors.test.ts
+++ b/test/e2e/app-dir/rsc-errors/rsc-errors.test.ts
@@ -1,4 +1,9 @@
-import { check, getRedboxSource, hasRedbox } from 'next-test-utils'
+import {
+  check,
+  getRedboxDescription,
+  getRedboxSource,
+  hasRedbox,
+} from 'next-test-utils'
 import { createNextDescribe } from 'e2e-utils'
 
 if (!(globalThis as any).isNextDev) {
@@ -131,6 +136,15 @@ if (!(globalThis as any).isNextDev) {
         const text = await getRedboxSource(browser)
         expect(text).toContain(
           `You're importing a component that needs server-only. That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.`
+        )
+      })
+
+      it('should error for invalid undefined module retuning from next dynamic', async () => {
+        const browser = await next.browser('/client-with-errors/dynamic')
+
+        await hasRedbox(browser)
+        expect(await getRedboxDescription(browser)).toContain(
+          `Element type is invalid. Received a promise that resolves to: undefined. Lazy element type must resolve to a class or function.`
         )
       })
     }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

x-ref: https://github.com/vercel/next.js/issues/42298#issuecomment-1382324697

could possibly caused by the resolved module is `undefined`

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

