### PR TITLE
Update default tracing root handling

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1,5 +1,13 @@
 import { existsSync } from 'fs'
-import { basename, extname, join, relative, isAbsolute, resolve } from 'path'
+import {
+  basename,
+  extname,
+  join,
+  relative,
+  isAbsolute,
+  resolve,
+  dirname,
+} from 'path'
 import { pathToFileURL } from 'url'
 import { Agent as HttpAgent } from 'http'
 import { Agent as HttpsAgent } from 'https'
@@ -664,6 +672,23 @@ function assignDefaults(
       Log.warn(
         `experimental.outputFileTracingRoot should be absolute, using: ${result.experimental.outputFileTracingRoot}`
       )
+    }
+  }
+
+  // use the closest lockfile as tracing root
+  if (!result.experimental?.outputFileTracingRoot) {
+    const lockFiles: string[] = [
+      'package-lock.json',
+      'yarn.lock',
+      'pnpm-lock.yaml',
+    ]
+    const foundLockfile = findUp.sync(lockFiles, { cwd: dir })
+
+    if (foundLockfile) {
+      if (!result.experimental) {
+        result.experimental = {}
+      }
+      result.experimental.outputFileTracingRoot = dirname(foundLockfile)
     }
   }
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -688,7 +688,12 @@ function assignDefaults(
       if (!result.experimental) {
         result.experimental = {}
       }
+      if (!defaultConfig.experimental) {
+        defaultConfig.experimental = {}
+      }
       result.experimental.outputFileTracingRoot = dirname(foundLockfile)
+      defaultConfig.experimental.outputFileTracingRoot =
+        result.experimental.outputFileTracingRoot
     }
   }
 

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -186,7 +186,6 @@ export function runNextCommand(argv, options = {}) {
     ...process.env,
     NODE_ENV: '',
     __NEXT_TEST_MODE: 'true',
-    NEXT_PRIVATE_OUTPUT_TRACE_ROOT: path.join(__dirname, '../../'),
     ...options.env,
   }
 


### PR DESCRIPTION
This updates the default tracing root used when one isn't manually provided to be the directory of the closest lockfile. Previously it defaulted to the directory of the project being built which is incorrect in monorepos as any top-level dependencies wouldn't be traced correctly. Our tests were previously passing without this handling due to the env variable being manually set which this removes.  

x-ref: https://github.com/vercel/next.js/discussions/39432
x-ref: https://github.com/vercel/vercel/pull/9402
x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1675821643786319)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

