### PR TITLE
Fix AsyncLocalStorage included in the client bundle

### DIFF
--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -12,7 +12,6 @@ import {
   PathnameContext,
   // LayoutSegmentsContext,
 } from '../../shared/lib/hooks-client-context'
-import { bailoutToClientRendering } from './bailout-to-client-rendering'
 import { clientHookInServerComponentError } from './client-hook-in-server-component-error'
 
 const INTERNAL_URLSEARCHPARAMS_INSTANCE = Symbol(
@@ -78,9 +77,14 @@ export function useSearchParams() {
     return new ReadonlyURLSearchParams(searchParams || new URLSearchParams())
   }, [searchParams])
 
-  if (bailoutToClientRendering()) {
-    // TODO-APP: handle dynamic = 'force-static' here and on the client
-    return readonlySearchParams
+  if (typeof window === 'undefined') {
+    // AsyncLocalStorage should not be included in the client bundle.
+    const { bailoutToClientRendering } =
+      require('./bailout-to-client-rendering') as typeof import('./bailout-to-client-rendering')
+    if (bailoutToClientRendering()) {
+      // TODO-APP: handle dynamic = 'force-static' here and on the client
+      return readonlySearchParams
+    }
   }
 
   if (!searchParams) {


### PR DESCRIPTION
Fixes #45587. `bailout-to-client-rendering` imports `static-generation-async-storage` which creates `AsyncLocalStorage` in the module level. It should only be included in the server bundles, not client.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
