### PR TITLE
Fix typo in `@next/mdx` readme

### DIFF
--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -99,7 +99,7 @@ yarn add @next/mdx
 
 ## Usage
 
-Create a `mdx-component.js` file at the root of your project with the following contents:
+Create a `mdx-components.js` file at the root of your project with the following contents:
 
 ```js
 // This file is required to use @next/mdx in the `app` directory.


### PR DESCRIPTION
Fixes a small typo in the `@next/mdx` [readme](url). The file that needs to be created is `mdx-components.{js,jsx,ts,tsx}`, not `mdx-component.{js,jsx,ts,tsx}`.

- Original MR where change was introduced: https://github.com/vercel/next.js/pull/44651/files#diff-bdcc8e0f4068c2d8bc8f1225c9776f3ec581e79a457abe748a053148925610d1R25
- This is also confirmed by the `app-dir-mdx` example: https://github.com/vercel/next.js/blob/3b1aa1c94174a293f8eb42b597ceb563264469dd/examples/app-dir-mdx/mdx-components.tsx

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
