### PR TITLE
Add unit test for shouldHardNavigate

### DIFF
--- a/packages/next/src/client/components/router-reducer/router-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer.ts
@@ -335,8 +335,7 @@ function clientReducer(
             shouldHardNavigate(
               // TODO-APP: remove ''
               ['', ...flightSegmentPath],
-              state.tree,
-              newTree
+              state.tree
             )
 
           if (hardNavigate) {

--- a/packages/next/src/client/components/router-reducer/should-hard-navigate.test.tsx
+++ b/packages/next/src/client/components/router-reducer/should-hard-navigate.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react'
+import type { FlightData, FlightRouterState } from '../../../server/app-render'
+import { shouldHardNavigate } from './should-hard-navigate'
+
+describe('shouldHardNavigate', () => {
+  it('should return false if the segments match', () => {
+    const getInitialRouterStateTree = (): FlightRouterState => [
+      '',
+      {
+        children: [
+          'linking',
+          {
+            children: ['', {}],
+          },
+        ],
+      },
+      undefined,
+      undefined,
+      true,
+    ]
+    const initialRouterStateTree = getInitialRouterStateTree()
+    const getFlightData = (): FlightData => {
+      return [
+        [
+          'children',
+          'linking',
+          'children',
+          'about',
+          [
+            'about',
+            {
+              children: ['', {}],
+            },
+          ],
+          <h1>About Page!</h1>,
+          <>
+            <title>About page!</title>
+          </>,
+        ],
+      ]
+    }
+    const flightData = getFlightData()
+
+    if (typeof flightData === 'string') {
+      throw new Error('invalid flight data')
+    }
+
+    // Mirrors the way router-reducer values are passed in.
+    const flightDataPath = flightData[0]
+    const flightSegmentPath = flightDataPath.slice(0, -3)
+
+    const result = shouldHardNavigate(
+      ['', ...flightSegmentPath],
+      initialRouterStateTree
+    )
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false if segments are dynamic and match', () => {
+    const getInitialRouterStateTree = (): FlightRouterState => [
+      '',
+      {
+        children: [
+          'link-hard-push',
+          {
+            children: [
+              ['id', '123', 'd'],
+              {
+                children: ['', {}],
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      null,
+      true,
+    ]
+    const initialRouterStateTree = getInitialRouterStateTree()
+    const getFlightData = (): FlightData => {
+      return [
+        [
+          'children',
+          'link-hard-push',
+          'children',
+          ['id', '123', 'd'],
+          [
+            ['id', '123', 'd'],
+            {
+              children: ['', {}],
+            },
+          ],
+          null,
+          null,
+        ],
+      ]
+    }
+    const flightData = getFlightData()
+
+    if (typeof flightData === 'string') {
+      throw new Error('invalid flight data')
+    }
+
+    // Mirrors the way router-reducer values are passed in.
+    const flightDataPath = flightData[0]
+    const flightSegmentPath = flightDataPath.slice(0, -3)
+
+    const result = shouldHardNavigate(
+      ['', ...flightSegmentPath],
+      initialRouterStateTree
+    )
+
+    expect(result).toBe(false)
+  })
+
+  it('should return true if segments are dynamic and mismatch', () => {
+    const getInitialRouterStateTree = (): FlightRouterState => [
+      '',
+      {
+        children: [
+          'link-hard-push',
+          {
+            children: [
+              ['id', '456', 'd'],
+              {
+                children: ['', {}],
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      null,
+      true,
+    ]
+    const initialRouterStateTree = getInitialRouterStateTree()
+    const getFlightData = (): FlightData => {
+      return [
+        [
+          'children',
+          'link-hard-push',
+          'children',
+          ['id', '123', 'd'],
+          [
+            ['id', '123', 'd'],
+            {
+              children: ['', {}],
+            },
+          ],
+          null,
+          null,
+        ],
+      ]
+    }
+    const flightData = getFlightData()
+
+    if (typeof flightData === 'string') {
+      throw new Error('invalid flight data')
+    }
+
+    // Mirrors the way router-reducer values are passed in.
+    const flightDataPath = flightData[0]
+    const flightSegmentPath = flightDataPath.slice(0, -3)
+
+    const result = shouldHardNavigate(
+      ['', ...flightSegmentPath],
+      initialRouterStateTree
+    )
+
+    expect(result).toBe(true)
+  })
+})

--- a/packages/next/src/client/components/router-reducer/should-hard-navigate.ts
+++ b/packages/next/src/client/components/router-reducer/should-hard-navigate.ts
@@ -5,10 +5,10 @@ import {
 } from '../../../server/app-render'
 import { matchSegment } from '../match-segments'
 
+// TODO-APP: flightSegmentPath will be empty in case of static response, needs to be handled.
 export function shouldHardNavigate(
   flightSegmentPath: FlightDataPath,
-  flightRouterState: FlightRouterState,
-  treePatch: FlightRouterState
+  flightRouterState: FlightRouterState
 ): boolean {
   const [segment, parallelRoutes] = flightRouterState
   // TODO-APP: Check if `as` can be replaced.
@@ -35,7 +35,6 @@ export function shouldHardNavigate(
 
   return shouldHardNavigate(
     flightSegmentPath.slice(2),
-    parallelRoutes[parallelRouteKey],
-    treePatch
+    parallelRoutes[parallelRouteKey]
   )
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Similar to the other PRs. This adds a test for shouldHardNavigate. It also removes the `treePatch` variable from the function as it was only passed around, not used.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
