### PR TITLE
add stricter regex to parse import alias

### DIFF
--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -350,7 +350,7 @@ async function run(): Promise<void> {
           message: `What ${styledImportAlias} would you like configured?`,
           initial: getPrefOrDefault('importAlias'),
           validate: (value) =>
-            /.+\/\*/.test(value)
+            /^[^/]+\/\*$/.test(value)
               ? true
               : 'Import alias must follow the pattern <prefix>/*',
         })


### PR DESCRIPTION
attempts to fix #45884 by using a stricter regex to parse import alias in cli promt.

## Before:
The path `@/something/*` would not cause any problem.

<img width="955" alt="Screenshot 2023-02-14 at 11 32 53 AM" src="https://user-images.githubusercontent.com/57995897/218652784-14cbed03-aa0a-4638-b9cc-1ee933957ca2.png">

## After:
Now the path`@/something/*` would error saying it's not a valid import path.

<img width="813" alt="Screenshot 2023-02-14 at 11 33 08 AM" src="https://user-images.githubusercontent.com/57995897/218652828-8f3acdcd-8a3f-4287-8ce8-1ec55d7699ac.png">

## The Core issue

The actual code that makes the duplication as shown in #45884 is [here](https://github.com/vercel/next.js/blob/canary/packages/create-next-app/templates/index.ts#L87).


```diff
- const files = await glob('**/*', { cwd: root, dot: true })
+ const files = await glob('**/*', { cwd: root, dot: true,  ignore: ['tsconfig.json', 'jsconfig.json'] })
```

The import path of the `tsconfig.json` and `jsonconfig.json` is already changed by
```tsx
  await fs.promises.writeFile(
    tsconfigFile,
    (await fs.promises.readFile(tsconfigFile, 'utf8'))
      .replace(
        `"@/*": ["./*"]`,
        srcDir ? `"@/*": ["./src/*"]` : `"@/*": ["./*"]`
      )
      .replace(`"@/*":`, `"${importAlias}":`)
  )
```

So if we can ignore `tsconfig.json` and `jsconfig.json` when using `glob` we can stop the override.
We can use the regex one or the add configs to glob ignore or both. currently I just added a better regex for now.



<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

fix NEXT-543 ([link](https://linear.app/vercel/issue/NEXT-543))