### PR TITLE
Fix broken argument for rewrites on link reference docs

### DIFF
--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -233,9 +233,9 @@ export function middleware(req) {
   const nextUrl = req.nextUrl
   if (nextUrl.pathname === '/dashboard') {
     if (req.cookies.authToken) {
-      return NextResponse.rewrite('/auth/dashboard')
+      return NextResponse.rewrite(new URL('/auth/dashboard', req.url))
     } else {
-      return NextResponse.rewrite('/public/dashboard')
+      return NextResponse.rewrite(new URL('/public/dashboard', req.url))
     }
   }
 }


### PR DESCRIPTION
Fixes #45072

Rewrites don't accept relative paths anymore, we have to pass an absolute URL (see https://nextjs.org/docs/messages/middleware-relative-urls)

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
