### PR TITLE
Add test for isNavigatingToNewRootLayout

### DIFF
--- a/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.ts.test.ts
+++ b/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.ts.test.ts
@@ -1,0 +1,100 @@
+import type { FlightRouterState } from '../../../server/app-render'
+import { isNavigatingToNewRootLayout } from './is-navigating-to-new-root-layout'
+
+describe('shouldHardNavigate', () => {
+  it('should return false if there is no new root layout', () => {
+    const getInitialRouterStateTree = (): FlightRouterState => [
+      '',
+      {
+        children: [
+          'linking',
+          {
+            children: ['', {}],
+          },
+        ],
+      },
+      undefined,
+      undefined,
+      true,
+    ]
+    const initialRouterStateTree = getInitialRouterStateTree()
+    const getNewRouterStateTree = (): FlightRouterState => {
+      return [
+        '',
+        {
+          children: [
+            'link-hard-push',
+            {
+              children: [
+                ['id', '456', 'd'],
+                {
+                  children: ['', {}],
+                },
+              ],
+            },
+          ],
+        },
+        null,
+        null,
+        true,
+      ]
+    }
+    const newRouterState = getNewRouterStateTree()
+
+    const result = isNavigatingToNewRootLayout(
+      newRouterState,
+      initialRouterStateTree
+    )
+
+    expect(result).toBe(false)
+  })
+
+  it('should return true if there is a mismatch between the root layouts', () => {
+    const getInitialRouterStateTree = (): FlightRouterState => [
+      '',
+      {
+        children: [
+          'linking',
+          {
+            children: ['', {}],
+          },
+          undefined,
+          undefined,
+          // Root layout at `linking` level.
+          true,
+        ],
+      },
+    ]
+    const initialRouterStateTree = getInitialRouterStateTree()
+    const getNewRouterStateTree = (): FlightRouterState => {
+      return [
+        '',
+        {
+          children: [
+            'link-hard-push',
+            {
+              children: [
+                ['id', '456', 'd'],
+                {
+                  children: ['', {}],
+                },
+              ],
+            },
+            null,
+            null,
+            // Root layout at `link-hard-push` level.
+            true,
+          ],
+        },
+      ]
+    }
+    const newRouterState = getNewRouterStateTree()
+
+    const result = isNavigatingToNewRootLayout(
+      newRouterState,
+      initialRouterStateTree
+    )
+
+    expect(result).toBe(true)
+  })
+})


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Adds a test for isNavigatingToNewRootLayout.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
