### PR TITLE
Show Vercel CLI version when it has to be installed

### DIFF
--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -33,6 +33,8 @@ export class NextDeployInstance extends NextInstance {
       await execa('npm', ['i', '-g', 'vercel@latest'], {
         stdio: 'inherit',
       })
+      const res = await execa('vercel', ['--version'])
+      require('console').log(`Using Vercel CLI version:`, res.stdout)
     }
     const vercelFlags = ['--scope', TEST_TEAM_NAME]
     const vercelEnv = { ...process.env, TOKEN: TEST_TOKEN }


### PR DESCRIPTION
In the e2e tests, when the Vercel CLI needs to be installed, it doesn't output what version was actually installed. This PR adds that log message.