### PR TITLE
Update app cache handling in development

### DIFF
--- a/packages/next/src/server/app-render.tsx
+++ b/packages/next/src/server/app-render.tsx
@@ -257,13 +257,10 @@ function createErrorHandler(
   }
 }
 
-let isFetchPatched = false
-
 // we patch fetch to collect cache information used for
 // determining if a page is static or not
 function patchFetch(ComponentMod: any) {
-  if (isFetchPatched) return
-  isFetchPatched = true
+  if ((globalThis.fetch as any).patched) return
 
   const { DynamicServerError } =
     ComponentMod.serverHooks as typeof import('../client/components/hooks-server-context')
@@ -448,6 +445,7 @@ function patchFetch(ComponentMod: any) {
 
     return doOriginalFetch()
   }
+  ;(globalThis.fetch as any).patched = true
 }
 
 interface FlightResponseRef {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -3,7 +3,7 @@ import cheerio from 'cheerio'
 import { promisify } from 'util'
 import { join } from 'path'
 import { createNextDescribe } from 'e2e-utils'
-import { check, normalizeRegEx, waitFor } from 'next-test-utils'
+import { check, fetchViaHTTP, normalizeRegEx, waitFor } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 const glob = promisify(globOrig)
@@ -289,7 +289,38 @@ createNextDescribe(
       })
     }
 
-    if (!isDev) {
+    if (isDev) {
+      it('should bypass fetch cache with cache-control: no-cache', async () => {
+        const res = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/revalidate-3'
+        )
+
+        expect(res.status).toBe(200)
+        const html = await res.text()
+        const $ = cheerio.load(html)
+
+        const layoutData = $('#layout-data').text()
+        const pageData = $('#page-data').text()
+
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/revalidate-3',
+          undefined,
+          {
+            headers: {
+              'cache-control': 'no-cache',
+            },
+          }
+        )
+
+        expect(res2.status).toBe(200)
+        const html2 = await res2.text()
+        const $2 = cheerio.load(html2)
+        expect($2('#layout-data').text()).not.toBe(layoutData)
+        expect($2('#page-data').text()).not.toBe(pageData)
+      })
+    } else {
       it('should properly error when static page switches to dynamic at runtime', async () => {
         const res = await next.fetch(
           '/static-to-dynamic-error/static-bailout-1'
@@ -323,6 +354,34 @@ createNextDescribe(
         }
       })
     }
+
+    it('should honor fetch cache correctly', async () => {
+      await fetchViaHTTP(next.url, '/variable-revalidate/revalidate-3')
+
+      const res = await fetchViaHTTP(
+        next.url,
+        '/variable-revalidate/revalidate-3'
+      )
+      expect(res.status).toBe(200)
+      const html = await res.text()
+      const $ = cheerio.load(html)
+
+      const layoutData = $('#layout-data').text()
+      const pageData = $('#page-data').text()
+
+      for (let i = 0; i < 3; i++) {
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/revalidate-3'
+        )
+        expect(res2.status).toBe(200)
+        const html2 = await res2.text()
+        const $2 = cheerio.load(html2)
+
+        expect($2('#layout-data').text()).toBe(layoutData)
+        expect($2('#page-data').text()).toBe(pageData)
+      }
+    })
 
     it('Should not throw Dynamic Server Usage error when using generateStaticParams with previewData', async () => {
       const browserOnIndexPage = await next.browser('/ssg-preview')


### PR DESCRIPTION
Ensures we handle caching correctly for app in development as discussed and allows bypassing the cache still via hard refreshing. 

x-ref: [slack thread](https://vercel.slack.com/archives/C042LHPJ1NX/p1674619016127809)