### PR TITLE
Fix middleware matcher for i18n with negative look ahead (#45504)closes https://github.com/vercel/next.js/issues/40305

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -159,7 +159,9 @@ function getMiddlewareMatchers(
     const isRoot = source === '/'
 
     if (i18n?.locales && r.locale !== false) {
-      source = `/:nextInternalLocale([^/.]{1,})${isRoot ? '' : source}`
+      source = `/:nextInternalLocale((?!_next/)[^/.]{1,})${
+        isRoot ? '' : source
+      }`
     }
 
     source = `/:nextData(_next/data/[^/]{1,})?${source}${


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

Found a bug with excluding `/_next/static` from Edge Middleware due to `/_next` being special-cased when deployed and i18n is configured.

```
export const config = {
  matcher: [
    '/',
    '/((?!api|_next/static|favicon|.well-known|auth|sitemap|robots.txt|files).*)',
  ],
};
```

closes: https://github.com/vercel/next.js/issues/40305

## Bug

- [X] Related issues linked using `fixes #number`
- [X] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
