### PR TITLE
Allow metadata related exports in TS plugin

### DIFF
--- a/packages/next/src/server/next-typescript.ts
+++ b/packages/next/src/server/next-typescript.ts
@@ -29,7 +29,12 @@ const DISALLOWED_SERVER_REACT_APIS: string[] = [
 ]
 
 const LEGACY_CONFIG_EXPORT = 'config'
-const ALLOWED_EXPORTS = ['config', 'generateStaticParams']
+const ALLOWED_EXPORTS = [
+  'config',
+  'generateStaticParams',
+  'metadata',
+  'generateMetadata',
+]
 
 const ALLOWED_PAGE_PROPS = ['params', 'searchParams']
 const ALLOWED_LAYOUT_PROPS = ['params', 'children']


### PR DESCRIPTION
This PR ensures that `metadata` and `generateMetadata` are valid exports for pages and layouts during the TS plugin check.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
