### PR TITLE
Remove unused optimistic tree parameters

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-optimistic-tree.ts
+++ b/packages/next/src/client/components/router-reducer/create-optimistic-tree.ts
@@ -8,9 +8,7 @@ import { matchSegment } from '../match-segments'
 export function createOptimisticTree(
   segments: string[],
   flightRouterState: FlightRouterState | null,
-  _isFirstSegment: boolean,
-  parentRefetch: boolean,
-  _href?: string
+  parentRefetch: boolean
 ): FlightRouterState {
   const [existingSegment, existingParallelRoutes] = flightRouterState || [
     null,
@@ -33,7 +31,6 @@ export function createOptimisticTree(
     const childItem = createOptimisticTree(
       segments.slice(1),
       parallelRoutes ? parallelRoutes.children : null,
-      false,
       parentRefetch || shouldRefetchThisLevel
     )
 

--- a/packages/next/src/client/components/router-reducer/router-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer.ts
@@ -391,13 +391,7 @@ function clientReducer(
 
         // Optimistic tree case.
         // If the optimistic tree is deeper than the current state leave that deeper part out of the fetch
-        const optimisticTree = createOptimisticTree(
-          segments,
-          state.tree,
-          true,
-          false,
-          href
-        )
+        const optimisticTree = createOptimisticTree(segments, state.tree, false)
 
         // Copy subTreeData for the root node of the cache.
         cache.status = CacheStates.READY


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Noticed that there were some leftover parameters. Removed them as they're no longer needed.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
