### PR TITLE
Add unit test for redirect.ts

### DIFF
--- a/packages/next/src/client/components/redirect.test.ts
+++ b/packages/next/src/client/components/redirect.test.ts
@@ -1,0 +1,13 @@
+/* eslint-disable jest/no-try-expect */
+import { redirect, REDIRECT_ERROR_CODE } from './redirect'
+describe('test', () => {
+  it('should throw a redirect error', () => {
+    try {
+      redirect('/dashboard')
+      throw new Error('did not throw')
+    } catch (err: any) {
+      expect(err.message).toBe(REDIRECT_ERROR_CODE)
+      expect(err.digest).toBe(`${REDIRECT_ERROR_CODE};/dashboard`)
+    }
+  })
+})


### PR DESCRIPTION
Adds a simple unit test for `redirect.ts` to test Graphite stacked changes.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
