### PR TITLE
Refactor freezing metadata while resolving and fix title merging

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -60,7 +60,7 @@ async function createAppRouteCode({
 
   return `
     import 'next/dist/server/node-polyfill-headers'
-    
+
     export * as handlers from ${JSON.stringify(resolvedPagePath)}
     export const resolvedPagePath = ${JSON.stringify(resolvedPagePath)}
 

--- a/packages/next/src/lib/metadata/generate/basic.tsx
+++ b/packages/next/src/lib/metadata/generate/basic.tsx
@@ -7,7 +7,7 @@ export function BasicMetadata({ metadata }: { metadata: ResolvedMetadata }) {
   return (
     <>
       <meta charSet="utf-8" />
-      {metadata.title !== null ? (
+      {metadata.title !== null && metadata.title.absolute ? (
         <title>{metadata.title.absolute}</title>
       ) : null}
       <Meta name="description" content={metadata.description} />

--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -2,7 +2,7 @@ import { accumulateMetadata, MetadataItems } from './resolve-metadata'
 
 describe('accumulateMetadata', () => {
   describe('merge title', () => {
-    it('should merge page title', async () => {
+    it('should merge title with page title', async () => {
       const metadataItems: MetadataItems = [
         [{ title: 'root' }, null],
         [{ title: 'layout' }, null],
@@ -14,7 +14,7 @@ describe('accumulateMetadata', () => {
       })
     })
 
-    it('should merge page title', async () => {
+    it('should merge title with parent layout ', async () => {
       const metadataItems: MetadataItems = [
         [{ title: 'root' }, null],
         [

--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -1,0 +1,37 @@
+import { accumulateMetadata, MetadataItems } from './resolve-metadata'
+
+describe('accumulateMetadata', () => {
+  describe('merge title', () => {
+    it('should merge page title', async () => {
+      const metadataItems: MetadataItems = [
+        [{ title: 'root' }, null],
+        [{ title: 'layout' }, null],
+        [{ title: 'page' }, null],
+      ]
+      const metadata = await accumulateMetadata(metadataItems)
+      expect(metadata).toMatchObject({
+        title: { absolute: 'page', template: null },
+      })
+    })
+
+    it('should merge page title', async () => {
+      const metadataItems: MetadataItems = [
+        [{ title: 'root' }, null],
+        [
+          { title: { absolute: 'layout', template: '1st parent layout %s' } },
+          null,
+        ],
+        [
+          { title: { absolute: 'layout', template: '2nd parent layout %s' } },
+          null,
+        ],
+        [null, null], // same level layout
+        [{ title: 'page' }, null],
+      ]
+      const metadata = await accumulateMetadata(metadataItems)
+      expect(metadata).toMatchObject({
+        title: { absolute: '2nd parent layout page', template: null },
+      })
+    })
+  })
+})

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -3,7 +3,6 @@ import type {
   ResolvedMetadata,
   ResolvingMetadata,
 } from './types/metadata-interface'
-import type { AbsoluteTemplateString } from './types/metadata-types'
 import type { MetadataImageModule } from '../../build/webpack/loaders/metadata/types'
 import { createDefaultMetadata } from './default-metadata'
 import { resolveOpenGraph, resolveTwitter } from './resolvers/resolve-opengraph'

--- a/packages/next/src/lib/metadata/resolvers/resolve-title.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-title.test.ts
@@ -1,0 +1,22 @@
+import { resolveTitle } from './resolve-title'
+
+describe('resolveTitle', () => {
+  it('should resolve nullable template as empty string title', () => {
+    expect(resolveTitle('', null)).toEqual({ absolute: '', template: null })
+    expect(resolveTitle(null, null)).toEqual({ absolute: '', template: null })
+  })
+
+  it('should resolve title with template', () => {
+    // returned template should equal the input title's template
+    expect(resolveTitle('title', 'dash %s')).toEqual({
+      absolute: 'dash title',
+      template: null,
+    })
+    expect(
+      resolveTitle({ default: 'title', template: '%s | absolute' }, 'dash %s')
+    ).toEqual({ absolute: 'dash title', template: '%s | absolute' })
+    expect(
+      resolveTitle({ default: '', template: '%s | absolute' }, 'fake template')
+    ).toEqual({ absolute: 'fake template', template: '%s | absolute' })
+  })
+})

--- a/packages/next/src/lib/metadata/resolvers/resolve-title.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-title.ts
@@ -1,23 +1,22 @@
 import type { Metadata } from '../types/metadata-interface'
 import type { AbsoluteTemplateString } from '../types/metadata-types'
 
-function resolveTitleTemplate(template: string | null, title: string) {
+function resolveTitleTemplate(
+  template: string | null | undefined,
+  title: string
+) {
   return template ? template.replace(/%s/g, title) : title
 }
 
-export function mergeTitle<T extends { title?: Metadata['title'] }>(
-  source: T,
-  stashedTemplate: string | null
-) {
-  const { title } = source
-
+export function resolveTitle(
+  title: Metadata['title'],
+  stashedTemplate: string | null | undefined
+): AbsoluteTemplateString {
   let resolved
   const template =
-    typeof source.title !== 'string' &&
-    source.title &&
-    'template' in source.title
-      ? source.title.template
-      : null
+    typeof title !== 'string' && title && 'template' in title
+      ? title.template
+      : stashedTemplate || null
 
   if (typeof title === 'string') {
     resolved = resolveTitleTemplate(stashedTemplate, title)
@@ -30,12 +29,12 @@ export function mergeTitle<T extends { title?: Metadata['title'] }>(
     }
   }
 
-  const target = source
   if (title && typeof title !== 'string') {
-    const targetTitle = title as AbsoluteTemplateString
-    targetTitle.template = template
-    targetTitle.absolute = resolved || ''
+    return {
+      template,
+      absolute: resolved || '',
+    }
   } else {
-    target.title = { absolute: resolved || title || '', template }
+    return { absolute: resolved || title || '', template }
   }
 }

--- a/packages/next/src/lib/metadata/resolvers/resolve-title.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-title.ts
@@ -16,7 +16,7 @@ export function resolveTitle(
   const template =
     typeof title !== 'string' && title && 'template' in title
       ? title.template
-      : stashedTemplate || null
+      : null
 
   if (typeof title === 'string') {
     resolved = resolveTitleTemplate(stashedTemplate, title)

--- a/packages/next/src/server/app-render.tsx
+++ b/packages/next/src/server/app-render.tsx
@@ -1138,10 +1138,7 @@ export async function renderToHTMLOrFlight(
         ...(isPage && searchParamsProps),
       }
 
-      // If the layout is located next to the page as leaf layer
-      const isLeafLayout =
-        typeof parallelRoutes.children?.[2].page !== 'undefined'
-      await collectMetadata(tree, layerProps, metadataItems, isLeafLayout)
+      await collectMetadata(tree, layerProps, metadataItems)
 
       for (const key in parallelRoutes) {
         const childTree = parallelRoutes[key]

--- a/packages/next/src/server/app-render.tsx
+++ b/packages/next/src/server/app-render.tsx
@@ -1116,9 +1116,8 @@ export async function renderToHTMLOrFlight(
       parentParams: { [key: string]: any },
       metadataItems: MetadataItems
     ): Promise<[React.ReactNode, MetadataItems]> {
-      const [segment, parallelRoutes, { head, layout, page }] = tree
+      const [segment, parallelRoutes, { head, page }] = tree
       const isPage = typeof page !== 'undefined'
-      const isLayout = typeof layout !== 'undefined'
       // Handle dynamic segment params.
       const segmentParam = getDynamicParamFromSegment(segment)
       /**

--- a/packages/next/src/server/app-render.tsx
+++ b/packages/next/src/server/app-render.tsx
@@ -1116,8 +1116,9 @@ export async function renderToHTMLOrFlight(
       parentParams: { [key: string]: any },
       metadataItems: MetadataItems
     ): Promise<[React.ReactNode, MetadataItems]> {
-      const [segment, parallelRoutes, { head, page }] = tree
+      const [segment, parallelRoutes, { head, layout, page }] = tree
       const isPage = typeof page !== 'undefined'
+      const isLayout = typeof layout !== 'undefined'
       // Handle dynamic segment params.
       const segmentParam = getDynamicParamFromSegment(segment)
       /**
@@ -1138,7 +1139,10 @@ export async function renderToHTMLOrFlight(
         ...(isPage && searchParamsProps),
       }
 
-      await collectMetadata(tree, layerProps, metadataItems)
+      // If the layout is located next to the page as leaf layer
+      const isLeafLayout =
+        typeof parallelRoutes.children?.[2].page !== 'undefined'
+      await collectMetadata(tree, layerProps, metadataItems, isLeafLayout)
 
       for (const key in parallelRoutes) {
         const childTree = parallelRoutes[key]

--- a/test/e2e/app-dir/metadata/app/title-template/extra/inner/deep/page.tsx
+++ b/test/e2e/app-dir/metadata/app/title-template/extra/inner/deep/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'deep'
+}

--- a/test/e2e/app-dir/metadata/app/title-template/extra/layout.tsx
+++ b/test/e2e/app-dir/metadata/app/title-template/extra/layout.tsx
@@ -5,5 +5,6 @@ export default function Layout(props) {
 export const metadata = {
   title: {
     template: '%s | Extra Layout',
+    default: 'extra layout default',
   },
 }

--- a/test/e2e/app-dir/metadata/app/title-template/layout.tsx
+++ b/test/e2e/app-dir/metadata/app/title-template/layout.tsx
@@ -5,6 +5,6 @@ export default function Layout(props) {
 export const metadata = {
   title: {
     template: '%s | Layout',
-    default: 'Layout title',
+    default: 'title template layout default',
   },
 }

--- a/test/e2e/app-dir/metadata/app/title-template/layout.tsx
+++ b/test/e2e/app-dir/metadata/app/title-template/layout.tsx
@@ -5,5 +5,6 @@ export default function Layout(props) {
 export const metadata = {
   title: {
     template: '%s | Layout',
+    default: 'Layout title',
   },
 }

--- a/test/e2e/app-dir/metadata/app/title-template/use-layout-title/page.tsx
+++ b/test/e2e/app-dir/metadata/app/title-template/use-layout-title/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'use layout title template'
+}

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -81,14 +81,14 @@ createNextDescribe(
 
       it('should support title template', async () => {
         const browser = await next.browser('/title-template')
-        expect(await browser.eval(`document.title`)).toBe('Page | Layout')
+        // Use the parent layout (root layout) instead of app/title-template/layout.tsx
+        expect(await browser.eval(`document.title`)).toBe('Page')
       })
 
       it('should support stashed title in one layer of page and layout', async () => {
         const browser = await next.browser('/title-template/extra')
-        expect(await browser.eval(`document.title`)).toBe(
-          'Extra Page | Extra Layout'
-        )
+        // Use the parent layout (app/title-template/layout.tsx) instead of app/title-template/extra/layout.tsx
+        expect(await browser.eval(`document.title`)).toBe('Extra Page | Layout')
       })
 
       it('should support stashed title in two layers of page and layout', async () => {

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -91,6 +91,11 @@ createNextDescribe(
         expect(await browser.eval(`document.title`)).toBe('Extra Page | Layout')
       })
 
+      it('should use parent layout title when no title is defined in page', async () => {
+        const browser = await next.browser('/title-template/use-layout-title')
+        expect(await browser.eval(`document.title`)).toBe('Layout title')
+      })
+
       it('should support stashed title in two layers of page and layout', async () => {
         const browser = await next.browser('/title-template/extra/inner')
         expect(await browser.eval(`document.title`)).toBe(

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -93,13 +93,18 @@ createNextDescribe(
 
       it('should use parent layout title when no title is defined in page', async () => {
         const browser = await next.browser('/title-template/use-layout-title')
-        expect(await browser.eval(`document.title`)).toBe('Layout title')
+        expect(await browser.eval(`document.title`)).toBe(
+          'title template layout default'
+        )
       })
 
       it('should support stashed title in two layers of page and layout', async () => {
-        const browser = await next.browser('/title-template/extra/inner')
-        expect(await browser.eval(`document.title`)).toBe(
-          'Inner Page | Extra Layout'
+        const $inner = await next.render$('/title-template/extra/inner')
+        expect(await $inner('title').text()).toBe('Inner Page | Extra Layout')
+
+        const $deep = await next.render$('/title-template/extra/inner/deep')
+        expect(await $deep('title').text()).toBe(
+          'extra layout default | Layout'
         )
       })
 


### PR DESCRIPTION
Addressing @gnoff 's comments from #45923

* Only freezing for the parentMetadata `argument`
* Group dev specific code in one place for less branches and better DEC
* Concurrently run the metadata resolving promises

Fix title merging: should use the parent layout instead of adjacent layout