### PR TITLE
chore: fix invalid-new-link error typo

### DIFF
--- a/errors/invalid-new-link-with-extra-anchor.md
+++ b/errors/invalid-new-link-with-extra-anchor.md
@@ -14,7 +14,7 @@ npx @next/codemod new-link .
 
 This will change `<Link><a id="link">Home<a></Link>` to `<Link id="link">Home</Link>`.
 
-Alternatively, you can add the `legacyBehavior` prop `<Link legacyBehavior><a id="link">Home<a></Link>`.
+Alternatively, you can add the `legacyBehavior` prop `<Link legacyBehavior><a id="link">Home</a></Link>`.
 
 ### Useful Links
 


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
