### PR TITLE
Add shared mutable type in router-reducer

### DIFF
--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -8,6 +8,14 @@ export const ACTION_RESTORE = 'restore'
 export const ACTION_SERVER_PATCH = 'server-patch'
 export const ACTION_PREFETCH = 'prefetch'
 
+export interface Mutable {
+  mpaNavigation?: boolean
+  previousTree?: FlightRouterState
+  patchedTree?: FlightRouterState
+  canonicalUrlOverride?: string
+  useExistingCache?: true
+}
+
 /**
  * Refresh triggers a refresh of the full page data.
  * - fetches the Flight data and fills subTreeData at the root of the cache.
@@ -16,12 +24,7 @@ export const ACTION_PREFETCH = 'prefetch'
 export interface RefreshAction {
   type: typeof ACTION_REFRESH
   cache: CacheNode
-  mutable: {
-    previousTree?: FlightRouterState
-    patchedTree?: FlightRouterState
-    mpaNavigation?: boolean
-    canonicalUrlOverride?: string
-  }
+  mutable: Mutable
 }
 
 /**
@@ -65,13 +68,7 @@ export interface NavigateAction {
   navigateType: 'push' | 'replace'
   forceOptimisticNavigation: boolean
   cache: CacheNode
-  mutable: {
-    mpaNavigation?: boolean
-    previousTree?: FlightRouterState
-    patchedTree?: FlightRouterState
-    canonicalUrlOverride?: string
-    useExistingCache?: true
-  }
+  mutable: Mutable
 }
 
 /**
@@ -98,11 +95,7 @@ export interface ServerPatchAction {
   previousTree: FlightRouterState
   overrideCanonicalUrl: URL | undefined
   cache: CacheNode
-  mutable: {
-    patchedTree?: FlightRouterState
-    mpaNavigation?: boolean
-    canonicalUrlOverride?: string
-  }
+  mutable: Mutable
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Preparation for making the mutable shared across the actions.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
