### PR TITLE
test(integration): emits successful test output for continue on error

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -420,25 +420,10 @@ async function main() {
           }
         }
       }
+
       if (!passed) {
         console.error(`${test} failed to pass within ${numRetries} retries`)
         children.forEach((child) => child.kill())
-
-        if (isTestJob) {
-          try {
-            const testsOutput = await fs.readFile(
-              `${test}${RESULTS_EXT}`,
-              'utf8'
-            )
-            console.log(
-              `--test output start--`,
-              testsOutput,
-              `--test output end--`
-            )
-          } catch (err) {
-            console.log(`Failed to load test output`, err)
-          }
-        }
 
         if (!shouldContinueTestsOnError) {
           cleanUpAndExit(1)
@@ -448,6 +433,21 @@ async function main() {
           )
         }
       }
+
+      // Emit test output if test failed or if we're continuing tests on error
+      if ((!passed || shouldContinueTestsOnError) && isTestJob) {
+        try {
+          const testsOutput = await fs.readFile(`${test}${RESULTS_EXT}`, 'utf8')
+          console.log(
+            `--test output start--`,
+            testsOutput,
+            `--test output end--`
+          )
+        } catch (err) {
+          console.log(`Failed to load test output`, err)
+        }
+      }
+
       sema.release()
       dirSema.release()
     })

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -11,7 +11,19 @@ import { shouldRunTurboDevTest } from './next-test-utils'
 export type { NextInstance }
 
 // increase timeout to account for yarn install time
-jest.setTimeout(240 * 1000)
+// if either test runs for the --turbo or have a custom timeout, set reduced timeout instead.
+// this is due to current --turbo test have a lot of tests fails with timeouts, ends up the whole
+// test job exceeds the 6 hours limit.
+let testTimeout = shouldRunTurboDevTest() ? (240 * 1000) / 4 : 240 * 1000
+if (process.env.NEXT_E2E_TEST_TIMEOUT) {
+  try {
+    testTimeout = parseInt(process.env.NEXT_E2E_TEST_TIMEOUT, 10)
+  } catch (_) {
+    // ignore
+  }
+}
+
+jest.setTimeout(testTimeout)
 
 const testsFolder = path.join(__dirname, '..')
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

- closes WEB-600
- partially resolves WEB-544

This PR applies minor ergonomics changes to the test runner. First, allows to emit successful test reports if continue_on_error is enabled: this allows to track total test stats with --turbo runs. Secondly allows to specify custom timeouts for the e2e - as written in comment otherwise it can exceed total 6 hours of job limit due to having lots of timeout-related failing tests.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
