### PR TITLE
perf: add experimental option to run webpack build in a worker (6/6)

### DIFF
--- a/packages/next/src/build/webpack-build.ts
+++ b/packages/next/src/build/webpack-build.ts
@@ -248,12 +248,13 @@ async function webpackBuildImpl(): Promise<number> {
   }
 }
 
+// the main function when this file is run as a worker
 async function workerMain() {
   const { buildContext } = workerData
-  // setup new build context
+  // setup new build context from the serialized data passed from the parent
   Object.assign(NextBuildContext, buildContext)
 
-  // regenerate config
+  /// load the config because it's not serializable
   NextBuildContext.config = await loadConfig(
     PHASE_PRODUCTION_BUILD,
     NextBuildContext.dir!,
@@ -261,7 +262,6 @@ async function workerMain() {
     undefined,
     true
   )
-
   NextBuildContext.nextBuildSpan = trace('next-build')
 
   try {

--- a/packages/next/src/build/webpack-build.ts
+++ b/packages/next/src/build/webpack-build.ts
@@ -269,6 +269,8 @@ async function workerMain() {
     parentPort!.postMessage(result)
   } catch (e) {
     parentPort!.postMessage(e)
+  } finally {
+    process.exit(0)
   }
 }
 

--- a/packages/next/src/build/webpack-build.ts
+++ b/packages/next/src/build/webpack-build.ts
@@ -6,6 +6,7 @@ import {
   COMPILER_NAMES,
   CLIENT_STATIC_FILES_RUNTIME_MAIN_APP,
   APP_CLIENT_INTERNALS,
+  PHASE_PRODUCTION_BUILD,
 } from '../shared/lib/constants'
 import { runCompiler } from './compiler'
 import * as Log from './output/log'
@@ -14,8 +15,10 @@ import { NextError } from '../lib/is-error'
 import { injectedClientEntries } from './webpack/plugins/flight-client-entry-plugin'
 import { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
 import { NextBuildContext } from './build-context'
-
+import { isMainThread, parentPort, Worker, workerData } from 'worker_threads'
 import { createEntrypoints } from './entries'
+import loadConfig from '../server/config'
+import { trace } from '../trace'
 
 type CompilerResult = {
   errors: webpack.StatsError[]
@@ -33,7 +36,7 @@ function isTelemetryPlugin(plugin: unknown): plugin is TelemetryPlugin {
   return plugin instanceof TelemetryPlugin
 }
 
-export async function webpackBuild(): Promise<number> {
+async function webpackBuildImpl(): Promise<number> {
   let result: CompilerResult | null = {
     warnings: [],
     errors: [],
@@ -45,7 +48,6 @@ export async function webpackBuild(): Promise<number> {
   const dir = NextBuildContext.dir!
 
   const runWebpackSpan = nextBuildSpan.traceChild('run-webpack-compiler')
-
   const entrypoints = await nextBuildSpan
     .traceChild('create-entrypoints')
     .traceAsyncFn(() =>
@@ -243,5 +245,70 @@ export async function webpackBuild(): Promise<number> {
       Log.info('Compiled successfully')
     }
     return webpackBuildEnd[0]
+  }
+}
+
+async function workerMain() {
+  const { buildContext } = workerData
+  // setup new build context
+  Object.assign(NextBuildContext, buildContext)
+
+  // regenerate config
+  NextBuildContext.config = await loadConfig(
+    PHASE_PRODUCTION_BUILD,
+    NextBuildContext.dir!,
+    undefined,
+    undefined,
+    true
+  )
+
+  NextBuildContext.nextBuildSpan = trace('next-build')
+
+  try {
+    const result = await webpackBuildImpl()
+    parentPort!.postMessage(result)
+  } catch (e) {
+    parentPort!.postMessage(e)
+  }
+}
+
+if (!isMainThread) {
+  workerMain()
+}
+
+async function webpackBuildWithWorker() {
+  const {
+    config,
+    telemetryPlugin,
+    buildSpinner,
+    nextBuildSpan,
+    ...prunedBuildContext
+  } = NextBuildContext
+  const worker = new Worker(new URL(import.meta.url), {
+    workerData: {
+      buildContext: prunedBuildContext,
+    },
+  })
+
+  const result = await new Promise((resolve, reject) => {
+    worker.on('message', resolve)
+    worker.on('error', reject)
+    worker.on('exit', (code) => {
+      if (code !== 0) {
+        reject(new Error(`Worker stopped with exit code ${code}`))
+      }
+    })
+  })
+
+  return result as number
+}
+
+export async function webpackBuild() {
+  const config = NextBuildContext.config!
+
+  if (config.experimental.webpackBuildWorker) {
+    return await webpackBuildWithWorker()
+  } else {
+    return await webpackBuildImpl()
   }
 }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -438,6 +438,9 @@ const configSchema = {
         mdxRs: {
           type: 'boolean',
         },
+        webpackBuildWorker: {
+          type: 'boolean',
+        },
         turbopackLoaders: {
           type: 'object',
         },

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -178,6 +178,10 @@ export interface ExperimentalConfig {
     memoryLimit?: number
   }
   mdxRs?: boolean
+  /**
+   * This option is to enable running the Webpack build in a worker thread.
+   */
+  webpackBuildWorker?: boolean
 }
 
 export type ExportPathMap = {


### PR DESCRIPTION
A lot of the memory used by Next during the build process comes from the webpack compilation. Unfortunately, this memory is not cleaned because of various memory leaks within Webpack. This can then impact subsequent steps in the build. In order to alleviate this issue, I'm adding an option to run the webpack compilation in a separate worker.

Note:
- this is experimental because it breaks telemetry + some random things like the spinners. I'll fix this once we release this for real, if it works well for us.

On a random app from the app directory, memory went down from 250MB to 50MB post-build

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
