### PR TITLE
Update to skip test timings on docs change

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -84,6 +84,7 @@ jobs:
       - run: pnpm install
 
       - run: TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }} node run-tests.js --timings --write-timings -g 1/1
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'nope' }}
 
       - run: pnpm run build
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -84,7 +84,7 @@ jobs:
       - run: pnpm install
 
       - run: TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN || secrets.GITHUB_TOKEN }} node run-tests.js --timings --write-timings -g 1/1
-        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'nope' }}
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
 
       - run: pnpm run build
 


### PR DESCRIPTION
This should reduce how often we hit the rate limit.

x-ref: https://github.com/vercel/next.js/actions/runs/3941456983/jobs/6743931224