### PR TITLE
Fix invalid source maps from terser-webpack-plugin

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1,3 +1,4 @@
+import '../lib/setup-exception-listeners'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { loadEnvConfig } from '@next/env'
 import chalk from 'next/dist/compiled/chalk'

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -882,9 +882,7 @@ export default async function getBaseWebpackConfig(
     extensions: isNodeServer
       ? ['.js', '.mjs', '.tsx', '.ts', '.jsx', '.json', '.wasm']
       : ['.mjs', '.js', '.tsx', '.ts', '.jsx', '.json', '.wasm'],
-    extensionAlias: {
-      '.js': ['.ts', '.tsx', '.js', '.jsx'],
-    },
+    extensionAlias: config.experimental.extensionAlias,
     modules: [
       'node_modules',
       ...nodePathList, // Support for NODE_PATH environment variable

--- a/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
@@ -253,6 +253,7 @@ export class TerserPlugin {
                     name,
                     output.map,
                     input,
+                    inputSourceMap,
                     true
                   )
                 } else {

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -1,4 +1,3 @@
-import '../lib/setup-exception-listeners'
 import type { FontManifest, FontConfig } from '../server/font-utils'
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { DomainLocale, NextConfigComplete } from '../server/config-shared'

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -1,3 +1,4 @@
+import '../lib/setup-exception-listeners'
 import type { FontManifest, FontConfig } from '../server/font-utils'
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { DomainLocale, NextConfigComplete } from '../server/config-shared'

--- a/packages/next/src/lib/setup-exception-listeners.ts
+++ b/packages/next/src/lib/setup-exception-listeners.ts
@@ -1,0 +1,9 @@
+process.on('uncaughtException', (err) => {
+  console.error('uncaughtException', err)
+  process.exit(1)
+})
+
+process.on('unhandledRejection', (err) => {
+  console.error('unhandledRejection', err)
+  process.exit(1)
+})

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -272,6 +272,9 @@ const configSchema = {
         appDir: {
           type: 'boolean',
         },
+        extensionAlias: {
+          type: 'object',
+        },
         externalDir: {
           type: 'boolean',
         },

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -79,6 +79,7 @@ export interface NextJsWebpackConfig {
 }
 
 export interface ExperimentalConfig {
+  extensionAlias?: Record<string, any>
   allowedRevalidateHeaderKeys?: string[]
   fetchCache?: boolean
   optimisticClientCache?: boolean

--- a/test/integration/webpack-config-extensionalias/next.config.js
+++ b/test/integration/webpack-config-extensionalias/next.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  webpack(config) {
-    return config
+  experimental: {
+    extensionAlias: {
+      '.js': ['.ts', '.tsx', '.js', '.jsx'],
+    },
   },
 }


### PR DESCRIPTION
This fixes a regression in our source map generating which got lost in the big diff from the `src` folder restructure in https://github.com/vercel/next.js/pull/44405

These invalid source maps broke plugins that attempted to leverage them like `@sentry/nextjs` which only attempts in a production environment https://github.com/getsentry/sentry-javascript/blob/15ec85bead77100413381be821f42841ae114f93/packages/nextjs/src/config/webpack.ts#L586

For a regression test in a follow-up we will need to investigate a production test fixture with `@sentry/nextjs` although this requires a DSN be configured. 

This also ensures we setup `unhandledRejection` and `uncaughtException` listeners during build so that we have proper stack information when these occur and the process isn't left hanging. 

This also moves the `extensionAlias` config from https://github.com/vercel/next.js/pull/44177 to an experimental config as it seems to cause conflicts with ESM packages that define `exports` in their `package.json` which can be considered a breaking change. 

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

Fixes: https://github.com/vercel/next.js/issues/45419
x-ref: [slack thread](https://vercel.slack.com/archives/C03DQ3QFV7C/p1674937545579229)
