### PR TITLE
Add proper error when app path switches static to dynamic

### DIFF
--- a/errors/app-static-to-dynamic-error.md
+++ b/errors/app-static-to-dynamic-error.md
@@ -10,7 +10,7 @@ This is a hard error by default as a path generated statically can switch betwee
 
 Prevent usage of these dynamic server values conditionally which can cause the static/dynamic mode of the page to differ between build time and runtime.
 
-Leverage `export const dynamic = 'force-static'` to ensure the page is handled statically regardless of the usage of dynamic server values.
+Leverage `export const dynamic = 'force-static'` to ensure the page is handled statically regardless of the usage of dynamic server values. Alternatively if you prefer your page to allows be dynamic you can set `export const dynamic = 'force-dynamic'` and it won't attempt to have the page be statically generated.
 
 ### Useful Links
 

--- a/errors/app-static-to-dynamic-error.md
+++ b/errors/app-static-to-dynamic-error.md
@@ -1,0 +1,18 @@
+# &#x60;app/&#x60; Static to Dynamic Error
+
+#### Why This Error Occurred
+
+Inside of one of your `app/` pages, the page was initially generated statically at build time and then during runtime either a fallback path or path being revalidated attempted to leverage dynamic server values e.g. `cookies()` or `headers()`.
+
+This is a hard error by default as a path generated statically can switch between types during runtime currently.
+
+#### Possible Ways to Fix It
+
+Prevent usage of these dynamic server values conditionally which can cause the static/dynamic mode of the page to differ between build time and runtime.
+
+Leverage `export const dynamic = 'force-static'` to ensure the page is handled statically regardless of the usage of dynamic server values.
+
+### Useful Links
+
+- [static/dynamic rendering](https://beta.nextjs.org/docs/rendering/static-and-dynamic-rendering)
+- [dynamic server value methods](https://beta.nextjs.org/docs/data-fetching/fetching#server-component-functions)

--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -785,6 +785,10 @@
         {
           "title": "class-component-in-server-component",
           "path": "/errors/class-component-in-server-component.md"
+        },
+        {
+          "title": "app-static-to-dynamic-error",
+          "path": "/errors/app-static-to-dynamic-error.md"
         }
       ]
     }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1373,6 +1373,12 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       isNotFound = (renderOpts as any).isNotFound
       isRedirect = (renderOpts as any).isRedirect
 
+      if (isAppPath && isSSG && isrRevalidate === 0) {
+        throw new Error(
+          `Page changed from static to dynamic at runtime ${urlPathname}, see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error`
+        )
+      }
+
       let value: ResponseCacheValue | null
       if (isNotFound) {
         value = null

--- a/test/e2e/app-dir/app-static/app/static-to-dynamic-error-forced/[id]/page.js
+++ b/test/e2e/app-dir/app-static/app/static-to-dynamic-error-forced/[id]/page.js
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers'
+
+export const dynamic = 'force-static'
+
+export default function Page({ params }) {
+  if (params.id.includes('static-bailout')) {
+    console.log('calling cookies', cookies())
+  }
+
+  return (
+    <>
+      <p>/static-to-dynamic-error-forced</p>
+      <p>id: {params.id}</p>
+      <p id="now">{Date.now()}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/static-to-dynamic-error/[id]/page.js
+++ b/test/e2e/app-dir/app-static/app/static-to-dynamic-error/[id]/page.js
@@ -1,0 +1,15 @@
+import { cookies } from 'next/headers'
+
+export default function Page({ params }) {
+  if (params.id.includes('static-bailout')) {
+    console.log('calling cookies', cookies())
+  }
+
+  return (
+    <>
+      <p>/static-to-dynamic-error</p>
+      <p>id: {params.id}</p>
+      <p id="now">{Date.now()}</p>
+    </>
+  )
+}


### PR DESCRIPTION
This ensures we properly error and explain when a page that was statically generated during build switches to dynamic at runtime. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

Fixes: https://github.com/vercel/next.js/issues/44875
Fixes: https://github.com/vercel/next.js/issues/43157
Fixes: https://github.com/vercel/next.js/issues/44860
