### PR TITLE
fix wrong variables assignment

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -54,8 +54,8 @@ const handleSessionStop = async () => {
         distDir: path.join(dir, config.distDir),
       })
 
-    let appDir: boolean = !!traceGlobals.get('pagesDir')
-    let pagesDir: boolean = !!traceGlobals.get('appDir')
+    let pagesDir: boolean = !!traceGlobals.get('pagesDir')
+    let appDir: boolean = !!traceGlobals.get('appDir')
 
     if (
       typeof traceGlobals.get('pagesDir') === 'undefined' ||


### PR DESCRIPTION
Correct me if I am wrong, but the variables were named in reverse to what they were doing.
`!!traceGlobals.get('pagesDir')` should be assigned to `pagesDir` but instead it was assigned to `appDir` and vice versa






<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
