### PR TITLE
Add support for --experimental-app-only

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -260,7 +260,8 @@ export default async function build(
   reactProductionProfiling = false,
   debugOutput = false,
   runLint = true,
-  noMangling = false
+  noMangling = false,
+  appDirOnly = false
 ): Promise<void> {
   try {
     const nextBuildSpan = trace('next-build', undefined, {
@@ -481,16 +482,17 @@ export default async function build(
         prefixText: `${Log.prefixes.info} Creating an optimized production build`,
       })
 
-      const pagesPaths = pagesDir
-        ? await nextBuildSpan
-            .traceChild('collect-pages')
-            .traceAsyncFn(() =>
-              recursiveReadDir(
-                pagesDir,
-                new RegExp(`\\.(?:${config.pageExtensions.join('|')})$`)
+      const pagesPaths =
+        !appDirOnly && pagesDir
+          ? await nextBuildSpan
+              .traceChild('collect-pages')
+              .traceAsyncFn(() =>
+                recursiveReadDir(
+                  pagesDir,
+                  new RegExp(`\\.(?:${config.pageExtensions.join('|')})$`)
+                )
               )
-            )
-        : []
+          : []
 
       let appPaths: string[] | undefined
 

--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -16,6 +16,7 @@ const nextBuild: CliCommand = (argv) => {
     '--debug': Boolean,
     '--no-lint': Boolean,
     '--no-mangling': Boolean,
+    '--experimental-app-only': Boolean,
     // Aliases
     '-h': '--help',
     '-d': '--debug',
@@ -43,9 +44,10 @@ const nextBuild: CliCommand = (argv) => {
       If no directory is provided, the current directory will be used.
 
       Options
-      --profile     Can be used to enable React Production Profiling
-      --no-lint     Disable linting
-      --no-mangling Disable mangling
+      --profile                 Can be used to enable React Production Profiling
+      --no-lint                 Disable linting
+      --no-mangling             Disable mangling
+      --experimental-app-only   Only build 'app' routes
     `,
       0
     )
@@ -74,7 +76,8 @@ const nextBuild: CliCommand = (argv) => {
     args['--profile'],
     args['--debug'] || process.env.NEXT_DEBUG_BUILD,
     !args['--no-lint'],
-    args['--no-mangling']
+    args['--no-mangling'],
+    args['--experimental-app-only']
   ).catch((err) => {
     console.error('')
     if (

--- a/test/production/app-dir/app-only-flag/app-only-flag.test.ts
+++ b/test/production/app-dir/app-only-flag/app-only-flag.test.ts
@@ -4,7 +4,7 @@ createNextDescribe(
   'app-only-flag',
   {
     files: __dirname,
-    buildCommand: 'next build --experimental-app-only',
+    buildCommand: 'pnpm next build --experimental-app-only',
   },
   ({ next }) => {
     it('should serve app route', async () => {

--- a/test/production/app-dir/app-only-flag/app-only-flag.test.ts
+++ b/test/production/app-dir/app-only-flag/app-only-flag.test.ts
@@ -1,0 +1,20 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'app-only-flag',
+  {
+    files: __dirname,
+    buildCommand: 'next build --experimental-app-only',
+  },
+  ({ next }) => {
+    it('should serve app route', async () => {
+      const $ = await next.render$('/')
+      expect($('p').text()).toBe('hello world')
+    })
+
+    it('should not serve about route', async () => {
+      const res = await next.fetch('/about')
+      expect(res.status).toBe(404)
+    })
+  }
+)

--- a/test/production/app-dir/app-only-flag/app/layout.tsx
+++ b/test/production/app-dir/app-only-flag/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/app-only-flag/app/page.tsx
+++ b/test/production/app-dir/app-only-flag/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/app-only-flag/next.config.js
+++ b/test/production/app-dir/app-only-flag/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  experimental: { appDir: true },
+}

--- a/test/production/app-dir/app-only-flag/pages/about.js
+++ b/test/production/app-dir/app-only-flag/pages/about.js
@@ -1,0 +1,3 @@
+export default function About() {
+  return <h1>About</h1>
+}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Allows you to `next build --experimental-app-only` which excludes `pages` altogether. Useful for quickly debugging while migrating.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
