### PR TITLE
misc: move entrypoints creation into webpack build step (3/6)

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -133,7 +133,7 @@ export function createPagesMapping({
   }
 }
 
-interface CreateEntrypointsParams {
+export interface CreateEntrypointsParams {
   buildId: string
   config: NextConfigComplete
   envFiles: LoadedEnvFiles

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1,5 +1,4 @@
 import '../lib/setup-exception-listeners'
-import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { loadEnvConfig } from '@next/env'
 import chalk from 'next/dist/compiled/chalk'
 import crypto from 'crypto'
@@ -82,7 +81,7 @@ import {
 } from '../telemetry/events'
 import { Telemetry } from '../telemetry/storage'
 import { getPageStaticInfo } from './analysis/get-page-static-info'
-import { createEntrypoints, createPagesMapping } from './entries'
+import { createPagesMapping } from './entries'
 import { generateBuildId } from './generate-build-id'
 import { isWriteable } from './is-writeable'
 import * as Log from './output/log'
@@ -149,12 +148,6 @@ export const NextBuildContext: Partial<{
   telemetryPlugin: TelemetryPlugin
   buildSpinner: any
   nextBuildSpan: Span
-  entrypoints: {
-    client: webpack.EntryObject
-    server: webpack.EntryObject
-    edgeServer: webpack.EntryObject
-    middlewareMatchers: undefined
-  }
   dir: string
 }> = {}
 
@@ -565,26 +558,6 @@ export default async function build(
         })
       }
 
-      const entrypoints = await nextBuildSpan
-        .traceChild('create-entrypoints')
-        .traceAsyncFn(() =>
-          createEntrypoints({
-            buildId,
-            config,
-            envFiles: loadedEnvFiles,
-            isDev: false,
-            pages: mappedPages,
-            pagesDir,
-            previewMode: previewProps,
-            rootDir: dir,
-            rootPaths: mappedRootPaths,
-            appDir,
-            appPaths: mappedAppPages,
-            pageExtensions: config.pageExtensions,
-          })
-        )
-      NextBuildContext.entrypoints = entrypoints
-
       const pagesPageKeys = Object.keys(mappedPages)
 
       const conflictingAppPagePaths: [pagePath: string, appPath: string][] = []
@@ -947,17 +920,32 @@ export default async function build(
           ignore: [] as string[],
         }))
 
-      const webpackBuildDuration = await webpackBuild({
-        buildId,
-        config,
-        pagesDir,
-        reactProductionProfiling,
-        rewrites,
-        target,
-        appDir,
-        noMangling,
-        middlewareMatchers: entrypoints.middlewareMatchers,
-      })
+      const webpackBuildDuration = await webpackBuild(
+        {
+          buildId,
+          config,
+          pagesDir,
+          reactProductionProfiling,
+          rewrites,
+          target,
+          appDir,
+          noMangling,
+        },
+        {
+          buildId,
+          config,
+          envFiles: loadedEnvFiles,
+          isDev: false,
+          pages: mappedPages,
+          pagesDir,
+          previewMode: previewProps,
+          rootDir: dir,
+          rootPaths: mappedRootPaths,
+          appDir,
+          appPaths: mappedAppPages,
+          pageExtensions: config.pageExtensions,
+        }
+      )
 
       telemetry.record(
         eventBuildCompleted(pagesPaths, {

--- a/packages/next/src/build/webpack-build.ts
+++ b/packages/next/src/build/webpack-build.ts
@@ -49,7 +49,6 @@ export async function webpackBuild(
     target: string
     appDir: string | undefined
     noMangling: boolean
-    middlewareMatchers: MiddlewareMatcher[] | undefined
   },
   entrypointsParams: CreateEntrypointsParams
 ): Promise<number> {
@@ -77,18 +76,21 @@ export async function webpackBuild(
           getBaseWebpackConfig(dir, {
             ...commonWebpackOptions,
             runWebpackSpan,
+            middlewareMatchers: entrypoints.middlewareMatchers,
             compilerType: COMPILER_NAMES.client,
             entrypoints: entrypoints.client,
           }),
           getBaseWebpackConfig(dir, {
             ...commonWebpackOptions,
             runWebpackSpan,
+            middlewareMatchers: entrypoints.middlewareMatchers,
             compilerType: COMPILER_NAMES.server,
             entrypoints: entrypoints.server,
           }),
           getBaseWebpackConfig(dir, {
             ...commonWebpackOptions,
             runWebpackSpan,
+            middlewareMatchers: entrypoints.middlewareMatchers,
             compilerType: COMPILER_NAMES.edgeServer,
             entrypoints: entrypoints.edgeServer,
           }),

--- a/packages/next/src/build/webpack-build.ts
+++ b/packages/next/src/build/webpack-build.ts
@@ -15,7 +15,6 @@ import { injectedClientEntries } from './webpack/plugins/flight-client-entry-plu
 import { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
 import { Rewrite } from '../lib/load-custom-routes'
 import { NextConfigComplete } from '../server/config-shared'
-import { MiddlewareMatcher } from './analysis/get-page-static-info'
 import { NextBuildContext } from '.'
 import { CreateEntrypointsParams, createEntrypoints } from './entries'
 


### PR DESCRIPTION
During build, entrypoint creation is only useful for the webpack build process. Since I extracted it to another file, it makes sense to also move it there.

Note: the way the params are added sucks, this is corrected in the next diff.


<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
