### PR TITLE
Fix global CSS loader behavior when appDir is enabled

### DIFF
--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -2223,7 +2223,7 @@ createNextDescribe(
 
         // Pages directory shouldn't be affected when `appDir` is enabled
         describe('pages dir', () => {
-          it('should include css modules after page transition', async () => {
+          it('should include css modules and global css after page transition', async () => {
             const browser = await next.browser('/css-modules/page1')
             await browser.elementByCss('a').click()
             await browser.waitForElementByCss('#page2')
@@ -2232,6 +2232,12 @@ createNextDescribe(
                 `window.getComputedStyle(document.querySelector('h1')).backgroundColor`
               )
             ).toBe('rgb(205, 92, 92)')
+
+            expect(
+              await browser.eval(
+                `window.getComputedStyle(document.querySelector('.page-2')).backgroundColor`
+              )
+            ).toBe('rgb(255, 228, 181)')
           })
         })
       }

--- a/test/e2e/app-dir/app/pages/css-modules/page1.css
+++ b/test/e2e/app-dir/app/pages/css-modules/page1.css
@@ -1,0 +1,3 @@
+.page-1 {
+  background: lavender;
+}

--- a/test/e2e/app-dir/app/pages/css-modules/page1.js
+++ b/test/e2e/app-dir/app/pages/css-modules/page1.js
@@ -1,11 +1,14 @@
 import Link from 'next/link'
 import classes from './page1.module.css'
+import './page1.css'
 
 export default function Page() {
   return (
     <>
       <h1 className={classes.box}>Page 1</h1>
-      <Link href="/css-modules/page2">Page 2</Link>
+      <div className="page-1">
+        <Link href="/css-modules/page2">Page 2</Link>
+      </div>
     </>
   )
 }

--- a/test/e2e/app-dir/app/pages/css-modules/page2.css
+++ b/test/e2e/app-dir/app/pages/css-modules/page2.css
@@ -1,0 +1,3 @@
+.page-2 {
+  background: moccasin;
+}

--- a/test/e2e/app-dir/app/pages/css-modules/page2.js
+++ b/test/e2e/app-dir/app/pages/css-modules/page2.js
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import classes from './page2.module.css'
+import './page2.css'
 
 export default function Page() {
   return (
@@ -7,7 +8,9 @@ export default function Page() {
       <h1 id="page2" className={classes.box}>
         Page 2
       </h1>
-      <Link href="/css-modules/page1">Page 1</Link>
+      <div className="page-2">
+        <Link href="/css-modules/page1">Page 1</Link>
+      </div>
     </>
   )
 }


### PR DESCRIPTION
The current behavior is, when `appDir` is enabled, global CSS should be allowed to be imported from anywhere (because components can be re-used by both pages and app). Changes in #45619 made it not behaving correctly and this PR fixes it.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
