### PR TITLE
migrate from yarn to pnpm

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -159,6 +159,13 @@ module.exports = (actionInfo) => {
             }
           }
 
+          if (pkgData?.scripts?.prepublishOnly) {
+            // There's a bug in `pnpm pack` where it will run
+            // the prepublishOnly script and that will fail.
+            // See https://github.com/pnpm/pnpm/issues/2941
+            delete pkgData.scripts.prepublishOnly
+          }
+
           await fs.writeFile(
             pkgDataPath,
             JSON.stringify(pkgData, null, 2),


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/45602
reverted more changes than needed so we migrate to pnpm again here

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
