### PR TITLE
Improved `pnpm clean`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "new-error": "plop error",
     "new-test": "plop test",
-    "clean": "pnpm lerna clean -y && pnpm lerna bootstrap && pnpm lerna exec 'rm -rf ./dist'",
+    "clean": "pnpm lerna clean -y && pnpm lerna bootstrap && pnpm lerna run clean && pnpm lerna exec 'rm -rf ./dist'",
     "build": "turbo run build",
     "lerna": "lerna",
     "dev": "turbo run dev --parallel",

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -3,6 +3,7 @@
   "version": "13.1.6-canary.1",
   "private": true,
   "scripts": {
+    "clean": "rm -rf ./native/*",
     "build-native": "napi build --platform -p next-swc-napi --cargo-name next_swc_napi --features plugin,rustls-tls --js false native",
     "build-native-woa": "napi build --platform -p next-swc-napi --cargo-name next_swc_napi --features plugin,native-tls --js false native",
     "build-native-no-plugin": "napi build --platform -p next-swc-napi --cargo-name next_swc_napi --js false native",


### PR DESCRIPTION
When incompatibilities with upgrades to `swc` occur between releases, these changes expand the existing `pnpm clean` script to additionally run any `clean` script under any of the lerna packages. In this case, a new script was created under `packages/next-swc` that removes `packages/next-swc/native/*`, allowing the default to automatically use the WASM build.

Users wanting to reset their repository can now run:

```sh
pnpm clean
```

Future packages or outputs that are built should have their `clean` script remove them to allow for easy repository resetting.