### PR TITLE
Don't dispaly "Error: " twice when router isn't mounted

### DIFF
--- a/packages/next/src/client/router.ts
+++ b/packages/next/src/client/router.ts
@@ -133,7 +133,7 @@ export function useRouter(): NextRouter {
   const router = React.useContext(RouterContext)
   if (!router) {
     throw new Error(
-      'Error: NextRouter was not mounted. https://nextjs.org/docs/messages/next-router-not-mounted'
+      'NextRouter was not mounted. https://nextjs.org/docs/messages/next-router-not-mounted'
     )
   }
 


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/25056922/213422675-d2865012-ea23-4ee7-b984-4021e698bce0.png)

After
![image](https://user-images.githubusercontent.com/25056922/213422561-5730efea-82da-4e13-aac6-a1e84b098605.png)

Fixes NEXT-381

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
