### PR TITLE
Ensure force-dynamic is honored during build

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1048,7 +1048,7 @@ export async function buildStaticPaths({
 export type AppConfig = {
   revalidate?: number | false
   dynamicParams?: true | false
-  dynamic?: 'auto' | 'error' | 'force-static'
+  dynamic?: 'auto' | 'error' | 'force-static' | 'force-dynamic'
   fetchCache?: 'force-cache' | 'only-cache'
   preferredRegion?: string
 }
@@ -1353,6 +1353,10 @@ export async function isPageStatic({
           },
           {}
         )
+
+        if (appConfig.dynamic === 'force-dynamic') {
+          appConfig.revalidate = 0
+        }
 
         if (isDynamicRoute(page)) {
           ;({

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -46,6 +46,7 @@ createNextDescribe(
           'dynamic-no-gen-params/[slug].html',
           'dynamic-no-gen-params/[slug].rsc',
           'dynamic-no-gen-params/[slug]/page.js',
+          'force-dynamic-no-prerender/[id]/page.js',
           'force-static/[slug]/page.js',
           'force-static/first.html',
           'force-static/first.rsc',

--- a/test/e2e/app-dir/app-static/app/force-dynamic-no-prerender/[id]/page.js
+++ b/test/e2e/app-dir/app-static/app/force-dynamic-no-prerender/[id]/page.js
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dynamic'
+
+export default function Page({ params }) {
+  throw new Error('this should not attempt prerendering with force-dynamic')
+}


### PR DESCRIPTION
This ensures we don't attempt the prerendering check to analyze if a path is static without `generateStaticParams` if `dynamic = 'force-dynamic'` is configured. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

Fixes: https://github.com/vercel/next.js/issues/45006
