### PR TITLE
Fix type checking for generateStaticParams (#45788

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-types-plugin.ts
@@ -29,7 +29,7 @@ type TEntry = typeof entry
 
 check<IEntry, TEntry>(entry)
 
-type PageParams = Record<string, string>
+type PageParams = any
 interface PageProps {
   params: any
   searchParams?: any
@@ -54,7 +54,7 @@ interface IEntry {
       : `default: PageComponent`
   }
   config?: {}
-  generateStaticParams?: (params?: PageParams) => any[] | Promise<any[]>
+  generateStaticParams?: (args: { params: PageParams }) => any[] | Promise<any[]>
   revalidate?: RevalidateRange<TEntry> | false
   dynamic?: 'auto' | 'force-dynamic' | 'error' | 'force-static'
   dynamicParams?: boolean

--- a/test/e2e/app-dir/app-alias/src/app/typing/[slug]/page.tsx
+++ b/test/e2e/app-dir/app-alias/src/app/typing/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export default function page() {
+  return 'typing'
+}
+
+export async function generateStaticParams({
+  params,
+}: {
+  params: { slug: 'a' | 'b' }
+}) {
+  console.log(params)
+  return []
+}


### PR DESCRIPTION
Address the problem reported in https://github.com/vercel/next.js/discussions/41745#discussioncomment-4936492.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
