### PR TITLE
Optimize size for the error component

### DIFF
--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -4,8 +4,9 @@ import React from 'react'
 
 const styles = {
   error: {
+    // https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css#L38-L52
     fontFamily:
-      '-apple-system, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
+      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
     height: '100vh',
     textAlign: 'center',
     display: 'flex',
@@ -14,18 +15,13 @@ const styles = {
     justifyContent: 'center',
   },
   desc: {
-    display: 'inline-block',
     textAlign: 'left',
-    lineHeight: '49px',
-    height: '49px',
-    verticalAlign: 'middle',
   },
   text: {
     fontSize: '14px',
-    fontWeight: 'normal',
-    lineHeight: '49px',
+    fontWeight: 400,
+    lineHeight: '3em',
     margin: 0,
-    padding: 0,
   },
 } as const
 

--- a/packages/next/src/client/components/error.tsx
+++ b/packages/next/src/client/components/error.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 
 const styles: { [k: string]: React.CSSProperties } = {
   error: {
+    // https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css#L38-L52
     fontFamily:
-      '-apple-system, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
+      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
     height: '100vh',
     textAlign: 'center',
     display: 'flex',
@@ -14,29 +15,23 @@ const styles: { [k: string]: React.CSSProperties } = {
 
   desc: {
     display: 'inline-block',
-    textAlign: 'left',
-    lineHeight: '49px',
-    height: '49px',
-    verticalAlign: 'middle',
   },
 
   h1: {
     display: 'inline-block',
-    margin: 0,
-    marginRight: '20px',
+    margin: '0 20px 0 0',
     padding: '0 23px 0 0',
-    fontSize: '24px',
+    fontSize: 24,
     fontWeight: 500,
     verticalAlign: 'top',
-    lineHeight: '49px',
+    lineHeight: 49,
   },
 
   h2: {
-    fontSize: '14px',
-    fontWeight: 'normal',
-    lineHeight: '49px',
+    fontSize: 14,
+    fontWeight: 400,
+    lineHeight: 49,
     margin: 0,
-    padding: 0,
   },
 }
 
@@ -49,19 +44,20 @@ export function NotFound() {
       <div>
         <style
           dangerouslySetInnerHTML={{
-            __html: `
-            body { margin: 0; color: #000; background: #fff; }
-            .next-error-h1 {
-              border-right: 1px solid rgba(0, 0, 0, .3);
-            }
-
-            @media (prefers-color-scheme: dark) {
-              body { color: #fff; background: #000; }
+            /* Minified CSS from
+              body { margin: 0; color: #000; background: #fff; }
               .next-error-h1 {
-                border-right: 1px solid rgba(255, 255, 255, .3);
+                border-right: 1px solid rgba(0, 0, 0, .3);
               }
-            }
-          `,
+
+              @media (prefers-color-scheme: dark) {
+                body { color: #fff; background: #000; }
+                .next-error-h1 {
+                  border-right: 1px solid rgba(255, 255, 255, .3);
+                }
+              }
+             */
+            __html: `body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}`,
           }}
         />
         <h1 className="next-error-h1" style={styles.h1}>

--- a/packages/next/src/pages/_error.tsx
+++ b/packages/next/src/pages/_error.tsx
@@ -26,8 +26,9 @@ function _getInitialProps({
 
 const styles: { [k: string]: React.CSSProperties } = {
   error: {
+    // https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css#L38-L52
     fontFamily:
-      '-apple-system, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
+      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
     height: '100vh',
     textAlign: 'center',
     display: 'flex',
@@ -39,28 +40,23 @@ const styles: { [k: string]: React.CSSProperties } = {
   desc: {
     display: 'inline-block',
     textAlign: 'left',
-    lineHeight: '49px',
-    height: '49px',
-    verticalAlign: 'middle',
   },
 
   h1: {
     display: 'inline-block',
-    margin: 0,
-    marginRight: '20px',
-    padding: '0 23px 0 0',
-    fontSize: '24px',
+    margin: '0 20px 0 0',
+    paddingRight: 23,
+    fontSize: 24,
     fontWeight: 500,
     verticalAlign: 'top',
-    lineHeight: '49px',
+    lineHeight: 49,
   },
 
   h2: {
-    fontSize: '14px',
-    fontWeight: 'normal',
-    lineHeight: '49px',
+    fontSize: 14,
+    fontWeight: 400,
+    lineHeight: 49,
     margin: 0,
-    padding: 0,
   },
 }
 
@@ -92,7 +88,7 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
         <div>
           <style
             dangerouslySetInnerHTML={{
-              __html: `
+              /* CSS minified from
                 body { margin: 0; color: #000; background: #fff; }
                 .next-error-h1 {
                   border-right: 1px solid rgba(0, 0, 0, .3);
@@ -107,7 +103,13 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
                   }
                 }`
                     : ''
-                }`,
+                }
+               */
+              __html: `body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}${
+                withDarkMode
+                  ? '@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}'
+                  : ''
+              }`,
             }}
           />
 


### PR DESCRIPTION
I noticed that by default all pages will contain the error component, but the payload isn't optimized enough even for prod:

<img width="848" alt="CleanShot-2023-02-05-NzKGPCDv@2x" src="https://user-images.githubusercontent.com/3676859/216833690-2b6a79d7-5a74-4c1d-a3b6-ad78c8145b03.png">

The selected payload above is already 1.6KB, and this PR makes it 397 bytes smaller without changing the styling.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
