### PR TITLE
Add edge support for route handlers

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -1,6 +1,7 @@
 import type { ClientPagesLoaderOptions } from './webpack/loaders/next-client-pages-loader'
 import type { MiddlewareLoaderOptions } from './webpack/loaders/next-middleware-loader'
 import type { EdgeSSRLoaderQuery } from './webpack/loaders/next-edge-ssr-loader'
+import type { EdgeAppRouteLoaderQuery } from './webpack/loaders/next-edge-app-route-loader'
 import type { NextConfigComplete } from '../server/config-shared'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type {
@@ -44,6 +45,7 @@ import { ServerRuntime } from '../../types'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import { encodeMatchers } from './webpack/loaders/next-middleware-loader'
 import { EdgeFunctionLoaderOptions } from './webpack/loaders/next-edge-function-loader'
+import { isAppRouteRoute } from '../lib/is-app-route-route'
 
 type ObjectValue<T> = T extends { [key: string]: infer V } ? V : never
 
@@ -162,6 +164,19 @@ export function getEdgeServerEntry(opts: {
   pagesType: 'app' | 'pages' | 'root'
   appDirLoader?: string
 }) {
+  if (
+    opts.pagesType === 'app' &&
+    isAppRouteRoute(opts.page) &&
+    opts.appDirLoader
+  ) {
+    const loaderParams: EdgeAppRouteLoaderQuery = {
+      absolutePagePath: opts.absolutePagePath,
+      page: opts.page,
+      appDirLoader: Buffer.from(opts.appDirLoader || '').toString('base64'),
+    }
+
+    return `next-edge-app-route-loader?${stringify(loaderParams)}!`
+  }
   if (isMiddlewareFile(opts.page)) {
     const loaderParams: MiddlewareLoaderOptions = {
       absolutePagePath: opts.absolutePagePath,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -128,7 +128,6 @@ import {
 } from '../client/components/app-router-headers'
 import { webpackBuild } from './webpack-build'
 import { NextBuildContext } from './build-context'
-import { isAppRouteRoute } from '../lib/is-app-route-route'
 
 export type SsgRoute = {
   initialRevalidateSeconds: number | false

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -128,6 +128,7 @@ import {
 } from '../client/components/app-router-headers'
 import { webpackBuild } from './webpack-build'
 import { NextBuildContext } from './build-context'
+import { isAppRouteRoute } from '../lib/is-app-route-route'
 
 export type SsgRoute = {
   initialRevalidateSeconds: number | false
@@ -1325,7 +1326,17 @@ export default async function build(
                   pageType === 'app' &&
                   staticInfo?.rsc !== RSC_MODULE_TYPES.client
 
-                if (!isReservedPage(page)) {
+                if (
+                  !isReservedPage(page) &&
+                  // TODO-APP: static generation of route
+                  !(
+                    pageType === 'app' &&
+                    isEdgeRuntime(pageRuntime) &&
+                    pagePath
+                      .replace(/\\/g, '/')
+                      .match(`/route\\.(?:${config.pageExtensions.join('|')})$`)
+                  )
+                ) {
                   try {
                     let edgeInfo: any
 

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1655,6 +1655,7 @@ export default async function getBaseWebpackConfig(
         'noop-loader',
         'next-middleware-loader',
         'next-edge-function-loader',
+        'next-edge-app-route-loader',
         'next-edge-ssr-loader',
         'next-middleware-asset-loader',
         'next-middleware-wasm-loader',

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/handle.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/handle.ts
@@ -17,19 +17,18 @@ export function getHandle({ page, mod }: any) {
     filename: '',
   })
 
-  function requestHandler(
-    pathname: string,
-    req: WebNextRequest,
-    res: WebNextResponse
-  ) {
-    const match = appRouteRouteMatcher.match(pathname)!
-    return appRouteRouteHandler.execute(match, mod, req, res)
-  }
-
   return async function handle(request: Request) {
     const extendedReq = new WebNextRequest(request)
     const extendedRes = new WebNextResponse()
-    requestHandler(new URL(request.url).pathname, extendedReq, extendedRes)
-    return await extendedRes.toResponse()
+    const match = appRouteRouteMatcher.match(new URL(request.url).pathname)!
+    const response = await appRouteRouteHandler.execute(
+      match,
+      mod,
+      extendedReq,
+      extendedRes,
+      request
+    )
+
+    return response
   }
 }

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/handle.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/handle.ts
@@ -1,0 +1,35 @@
+import {
+  WebNextRequest,
+  WebNextResponse,
+} from '../../../../server/base-http/web'
+import { AppRouteRouteHandler } from '../../../../server/future/route-handlers/app-route-route-handler'
+import { RouteKind } from '../../../../server/future/route-kind'
+import { AppRouteRouteMatcher } from '../../../../server/future/route-matchers/app-route-route-matcher'
+import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
+
+export function getHandle({ page, mod }: any) {
+  const appRouteRouteHandler = new AppRouteRouteHandler()
+  const appRouteRouteMatcher = new AppRouteRouteMatcher({
+    kind: RouteKind.APP_ROUTE,
+    pathname: normalizeAppPath(page),
+    page: '',
+    bundlePath: '',
+    filename: '',
+  })
+
+  function requestHandler(
+    pathname: string,
+    req: WebNextRequest,
+    res: WebNextResponse
+  ) {
+    const match = appRouteRouteMatcher.match(pathname)!
+    return appRouteRouteHandler.execute(match, mod, req, res)
+  }
+
+  return async function handle(request: Request) {
+    const extendedReq = new WebNextRequest(request)
+    const extendedRes = new WebNextResponse()
+    requestHandler(new URL(request.url).pathname, extendedReq, extendedRes)
+    return await extendedRes.toResponse()
+  }
+}

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
@@ -1,0 +1,61 @@
+import { getModuleBuildInfo } from '../get-module-build-info'
+import { stringifyRequest } from '../../stringify-request'
+
+export type EdgeAppRouteLoaderQuery = {
+  absolutePagePath: string
+  page: string
+  appDirLoader: string
+}
+
+export default async function edgeSSRLoader(this: any) {
+  const {
+    page,
+    absolutePagePath,
+    appDirLoader: appDirLoaderBase64,
+  } = this.getOptions()
+
+  const appDirLoader = Buffer.from(
+    appDirLoaderBase64 || '',
+    'base64'
+  ).toString()
+
+  const buildInfo = getModuleBuildInfo(this._module)
+  buildInfo.nextEdgeSSR = {
+    isServerComponent: false,
+    page: page,
+    isAppDir: true,
+  }
+  buildInfo.route = {
+    page,
+    absolutePagePath,
+  }
+
+  const stringifiedPagePath = stringifyRequest(this, absolutePagePath)
+
+  const pageModPath = `${appDirLoader}${stringifiedPagePath.substring(
+    1,
+    stringifiedPagePath.length - 1
+  )}?__edge_ssr_entry__`
+
+  const transformed = `
+    import { adapter, enhanceGlobals } from 'next/dist/esm/server/web/adapter'
+    import { getHandle } from 'next/dist/esm/build/webpack/loaders/next-edge-app-route-loader/handle'
+
+    enhanceGlobals()
+
+    import * as mod from ${JSON.stringify(pageModPath)}
+
+    const render = getHandle({
+      mod,
+      page: ${JSON.stringify(page)},
+    })
+
+    export default function(opts) {
+      return adapter({
+        ...opts,
+        handler: render
+      })
+    }`
+
+  return transformed
+}

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
@@ -7,7 +7,7 @@ export type EdgeAppRouteLoaderQuery = {
   appDirLoader: string
 }
 
-export default async function edgeSSRLoader(this: any) {
+export default async function edgeAppRouteLoader(this: any) {
   const {
     page,
     absolutePagePath,

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -1303,8 +1303,8 @@ export default class DevServer extends Server {
     return this.middleware
   }
 
-  protected getEdgeFunctions() {
-    return this.edgeFunctions ?? []
+  protected getEdgeFunctionsPages() {
+    return this.edgeFunctions ? this.edgeFunctions.map(({ page }) => page) : []
   }
 
   protected getServerComponentManifest() {

--- a/packages/next/src/server/future/route-kind.ts
+++ b/packages/next/src/server/future/route-kind.ts
@@ -2,19 +2,19 @@ export const enum RouteKind {
   /**
    * `PAGES` represents all the React pages that are under `pages/`.
    */
-  PAGES,
+  PAGES = 'PAGES',
   /**
    * `PAGES_API` represents all the API routes under `pages/api/`.
    */
-  PAGES_API,
+  PAGES_API = 'PAGES_API',
   /**
    * `APP_PAGE` represents all the React pages that are under `app/` with the
    * filename of `page.{j,t}s{,x}`.
    */
-  APP_PAGE,
+  APP_PAGE = 'APP_PAGE',
   /**
    * `APP_ROUTE` represents all the API routes that are under `app/` with the
    * filename of `route.{j,t}s{,x}`.
    */
-  APP_ROUTE,
+  APP_ROUTE = 'APP_ROUTE',
 }

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -72,6 +72,6 @@ export async function findPageFile(
 // The filename should start with 'page' and end with one of the allowed extensions
 export function isLayoutsLeafPage(filePath: string, pageExtensions: string[]) {
   return new RegExp(
-    `(^page|[\\\\/]page)\\.(?:${pageExtensions.join('|')})$`
+    `(^page|[\\\\/]page|^route|[\\\\/]route)\\.(?:${pageExtensions.join('|')})$`
   ).test(filePath)
 }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -19,10 +19,7 @@ import type { BaseNextRequest, BaseNextResponse } from './base-http'
 import type { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
 import type { PayloadOptions } from './send-payload'
 import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
-import type {
-  Params,
-  RouteMatchFn,
-} from '../shared/lib/router/utils/route-matcher'
+import type { Params } from '../shared/lib/router/utils/route-matcher'
 import type { MiddlewareRouteMatch } from '../shared/lib/router/utils/middleware-route-matcher'
 
 import fs from 'fs'
@@ -80,7 +77,6 @@ import { splitCookiesString, toNodeHeaders } from './web/utils'
 import { relativizeURL } from '../shared/lib/router/utils/relativize-url'
 import { prepareDestination } from '../shared/lib/router/utils/prepare-destination'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
-import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
 import { getMiddlewareRouteMatcher } from '../shared/lib/router/utils/middleware-route-matcher'
 import { loadEnvConfig } from '@next/env'
 import { getCustomRoute, stringifyQuery } from './server-route-utils'
@@ -120,11 +116,6 @@ export interface NodeRequestHandler {
 const MiddlewareMatcherCache = new WeakMap<
   MiddlewareManifest['middleware'][string],
   MiddlewareRouteMatch
->()
-
-const EdgeMatcherCache = new WeakMap<
-  MiddlewareManifest['functions'][string],
-  RouteMatchFn
 >()
 
 function getMiddlewareMatcher(

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -67,7 +67,6 @@ import BaseServer, {
   Options,
   FindComponentsResult,
   MiddlewareRoutingItem,
-  RoutingItem,
   NoFallbackError,
   RequestContext,
 } from './base-server'
@@ -181,28 +180,6 @@ const POSSIBLE_ERROR_CODE_FROM_SERVE_STATIC = new Set([
   // https://github.com/pillarjs/send/blob/53f0ab476145670a9bdd3dc722ab2fdc8d358fc6/index.js#L669
   416,
 ])
-
-function getEdgeMatcher(
-  info: MiddlewareManifest['functions'][string]
-): RouteMatchFn {
-  const stored = EdgeMatcherCache.get(info)
-  if (stored) {
-    return stored
-  }
-
-  if (!Array.isArray(info.matchers) || info.matchers.length !== 1) {
-    throw new Error(
-      `Invariant: invalid matchers for middleware ${JSON.stringify(info)}`
-    )
-  }
-
-  const matcher = getRouteMatcher({
-    re: new RegExp(info.matchers[0].regexp),
-    groups: {},
-  })
-  EdgeMatcherCache.set(info, matcher)
-  return matcher
-}
 
 export default class NextNodeServer extends BaseServer {
   private imageResponseCache?: ResponseCache

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1175,6 +1175,8 @@ export default class NextNodeServer extends BaseServer {
           const edgeFunctionsPages = this.getEdgeFunctionsPages()
           for (const edgeFunctionsPage of edgeFunctionsPages) {
             if (edgeFunctionsPage === match.definition.page) {
+              delete query._nextBubbleNoFallback
+
               const handledAsEdgeFunction = await this.runEdgeFunction({
                 req,
                 res,

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -312,6 +312,15 @@ createNextDescribe(
       })
     })
 
+    describe('edge functions', () => {
+      it('returns response using edge runtime', async () => {
+        const res = await next.fetch('/edge')
+
+        expect(res.status).toEqual(200)
+        expect(await res.text()).toContain('hello, world')
+      })
+    })
+
     if (isNextDev) {
       describe('lowercase exports', () => {
         it.each([

--- a/test/e2e/app-dir/app-routes/app/edge/route.ts
+++ b/test/e2e/app-dir/app-routes/app/edge/route.ts
@@ -1,0 +1,3 @@
+export const runtime = 'edge'
+
+export * from '../../handlers/hello'


### PR DESCRIPTION
- Add test for edge route
- Add edge route loader
- Ensure edge route does not trigger static generation
- Remove unused import
- Use new loader during compilation
- Add names for routeKind to help debugging
- Ensure route is considered a appDir page
- Return response from edge runtime
- Handle edge route in dev and prod

Fixes NEXT-510

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
