### PR TITLE
Fix prepublish compiled handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "clean-trace-jaeger": "rm -rf test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",
     "debug": "cross-env NEXT_TELEMETRY_DISABLED=1 node --inspect packages/next/dist/bin/next",
     "postinstall": "git config feature.manyFiles true && node scripts/install-native.mjs",
-    "version": "npx pnpm@7.24.3 install && ./scripts/check-pre-compiled.sh && git add .",
+    "version": "npx pnpm@7.24.3 install && IS_PUBLISH=yes ./scripts/check-pre-compiled.sh && git add .",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/scripts/check-pre-compiled.sh
+++ b/scripts/check-pre-compiled.sh
@@ -16,7 +16,7 @@ cd ../../
 # Make sure to exit with 1 if there are changes after running ncc-compiled
 # step to ensure we get any changes committed
 
-if [[ ! -z $(git status -s) ]];then
+if [[ ! -z $(git status -s) ]] && [[ -z $IS_PUBLISH ]];then
   echo "Detected changes"
   git diff -a --stat
   exit 1


### PR DESCRIPTION
Ensures the `check-pre-compiled` script doesn't block publish when there are changes from module id shift. 