### PR TITLE
More explicit errors for invalid exports in SWC (#45679

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -10,10 +10,10 @@ use next_binding::swc::core::{
     ecma::{
         ast::{
             op, ArrayLit, AssignExpr, AssignPatProp, BlockStmt, CallExpr, ComputedPropName, Decl,
-            ExportDecl, Expr, ExprStmt, FnDecl, Function, Id, Ident, KeyValuePatProp, KeyValueProp,
-            Lit, MemberExpr, MemberProp, Module, ModuleDecl, ModuleItem, ObjectPatProp,
-            OptChainBase, OptChainExpr, Param, Pat, PatOrExpr, Prop, PropName, RestPat, ReturnStmt,
-            Stmt, Str, VarDecl, VarDeclKind, VarDeclarator,
+            DefaultDecl, ExportDecl, ExportDefaultDecl, Expr, ExprStmt, FnDecl, Function, Id,
+            Ident, KeyValuePatProp, KeyValueProp, Lit, MemberExpr, MemberProp, Module, ModuleDecl,
+            ModuleItem, ObjectPatProp, OptChainBase, OptChainExpr, Param, Pat, PatOrExpr, Prop,
+            PropName, RestPat, ReturnStmt, Stmt, Str, VarDecl, VarDeclKind, VarDeclarator,
         },
         atoms::JsWord,
         utils::{private_ident, quote_ident, ExprFactory},
@@ -329,6 +329,46 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         let mut new = Vec::with_capacity(stmts.len());
         for mut stmt in stmts.take() {
             self.top_level = true;
+
+            // For action file, it's not allowed to export things other than async
+            // functions.
+            if self.in_action_file {
+                let mut disallowed_export_span = DUMMY_SP;
+                match &mut stmt {
+                    ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl { decl, span })) => {
+                        match decl {
+                            Decl::Fn(_f) => {}
+                            _ => {
+                                disallowed_export_span = *span;
+                            }
+                        }
+                    }
+                    ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(ExportDefaultDecl {
+                        decl,
+                        span,
+                        ..
+                    })) => match decl {
+                        DefaultDecl::Fn(_f) => {}
+                        _ => {
+                            disallowed_export_span = *span;
+                        }
+                    },
+                    _ => {}
+                }
+
+                if disallowed_export_span != DUMMY_SP {
+                    HANDLER.with(|handler| {
+                        handler
+                            .struct_span_err(
+                                disallowed_export_span,
+                                "Only async functions are allowed to be exported in a \"use \
+                                 server\" file.",
+                            )
+                            .emit();
+                    });
+                }
+            }
+
             stmt.visit_mut_with(self);
 
             new.push(stmt);

--- a/packages/next-swc/crates/core/tests/errors/server-actions/3/input.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/3/input.js
@@ -1,0 +1,4 @@
+'use server';
+
+export const x = 1
+

--- a/packages/next-swc/crates/core/tests/errors/server-actions/3/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/3/output.js
@@ -1,0 +1,1 @@
+/* __next_internal_action_entry_do_not_use__  */ export const x = 1;

--- a/packages/next-swc/crates/core/tests/errors/server-actions/3/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/3/output.stderr
@@ -1,0 +1,7 @@
+
+  x Only async functions are allowed to be exported in a "use server" file.
+   ,-[input.js:2:1]
+ 2 | 
+ 3 | export const x = 1
+   : ^^^^^^^^^^^^^^^^^^
+   `----

--- a/packages/next-swc/crates/core/tests/errors/server-actions/4/input.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/4/input.js
@@ -1,0 +1,7 @@
+'use server';
+
+export default class Component {
+  render() {
+    return null;
+  }
+}

--- a/packages/next-swc/crates/core/tests/errors/server-actions/4/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/4/output.js
@@ -1,0 +1,5 @@
+/* __next_internal_action_entry_do_not_use__  */ export default class Component {
+  render() {
+    return null;
+}
+}

--- a/packages/next-swc/crates/core/tests/errors/server-actions/4/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/4/output.stderr
@@ -1,0 +1,10 @@
+
+  x Only async functions are allowed to be exported in a "use server" file.
+   ,-[input.js:2:1]
+ 2 |     
+ 3 | ,-> export default class Component {
+ 4 | |     render() {
+ 5 | |       return null;
+ 6 | |     }
+ 7 | `-> }
+   `----


### PR DESCRIPTION
NEXT-476

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
