### PR TITLE
fix standalone wrong url being logged

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1789,7 +1789,7 @@ server.listen(currentPort, (err) => {
   console.log(
     'Listening on port',
     currentPort,
-    'url: http://' hostname + ':' + currentPort
+    'url: http://' + hostname + ':' + currentPort
   )
 })`
   )

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1789,7 +1789,7 @@ server.listen(currentPort, (err) => {
   console.log(
     'Listening on port',
     currentPort,
-    'url:', hostname + ':' + currentPort
+    'url: http://' hostname + ':' + currentPort
   )
 })`
   )

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1789,7 +1789,7 @@ server.listen(currentPort, (err) => {
   console.log(
     'Listening on port',
     currentPort,
-    'url: http://localhost:' + currentPort
+    'url:', hostname + ':' + currentPort
   )
 })`
   )

--- a/test/production/standalone-mode/response-cache/index.test.ts
+++ b/test/production/standalone-mode/response-cache/index.test.ts
@@ -23,6 +23,9 @@ describe('minimal-mode-response-cache', () => {
 
     next = await createNext({
       files: new FileRef(join(__dirname, 'app')),
+      env: {
+        HOSTNAME: '',
+      },
     })
     await next.stop()
 

--- a/test/production/standalone-mode/response-cache/index.test.ts
+++ b/test/production/standalone-mode/response-cache/index.test.ts
@@ -23,9 +23,6 @@ describe('minimal-mode-response-cache', () => {
 
     next = await createNext({
       files: new FileRef(join(__dirname, 'app')),
-      env: {
-        HOSTNAME: '',
-      },
     })
     await next.stop()
 
@@ -63,6 +60,7 @@ describe('minimal-mode-response-cache', () => {
       /Listening on/,
       {
         ...process.env,
+        HOSTNAME: '',
         PORT: appPort,
       },
       undefined,

--- a/test/production/standalone-mode/response-cache/index.test.ts
+++ b/test/production/standalone-mode/response-cache/index.test.ts
@@ -15,6 +15,7 @@ describe('minimal-mode-response-cache', () => {
   let next: NextInstance
   let server
   let appPort
+  let output = ''
 
   beforeAll(async () => {
     // test build against environment with next support
@@ -64,12 +65,23 @@ describe('minimal-mode-response-cache', () => {
       undefined,
       {
         cwd: next.testDir,
+        onStdout(msg) {
+          output += msg
+        },
+        onStderr(msg) {
+          output += msg
+        },
       }
     )
   })
   afterAll(async () => {
     await next.destroy()
     if (server) await killApp(server)
+  })
+
+  it('should have correct "Listening on" log', async () => {
+    expect(output).toContain(`Listening on port`)
+    expect(output).toContain(`url: http://localhost:${appPort}`)
   })
 
   it('should have correct responses', async () => {


### PR DESCRIPTION
This PR ensures that the correct URL is logged for the running server. Earlier the URL was hard-coded which might cause confusion that the wrong hostname is being used.