### PR TITLE
Fix nested example setup with create-next-app

### DIFF
--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -123,7 +123,7 @@ export async function downloadAndExtractExample(root: string, name: string) {
   await tar.x({
     file: tempFile,
     cwd: root,
-    strip: 3,
+    strip: 2 + name.split('/').length,
     filter: (p) => p.includes(`next.js-canary/examples/${name}/`),
   })
 


### PR DESCRIPTION
Noticed in https://github.com/vercel/next.js/pull/45387 we aren't properly setting up nested examples due to not stripping to the right level so this ensures we handle that case properly. 
