### PR TITLE
Fix invalid sourcemaps in taskfile-swc

### DIFF
--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -99,7 +99,11 @@ module.exports = function (task) {
 
       const filePath = path.join(file.dir, file.base)
       const fullFilePath = path.join(__dirname, filePath)
-      const distFilePath = path.dirname(path.join(__dirname, 'dist', filePath))
+      const distFilePath = path.dirname(
+        // we must strip src from filePath as it isn't carried into
+        // the dist file path
+        path.join(__dirname, 'dist', filePath.replace(/^src[/\\]/, ''))
+      )
 
       const options = {
         filename: path.join(file.dir, file.base),


### PR DESCRIPTION
While debugging locally the generated sourcemaps are incorrect as we aren't stripping `src` from the destination path making them unhelpful. Notice the `packages/src` instead of `packages/next/src`. 

<details>

<summary>Before</summary>

![CleanShot 2023-02-05 at 22 58 37@2x](https://user-images.githubusercontent.com/22380829/216904386-1e214c30-be51-480a-b47f-6c5e1cc6751c.png)

</details>

<details>

<summary>After</summary>

![CleanShot 2023-02-05 at 22 59 30@2x](https://user-images.githubusercontent.com/22380829/216904416-9dce9aaa-a62c-4093-8921-6759eeadd7d1.png)

</details>