### PR TITLE
Update Material UI examples

### DIFF
--- a/examples/with-material-ui/README.md
+++ b/examples/with-material-ui/README.md
@@ -2,5 +2,5 @@
 
 **Note:** These examples are maintained outside of the Next.js repository:
 
-1. Official [TypeScript example](https://github.com/mui/material-ui/tree/master/examples/nextjs-with-typescript)
-2. Official [JavaScript example](https://github.com/mui/material-ui/tree/master/examples/nextjs)
+1. Official [TypeScript example](https://github.com/mui/material-ui/tree/master/examples/material-next-ts)
+2. Official [JavaScript example](https://github.com/mui/material-ui/tree/master/examples/material-next)


### PR DESCRIPTION
The links to the material-ui examples were broken and have been corrected.

## Documentation / Examples

- [ ] ~Make sure the linting passes by running `pnpm build && pnpm lint`~
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
