### PR TITLE
Increase GitHub actions job timeouts (#45638

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -73,7 +73,7 @@ jobs:
         run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         id: cache-pnpm-store
         with:
           path: ${{ steps.get-store-path.outputs.STORE_PATH }}
@@ -102,7 +102,7 @@ jobs:
         run: echo "WEEK=$(date +%U)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         id: cache-build
         with:
           path: ./*
@@ -121,7 +121,7 @@ jobs:
       - run: npm i -g pnpm@${PNPM_VERSION}
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         id: restore-build
         with:
           path: ./*
@@ -134,7 +134,7 @@ jobs:
     needs: build
     steps:
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         id: restore-build
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         with:
@@ -156,7 +156,7 @@ jobs:
 
       - name: Cache cargo registry
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{ steps.swc-change.outputs.SWC_CHANGE == 'yup' }}
         with:
           path: ~/.cargo/registry
@@ -164,7 +164,7 @@ jobs:
 
       - name: Cache cargo index
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{ steps.swc-change.outputs.SWC_CHANGE == 'yup' }}
         with:
           path: ~/.cargo/git
@@ -203,7 +203,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -240,7 +240,7 @@ jobs:
           check-latest: true
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -280,7 +280,7 @@ jobs:
         run: sudo ethtool -K eth0 tx off rx off
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -341,7 +341,7 @@ jobs:
         run: sudo ethtool -K eth0 tx off rx off
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -401,7 +401,7 @@ jobs:
         run: sudo ethtool -K eth0 tx off rx off
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -452,7 +452,7 @@ jobs:
         run: sudo ethtool -K eth0 tx off rx off
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -498,7 +498,7 @@ jobs:
         run: sudo ethtool -K eth0 tx off rx off
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{ needs.build.outputs.docsChange == 'nope' }}
         id: restore-build
         with:
@@ -574,7 +574,7 @@ jobs:
         run: sudo ethtool -K eth0 tx off rx off
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -630,7 +630,7 @@ jobs:
           check-latest: true
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -678,7 +678,7 @@ jobs:
       NEXT_TELEMETRY_DISABLED: 1
     steps:
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -707,7 +707,7 @@ jobs:
         run: sudo ethtool -K eth0 tx off rx off
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -732,7 +732,7 @@ jobs:
       NEXT_TELEMETRY_DISABLED: 1
     steps:
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -772,7 +772,7 @@ jobs:
         run: sudo ethtool -K eth0 tx off rx off
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         id: restore-build
         with:
           path: ./*
@@ -803,7 +803,7 @@ jobs:
       VERCEL_TEST_TEAM: vtest314-next-e2e-tests
     steps:
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         id: restore-build
         with:
           path: ./*
@@ -843,7 +843,7 @@ jobs:
           check-latest: true
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         id: restore-build
         with:
           path: ./*
@@ -878,7 +878,7 @@ jobs:
 
       - name: Cache cargo registry
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         with:
           path: ~/.cargo/registry
@@ -886,7 +886,7 @@ jobs:
 
       - name: Cache cargo index
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         with:
           path: ~/.cargo/git
@@ -899,7 +899,7 @@ jobs:
       - name: Turbo Cache
         id: turbo-cache
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         with:
           path: .turbo
@@ -987,7 +987,7 @@ jobs:
 
     steps:
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -1197,14 +1197,14 @@ jobs:
 
       - name: Cache cargo registry
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.settings.target }}-cargo-registry
 
       - name: Cache cargo index
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         with:
           path: ~/.cargo/git
           key: ${{ matrix.settings.target }}-cargo-index
@@ -1383,7 +1383,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         id: restore-build
         with:
@@ -1411,7 +1411,7 @@ jobs:
       - name: Turbo Cache
         id: turbo-cache
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         with:
           path: .turbo
@@ -1471,7 +1471,7 @@ jobs:
           check-latest: true
 
       - uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         id: restore-build
         if: ${{needs.build.outputs.docsChange == 'nope'}}
         with:

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Cache cargo registry
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         with:
           path: ~/.cargo/registry
@@ -37,7 +37,7 @@ jobs:
 
       - name: Cache cargo index
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         with:
           path: ~/.cargo/git
@@ -50,7 +50,7 @@ jobs:
       - name: Turbo Cache
         id: turbo-cache
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         with:
           path: .turbo
@@ -65,7 +65,7 @@ jobs:
       # So we get latest cache
       - name: Cache built files
         uses: actions/cache@v3
-        timeout-minutes: 2
+        timeout-minutes: 5
         with:
           path: ./packages/next-target
           key: next-swc-cargo-cache-ubuntu-latest--${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
Sometimes just slow and 5 minutes shouldn't necessarily mean it's stalled.

x-ref: https://github.com/vercel/next.js/actions/runs/4108689367/jobs/7089706579
x-ref: https://github.com/vercel/next.js/actions/runs/4108034590/jobs/7088293296
x-ref: https://github.com/vercel/next.js/actions/runs/4104654636/jobs/7080497165