### PR TITLE
test pinning Vercel CLI version

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -796,7 +796,7 @@ jobs:
   testDeployE2E:
     name: E2E (deploy)
     runs-on: ubuntu-latest
-    needs: [publishRelease, build, build-native-test]
+    needs: [build, build-native-test]
     env:
       NEXT_TELEMETRY_DISABLED: 1
       VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -30,7 +30,7 @@ export class NextDeployInstance extends NextInstance {
       require('console').log(`Using Vercel CLI version:`, res.stdout)
     } catch (_) {
       require('console').log(`Installing Vercel CLI`)
-      await execa('npm', ['i', '-g', 'vercel@28.13.2'], {
+      await execa('npm', ['i', '-g', 'vercel@28.13.0'], {
         stdio: 'inherit',
       })
     }

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -30,7 +30,7 @@ export class NextDeployInstance extends NextInstance {
       require('console').log(`Using Vercel CLI version:`, res.stdout)
     } catch (_) {
       require('console').log(`Installing Vercel CLI`)
-      await execa('npm', ['i', '-g', 'vercel@28.13.0'], {
+      await execa('npm', ['i', '-g', 'vercel@28.13.1'], {
         stdio: 'inherit',
       })
     }

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -30,7 +30,7 @@ export class NextDeployInstance extends NextInstance {
       require('console').log(`Using Vercel CLI version:`, res.stdout)
     } catch (_) {
       require('console').log(`Installing Vercel CLI`)
-      await execa('npm', ['i', '-g', 'vercel@latest'], {
+      await execa('npm', ['i', '-g', 'vercel@28.13.2'], {
         stdio: 'inherit',
       })
     }

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -30,7 +30,7 @@ export class NextDeployInstance extends NextInstance {
       require('console').log(`Using Vercel CLI version:`, res.stdout)
     } catch (_) {
       require('console').log(`Installing Vercel CLI`)
-      await execa('npm', ['i', '-g', 'vercel@28.13.1'], {
+      await execa('npm', ['i', '-g', 'vercel@28.13.2'], {
         stdio: 'inherit',
       })
     }


### PR DESCRIPTION
Try pinning the Vercel CLI version to see if it resolves the [npm warnings](https://github.com/vercel/next.js/actions/runs/4027328455/jobs/6923778422#step:5:235).
