### PR TITLE
Use only 1 worker for type checking and linting

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -160,14 +160,13 @@ function verifyTypeScriptSetup(
   tsconfigPath: string,
   disableStaticImages: boolean,
   cacheDir: string | undefined,
-  numWorkers: number | undefined,
   enableWorkerThreads: boolean | undefined,
   isAppDirEnabled: boolean
 ) {
   const typeCheckWorker = new JestWorker(
     require.resolve('../lib/verifyTypeScriptSetup'),
     {
-      numWorkers,
+      numWorkers: 1,
       enableWorkerThreads,
       maxRetries: 0,
     }
@@ -409,7 +408,6 @@ export default async function build(
                   config.typescript.tsconfigPath,
                   config.images.disableStaticImages,
                   cacheDir,
-                  config.experimental.cpus,
                   config.experimental.workerThreads,
                   isAppDirEnabled
                 ).then((resolved) => {
@@ -425,7 +423,6 @@ export default async function build(
                     dir,
                     eslintCacheDir,
                     config.eslint?.dirs,
-                    config.experimental.cpus,
                     config.experimental.workerThreads,
                     telemetry,
                     isAppDirEnabled && !!appDir

--- a/packages/next/src/lib/verifyAndLint.ts
+++ b/packages/next/src/lib/verifyAndLint.ts
@@ -12,14 +12,13 @@ export async function verifyAndLint(
   dir: string,
   cacheLocation: string,
   configLintDirs: string[] | undefined,
-  numWorkers: number | undefined,
   enableWorkerThreads: boolean | undefined,
   telemetry: Telemetry,
   hasAppDir: boolean
 ): Promise<void> {
   try {
     const lintWorkers = new Worker(require.resolve('./eslint/runLintCheck'), {
-      numWorkers,
+      numWorkers: 1,
       enableWorkerThreads,
       maxRetries: 0,
     }) as Worker & {


### PR DESCRIPTION
During build, there's no need to start N workers for type checking and linting, because there's no concurrency at all for these tasks (both TypeScript and ESLint are checking all files globally).

During my test of `next build` for a small size project of 5 pages, this change reduces the peak memory usage by 545MB (as each worker holds a huge dependency chain). Before (there are too many worker threads initiated):

<img width="1278" alt="before" src="https://user-images.githubusercontent.com/3676859/217116925-5594a45c-f1bb-4d11-8699-f6fe12ce7ee5.png">

After:

<img width="1189" alt="CleanShot-2023-02-07-WfQTnB1D@2x" src="https://user-images.githubusercontent.com/3676859/217116940-a08a256e-b80d-4836-8b97-2837c845435e.png">

It improves the CPU usage as well.

In the future we can spin up multiple workers and assign sub-task for each, but that only makes sense when the number of pages is large.

NEXT-470

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
