### PR TITLE
Removes title warning from cms example

### DIFF
--- a/examples/blog-starter/pages/index.tsx
+++ b/examples/blog-starter/pages/index.tsx
@@ -19,7 +19,7 @@ export default function Index({ allPosts }: Props) {
     <>
       <Layout>
         <Head>
-           <title>{`Next.js Blog Example with ${CMS_NAME}`}</title>
+          <title>{`Next.js Blog Example with ${CMS_NAME}`}</title>
         </Head>
         <Container>
           <Intro />

--- a/examples/blog-starter/pages/index.tsx
+++ b/examples/blog-starter/pages/index.tsx
@@ -19,7 +19,7 @@ export default function Index({ allPosts }: Props) {
     <>
       <Layout>
         <Head>
-          <title>Next.js Blog Example with {CMS_NAME}</title>
+           <title>{`Next.js Blog Example with ${CMS_NAME}`}</title>
         </Head>
         <Container>
           <Intro />


### PR DESCRIPTION
Warning: Title element received an array with more than 1 element as children.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
