### PR TITLE
Update some flakey acceptance tests

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts
@@ -38,7 +38,7 @@ describe('ReactRefreshLogBox app', () => {
       `
     )
 
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     // Syntax error
     await session.patch('index.module.scss', `.button { font-size: :5px; }`)
@@ -48,7 +48,7 @@ describe('ReactRefreshLogBox app', () => {
 
     // Fix syntax error
     await session.patch('index.module.scss', `.button { font-size: 5px; }`)
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     // Not local error
     await session.patch('index.module.scss', `button { font-size: 5px; }`)

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -107,7 +107,7 @@ for (const variant of ['default', 'turbo']) {
         /Count: 1/
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       await cleanup()
     })
@@ -169,7 +169,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       expect(await session.hasErrorToast()).toBe(false)
 
       expect(
@@ -180,7 +180,7 @@ for (const variant of ['default', 'turbo']) {
         await session.evaluate(() => document.querySelector('p').textContent)
       ).toBe('Count: 2')
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       expect(await session.hasErrorToast()).toBe(false)
 
       await cleanup()
@@ -242,7 +242,7 @@ for (const variant of ['default', 'turbo']) {
 
       // TODO-APP: re-enable when error recovery doesn't reload the page.
       // expect(didNotReload).toBe(true)
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       expect(
         await session.evaluate(() => document.querySelector('p').textContent)
       ).toBe('Hello')
@@ -526,7 +526,7 @@ for (const variant of ['default', 'turbo']) {
       )
 
       // Expected: this fixes the problem
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       await cleanup()
     })
@@ -701,7 +701,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       await session.patch(
         'index.js',
@@ -752,7 +752,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       expect(
         await session.evaluate(() => document.querySelector('p').textContent)
       ).toBe('hello')
@@ -784,7 +784,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       expect(
         await session.evaluate(() => document.querySelector('p').textContent)
       ).toBe('hello new')
@@ -810,7 +810,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       // Syntax error
       await session.patch('index.module.css', `.button {`)
@@ -1219,7 +1219,7 @@ for (const variant of ['default', 'turbo']) {
         () => browser.elementByCss('.nextjs-toast-errors').text(),
         /4 errors/
       )
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       // Add Component error
       await session.patch(
@@ -1328,7 +1328,7 @@ for (const variant of ['default', 'turbo']) {
       expect(await browser.waitForElementByCss('#text').text()).toBe(
         'Hello world'
       )
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       // Re-add error
       await session.patch(

--- a/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
@@ -88,7 +88,7 @@ describe.skip('ReactRefreshLogBox app', () => {
         }
       `
     )
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     await session.patch(
       'index.js',
@@ -112,7 +112,7 @@ describe.skip('ReactRefreshLogBox app', () => {
         }
       `
     )
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     await session.patch(
       'index.js',
@@ -136,7 +136,7 @@ describe.skip('ReactRefreshLogBox app', () => {
         }
       `
     )
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     await session.patch(
       'index.js',
@@ -160,7 +160,7 @@ describe.skip('ReactRefreshLogBox app', () => {
         }
       `
     )
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     await session.patch(
       'index.js',

--- a/test/development/acceptance-app/ReactRefreshModule.test.ts
+++ b/test/development/acceptance-app/ReactRefreshModule.test.ts
@@ -20,7 +20,7 @@ describe('ReactRefreshModule app', () => {
 
   it('should allow any variable names', async () => {
     const { session, cleanup } = await sandbox(next, new Map([]))
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     const variables = [
       '_a',
@@ -39,7 +39,7 @@ describe('ReactRefreshModule app', () => {
           return null
         }`
       )
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       expect(next.cliOutput).not.toContain(
         `'${variable}' has already been declared`
       )

--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -3,6 +3,7 @@ import { sandbox } from './helpers'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import path from 'path'
+import { check } from 'next-test-utils'
 
 describe('ReactRefreshRegression app', () => {
   let next: NextInstance
@@ -80,7 +81,7 @@ describe('ReactRefreshRegression app', () => {
     )
 
     // Verify no hydration mismatch:
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     await cleanup()
   })
@@ -250,9 +251,11 @@ describe('ReactRefreshRegression app', () => {
       `
     )
 
-    expect(
-      await session.evaluate(() => document.querySelector('p').textContent)
-    ).toBe('0')
+    await check(
+      () => session.evaluate(() => document.querySelector('p').textContent),
+      '0'
+    )
+
     await session.evaluate(() => document.querySelector('button').click())
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
@@ -356,7 +359,7 @@ describe('ReactRefreshRegression app', () => {
 
     let didNotReload = await session.patch('app/content.mdx', `Hello Foo!`)
     expect(didNotReload).toBe(true)
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
     expect(
       await session.evaluate(
         () => document.querySelector('#content').textContent
@@ -365,7 +368,7 @@ describe('ReactRefreshRegression app', () => {
 
     didNotReload = await session.patch('app/content.mdx', `Hello Bar!`)
     expect(didNotReload).toBe(true)
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
     expect(
       await session.evaluate(
         () => document.querySelector('#content').textContent

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -41,7 +41,7 @@ for (const variant of ['default', 'turbo']) {
         export default MyApp
       `
       )
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       await cleanup()
     })
 
@@ -89,7 +89,7 @@ for (const variant of ['default', 'turbo']) {
         export default MyDocument
       `
       )
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       await cleanup()
     })
 
@@ -120,7 +120,7 @@ for (const variant of ['default', 'turbo']) {
         export default MyApp
       `
       )
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       await cleanup()
     })
 
@@ -187,7 +187,7 @@ for (const variant of ['default', 'turbo']) {
         export default MyDocument
       `
       )
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       await cleanup()
     })
   })

--- a/test/development/acceptance/ReactRefreshLogBox-scss.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-scss.test.ts
@@ -37,7 +37,7 @@ describe.skip('ReactRefreshLogBox', () => {
       `
     )
 
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     // Syntax error
     await session.patch('index.module.scss', `.button { font-size: :5px; }`)

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -100,7 +100,7 @@ for (const variant of ['default', 'turbo']) {
         /Count: 1/
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       await cleanup()
     })
@@ -162,7 +162,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       expect(
         await session.evaluate(() => document.querySelector('p').textContent)
@@ -172,7 +172,7 @@ for (const variant of ['default', 'turbo']) {
         await session.evaluate(() => document.querySelector('p').textContent)
       ).toBe('Count: 2')
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       await cleanup()
     })
