### PR TITLE
Ensure bundle 404 can be rewritten in dev

### DIFF
--- a/packages/next/src/server/dev/hot-reloader.ts
+++ b/packages/next/src/server/dev/hot-reloader.ts
@@ -60,7 +60,7 @@ export async function renderScriptError(
   res: ServerResponse,
   error: Error,
   { verbose = true } = {}
-) {
+): Promise<{ finished: true | undefined }> {
   // Asks CDNs and others to not to cache the errored page
   res.setHeader(
     'Cache-Control',
@@ -68,9 +68,7 @@ export async function renderScriptError(
   )
 
   if ((error as any).code === 'ENOENT') {
-    res.statusCode = 404
-    res.end('404 - Not Found')
-    return
+    return { finished: undefined }
   }
 
   if (verbose) {
@@ -78,6 +76,7 @@ export async function renderScriptError(
   }
   res.statusCode = 500
   res.end('500 - Internal Error')
+  return { finished: true }
 }
 
 function addCorsSupport(req: IncomingMessage, res: ServerResponse) {
@@ -271,14 +270,14 @@ export default class HotReloader {
         try {
           await this.ensurePage({ page, clientOnly: true })
         } catch (error) {
-          await renderScriptError(pageBundleRes, getProperError(error))
-          return { finished: true }
+          return await renderScriptError(pageBundleRes, getProperError(error))
         }
 
         const errors = await this.getCompilationErrors(page)
         if (errors.length > 0) {
-          await renderScriptError(pageBundleRes, errors[0], { verbose: false })
-          return { finished: true }
+          return await renderScriptError(pageBundleRes, errors[0], {
+            verbose: false,
+          })
         }
       }
 

--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -49,7 +49,7 @@ export async function middleware(request) {
     return NextResponse.next()
   }
 
-  if (url.pathname.includes('/_next/static/_app-non-existent.js')) {
+  if (url.pathname.includes('/_next/static/chunks/pages/_app-non-existent.js')) {
     return NextResponse.rewrite('https://example.vercel.sh')
   }
 

--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -49,7 +49,9 @@ export async function middleware(request) {
     return NextResponse.next()
   }
 
-  if (url.pathname.includes('/_next/static/chunks/pages/_app-non-existent.js')) {
+  if (
+    url.pathname.includes('/_next/static/chunks/pages/_app-non-existent.js')
+  ) {
     return NextResponse.rewrite('https://example.vercel.sh')
   }
 

--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -49,6 +49,10 @@ export async function middleware(request) {
     return NextResponse.next()
   }
 
+  if (url.pathname.includes('/_next/static/_app-non-existent.js')) {
+    return NextResponse.rewrite('https://example.vercel.sh')
+  }
+
   if (url.pathname === '/api/edge-search-params') {
     const newUrl = url.clone()
     newUrl.searchParams.set('foo', 'bar')

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -70,10 +70,10 @@ describe('Middleware Runtime', () => {
   }
 
   function runTests({ i18n }: { i18n?: boolean }) {
-    it('should be able to rewrite on _next/static 404', async () => {
+    it('should be able to rewrite on _next/static/chunks/pages/ 404', async () => {
       const res = await fetchViaHTTP(
         next.url,
-        '/_next/static/_app-non-existent.js'
+        '/_next/static/chunks/pages/_app-non-existent.js'
       )
 
       expect(res.status).toBe(200)

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -70,6 +70,16 @@ describe('Middleware Runtime', () => {
   }
 
   function runTests({ i18n }: { i18n?: boolean }) {
+    it('should be able to rewrite on _next/static 404', async () => {
+      const res = await fetchViaHTTP(
+        next.url,
+        '/_next/static/_app-non-existent.js'
+      )
+
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('Example Domain')
+    })
+
     if ((global as any).isNextDev) {
       it('refreshes the page when middleware changes ', async () => {
         const browser = await webdriver(next.url, `/about`)


### PR DESCRIPTION
This fixes a mismatch in behavior between dev/start where bundle 404s could be rewritten in production but not dev. Also ensures we have a regression test for this behavior. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1675869554570429)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

