### PR TITLE
Fix error page line height (#45676

### DIFF
--- a/packages/next/src/client/components/error.tsx
+++ b/packages/next/src/client/components/error.tsx
@@ -24,13 +24,13 @@ const styles: { [k: string]: React.CSSProperties } = {
     fontSize: 24,
     fontWeight: 500,
     verticalAlign: 'top',
-    lineHeight: 49,
+    lineHeight: '49px',
   },
 
   h2: {
     fontSize: 14,
     fontWeight: 400,
-    lineHeight: 49,
+    lineHeight: '49px',
     margin: 0,
   },
 }

--- a/packages/next/src/pages/_error.tsx
+++ b/packages/next/src/pages/_error.tsx
@@ -49,13 +49,13 @@ const styles: { [k: string]: React.CSSProperties } = {
     fontSize: 24,
     fontWeight: 500,
     verticalAlign: 'top',
-    lineHeight: 49,
+    lineHeight: '49px',
   },
 
   h2: {
     fontSize: 14,
     fontWeight: 400,
-    lineHeight: 49,
+    lineHeight: '49px',
     margin: 0,
   },
 }


### PR DESCRIPTION
Fixes styling issue introduced in #45586, lineHeight: 49 should be px instead of number

**After**
<img width="493" alt="image" src="https://user-images.githubusercontent.com/4800338/217356260-11f7d57b-31e0-401f-901f-f67eede3f6e3.png">


**Before**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/4800338/217356328-c5a1e0eb-cdaf-4f01-b6cb-a9323d740c22.png">
