### PR TITLE
Rename precedence

### DIFF
--- a/packages/next/src/server/app-render.tsx
+++ b/packages/next/src/server/app-render.tsx
@@ -1567,7 +1567,7 @@ export async function renderToHTMLOrFlight(
                       // resource loading and deduplication, etc:
                       // https://github.com/facebook/react/pull/25060
                       // @ts-ignore
-                      precedence="high"
+                      precedence="next.js"
                       key={index}
                     />
                   ))


### PR DESCRIPTION
This field behaves the same as a CSS layers. Where they get added in the order they're discovered. This means that the first discovered one is always the lowest precedence. The stylesheet imported as modules in Webpack are always added first. Which means that they have the lowest precedence. The string `"high"` doesn't make any sense to add first.

We might add ways to add other ones but the string can just be anything. So we'll make it "next.js" to indicate that this is the grouping where all the Next.js styles are added.