### PR TITLE
@next/font change default font-display

### DIFF
--- a/docs/api-reference/next/font.md
+++ b/docs/api-reference/next/font.md
@@ -107,7 +107,7 @@ Examples:
 
 ### `display`
 
-The font [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) with possible string [values](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display#values) of `'auto'`, `'block'`, `'swap'`, `'fallback'` or `'optional'` with default value of `'optional'`.
+The font [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) with possible string [values](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display#values) of `'auto'`, `'block'`, `'swap'`, `'fallback'` or `'optional'` with default value of `'swap'`.
 
 Used in `@next/font/google` and `@next/font/local`
 

--- a/docs/basic-features/font-optimization.md
+++ b/docs/basic-features/font-optimization.md
@@ -22,12 +22,6 @@ To get started, install `@next/font`:
 npm install @next/font
 ```
 
-### Choosing font-display
-
-[`font-display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) lets you to control how your font is displayed while it's loading. `@next/font` uses `font-display: optional` by default. When the primary font used by `@next/font` does not load within 100ms, the auto generated fallback font will be displayed in the browser. While it is automatically generated to be as visually similar to the primary font as possible to reduce layout shift, it does come with the tradeoff that your intended font might not be shown on slower networks unless it's cached.
-
-If you want guarantees around your intended font always showing, and accept the tradeoff of minimal layout shift from swapping your fallback font for the primary font, you can [use `font-display: swap`](/docs/api-reference/next/font.md#display).
-
 ### Google Fonts
 
 Automatically self-host any Google Font. Fonts are included in the deployment and served from the same domain as your deployment. **No requests are sent to Google by the browser.**

--- a/packages/font/src/google/utils.ts
+++ b/packages/font/src/google/utils.ts
@@ -29,9 +29,7 @@ export function validateData(
     weight,
     style,
     preload = true,
-    // If preload is disabled set display to 'swap' by default.
-    // If display is 'optional' and we don't preload, we will never fetch the font in time to display it, not even in dev.
-    display = preload ? 'optional' : 'swap',
+    display = 'swap',
     axes,
     fallback,
     adjustFontFallback = true,
@@ -52,9 +50,8 @@ export function validateData(
 
   const availableSubsets = fontFamilyData.subsets
   if (availableSubsets.length === 0) {
-    // If the font doesn't have any preloaded subsets, disable preload and set display to 'swap'
+    // If the font doesn't have any preloaded subsets, disable preload
     preload = false
-    display = 'swap'
   } else {
     if (preload && !callSubsets && !config?.subsets) {
       nextFontError(

--- a/packages/font/src/local/utils.ts
+++ b/packages/font/src/local/utils.ts
@@ -36,7 +36,7 @@ export function validateData(functionName: string, fontData: any): FontOptions {
   }
   let {
     src,
-    display = 'optional',
+    display = 'swap',
     weight,
     style,
     fallback,

--- a/test/e2e/next-font/google-font-mocked-responses.js
+++ b/test/e2e/next-font/google-font-mocked-responses.js
@@ -1,14 +1,14 @@
 const path = require('path')
 
 module.exports = {
-  'https://fonts.googleapis.com/css2?family=Open+Sans:wght@300..800&display=optional': `
+  'https://fonts.googleapis.com/css2?family=Open+Sans:wght@300..800&display=swap': `
 /* cyrillic-ext */
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 300 800;
   font-stretch: 100%;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/opensans/v34/memvYaGs126MiZpBA-UvWbX2vVnXBbObj2OVTSKmu0SC55K5gw.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
@@ -18,7 +18,7 @@ module.exports = {
   font-style: normal;
   font-weight: 300 800;
   font-stretch: 100%;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/opensans/v34/memvYaGs126MiZpBA-UvWbX2vVnXBbObj2OVTSumu0SC55K5gw.woff2) format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -28,7 +28,7 @@ module.exports = {
   font-style: normal;
   font-weight: 300 800;
   font-stretch: 100%;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/opensans/v34/memvYaGs126MiZpBA-UvWbX2vVnXBbObj2OVTSOmu0SC55K5gw.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
@@ -38,7 +38,7 @@ module.exports = {
   font-style: normal;
   font-weight: 300 800;
   font-stretch: 100%;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/opensans/v34/memvYaGs126MiZpBA-UvWbX2vVnXBbObj2OVTSymu0SC55K5gw.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
@@ -48,7 +48,7 @@ module.exports = {
   font-style: normal;
   font-weight: 300 800;
   font-stretch: 100%;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/opensans/v34/memvYaGs126MiZpBA-UvWbX2vVnXBbObj2OVTS2mu0SC55K5gw.woff2) format('woff2');
   unicode-range: U+0590-05FF, U+200C-2010, U+20AA, U+25CC, U+FB1D-FB4F;
 }
@@ -58,7 +58,7 @@ module.exports = {
   font-style: normal;
   font-weight: 300 800;
   font-stretch: 100%;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/opensans/v34/memvYaGs126MiZpBA-UvWbX2vVnXBbObj2OVTSCmu0SC55K5gw.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
@@ -68,7 +68,7 @@ module.exports = {
   font-style: normal;
   font-weight: 300 800;
   font-stretch: 100%;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/opensans/v34/memvYaGs126MiZpBA-UvWbX2vVnXBbObj2OVTSGmu0SC55K5gw.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -78,7 +78,7 @@ module.exports = {
   font-style: normal;
   font-weight: 300 800;
   font-stretch: 100%;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/opensans/v34/memvYaGs126MiZpBA-UvWbX2vVnXBbObj2OVTS-mu0SC55I.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -213,13 +213,13 @@ module.exports = {
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
   `,
-  'https://fonts.googleapis.com/css2?family=Roboto:wght@400&display=optional': `
+  'https://fonts.googleapis.com/css2?family=Roboto:wght@400&display=swap': `
   /* cyrillic-ext */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
@@ -228,7 +228,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu5mxKKTU1Kvnz.woff2) format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -237,7 +237,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu7mxKKTU1Kvnz.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
@@ -246,7 +246,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu4WxKKTU1Kvnz.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
@@ -255,7 +255,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu7WxKKTU1Kvnz.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
@@ -264,7 +264,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu7GxKKTU1Kvnz.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -273,7 +273,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu4mxKKTU1Kg.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -419,13 +419,13 @@ module.exports = {
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
   `,
-  'https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&display=optional': `
+  'https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&display=swap': `
   /* cyrillic-ext */
 @font-face {
   font-family: 'Fira Code';
   font-style: normal;
   font-weight: 300 700;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/firacode/v21/uU9NCBsR6Z2vfE9aq3bh0NSDqFGedCMX.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
@@ -434,7 +434,7 @@ module.exports = {
   font-family: 'Fira Code';
   font-style: normal;
   font-weight: 300 700;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/firacode/v21/uU9NCBsR6Z2vfE9aq3bh2dSDqFGedCMX.woff2) format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -443,7 +443,7 @@ module.exports = {
   font-family: 'Fira Code';
   font-style: normal;
   font-weight: 300 700;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/firacode/v21/uU9NCBsR6Z2vfE9aq3bh0dSDqFGedCMX.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
@@ -452,7 +452,7 @@ module.exports = {
   font-family: 'Fira Code';
   font-style: normal;
   font-weight: 300 700;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/firacode/v21/uU9NCBsR6Z2vfE9aq3bh3tSDqFGedCMX.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
@@ -461,7 +461,7 @@ module.exports = {
   font-family: 'Fira Code';
   font-style: normal;
   font-weight: 300 700;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/firacode/v21/uU9NCBsR6Z2vfE9aq3bh09SDqFGedCMX.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -470,18 +470,18 @@ module.exports = {
   font-family: 'Fira Code';
   font-style: normal;
   font-weight: 300 700;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/firacode/v21/uU9NCBsR6Z2vfE9aq3bh3dSDqFGedA.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }  
   `,
-  'https://fonts.googleapis.com/css2?family=Albert+Sans:ital,wght@1,100..900&display=optional': `
+  'https://fonts.googleapis.com/css2?family=Albert+Sans:ital,wght@1,100..900&display=swap': `
   /* latin-ext */
 @font-face {
   font-family: 'Albert Sans';
   font-style: italic;
   font-weight: 100 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/albertsans/v1/i7dMIFdwYjGaAMFtZd_QA1ZeUFuaHi6WZ3S_Yg.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -490,7 +490,7 @@ module.exports = {
   font-family: 'Albert Sans';
   font-style: italic;
   font-weight: 100 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/albertsans/v1/i7dMIFdwYjGaAMFtZd_QA1ZeUFWaHi6WZ3Q.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -543,13 +543,13 @@ module.exports = {
     )}) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }`,
-  'https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,100..900,0..100,0..1;1,9..144,100..900,0..100,0..1&display=optional': `
+  'https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,100..900,0..100,0..1;1,9..144,100..900,0..100,0..1&display=swap': `
   /* vietnamese */
 @font-face {
   font-family: 'Fraunces';
   font-style: italic;
   font-weight: 100 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUT8FyLNQOQZAnv9ZwNpOQkzP9Ddt2Wew.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
@@ -558,7 +558,7 @@ module.exports = {
   font-family: 'Fraunces';
   font-style: italic;
   font-weight: 100 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUT8FyLNQOQZAnv9ZwNpOUkzP9Ddt2Wew.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -567,7 +567,7 @@ module.exports = {
   font-family: 'Fraunces';
   font-style: italic;
   font-weight: 100 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUT8FyLNQOQZAnv9ZwNpOskzP9Ddt0.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -576,7 +576,7 @@ module.exports = {
   font-family: 'Fraunces';
   font-style: normal;
   font-weight: 100 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUV8FyLNQOQZAnv9ZwHlOkuy91BRtw.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
@@ -585,7 +585,7 @@ module.exports = {
   font-family: 'Fraunces';
   font-style: normal;
   font-weight: 100 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUV8FyLNQOQZAnv9ZwGlOkuy91BRtw.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -594,18 +594,18 @@ module.exports = {
   font-family: 'Fraunces';
   font-style: normal;
   font-weight: 100 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUV8FyLNQOQZAnv9ZwIlOkuy91B.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
   `,
-  'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,900;1,100;1,900&display=optional': `
+  'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,900;1,100;1,900&display=swap': `
   /* cyrillic-ext */
 @font-face {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOiCnqEu92Fr1Mu51QrEz0dL-vwnYh2eg.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
@@ -614,7 +614,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOiCnqEu92Fr1Mu51QrEzQdL-vwnYh2eg.woff2) format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -623,7 +623,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOiCnqEu92Fr1Mu51QrEzwdL-vwnYh2eg.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
@@ -632,7 +632,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOiCnqEu92Fr1Mu51QrEzMdL-vwnYh2eg.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
@@ -641,7 +641,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOiCnqEu92Fr1Mu51QrEz8dL-vwnYh2eg.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
@@ -650,7 +650,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOiCnqEu92Fr1Mu51QrEz4dL-vwnYh2eg.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -659,7 +659,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOiCnqEu92Fr1Mu51QrEzAdL-vwnYg.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -668,7 +668,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOjCnqEu92Fr1Mu51TLBCc3CsTYl4BOQ3o.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
@@ -677,7 +677,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOjCnqEu92Fr1Mu51TLBCc-CsTYl4BOQ3o.woff2) format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -686,7 +686,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOjCnqEu92Fr1Mu51TLBCc2CsTYl4BOQ3o.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
@@ -695,7 +695,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOjCnqEu92Fr1Mu51TLBCc5CsTYl4BOQ3o.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
@@ -704,7 +704,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOjCnqEu92Fr1Mu51TLBCc1CsTYl4BOQ3o.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
@@ -713,7 +713,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOjCnqEu92Fr1Mu51TLBCc0CsTYl4BOQ3o.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -722,7 +722,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOjCnqEu92Fr1Mu51TLBCc6CsTYl4BO.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -731,7 +731,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOkCnqEu92Fr1MmgVxFIzIXKMnyrYk.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
@@ -740,7 +740,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOkCnqEu92Fr1MmgVxMIzIXKMnyrYk.woff2) format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -749,7 +749,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOkCnqEu92Fr1MmgVxEIzIXKMnyrYk.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
@@ -758,7 +758,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOkCnqEu92Fr1MmgVxLIzIXKMnyrYk.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
@@ -767,7 +767,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOkCnqEu92Fr1MmgVxHIzIXKMnyrYk.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
@@ -776,7 +776,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOkCnqEu92Fr1MmgVxGIzIXKMnyrYk.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -785,7 +785,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 100;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOkCnqEu92Fr1MmgVxIIzIXKMny.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -794,7 +794,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOlCnqEu92Fr1MmYUtfCRc4AMP6lbBP.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
@@ -803,7 +803,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOlCnqEu92Fr1MmYUtfABc4AMP6lbBP.woff2) format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -812,7 +812,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOlCnqEu92Fr1MmYUtfCBc4AMP6lbBP.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
@@ -821,7 +821,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOlCnqEu92Fr1MmYUtfBxc4AMP6lbBP.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
@@ -830,7 +830,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOlCnqEu92Fr1MmYUtfCxc4AMP6lbBP.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
@@ -839,7 +839,7 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOlCnqEu92Fr1MmYUtfChc4AMP6lbBP.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -848,18 +848,18 @@ module.exports = {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 900;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/roboto/v30/KFOlCnqEu92Fr1MmYUtfBBc4AMP6lQ.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
   `,
-  'https://fonts.googleapis.com/css2?family=Fraunces:wght@100;400;900&display=optional': `
+  'https://fonts.googleapis.com/css2?family=Fraunces:wght@100;400;900&display=swap': `
   /* vietnamese */
   @font-face {
     font-family: 'Fraunces';
     font-style: normal;
     font-weight: 100;
-    font-display: optional;
+    font-display: swap;
     src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUu8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib14c0qv8oRcTnaIM.woff2) format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
   }
@@ -868,7 +868,7 @@ module.exports = {
     font-family: 'Fraunces';
     font-style: normal;
     font-weight: 100;
-    font-display: optional;
+    font-display: swap;
     src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUu8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib14c1qv8oRcTnaIM.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
   }
@@ -877,7 +877,7 @@ module.exports = {
     font-family: 'Fraunces';
     font-style: normal;
     font-weight: 100;
-    font-display: optional;
+    font-display: swap;
     src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUu8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib14c7qv8oRcTn.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
@@ -886,7 +886,7 @@ module.exports = {
     font-family: 'Fraunces';
     font-style: normal;
     font-weight: 400;
-    font-display: optional;
+    font-display: swap;
     src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUu8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib14c0qv8oRcTnaIM.woff2) format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
   }
@@ -895,7 +895,7 @@ module.exports = {
     font-family: 'Fraunces';
     font-style: normal;
     font-weight: 400;
-    font-display: optional;
+    font-display: swap;
     src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUu8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib14c1qv8oRcTnaIM.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
   }
@@ -904,7 +904,7 @@ module.exports = {
     font-family: 'Fraunces';
     font-style: normal;
     font-weight: 400;
-    font-display: optional;
+    font-display: swap;
     src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUu8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib14c7qv8oRcTn.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
@@ -913,7 +913,7 @@ module.exports = {
     font-family: 'Fraunces';
     font-style: normal;
     font-weight: 900;
-    font-display: optional;
+    font-display: swap;
     src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUu8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib14c0qv8oRcTnaIM.woff2) format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
   }
@@ -922,7 +922,7 @@ module.exports = {
     font-family: 'Fraunces';
     font-style: normal;
     font-weight: 900;
-    font-display: optional;
+    font-display: swap;
     src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUu8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib14c1qv8oRcTnaIM.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
   }
@@ -931,20 +931,19 @@ module.exports = {
     font-family: 'Fraunces';
     font-style: normal;
     font-weight: 900;
-    font-display: optional;
+    font-display: swap;
     src: url(https://fonts.gstatic.com/s/fraunces/v24/6NUu8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib14c7qv8oRcTn.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
   `,
-  'https://fonts.googleapis.com/css2?family=Inter:wght@400&display=optional':
-    null,
-  'https://fonts.googleapis.com/css2?family=Nabla&display=optional': `
+  'https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap': null,
+  'https://fonts.googleapis.com/css2?family=Nabla&display=swap': `
   /* cyrillic-ext */
 @font-face {
   font-family: 'Nabla';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/nabla/v9/j8_D6-LI0Lvpe7Makz5UhJt9C3uqg_X_75gyGS4jAxsNIjrRBRpeFXZ6x96OvGloBgM.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
@@ -953,7 +952,7 @@ module.exports = {
   font-family: 'Nabla';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/nabla/v9/j8_D6-LI0Lvpe7Makz5UhJt9C3uqg_X_75gyGS4jAxsNIjrRBWteFXZ6x96OvGloBgM.woff2) format('woff2');
   unicode-range: U+0302-0303, U+0305, U+0307-0308, U+0330, U+0391-03A1, U+03A3-03A9, U+03B1-03C9, U+03D1, U+03D5-03D6, U+03F0-03F1, U+03F4-03F5, U+2034-2037, U+2057, U+20D0-20DC, U+20E1, U+20E5-20EF, U+2102, U+210A-210E, U+2110-2112, U+2115, U+2119-211D, U+2124, U+2128, U+212C-212D, U+212F-2131, U+2133-2138, U+213C-2140, U+2145-2149, U+2190, U+2192, U+2194-21AE, U+21B0-21E5, U+21F1-21F2, U+21F4-2211, U+2213-2214, U+2216-22FF, U+2308-230B, U+2310, U+2319, U+231C-2321, U+2336-237A, U+237C, U+2395, U+239B-23B6, U+23D0, U+23DC-23E1, U+2474-2475, U+25AF, U+25B3, U+25B7, U+25BD, U+25C1, U+25CA, U+25CC, U+25FB, U+266D-266F, U+27C0-27FF, U+2900-2AFF, U+2B0E-2B11, U+2B30-2B4C, U+2BFE, U+FF5B, U+FF5D, U+1D400-1D7FF, U+1EE00-1EEFF;
 }
@@ -962,7 +961,7 @@ module.exports = {
   font-family: 'Nabla';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/nabla/v9/j8_D6-LI0Lvpe7Makz5UhJt9C3uqg_X_75gyGS4jAxsNIjrRBRheFXZ6x96OvGloBgM.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
@@ -971,7 +970,7 @@ module.exports = {
   font-family: 'Nabla';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/nabla/v9/j8_D6-LI0Lvpe7Makz5UhJt9C3uqg_X_75gyGS4jAxsNIjrRBRleFXZ6x96OvGloBgM.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -980,7 +979,7 @@ module.exports = {
   font-family: 'Nabla';
   font-style: normal;
   font-weight: 400;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/nabla/v9/j8_D6-LI0Lvpe7Makz5UhJt9C3uqg_X_75gyGS4jAxsNIjrRBRdeFXZ6x96OvAFr.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/test/production/next-font/google-font-mocked-responses.js
+++ b/test/production/next-font/google-font-mocked-responses.js
@@ -1,12 +1,12 @@
 module.exports = {
-  'https://fonts.googleapis.com/css2?family=Open+Sans:wght@300..800&display=optional': `
+  'https://fonts.googleapis.com/css2?family=Open+Sans:wght@300..800&display=swap': `
 /* latin */
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 300 800;
   font-stretch: 100%;
-  font-display: optional;
+  font-display: swap;
   src: url(https://fonts.gstatic.com/s/opensans/v34/memvYaGs126MiZpBA-UvWbX2vVnXBbObj2OVTS-mu0SC55I.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/test/unit/google-font-loader.test.ts
+++ b/test/unit/google-font-loader.test.ts
@@ -13,12 +13,12 @@ describe('@next/font/google loader', () => {
       [
         'Inter',
         {},
-        'https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=optional',
+        'https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap',
       ],
       [
         'Inter',
         { weight: '400' },
-        'https://fonts.googleapis.com/css2?family=Inter:wght@400&display=optional',
+        'https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap',
       ],
       [
         'Inter',
@@ -33,7 +33,7 @@ describe('@next/font/google loader', () => {
       [
         'Source_Sans_Pro',
         { weight: '200', style: 'italic' },
-        'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@1,200&display=optional',
+        'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@1,200&display=swap',
       ],
       [
         'Roboto_Flex',
@@ -56,32 +56,32 @@ describe('@next/font/google loader', () => {
       [
         'Oooh_Baby',
         { weight: '400' },
-        'https://fonts.googleapis.com/css2?family=Oooh+Baby:wght@400&display=optional',
+        'https://fonts.googleapis.com/css2?family=Oooh+Baby:wght@400&display=swap',
       ],
       [
         'Albert_Sans',
         { weight: 'variable', style: 'italic' },
-        'https://fonts.googleapis.com/css2?family=Albert+Sans:ital,wght@1,100..900&display=optional',
+        'https://fonts.googleapis.com/css2?family=Albert+Sans:ital,wght@1,100..900&display=swap',
       ],
       [
         'Fraunces',
         { weight: 'variable', style: 'italic', axes: ['WONK', 'opsz', 'SOFT'] },
-        'https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@1,9..144,100..900,0..100,0..1&display=optional',
+        'https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@1,9..144,100..900,0..100,0..1&display=swap',
       ],
       [
         'Molle',
         { weight: '400' },
-        'https://fonts.googleapis.com/css2?family=Molle:ital,wght@1,400&display=optional',
+        'https://fonts.googleapis.com/css2?family=Molle:ital,wght@1,400&display=swap',
       ],
       [
         'Roboto',
         { weight: ['500', '300', '400'], style: ['normal', 'italic'] },
-        'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=optional',
+        'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap',
       ],
       [
         'Roboto Mono',
         { style: ['italic', 'normal'] },
-        'https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&display=optional',
+        'https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&display=swap',
       ],
       [
         'Fraunces',
@@ -89,27 +89,27 @@ describe('@next/font/google loader', () => {
           style: ['normal', 'italic'],
           axes: ['WONK', 'opsz', 'SOFT'],
         },
-        'https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,100..900,0..100,0..1;1,9..144,100..900,0..100,0..1&display=optional',
+        'https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,100..900,0..100,0..1;1,9..144,100..900,0..100,0..1&display=swap',
       ],
       [
         'Poppins',
         { weight: ['900', '400', '100'] },
-        'https://fonts.googleapis.com/css2?family=Poppins:wght@100;400;900&display=optional',
+        'https://fonts.googleapis.com/css2?family=Poppins:wght@100;400;900&display=swap',
       ],
       [
         'Nabla',
         {},
-        'https://fonts.googleapis.com/css2?family=Nabla&display=optional',
+        'https://fonts.googleapis.com/css2?family=Nabla&display=swap',
       ],
       [
         'Nabla',
         { axes: ['EDPT', 'EHLT'] },
-        'https://fonts.googleapis.com/css2?family=Nabla:EDPT,EHLT@0..200,0..24&display=optional',
+        'https://fonts.googleapis.com/css2?family=Nabla:EDPT,EHLT@0..200,0..24&display=swap',
       ],
       [
         'Ballet',
         {},
-        'https://fonts.googleapis.com/css2?family=Ballet&display=optional',
+        'https://fonts.googleapis.com/css2?family=Ballet&display=swap',
       ],
     ])('%s', async (functionName: string, data: any, url: string) => {
       fetch.mockResolvedValue({

--- a/test/unit/local-font-loader.test.ts
+++ b/test/unit/local-font-loader.test.ts
@@ -23,7 +23,7 @@ describe('@next/font/local', () => {
         "@font-face {
         font-family: myFont;
         src: url(/_next/static/media/my-font.woff2) format('woff2');
-        font-display: optional;
+        font-display: swap;
         }
         "
       `)
@@ -50,7 +50,7 @@ describe('@next/font/local', () => {
         "@font-face {
         font-family: myFont;
         src: url(/_next/static/media/my-font.woff2) format('woff2');
-        font-display: optional;
+        font-display: swap;
         font-weight: 100 900;
         font-style: italic;
         }
@@ -89,7 +89,7 @@ describe('@next/font/local', () => {
         ascent-override: 90%;
         font-family: myFont;
         src: url(/_next/static/media/my-font.woff2) format('woff2');
-        font-display: optional;
+        font-display: swap;
         }
         "
       `)
@@ -140,7 +140,7 @@ describe('@next/font/local', () => {
         "@font-face {
         font-family: myFont;
         src: url(/_next/static/media/my-font.woff2) format('woff2');
-        font-display: optional;
+        font-display: swap;
         font-weight: 100;
         font-style: italic;
         }
@@ -148,7 +148,7 @@ describe('@next/font/local', () => {
         @font-face {
         font-family: myFont;
         src: url(/_next/static/media/my-font.woff2) format('woff2');
-        font-display: optional;
+        font-display: swap;
         font-weight: 400;
         font-style: italic;
         }
@@ -156,7 +156,7 @@ describe('@next/font/local', () => {
         @font-face {
         font-family: myFont;
         src: url(/_next/static/media/my-font.woff2) format('woff2');
-        font-display: optional;
+        font-display: swap;
         font-weight: 700;
         font-style: italic;
         }
@@ -164,7 +164,7 @@ describe('@next/font/local', () => {
         @font-face {
         font-family: myFont;
         src: url(/_next/static/media/my-font.woff2) format('woff2');
-        font-display: optional;
+        font-display: swap;
         font-weight: 400;
         font-style: normal;
         }
@@ -212,7 +212,7 @@ describe('@next/font/local', () => {
         "@font-face {
         font-family: myFont;
         src: url(/_next/static/media/my-font.woff2) format('woff2');
-        font-display: optional;
+        font-display: swap;
         font-weight: 400;
         font-style: normal;
         }
@@ -220,7 +220,7 @@ describe('@next/font/local', () => {
         @font-face {
         font-family: myFont;
         src: url(/_next/static/media/my-font.woff2) format('woff2');
-        font-display: optional;
+        font-display: swap;
         font-weight: 400;
         font-style: italic;
         }
@@ -228,7 +228,7 @@ describe('@next/font/local', () => {
         @font-face {
         font-family: myFont;
         src: url(/_next/static/media/my-font.woff2) format('woff2');
-        font-display: optional;
+        font-display: swap;
         font-weight: 700;
         }
         "


### PR DESCRIPTION
The current default [font-display](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) is `optional`. With it, the browser only renders the font if it's loaded within 100ms. This is the best option for performance, your text always renders quickly, independent of network speed.

The downside is that your intended font isn't guaranteed to be used. This has caused a lot of confusion. Given user feedback this PR changes the default `font-display` to `swap`. This ensures the intended font always is displayed with the tradeoff of minimal layout shifts.

[slack ref](https://vercel.slack.com/archives/C03KED0D4N7/p1674949620477649)

fix NEXT-430 ([link](https://linear.app/vercel/issue/NEXT-430))

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
