### PR TITLE
feat: add beforeNextInit hook to next.config.js

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -27,6 +27,9 @@ const configSchema = {
     basePath: {
       type: 'string',
     },
+    beforeNextInit: {
+      isFunction: true,
+    } as any,
     cleanDistDir: {
       type: 'boolean',
     },

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -448,6 +448,11 @@ export interface NextConfig extends Record<string, any> {
   swcMinify?: boolean
 
   /**
+   * A function that gets called before the Next server is initialized.
+   */
+  beforeNextInit?: () => void | Promise<void>
+
+  /**
    * Optionally enable compiler transforms
    *
    * @see [Supported Compiler Options](https://nextjs.org/docs/advanced-features/compiler#supported-features)

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -155,6 +155,10 @@ export class NextServer {
           overrideBuiltInReactPackages()
         }
 
+        if (conf.beforeNextInit) {
+          await conf.beforeNextInit()
+        }
+
         this.server = await this.createServer({
           ...this.options,
           conf,

--- a/test/e2e/config-before-next-init/config-before-next-init.test.ts
+++ b/test/e2e/config-before-next-init/config-before-next-init.test.ts
@@ -1,0 +1,23 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'beforeNextInit',
+  {
+    skipDeployment: true,
+    files: __dirname,
+    nextConfig: {
+      beforeNextInit: () => {
+        console.log('beforeNextInit')
+      },
+    },
+  },
+  ({ next, isNextDev, isNextStart }) => {
+    if (isNextDev || isNextStart) {
+      it('should run before the Next server is instantiated', async () => {
+        // await next.start()
+        await next.fetch('/') // ensure the Next server is instantiated
+        expect(next.cliOutput).toContain('beforeNextInit')
+      })
+    }
+  }
+)

--- a/test/e2e/config-before-next-init/pages/index.tsx
+++ b/test/e2e/config-before-next-init/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}


### PR DESCRIPTION
Adds a hook that gets called once before we initialise the Next.js server. This is useful if you want to do some kind of setup before starting your server.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
