### PR TITLE
Exclude system entrypoints from client manifest's chunk list

### DIFF
--- a/packages/next/src/build/webpack/plugins/app-build-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/app-build-manifest-plugin.ts
@@ -1,10 +1,8 @@
 import { webpack, sources } from 'next/dist/compiled/webpack/webpack'
 import {
   APP_BUILD_MANIFEST,
-  CLIENT_STATIC_FILES_RUNTIME_AMP,
-  CLIENT_STATIC_FILES_RUNTIME_MAIN,
   CLIENT_STATIC_FILES_RUNTIME_MAIN_APP,
-  CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH,
+  SYSTEM_ENTRYPOINTS,
 } from '../../../shared/lib/constants'
 import { getEntrypointFiles } from './build-manifest-plugin'
 import getAppRouteFromEntrypoint from '../../../server/get-app-route-from-entrypoint'
@@ -57,13 +55,6 @@ export class AppBuildManifestPlugin {
       pages: {},
     }
 
-    const systemEntrypoints = new Set<string>([
-      CLIENT_STATIC_FILES_RUNTIME_MAIN,
-      CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH,
-      CLIENT_STATIC_FILES_RUNTIME_AMP,
-      CLIENT_STATIC_FILES_RUNTIME_MAIN_APP,
-    ])
-
     const mainFiles = new Set(
       getEntrypointFiles(
         compilation.entrypoints.get(CLIENT_STATIC_FILES_RUNTIME_MAIN_APP)
@@ -75,7 +66,7 @@ export class AppBuildManifestPlugin {
         continue
       }
 
-      if (systemEntrypoints.has(entrypoint.name)) {
+      if (SYSTEM_ENTRYPOINTS.has(entrypoint.name)) {
         continue
       }
 

--- a/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
@@ -10,6 +10,7 @@ import {
   CLIENT_STATIC_FILES_RUNTIME_POLYFILLS_SYMBOL,
   CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH,
   CLIENT_STATIC_FILES_RUNTIME_AMP,
+  SYSTEM_ENTRYPOINTS,
 } from '../../../shared/lib/constants'
 import { BuildManifest } from '../../../server/get-page-files'
 import getRouteFromEntrypoint from '../../../server/get-route-from-entrypoint'
@@ -188,15 +189,8 @@ export default class BuildManifestPlugin {
         entrypoints.get(CLIENT_STATIC_FILES_RUNTIME_AMP)
       )
 
-      const systemEntrypoints = new Set([
-        CLIENT_STATIC_FILES_RUNTIME_MAIN,
-        CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH,
-        CLIENT_STATIC_FILES_RUNTIME_AMP,
-        ...(this.appDirEnabled ? [CLIENT_STATIC_FILES_RUNTIME_MAIN_APP] : []),
-      ])
-
       for (const entrypoint of compilation.entrypoints.values()) {
-        if (systemEntrypoints.has(entrypoint.name)) continue
+        if (SYSTEM_ENTRYPOINTS.has(entrypoint.name)) continue
         const pagePath = getRouteFromEntrypoint(entrypoint.name)
 
         if (!pagePath) {

--- a/packages/next/src/shared/lib/constants.ts
+++ b/packages/next/src/shared/lib/constants.ts
@@ -148,3 +148,10 @@ export const EDGE_UNSUPPORTED_NODE_APIS = [
   'TransformStreamDefaultController',
   'WritableStreamDefaultController',
 ]
+
+export const SYSTEM_ENTRYPOINTS = new Set<string>([
+  CLIENT_STATIC_FILES_RUNTIME_MAIN,
+  CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH,
+  CLIENT_STATIC_FILES_RUNTIME_AMP,
+  CLIENT_STATIC_FILES_RUNTIME_MAIN_APP,
+])


### PR DESCRIPTION
System entrypoints such as like `amp` can be included in the same chunk group of a module we are trying to load, but they are guaranteed to be existing and there's no need to list them in the manifest's chunks.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
