### PR TITLE
fix(#44077): allow edge runtime for api routes inside src/ folder

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -332,7 +332,7 @@ export async function getPageStaticInfo(params: {
 
     const requiresServerRuntime = ssr || ssg || pageType === 'app'
 
-    const isAnAPIRoute = isAPIRoute(page?.replace(/^\/pages\//, '/'))
+    const isAnAPIRoute = isAPIRoute(page?.replace(/^(?:\/src)?\/pages\//, '/'))
 
     resolvedRuntime = isEdgeRuntime(resolvedRuntime)
       ? resolvedRuntime

--- a/test/e2e/edge-configurable-runtime/app/src/pages/api/edge.js
+++ b/test/e2e/edge-configurable-runtime/app/src/pages/api/edge.js
@@ -1,0 +1,2 @@
+export default () => new Response('ok')
+export const config = { runtime: 'edge' }

--- a/test/e2e/edge-configurable-runtime/app/src/pages/index.jsx
+++ b/test/e2e/edge-configurable-runtime/app/src/pages/index.jsx
@@ -1,0 +1,1 @@
+export default () => <p>hello world</p>

--- a/test/e2e/edge-configurable-runtime/index.test.ts
+++ b/test/e2e/edge-configurable-runtime/index.test.ts
@@ -4,14 +4,16 @@ import { fetchViaHTTP, File, nextBuild } from 'next-test-utils'
 import { join } from 'path'
 import stripAnsi from 'strip-ansi'
 
-const appDir = join(__dirname, './app')
 const pagePath = 'pages/index.jsx'
 const apiPath = 'pages/api/edge.js'
-const page = new File(join(appDir, pagePath))
-const api = new File(join(appDir, apiPath))
 
-describe('Configurable runtime for pages and API routes', () => {
+describe.each([
+  { appDir: join(__dirname, './app/src'), title: 'src/pages and API routes' },
+  { appDir: join(__dirname, './app'), title: 'pages and API routes' },
+])('Configurable runtime for $title', ({ appDir }) => {
   let next: NextInstance
+  const page = new File(join(appDir, pagePath))
+  const api = new File(join(appDir, apiPath))
 
   if ((global as any).isNextDev) {
     describe('In dev mode', () => {


### PR DESCRIPTION
## 🐛  Bug

When introducing `edge` as a valid runtime key (alongside `experimental-edge`, I overlooked the `src/` folder.

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## 🧪 How to reproduce

Create a minimal next.js application with:
```js
// src/pages/api/edge.js
const api = () => new Response('ok')
export default api
export const config = { runtime: 'edge' }

// src/pages/index.js
const Home = () => <p>hello world</p>
export default Home
```

1. Run in dev mode `next dev`:
   > `error - Page /src/pages/api/edge provided runtime 'edge', the edge runtime for rendering is currently experimental. Use runtime 'experimental-edge' instead.`
   > It should run with no errors.

This is now covered with e2e tests:
- `NEXT_TEST_MODE=dev pnpm testheadless --testPathPattern edge-configurable-runtime`(dev mode)
- `NEXT_TEST_MODE=start pnpm testheadless --testPathPattern edge-configurable-runtime`(build mode)

fixes: https://github.com/vercel/next.js/issues/44077
fixes: https://github.com/vercel/next.js/issues/44382
closes: https://github.com/vercel/next.js/pull/44882
closes: https://github.com/vercel/next.js/pull/44383 