### PR TITLE
Gracefully handle telemetry not being available

### DIFF
--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -607,7 +607,7 @@ function getExtractMetadata(params: {
   return async () => {
     metadataByEntry.clear()
     const resolver = compilation.resolverFactory.get('normal')
-    const telemetry: Telemetry = traceGlobals.get('telemetry')
+    const telemetry: Telemetry | undefined = traceGlobals.get('telemetry')
 
     for (const [entryName, entry] of compilation.entries) {
       if (entry.options.runtime !== EDGE_RUNTIME_WEBPACK) {
@@ -683,7 +683,7 @@ function getExtractMetadata(params: {
           }
 
           if (edgeFunctionConfig?.config?.unstable_allowDynamicGlobs) {
-            telemetry.record({
+            telemetry?.record({
               eventName: 'NEXT_EDGE_ALLOW_DYNAMIC_USED',
               payload: {
                 ...edgeFunctionConfig,
@@ -773,7 +773,7 @@ function getExtractMetadata(params: {
         }
       }
 
-      telemetry.record({
+      telemetry?.record({
         eventName: EVENT_BUILD_FEATURE_USAGE,
         payload: {
           featureName: 'vercelImageGeneration',

--- a/packages/next/src/telemetry/events/swc-load-failure.ts
+++ b/packages/next/src/telemetry/events/swc-load-failure.ts
@@ -20,7 +20,7 @@ export type EventSwcLoadFailure = {
 export async function eventSwcLoadFailure(
   event?: EventSwcLoadFailure['payload']
 ): Promise<void> {
-  const telemetry: Telemetry = traceGlobals.get('telemetry')
+  const telemetry: Telemetry | undefined = traceGlobals.get('telemetry')
   // can't continue if telemetry isn't set
   if (!telemetry) return
 

--- a/packages/next/src/trace/report/to-telemetry.ts
+++ b/packages/next/src/trace/report/to-telemetry.ts
@@ -1,3 +1,4 @@
+import { Telemetry } from '../../telemetry/storage'
 import { traceGlobals } from '../shared'
 
 const TRACE_EVENT_ACCESSLIST = new Map(
@@ -11,7 +12,7 @@ const reportToTelemetry = (spanName: string, duration: number) => {
   if (!eventName) {
     return
   }
-  const telemetry = traceGlobals.get('telemetry')
+  const telemetry: Telemetry | undefined = traceGlobals.get('telemetry')
   if (!telemetry) {
     return
   }

--- a/packages/next/src/trace/shared.ts
+++ b/packages/next/src/trace/shared.ts
@@ -1,6 +1,13 @@
 export type SpanId = number
 
-export const traceGlobals: Map<any, any> = new Map()
+let _traceGlobals: Map<any, any> = (global as any)._traceGlobals
+
+if (!_traceGlobals) {
+  _traceGlobals = new Map()
+}
+;(global as any)._traceGlobals = _traceGlobals
+
+export const traceGlobals: Map<any, any> = _traceGlobals
 export const setGlobal = (key: any, val: any) => {
   traceGlobals.set(key, val)
 }

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -6,7 +6,11 @@ import { NextInstance } from 'test/lib/next-modes/base'
 
 jest.setTimeout(2 * 60 * 1000)
 
-export function runTests(example = '') {
+export function runTests(
+  example = '',
+  testPath = '/',
+  expectedContent = ['index page']
+) {
   const versionParts = process.versions.node.split('.').map((i) => Number(i))
 
   if ((global as any).isNextDeploy) {
@@ -42,7 +46,7 @@ export function runTests(example = '') {
             prev.push(`${cur}@${dependencies[cur]}`)
             return prev
           }, [] as string[])
-          return `yarn set version 4.0.0-rc.13 && yarn config set enableGlobalCache true && yarn config set compressionLevel 0 && yarn add ${pkgs.join(
+          return `yarn set version berry && yarn config set enableGlobalCache true && yarn config set compressionLevel 0 && yarn add ${pkgs.join(
             ' '
           )}`
         },
@@ -55,9 +59,14 @@ export function runTests(example = '') {
     afterAll(() => next?.destroy())
 
     it(`should compile and serve the index page correctly ${example}`, async () => {
-      const res = await fetchViaHTTP(next.url, '/')
+      const res = await fetchViaHTTP(next.url, testPath)
       expect(res.status).toBe(200)
-      expect(await res.text()).toContain('<html')
+
+      const text = await res.text()
+
+      for (const content of expectedContent) {
+        expect(text).toContain(content)
+      }
     })
   } else {
     it('should not run PnP test for older node versions', () => {})

--- a/test/e2e/yarn-pnp/test/with-eslint.test.ts
+++ b/test/e2e/yarn-pnp/test/with-eslint.test.ts
@@ -1,5 +1,5 @@
 import { runTests } from './utils'
 
 describe('yarn PnP', () => {
-  runTests('with-eslint')
+  runTests('with-eslint', '/', ['<html', 'Home', 'fake-script'])
 })

--- a/test/e2e/yarn-pnp/test/with-mdx.test.ts
+++ b/test/e2e/yarn-pnp/test/with-mdx.test.ts
@@ -1,5 +1,5 @@
 import { runTests } from './utils'
 
 describe('yarn PnP', () => {
-  runTests('with-mdx')
+  runTests('with-mdx', '/', ['Look, a button', 'Hello'])
 })

--- a/test/e2e/yarn-pnp/test/with-next-sass.test.ts
+++ b/test/e2e/yarn-pnp/test/with-next-sass.test.ts
@@ -1,5 +1,7 @@
 import { runTests } from './utils'
 
 describe('yarn PnP', () => {
-  runTests('with-next-sass')
+  runTests('with-next-sass', '/', [
+    'Hello World, I am being styled using SCSS Modules',
+  ])
 })


### PR DESCRIPTION
It seems there is an issue with yarn v3 where the exports for our `traceGlobals` may not be set as we expect causing calls to `telemetry.record()` to hang the build process since webpack stalls when an uncaught exception is thrown in a plugin. 

Verified on the reproduction repo manually as well via `yarn add next@https://files-620kx9vw0-vtest314-ijjk-testing.vercel.app/next-v13.1.3-canary.3.tgz`

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

Fixes: https://github.com/vercel/next.js/issues/44976