### PR TITLE
Add test for issue 45393

### DIFF
--- a/test/e2e/html-extension-navigation-bug/html-extension-navigation-bug.test.ts
+++ b/test/e2e/html-extension-navigation-bug/html-extension-navigation-bug.test.ts
@@ -1,0 +1,70 @@
+import { createNextDescribe } from 'e2e-utils'
+
+for (const item of ['trailing-slash', 'no-trailing-slash']) {
+  createNextDescribe(
+    `html-extension-navigation-bug-${item}`,
+    {
+      files: __dirname,
+      nextConfig: {
+        trailingSlash: item === 'trailing-slash',
+      },
+    },
+    ({ next }) => {
+      describe('with .html extension', () => {
+        it('should work when requesting the page directly', async () => {
+          const $ = await next.render$(
+            '/product/shirts_and_tops/mens_ua_playoff_polo_2.0/1327037.html'
+          )
+          expect($('#text').text()).toBe(
+            'Param found: shirts_and_tops, mens_ua_playoff_polo_2.0, 1327037.html'
+          )
+        })
+
+        it('should work using browser', async () => {
+          const browser = await next.browser(
+            '/product/shirts_and_tops/mens_ua_playoff_polo_2.0/1327037.html'
+          )
+          expect(await browser.elementByCss('#text').text()).toBe(
+            'Param found: shirts_and_tops, mens_ua_playoff_polo_2.0, 1327037.html'
+          )
+        })
+
+        it('should work when navigating', async () => {
+          const browser = await next.browser('/')
+          await browser.elementByCss('#with-html').click()
+          expect(await browser.waitForElementByCss('#text').text()).toBe(
+            'Param found: shirts_and_tops, mens_ua_playoff_polo_2.0, 1327037.html'
+          )
+        })
+      })
+
+      describe('without .html extension', () => {
+        it('should work when requesting the page directly', async () => {
+          const $ = await next.render$(
+            '/product/shirts_and_tops/mens_ua_playoff_polo_2.0/1327037'
+          )
+          expect($('#text').text()).toBe(
+            'Param found: shirts_and_tops, mens_ua_playoff_polo_2.0, 1327037'
+          )
+        })
+
+        it('should work using browser', async () => {
+          const browser = await next.browser(
+            '/product/shirts_and_tops/mens_ua_playoff_polo_2.0/1327037'
+          )
+          expect(await browser.elementByCss('#text').text()).toBe(
+            'Param found: shirts_and_tops, mens_ua_playoff_polo_2.0, 1327037'
+          )
+        })
+
+        it('should work when navigating', async () => {
+          const browser = await next.browser('/')
+          await browser.elementByCss('#without-html').click()
+          expect(await browser.waitForElementByCss('#text').text()).toBe(
+            'Param found: shirts_and_tops, mens_ua_playoff_polo_2.0, 1327037'
+          )
+        })
+      })
+    }
+  )
+}

--- a/test/e2e/html-extension-navigation-bug/middleware.ts
+++ b/test/e2e/html-extension-navigation-bug/middleware.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export default async function middleware(req: NextRequest) {
+  return NextResponse.next()
+}

--- a/test/e2e/html-extension-navigation-bug/pages/_app.tsx
+++ b/test/e2e/html-extension-navigation-bug/pages/_app.tsx
@@ -1,0 +1,5 @@
+import type { AppProps } from 'next/app'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/test/e2e/html-extension-navigation-bug/pages/_document.tsx
+++ b/test/e2e/html-extension-navigation-bug/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/test/e2e/html-extension-navigation-bug/pages/index.tsx
+++ b/test/e2e/html-extension-navigation-bug/pages/index.tsx
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+/* eslint-disable no-param-reassign */
+
+import Link from 'next/link'
+
+export default function Test() {
+  return (
+    <>
+      <ul>
+        <li>
+          <Link
+            id="with-html"
+            href="/product/shirts_and_tops/mens_ua_playoff_polo_2.0/1327037.html"
+          >
+            Does not work
+          </Link>
+        </li>
+        <li>
+          <Link
+            id="without-html"
+            href="/product/shirts_and_tops/mens_ua_playoff_polo_2.0/1327037"
+          >
+            Works
+          </Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/html-extension-navigation-bug/pages/product/[...product-params].tsx
+++ b/test/e2e/html-extension-navigation-bug/pages/product/[...product-params].tsx
@@ -1,0 +1,27 @@
+import { GetServerSideProps } from 'next'
+import React from 'react'
+
+export interface ProductPageProps {
+  test: string
+}
+
+const ProductPage = (params: ProductPageProps) => {
+  return (
+    <>
+      <h1 id="text">Param found: {params.test}</h1>
+    </>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  const joined = Array.isArray(params['product-params'])
+    ? params['product-params'].join(', ')
+    : params['product-params']
+  return {
+    props: {
+      test: joined ? joined : 'Not Found',
+    },
+  }
+}
+
+export default ProductPage


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Test for #45393. So far I've been able to reduce it to a combination of `middleware.ts` and `trailingSlash: true`. With `trailingSlash: false` this issue doesn't happen.

After investigating further it seems the root cause is https://github.com/vercel/next.js/blob/9fe323a8371a041037c5bc86a28c48438200c6f3/packages/next/src/lib/load-custom-routes.ts#L665-L671 that matches `.html` when it's part of the `_next/data` route 🤔 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
