### PR TITLE
Fix next/dynamic non ssr in pages when appDir is enabled

### DIFF
--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -190,12 +190,11 @@ where
             opts.is_development,
             opts.is_server,
             match &opts.server_components {
-                Some(config) if config.truthy() =>
-                    match config {
-                        react_server_components::Config::WithOptions(x) => x.is_server,
-                        _ => false
-                    }
-                _ => false
+                Some(config) if config.truthy() => match config {
+                    react_server_components::Config::WithOptions(x) => x.is_server,
+                    _ => false,
+                },
+                _ => false,
             },
             file.name.clone(),
             opts.pages_dir.clone()

--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -189,7 +189,14 @@ where
         next_dynamic::next_dynamic(
             opts.is_development,
             opts.is_server,
-            opts.server_components.is_some(),
+            match &opts.server_components {
+                Some(config) if config.truthy() =>
+                    match config {
+                        react_server_components::Config::WithOptions(x) => x.is_server,
+                        _ => false
+                    }
+                _ => false
+            },
             file.name.clone(),
             opts.pages_dir.clone()
         ),

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -33,6 +33,7 @@ function getBaseSWCOptions({
   jsConfig,
   swcCacheDir,
   isServerLayer,
+  hasServerComponents,
 }: any) {
   const parserConfig = getParserOptions({ filename, jsConfig })
   const paths = jsConfig?.compilerOptions?.paths
@@ -125,7 +126,9 @@ function getBaseSWCOptions({
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       styledComponents: getStyledComponentsOptions(nextConfig, development),
     }),
-    serverComponents: isServerLayer ? { isServer: true } : undefined,
+    serverComponents: hasServerComponents
+      ? { isServer: !!isServerLayer }
+      : undefined,
   }
 }
 

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -33,7 +33,6 @@ function getBaseSWCOptions({
   jsConfig,
   swcCacheDir,
   isServerLayer,
-  hasServerComponents,
 }: any) {
   const parserConfig = getParserOptions({ filename, jsConfig })
   const paths = jsConfig?.compilerOptions?.paths
@@ -126,11 +125,7 @@ function getBaseSWCOptions({
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       styledComponents: getStyledComponentsOptions(nextConfig, development),
     }),
-    serverComponents: hasServerComponents
-      ? {
-          isServer: !!isServerLayer,
-        }
-      : undefined,
+    serverComponents: isServerLayer ? { isServer: true } : undefined,
   }
 }
 
@@ -220,7 +215,6 @@ export function getLoaderSWCOptions({
   filename,
   development,
   isServer,
-  isServerLayer,
   pagesDir,
   isPageFile,
   hasReactRefresh,
@@ -230,6 +224,7 @@ export function getLoaderSWCOptions({
   swcCacheDir,
   relativeFilePathFromRoot,
   hasServerComponents,
+  isServerLayer,
 }: // This is not passed yet as "paths" resolving is handled by webpack currently.
 // resolvedBaseUrl,
 any) {
@@ -242,9 +237,9 @@ any) {
     jsConfig,
     // resolvedBaseUrl,
     swcCacheDir,
-    isServerLayer,
     relativeFilePathFromRoot,
     hasServerComponents,
+    isServerLayer,
   })
 
   if (nextConfig?.experimental?.fontLoaders && relativeFilePathFromRoot) {

--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -43,7 +43,6 @@ async function loaderTransform(
 
   const {
     isServer,
-    isServerLayer,
     rootDir,
     pagesDir,
     hasReactRefresh,
@@ -52,6 +51,7 @@ async function loaderTransform(
     supportedBrowsers,
     swcCacheDir,
     hasServerComponents,
+    isServerLayer,
   } = loaderOptions
   const isPageFile = filename.startsWith(pagesDir)
   const relativeFilePathFromRoot = path.relative(rootDir, filename)
@@ -60,7 +60,6 @@ async function loaderTransform(
     pagesDir,
     filename,
     isServer,
-    isServerLayer,
     isPageFile,
     development: this.mode === 'development',
     hasReactRefresh,
@@ -70,6 +69,7 @@ async function loaderTransform(
     swcCacheDir,
     relativeFilePathFromRoot,
     hasServerComponents,
+    isServerLayer,
   })
 
   const programmaticOptions = {

--- a/test/e2e/app-dir/dynamic/dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic/dynamic.test.ts
@@ -1,0 +1,20 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'app dir - next/dynamic',
+  {
+    files: __dirname,
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should handle ssr: false in pages when appDir is enabled', async () => {
+      const $ = await next.render$('/no-ssr')
+      expect($.html()).not.toContain('navigator')
+
+      const browser = await next.browser('/no-ssr')
+      expect(
+        await browser.waitForElementByCss('#pure-client').text()
+      ).toContain('navigator')
+    })
+  }
+)

--- a/test/e2e/app-dir/dynamic/next.config.js
+++ b/test/e2e/app-dir/dynamic/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true,
+  },
+}

--- a/test/e2e/app-dir/dynamic/pages/no-ssr.js
+++ b/test/e2e/app-dir/dynamic/pages/no-ssr.js
@@ -1,0 +1,5 @@
+import dynamic from 'next/dynamic'
+
+const PureClient = dynamic(() => import('../ui/pure-client'), { ssr: false })
+
+export default PureClient

--- a/test/e2e/app-dir/dynamic/ui/pure-client.js
+++ b/test/e2e/app-dir/dynamic/ui/pure-client.js
@@ -1,0 +1,5 @@
+console.log('navigator.userAgent', navigator.userAgent)
+
+export default function PureClient() {
+  return <p id="pure-client">navigator</p>
+}


### PR DESCRIPTION
When `appDir` is enabled, `next/dynamic` with `ssr: false` didn't get correctly compiled with swc. The `server_components` condition in next_dynamic transform should respect to the server components compilation, but it was accidently turned on when server components is enabled. 

This PR fixes it that only turn on the flag when it's in server components compilation (when `is_server` option is `true`)

reported by @MaxLeiter 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
