### PR TITLE
Add warning when mismatching @next/swc version is being used

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -212,9 +212,6 @@ async function loadWasm(importPath = '') {
       if (pkg === '@next/swc-wasm-web') {
         bindings = await bindings.default()
       }
-      checkVersionMismatch(
-        await import(pkgPath.replace('wasm.js', 'package.json'))
-      )
       Log.info('Using wasm build of next-swc')
 
       // Note wasm binary does not support async intefaces yet, all async


### PR DESCRIPTION
This adds a debug warning to help catch when a stale `@next/swc` version is being used. 

x-ref: [slack thread](https://vercel.slack.com/archives/C02HY34AKME/p1676331498415309?thread_ts=1676315836.304549&cid=C02HY34AKME)
