### PR TITLE
Fix unsafe caching for isolated tests

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -55,27 +55,131 @@ module.exports = (actionInfo) => {
       }
     },
     async linkPackages({ repoDir, nextSwcVersion }) {
-      execa.sync('pnpm', ['turbo', 'run', 'test-pack'], {
-        cwd: repoDir,
-        env: { NEXT_SWC_VERSION: nextSwcVersion },
-      })
+      let useTestPack = process.env.NEXT_TEST_PACK
 
-      const pkgPaths = new Map()
-      const pkgs = await fs.readdir(path.join(repoDir, 'packages'))
+      if (useTestPack) {
+        execa.sync('pnpm', ['turbo', 'run', 'test-pack'], {
+          cwd: repoDir,
+          env: { NEXT_SWC_VERSION: nextSwcVersion },
+        })
 
-      pkgs.forEach((pkgDirname) => {
-        const { name } = require(path.join(
-          repoDir,
-          'packages',
-          pkgDirname,
-          'package.json'
-        ))
-        pkgPaths.set(
-          name,
-          path.join(repoDir, 'packages', pkgDirname, `packed-${pkgDirname}.tgz`)
+        const pkgPaths = new Map()
+        const pkgs = (await fs.readdir(path.join(repoDir, 'packages'))).filter(
+          (item) => !item.startsWith('.')
         )
-      })
-      return pkgPaths
+
+        pkgs.forEach((pkgDirname) => {
+          const { name } = require(path.join(
+            repoDir,
+            'packages',
+            pkgDirname,
+            'package.json'
+          ))
+          pkgPaths.set(
+            name,
+            path.join(
+              repoDir,
+              'packages',
+              pkgDirname,
+              `packed-${pkgDirname}.tgz`
+            )
+          )
+        })
+        return pkgPaths
+      } else {
+        // TODO: remove after next stable release (current v13.1.2)
+        const pkgPaths = new Map()
+        const pkgDatas = new Map()
+        let pkgs
+
+        try {
+          pkgs = await fs.readdir(path.join(repoDir, 'packages'))
+        } catch (err) {
+          if (err.code === 'ENOENT') {
+            require('console').log('no packages to link')
+            return pkgPaths
+          }
+          throw err
+        }
+
+        for (const pkg of pkgs) {
+          const pkgPath = path.join(repoDir, 'packages', pkg)
+          const packedPkgPath = path.join(pkgPath, `${pkg}-packed.tgz`)
+
+          const pkgDataPath = path.join(pkgPath, 'package.json')
+          if (!fs.existsSync(pkgDataPath)) {
+            require('console').log(`Skipping ${pkgDataPath}`)
+            continue
+          }
+          const pkgData = require(pkgDataPath)
+          const { name } = pkgData
+          pkgDatas.set(name, {
+            pkgDataPath,
+            pkg,
+            pkgPath,
+            pkgData,
+            packedPkgPath,
+          })
+          pkgPaths.set(name, packedPkgPath)
+        }
+
+        for (const pkg of pkgDatas.keys()) {
+          const { pkgDataPath, pkgData } = pkgDatas.get(pkg)
+
+          for (const pkg of pkgDatas.keys()) {
+            const { packedPkgPath } = pkgDatas.get(pkg)
+            if (!pkgData.dependencies || !pkgData.dependencies[pkg]) continue
+            pkgData.dependencies[pkg] = packedPkgPath
+          }
+
+          // make sure native binaries are included in local linking
+          if (pkg === '@next/swc') {
+            if (!pkgData.files) {
+              pkgData.files = []
+            }
+            pkgData.files.push('native')
+            require('console').log(
+              'using swc binaries: ',
+              await exec(`ls ${path.join(path.dirname(pkgDataPath), 'native')}`)
+            )
+          }
+
+          if (pkg === 'next') {
+            if (nextSwcVersion) {
+              Object.assign(pkgData.dependencies, {
+                '@next/swc-linux-x64-gnu': nextSwcVersion,
+              })
+            } else {
+              if (pkgDatas.get('@next/swc')) {
+                pkgData.dependencies['@next/swc'] =
+                  pkgDatas.get('@next/swc').packedPkgPath
+              } else {
+                pkgData.files.push('native')
+              }
+            }
+          }
+
+          await fs.writeFile(
+            pkgDataPath,
+            JSON.stringify(pkgData, null, 2),
+            'utf8'
+          )
+        }
+
+        // wait to pack packages until after dependency paths have been updated
+        // to the correct versions
+        await Promise.all(
+          Array.from(pkgDatas.keys()).map(async (pkgName) => {
+            const { pkg, pkgPath } = pkgDatas.get(pkgName)
+            await exec(
+              `cd ${pkgPath} && yarn pack -f '${pkg}-packed.tgz'`,
+              true
+            )
+          })
+        )
+
+        return pkgPaths
+      }
     },
   }
 }


### PR DESCRIPTION
Noticed while testing across CI environments that the `test-pack` handling is not-concurrent or cache safe so this removes it from being used by default and moves it behind a flag to allow further investigating later. 

In CI if `test-pack` is called at the same time due to multiple concurrency it can cause the resulted archive to be corrupted so may require a form of lock to resolve in CI although locally re-using the same archive name/path isn't safe with pnpm as it won't bust the store cache and continue to leverage previous cache. 
