### PR TITLE
Use sequentialRead while encoding images with sharp

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -408,7 +408,9 @@ export async function optimizeImage({
   let optimizedBuffer = buffer
   if (sharp) {
     // Begin sharp transformation logic
-    const transformer = sharp(buffer)
+    const transformer = sharp(buffer, {
+      sequentialRead: true,
+    })
 
     transformer.rotate()
 


### PR DESCRIPTION
This can reduce memory usage and might improve performance on some systems.

Related: https://github.com/Brooooooklyn/Image/pull/34#issuecomment-1382182686