### PR TITLE
Update with-redux example tsconfig to use strict: true

### DIFF
--- a/examples/with-redux/tsconfig.json
+++ b/examples/with-redux/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
I was updating one of my old next.js v3 apps to v13, and decided to play around with RTK. Using the with-redux example sort of sets users up for some weird typing issues as mentioned here: https://github.com/reduxjs/redux-toolkit/issues/2862

I found that github issue _after_ reading through all the official RTK x TS docs, and it seems it could have all been avoided with stricter typing. I'm hoping RTK can add this bit to their docs soon.
