### PR TITLE
Add `MDXComponents` type to `useMDXComponents`

### DIFF
--- a/examples/app-dir-mdx/mdx-components.tsx
+++ b/examples/app-dir-mdx/mdx-components.tsx
@@ -1,7 +1,7 @@
+import type { MDXComponents } from "mdx/types";
+
 // This file is required to use MDX in `app` directory.
-export function useMDXComponents(components: {
-  [component: string]: React.ComponentType
-}) {
+export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     // Allows customizing built-in components, e.g. to add styling.
     // h1: ({ children }) => <h1 style={{ fontSize: "100px" }}>{children}</h1>,

--- a/examples/app-dir-mdx/mdx-components.tsx
+++ b/examples/app-dir-mdx/mdx-components.tsx
@@ -1,4 +1,4 @@
-import type { MDXComponents } from "mdx/types";
+import type { MDXComponents } from 'mdx/types'
 
 // This file is required to use MDX in `app` directory.
 export function useMDXComponents(components: MDXComponents): MDXComponents {


### PR DESCRIPTION
MDX publishes types which includes a proper `MDXComponents` type, provides nicer autocomplete for users and also includes the `wrapper` option:

![image](https://user-images.githubusercontent.com/55017335/217798272-2fc5e574-5a0b-49e5-92d8-62b56ad4d043.png)



<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
