### PR TITLE
Add next/font imports codemod

### DIFF
--- a/packages/next-codemod/bin/cli.ts
+++ b/packages/next-codemod/bin/cli.ts
@@ -15,6 +15,7 @@ import path from 'path'
 import execa from 'execa'
 import chalk from 'chalk'
 import isGitClean from 'is-git-clean'
+import { uninstallPackage } from '../lib/uninstall-package'
 
 export const jscodeshiftExecutable = require.resolve('.bin/jscodeshift')
 export const transformerDirectory = path.join(__dirname, '../', 'transforms')
@@ -97,6 +98,17 @@ export function runTransform({ files, flags, transformer }) {
   if (result.failed) {
     throw new Error(`jscodeshift exited with code ${result.exitCode}`)
   }
+
+  if (!dry && transformer === 'built-in-next-font') {
+    console.log('Uninstalling `@next/font`')
+    try {
+      uninstallPackage('@next/font')
+    } catch {
+      console.error(
+        "Couldn't uninstall `@next/font`, please uninstall it manually"
+      )
+    }
+  }
 }
 
 const TRANSFORMER_INQUIRER_CHOICES = [
@@ -131,6 +143,10 @@ const TRANSFORMER_INQUIRER_CHOICES = [
   {
     name: 'next-image-experimental (experimental): dangerously migrates from `next/legacy/image` to the new `next/image` by adding inline styles and removing unused props',
     value: 'next-image-experimental',
+  },
+  {
+    name: 'built-in-next-font: Uninstall `@next/font` and transform imports to `next/font`',
+    value: 'built-in-next-font',
   },
 ]
 

--- a/packages/next-codemod/lib/uninstall-package.ts
+++ b/packages/next-codemod/lib/uninstall-package.ts
@@ -1,0 +1,29 @@
+import fs from 'fs'
+import path from 'path'
+import execa from 'execa'
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn'
+
+function getPkgManager(baseDir: string): PackageManager {
+  for (const { lockFile, packageManager } of [
+    { lockFile: 'yarn.lock', packageManager: 'yarn' },
+    { lockFile: 'pnpm-lock.yaml', packageManager: 'pnpm' },
+    { lockFile: 'package-lock.json', packageManager: 'npm' },
+  ]) {
+    if (fs.existsSync(path.join(baseDir, lockFile))) {
+      return packageManager as PackageManager
+    }
+  }
+}
+
+export function uninstallPackage(packageToUninstall: string) {
+  const pkgManager = getPkgManager(process.cwd())
+  if (!pkgManager) throw new Error('Failed to find package manager')
+
+  let command = 'uninstall'
+  if (pkgManager === 'yarn') {
+    command = 'remove'
+  }
+
+  execa.sync(pkgManager, [command, packageToUninstall], { stdio: 'inherit' })
+}

--- a/packages/next-codemod/transforms/__testfixtures__/built-in-next-font/page.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/built-in-next-font/page.input.js
@@ -1,0 +1,27 @@
+import { Oswald } from "@next/font/google";
+import localFont1 from "@next/font/local";
+
+const oswald = Oswald({ subsets: ["latin"] });
+const myFont = localFont1({
+  src: "./my-font.woff2",
+});
+
+import { Inter } from "next/font/google";
+import localFont2 from "next/font/local";
+
+const inter = Inter({ subsets: ["latin"] });
+const myOtherFont = localFont2({
+  src: "./my-other-font.woff2",
+});
+
+export default function WithFonts() {
+  return (
+    <>
+      <p className={oswald.className}>oswald</p>
+      <p className={myFont.className}>myFont</p>
+
+      <p className={inter.className}>inter</p>
+      <p className={myOtherFont.className}>myOtherFont</p>
+    </>
+  );
+}

--- a/packages/next-codemod/transforms/__testfixtures__/built-in-next-font/page.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/built-in-next-font/page.output.js
@@ -1,0 +1,27 @@
+import { Oswald } from "next/font/google";
+import localFont1 from "next/font/local";
+
+const oswald = Oswald({ subsets: ["latin"] });
+const myFont = localFont1({
+  src: "./my-font.woff2",
+});
+
+import { Inter } from "next/font/google";
+import localFont2 from "next/font/local";
+
+const inter = Inter({ subsets: ["latin"] });
+const myOtherFont = localFont2({
+  src: "./my-other-font.woff2",
+});
+
+export default function WithFonts() {
+  return (
+    <>
+      <p className={oswald.className}>oswald</p>
+      <p className={myFont.className}>myFont</p>
+
+      <p className={inter.className}>inter</p>
+      <p className={myOtherFont.className}>myOtherFont</p>
+    </>
+  );
+}

--- a/packages/next-codemod/transforms/__tests__/built-in-next-font.test.js
+++ b/packages/next-codemod/transforms/__tests__/built-in-next-font.test.js
@@ -1,0 +1,16 @@
+/* global jest */
+jest.autoMockOff()
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+const { readdirSync } = require('fs')
+const { join } = require('path')
+
+const fixtureDir = 'built-in-next-font'
+const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir)
+const fixtures = readdirSync(fixtureDirPath)
+  .filter(file => file.endsWith('.input.js'))
+  .map(file => file.replace('.input.js', ''))
+
+for (const fixture of fixtures) {
+  const prefix = `${fixtureDir}/${fixture}`;
+  defineTest(__dirname, fixtureDir,  null, prefix)
+}

--- a/packages/next-codemod/transforms/built-in-next-font.ts
+++ b/packages/next-codemod/transforms/built-in-next-font.ts
@@ -1,0 +1,42 @@
+import type { API, FileInfo, Options } from 'jscodeshift'
+
+export default function transformer(
+  file: FileInfo,
+  api: API,
+  options: Options
+) {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  // Before: import { ... } from '@next/font/google'
+  // After: import { ... } from 'next/font/google'
+  root
+    .find(j.ImportDeclaration, {
+      source: { value: '@next/font/google' },
+    })
+    .forEach((imageImport) => {
+      j(imageImport).replaceWith(
+        j.importDeclaration(
+          imageImport.node.specifiers,
+          j.stringLiteral('next/font/google')
+        )
+      )
+    })
+
+  // Before: import localFont from '@next/font/local'
+  // After: import localFont from 'next/font/local'
+  root
+    .find(j.ImportDeclaration, {
+      source: { value: '@next/font/local' },
+    })
+    .forEach((imageImport) => {
+      j(imageImport).replaceWith(
+        j.importDeclaration(
+          imageImport.node.specifiers,
+          j.stringLiteral('next/font/local')
+        )
+      )
+    })
+
+  return root.toSource(options)
+}


### PR DESCRIPTION
Add `built-in-next-font` codemod that transforms `@next/font` imports to `next/font` and then uninstalls the `@next/font` package.

Tested locally with npm, yarn and pnpm.

fix NEXT-453 ([link](https://linear.app/vercel/issue/NEXT-453))

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
