### PR TITLE
fix: react18.0.0 compatibility

### DIFF
--- a/packages/next/src/client/on-recoverable-error.ts
+++ b/packages/next/src/client/on-recoverable-error.ts
@@ -1,7 +1,7 @@
 import { NEXT_DYNAMIC_NO_SSR_CODE } from '../shared/lib/app-dynamic/no-ssr-error'
 
 export default function onRecoverableError(err: any, errorInfo: any) {
-  const digest = err.digest || errorInfo.digest
+  const digest = err.digest || (errorInfo && errorInfo.digest)
 
   // Using default react onRecoverableError
   // x-ref: https://github.com/facebook/react/blob/d4bc16a7d69eb2ea38a88c8ac0b461d5f72cdcab/packages/react-dom/src/client/ReactDOMRoot.js#L83


### PR DESCRIPTION
## Bug

- [x] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

![image](https://user-images.githubusercontent.com/9263655/217177952-740885a5-4110-4a8b-8d49-a6ee8d8dbb8d.png)

I'm not sure whether this pr is necessary. React adjusted the signature of this callback in react18.0.0, so it will report an error in version 18.0.0.

It is no problem that next peerDependence depends on 18.2.0. For some old projects (such as upgrading from next12 to next13), there may be such bugs, and it is not easy to troubleshoot.

https://github.com/facebook/react/blob/v18.0.0/packages/react-dom/src/client/ReactDOMRoot.js#L30

<img width="673" alt="image" src="https://user-images.githubusercontent.com/9263655/217179287-ea997f26-0d5f-4ef6-b98d-45ddb0fbe69b.png">


