### PR TITLE
Add catchall 404 page in app/

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -138,10 +138,6 @@ async function createTreeCodeFromPath(
         rootLayout = layoutPath
       }
 
-      if (!rootLayout) {
-        rootLayout = layoutPath
-      }
-
       if (!globalError) {
         globalError = await resolver(
           `${appDirPrefix}${parallelSegmentPath}/${GLOBAL_ERROR_FILE_TYPE}`

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -240,6 +240,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
   protected abstract getFilesystemPaths(): Set<string>
   protected abstract findPageComponents(params: {
+    /** it should include page type suffix in app/, like `/page` or `/layout` */
     pathname: string
     query: NextParsedUrlQuery
     params: Params

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1895,14 +1895,18 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       let using404Page = false
 
       // use static 404 page if available and is 404 response
-      if (is404 && (await this.hasPage('/404'))) {
-        result = await this.findPageComponents({
-          pathname: '/404',
-          query,
-          params: {},
-          isAppPath: false,
-        })
-        using404Page = result !== null
+      if (is404) {
+        if (this.nextConfig.experimental.appDir) {
+          // find not-found.tsx in the app directory
+        } else if (await this.hasPage('/404')) {
+          result = await this.findPageComponents({
+            pathname: '/404',
+            query,
+            params: {},
+            isAppPath: false,
+          })
+          using404Page = result !== null
+        }
       }
       let statusPage = `/${res.statusCode}`
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1891,6 +1891,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     const { res, query } = ctx
     try {
       let result: null | FindComponentsResult = null
+      let statusPage = `/${res.statusCode}`
 
       const is404 = res.statusCode === 404
       let using404Page = false
@@ -1899,6 +1900,13 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       if (is404) {
         if (this.nextConfig.experimental.appDir) {
           // find not-found.tsx in the app directory
+          result = await this.findPageComponents({
+            pathname: '/not-found',
+            query,
+            params: {},
+            isAppPath: true,
+          })
+          using404Page = result !== null
         } else if (await this.hasPage('/404')) {
           result = await this.findPageComponents({
             pathname: '/404',
@@ -1909,7 +1917,6 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           using404Page = result !== null
         }
       }
-      let statusPage = `/${res.statusCode}`
 
       if (
         !ctx.query.__nextCustomErrorRender &&

--- a/packages/next/src/shared/lib/page-path/normalize-page-path.test.ts
+++ b/packages/next/src/shared/lib/page-path/normalize-page-path.test.ts
@@ -1,0 +1,13 @@
+import { normalizePagePath } from './normalize-page-path'
+
+describe('normalizePagePath', () => {
+  ;[
+    ['/', '/index'],
+    ['/index/foo', '/index/index/foo'],
+    ['/index', '/index/index'],
+  ].forEach(([input, expected]) => {
+    it(`${input} -> ${expected}`, () => {
+      expect(normalizePagePath(input)).toBe(expected)
+    })
+  })
+})

--- a/test/e2e/app-dir/catchall-not-found/app/layout.tsx
+++ b/test/e2e/app-dir/catchall-not-found/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/catchall-not-found/app/layout.tsx
+++ b/test/e2e/app-dir/catchall-not-found/app/layout.tsx
@@ -1,7 +1,10 @@
 export default function Root({ children }: { children: React.ReactNode }) {
   return (
     <html>
-      <body>{children}</body>
+      <body>
+        <h1>Layout</h1>
+        {children}
+      </body>
     </html>
   )
 }

--- a/test/e2e/app-dir/catchall-not-found/app/not-found.tsx
+++ b/test/e2e/app-dir/catchall-not-found/app/not-found.tsx
@@ -1,3 +1,8 @@
-export default function Page() {
-  return <p id="not-found">/</p>
+export default function NotFound() {
+  return (
+    <>
+      <h2>Not Found</h2>
+      <p>Could not find requested resource</p>
+    </>
+  )
 }

--- a/test/e2e/app-dir/catchall-not-found/app/not-found.tsx
+++ b/test/e2e/app-dir/catchall-not-found/app/not-found.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="not-found">/</p>
+}

--- a/test/e2e/app-dir/catchall-not-found/app/page.tsx
+++ b/test/e2e/app-dir/catchall-not-found/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="page">Page /</p>
+}

--- a/test/e2e/app-dir/catchall-not-found/app/page.tsx
+++ b/test/e2e/app-dir/catchall-not-found/app/page.tsx
@@ -1,3 +1,6 @@
+import { notFound } from 'next/navigation'
+
 export default function Page() {
-  return <p id="page">Page /</p>
+  notFound()
+  return <p id="page">Page: /</p>
 }

--- a/test/e2e/app-dir/catchall-not-found/app/page.tsx
+++ b/test/e2e/app-dir/catchall-not-found/app/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 
 export default function Page() {
-  notFound()
+  //  notFound()
   return <p id="page">Page: /</p>
 }

--- a/test/e2e/app-dir/catchall-not-found/catchall-not-found.test.ts
+++ b/test/e2e/app-dir/catchall-not-found/catchall-not-found.test.ts
@@ -1,0 +1,14 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'Catchall not-found.tsx',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('/not-found should be used when available', async () => {
+      const browser = await next.browser('/missing-page')
+      expect(await browser.elementByCss('p#not-found').text()).toBe('/')
+    })
+  }
+)

--- a/test/e2e/app-dir/catchall-not-found/next.config.js
+++ b/test/e2e/app-dir/catchall-not-found/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  experimental: { appDir: true },
+}

--- a/test/e2e/app-dir/catchall-not-found/not-found.js
+++ b/test/e2e/app-dir/catchall-not-found/not-found.js
@@ -1,0 +1,28 @@
+const _ = {
+  children: [
+    '',
+    {},
+    {
+      layout: [
+        () =>
+          Promise.resolve(/*! import() eager */).then(
+            __webpack_require__.bind(
+              __webpack_require__,
+              /*! ./app/layout.tsx */ '(sc_server)/./app/layout.tsx'
+            )
+          ),
+        '/home/pearman/dev/vercel/next.js/test/e2e/app-dir/catchall-not-found/app/layout.tsx',
+      ],
+      'not-found': [
+        () =>
+          Promise.resolve(/*! import() eager */).then(
+            __webpack_require__.bind(
+              __webpack_require__,
+              /*! ./app/not-found.tsx */ '(sc_server)/./app/not-found.tsx'
+            )
+          ),
+        '/home/pearman/dev/vercel/next.js/test/e2e/app-dir/catchall-not-found/app/not-found.tsx',
+      ],
+    },
+  ],
+}

--- a/test/e2e/app-dir/catchall-not-found/page.js
+++ b/test/e2e/app-dir/catchall-not-found/page.js
@@ -1,0 +1,45 @@
+const _ = {
+  children: [
+    '',
+    {
+      children: [
+        '',
+        {},
+        {
+          page: [
+            () =>
+              Promise.resolve(/*! import() eager */).then(
+                __webpack_require__.bind(
+                  __webpack_require__,
+                  /*! ./app/page.tsx */ '(sc_server)/./app/page.tsx'
+                )
+              ),
+            '/home/pearman/dev/vercel/next.js/test/e2e/app-dir/catchall-not-found/app/page.tsx',
+          ],
+        },
+      ],
+    },
+    {
+      layout: [
+        () =>
+          Promise.resolve(/*! import() eager */).then(
+            __webpack_require__.bind(
+              __webpack_require__,
+              /*! ./app/layout.tsx */ '(sc_server)/./app/layout.tsx'
+            )
+          ),
+        '/home/pearman/dev/vercel/next.js/test/e2e/app-dir/catchall-not-found/app/layout.tsx',
+      ],
+      'not-found': [
+        () =>
+          Promise.resolve(/*! import() eager */).then(
+            __webpack_require__.bind(
+              __webpack_require__,
+              /*! ./app/not-found.tsx */ '(sc_server)/./app/not-found.tsx'
+            )
+          ),
+        '/home/pearman/dev/vercel/next.js/test/e2e/app-dir/catchall-not-found/app/not-found.tsx',
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
- add tests for normalize-page-path.test.ts
- remove duplicated code
- add branching for custom 404 behavior in app dir
- add clarifying comment
- add test
- add not-found rendering fallback
- modify test
- added sample tree codes

fix NEXT-463 ([link](https://linear.app/vercel/issue/NEXT-463)) ([NEXT-463](https://linear.app/vercel/issue/NEXT-463))