### PR TITLE
Add support for navigating to external urls

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -180,9 +180,12 @@ function Router({
       navigateType: 'push' | 'replace',
       forceOptimisticNavigation: boolean
     ) => {
+      const url = new URL(href, location.origin)
+
       return dispatch({
         type: ACTION_NAVIGATE,
-        url: new URL(href, location.origin),
+        url,
+        isExternalUrl: url.origin !== location.origin,
         forceOptimisticNavigation,
         navigateType,
         cache: {

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -272,7 +272,12 @@ function Router({
   useEffect(() => {
     // When mpaNavigation flag is set do a hard navigation to the new url.
     if (pushRef.mpaNavigation) {
-      window.location.href = canonicalUrl
+      const location = window.location
+      if (pushRef.pendingPush) {
+        location.assign(canonicalUrl)
+      } else {
+        location.replace(canonicalUrl)
+      }
       return
     }
 

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -96,6 +96,10 @@ function findHeadInCache(
   return undefined
 }
 
+function isExternalURL(url: URL) {
+  return url.origin !== location.origin
+}
+
 /**
  * The global router that wraps the application components.
  */
@@ -185,7 +189,7 @@ function Router({
       return dispatch({
         type: ACTION_NAVIGATE,
         url,
-        isExternalUrl: url.origin !== location.origin,
+        isExternalUrl: isExternalURL(url),
         forceOptimisticNavigation,
         navigateType,
         cache: {
@@ -208,6 +212,10 @@ function Router({
         }
         prefetched.add(href)
         const url = new URL(href, location.origin)
+        // External urls can't be prefetched in the same way.
+        if (isExternalURL(url)) {
+          return
+        }
         try {
           const routerTree = window.history.state?.tree || initialTree
           const serverResponse = await fetchServerResponse(

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -22,8 +22,33 @@ export function navigateReducer(
   state: ReadonlyReducerState,
   action: NavigateAction
 ): ReducerState {
-  const { url, navigateType, cache, mutable, forceOptimisticNavigation } =
-    action
+  const {
+    url,
+    isExternalUrl,
+    navigateType,
+    cache,
+    mutable,
+    forceOptimisticNavigation,
+  } = action
+
+  if (isExternalUrl) {
+    return {
+      // Set href.
+      canonicalUrl: url.toString(),
+      pushRef: {
+        pendingPush: false,
+        mpaNavigation: true,
+      },
+      // All navigation requires scroll and focus management to trigger.
+      focusAndScrollRef: { apply: false },
+      // Apply cache.
+      cache: state.cache,
+      prefetchCache: state.prefetchCache,
+      // Apply patched router state.
+      tree: state.tree,
+    }
+  }
+
   const { pathname, search } = url
   const href = createHrefFromUrl(url)
   const pendingPush = navigateType === 'push'

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -30,13 +30,14 @@ export function navigateReducer(
     mutable,
     forceOptimisticNavigation,
   } = action
+  const pendingPush = navigateType === 'push'
 
   if (isExternalUrl) {
     return {
       // Set href.
       canonicalUrl: url.toString(),
       pushRef: {
-        pendingPush: false,
+        pendingPush,
         mpaNavigation: true,
       },
       // All navigation requires scroll and focus management to trigger.
@@ -51,7 +52,6 @@ export function navigateReducer(
 
   const { pathname, search } = url
   const href = createHrefFromUrl(url)
-  const pendingPush = navigateType === 'push'
 
   const isForCurrentTree =
     JSON.stringify(mutable.previousTree) === JSON.stringify(state.tree)

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -65,6 +65,7 @@ export interface RefreshAction {
 export interface NavigateAction {
   type: typeof ACTION_NAVIGATE
   url: URL
+  isExternalUrl: boolean
   navigateType: 'push' | 'replace'
   forceOptimisticNavigation: boolean
   cache: CacheNode

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -553,6 +553,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       prefetchEnabled,
       pagesRouter?.locale,
       router,
+      isAppRouter,
     ])
 
     const childProps: {
@@ -626,12 +627,18 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
           return
         }
 
-        prefetch(router, href, as, {
-          locale,
-          priority: true,
-          // @see {https://github.com/vercel/next.js/discussions/40268?sort=top#discussioncomment-3572642}
-          bypassPrefetchedCheck: true,
-        })
+        prefetch(
+          router,
+          href,
+          as,
+          {
+            locale,
+            priority: true,
+            // @see {https://github.com/vercel/next.js/discussions/40268?sort=top#discussioncomment-3572642}
+            bypassPrefetchedCheck: true,
+          },
+          isAppRouter
+        )
       },
       onTouchStart(e) {
         if (!legacyBehavior && typeof onTouchStartProp === 'function') {
@@ -654,12 +661,18 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
           return
         }
 
-        prefetch(router, href, as, {
-          locale,
-          priority: true,
-          // @see {https://github.com/vercel/next.js/discussions/40268?sort=top#discussioncomment-3572642}
-          bypassPrefetchedCheck: true,
-        })
+        prefetch(
+          router,
+          href,
+          as,
+          {
+            locale,
+            priority: true,
+            // @see {https://github.com/vercel/next.js/discussions/40268?sort=top#discussioncomment-3572642}
+            bypassPrefetchedCheck: true,
+          },
+          isAppRouter
+        )
       },
     }
 

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -117,13 +117,15 @@ function prefetch(
   router: NextRouter | AppRouterInstance,
   href: string,
   as: string,
-  options: PrefetchOptions
+  options: PrefetchOptions,
+  isAppRouter: boolean
 ): void {
   if (typeof window === 'undefined') {
     return
   }
 
-  if (!isLocalURL(href)) {
+  // app-router supports external urls out of the box so it shouldn't short-circuit here as support for e.g. `replace` is added in the app-router.
+  if (!isAppRouter && !isLocalURL(href)) {
     return
   }
 
@@ -191,7 +193,12 @@ function linkClicked(
   // anchors inside an svg have a lowercase nodeName
   const isAnchorNodeName = nodeName.toUpperCase() === 'A'
 
-  if (isAnchorNodeName && (isModifiedEvent(e) || !isLocalURL(href))) {
+  if (
+    isAnchorNodeName &&
+    (isModifiedEvent(e) ||
+      // app-router supports external urls out of the box so it shouldn't short-circuit here as support for e.g. `replace` is added in the app-router.
+      (!isAppRouter && !isLocalURL(href)))
+  ) {
     // ignore click for browser’s default behavior
     return
   }
@@ -537,7 +544,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       }
 
       // Prefetch the URL.
-      prefetch(router, href, as, { locale })
+      prefetch(router, href, as, { locale }, isAppRouter)
     }, [
       as,
       href,

--- a/test/e2e/app-dir/app/app/link-external/push/page.js
+++ b/test/e2e/app-dir/app/app/link-external/push/page.js
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <>
+      <Link href="https://example.vercel.sh/" id="external-link">
+        External Link
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/link-external/replace/page.js
+++ b/test/e2e/app-dir/app/app/link-external/replace/page.js
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <>
+      <Link href="https://example.vercel.sh/" id="external-link" replace>
+        External Link
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/redirect/external/page.js
+++ b/test/e2e/app-dir/app/app/redirect/external/page.js
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('https://example.vercel.sh/')
+  return <></>
+}

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -2502,7 +2502,6 @@ createNextDescribe(
           )
         })
 
-        // TODO-APP: Enable in development
         it('should redirect client-side', async () => {
           const browser = await next.browser('/redirect/client-side')
           await browser
@@ -2512,6 +2511,13 @@ createNextDescribe(
           // eslint-disable-next-line jest/no-standalone-expect
           expect(await browser.elementByCss('#result-page').text()).toBe(
             'Result Page'
+          )
+        })
+
+        it('should redirect to external url', async () => {
+          const browser = await next.browser('/redirect/external')
+          expect(await browser.waitForElementByCss('h1').text()).toBe(
+            'Example Domain'
           )
         })
       })

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -639,6 +639,22 @@ createNextDescribe(
           await browser.close()
         }
       })
+
+      it('should push to external url', async () => {
+        const browser = await next.browser('/link-external/push')
+        await browser.elementByCss('#external-link').click()
+        expect(await browser.waitForElementByCss('h1').text()).toBe(
+          'Example Domain'
+        )
+      })
+
+      it('should replace to external url', async () => {
+        const browser = await next.browser('/link-external/replace')
+        await browser.elementByCss('#external-link').click()
+        expect(await browser.waitForElementByCss('h1').text()).toBe(
+          'Example Domain'
+        )
+      })
     })
 
     describe('server components', () => {

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -642,18 +642,22 @@ createNextDescribe(
 
       it('should push to external url', async () => {
         const browser = await next.browser('/link-external/push')
+        expect(await browser.eval('window.history.length')).toBe(2)
         await browser.elementByCss('#external-link').click()
         expect(await browser.waitForElementByCss('h1').text()).toBe(
           'Example Domain'
         )
+        expect(await browser.eval('window.history.length')).toBe(3)
       })
 
       it('should replace to external url', async () => {
         const browser = await next.browser('/link-external/replace')
+        expect(await browser.eval('window.history.length')).toBe(2)
         await browser.elementByCss('#external-link').click()
         expect(await browser.waitForElementByCss('h1').text()).toBe(
           'Example Domain'
         )
+        expect(await browser.eval('window.history.length')).toBe(2)
       })
     })
 


### PR DESCRIPTION
Adds support for `router.push('https://google.com')`, `router.replace('https://google.com')`, and `redirect('https://google.com')`.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
