### PR TITLE
build(cargo): update turbopack to turbopack-230126.1

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "serde",
 ]
@@ -2303,7 +2303,7 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 [[package]]
 name = "next-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "mdxjs",
  "modularize_imports",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "next-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -2329,8 +2329,10 @@ dependencies = [
  "once_cell",
  "qstring",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-env",
@@ -2348,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "next-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "futures",
@@ -2373,7 +2375,7 @@ dependencies = [
 [[package]]
 name = "next-font"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "fxhash",
  "serde",
@@ -2424,7 +2426,7 @@ dependencies = [
 [[package]]
 name = "next-transform-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "pathdiff",
  "swc_core",
@@ -2433,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "next-transform-strip-page-exports"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "fxhash",
  "swc_core",
@@ -2443,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "clap",
@@ -3205,10 +3207,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -5454,7 +5458,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "mimalloc",
 ]
@@ -5462,7 +5466,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -5491,7 +5495,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -5503,7 +5507,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5517,7 +5521,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -5534,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -5559,7 +5563,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "base16",
  "hex",
@@ -5571,7 +5575,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "convert_case 0.5.0",
@@ -5585,7 +5589,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5595,7 +5599,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -5617,7 +5621,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -5642,7 +5646,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "clap",
@@ -5658,7 +5662,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5684,7 +5688,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5703,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "futures",
@@ -5732,7 +5736,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5769,7 +5773,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "serde",
@@ -5784,7 +5788,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "serde",
@@ -5799,7 +5803,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -5814,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "futures",
@@ -5836,7 +5840,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "anyhow",
  "serde",
@@ -5852,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230125.1#318e6559ffd5344dd681ad136d84c36ce386c708"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230126.1#3bbbc471d3f8b9f6c141d620ae6f18dd206fd8cd"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -6156,6 +6160,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ab2fe77b325731603297debb4573e002d06ae0aa1f4dc108585c81961e0609"
 dependencies = [
  "leb128",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1"
 serde_json = "1"
 tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 
-next-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230125.1", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230126.1", features = [
   "__swc_core",
   "__swc_core_next_core",
   "__swc_transform_styled_jsx",
@@ -29,7 +29,7 @@ next-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-2
 ] }
 
 [dev-dependencies]
-next-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230125.1", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230126.1", features = [
   "__swc_core_testing_transform",
   "__swc_testing",
 ] }

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -39,7 +39,7 @@ tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.9"
 tracing-chrome = "0.5.0"
-next-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230125.1", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230126.1", features = [
   "__swc_core_binding_napi",
   "__turbo_next_dev_server",
   "__turbo_node_file_trace",

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -31,7 +31,7 @@ wasm-bindgen-futures = "0.4.8"
 getrandom = { version = "0.2.5", optional = true, default-features = false }
 js-sys = "0.3.59"
 serde-wasm-bindgen = "0.4.3"
-next-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230125.1", features = [
+next-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230126.1", features = [
   "__swc_core_binding_wasm",
   "__feature_mdx_rs",
 ] }


### PR DESCRIPTION
**Note**: This requires https://github.com/vercel/next.js/pull/45314, otherwise the following error is shown, but does not block builds:

```
error - [build] examples/create-app
  Error evaluating Node.js code
  TypeError: makeResolver is not a function
    at getResolveRoute (path/to/next.js/examples/create-app/.next/build/chunks/router.js:21:18)
    at async Module.route (path/to/next.js/examples/create-app/.next/build/chunks/router.js:24:36)
    at async Module.run (path/to/next.js/examples/create-app/.next/build/chunks/[turbopack-node]_ipc_evaluate.ts.js:19:39)
```

### Features

- https://github.com/vercel/turbo/pull/3446
- https://github.com/vercel/turbo/pull/3396
- https://github.com/vercel/turbo/pull/3499

### Bug fixes

- https://github.com/vercel/turbo/pull/3433

### Misc

- https://github.com/vercel/turbo/pull/3479