### PR TITLE
Avoid injecting the TS plugin if `extends` is used

### DIFF
--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -195,20 +195,33 @@ export async function writeConfigurationDefaults(
   // Enable the Next.js typescript plugin.
   if (isAppDirEnabled) {
     if (userTsConfig.compilerOptions) {
-      if (!('plugins' in userTsConfig.compilerOptions)) {
-        userTsConfig.compilerOptions.plugins = []
-      }
-      if (
-        !userTsConfig.compilerOptions.plugins.some(
-          (plugin: { name: string }) => plugin.name === 'next'
+      // If the TS config extends on another config, we can't add the `plugin` field
+      // because that will override the parent config's plugins.
+      // Instead we have to show a message to the user to add the plugin manually.
+      if ('extends' in userTsConfig && !('plugins' in userTsConfig)) {
+        console.log(
+          `\nYour ${chalk.cyan(
+            'tsconfig.json'
+          )} extends another configuration, which means we cannot add the Next.js TypeScript plugin automatically. To improve your development experience, we recommend adding the Next.js plugin (\`${chalk.cyan(
+            '"plugins": [{ "name": "next" }]'
+          )}\`) manually to your TypeScript configuration.\n`
         )
-      ) {
-        userTsConfig.compilerOptions.plugins.push({ name: 'next' })
-        suggestedActions.push(
-          chalk.cyan('plugins') +
-            ' was updated to add ' +
-            chalk.bold(`{ name: 'next' }`)
-        )
+      } else {
+        if (!('plugins' in userTsConfig.compilerOptions)) {
+          userTsConfig.compilerOptions.plugins = []
+        }
+        if (
+          !userTsConfig.compilerOptions.plugins.some(
+            (plugin: { name: string }) => plugin.name === 'next'
+          )
+        ) {
+          userTsConfig.compilerOptions.plugins.push({ name: 'next' })
+          suggestedActions.push(
+            chalk.cyan('plugins') +
+              ' was updated to add ' +
+              chalk.bold(`{ name: 'next' }`)
+          )
+        }
       }
     }
   }

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -204,7 +204,7 @@ export async function writeConfigurationDefaults(
             'tsconfig.json'
           )} extends another configuration, which means we cannot add the Next.js TypeScript plugin automatically. To improve your development experience, we recommend adding the Next.js plugin (\`${chalk.cyan(
             '"plugins": [{ "name": "next" }]'
-          )}\`) manually to your TypeScript configuration.\n`
+          )}\`) manually to your TypeScript configuration. Learn more: https://beta.nextjs.org/docs/configuring/typescript#using-the-typescript-plugin\n`
         )
       } else {
         if (!('plugins' in userTsConfig.compilerOptions)) {


### PR DESCRIPTION
This is necessary because TS config won't merge array fields and it will override parent plugins. In that case we will output a message instead:

![CleanShot-2023-02-07-RqtKpP75@2x](https://user-images.githubusercontent.com/3676859/217249167-b79f11f6-d5e8-4244-9a32-a2c2af0f2c7d.png)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
