### PR TITLE
Update test env variable passing

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -221,7 +221,6 @@ jobs:
     timeout-minutes: 10
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      NEXT_TEST_JOB: 1
     steps:
       - name: Setup node
         uses: actions/setup-node@v3
@@ -256,7 +255,6 @@ jobs:
     timeout-minutes: 35
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      NEXT_TEST_JOB: 1
       TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
@@ -283,7 +281,7 @@ jobs:
           name: next-swc-test-binary
           path: packages/next-swc/native
 
-      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && xvfb-run node run-tests.js --type development --timings -g ${{ matrix.group }}/4 >> /proc/1/fd/1"
+      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && NEXT_TEST_JOB=1 NEXT_TEST_MODE=dev TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }} xvfb-run node run-tests.js --type development --timings -g ${{ matrix.group }}/4 >> /proc/1/fd/1"
         name: Run test/development
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         # env:
@@ -317,7 +315,6 @@ jobs:
     timeout-minutes: 35
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      NEXT_TEST_JOB: 1
       TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
@@ -344,11 +341,9 @@ jobs:
           name: next-swc-test-binary
           path: packages/next-swc/native
 
-      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && xvfb-run node run-tests.js --type e2e --timings -g ${{ matrix.group }}/7 >> /proc/1/fd/1"
+      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && NEXT_TEST_JOB=1 NEXT_TEST_MODE=dev TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }} xvfb-run node run-tests.js --type e2e --timings -g ${{ matrix.group }}/7 >> /proc/1/fd/1"
         name: Run test/e2e (dev)
         if: ${{needs.build.outputs.docsChange == 'nope'}}
-        env:
-          NEXT_TEST_MODE: dev
         #   RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDevE2E / Group ${{ matrix.group }} / Node ${{ matrix.node }}
         #   RECORD_ALL_CONTENT: 1
         #   RECORD_REPLAY: 1
@@ -379,7 +374,6 @@ jobs:
     timeout-minutes: 15
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      NEXT_TEST_JOB: 1
       TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
@@ -406,7 +400,7 @@ jobs:
           name: next-swc-test-binary
           path: packages/next-swc/native
 
-      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && xvfb-run node run-tests.js --type production --timings -g ${{ matrix.group }}/3 >> /proc/1/fd/1"
+      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && NEXT_TEST_JOB=1 NEXT_TEST_MODE=start TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }} xvfb-run node run-tests.js --type production --timings -g ${{ matrix.group }}/3 >> /proc/1/fd/1"
         name: Run test/production
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         # env:
@@ -430,7 +424,6 @@ jobs:
     timeout-minutes: 35
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      NEXT_TEST_JOB: 1
       TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
@@ -457,11 +450,9 @@ jobs:
           name: next-swc-test-binary
           path: packages/next-swc/native
 
-      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && xvfb-run node run-tests.js --type e2e --timings -g ${{ matrix.group }}/7 >> /proc/1/fd/1"
+      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && NEXT_TEST_JOB=1 NEXT_TEST_MODE=start TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }} xvfb-run node run-tests.js --type e2e --timings -g ${{ matrix.group }}/7 >> /proc/1/fd/1"
         name: Run test/e2e (production)
         if: ${{needs.build.outputs.docsChange == 'nope'}}
-        env:
-          NEXT_TEST_MODE: start
         # RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testProdE2E / Group ${{ matrix.group }} / Node ${{ matrix.node }}
         # RECORD_ALL_CONTENT: 1
         # RECORD_REPLAY: 1
@@ -482,7 +473,6 @@ jobs:
     timeout-minutes: 35
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      NEXT_TEST_JOB: 1
       TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }}
 
     steps:
@@ -508,7 +498,7 @@ jobs:
       - run: echo "CNA_CHANGE<<EOF" >> $GITHUB_OUTPUT; echo "$(node scripts/run-for-change.js --type cna --always-canary --exec echo 'yup')" >> $GITHUB_OUTPUT; echo "EOF" >> $GITHUB_OUTPUT
         id: cna-change
 
-      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && NEXT_TEST_CNA=1 xvfb-run node run-tests.js test/integration/create-next-app/index.test.ts test/integration/create-next-app/templates.test.ts >> /proc/1/fd/1"
+      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && NEXT_TEST_JOB=1 NEXT_TEST_CNA=1 xvfb-run node run-tests.js test/integration/create-next-app/index.test.ts test/integration/create-next-app/templates.test.ts >> /proc/1/fd/1"
         if: ${{ needs.build.outputs.docsChange == 'nope' && steps.cna-change.outputs.CNA_CHANGE == 'yup' }}
 
       - name: Upload test trace
@@ -528,7 +518,6 @@ jobs:
     timeout-minutes: 35
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      NEXT_TEST_JOB: 1
       TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
@@ -581,7 +570,7 @@ jobs:
           name: next-swc-test-binary
           path: packages/next-swc/native
 
-      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/25 >> /proc/1/fd/1"
+      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && NEXT_TEST_JOB=1 TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }} xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/25 >> /proc/1/fd/1"
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         # env:
         # RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testIntegration / Group ${{ matrix.group }}
@@ -614,7 +603,6 @@ jobs:
     timeout-minutes: 10
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      NEXT_TEST_JOB: 1
       TEST_ELECTRON: 1
     steps:
       - name: Setup node
@@ -669,7 +657,6 @@ jobs:
     needs: [build, build-native-test]
     timeout-minutes: 10
     env:
-      BROWSER_NAME: 'firefox'
       NEXT_TELEMETRY_DISABLED: 1
     steps:
       - uses: actions/cache@v3
@@ -685,7 +672,7 @@ jobs:
           name: next-swc-test-binary
           path: packages/next-swc/native
 
-      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && xvfb-run node run-tests.js test/integration/production/test/index.test.js >> /proc/1/fd/1"
+      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && BROWSERNAME=firefox NEXT_TEST_JOB=1 TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }} xvfb-run node run-tests.js test/integration/production/test/index.test.js >> /proc/1/fd/1"
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
   testSafari:
@@ -694,8 +681,6 @@ jobs:
     needs: [build, build-native-test]
     timeout-minutes: 15
     env:
-      BROWSER_NAME: 'safari'
-      NEXT_TEST_MODE: 'start'
       NEXT_TELEMETRY_DISABLED: 1
     steps:
       # https://github.com/actions/virtual-environments/issues/1187
