### PR TITLE
update redirects.md

### DIFF
--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -251,7 +251,7 @@ module.exports = {
       {
         // does not add /docs since basePath: false is set
         source: '/without-basePath',
-        destination: '/another',
+        destination: 'https://example.com',
         basePath: false,
         permanent: false,
       },


### PR DESCRIPTION
I read the description about `basepath` at the front of this page 
<img width="625" alt="image" src="https://user-images.githubusercontent.com/77158595/212905869-d9c1452d-4616-4e6c-b5f6-27b396d59b5e.png">

and then when I checked the detail at the bottom of same page, I saw there is internal destination as an example of  basepath. I thought there is an irony between definition and example.

<img width="683" alt="image" src="https://user-images.githubusercontent.com/77158595/212906008-4c40cf54-172a-453d-a84f-b278b9797528.png">

so I want to change the example of basepath using external url

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
