### PR TITLE
Support favicon.ico for metadata (#45759

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -217,6 +217,7 @@ export function getAppEntry(opts: {
   appDir: string
   appPaths: string[] | null
   pageExtensions: string[]
+  assetPrefix: string
   isDev?: boolean
   rootDir?: string
   tsconfigPath?: string
@@ -410,6 +411,7 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
               appDir,
               appPaths: matchedAppPaths,
               pageExtensions,
+              assetPrefix: config.assetPrefix,
             })
           } else {
             server[serverBundlePath] = [mappings[page]]
@@ -426,6 +428,7 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
               appDir: appDir!,
               appPaths: matchedAppPaths,
               pageExtensions,
+              assetPrefix: config.assetPrefix,
             }).import
           }
 

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -39,7 +39,6 @@ async function createTreeCodeFromPath(
     resolver,
     resolvePath,
     resolveParallelSegments,
-    isDev,
     loaderContext,
     loaderOptions,
   }: {
@@ -51,7 +50,6 @@ async function createTreeCodeFromPath(
     resolveParallelSegments: (
       pathname: string
     ) => [key: string, segment: string][]
-    isDev: boolean
     loaderContext: webpack.LoaderContext<AppLoaderOptions>
     loaderOptions: AppLoaderOptions
   }
@@ -291,7 +289,6 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
     resolver,
     resolvePath: (pathname: string) => resolve(this.rootContext, pathname),
     resolveParallelSegments,
-    isDev: !!isDev,
     loaderContext: this,
     loaderOptions: loaderOptions,
   })

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -5,18 +5,18 @@ interface Options {
   isServer: boolean
   isDev: boolean
   assetPrefix: string
-  basePath: string
 }
+
+const mimeTypeMap = {
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  ico: 'image/x-icon',
+  svg: 'image/svg+xml',
+} as const
 
 async function nextMetadataImageLoader(this: any, content: Buffer) {
   const options: Options = this.getOptions()
-  const {
-    // TODO-APP: support assetPrefix
-    assetPrefix = '',
-    // isServer,
-    isDev,
-    // basePath
-  } = options
+  const { assetPrefix, isDev } = options
   const context = this.rootContext
 
   const opts = { context, content }
@@ -43,7 +43,11 @@ async function nextMetadataImageLoader(this: any, content: Buffer) {
 
   const stringifiedData = JSON.stringify({
     url: outputPath,
-    sizes: `${imageSize.width}x${imageSize.height}`,
+    ...(extension in mimeTypeMap && {
+      type: mimeTypeMap[extension as keyof typeof mimeTypeMap],
+    }),
+    sizes:
+      extension === 'ico' ? 'any' : `${imageSize.width}x${imageSize.height}`,
   })
 
   this.emitFile(`../${isDev ? '' : '../'}${interpolatedName}`, content, null)

--- a/packages/next/src/server/dev/hot-reloader.ts
+++ b/packages/next/src/server/dev/hot-reloader.ts
@@ -654,6 +654,7 @@ export default class HotReloader {
                       rootDir: this.dir,
                       isDev: true,
                       tsconfigPath: this.config.typescript.tsconfigPath,
+                      assetPrefix: this.config.assetPrefix,
                     }).import
                   : undefined
 
@@ -735,6 +736,7 @@ export default class HotReloader {
                         rootDir: this.dir,
                         isDev: true,
                         tsconfigPath: this.config.typescript.tsconfigPath,
+                        assetPrefix: this.config.assetPrefix,
                       })
                     : relativeRequest,
                   hasAppDir,

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -37,7 +37,12 @@ export async function findPageFile(
     await Promise.all(
       pagePaths.map(async (path) => {
         const filePath = join(pagesDir, path)
-        return (await fileExists(filePath)) ? path : null
+        try {
+          return (await fileExists(filePath)) ? path : null
+        } catch (err: any) {
+          if (!err?.code?.includes('ENOTDIR')) throw err
+        }
+        return null
       })
     )
   ).filter(nonNullable)

--- a/test/e2e/app-dir/metadata/app/params/[slug]/page.tsx
+++ b/test/e2e/app-dir/metadata/app/params/[slug]/page.tsx
@@ -10,6 +10,7 @@ export default function page(props) {
 
 export async function generateMetadata(props, parent) {
   const parentMetadata = await parent
+
   return {
     ...parentMetadata,
     title: format(props),

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -454,6 +454,23 @@ createNextDescribe(
           ])
         ).toEqual({ sizes: '180x180', type: 'image/png' })
       })
+
+      it('should support root level of favicon.ico', async () => {
+        let $ = await next.render$('/')
+        let $icon = $('link[rel="icon"]')
+        expect($icon.attr('href')).toMatch(
+          /_next\/static\/media\/metadata\/favicon.\w+.ico/
+        )
+        expect($icon.attr('type')).toBe('image/x-icon')
+        expect($icon.attr('sizes')).toBe('any')
+
+        $ = await next.render$('/basic')
+        $icon = $('link[rel="icon"]')
+        expect($icon.attr('href')).toMatch(
+          /_next\/static\/media\/metadata\/favicon.\w+.ico/
+        )
+        expect($icon.attr('sizes')).toBe('any')
+      })
     })
 
     describe('file based icons', () => {
@@ -467,9 +484,11 @@ createNextDescribe(
           /\/_next\/static\/media\/metadata\/icon1\.\w+\.png/
         )
         expect($icon.attr('sizes')).toBe('32x32')
+        expect($icon.attr('type')).toBe('image/png')
         expect($appleIcon.attr('href')).toMatch(
           /\/_next\/static\/media\/metadata\/apple-icon\.\w+\.png/
         )
+        expect($appleIcon.attr('type')).toBe('image/png')
         expect($appleIcon.attr('sizes')).toMatch('114x114')
       })
 


### PR DESCRIPTION
## Feature

* Picking up root favicon (`/app/favicon.ico`) into icons, and add missing `type` prop for `<link>`
* Fixes the `/favicon.ico` 500 in dev server (`fileExists` checking part)

Closes NEXT-475

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