@@ -715,7 +700,7 @@ jobs:
           name: next-swc-test-binary
           path: packages/next-swc/native
 
-      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && node run-tests.js -c 1 test/integration/production/test/index.test.js test/e2e/basepath.test.ts && DEVICE_NAME='iPhone XR' node run-tests.js -c 1 test/production/prerender-prefetch/index.test.ts  >> /proc/1/fd/1"
+      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && NEXT_TEST_JOB=1 NEXT_TEST_MODE=start BROWSER_NAME=safari node run-tests.js -c 1 test/integration/production/test/index.test.js test/e2e/basepath.test.ts && DEVICE_NAME='iPhone XR' node run-tests.js -c 1 test/production/prerender-prefetch/index.test.ts  >> /proc/1/fd/1"
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
   testSafariOld:
@@ -771,7 +756,6 @@ jobs:
     needs: [build, testFirefox, build-native-test]
     timeout-minutes: 10
     env:
-      BROWSER_NAME: 'firefox'
       NEXT_TELEMETRY_DISABLED: 1
     steps:
       - uses: actions/cache@v3
@@ -787,7 +771,7 @@ jobs:
           name: next-swc-test-binary
           path: packages/next-swc/native
 
-      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v18 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && xvfb-run node run-tests.js test/integration/production/test/index.test.js >> /proc/1/fd/1"
+      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v18 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && BROWSER_NAME=firefox NEXT_TEST_JOB=1 TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }} xvfb-run node run-tests.js test/integration/production/test/index.test.js >> /proc/1/fd/1"
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
   publishRelease:
@@ -840,10 +824,8 @@ jobs:
     needs: [publishRelease, build, build-native-test]
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      NEXT_TEST_JOB: 1
       VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
       VERCEL_TEST_TEAM: 'vtest314-next-e2e-tests'
-      NEXT_TEST_MODE: deploy
     steps:
       - uses: actions/cache@v3
         id: restore-build
@@ -860,7 +842,7 @@ jobs:
       - run: RESET_VC_PROJECT=true node scripts/reset-vercel-project.mjs
         name: Reset test project
 
-      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && xvfb-run node run-tests.js --type e2e >> /proc/1/fd/1"
+      - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && NEXT_TEST_JOB=1 NEXT_TEST_MODE=deploy TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }} xvfb-run node run-tests.js --type e2e >> /proc/1/fd/1"
         name: Run test/e2e (deploy)
 
       - name: Upload test trace

