### PR TITLE
Add debug info to static bailout message

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2210,6 +2210,7 @@ export default async function build(
           const exportOptions = {
             silent: false,
             buildExport: true,
+            debugOutput,
             threads: config.experimental.cpus,
             pages: combinedPages,
             outdir: path.join(distDir, 'export'),

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2359,7 +2359,9 @@ export default async function build(
           for (const [originalAppPath, routes] of appStaticPaths) {
             const page = appNormalizedPaths.get(originalAppPath) || ''
             const appConfig = appDefaultConfigs.get(originalAppPath) || {}
-            let hasDynamicData = appConfig.revalidate === 0
+            let hasDynamicData =
+              appConfig.revalidate === 0 ||
+              exportConfig.initialPageRevalidationMap[page] === 0
 
             routes.forEach((route) => {
               if (isDynamicRoute(page) && route === page) return

--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -72,7 +72,7 @@ const nextBuild: CliCommand = (argv) => {
     dir,
     null,
     args['--profile'],
-    args['--debug'],
+    args['--debug'] || process.env.NEXT_DEBUG_BUILD,
     !args['--no-lint'],
     args['--no-mangling']
   ).catch((err) => {

--- a/packages/next/src/client/components/static-generation-async-storage.ts
+++ b/packages/next/src/client/components/static-generation-async-storage.ts
@@ -7,11 +7,13 @@ export interface StaticGenerationStore {
   readonly incrementalCache?: import('../../server/lib/incremental-cache').IncrementalCache
   readonly isRevalidate?: boolean
 
-  revalidate?: number
   forceDynamic?: boolean
-  fetchRevalidate?: boolean | number
+  revalidate?: boolean | number
   forceStatic?: boolean
   pendingRevalidates?: Promise<any>[]
+
+  dynamicUsageDescription?: string
+  dynamicUsageStack?: string
 }
 
 export type StaticGenerationAsyncStorage =

--- a/packages/next/src/client/components/static-generation-bailout.ts
+++ b/packages/next/src/client/components/static-generation-bailout.ts
@@ -9,10 +9,13 @@ export function staticGenerationBailout(reason: string): boolean | never {
   }
 
   if (staticGenerationStore?.isStaticGeneration) {
-    if (staticGenerationStore) {
-      staticGenerationStore.fetchRevalidate = 0
-    }
-    throw new DynamicServerError(reason)
+    staticGenerationStore.revalidate = 0
+    const err = new DynamicServerError(reason)
+
+    staticGenerationStore.dynamicUsageDescription = reason
+    staticGenerationStore.dynamicUsageStack = err.stack
+
+    throw err
   }
 
   return false

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -140,6 +140,7 @@ interface ExportOptions {
   outdir: string
   silent?: boolean
   threads?: number
+  debugOutput?: boolean
   pages?: string[]
   buildExport?: boolean
   statusMessage?: string
@@ -630,6 +631,7 @@ export default async function exportApp(
             serverComponents: hasAppDir,
             appPaths: options.appPaths || [],
             enableUndici: nextConfig.experimental.enableUndici,
+            debugOutput: options.debugOutput,
           })
 
           for (const validation of result.ampValidations || []) {

--- a/packages/next/src/server/app-render.tsx
+++ b/packages/next/src/server/app-render.tsx
@@ -293,11 +293,11 @@ function patchFetch(ComponentMod: any) {
     }
 
     if (
-      !staticGenerationStore.fetchRevalidate ||
+      !staticGenerationStore.revalidate ||
       (typeof revalidate === 'number' &&
-        revalidate < staticGenerationStore.fetchRevalidate)
+        revalidate < staticGenerationStore.revalidate)
     ) {
-      staticGenerationStore.fetchRevalidate = revalidate
+      staticGenerationStore.revalidate = revalidate
     }
 
     let cacheKey: string | undefined
@@ -399,39 +399,47 @@ function patchFetch(ComponentMod: any) {
           delete init.cache
         }
         if (cache === 'no-store') {
-          staticGenerationStore.fetchRevalidate = 0
+          staticGenerationStore.revalidate = 0
           // TODO: ensure this error isn't logged to the user
           // seems it's slipping through currently
-          throw new DynamicServerError(
-            `no-store fetch ${input}${
-              staticGenerationStore.pathname
-                ? ` ${staticGenerationStore.pathname}`
-                : ''
-            }`
-          )
+          const dynamicUsageReason = `no-store fetch ${input}${
+            staticGenerationStore.pathname
+              ? ` ${staticGenerationStore.pathname}`
+              : ''
+          }`
+          const err = new DynamicServerError(dynamicUsageReason)
+          staticGenerationStore.dynamicUsageStack = err.stack
+          staticGenerationStore.dynamicUsageDescription = dynamicUsageReason
+
+          throw err
         }
 
         const hasNextConfig = 'next' in init
         const next = init.next || {}
         if (
           typeof next.revalidate === 'number' &&
-          (typeof staticGenerationStore.fetchRevalidate === 'undefined' ||
-            next.revalidate < staticGenerationStore.fetchRevalidate)
+          (typeof staticGenerationStore.revalidate === 'undefined' ||
+            next.revalidate < staticGenerationStore.revalidate)
         ) {
           const forceDynamic = staticGenerationStore.forceDynamic
 
           if (!forceDynamic || next.revalidate !== 0) {
-            staticGenerationStore.fetchRevalidate = next.revalidate
+            staticGenerationStore.revalidate = next.revalidate
           }
 
           if (!forceDynamic && next.revalidate === 0) {
-            throw new DynamicServerError(
-              `revalidate: ${next.revalidate} fetch ${input}${
-                staticGenerationStore.pathname
-                  ? ` ${staticGenerationStore.pathname}`
-                  : ''
-              }`
-            )
+            const dynamicUsageReason = `revalidate: ${
+              next.revalidate
+            } fetch ${input}${
+              staticGenerationStore.pathname
+                ? ` ${staticGenerationStore.pathname}`
+                : ''
+            }`
+            const err = new DynamicServerError(dynamicUsageReason)
+            staticGenerationStore.dynamicUsageStack = err.stack
+            staticGenerationStore.dynamicUsageDescription = dynamicUsageReason
+
+            throw err
           }
         }
         if (hasNextConfig) delete init.next
@@ -1288,7 +1296,11 @@ export async function renderToHTMLOrFlight(
           const { DynamicServerError } =
             ComponentMod.serverHooks as typeof import('../client/components/hooks-server-context')
 
-          throw new DynamicServerError(`revalidate: 0 configured ${segment}`)
+          const dynamicUsageDescription = `revalidate: 0 configured ${segment}`
+          staticGenerationStore.dynamicUsageDescription =
+            dynamicUsageDescription
+
+          throw new DynamicServerError(dynamicUsageDescription)
         }
       }
 
@@ -1959,7 +1971,7 @@ export async function renderToHTMLOrFlight(
       )
 
       if (staticGenerationStore.forceStatic === false) {
-        staticGenerationStore.fetchRevalidate = 0
+        staticGenerationStore.revalidate = 0
       }
 
       // TODO: investigate why `pageData` is not in RenderOpts
@@ -1967,7 +1979,15 @@ export async function renderToHTMLOrFlight(
 
       // TODO: investigate why `revalidate` is not in RenderOpts
       ;(renderOpts as any).revalidate =
-        staticGenerationStore.fetchRevalidate ?? defaultRevalidate
+        staticGenerationStore.revalidate ?? defaultRevalidate
+
+      // provide bailout info for debugging
+      if ((renderOpts as any).revalidate === 0) {
+        ;(renderOpts as any).staticBailoutInfo = {
+          description: staticGenerationStore.dynamicUsageDescription,
+          stack: staticGenerationStore.dynamicUsageStack,
+        }
+      }
 
       return new RenderResult(htmlResult)
     }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1374,9 +1374,26 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       isRedirect = (renderOpts as any).isRedirect
 
       if (isAppPath && isSSG && isrRevalidate === 0) {
-        throw new Error(
-          `Page changed from static to dynamic at runtime ${urlPathname}, see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error`
+        const staticBailoutInfo: {
+          stack?: string
+          description?: string
+        } = (renderOpts as any).staticBailoutInfo || {}
+
+        const err = new Error(
+          `Page changed from static to dynamic at runtime ${urlPathname}${
+            staticBailoutInfo.description
+              ? `, reason: ${staticBailoutInfo.description}`
+              : ``
+          }` +
+            `\nsee more here https://nextjs.org/docs/messages/app-static-to-dynamic-error`
         )
+
+        if (staticBailoutInfo.stack) {
+          const stack = staticBailoutInfo.stack as string
+          err.stack = err.message + stack.substring(stack.indexOf('\n'))
+        }
+
+        throw err
       }
 
       let value: ResponseCacheValue | null


### PR DESCRIPTION
This adds debug info to explain more where a page is using dynamic usage including the stack to the dynamic usage. Users can also surface this information during a build with `next build --debug`. 

x-ref: https://github.com/vercel/next.js/issues/45134
x-ref: https://github.com/vercel/next.js/issues/45068

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
