### PR TITLE
Avoid loading project config multiple times

### DIFF
--- a/packages/next/src/build/webpack-build.ts
+++ b/packages/next/src/build/webpack-build.ts
@@ -10,7 +10,7 @@ import {
 } from '../shared/lib/constants'
 import { runCompiler } from './compiler'
 import * as Log from './output/log'
-import getBaseWebpackConfig from './webpack-config'
+import getBaseWebpackConfig, { loadProjectInfo } from './webpack-config'
 import { NextError } from '../lib/is-error'
 import { injectedClientEntries } from './webpack/plugins/flight-client-entry-plugin'
 import { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
@@ -81,14 +81,20 @@ async function webpackBuildImpl(): Promise<number> {
 
   const configs = await runWebpackSpan
     .traceChild('generate-webpack-config')
-    .traceAsyncFn(() =>
-      Promise.all([
+    .traceAsyncFn(async () => {
+      const info = await loadProjectInfo({
+        dir,
+        config: commonWebpackOptions.config,
+        dev: false,
+      })
+      return Promise.all([
         getBaseWebpackConfig(dir, {
           ...commonWebpackOptions,
           middlewareMatchers: entrypoints.middlewareMatchers,
           runWebpackSpan,
           compilerType: COMPILER_NAMES.client,
           entrypoints: entrypoints.client,
+          ...info,
         }),
         getBaseWebpackConfig(dir, {
           ...commonWebpackOptions,
@@ -96,6 +102,7 @@ async function webpackBuildImpl(): Promise<number> {
           middlewareMatchers: entrypoints.middlewareMatchers,
           compilerType: COMPILER_NAMES.server,
           entrypoints: entrypoints.server,
+          ...info,
         }),
         getBaseWebpackConfig(dir, {
           ...commonWebpackOptions,
@@ -103,9 +110,10 @@ async function webpackBuildImpl(): Promise<number> {
           middlewareMatchers: entrypoints.middlewareMatchers,
           compilerType: COMPILER_NAMES.edgeServer,
           entrypoints: entrypoints.edgeServer,
+          ...info,
         }),
       ])
-    )
+    })
 
   const clientConfig = configs[0]
 

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -575,6 +575,24 @@ export async function resolveExternal(
   return { res, isEsm }
 }
 
+export async function loadProjectInfo({
+  dir,
+  config,
+  dev,
+}: {
+  dir: string
+  config: NextConfigComplete
+  dev: boolean
+}) {
+  const { jsConfig, resolvedBaseUrl } = await loadJsConfig(dir, config)
+  const supportedBrowsers = await getSupportedBrowsers(dir, dev, config)
+  return {
+    jsConfig,
+    resolvedBaseUrl,
+    supportedBrowsers,
+  }
+}
+
 export default async function getBaseWebpackConfig(
   dir: string,
   {
@@ -592,6 +610,9 @@ export default async function getBaseWebpackConfig(
     appDir,
     middlewareMatchers,
     noMangling = false,
+    jsConfig,
+    resolvedBaseUrl,
+    supportedBrowsers,
   }: {
     buildId: string
     config: NextConfigComplete
@@ -607,14 +628,14 @@ export default async function getBaseWebpackConfig(
     appDir?: string
     middlewareMatchers?: MiddlewareMatcher[]
     noMangling?: boolean
+    jsConfig: any
+    resolvedBaseUrl: string | undefined
+    supportedBrowsers: string[] | undefined
   }
 ): Promise<webpack.Configuration> {
   const isClient = compilerType === COMPILER_NAMES.client
   const isEdgeServer = compilerType === COMPILER_NAMES.edgeServer
   const isNodeServer = compilerType === COMPILER_NAMES.server
-
-  const { jsConfig, resolvedBaseUrl } = await loadJsConfig(dir, config)
-  const supportedBrowsers = await getSupportedBrowsers(dir, dev, config)
 
   const hasRewrites =
     rewrites.beforeFiles.length > 0 ||


### PR DESCRIPTION
While debugging another thing I found that we are loading `loadJsConfig` 3 times during a build. Inside `loadJsConfig` we load TypeScript and call `ts.readConfigFile(tsConfigPath, ts.sys.readFile)` and `ts.parseJsonConfigFileContent`, which are expensive (411ms, about 10% of the build time of a demo app):

![CleanShot-2023-02-07-90Jwesnx@2x](https://user-images.githubusercontent.com/3676859/217114840-510c254b-6a00-44b0-ab62-138f32398849.png)

In one process these things are the same for all compilers and we should reuse them.

NEXT-469

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
