### PR TITLE
Fixing nextjs-recoil example

### DIFF
--- a/examples/with-recoil/lib/recoil-atoms.js
+++ b/examples/with-recoil/lib/recoil-atoms.js
@@ -7,10 +7,12 @@ export const countState = atom({
 
 export const incrementCount = selector({
   key: 'incrementCount',
+  get: ({ get }) => get(countState),
   set: ({ set }) => set(countState, (currCount) => currCount + 1),
 })
 
 export const decrementCount = selector({
   key: 'decrementCount',
+  get: ({ get }) => get(countState),
   set: ({ set }) => set(countState, (currCount) => currCount - 1),
 })

--- a/examples/with-recoil/package.json
+++ b/examples/with-recoil/package.json
@@ -9,6 +9,6 @@
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "recoil": "0.0.7"
+    "recoil": "0.7.6"
   }
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

Update the recoil version as previous one is not compatible with react-18.
The issue with this example is that it only defines a set function for the incrementCount and decrementCount selector, but it does not define a get function. In Recoil, every selector needs to have a get function defined in order to retrieve its value.

## Before

<img width="966" alt="Screenshot 2023-02-17 at 7 32 06 AM" src="https://user-images.githubusercontent.com/85363195/219532017-ec0d4c7e-adb7-453d-9709-35e4136a13a4.png">

## After

![recoil-up](https://user-images.githubusercontent.com/85363195/219532101-1105d6a9-790d-4538-a3f0-86ac6309f4c9.gif)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
