### PR TITLE
stop scrolling to the top onPopState

### DIFF
--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -1101,7 +1101,7 @@ export default class Router implements BaseRouter {
       return
     }
 
-    let forcedScroll: { x: number; y: number } | undefined
+    let forcedScroll: { x: number; y: number } | 'stopScrollingToTop!' = 'stopScrollingToTop!'
     const { url, as, options, key } = state
     if (process.env.__NEXT_SCROLL_RESTORATION) {
       if (manualScrollRestoration) {
@@ -1216,7 +1216,7 @@ export default class Router implements BaseRouter {
     url: string,
     as: string,
     options: TransitionOptions,
-    forcedScroll?: { x: number; y: number }
+    forcedScroll?: { x: number; y: number } | 'stopScrollingToTop!'
   ): Promise<boolean> {
     if (!isLocalURL(url)) {
       handleHardNavigation({ url, router: this })
@@ -1762,7 +1762,10 @@ export default class Router implements BaseRouter {
       const shouldScroll =
         options.scroll ?? (!isQueryUpdating && !isValidShallowRoute)
       const resetScroll = shouldScroll ? { x: 0, y: 0 } : null
-      const upcomingScrollState = forcedScroll ?? resetScroll
+      const upcomingScrollState =
+        forcedScroll === 'stopScrollingToTop!'
+          ? null
+          : forcedScroll ?? resetScroll
 
       // the new state that the router gonna set
       const upcomingRouterState = {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Hi @wyattjoh, this might be nice to get fixed: history.back() should not scroll to top, right? Pardon the code i've butchered in as a fix in this PR - perhaps you could help me to make it better? 

Thanks!

fixes #44999

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
link NEXT-737