### PR TITLE
Ensure additional windows are not created on Windows OS

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -487,6 +487,9 @@ If you cannot make the changes above, but still want to try out\nNext.js v13 wit
         return () => cluster.removeListener('exit', callback)
       }
       let clusterExitUnsub = handleClusterExit()
+      // x-ref: https://nodejs.org/api/cluster.html#clustersettings
+      // @ts-expect-error type is incorrect
+      cluster.settings.windowsHide = true
       cluster.settings.stdio = ['ipc', 'pipe', 'pipe']
 
       setupFork()

--- a/packages/next/src/telemetry/project-id.ts
+++ b/packages/next/src/telemetry/project-id.ts
@@ -18,6 +18,7 @@ function _getProjectIdByGit() {
       {
         timeout: 1000,
         stdio: `pipe`,
+        windowsHide: true,
       }
     )
 

--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -10,7 +10,9 @@ import { _postPayload } from './post-payload'
 import { getRawProjectId } from './project-id'
 import { AbortController } from 'next/dist/compiled/@edge-runtime/primitives/abort-controller'
 import fs from 'fs'
-import spawn from 'next/dist/compiled/cross-spawn'
+// Note: cross-spawn is not used here as it causes
+// a new command window to appear when we don't want it to
+import { spawn } from 'child_process'
 
 // This is the key that stores whether or not telemetry is enabled or disabled.
 const TELEMETRY_KEY_ENABLED = 'telemetry.enabled'
@@ -245,8 +247,10 @@ export class Telemetry {
       JSON.stringify(allEvents)
     )
 
-    spawn('node', [require.resolve('./deteched-flush'), mode, dir], {
+    spawn(process.execPath, [require.resolve('./deteched-flush'), mode, dir], {
       detached: !this.NEXT_TELEMETRY_DEBUG,
+      windowsHide: true,
+      shell: false,
       ...(this.NEXT_TELEMETRY_DEBUG
         ? {
             stdio: 'inherit',


### PR DESCRIPTION
This ensures we don't create un-necessary command windows for separate processes on Windows. We can't test this in CI consistently although was manually tested on Windows 11. 


**Before** 

https://user-images.githubusercontent.com/22380829/213327609-1b12e2fc-4cf3-4824-9cd4-30eef88e1d88.mp4



## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

Fixes: https://github.com/vercel/next.js/issues/44992
