### PR TITLE
fix: proper check for plugin in tsconfig

### DIFF
--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -198,7 +198,10 @@ export async function writeConfigurationDefaults(
       // If the TS config extends on another config, we can't add the `plugin` field
       // because that will override the parent config's plugins.
       // Instead we have to show a message to the user to add the plugin manually.
-      if ('extends' in userTsConfig && !('plugins' in userTsConfig.compilerOptions)) {
+      if (
+        'extends' in userTsConfig &&
+        !('plugins' in userTsConfig.compilerOptions)
+      ) {
         console.log(
           `\nYour ${chalk.cyan(
             'tsconfig.json'

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -198,7 +198,7 @@ export async function writeConfigurationDefaults(
       // If the TS config extends on another config, we can't add the `plugin` field
       // because that will override the parent config's plugins.
       // Instead we have to show a message to the user to add the plugin manually.
-      if ('extends' in userTsConfig && !('plugins' in userTsConfig)) {
+      if ('extends' in userTsConfig && !('plugins' in userTsConfig.compilerOptions)) {
         console.log(
           `\nYour ${chalk.cyan(
             'tsconfig.json'


### PR DESCRIPTION
`plugin` is a key of `tsconfig.compilerOptions`

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
