### PR TITLE
Fix CSS imports being tracked multiple times

### DIFF
--- a/packages/next/src/build/webpack/loaders/get-module-build-info.ts
+++ b/packages/next/src/build/webpack/loaders/get-module-build-info.ts
@@ -21,7 +21,14 @@ export function getModuleBuildInfo(webpackModule: webpack.Module) {
     importLocByPath?: Map<string, any>
     rootDir?: string
     rsc?: RSCMeta
+    treeInfo?: TreeNode
   }
+}
+
+// This attaches the app tree structure to the build into
+export interface TreeNode {
+  resource: string
+  children: TreeNode[]
 }
 
 export interface RSCMeta {

--- a/packages/next/src/build/webpack/loaders/get-module-build-info.ts
+++ b/packages/next/src/build/webpack/loaders/get-module-build-info.ts
@@ -21,14 +21,7 @@ export function getModuleBuildInfo(webpackModule: webpack.Module) {
     importLocByPath?: Map<string, any>
     rootDir?: string
     rsc?: RSCMeta
-    treeInfo?: TreeNode
   }
-}
-
-// This attaches the app tree structure to the build info
-export interface TreeNode {
-  resource: string
-  children: TreeNode[]
 }
 
 export interface RSCMeta {

--- a/packages/next/src/build/webpack/loaders/get-module-build-info.ts
+++ b/packages/next/src/build/webpack/loaders/get-module-build-info.ts
@@ -25,7 +25,7 @@ export function getModuleBuildInfo(webpackModule: webpack.Module) {
   }
 }
 
-// This attaches the app tree structure to the build into
+// This attaches the app tree structure to the build info
 export interface TreeNode {
   resource: string
   children: TreeNode[]

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -25,7 +25,6 @@ import { ASYNC_CLIENT_MODULES } from './flight-manifest-plugin'
 import { isClientComponentModule, regexCSS } from '../loaders/utils'
 import { traverseModules } from '../utils'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
-import { TreeNode } from '../loaders/get-module-build-info'
 
 interface Options {
   dev: boolean
@@ -340,37 +339,6 @@ export class FlightClientEntryPlugin {
             })
 
           Object.assign(cssManifest, cssImports)
-        }
-
-        // Finally, we need to clean up CSS imports a bit. If a parent or
-        // current layout already imports a CSS file, we can remove it from
-        // the current entry's CSS imports.
-        const { treeInfo } = entryModule.buildInfo
-        if (treeInfo) {
-          function filterIncludedCSS(
-            tree: TreeNode,
-            parentCSSImports: Set<string>
-          ) {
-            const used = new Set(parentCSSImports)
-
-            // Remove CSS imports that are already imported by the parent
-            const collected = cssManifest[tree.resource]
-            if (collected?.length) {
-              cssManifest[tree.resource] = collected.filter((cssImport) => {
-                if (!parentCSSImports.has(cssImport)) {
-                  used.add(cssImport)
-                  return true
-                }
-                return false
-              })
-            }
-
-            // Recursively check children
-            tree.children.forEach((child) => {
-              filterIncludedCSS(child, used)
-            })
-          }
-          filterIncludedCSS(treeInfo, new Set())
         }
       })
     })

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -361,6 +361,7 @@ export class FlightClientEntryPlugin {
                   used.add(cssImport)
                   return true
                 }
+                return false
               })
             }
 

--- a/packages/next/src/server/app-render.tsx
+++ b/packages/next/src/server/app-render.tsx
@@ -725,7 +725,7 @@ function getCssInlinedLinkTags(
     // entrypoint.
     if (
       serverCSSForEntries.includes(mod) ||
-      !/\.module\.(css|sass)$/.test(mod)
+      !/\.module\.(css|sass|scss)$/.test(mod)
     ) {
       // If the CSS is already injected by a parent layer, we don't need
       // to inject it again.

--- a/test/e2e/app-dir/app/app/css/css-duplicate-2/client/page.js
+++ b/test/e2e/app-dir/app/app/css/css-duplicate-2/client/page.js
@@ -2,6 +2,6 @@
 
 import styles from '../style.module.css'
 
-export default function Page({}) {
+export default function Page() {
   return <div className={styles.foo}>Hello</div>
 }

--- a/test/e2e/app-dir/app/app/css/css-duplicate-2/client/page.js
+++ b/test/e2e/app-dir/app/app/css/css-duplicate-2/client/page.js
@@ -1,0 +1,7 @@
+'use client'
+
+import styles from '../style.module.css'
+
+export default function Page({}) {
+  return <div className={styles.foo}>Hello</div>
+}

--- a/test/e2e/app-dir/app/app/css/css-duplicate-2/layout.js
+++ b/test/e2e/app-dir/app/app/css/css-duplicate-2/layout.js
@@ -1,0 +1,5 @@
+import styles from './style.module.css'
+
+export default function Layout({ children }) {
+  return <div className={styles.foo}>{children}</div>
+}

--- a/test/e2e/app-dir/app/app/css/css-duplicate-2/server/page.js
+++ b/test/e2e/app-dir/app/app/css/css-duplicate-2/server/page.js
@@ -1,5 +1,5 @@
 import styles from '../style.module.css'
 
-export default function Page({}) {
+export default function Page() {
   return <div className={styles.foo}>Hello</div>
 }

--- a/test/e2e/app-dir/app/app/css/css-duplicate-2/server/page.js
+++ b/test/e2e/app-dir/app/app/css/css-duplicate-2/server/page.js
@@ -1,0 +1,5 @@
+import styles from '../style.module.css'
+
+export default function Page({}) {
+  return <div className={styles.foo}>Hello</div>
+}

--- a/test/e2e/app-dir/app/app/css/css-duplicate-2/style.module.css
+++ b/test/e2e/app-dir/app/app/css/css-duplicate-2/style.module.css
@@ -1,0 +1,3 @@
+.foo::before {
+  content: '_randomized_string_for_testing_';
+}

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -1466,6 +1466,27 @@ createNextDescribe(
 
       if (isDev) {
         describe('multiple entries', () => {
+          it('should only inject the same style once if used by different layers', async () => {
+            const browser = await next.browser('/css/css-duplicate-2/client')
+            expect(
+              await browser.eval(
+                `[...document.styleSheets].filter(({ cssRules }) =>
+                  [...cssRules].some(({ cssText }) => (cssText||'').includes('_randomized_string_for_testing_'))
+                ).length`
+              )
+            ).toBe(1)
+          })
+
+          it('should only include the same style once in the flight data', async () => {
+            const initialHtml = await next.render('/css/css-duplicate-2/server')
+
+            // Even if it's deduped by Float, it should still only be included once in the payload.
+            // There are two matches, one for the rendered <link> and one for the flight data.
+            expect(
+              initialHtml.match(/duplicate-2_style_module_css\.css/g).length
+            ).toBe(2)
+          })
+
           it('should only load chunks for the css module that is used by the specific entrypoint', async () => {
             // Visit /b first
             await next.render('/css/css-duplicate/b')


### PR DESCRIPTION
Currently the way our renderer injects CSS is to first track CSS imports on the module level, and then render these links on each layer. However, in a complex application it's possible that one CSS being imported in many modules, and in multiple layouts. This causes an issue of duplication. And if there are many rules the order could be messed up by that. 

This PR deduplicates CSS resources used by one entry (layout, page, error, ...) and all its parent layouts. If an entry is rendered, all its ancestors are rendered too.

See test case for more details. Currently those two tests will all fail.

Fixes #42862.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
