### PR TITLE
Re-prompt on invalid import alias

### DIFF
--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -310,22 +310,28 @@ async function run(): Promise<void> {
       if (ciInfo.isCI) {
         program.importAlias = '@/*'
       } else {
-        const styledImportAlias = chalk.hex('#007acc')('import alias')
-        const { importAlias } = await prompts({
-          type: 'text',
-          name: 'importAlias',
-          message: `What ${styledImportAlias} would you like configured?`,
-          initial: getPrefOrDefault('importAlias'),
-        })
+        let importAlias = ''
 
-        if (!/.+\/\*/.test(importAlias)) {
-          console.error(
-            `${chalk.red(
-              'Error:'
-            )} invalid import alias (${importAlias}), it must follow the pattern <prefix>/*`
-          )
-          process.exit(1)
+        const promptAlias = async () => {
+          const styledImportAlias = chalk.hex('#007acc')('import alias')
+          const promptResult = await prompts({
+            type: 'text',
+            name: 'importAlias',
+            message: `What ${styledImportAlias} would you like configured?`,
+            initial: getPrefOrDefault('importAlias'),
+          })
+          importAlias = promptResult.importAlias
+
+          if (!/.+\/\*/.test(importAlias)) {
+            console.error(
+              `${chalk.red(
+                'Error:'
+              )} invalid import alias (${importAlias}), it must follow the pattern <prefix>/*`
+            )
+            await promptAlias()
+          }
         }
+        await promptAlias()
 
         program.importAlias = importAlias
         preferences.importAlias = importAlias


### PR DESCRIPTION
This updates to re-prompt on an invalid import alias being provided to CNA instead of exiting. 

![CleanShot 2023-01-23 at 11 06 28@2x](https://user-images.githubusercontent.com/22380829/214127702-7c591501-34ae-4f1f-9c3a-f5fb55a51e93.png)

x-ref: https://github.com/vercel/next.js/discussions/45132

