### PR TITLE
create-next-app: warn if project dir isn't empty before prompts

### DIFF
--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -11,6 +11,8 @@ import { getPkgManager } from './helpers/get-pkg-manager'
 import { validateNpmName } from './helpers/validate-pkg'
 import packageJson from './package.json'
 import ciInfo from 'ci-info'
+import { isFolderEmpty } from './helpers/is-folder-empty'
+import fs from 'fs'
 
 let projectPath: string = ''
 
@@ -177,6 +179,17 @@ async function run(): Promise<void> {
     console.error(
       'Please provide an example name or url, otherwise remove the example option.'
     )
+    process.exit(1)
+  }
+
+  /**
+   * Verify the project dir is empty or doesn't exist
+   */
+  const root = path.resolve(resolvedProjectPath)
+  const appName = path.basename(root)
+  const folderExists = fs.existsSync(root)
+
+  if (folderExists && !isFolderEmpty(root, appName)) {
     process.exit(1)
   }
 


### PR DESCRIPTION
Checks if the dir is empty before prompting the user rather than just after trying to create it. Has the benefit of not having a stacktrace if we catch it the first time because we don’t throw an error in `createApp`

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. 
   - [x] I talked to JJ
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

