### PR TITLE
Next/Script documentation beforeInteractive inconsistency

### DIFF
--- a/docs/api-reference/next/script.md
+++ b/docs/api-reference/next/script.md
@@ -71,22 +71,27 @@ Scripts that load with the `beforeInteractive` strategy are injected into the in
 
 Scripts denoted with this strategy are preloaded and fetched before any first-party code, but their execution does not block page hydration from occuring.
 
-`beforeInteractive` scripts must be placed inside `pages/_app.js` and are designed to load scripts that are needed by the entire site (i.e. the script will load when any page in the application has been loaded server-side).
+`beforeInteractive` scripts must be placed inside `pages/_document.js` and are designed to load scripts that are needed by the entire site (i.e. the script will load when any page in the application has been loaded server-side).
 
 **This strategy should only be used for critical scripts that need to be fetched before any part of the page becomes interactive.**
 
 ```jsx
-import Script from 'next/script'
+import { Html, Head, Main, NextScript } from "next/document";
+import Script from "next/script";
 
-export default function MyApp({ Component, pageProps }) {
+export default function Document() {
   return (
-    <>
-      <Script
-        src="https://example.com/script.js"
-        strategy="beforeInteractive"
-      />
-      <Component {...pageProps} />
-    </>
+    <Html>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+        <Script
+            src="https://example.com/script.js"
+            strategy="beforeInteractive"
+        />
+      </body>
+    </Html>
   )
 }
 ```

--- a/docs/api-reference/next/script.md
+++ b/docs/api-reference/next/script.md
@@ -76,8 +76,8 @@ Scripts denoted with this strategy are preloaded and fetched before any first-pa
 **This strategy should only be used for critical scripts that need to be fetched before any part of the page becomes interactive.**
 
 ```jsx
-import { Html, Head, Main, NextScript } from "next/document";
-import Script from "next/script";
+import { Html, Head, Main, NextScript } from 'next/document'
+import Script from 'next/script'
 
 export default function Document() {
   return (
@@ -87,8 +87,8 @@ export default function Document() {
         <Main />
         <NextScript />
         <Script
-            src="https://example.com/script.js"
-            strategy="beforeInteractive"
+          src="https://example.com/script.js"
+          strategy="beforeInteractive"
         />
       </body>
     </Html>

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -307,7 +307,6 @@ async function run(): Promise<void> {
       typeof program.importAlias !== 'string' ||
       !program.importAlias.length
     ) {
-      console.log({ idk: program.importAlias })
       if (ciInfo.isCI) {
         program.importAlias = '@/*'
       } else {


### PR DESCRIPTION
Closes #43566

Following linter syntax & [error documentation](https://nextjs.org/docs/messages/no-before-interactive-script-outside-document)


![image](https://user-images.githubusercontent.com/37253958/212552229-5e63b320-ed66-47ba-b42b-eb96f95cb327.png)
![image](https://user-images.githubusercontent.com/37253958/212552335-cd400ba7-5df8-42c6-9028-c8d1c6d4ac40.png)