### PR TITLE
Add experimental.allowedRevalidateHeaderKeys config

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -229,6 +229,9 @@ const configSchema = {
         adjustFontFallbacksWithSizeAdjust: {
           type: 'boolean',
         },
+        allowedRevalidateHeaderKeys: {
+          type: 'array',
+        },
         amp: {
           additionalProperties: false,
           properties: {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -79,6 +79,7 @@ export interface NextJsWebpackConfig {
 }
 
 export interface ExperimentalConfig {
+  allowedRevalidateHeaderKeys?: string[]
   fetchCache?: boolean
   optimisticClientCache?: boolean
   middlewarePrefetch?: 'strict' | 'flexible'

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -810,7 +810,10 @@ export default class NextNodeServer extends BaseServer {
             new NodeNextResponse(newRes)
           ),
         // internal config so is not typed
-        trustHostHeader: (this.nextConfig.experimental as any).trustHostHeader,
+        trustHostHeader: (this.nextConfig.experimental as Record<string, any>)
+          .trustHostHeader,
+        allowedRevalidateHeaderKeys:
+          this.nextConfig.experimental.allowedRevalidateHeaderKeys,
       },
       this.minimalMode,
       this.renderOpts.dev,


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/44981 this changes the approach slightly back to an allow list which is configurable via an experimental `allowedRevalidateHeaders` config. 