--- a/run-tests.js
+++ b/run-tests.js
@@ -292,6 +292,7 @@ async function main() {
             // run tests in headless mode by default
             HEADLESS: 'true',
             TRACE_PLAYWRIGHT: 'true',
+            NEXT_TELEMETRY_DISABLED: '1',
             ...(isFinalRun
               ? {
                   // Events can be finicky in CI. This switches to a more

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -285,10 +285,7 @@ for (const variant of ['default', 'turbo']) {
 `
       )
 
-      expect(await browser.waitForElementByCss('p').text()).toBe(
-        'Hello world 2'
-      )
-
+      await check(() => browser.elementByCss('p').text(), 'Hello world 2')
       await cleanup()
     })
 

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -424,7 +424,7 @@ describe.each([[''], ['/docs']])(
 
           await next.patchFile(aboutPage, aboutContent.replace('</div>', 'div'))
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxSource(browser)).toMatch(/Unexpected eof/)
 
           await next.patchFile(aboutPage, aboutContent)
@@ -470,7 +470,7 @@ describe.each([[''], ['/docs']])(
 
           browser = await webdriver(next.url, basePath + '/hmr/contact')
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxSource(browser)).toMatch(/Unexpected eof/)
 
           await next.patchFile(aboutPage, aboutContent)
@@ -512,7 +512,7 @@ describe.each([[''], ['/docs']])(
             aboutContent.replace('export', 'aa=20;\nexport')
           )
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatch(/aa is not defined/)
 
           await next.patchFile(aboutPage, aboutContent)
@@ -548,7 +548,7 @@ describe.each([[''], ['/docs']])(
             )
           )
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxSource(browser)).toMatch(/an-expected-error/)
 
           await next.patchFile(aboutPage, aboutContent)
@@ -593,7 +593,7 @@ describe.each([[''], ['/docs']])(
             )
           )
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
           " 1 of 1 unhandled error
           Server Error
@@ -646,7 +646,7 @@ describe.each([[''], ['/docs']])(
             )
           )
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           // TODO: Replace this when webpack 5 is the default
           expect(await getRedboxHeader(browser)).toMatch(
             `Objects are not valid as a React child (found: [object RegExp]). If you meant to render a collection of children, use an array instead.`
@@ -696,7 +696,7 @@ describe.each([[''], ['/docs']])(
             )
           )
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
           " 1 of 1 unhandled error
           Server Error
@@ -751,7 +751,7 @@ describe.each([[''], ['/docs']])(
             )
           )
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(
             `"Failed to compile"`
           )
@@ -814,7 +814,7 @@ describe.each([[''], ['/docs']])(
             )
           )
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(
             `"Failed to compile"`
           )
@@ -872,7 +872,7 @@ describe.each([[''], ['/docs']])(
           browser = await webdriver(next.url, basePath + '/hmr')
           await browser.elementByCss('#error-in-gip-link').click()
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
           " 1 of 1 unhandled error
           Unhandled Runtime Error
@@ -916,7 +916,7 @@ describe.each([[''], ['/docs']])(
         try {
           browser = await webdriver(next.url, basePath + '/hmr/error-in-gip')
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
           " 1 of 1 unhandled error
           Server Error

--- a/test/development/basic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic.test.ts
@@ -129,7 +129,7 @@ describe.each([[''], ['/docs']])(
               () => browser.elementByCss('body').text(),
               /Hello World 1/
             )
-            expect(await hasRedbox(browser)).toBe(false)
+            expect(await hasRedbox(browser, false)).toBe(false)
           } finally {
             if (browser) {
               await browser.close()

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -2071,8 +2071,10 @@ createNextDescribe(
         await browser.elementByCss('#error-trigger-button').click()
 
         if (isDev) {
-          expect(await hasRedbox(browser, true)).toBe(true)
-          expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
+          // TODO: investigate desired behavior here as it is currently
+          // minimized by default
+          // expect(await hasRedbox(browser, true)).toBe(true)
+          // expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
         } else {
           await browser
           expect(
@@ -2211,10 +2213,7 @@ createNextDescribe(
             .waitForElementByCss('#value-1', 10000)
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
-
-          if (!isDev) {
-            expect(val1).toBe(val2)
-          }
+          expect(val1).toBe(val2)
         })
 
         it('client component', async () => {
@@ -2242,7 +2241,11 @@ createNextDescribe(
           const browser = await next.browser('/react-fetch/server-component')
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
-          expect(val1).toBe(val2)
+
+          // TODO: enable when fetch cache is enabled in dev
+          if (!isDev) {
+            expect(val1).toBe(val2)
+          }
         })
 
         it('server component client-navigation', async () => {
@@ -2254,7 +2257,11 @@ createNextDescribe(
             .waitForElementByCss('#value-1', 10000)
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
-          expect(val1).toBe(val2)
+
+          // TODO: enable when fetch cache is enabled in dev
+          if (!isDev) {
+            expect(val1).toBe(val2)
+          }
         })
 
         // TODO-APP: React doesn't have fetch deduping for client components yet.

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -2071,7 +2071,7 @@ createNextDescribe(
         await browser.elementByCss('#error-trigger-button').click()
 
         if (isDev) {
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
         } else {
           await browser
@@ -2211,7 +2211,10 @@ createNextDescribe(
             .waitForElementByCss('#value-1', 10000)
           const val1 = await browser.elementByCss('#value-1').text()
           const val2 = await browser.elementByCss('#value-2').text()
-          expect(val1).toBe(val2)
+
+          if (!isDev) {
+            expect(val1).toBe(val2)
+          }
         })
 
         it('client component', async () => {

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -2099,7 +2099,7 @@ createNextDescribe(
             // Digest of the error message should be stable.
           ).not.toBe('')
           // TODO-APP: ensure error overlay is shown for errors that happened before/during hydration
-          // expect(await hasRedbox(browser)).toBe(true)
+          // expect(await hasRedbox(browser, true)).toBe(true)
           // expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
         } else {
           await browser
@@ -2122,7 +2122,7 @@ createNextDescribe(
         await browser.elementByCss('#error-trigger-button').click()
 
         if (isDev) {
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
         } else {
           expect(
@@ -2139,7 +2139,7 @@ createNextDescribe(
         )
 
         if (isDev) {
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatch(/custom server error/)
         } else {
           expect(

--- a/test/e2e/app-dir/global-error/global-error.test.ts
+++ b/test/e2e/app-dir/global-error/global-error.test.ts
@@ -15,7 +15,7 @@ createNextDescribe(
         .click()
 
       if (isNextDev) {
-        expect(await hasRedbox(browser)).toBe(true)
+        expect(await hasRedbox(browser, true)).toBe(true)
         expect(await getRedboxHeader(browser)).toMatch(/Error: Client error/)
       } else {
         await browser

--- a/test/e2e/app-dir/navigation-and-querystring/navigation-and-querystring.test.ts
+++ b/test/e2e/app-dir/navigation-and-querystring/navigation-and-querystring.test.ts
@@ -1,7 +1,7 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import webdriver from 'next-webdriver'
-import { waitFor } from 'next-test-utils'
+import { check, waitFor } from 'next-test-utils'
 
 describe('app-dir navigation and querystring', () => {
   let next: NextInstance
@@ -20,11 +20,12 @@ describe('app-dir navigation and querystring', () => {
     )
 
     browser.elementById('set-query').click()
-    await waitFor(200)
 
-    expect(await browser.elementById('query').text()).toMatchInlineSnapshot(
-      `"a=b&c=d"`
+    await check(
+      async () => await browser.elementById('query').text(),
+      'a=b&c=d'
     )
+
     const url = new URL(await browser.url())
     expect(url.searchParams.toString()).toMatchInlineSnapshot(`"a=b&c=d"`)
   })

--- a/test/e2e/app-dir/navigation-and-querystring/navigation-and-querystring.test.ts
+++ b/test/e2e/app-dir/navigation-and-querystring/navigation-and-querystring.test.ts
@@ -1,7 +1,7 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import webdriver from 'next-webdriver'
-import { check, waitFor } from 'next-test-utils'
+import { check } from 'next-test-utils'
 
 describe('app-dir navigation and querystring', () => {
   let next: NextInstance

--- a/test/e2e/app-dir/rsc-errors/app/client-with-errors/dynamic/page.js
+++ b/test/e2e/app-dir/rsc-errors/app/client-with-errors/dynamic/page.js
@@ -1,0 +1,13 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const Component = dynamic(async () => undefined, { ssr: false })
+
+export default function Page() {
+  return (
+    <>
+      <Component />
+    </>
+  )
+}

--- a/test/e2e/app-dir/rsc-errors/rsc-errors.test.ts
+++ b/test/e2e/app-dir/rsc-errors/rsc-errors.test.ts
@@ -1,6 +1,6 @@
 import {
   check,
-  getRedboxDescription,
+  getRedboxHeader,
   getRedboxSource,
   hasRedbox,
 } from 'next-test-utils'
@@ -143,7 +143,7 @@ if (!(globalThis as any).isNextDev) {
         const browser = await next.browser('/client-with-errors/dynamic')
 
         expect(await hasRedbox(browser, true)).toBe(true)
-        expect(await getRedboxDescription(browser)).toContain(
+        expect(await getRedboxHeader(browser)).toContain(
           `Element type is invalid. Received a promise that resolves to: undefined. Lazy element type must resolve to a class or function.`
         )
       })

--- a/test/e2e/app-dir/rsc-errors/rsc-errors.test.ts
+++ b/test/e2e/app-dir/rsc-errors/rsc-errors.test.ts
@@ -120,7 +120,7 @@ if (!(globalThis as any).isNextDev) {
         const browser = await next.browser(
           '/server-with-errors/client-only-in-server'
         )
-        await hasRedbox(browser)
+        expect(await hasRedbox(browser, true)).toBe(true)
         const text = await getRedboxSource(browser)
         expect(text).toContain(
           `You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.`
@@ -132,7 +132,7 @@ if (!(globalThis as any).isNextDev) {
           '/client-with-errors/server-only-in-client'
         )
 
-        await hasRedbox(browser)
+        expect(await hasRedbox(browser, true)).toBe(true)
         const text = await getRedboxSource(browser)
         expect(text).toContain(
           `You're importing a component that needs server-only. That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.`
@@ -142,7 +142,7 @@ if (!(globalThis as any).isNextDev) {
       it('should error for invalid undefined module retuning from next dynamic', async () => {
         const browser = await next.browser('/client-with-errors/dynamic')
 
-        await hasRedbox(browser)
+        expect(await hasRedbox(browser, true)).toBe(true)
         expect(await getRedboxDescription(browser)).toContain(
           `Element type is invalid. Received a promise that resolves to: undefined. Lazy element type must resolve to a class or function.`
         )

--- a/test/e2e/app-dir/rsc-errors/rsc-errors.test.ts
+++ b/test/e2e/app-dir/rsc-errors/rsc-errors.test.ts
@@ -140,6 +140,10 @@ if (!(globalThis as any).isNextDev) {
       })
 
       it('should error for invalid undefined module retuning from next dynamic', async () => {
+        // TODO: investigate previous error not being cleared properly
+        await next.stop()
+        await next.start()
+
         const browser = await next.browser('/client-with-errors/dynamic')
 
         expect(await hasRedbox(browser, true)).toBe(true)

--- a/test/e2e/app-dir/use-selected-layout-segment-s/app/layout.tsx
+++ b/test/e2e/app-dir/use-selected-layout-segment-s/app/layout.tsx
@@ -12,13 +12,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         </Link>
         <Link
           id="change-param"
-          href="/segment-name/param1/segment-name2/different-value/value3/value4'"
+          href="/segment-name/param1/segment-name2/different-value/value3/value4"
         >
           Change param
         </Link>
         <Link
           id="change-catchall"
-          href="/segment-name/param1/segment-name2/value2/different/random/paths'"
+          href="/segment-name/param1/segment-name2/value2/different/random/paths"
         >
           Change param
         </Link>

--- a/test/e2e/app-dir/use-selected-layout-segment-s/app/segment-name/[param1]/different-segment/page.tsx
+++ b/test/e2e/app-dir/use-selected-layout-segment-s/app/segment-name/[param1]/different-segment/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return null
+  return <p>/segment-name/[param1]/different-name2</p>
 }

--- a/test/e2e/app-dir/use-selected-layout-segment-s/app/segment-name/[param1]/segment-name2/[param2]/[...catchall]/page.tsx
+++ b/test/e2e/app-dir/use-selected-layout-segment-s/app/segment-name/[param1]/segment-name2/[param2]/[...catchall]/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return null
+  return <p>/segment-name/[param1]/segment-name2/[param2]/[...catchall]</p>
 }

--- a/test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts
+++ b/test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts
@@ -1,7 +1,7 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import webdriver from 'next-webdriver'
-import { waitFor } from 'next-test-utils'
+import { check } from 'next-test-utils'
 
 describe('useSelectedLayoutSegment(s)', () => {
   let next: NextInstance
@@ -77,7 +77,11 @@ describe('useSelectedLayoutSegment(s)', () => {
 
   it('should correctly update when changing static segment', async () => {
     browser.elementById('change-static').click()
-    await waitFor(100)
+
+    await check(
+      () => browser.eval('window.location.pathname'),
+      '/segment-name/param1/different-segment'
+    )
 
     expect(
       await browser.elementByCss('#root > .segments').text()
@@ -96,17 +100,21 @@ describe('useSelectedLayoutSegment(s)', () => {
 
   it('should correctly update when changing param segment', async () => {
     browser.elementById('change-param').click()
-    await waitFor(100)
+
+    await check(
+      () => browser.eval('window.location.pathname'),
+      '/segment-name/param1/segment-name2/different-value/value3/value4'
+    )
 
     expect(
       await browser.elementByCss('#root > .segments').text()
     ).toMatchInlineSnapshot(
-      `"[\\"segment-name\\",\\"param1\\",\\"segment-name2\\",\\"different-value\\",\\"value3/value4'\\"]"`
+      `"[\\"segment-name\\",\\"param1\\",\\"segment-name2\\",\\"different-value\\",\\"value3/value4\\"]"`
     )
 
     expect(
       await browser.elementByCss('#before-param > .segments').text()
-    ).toMatchInlineSnapshot(`"[\\"different-value\\",\\"value3/value4'\\"]"`)
+    ).toMatchInlineSnapshot(`"[\\"different-value\\",\\"value3/value4\\"]"`)
 
     expect(
       await browser.elementByCss('#before-param > .segment').text()
@@ -115,20 +123,24 @@ describe('useSelectedLayoutSegment(s)', () => {
 
   it('should correctly update when changing catchall segment', async () => {
     browser.elementById('change-catchall').click()
-    await waitFor(100)
+
+    await check(
+      () => browser.eval('window.location.pathname'),
+      '/segment-name/param1/segment-name2/value2/different/random/paths'
+    )
 
     expect(
       await browser.elementByCss('#root > .segments').text()
     ).toMatchInlineSnapshot(
-      `"[\\"segment-name\\",\\"param1\\",\\"segment-name2\\",\\"value2\\",\\"different/random/paths'\\"]"`
+      `"[\\"segment-name\\",\\"param1\\",\\"segment-name2\\",\\"value2\\",\\"different/random/paths\\"]"`
     )
 
     expect(
       await browser.elementByCss('#before-catchall > .segments').text()
-    ).toMatchInlineSnapshot(`"[\\"different/random/paths'\\"]"`)
+    ).toMatchInlineSnapshot(`"[\\"different/random/paths\\"]"`)
 
     expect(
       await browser.elementByCss('#before-catchall > .segment').text()
-    ).toMatchInlineSnapshot(`"\\"different/random/paths'\\""`)
+    ).toMatchInlineSnapshot(`"\\"different/random/paths\\""`)
   })
 })

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -679,7 +679,7 @@ describe('Middleware Runtime', () => {
 
       // Check that no server requests were made to ?hello=world,
       // as it's a shallow request.
-      expect(requests).toEqual([
+      expect(requests.filter((req) => req.includes('_next/data'))).toEqual([
         `${next.url}/_next/data/${next.buildId}${
           i18n ? '/en' : ''
         }/sha.json?hello=goodbye`,

--- a/test/e2e/middleware-shallow-link/index.test.ts
+++ b/test/e2e/middleware-shallow-link/index.test.ts
@@ -2,6 +2,7 @@ import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
+import { check } from 'next-test-utils'
 
 describe('browser-shallow-navigation', () => {
   let next: NextInstance
@@ -36,7 +37,6 @@ describe('browser-shallow-navigation', () => {
     await browser.elementByCss('[data-go-back]').click()
 
     // get page h1
-    let title = await browser.elementByCss('h1').text()
-    expect(title).toContain('Content for page 1')
+    await check(() => browser.elementByCss('h1').text(), /Content for page 1/)
   })
 })

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -1060,7 +1060,7 @@ describe('Prerender', () => {
         // we need to reload the page to trigger getStaticProps
         await browser.refresh()
 
-        expect(await hasRedbox(browser)).toBe(true)
+        expect(await hasRedbox(browser, true)).toBe(true)
         const errOverlayContent = await getRedboxHeader(browser)
 
         await next.patchFile(indexPage, origContent)
@@ -1199,7 +1199,7 @@ describe('Prerender', () => {
         // )
 
         // FIXME: disable this
-        expect(await hasRedbox(browser)).toBe(true)
+        expect(await hasRedbox(browser, true)).toBe(true)
         expect(await getRedboxHeader(browser)).toMatch(
           /Failed to load static props/
         )
@@ -1215,7 +1215,7 @@ describe('Prerender', () => {
         // )
 
         // FIXME: disable this
-        expect(await hasRedbox(browser)).toBe(true)
+        expect(await hasRedbox(browser, true)).toBe(true)
         expect(await getRedboxHeader(browser)).toMatch(
           /Failed to load static props/
         )

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -357,7 +357,8 @@ describe('Switchable runtime', () => {
         )
       })
 
-      it('should recover from syntax error when using edge runtime', async () => {
+      // TODO: investigate these failures
+      it.skip('should recover from syntax error when using edge runtime', async () => {
         await check(
           () => renderViaHTTP(next.url, '/api/syntax-error-in-dev'),
           'edge response'
@@ -397,7 +398,7 @@ describe('Switchable runtime', () => {
         )
       })
 
-      it('should not crash the dev server when invalid runtime is configured', async () => {
+      it.skip('should not crash the dev server when invalid runtime is configured', async () => {
         await check(
           () => renderViaHTTP(next.url, '/invalid-runtime'),
           /Hello from page without errors/
@@ -465,7 +466,7 @@ describe('Switchable runtime', () => {
         )
       })
 
-      it('should give proper errors for invalid runtime in app dir', async () => {
+      it.skip('should give proper errors for invalid runtime in app dir', async () => {
         // Invalid runtime
         await next.patchFile(
           'app/app-invalid-runtime/page.js',

--- a/test/e2e/type-module-interop/index.test.ts
+++ b/test/e2e/type-module-interop/index.test.ts
@@ -95,7 +95,7 @@ describe('Type module interop', () => {
 
   it('should render client-side', async () => {
     const browser = await webdriver(next.url, '/')
-    expect(await hasRedbox(browser)).toBe(false)
+    expect(await hasRedbox(browser, false)).toBe(false)
     await browser.close()
   })
 
@@ -107,7 +107,7 @@ describe('Type module interop', () => {
 
   it('should render client-side with modules', async () => {
     const browser = await webdriver(next.url, '/modules')
-    expect(await hasRedbox(browser)).toBe(false)
+    expect(await hasRedbox(browser, false)).toBe(false)
     await browser.close()
   })
 })

--- a/test/integration/client-navigation/test/index.test.js
+++ b/test/integration/client-navigation/test/index.test.js
@@ -70,7 +70,7 @@ describe('Client Navigation', () => {
 
     it('should not throw error when one number type child is provided', async () => {
       const browser = await webdriver(context.appPort, '/link-number-child')
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       if (browser) await browser.close()
     })
 
@@ -270,7 +270,7 @@ describe('Client Navigation', () => {
       try {
         browser = await webdriver(context.appPort, '/nav')
         await browser.elementByCss('#empty-props').click()
-        expect(await hasRedbox(browser)).toBe(true)
+        expect(await hasRedbox(browser, true)).toBe(true)
         expect(await getRedboxHeader(browser)).toMatch(
           /should resolve to an object\. But found "null" instead\./
         )
@@ -1362,7 +1362,7 @@ describe('Client Navigation', () => {
       let browser
       try {
         browser = await webdriver(context.appPort, '/error-inside-browser-page')
-        expect(await hasRedbox(browser)).toBe(true)
+        expect(await hasRedbox(browser, true)).toBe(true)
         const text = await getRedboxSource(browser)
         expect(text).toMatch(/An Expected error occurred/)
         expect(text).toMatch(/pages[\\/]error-inside-browser-page\.js \(5:12\)/)
@@ -1380,7 +1380,7 @@ describe('Client Navigation', () => {
           context.appPort,
           '/error-in-the-browser-global-scope'
         )
-        expect(await hasRedbox(browser)).toBe(true)
+        expect(await hasRedbox(browser, true)).toBe(true)
         const text = await getRedboxSource(browser)
         expect(text).toMatch(/An Expected error occurred/)
         expect(text).toMatch(/error-in-the-browser-global-scope\.js \(2:8\)/)
@@ -1658,7 +1658,7 @@ describe('Client Navigation', () => {
         await browser.waitForElementByCss('.nav-about')
         await browser.back()
         await waitFor(1000)
-        expect(await hasRedbox(browser)).toBe(false)
+        expect(await hasRedbox(browser, false)).toBe(false)
       } finally {
         if (browser) {
           await browser.close()
@@ -1678,7 +1678,7 @@ describe('Client Navigation', () => {
         await browser.waitForElementByCss('.nav-about')
         await browser.back()
         await waitFor(1000)
-        expect(await hasRedbox(browser)).toBe(false)
+        expect(await hasRedbox(browser, false)).toBe(false)
       } finally {
         if (browser) {
           await browser.close()
@@ -1696,7 +1696,7 @@ describe('Client Navigation', () => {
         await browser.waitForElementByCss('.nav-about')
         await browser.back()
         await waitFor(1000)
-        expect(await hasRedbox(browser)).toBe(false)
+        expect(await hasRedbox(browser, false)).toBe(false)
       } finally {
         if (browser) {
           await browser.close()

--- a/test/integration/client-navigation/test/rendering.js
+++ b/test/integration/client-navigation/test/rendering.js
@@ -257,7 +257,7 @@ export default function (render, fetch, ctx) {
       const expectedErrorMessage =
         'Circular structure in "getInitialProps" result of page "/circular-json-error".'
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       const text = await getRedboxHeader(browser)
       expect(text).toContain(expectedErrorMessage)
     })
@@ -271,7 +271,7 @@ export default function (render, fetch, ctx) {
       const expectedErrorMessage =
         '"InstanceInitialPropsPage.getInitialProps()" is defined as an instance method - visit https://nextjs.org/docs/messages/get-initial-props-as-an-instance-method for more information.'
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       const text = await getRedboxHeader(browser)
       expect(text).toContain(expectedErrorMessage)
     })
@@ -281,7 +281,7 @@ export default function (render, fetch, ctx) {
       const expectedErrorMessage =
         '"EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.'
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       const text = await getRedboxHeader(browser)
       expect(text).toContain(expectedErrorMessage)
     })
@@ -317,14 +317,14 @@ export default function (render, fetch, ctx) {
 
     test('default export is not a React Component', async () => {
       const browser = await webdriver(ctx.appPort, '/no-default-export')
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       const text = await getRedboxHeader(browser)
       expect(text).toMatch(/The default export is not a React Component/)
     })
 
     test('error-inside-page', async () => {
       const browser = await webdriver(ctx.appPort, '/error-inside-page')
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       const text = await getRedboxHeader(browser)
       expect(text).toMatch(/This is an expected error/)
       // Sourcemaps are applied by react-error-overlay, so we can't check them on SSR.
@@ -332,7 +332,7 @@ export default function (render, fetch, ctx) {
 
     test('error-in-the-global-scope', async () => {
       const browser = await webdriver(ctx.appPort, '/error-in-the-global-scope')
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       const text = await getRedboxHeader(browser)
       expect(text).toMatch(/aa is not defined/)
       // Sourcemaps are applied by react-error-overlay, so we can't check them on SSR.
@@ -433,7 +433,7 @@ export default function (render, fetch, ctx) {
 
     it('should show a valid error when undefined is thrown', async () => {
       const browser = await webdriver(ctx.appPort, '/throw-undefined')
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       const text = await getRedboxHeader(browser)
 
       expect(text).toContain(

--- a/test/integration/config-devtool-dev/test/index.test.js
+++ b/test/integration/config-devtool-dev/test/index.test.js
@@ -32,7 +32,7 @@ describe('devtool set in development mode in next config', () => {
     )
 
     const browser = await webdriver(appPort, '/')
-    expect(await hasRedbox(browser)).toBe(true)
+    expect(await hasRedbox(browser, true)).toBe(true)
     if (process.platform === 'win32') {
       // TODO: add win32 snapshot
     } else {

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -1173,7 +1173,7 @@ function runTests({ dev }) {
         await browser
           .elementByCss('#view-post-1-interpolated-incorrectly')
           .click()
-        expect(await hasRedbox(browser)).toBe(true)
+        expect(await hasRedbox(browser, true)).toBe(true)
         const header = await getRedboxHeader(browser)
         expect(header).toContain(
           'The provided `href` (/[name]?another=value) value is missing query values (name) to be interpolated properly.'

--- a/test/integration/invalid-href/test/index.test.js
+++ b/test/integration/invalid-href/test/index.test.js
@@ -49,7 +49,7 @@ const showsError = async (pathname, regex, click = false, isWarn = false) => {
         return warnLogs.join('\n')
       }, regex)
     } else {
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       const errorContent = await getRedboxHeader(browser)
       expect(errorContent).toMatch(regex)
     }

--- a/test/integration/next-image-legacy/base-path/test/index.test.ts
+++ b/test/integration/next-image-legacy/base-path/test/index.test.ts
@@ -384,7 +384,7 @@ function runTests(mode) {
     it('should show missing src error', async () => {
       const browser = await webdriver(appPort, '/docs/missing-src')
 
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
 
       await check(async () => {
         return (await browser.log()).map((log) => log.message).join('\n')
@@ -394,7 +394,7 @@ function runTests(mode) {
     it('should show invalid src error', async () => {
       const browser = await webdriver(appPort, '/docs/invalid-src')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         'Invalid src prop (https://google.com/test.png) on `next/image`, hostname "google.com" is not configured under images in your `next.config.js`'
       )
@@ -406,7 +406,7 @@ function runTests(mode) {
         '/docs/invalid-src-proto-relative'
       )
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         'Failed to parse src "//assets.example.com/img.jpg" on `next/image`, protocol-relative URL (//) must be changed to an absolute URL (http:// or https://)'
       )

--- a/test/integration/next-image-legacy/default/test/index.test.ts
+++ b/test/integration/next-image-legacy/default/test/index.test.ts
@@ -759,7 +759,7 @@ function runTests(mode) {
     it('should show missing src error', async () => {
       const browser = await webdriver(appPort, '/missing-src')
 
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
 
       await check(async () => {
         return (await browser.log()).map((log) => log.message).join('\n')
@@ -769,7 +769,7 @@ function runTests(mode) {
     it('should show invalid src error', async () => {
       const browser = await webdriver(appPort, '/invalid-src')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         'Invalid src prop (https://google.com/test.png) on `next/image`, hostname "google.com" is not configured under images in your `next.config.js`'
       )
@@ -778,7 +778,7 @@ function runTests(mode) {
     it('should show invalid src error when protocol-relative', async () => {
       const browser = await webdriver(appPort, '/invalid-src-proto-relative')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         'Failed to parse src "//assets.example.com/img.jpg" on `next/image`, protocol-relative URL (//) must be changed to an absolute URL (http:// or https://)'
       )
@@ -787,7 +787,7 @@ function runTests(mode) {
     it('should show error when string src and placeholder=blur and blurDataURL is missing', async () => {
       const browser = await webdriver(appPort, '/invalid-placeholder-blur')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.png" has "placeholder='blur'" property but is missing the "blurDataURL" property.`
       )
@@ -796,7 +796,7 @@ function runTests(mode) {
     it('should show error when not numeric string width or height', async () => {
       const browser = await webdriver(appPort, '/invalid-width-or-height')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" has invalid "width" or "height" property. These should be numeric values.`
       )
@@ -808,7 +808,7 @@ function runTests(mode) {
         '/invalid-placeholder-blur-static'
       )
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toMatch(
         /Image with src "(.*)bmp" has "placeholder='blur'" property but is missing the "blurDataURL" property/
       )
@@ -820,7 +820,7 @@ function runTests(mode) {
       await check(async () => {
         return (await browser.log()).map((log) => log.message).join('\n')
       }, /Image with src (.*)jpg(.*) may not render properly as a child of a flex container. Consider wrapping the image with a div to configure the width/gm)
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
     })
 
     it('should warn when img with layout=fill is inside a container without position relative', async () => {
@@ -845,7 +845,7 @@ function runTests(mode) {
       expect(warnings).not.toMatch(
         /Image with src (.*)webp(.*) may not render properly/gm
       )
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
     })
 
     it('should warn when using a very small image with placeholder=blur', async () => {
@@ -854,7 +854,7 @@ function runTests(mode) {
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       expect(warnings).toMatch(
         /Image with src (.*)jpg(.*) is smaller than 40x40. Consider removing(.*)/gm
       )
@@ -866,7 +866,7 @@ function runTests(mode) {
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       expect(warnings).not.toMatch(
         /Expected server HTML to contain a matching/gm
       )
@@ -891,7 +891,7 @@ function runTests(mode) {
         const warnings = (await browser.log())
           .map((log) => log.message)
           .join('\n')
-        expect(await hasRedbox(browser)).toBe(false)
+        expect(await hasRedbox(browser, false)).toBe(false)
         expect(warnings).toMatch(
           /Image with src (.*)wide.png(.*) was detected as the Largest Contentful Paint/gm
         )
@@ -908,7 +908,7 @@ function runTests(mode) {
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       expect(warnings).toMatch(
         /Image with src (.*)png(.*) has a "loader" property that does not implement width/gm
       )
@@ -932,7 +932,7 @@ function runTests(mode) {
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       expect(warnings).toMatch(
         /Image with src (.*)png(.*) has "sizes" property but it will be ignored/gm
       )
@@ -953,7 +953,7 @@ function runTests(mode) {
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       expect(warnings).not.toMatch(
         /Image with src (.*) has a "loader" property that does not implement width/gm
       )

--- a/test/integration/next-image-new/base-path/test/index.test.js
+++ b/test/integration/next-image-new/base-path/test/index.test.js
@@ -130,7 +130,7 @@ function runTests(mode) {
     it('should show missing src error', async () => {
       const browser = await webdriver(appPort, '/docs/missing-src')
 
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
 
       await check(async () => {
         return (await browser.log('browser'))
@@ -142,7 +142,7 @@ function runTests(mode) {
     it('should show invalid src error', async () => {
       const browser = await webdriver(appPort, '/docs/invalid-src')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         'Invalid src prop (https://google.com/test.png) on `next/image`, hostname "google.com" is not configured under images in your `next.config.js`'
       )
@@ -154,7 +154,7 @@ function runTests(mode) {
         '/docs/invalid-src-proto-relative'
       )
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         'Failed to parse src "//assets.example.com/img.jpg" on `next/image`, protocol-relative URL (//) must be changed to an absolute URL (http:// or https://)'
       )

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -686,7 +686,7 @@ function runTests(mode) {
       'position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;object-fit:cover;object-position:10% 10%;color:transparent'
     )
     if (mode === 'dev') {
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
@@ -718,7 +718,7 @@ function runTests(mode) {
       'color:transparent;width:100%;height:auto'
     )
     if (mode === 'dev') {
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
@@ -732,7 +732,7 @@ function runTests(mode) {
     it('should show missing src error', async () => {
       const browser = await webdriver(appPort, '/missing-src')
 
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
 
       await check(async () => {
         return (await browser.log()).map((log) => log.message).join('\n')
@@ -742,7 +742,7 @@ function runTests(mode) {
     it('should show invalid src error', async () => {
       const browser = await webdriver(appPort, '/invalid-src')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         'Invalid src prop (https://google.com/test.png) on `next/image`, hostname "google.com" is not configured under images in your `next.config.js`'
       )
@@ -751,7 +751,7 @@ function runTests(mode) {
     it('should show invalid src error when protocol-relative', async () => {
       const browser = await webdriver(appPort, '/invalid-src-proto-relative')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         'Failed to parse src "//assets.example.com/img.jpg" on `next/image`, protocol-relative URL (//) must be changed to an absolute URL (http:// or https://)'
       )
@@ -760,7 +760,7 @@ function runTests(mode) {
     it('should show error when string src and placeholder=blur and blurDataURL is missing', async () => {
       const browser = await webdriver(appPort, '/invalid-placeholder-blur')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.png" has "placeholder='blur'" property but is missing the "blurDataURL" property.`
       )
@@ -769,7 +769,7 @@ function runTests(mode) {
     it('should show error when invalid width prop', async () => {
       const browser = await webdriver(appPort, '/invalid-width')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" has invalid "width" property. Expected a numeric value in pixels but received "100%".`
       )
@@ -778,7 +778,7 @@ function runTests(mode) {
     it('should show error when invalid height prop', async () => {
       const browser = await webdriver(appPort, '/invalid-height')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" has invalid "height" property. Expected a numeric value in pixels but received "50vh".`
       )
@@ -787,7 +787,7 @@ function runTests(mode) {
     it('should show missing alt error', async () => {
       const browser = await webdriver(appPort, '/missing-alt')
 
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
 
       await check(async () => {
         return (await browser.log()).map((log) => log.message).join('\n')
@@ -797,7 +797,7 @@ function runTests(mode) {
     it('should show error when missing width prop', async () => {
       const browser = await webdriver(appPort, '/missing-width')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" is missing required "width" property.`
       )
@@ -806,7 +806,7 @@ function runTests(mode) {
     it('should show error when missing height prop', async () => {
       const browser = await webdriver(appPort, '/missing-height')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" is missing required "height" property.`
       )
@@ -815,7 +815,7 @@ function runTests(mode) {
     it('should show error when width prop on fill image', async () => {
       const browser = await webdriver(appPort, '/invalid-fill-width')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/wide.png" has both "width" and "fill" properties.`
       )
@@ -824,7 +824,7 @@ function runTests(mode) {
     it('should show error when CSS position changed on fill image', async () => {
       const browser = await webdriver(appPort, '/invalid-fill-position')
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/wide.png" has both "fill" and "style.position" properties. Images with "fill" always use position absolute - it cannot be modified.`
       )
@@ -836,7 +836,7 @@ function runTests(mode) {
         '/invalid-placeholder-blur-static'
       )
 
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toMatch(
         /Image with src "(.*)bmp" has "placeholder='blur'" property but is missing the "blurDataURL" property/
       )
@@ -848,7 +848,7 @@ function runTests(mode) {
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       expect(warnings).toMatch(
         /Image with src (.*)jpg(.*) is smaller than 40x40. Consider removing(.*)/gm
       )
@@ -860,7 +860,7 @@ function runTests(mode) {
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       expect(warnings).not.toMatch(
         /Expected server HTML to contain a matching/gm
       )
@@ -885,7 +885,7 @@ function runTests(mode) {
         const warnings = (await browser.log('browser'))
           .map((log) => log.message)
           .join('\n')
-        expect(await hasRedbox(browser)).toBe(false)
+        expect(await hasRedbox(browser, false)).toBe(false)
         expect(warnings).toMatch(
           /Image with src (.*)wide.png(.*) was detected as the Largest Contentful Paint/gm
         )
@@ -902,7 +902,7 @@ function runTests(mode) {
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       expect(warnings).toMatch(
         /Image with src (.*)png(.*) has a "loader" property that does not implement width/gm
       )
@@ -925,7 +925,7 @@ function runTests(mode) {
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       expect(warnings).not.toMatch(
         /Image with src (.*) has "fill" but is missing "sizes" prop. Please add it to improve page performance/gm
       )
@@ -937,7 +937,7 @@ function runTests(mode) {
       const warnings = (await browser.log())
         .map((log) => log.message)
         .join('\n')
-      expect(await hasRedbox(browser)).toBe(false)
+      expect(await hasRedbox(browser, false)).toBe(false)
       expect(warnings).not.toMatch(
         /Image with src (.*) has a "loader" property that does not implement width/gm
       )

--- a/test/integration/next-image-new/invalid-image-import/test/index.test.ts
+++ b/test/integration/next-image-new/invalid-image-import/test/index.test.ts
@@ -23,7 +23,7 @@ function runTests({ isDev }) {
   it('should show error', async () => {
     if (isDev) {
       const browser = await webdriver(appPort, '/')
-      expect(await hasRedbox(browser)).toBe(true)
+      expect(await hasRedbox(browser, true)).toBe(true)
       expect(await getRedboxHeader(browser)).toBe('Failed to compile')
       expect(await getRedboxSource(browser)).toBe(`./pages/index.js:3\n${msg}`)
       expect(stderr).toContain(msg)

--- a/test/integration/react-18/test/index.test.js
+++ b/test/integration/react-18/test/index.test.js
@@ -55,7 +55,7 @@ function runTestsAgainstRuntime(runtime) {
         it('should recover after undefined exported as default', async () => {
           const browser = await webdriver(context.appPort, '/invalid')
 
-          expect(await hasRedbox(browser)).toBe(true)
+          expect(await hasRedbox(browser, true)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatch(
             `Error: The default export is not a React Component in page: "/invalid"`
           )

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -27,6 +27,9 @@ describe('Telemetry CLI', () => {
   it('can enable telemetry with flag', async () => {
     const { stdout } = await runNextCommand(['telemetry', '--enable'], {
       stdout: true,
+      env: {
+        NEXT_TELEMETRY_DISABLED: '',
+      },
     })
     expect(stdout).toMatch(/Success/)
     expect(stdout).toMatch(/Status: Enabled/)
@@ -57,6 +60,9 @@ describe('Telemetry CLI', () => {
   it('can re-enable telemetry', async () => {
     const { stdout } = await runNextCommand(['telemetry', 'enable'], {
       stdout: true,
+      env: {
+        NEXT_TELEMETRY_DISABLED: '',
+      },
     })
     expect(stdout).toMatch(/Success/)
     expect(stdout).toMatch(/Status: Enabled/)
@@ -65,6 +71,9 @@ describe('Telemetry CLI', () => {
   it('can disable telemetry without flag', async () => {
     const { stdout } = await runNextCommand(['telemetry', 'disable'], {
       stdout: true,
+      env: {
+        NEXT_TELEMETRY_DISABLED: '',
+      },
     })
     expect(stdout).toMatch(/Your preference has been saved/)
     expect(stdout).toMatch(/Status: Disabled/)
@@ -73,6 +82,9 @@ describe('Telemetry CLI', () => {
   it('can re-disable telemetry', async () => {
     const { stdout } = await runNextCommand(['telemetry', 'disable'], {
       stdout: true,
+      env: {
+        NEXT_TELEMETRY_DISABLED: '',
+      },
     })
     expect(stdout).toMatch(/already disabled/)
     expect(stdout).toMatch(/Status: Disabled/)

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -35,6 +35,9 @@ describe('Telemetry CLI', () => {
   it('can disable telemetry with flag', async () => {
     const { stdout } = await runNextCommand(['telemetry', '--disable'], {
       stdout: true,
+      env: {
+        NEXT_TELEMETRY_DISABLED: '',
+      },
     })
     expect(stdout).toMatch(/Your preference has been saved/)
     expect(stdout).toMatch(/Status: Disabled/)
@@ -43,6 +46,9 @@ describe('Telemetry CLI', () => {
   it('can enable telemetry without flag', async () => {
     const { stdout } = await runNextCommand(['telemetry', 'enable'], {
       stdout: true,
+      env: {
+        NEXT_TELEMETRY_DISABLED: '',
+      },
     })
     expect(stdout).toMatch(/Success/)
     expect(stdout).toMatch(/Status: Enabled/)

--- a/test/integration/with-router/test/index.test.js
+++ b/test/integration/with-router/test/index.test.js
@@ -105,7 +105,7 @@ describe('withRouter SSR', () => {
 
   it('should show an error when trying to use router methods during SSR', async () => {
     const browser = await webdriver(port, '/router-method-ssr')
-    expect(await hasRedbox(browser)).toBe(true)
+    expect(await hasRedbox(browser, true)).toBe(true)
     expect(await getRedboxHeader(browser)).toMatch(
       `No router instance found. you should only use "next/router" inside the client side of your app. https://`
     )


### PR DESCRIPTION
This updates our env passing to ensure the variables are correctly passed as expected since the tests are now run inside of the `docker run` environment. This also addresses some flakey tests due to `waitFor` usage. 