### PR TITLE
Support Prefer Offline for testing

### DIFF
--- a/contributing/core/testing.md
+++ b/contributing/core/testing.md
@@ -72,6 +72,7 @@ Some test-specific environment variables can be used to help debug isolated test
 - When investigating failures in isolated tests you can use `NEXT_TEST_SKIP_CLEANUP=1` to prevent deleting the temp folder created for the test, then you can run `pnpm next` while inside of the temp folder to debug the fully set-up test project.
 - You can also use `NEXT_SKIP_ISOLATE=1` if the test doesn't need to be installed to debug and it will run inside of the Next.js repo instead of the temp directory, this can also reduce test times locally but is not compatible with all tests.
 - The `NEXT_TEST_MODE` env variable allows toggling specific test modes for the `e2e` folder, it can be used when not using `pnpm test-dev` or `pnpm test-start` directly. Valid test modes can be seen here: https://github.com/vercel/next.js/blob/aa664868c102ddc5adc618415162d124503ad12e/test/lib/e2e-utils.ts#L46
+- You can use `NEXT_TEST_PREFER_OFFLINE=1` while testing to configure the package manager to include the [`--prefer-offline`](https://pnpm.io/cli/install#--prefer-offline) argument during test setup. This is helpful when running tests in internet restricted environments such as planes or public wifi.
 
 ### Debugging
 

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -159,16 +159,19 @@ async function createNextInstall({
         await rootSpan
           .traceChild('run generic install command')
           .traceAsyncFn(async () => {
-            const runInstall = async () =>
-              await execa(
-                'pnpm',
-                ['install', '--strict-peer-dependencies=false'],
-                {
-                  cwd: installDir,
-                  stdio: ['ignore', 'inherit', 'inherit'],
-                  env: process.env,
-                }
-              )
+            const runInstall = async () => {
+              const args = ['install', '--strict-peer-dependencies=false']
+
+              if (process.env.NEXT_TEST_PREFER_OFFLINE) {
+                args.push('--prefer-offline')
+              }
+
+              return await execa('pnpm', args, {
+                cwd: installDir,
+                stdio: ['ignore', 'inherit', 'inherit'],
+                env: process.env,
+              })
+            }
 
             if (!areGenericDependencies(combinedDependencies)) {
               await runInstall()

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -162,7 +162,7 @@ async function createNextInstall({
             const runInstall = async () => {
               const args = ['install', '--strict-peer-dependencies=false']
 
-              if (process.env.NEXT_TEST_PREFER_OFFLINE) {
+              if (process.env.NEXT_TEST_PREFER_OFFLINE === '1') {
                 args.push('--prefer-offline')
               }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Adds support for a new environment variable, `NEXT_TEST_PREFER_OFFLINE=1` which automatically adds the `--prefer-offline` argument to the `pnpm install` command used during test setup. This is useful for developers performing testing whilst in internet restricted environments ✈️.