### PR TITLE
Add handling for app/pages manifest race condition

### DIFF
--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -87,8 +87,11 @@ export async function loadComponents({
 
   const [buildManifest, reactLoadableManifest, serverComponentManifest] =
     await Promise.all([
-      require(join(distDir, BUILD_MANIFEST)),
-      require(join(distDir, REACT_LOADABLE_MANIFEST)),
+      // We shouldn't attempt loading build-manifest or react-loadable
+      // manifest when loading app paths as it may still be writing to
+      // disk causing a race condition
+      isAppPath ? {} : require(join(distDir, BUILD_MANIFEST)),
+      isAppPath ? {} : require(join(distDir, REACT_LOADABLE_MANIFEST)),
       hasServerComponents
         ? require(join(distDir, 'server', FLIGHT_MANIFEST + '.json'))
         : null,

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -62,6 +62,18 @@ export async function loadDefaultErrorComponents(distDir: string) {
   }
 }
 
+async function loadManifest<T>(manifestPath: string, attempts = 1): Promise<T> {
+  try {
+    return require(manifestPath)
+  } catch (err) {
+    if (attempts >= 3) {
+      throw err
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    return loadManifest(manifestPath, attempts + 1)
+  }
+}
+
 export async function loadComponents({
   distDir,
   pathname,
@@ -87,13 +99,12 @@ export async function loadComponents({
 
   const [buildManifest, reactLoadableManifest, serverComponentManifest] =
     await Promise.all([
-      // We shouldn't attempt loading build-manifest or react-loadable
-      // manifest when loading app paths as it may still be writing to
-      // disk causing a race condition
-      isAppPath ? {} : require(join(distDir, BUILD_MANIFEST)),
-      isAppPath ? {} : require(join(distDir, REACT_LOADABLE_MANIFEST)),
+      loadManifest<BuildManifest>(join(distDir, BUILD_MANIFEST)),
+      loadManifest<ReactLoadableManifest>(
+        join(distDir, REACT_LOADABLE_MANIFEST)
+      ),
       hasServerComponents
-        ? require(join(distDir, 'server', FLIGHT_MANIFEST + '.json'))
+        ? loadManifest(join(distDir, 'server', FLIGHT_MANIFEST + '.json'))
         : null,
     ])
 


### PR DESCRIPTION
These handles the race condition that can occur while app and pages are compiling at the same time and the build-manifest is still being written to disk while an app path is attempting to load. A test case for this isn't able to be reliably added so isn't present here. 

Fixes: 

<img width="1449" alt="CleanShot 2023-01-24 at 16 07 04@2x" src="https://user-images.githubusercontent.com/22380829/214450574-18007135-a14c-4754-a898-b772cc84e15e.png">

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
