### PR TITLE
Refactor navigateReducer to handle mutable consistently

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -194,6 +194,7 @@ function Router({
         type: ACTION_NAVIGATE,
         url,
         isExternalUrl: isExternalURL(url),
+        locationSearch: location.search,
         forceOptimisticNavigation,
         navigateType,
         cache: {

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
@@ -131,6 +131,7 @@ describe('navigateReducer', () => {
       type: ACTION_NAVIGATE,
       url: new URL('/linking/about', 'https://localhost'),
       isExternalUrl: false,
+      locationSearch: '',
       navigateType: 'push',
       forceOptimisticNavigation: false,
       cache: {
@@ -308,6 +309,7 @@ describe('navigateReducer', () => {
       type: ACTION_NAVIGATE,
       url: new URL('/linking/about', 'https://localhost'),
       isExternalUrl: false,
+      locationSearch: '',
       navigateType: 'push',
       forceOptimisticNavigation: false,
       cache: {
@@ -490,6 +492,7 @@ describe('navigateReducer', () => {
       type: ACTION_NAVIGATE,
       url,
       isExternalUrl,
+      locationSearch: '',
       navigateType: 'push',
       forceOptimisticNavigation: false,
       cache: {
@@ -643,6 +646,7 @@ describe('navigateReducer', () => {
       type: ACTION_NAVIGATE,
       url,
       isExternalUrl,
+      locationSearch: '',
       navigateType: 'replace',
       forceOptimisticNavigation: false,
       cache: {
@@ -793,6 +797,7 @@ describe('navigateReducer', () => {
       type: ACTION_NAVIGATE,
       url: new URL('/linking/about', 'https://localhost'),
       isExternalUrl: false,
+      locationSearch: '',
       navigateType: 'push',
       forceOptimisticNavigation: true,
       cache: {

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
@@ -1,27 +1,30 @@
 import React from 'react'
-import type { fetchServerResponse } from '../fetch-server-response'
+import type { fetchServerResponse as fetchServerResponseType } from '../fetch-server-response'
 import type { FlightData } from '../../../../server/app-render'
-jest.mock('../fetch-server-response', () => {
-  const flightData: FlightData = [
+const flightData: FlightData = [
+  [
+    'children',
+    'linking',
+    'children',
+    'about',
     [
-      'children',
-      'linking',
-      'children',
       'about',
-      [
-        'about',
-        {
-          children: ['', {}],
-        },
-      ],
-      <h1>About Page!</h1>,
-      <>
-        <title>About page!</title>
-      </>,
+      {
+        children: ['', {}],
+      },
     ],
-  ]
+    <h1>About Page!</h1>,
+    <>
+      <title>About page!</title>
+    </>,
+  ],
+]
+
+jest.mock('../fetch-server-response', () => {
   return {
-    fetchServerResponse: (url: URL): ReturnType<typeof fetchServerResponse> => {
+    fetchServerResponse: (
+      url: URL
+    ): ReturnType<typeof fetchServerResponseType> => {
       if (url.pathname === '/linking/about') {
         return Promise.resolve([flightData, undefined])
       }
@@ -36,8 +39,15 @@ import {
   CacheStates,
 } from '../../../../shared/lib/app-router-context'
 import { createInitialRouterState } from '../create-initial-router-state'
-import { NavigateAction, ACTION_NAVIGATE } from '../router-reducer-types'
+import {
+  NavigateAction,
+  ACTION_NAVIGATE,
+  ACTION_PREFETCH,
+  PrefetchAction,
+} from '../router-reducer-types'
 import { navigateReducer } from './navigate-reducer'
+import { prefetchReducer } from './prefetch-reducer'
+import { fetchServerResponse } from '../fetch-server-response'
 
 const getInitialRouterStateTree = (): FlightRouterState => [
   '',
@@ -382,6 +392,710 @@ describe('navigateReducer', () => {
                                 ]),
                               ],
                             ]),
+                          },
+                        ],
+                      ]),
+                    ],
+                  ]),
+                  data: null,
+                  subTreeData: <>Linking layout level</>,
+                },
+              ],
+            ]),
+          ],
+        ]),
+      },
+      tree: [
+        '',
+        {
+          children: [
+            'linking',
+            {
+              children: ['about', { children: ['', {}] }],
+            },
+          ],
+        },
+        undefined,
+        undefined,
+        true,
+      ],
+    }
+
+    expect(newState).toMatchObject(expectedState)
+  })
+
+  it('should apply navigation for external url (push)', async () => {
+    const initialTree = getInitialRouterStateTree()
+    const initialCanonicalUrl = '/linking'
+    const children = (
+      <html>
+        <head></head>
+        <body>Root layout</body>
+      </html>
+    )
+    const initialParallelRoutes: CacheNode['parallelRoutes'] = new Map([
+      [
+        'children',
+        new Map([
+          [
+            'linking',
+            {
+              status: CacheStates.READY,
+              parallelRoutes: new Map([
+                [
+                  'children',
+                  new Map([
+                    [
+                      '',
+                      {
+                        status: CacheStates.READY,
+                        data: null,
+                        subTreeData: <>Linking page</>,
+                        parallelRoutes: new Map(),
+                      },
+                    ],
+                  ]),
+                ],
+              ]),
+              data: null,
+              subTreeData: <>Linking layout level</>,
+            },
+          ],
+        ]),
+      ],
+    ])
+
+    const state = createInitialRouterState({
+      initialTree,
+      initialCanonicalUrl,
+      children,
+      initialParallelRoutes,
+      isServer: false,
+      location: new URL('/linking', 'https://localhost') as any,
+    })
+
+    const state2 = createInitialRouterState({
+      initialTree,
+      initialCanonicalUrl,
+      children,
+      initialParallelRoutes,
+      isServer: false,
+      location: new URL('/linking', 'https://localhost') as any,
+    })
+
+    const url = new URL('https://example.vercel.sh', 'https://localhost')
+    const isExternalUrl = url.origin !== 'localhost'
+
+    const action: NavigateAction = {
+      type: ACTION_NAVIGATE,
+      url,
+      isExternalUrl,
+      navigateType: 'push',
+      forceOptimisticNavigation: false,
+      cache: {
+        status: CacheStates.LAZY_INITIALIZED,
+        data: null,
+        subTreeData: null,
+        parallelRoutes: new Map(),
+      },
+      mutable: {},
+    }
+
+    await runPromiseThrowChain(() => navigateReducer(state, action))
+
+    const newState = await runPromiseThrowChain(() =>
+      navigateReducer(state2, action)
+    )
+
+    const expectedState: ReturnType<typeof navigateReducer> = {
+      prefetchCache: new Map(),
+      pushRef: {
+        mpaNavigation: true,
+        pendingPush: true,
+      },
+      focusAndScrollRef: {
+        apply: false,
+      },
+      canonicalUrl: 'https://example.vercel.sh/',
+      cache: {
+        status: CacheStates.READY,
+        data: null,
+        subTreeData: (
+          <html>
+            <head></head>
+            <body>Root layout</body>
+          </html>
+        ),
+        parallelRoutes: new Map([
+          [
+            'children',
+            new Map([
+              [
+                'linking',
+                {
+                  status: CacheStates.READY,
+                  parallelRoutes: new Map([
+                    [
+                      'children',
+                      new Map([
+                        [
+                          '',
+                          {
+                            status: CacheStates.READY,
+                            data: null,
+                            subTreeData: <>Linking page</>,
+                            parallelRoutes: new Map(),
+                          },
+                        ],
+                      ]),
+                    ],
+                  ]),
+                  data: null,
+                  subTreeData: <>Linking layout level</>,
+                },
+              ],
+            ]),
+          ],
+        ]),
+      },
+      tree: [
+        '',
+        {
+          children: [
+            'linking',
+            {
+              children: ['', {}],
+            },
+          ],
+        },
+        undefined,
+        undefined,
+        true,
+      ],
+    }
+
+    expect(newState).toMatchObject(expectedState)
+  })
+
+  it('should apply navigation for external url (replace)', async () => {
+    const initialTree = getInitialRouterStateTree()
+    const initialCanonicalUrl = '/linking'
+    const children = (
+      <html>
+        <head></head>
+        <body>Root layout</body>
+      </html>
+    )
+    const initialParallelRoutes: CacheNode['parallelRoutes'] = new Map([
+      [
+        'children',
+        new Map([
+          [
+            'linking',
+            {
+              status: CacheStates.READY,
+              parallelRoutes: new Map([
+                [
+                  'children',
+                  new Map([
+                    [
+                      '',
+                      {
+                        status: CacheStates.READY,
+                        data: null,
+                        subTreeData: <>Linking page</>,
+                        parallelRoutes: new Map(),
+                      },
+                    ],
+                  ]),
+                ],
+              ]),
+              data: null,
+              subTreeData: <>Linking layout level</>,
+            },
+          ],
+        ]),
+      ],
+    ])
+
+    const state = createInitialRouterState({
+      initialTree,
+      initialCanonicalUrl,
+      children,
+      initialParallelRoutes,
+      isServer: false,
+      location: new URL('/linking', 'https://localhost') as any,
+    })
+
+    const state2 = createInitialRouterState({
+      initialTree,
+      initialCanonicalUrl,
+      children,
+      initialParallelRoutes,
+      isServer: false,
+      location: new URL('/linking', 'https://localhost') as any,
+    })
+
+    const url = new URL('https://example.vercel.sh', 'https://localhost')
+    const isExternalUrl = url.origin !== 'localhost'
+
+    const action: NavigateAction = {
+      type: ACTION_NAVIGATE,
+      url,
+      isExternalUrl,
+      navigateType: 'replace',
+      forceOptimisticNavigation: false,
+      cache: {
+        status: CacheStates.LAZY_INITIALIZED,
+        data: null,
+        subTreeData: null,
+        parallelRoutes: new Map(),
+      },
+      mutable: {},
+    }
+
+    await runPromiseThrowChain(() => navigateReducer(state, action))
+
+    const newState = await runPromiseThrowChain(() =>
+      navigateReducer(state2, action)
+    )
+
+    const expectedState: ReturnType<typeof navigateReducer> = {
+      prefetchCache: new Map(),
+      pushRef: {
+        mpaNavigation: true,
+        pendingPush: false,
+      },
+      focusAndScrollRef: {
+        apply: false,
+      },
+      canonicalUrl: 'https://example.vercel.sh/',
+      cache: {
+        status: CacheStates.READY,
+        data: null,
+        subTreeData: (
+          <html>
+            <head></head>
+            <body>Root layout</body>
+          </html>
+        ),
+        parallelRoutes: new Map([
+          [
+            'children',
+            new Map([
+              [
+                'linking',
+                {
+                  status: CacheStates.READY,
+                  parallelRoutes: new Map([
+                    [
+                      'children',
+                      new Map([
+                        [
+                          '',
+                          {
+                            status: CacheStates.READY,
+                            data: null,
+                            subTreeData: <>Linking page</>,
+                            parallelRoutes: new Map(),
+                          },
+                        ],
+                      ]),
+                    ],
+                  ]),
+                  data: null,
+                  subTreeData: <>Linking layout level</>,
+                },
+              ],
+            ]),
+          ],
+        ]),
+      },
+      tree: [
+        '',
+        {
+          children: [
+            'linking',
+            {
+              children: ['', {}],
+            },
+          ],
+        },
+        undefined,
+        undefined,
+        true,
+      ],
+    }
+
+    expect(newState).toMatchObject(expectedState)
+  })
+
+  it('should apply navigation for forceOptimisticNavigation', async () => {
+    const initialTree = getInitialRouterStateTree()
+    const initialCanonicalUrl = '/linking'
+    const children = (
+      <html>
+        <head></head>
+        <body>Root layout</body>
+      </html>
+    )
+    const initialParallelRoutes: CacheNode['parallelRoutes'] = new Map([
+      [
+        'children',
+        new Map([
+          [
+            'linking',
+            {
+              status: CacheStates.READY,
+              parallelRoutes: new Map([
+                [
+                  'children',
+                  new Map([
+                    [
+                      '',
+                      {
+                        status: CacheStates.READY,
+                        data: null,
+                        subTreeData: <>Linking page</>,
+                        parallelRoutes: new Map(),
+                      },
+                    ],
+                  ]),
+                ],
+              ]),
+              data: null,
+              subTreeData: <>Linking layout level</>,
+            },
+          ],
+        ]),
+      ],
+    ])
+
+    const state = createInitialRouterState({
+      initialTree,
+      initialCanonicalUrl,
+      children,
+      initialParallelRoutes,
+      isServer: false,
+      location: new URL('/linking', 'https://localhost') as any,
+    })
+
+    const state2 = createInitialRouterState({
+      initialTree,
+      initialCanonicalUrl,
+      children,
+      initialParallelRoutes,
+      isServer: false,
+      location: new URL('/linking', 'https://localhost') as any,
+    })
+
+    const action: NavigateAction = {
+      type: ACTION_NAVIGATE,
+      url: new URL('/linking/about', 'https://localhost'),
+      isExternalUrl: false,
+      navigateType: 'push',
+      forceOptimisticNavigation: true,
+      cache: {
+        status: CacheStates.LAZY_INITIALIZED,
+        data: null,
+        subTreeData: null,
+        parallelRoutes: new Map(),
+      },
+      mutable: {},
+    }
+
+    await runPromiseThrowChain(() => navigateReducer(state, action))
+
+    const newState = await runPromiseThrowChain(() =>
+      navigateReducer(state2, action)
+    )
+
+    const expectedState: ReturnType<typeof navigateReducer> = {
+      prefetchCache: new Map(),
+      pushRef: {
+        mpaNavigation: false,
+        pendingPush: true,
+      },
+      focusAndScrollRef: {
+        apply: true,
+      },
+      canonicalUrl: '/linking/about',
+      cache: {
+        status: CacheStates.READY,
+        data: null,
+        subTreeData: (
+          <html>
+            <head></head>
+            <body>Root layout</body>
+          </html>
+        ),
+        parallelRoutes: new Map([
+          [
+            'children',
+            new Map([
+              [
+                'linking',
+                {
+                  status: CacheStates.READY,
+                  parallelRoutes: new Map([
+                    [
+                      'children',
+                      new Map([
+                        [
+                          '',
+                          {
+                            status: CacheStates.READY,
+                            data: null,
+                            subTreeData: <>Linking page</>,
+                            parallelRoutes: new Map(),
+                          },
+                        ],
+                        [
+                          'about',
+                          {
+                            status: CacheStates.DATA_FETCH,
+                            // Real promise is not needed here.
+                            data: Promise.resolve() as any,
+                            parallelRoutes: new Map(),
+                            subTreeData: null,
+                          },
+                        ],
+                      ]),
+                    ],
+                  ]),
+                  data: null,
+                  subTreeData: <>Linking layout level</>,
+                },
+              ],
+            ]),
+          ],
+        ]),
+      },
+      tree: [
+        '',
+        {
+          children: [
+            'linking',
+            {
+              children: ['about', { children: ['', {}] }, undefined, 'refetch'],
+            },
+          ],
+        },
+        // TODO-APP: optimistic tree is wrong
+        // undefined,
+        // undefined,
+        // true,
+      ],
+    }
+
+    expect(newState).toMatchObject(expectedState)
+  })
+
+  it('should apply navigation with prefetched data', async () => {
+    const initialTree = getInitialRouterStateTree()
+    const initialCanonicalUrl = '/linking'
+    const children = (
+      <html>
+        <head></head>
+        <body>Root layout</body>
+      </html>
+    )
+    const initialParallelRoutes: CacheNode['parallelRoutes'] = new Map([
+      [
+        'children',
+        new Map([
+          [
+            'linking',
+            {
+              status: CacheStates.READY,
+              parallelRoutes: new Map([
+                [
+                  'children',
+                  new Map([
+                    [
+                      '',
+                      {
+                        status: CacheStates.READY,
+                        data: null,
+                        subTreeData: <>Linking page</>,
+                        parallelRoutes: new Map(),
+                      },
+                    ],
+                  ]),
+                ],
+              ]),
+              data: null,
+              subTreeData: <>Linking layout level</>,
+            },
+          ],
+        ]),
+      ],
+    ])
+
+    const url = new URL('/linking/about', 'https://localhost')
+    const serverResponse = await fetchServerResponse(url, initialTree, true)
+    const prefetchAction: PrefetchAction = {
+      type: ACTION_PREFETCH,
+      url,
+      tree: initialTree,
+      serverResponse,
+    }
+
+    const state = createInitialRouterState({
+      initialTree,
+      initialCanonicalUrl,
+      children,
+      initialParallelRoutes,
+      isServer: false,
+      location: new URL('/linking', 'https://localhost') as any,
+    })
+
+    await runPromiseThrowChain(() => prefetchReducer(state, prefetchAction))
+
+    const state2 = createInitialRouterState({
+      initialTree,
+      initialCanonicalUrl,
+      children,
+      initialParallelRoutes,
+      isServer: false,
+      location: new URL('/linking', 'https://localhost') as any,
+    })
+
+    await runPromiseThrowChain(() => prefetchReducer(state2, prefetchAction))
+
+    const action: NavigateAction = {
+      type: ACTION_NAVIGATE,
+      url: new URL('/linking/about', 'https://localhost'),
+      isExternalUrl: false,
+      navigateType: 'push',
+      locationSearch: '',
+      forceOptimisticNavigation: false,
+      cache: {
+        status: CacheStates.LAZY_INITIALIZED,
+        data: null,
+        subTreeData: null,
+        parallelRoutes: new Map(),
+      },
+      mutable: {},
+    }
+
+    await runPromiseThrowChain(() => navigateReducer(state, action))
+
+    const newState = await runPromiseThrowChain(() =>
+      navigateReducer(state2, action)
+    )
+
+    const expectedState: ReturnType<typeof navigateReducer> = {
+      prefetchCache: new Map([
+        [
+          '/linking/about',
+          {
+            canonicalUrlOverride: undefined,
+            flightData: [
+              [
+                'children',
+                'linking',
+                'children',
+                'about',
+                [
+                  'about',
+                  {
+                    children: ['', {}],
+                  },
+                ],
+                <h1>About Page!</h1>,
+                <React.Fragment>
+                  <title>About page!</title>
+                </React.Fragment>,
+              ],
+            ],
+            tree: [
+              '',
+              {
+                children: [
+                  'linking',
+                  {
+                    children: [
+                      'about',
+                      {
+                        children: ['', {}],
+                      },
+                    ],
+                  },
+                ],
+              },
+              undefined,
+              undefined,
+              true,
+            ],
+          },
+        ],
+      ]),
+      pushRef: {
+        mpaNavigation: false,
+        pendingPush: true,
+      },
+      focusAndScrollRef: {
+        apply: true,
+      },
+      canonicalUrl: '/linking/about',
+      cache: {
+        status: CacheStates.READY,
+        data: null,
+        subTreeData: (
+          <html>
+            <head></head>
+            <body>Root layout</body>
+          </html>
+        ),
+        parallelRoutes: new Map([
+          [
+            'children',
+            new Map([
+              [
+                'linking',
+                {
+                  status: CacheStates.READY,
+                  parallelRoutes: new Map([
+                    [
+                      'children',
+                      new Map([
+                        [
+                          '',
+                          {
+                            status: CacheStates.READY,
+                            data: null,
+                            subTreeData: <>Linking page</>,
+                            parallelRoutes: new Map(),
+                          },
+                        ],
+                        [
+                          'about',
+                          {
+                            status: CacheStates.READY,
+                            data: null,
+                            parallelRoutes: new Map([
+                              [
+                                'children',
+                                new Map([
+                                  [
+                                    '',
+                                    {
+                                      status: CacheStates.LAZY_INITIALIZED,
+                                      subTreeData: null,
+                                      data: null,
+                                      head: (
+                                        <>
+                                          <title>About page!</title>
+                                        </>
+                                      ),
+                                      parallelRoutes: new Map(),
+                                    },
+                                  ],
+                                ]),
+                              ],
+                            ]),
+                            subTreeData: <h1>About Page!</h1>,
                           },
                         ],
                       ]),

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -25,8 +25,8 @@ export function refreshReducer(
   if (mutable.mpaNavigation && isForCurrentTree) {
     return {
       // Set href.
-      canonicalUrl: mutable.canonicalUrlOverride
-        ? mutable.canonicalUrlOverride
+      canonicalUrl: mutable.canonicalUrl
+        ? mutable.canonicalUrl
         : state.canonicalUrl,
       // TODO-APP: verify mpaNavigation not being set is correct here.
       pushRef: {
@@ -47,9 +47,7 @@ export function refreshReducer(
   if (mutable.patchedTree && isForCurrentTree) {
     return {
       // Set href.
-      canonicalUrl: mutable.canonicalUrlOverride
-        ? mutable.canonicalUrlOverride
-        : href,
+      canonicalUrl: mutable.canonicalUrl ? mutable.canonicalUrl : href,
       // set pendingPush (always false in this case).
       pushRef: state.pushRef,
       // Apply focus and scroll.
@@ -118,7 +116,7 @@ export function refreshReducer(
     : undefined
 
   if (canonicalUrlOverride) {
-    mutable.canonicalUrlOverride = canonicalUrlOverrideHref
+    mutable.canonicalUrl = canonicalUrlOverrideHref
   }
 
   mutable.previousTree = state.tree

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -29,8 +29,8 @@ export function serverPatchReducer(
   if (mutable.mpaNavigation) {
     return {
       // Set href.
-      canonicalUrl: mutable.canonicalUrlOverride
-        ? mutable.canonicalUrlOverride
+      canonicalUrl: mutable.canonicalUrl
+        ? mutable.canonicalUrl
         : state.canonicalUrl,
       // TODO-APP: verify mpaNavigation not being set is correct here.
       pushRef: {
@@ -51,8 +51,8 @@ export function serverPatchReducer(
   if (mutable.patchedTree) {
     return {
       // Keep href as it was set during navigate / restore
-      canonicalUrl: mutable.canonicalUrlOverride
-        ? mutable.canonicalUrlOverride
+      canonicalUrl: mutable.canonicalUrl
+        ? mutable.canonicalUrl
         : state.canonicalUrl,
       // Keep pushRef as server-patch only causes cache/tree update.
       pushRef: state.pushRef,
@@ -105,7 +105,7 @@ export function serverPatchReducer(
     : undefined
 
   if (canonicalUrlOverrideHref) {
-    mutable.canonicalUrlOverride = canonicalUrlOverrideHref
+    mutable.canonicalUrl = canonicalUrlOverrideHref
   }
 
   mutable.patchedTree = newTree

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -12,8 +12,10 @@ export interface Mutable {
   mpaNavigation?: boolean
   previousTree?: FlightRouterState
   patchedTree?: FlightRouterState
-  canonicalUrlOverride?: string
-  useExistingCache?: true
+  canonicalUrl?: string
+  applyFocusAndScroll?: boolean
+  pendingPush?: boolean
+  cache?: CacheNode
 }
 
 /**
@@ -67,6 +69,7 @@ export interface NavigateAction {
   type: typeof ACTION_NAVIGATE
   url: URL
   isExternalUrl: boolean
+  locationSearch: Location['search']
   navigateType: 'push' | 'replace'
   forceOptimisticNavigation: boolean
   cache: CacheNode


### PR DESCRIPTION
Creates a separate handleMutable function that ensures the initial call and the second call are the same.
This only changes navigateReducer right now but I'll reuse the same handling for serverPatch and refresh too when this lands.

Additionally found a bug where mpaNavigation was checked incorrectly with `forceOptimisticNavigation`.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
