### PR TITLE
Fix app routes on deploy

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -2051,6 +2051,8 @@ export default class NextNodeServer extends BaseServer {
     const initUrl =
       this.hostname && this.port
         ? `${protocol}://${this.hostname}:${this.port}${req.url}`
+        : (this.nextConfig.experimental as any).trustHostHeader
+        ? `https://${req.headers.host || 'localhost'}${req.url}`
         : req.url
 
     addRequestMeta(req, '__NEXT_INIT_URL', initUrl)

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -11,7 +11,7 @@ createNextDescribe(
   {
     files: __dirname,
     // TODO-APP: enable after deploy support is added
-    skipDeployment: true,
+    // skipDeployment: true,
   },
   ({ next }) => {
     describe('basic fetch request with a response', () => {
@@ -92,26 +92,29 @@ createNextDescribe(
     })
 
     describe('body', () => {
-      it('can handle handle a streaming request and streaming response', async () => {
-        const body = new Array(10).fill(JSON.stringify({ ping: 'pong' }))
-        let index = 0
-        const stream = new Readable({
-          read() {
-            if (index >= body.length) return this.push(null)
+      // we can't stream a body to a function currently only stream response
+      if (!(global as any).isNextDeploy) {
+        it('can handle handle a streaming request and streaming response', async () => {
+          const body = new Array(10).fill(JSON.stringify({ ping: 'pong' }))
+          let index = 0
+          const stream = new Readable({
+            read() {
+              if (index >= body.length) return this.push(null)
 
-            this.push(body[index] + '\n')
-            index++
-          },
+              this.push(body[index] + '\n')
+              index++
+            },
+          })
+
+          const res = await next.fetch('/advanced/body/streaming', {
+            method: 'POST',
+            body: stream,
+          })
+
+          expect(res.status).toEqual(200)
+          expect(await res.text()).toEqual(body.join('\n') + '\n')
         })
-
-        const res = await next.fetch('/advanced/body/streaming', {
-          method: 'POST',
-          body: stream,
-        })
-
-        expect(res.status).toEqual(200)
-        expect(await res.text()).toEqual(body.join('\n') + '\n')
-      })
+      }
 
       it('can read a JSON encoded body', async () => {
         const body = { ping: 'pong' }
@@ -125,27 +128,30 @@ createNextDescribe(
         expect(meta.body).toEqual(body)
       })
 
-      it('can read a streamed JSON encoded body', async () => {
-        const body = { ping: 'pong' }
-        const encoded = JSON.stringify(body)
-        let index = 0
-        const stream = new Readable({
-          async read() {
-            if (index >= encoded.length) return this.push(null)
+      // we can't stream a body to a function currently only stream response
+      if (!(global as any).isNextDeploy) {
+        it('can read a streamed JSON encoded body', async () => {
+          const body = { ping: 'pong' }
+          const encoded = JSON.stringify(body)
+          let index = 0
+          const stream = new Readable({
+            async read() {
+              if (index >= encoded.length) return this.push(null)
 
-            this.push(encoded[index])
-            index++
-          },
-        })
-        const res = await next.fetch('/advanced/body/json', {
-          method: 'POST',
-          body: stream,
-        })
+              this.push(encoded[index])
+              index++
+            },
+          })
+          const res = await next.fetch('/advanced/body/json', {
+            method: 'POST',
+            body: stream,
+          })
 
-        expect(res.status).toEqual(200)
-        const meta = getRequestMeta(res.headers)
-        expect(meta.body).toEqual(body)
-      })
+          expect(res.status).toEqual(200)
+          const meta = getRequestMeta(res.headers)
+          expect(meta.body).toEqual(body)
+        })
+      }
 
       it('can read the text body', async () => {
         const body = 'hello, world'
@@ -267,15 +273,17 @@ createNextDescribe(
         const error =
           'https://nextjs.org/docs/messages/next-response-next-in-app-route-handler'
 
-        // Precondition. We shouldn't have seen this before. This ensures we're
-        // testing that the specific route throws this error in the console.
-        expect(next.cliOutput).not.toContain(error)
-
         const res = await next.fetch('/status/500/next')
 
         expect(res.status).toEqual(500)
         expect(await res.text()).toBeEmpty()
-        expect(next.cliOutput).toContain(error)
+
+        if (!(global as any).isNextDeploy) {
+          // Precondition. We shouldn't have seen this before. This ensures we're
+          // testing that the specific route throws this error in the console.
+          expect(next.cliOutput).not.toContain(error)
+          expect(next.cliOutput).toContain(error)
+        }
       })
     })
 

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -274,15 +274,16 @@ createNextDescribe(
         const error =
           'https://nextjs.org/docs/messages/next-response-next-in-app-route-handler'
 
+        // Precondition. We shouldn't have seen this before. This ensures we're
+        // testing that the specific route throws this error in the console.
+        expect(next.cliOutput).not.toContain(error)
+
         const res = await next.fetch('/status/500/next')
 
         expect(res.status).toEqual(500)
         expect(await res.text()).toBeEmpty()
 
         if (!(global as any).isNextDeploy) {
-          // Precondition. We shouldn't have seen this before. This ensures we're
-          // testing that the specific route throws this error in the console.
-          expect(next.cliOutput).not.toContain(error)
           await check(() => {
             expect(next.cliOutput).toContain(error)
             return 'yes'

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -5,6 +5,7 @@ import {
   cookieWithRequestMeta,
 } from './helpers'
 import { Readable } from 'stream'
+import { check } from 'next-test-utils'
 
 createNextDescribe(
   'app-custom-routes',
@@ -282,7 +283,10 @@ createNextDescribe(
           // Precondition. We shouldn't have seen this before. This ensures we're
           // testing that the specific route throws this error in the console.
           expect(next.cliOutput).not.toContain(error)
-          expect(next.cliOutput).toContain(error)
+          await check(() => {
+            expect(next.cliOutput).toContain(error)
+            return 'yes'
+          }, 'yes')
         }
       })
     })

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -11,7 +11,7 @@ createNextDescribe(
   {
     files: __dirname,
     // TODO-APP: enable after deploy support is added
-    // skipDeployment: true,
+    skipDeployment: true,
   },
   ({ next }) => {
     describe('basic fetch request with a response', () => {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/45716 this ensures we correctly construct the initial URL value as it must be a fully qualified URL. Existing tests caught this failure when running in deploy mode. 


