### PR TITLE
add getLayout into withRouter

### DIFF
--- a/packages/next/src/client/with-router.tsx
+++ b/packages/next/src/client/with-router.tsx
@@ -20,13 +20,16 @@ export default function withRouter<
   P extends WithRouterProps,
   C extends BaseContext = NextPageContext
 >(
-  ComposedComponent: NextComponentType<C, any, P>
+  ComposedComponent: NextComponentType<C, any, P> & {
+    getLayout?: (page: React.ReactElement) => React.ReactNode
+  }
 ): React.ComponentType<ExcludeRouterProps<P>> {
   function WithRouterWrapper(props: any): JSX.Element {
     return <ComposedComponent router={useRouter()} {...props} />
   }
 
   WithRouterWrapper.getInitialProps = ComposedComponent.getInitialProps
+  WithRouterWrapper.getLayout = ComposedComponent.getLayout
   // This is needed to allow checking for custom getInitialProps in _app
   ;(WithRouterWrapper as any).origGetInitialProps = (
     ComposedComponent as any


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

I have had a problem that the `getLayout` function of the page component returned by the `withRouter` function is always undefined.

And finally I found that the `getLayout` function is not transferred inside the `withRouter` function.

Of course, `getLayout` function can be defined separately to solve this problem, but I think it might be better to transfer it inside `withRouter` function.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
