### PR TITLE
build(cargo): Automate Turbopack updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,21 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  commitMessageTopic: 'Rust crate {{depName}}',
+  enabledManagers: ['cargo'],
+  rangeStrategy: 'bump',
+  packageRules: [
+    // Update next-binding whenever a new GH tag is released.
+    {
+      matchPackageNames: ['next-binding'],
+      matchDatasources: ['github-tags'],
+      // Turbopack's fast releases use tags like `turbopack-YYMMDD.XYZ`
+      versioning: 'regex:^turbopack-(?<major>\\d{2})(?<minor>\\d{2})(?<patch>\\d{2})\\.(?<prerelease>\\d+)$',
+    },
+    // Ignore any packages that aren't next-binding
+    {
+      matchPackagePatterns: ['*'],
+      excludePackageNames: ['next-binding'],
+      enabled: false,
+    },
+  ],
+}


### PR DESCRIPTION
This adds a new renovate configuration to automatically create PRs as we release new Turbopack versions.

This is the easiest way for us to start our release automation, but the end goal is to eventually split the `next-swc` crate out of the `vercel/next.js` repo and move it into `verce/turbo`. That's because one of our pain points during release is that `next-swc` includes several dependencies which frequently cause build conflicts with Turbopack's dependencies. But that'll be a longer task, because we need to setup the binary building and release process.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
