### PR TITLE
Make client boundary unserializable props a warning instead of an error

### DIFF
--- a/packages/next/src/server/typescript/rules/client-boundary.ts
+++ b/packages/next/src/server/typescript/rules/client-boundary.ts
@@ -48,15 +48,15 @@ const clientBoundary = {
 
         if (typeDeclarationNode) {
           if (
-            // Show errors for not serializable props.
+            // Show warning for not serializable props.
             ts.isFunctionOrConstructorTypeNode(typeDeclarationNode) ||
             ts.isClassDeclaration(typeDeclarationNode)
           ) {
             diagnostics.push({
               file: source,
-              category: ts.DiagnosticCategory.Error,
+              category: ts.DiagnosticCategory.Warning,
               code: NEXT_TS_ERRORS.INVALID_CLIENT_ENTRY_PROP,
-              messageText: `All props must be serializable for client components in the entry file, "${propName}" is invalid.`,
+              messageText: `Props must be serializable for components in the "use client" entry file, "${propName}" is invalid.`,
               start: prop.getStart(),
               length: prop.getWidth(),
             })


### PR DESCRIPTION
It's not always an error when this occurred, like you can still import a client boundary from a client component. Although we want to make it a conventional thing so it's more like a warning in the moment.

Thanks to @MaxLeiter's feedback.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
