### PR TITLE
Replace eslint rule for `no-shadow` with `typescript-eslint/no-shadow`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -158,6 +158,9 @@
     {
       "files": ["packages/**/*.tsx", "packages/**/*.ts"],
       "rules": {
+        // Note: you must disable the base rule as it can report incorrect errors
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": ["warn", { "builtinGlobals": false }],
         "@typescript-eslint/no-unused-vars": [
           "warn",
           {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1325,9 +1325,9 @@ export default async function build(
           runtimeEnvConfig
         )
 
-        // eslint-disable-next-line no-shadow
+        // eslint-disable-next-line @typescript-eslint/no-shadow
         let isNextImageImported: boolean | undefined
-        // eslint-disable-next-line no-shadow
+        // eslint-disable-next-line @typescript-eslint/no-shadow
         let hasSsrAmpPages = false
 
         const computedManifestData = await computeFromManifest(

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2448,7 +2448,7 @@ export default async function getBaseWebpackConfig(
       devtoolRevertWarning(originalDevtool)
     }
 
-    // eslint-disable-next-line no-shadow
+    // eslint-disable-next-line @typescript-eslint/no-shadow
     const webpack5Config = webpackConfig as webpack.Configuration
 
     // disable lazy compilation of entries as next.js has it's own method here


### PR DESCRIPTION
When using enum's in Typescript, the `no-shadow` eslint rule throws an error for the following:

```ts
// 'State' is already declared in the upper scope `no-shadow`
enum State {
  Started,
  Running,
  Finished,
}
```

Typescript instead offers the `typescript-eslint/no-shadow` rule that [should be used instead, see documentation here](https://typescript-eslint.io/rules/no-shadow/#how-to-use).