### PR TITLE
Export the Metadata type

### DIFF
--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -32,7 +32,7 @@ import { ResolvedTwitterMetadata, Twitter } from './twitter-types'
 export interface Metadata {
   // origin and base path for absolute urls for various metadata links such as
   // opengraph-image
-  metadataBase: null | URL
+  metadataBase?: null | URL
 
   // The Document title
   title?: null | string | TemplateString

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -28,6 +28,9 @@ export type ServerRuntime = 'nodejs' | 'experimental-edge' | 'edge' | undefined
 // @ts-ignore This path is generated at build time and conflicts otherwise
 export { NextConfig } from '../dist/server/config'
 
+// @ts-ignore This path is generated at build time and conflicts otherwise
+export { Metadata } from '../dist/lib/metadata/types/metadata-interface'
+
 // Extend the React types with missing properties
 declare module 'react' {
   // <html amp=""> support

--- a/test/e2e/app-dir/metadata/app/title/page.tsx
+++ b/test/e2e/app-dir/metadata/app/title/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
+import type { Metadata } from 'next'
 
 export default function Page() {
   return (
@@ -11,6 +12,6 @@ export default function Page() {
   )
 }
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'this is the page title',
 }


### PR DESCRIPTION
This allows people to manually type their exported `metadata` field:

<img width="610" alt="CleanShot 2023-01-31 at 15 43 00@2x" src="https://user-images.githubusercontent.com/3676859/215792182-8d9cf72a-dedf-4cc9-8613-d4eb49501abc.png">

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
