### PR TITLE
Reduce component stack spacing for components without metadata

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/ComponentStackFrameRow.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/ComponentStackFrameRow.tsx
@@ -40,9 +40,7 @@ export function ComponentStackFrameRow({
             <line x1="10" y1="14" x2="21" y2="3"></line>
           </svg>
         </div>
-      ) : (
-        <div />
-      )}
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
Reduces the spacing when the component doesn't have any metadata.

Before
![image](https://user-images.githubusercontent.com/25056922/214269347-a9da3372-b22e-45ef-89a8-f9c794e661f4.png)

After
![image](https://user-images.githubusercontent.com/25056922/214269203-0fd6fb53-1cf8-44a2-94e1-427ab234c1d6.png)

Compared to components with file
![image](https://user-images.githubusercontent.com/25056922/214269573-5e723669-5eb9-446d-bc1a-ca8d9d8fe612.png)


## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
