### PR TITLE
Fix missing hasHeader mock during revalidate

### DIFF
--- a/packages/next/src/server/lib/mock-request.ts
+++ b/packages/next/src/server/lib/mock-request.ts
@@ -35,6 +35,7 @@ export function mockRequest(
 
   mockRes.writeHead = (_status: any, _headers: any) =>
     Object.assign(mockHeaders, _headers)
+  mockRes.hasHeader = (name: string) => Boolean(mockHeaders[name.toLowerCase()])
   mockRes.getHeader = (name: string) => mockHeaders[name.toLowerCase()]
   mockRes.getHeaders = () => mockHeaders
   mockRes.getHeaderNames = () => Object.keys(mockHeaders)

--- a/packages/next/src/server/send-payload/revalidate-headers.ts
+++ b/packages/next/src/server/send-payload/revalidate-headers.ts
@@ -7,7 +7,7 @@ export function setRevalidateHeaders(
   options: PayloadOptions
 ) {
   if (options.private || options.stateful) {
-    if (options.private || !res.hasHeader('Cache-Control')) {
+    if (options.private || !res.getHeader('Cache-Control')) {
       res.setHeader(
         'Cache-Control',
         `private, no-cache, no-store, max-age=0, must-revalidate`

--- a/run-tests.js
+++ b/run-tests.js
@@ -492,10 +492,9 @@ async function main() {
       }
     }
   }
-  await cleanUpAndExit(0)
 }
 
 main().catch((err) => {
   console.error(err)
-  process.exit(1)
+  cleanUpAndExit(1)
 })

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -16,6 +16,7 @@ import {
   waitFor,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
+import stripAnsi from 'strip-ansi'
 
 describe('Prerender', () => {
   let next: NextInstance
@@ -1771,6 +1772,16 @@ describe('Prerender', () => {
           expect(initialHtml).toBe(newHtml)
         })
       }
+
+      it('should not throw error for manual revalidate for SSR path', async () => {
+        const res = await fetchViaHTTP(next.url, '/api/manual-revalidate', {
+          pathname: '/ssr',
+        })
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ revalidated: false })
+        expect(stripAnsi(next.cliOutput)).not.toContain('hasHeader')
+      })
 
       it('should revalidate manual revalidate with preview cookie', async () => {
         const initialRes = await fetchViaHTTP(next.url, '/preview')

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -1528,6 +1528,12 @@ describe('Prerender', () => {
               page: '/something',
             },
             {
+              dataRouteRegex: normalizeRegEx(
+                `^\\/_next\\/data\\/${escapeRegex(next.buildId)}\\/ssr.json$`
+              ),
+              page: '/ssr',
+            },
+            {
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
               )}/user/(?<user>[^/]+?)/profile\\.json$`,

--- a/test/e2e/prerender/pages/ssr.js
+++ b/test/e2e/prerender/pages/ssr.js
@@ -1,0 +1,7 @@
+export function getServerSideProps() {
+  return { props: {} }
+}
+
+export default function Page() {
+  return <p>/ssr</p>
+}


### PR DESCRIPTION
Replaces usage of `hasHeader` of `getHeader` and also ensures we include `hasHeader` in our `mockRes` we create during revalidate for good measure. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

Closes: https://github.com/vercel/next.js/issues/34929
Closes: https://github.com/vercel/next.js/issues/37338
Closes: https://github.com/vercel/next.js/issues/45481