### PR TITLE
Update warning links back to new Metadata docs.

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -25,7 +25,7 @@ export default async function transformSource(
   if (buildInfo.rsc?.type !== RSC_MODULE_TYPES.client) {
     if (noopHeadPath === this.resourcePath) {
       warnOnce(
-        `Warning: You're using \`next/head\` inside app directory, please migrate to \`head.js\`. Checkout https://beta.nextjs.org/docs/api-reference/file-conventions/head for details.`
+        `Warning: You're using \`next/head\` inside the \`app\` directory, please migrate to the Metadata API. See https://beta.nextjs.org/docs/api-reference/metadata for more details.`
       )
     }
   }

--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -110,7 +110,7 @@ const API_DOCS: Record<
   },
   metadata: {
     description: 'Next.js Metadata configurations',
-    link: 'https://beta.nextjs.org/docs/',
+    link: 'https://beta.nextjs.org/docs/api-reference/metadata',
   },
 }
 


### PR DESCRIPTION
On `canary`, we now support the new [Metadata API](https://beta.nextjs.org/docs/guides/seo) (to be announced in `13.2`), which replaces `head.js`. This PR updates two warning links to point back to the new [API reference](https://beta.nextjs.org/docs/api-reference/metadata).