### PR TITLE
Add status code to app-render redirect response

### DIFF
--- a/packages/next/src/server/app-render.tsx
+++ b/packages/next/src/server/app-render.tsx
@@ -2020,6 +2020,9 @@ export async function renderToHTMLOrFlight(
         if (err.digest === NOT_FOUND_ERROR_CODE) {
           res.statusCode = 404
         }
+        if (err.digest?.startsWith(REDIRECT_ERROR_CODE)) {
+          res.statusCode = 307
+        }
 
         const renderStream = await renderToInitialStream({
           ReactDOMServer,

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -181,6 +181,17 @@ createNextDescribe(
           expect(await browser.url()).toBe(next.url + '/redirect-dest')
         })
       })
+
+      describe('status code', () => {
+        it('should respond with 307 status code in server component', async () => {
+          const res = await next.fetch('/redirect/servercomponent')
+          expect(res.status).toBe(307)
+        })
+        it('should respond with 307 status code in client component', async () => {
+          const res = await next.fetch('/redirect/clientcomponent')
+          expect(res.status).toBe(307)
+        })
+      })
     })
 
     describe('nested navigation', () => {


### PR DESCRIPTION
Responds with `307` status code when `redirect(...)` is called during app-render.

fix NEXT-512 ([link](https://linear.app/vercel/issue/NEXT-512))

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
