### PR TITLE
Disable un-necessary lint rule by default

### DIFF
--- a/packages/eslint-config-next/index.js
+++ b/packages/eslint-config-next/index.js
@@ -75,6 +75,7 @@ module.exports = {
     'jsx-a11y/aria-unsupported-elements': 'warn',
     'jsx-a11y/role-has-required-aria-props': 'warn',
     'jsx-a11y/role-supports-aria-props': 'warn',
+    'react/jsx-no-target-blank': 'off',
   },
   parser: './parser.js',
   parserOptions: {


### PR DESCRIPTION
This lint rule is now outdated as our [default supported browserslist is for the most part unaffected](https://nextjs.org/docs/basic-features/supported-browsers-features) now handles `target='_blank'` with `rel='noopener'` automatically https://caniuse.com/mdn-html_elements_a_implicit_noopener

Users configuring older browsers in their list can still manually enable this rule if desired. 

x-ref: https://github.com/vercel/next.js/pull/37940
x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1676143674720769?thread_ts=1676139395.828479&cid=C03KAR5DCKC)