### PR TITLE
Cannot redeclare block-scoped variable 'cookie'.

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -164,7 +164,7 @@ import type { NextRequest } from 'next/server'
 export function middleware(request: NextRequest) {
   // Assume a "Cookie:nextjs=fast" header to be present on the incoming request
   // Getting cookies from the request using the `RequestCookies` API
-  const cookie = request.cookies.get('nextjs')?.value
+  let cookie = request.cookies.get('nextjs')?.value
   console.log(cookie) // => 'fast'
   const allCookies = request.cookies.getAll()
   console.log(allCookies) // => [{ name: 'nextjs', value: 'fast' }]
@@ -181,7 +181,7 @@ export function middleware(request: NextRequest) {
     value: 'fast',
     path: '/test',
   })
-  const cookie = response.cookies.get('vercel')
+  cookie = response.cookies.get('vercel')
   console.log(cookie) // => { name: 'vercel', value: 'fast', Path: '/test' }
   // The outgoing response will have a `Set-Cookie:vercel=fast;path=/test` header.
 


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
