### PR TITLE
Update testing.md to reflect that we don't use `yarn` anymore

### DIFF
--- a/contributing/core/testing.md
+++ b/contributing/core/testing.md
@@ -38,8 +38,6 @@ When you run an e2e test, a local version of next will be created inside your sy
 which is then linked to the app, also created inside a temp folder. A server is started on a random port, against which the tests will run.
 After all tests have finished, the server is destroyed and all remaining files are deleted from the temp folder.
 
-You will need `yarn` for running e2e tests. Installing it `corepack` won't work because `next.js` is `pnpm` workspace.
-
 ## Writing tests for Next.js
 
 ### Getting Started


### PR DESCRIPTION
We don't use yarn since https://github.com/vercel/next.js/pull/45167

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
