### PR TITLE
Use latest CLI for E2E tests

### DIFF
--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -75,10 +75,10 @@ export class NextDeployInstance extends NextInstance {
       additionalEnv.push(`${key}=${this.env[key]}`)
     }
 
-    if (process.env.VERCEL_CLI_VERSION) {
-      additionalEnv.push('--build-env')
-      additionalEnv.push(`VERCEL_CLI_VERSION=${process.env.VERCEL_CLI_VERSION}`)
-    }
+    additionalEnv.push('--build-env')
+    additionalEnv.push(
+      `VERCEL_CLI_VERSION=${process.env.VERCEL_CLI_VERSION || 'vercel@latest'}`
+    )
 
     const deployRes = await execa(
       'vercel',


### PR DESCRIPTION
Ensures we're testing against the latest version of the CLI even if it hasn't been rolled yet to catch regressions faster. 

x-ref: https://github.com/vercel/next.js/actions/runs/4176809448/jobs/7235660705