@@ -231,7 +231,7 @@ for (const variant of ['default', 'turbo']) {
       )
 
       expect(didNotReload).toBe(true)
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       expect(
         await session.evaluate(() => document.querySelector('p').textContent)
       ).toBe('Hello')
@@ -422,7 +422,7 @@ for (const variant of ['default', 'turbo']) {
       )
 
       // Expected: this fixes the problem
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       await cleanup()
     })
@@ -597,7 +597,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       await session.patch(
         'index.js',
@@ -648,7 +648,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       expect(
         await session.evaluate(() => document.querySelector('p').textContent)
       ).toBe('hello')
@@ -680,7 +680,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       expect(
         await session.evaluate(() => document.querySelector('p').textContent)
       ).toBe('hello new')
@@ -706,7 +706,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
 
       // Syntax error
       await session.patch('index.module.css', `.button {`)
@@ -748,7 +748,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       await session.evaluate(() => document.querySelector('button').click())
       expect(await session.hasRedbox(true)).toBe(true)
 
@@ -794,7 +794,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       await session.evaluate(() => document.querySelector('button').click())
       expect(await session.hasRedbox(true)).toBe(true)
 
@@ -840,7 +840,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       await session.evaluate(() => document.querySelector('button').click())
       expect(await session.hasRedbox(true)).toBe(true)
 
@@ -886,7 +886,7 @@ for (const variant of ['default', 'turbo']) {
       `
       )
 
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       await session.evaluate(() => document.querySelector('button').click())
       expect(await session.hasRedbox(true)).toBe(true)
 

--- a/test/development/acceptance/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBoxMisc.test.ts
@@ -83,7 +83,7 @@ describe.skip('ReactRefreshLogBox', () => {
         }
       `
     )
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     await session.patch(
       'index.js',
@@ -107,7 +107,7 @@ describe.skip('ReactRefreshLogBox', () => {
         }
       `
     )
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     await session.patch(
       'index.js',
@@ -131,7 +131,7 @@ describe.skip('ReactRefreshLogBox', () => {
         }
       `
     )
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     await session.patch(
       'index.js',
@@ -155,7 +155,7 @@ describe.skip('ReactRefreshLogBox', () => {
         }
       `
     )
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     await session.patch(
       'index.js',

--- a/test/development/acceptance/ReactRefreshModule.test.ts
+++ b/test/development/acceptance/ReactRefreshModule.test.ts
@@ -15,7 +15,7 @@ describe('ReactRefreshModule', () => {
 
   it('should allow any variable names', async () => {
     const { session, cleanup } = await sandbox(next, new Map([]))
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     const variables = [
       '_a',
@@ -33,7 +33,7 @@ describe('ReactRefreshModule', () => {
           return null
         }`
       )
-      expect(await session.hasRedbox()).toBe(false)
+      expect(await session.hasRedbox(false)).toBe(false)
       expect(next.cliOutput).not.toContain(
         `'${variable}' has already been declared`
       )

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -2,6 +2,7 @@
 import { sandbox } from './helpers'
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
+import { check } from 'next-test-utils'
 
 describe('ReactRefreshRegression', () => {
   let next: NextInstance
@@ -76,7 +77,7 @@ describe('ReactRefreshRegression', () => {
     )
 
     // Verify no hydration mismatch:
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
 
     await cleanup()
   })
@@ -231,9 +232,11 @@ describe('ReactRefreshRegression', () => {
       `
     )
 
-    expect(
-      await session.evaluate(() => document.querySelector('p').textContent)
-    ).toBe('0')
+    await check(
+      () => session.evaluate(() => document.querySelector('p').textContent),
+      '0'
+    )
+
     await session.evaluate(() => document.querySelector('button').click())
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
@@ -319,7 +322,7 @@ describe('ReactRefreshRegression', () => {
 
     let didNotReload = await session.patch('pages/index.mdx', `Hello Foo!`)
     expect(didNotReload).toBe(true)
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
     expect(
       await session.evaluate(
         () => document.querySelector('#__next').textContent
@@ -328,7 +331,7 @@ describe('ReactRefreshRegression', () => {
 
     didNotReload = await session.patch('pages/index.mdx', `Hello Bar!`)
     expect(didNotReload).toBe(true)
-    expect(await session.hasRedbox()).toBe(false)
+    expect(await session.hasRedbox(false)).toBe(false)
     expect(
       await session.evaluate(
         () => document.querySelector('#__next').textContent


### PR DESCRIPTION
Updates some flakey tests in the acceptance test suites. Note, we should be using `check` where ever we can to eliminate flakiness. 

x-ref: https://github.com/vercel/next.js/actions/runs/3942884587/jobs/6747157704