### PR TITLE
Fix flakey app metadata test

### DIFF
--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -275,19 +275,19 @@ createNextDescribe(
           await browser
             .elementByCss('#to-basic')
             .click()
-            .waitForElementByCss('#basic', 2000)
+            .waitForElementByCss('#basic')
 
           await checkMetaNameContentPair(
             browser,
             'referrer',
             'origin-when-crossorigin'
           )
-          await browser.back().waitForElementByCss('#index', 2000)
+          await browser.back().waitForElementByCss('#index')
           expect(await getTitle(browser)).toBe('index page')
           await browser
             .elementByCss('#to-title')
             .click()
-            .waitForElementByCss('#title', 2000)
+            .waitForElementByCss('#title')
           expect(await getTitle(browser)).toBe('this is the page title')
         })
       })


### PR DESCRIPTION
We shouldn't use an arbitrary timeout here.

x-ref: https://github.com/vercel/next.js/actions/runs/4038320521/jobs/6942258801