### PR TITLE
Allow specifying initial branch name in CNA

### DIFF
--- a/docs/api-reference/create-next-app.md
+++ b/docs/api-reference/create-next-app.md
@@ -82,6 +82,10 @@ Options:
     In this case, you must specify the path to the example separately:
     --example-path foo/bar
 
+  --branch <branch-name>
+
+    Use this branch name when initializing the git repository (default "main")
+
   --reset-preferences
 
     Explicitly tell the CLI to reset any stored preferences

--- a/packages/create-next-app/README.md
+++ b/packages/create-next-app/README.md
@@ -61,6 +61,14 @@ Options:
     a slash (e.g. bug/fix-1) and the path to the example (e.g. foo/bar).
     In this case, you must specify the path to the example separately:
     --example-path foo/bar
+
+  --branch <branch-name>
+
+    Use this branch name when initializing the git repository (default "main")
+
+  --reset-preferences
+
+    Explicitly tell the CLI to reset any stored preferences
 ```
 
 ### Why use Create Next App?

--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -38,6 +38,7 @@ export async function createApp({
   experimentalApp,
   srcDir,
   importAlias,
+  branch,
 }: {
   appPath: string
   packageManager: PackageManager
@@ -48,6 +49,7 @@ export async function createApp({
   experimentalApp: boolean
   srcDir: boolean
   importAlias: string
+  branch: string
 }): Promise<void> {
   let repoInfo: RepoInfo | undefined
   const mode: TemplateMode = typescript ? 'ts' : 'js'
@@ -228,7 +230,7 @@ export async function createApp({
     })
   }
 
-  if (tryGitInit(root)) {
+  if (tryGitInit(root, branch)) {
     console.log('Initialized a git repository.')
     console.log()
   }

--- a/packages/create-next-app/helpers/git.ts
+++ b/packages/create-next-app/helpers/git.ts
@@ -19,7 +19,7 @@ function isInMercurialRepository(): boolean {
   return false
 }
 
-export function tryGitInit(root: string): boolean {
+export function tryGitInit(root: string, branch: string): boolean {
   let didInit = false
   try {
     execSync('git --version', { stdio: 'ignore' })
@@ -30,7 +30,7 @@ export function tryGitInit(root: string): boolean {
     execSync('git init', { stdio: 'ignore' })
     didInit = true
 
-    execSync('git checkout -b main', { stdio: 'ignore' })
+    execSync(`git checkout -b ${branch}`, { stdio: 'ignore' })
 
     execSync('git add -A', { stdio: 'ignore' })
     execSync('git commit -m "Initial commit from Create Next App"', {


### PR DESCRIPTION
Allowing users to specify the initial git branch name when using create-next-app (defaults to "main").

fixes #45107  

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
