### PR TITLE
Add missing isRootLayout when creating optimistic tree

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-optimistic-tree.test.ts
+++ b/packages/next/src/client/components/router-reducer/create-optimistic-tree.test.ts
@@ -42,6 +42,9 @@ describe('createOptimisticTree', () => {
           'refetch',
         ],
       },
+      undefined,
+      undefined,
+      true,
     ])
   })
 })

--- a/packages/next/src/client/components/router-reducer/create-optimistic-tree.ts
+++ b/packages/next/src/client/components/router-reducer/create-optimistic-tree.ts
@@ -10,10 +10,8 @@ export function createOptimisticTree(
   flightRouterState: FlightRouterState | null,
   parentRefetch: boolean
 ): FlightRouterState {
-  const [existingSegment, existingParallelRoutes] = flightRouterState || [
-    null,
-    {},
-  ]
+  const [existingSegment, existingParallelRoutes, url, refresh, isRootLayout] =
+    flightRouterState || [null, {}]
   const segment = segments[0]
   const isLastSegment = segments.length === 1
 
@@ -45,8 +43,18 @@ export function createOptimisticTree(
     },
   ]
 
+  if (url) {
+    result[2] = url
+  }
+
   if (!parentRefetch && shouldRefetchThisLevel) {
     result[3] = 'refetch'
+  } else if (refresh) {
+    result[3] = refresh
+  }
+
+  if (isRootLayout) {
+    result[4] = isRootLayout
   }
 
   return result

--- a/packages/next/src/client/components/router-reducer/create-optimistic-tree.ts
+++ b/packages/next/src/client/components/router-reducer/create-optimistic-tree.ts
@@ -49,11 +49,11 @@ export function createOptimisticTree(
 
   if (!parentRefetch && shouldRefetchThisLevel) {
     result[3] = 'refetch'
-  } else if (refresh) {
+  } else if (segmentMatches && refresh) {
     result[3] = refresh
   }
 
-  if (isRootLayout) {
+  if (segmentMatches && isRootLayout) {
     result[4] = isRootLayout
   }
 

--- a/test/e2e/app-dir/app-prefetch/app/prefetch-false/initial/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/prefetch-false/initial/page.js
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <>
+      <Link
+        href="/prefetch-false/result"
+        prefetch={false}
+        id="to-prefetch-false-result"
+      >
+        To prefetch false
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-prefetch/app/prefetch-false/result/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/prefetch-false/result/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="prefetch-false-page-result">Result page</h1>
+}

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -98,5 +98,17 @@ createNextDescribe(
         ).toBe(0)
       }
     })
+
+    it('should navigate when prefetch is false', async () => {
+      const browser = await next.browser('/prefetch-false/initial')
+      await browser
+        .elementByCss('#to-prefetch-false-result')
+        .click()
+        .waitForElementByCss('#prefetch-false-page-result')
+
+      expect(
+        await browser.elementByCss('#prefetch-false-page-result').text()
+      ).toBe('Result page')
+    })
   }
 )


### PR DESCRIPTION
Fixes #45750
Closes #45822 
fix NEXT-514 ([link](https://linear.app/vercel/issue/NEXT-514))

Ensures rootlayout marker is copied into the optimistic tree.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
