### PR TITLE
Ensure terminal sequence is reset on dev exit

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -81,6 +81,11 @@ const handleSessionStop = async () => {
     // errors here aren't actionable so don't add
     // noise to the output
   }
+
+  // ensure we re-enable the terminal cursor before exiting
+  // the program, or the cursor could remain hidden
+  process.stdout.write('\x1B[?25h')
+  process.stdout.write('\n')
   process.exit(0)
 }
 

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -11,6 +11,7 @@ import {
 import { join } from 'path'
 import pkg from 'next/package'
 import http from 'http'
+import stripAnsi from 'strip-ansi'
 
 const dir = join(__dirname, '..')
 const dirDuplicateSass = join(__dirname, '../duplicate-sass')
@@ -254,7 +255,7 @@ describe('CLI Usage', () => {
       expect(stdout).not.toMatch('ready')
       expect(stdout).not.toMatch('started')
       expect(stdout).not.toMatch(`${port}`)
-      expect(stdout).toBeFalsy()
+      expect(stripAnsi(stdout).trim()).toBeFalsy()
     })
 
     test('--hostname', async () => {


### PR DESCRIPTION
Similar to our CNA handling when `ctrl` + `c` is used this ensures we reset the cursor for `next-dev`. 

