### PR TITLE
Fix `with-stencil` example

### DIFF
--- a/examples/with-stencil/packages/test-component/package.json
+++ b/examples/with-stencil/packages/test-component/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "test-component",
+  "version": "1.0.0",
   "private": true,
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/examples/with-stencil/packages/web-app/package.json
+++ b/examples/with-stencil/packages/web-app/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "web-app",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "next",


### PR DESCRIPTION
## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm build && pnpm lint`
- [X] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

## Description

The `name` and `version` props were missing in `package.json` fields in `with-stencil` monorepo example which was causing issues while installing the dependencies.

```bash
with-stencil-app on main
❯ yarn install
yarn install v1.22.17
warning Missing version in workspace at ".../with-stencil-app/packages/test-component", ignoring.
warning Missing version in workspace at ".../with-stencil-app/packages/web-app", ignoring.
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.04s.
```