### PR TITLE
fix: invalid attribute

### DIFF
--- a/docs/basic-features/font-optimization.md
+++ b/docs/basic-features/font-optimization.md
@@ -223,7 +223,7 @@ const inter = Inter({
 
 export default function MyApp({ Component, pageProps }) {
   return (
-    <main className={`${inter.variable} font-sans`}>
+    <main className={`${inter.className} font-sans`}>
       <Component {...pageProps} />
     </main>
   )


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

This PR changes `<font>.variable` to `<font>.className` which fixes the issue of the font not being recognized by Tailwind in the old example.
