### PR TITLE
Add globalThis to polyfill for old browswers

### DIFF
--- a/packages/next-polyfill-module/src/index.js
+++ b/packages/next-polyfill-module/src/index.js
@@ -118,3 +118,17 @@ if (!Object.fromEntries) {
     }, {})
   }
 }
+
+/**
+ * Available in:
+ * Edge: 79
+ * Firefox: 65
+ * Chrome: 71
+ * Safari: 12.1
+ *
+ * https://caniuse.com/mdn-javascript_builtins_globalthis
+ */
+// Assume this polyfill module only running in browser environment.
+if (typeof globalThis === 'undefined' && typeof window !== 'undefined') {
+  window.globalThis = window
+}


### PR DESCRIPTION
fixes #45587
In this [PR](https://github.com/vercel/next.js/pull/45589), @shuding  already tried to fix #45587 bug.
However there are multiple places that using `globalThis` in browser environment.
under `packages/next/src/compiled` there are many places like `react-server-dom-webpack`, `react/cjs`, etc.

So I added globalThis polyfill on `polyfill module`

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
