### PR TITLE
Fix normalization of .rsc extension

### DIFF
--- a/packages/next/src/shared/lib/router/utils/app-paths.test.ts
+++ b/packages/next/src/shared/lib/router/utils/app-paths.test.ts
@@ -1,0 +1,22 @@
+import { normalizeRscPath } from './app-paths'
+
+describe('normalizeRscPath', () => {
+  describe('enabled', () => {
+    it('should normalize url with .rsc', () => {
+      expect(normalizeRscPath('/test.rsc', true)).toBe('/test')
+    })
+    it('should normalize url with .rsc and querystring', () => {
+      expect(normalizeRscPath('/test.rsc?abc=def', true)).toBe('/test?abc=def')
+    })
+  })
+  describe('disabled', () => {
+    it('should normalize url with .rsc', () => {
+      expect(normalizeRscPath('/test.rsc', false)).toBe('/test.rsc')
+    })
+    it('should normalize url with .rsc and querystring', () => {
+      expect(normalizeRscPath('/test.rsc?abc=def', false)).toBe(
+        '/test.rsc?abc=def'
+      )
+    })
+  })
+})

--- a/packages/next/src/shared/lib/router/utils/app-paths.test.ts
+++ b/packages/next/src/shared/lib/router/utils/app-paths.test.ts
@@ -5,7 +5,7 @@ describe('normalizeRscPath', () => {
     it('should normalize url with .rsc', () => {
       expect(normalizeRscPath('/test.rsc', true)).toBe('/test')
     })
-    it('should normalize url with .rsc and querystring', () => {
+    it('should normalize url with .rsc and searchparams', () => {
       expect(normalizeRscPath('/test.rsc?abc=def', true)).toBe('/test?abc=def')
     })
   })
@@ -13,7 +13,7 @@ describe('normalizeRscPath', () => {
     it('should normalize url with .rsc', () => {
       expect(normalizeRscPath('/test.rsc', false)).toBe('/test.rsc')
     })
-    it('should normalize url with .rsc and querystring', () => {
+    it('should normalize url with .rsc and searchparams', () => {
       expect(normalizeRscPath('/test.rsc?abc=def', false)).toBe(
         '/test.rsc?abc=def'
       )

--- a/packages/next/src/shared/lib/router/utils/app-paths.ts
+++ b/packages/next/src/shared/lib/router/utils/app-paths.ts
@@ -51,5 +51,11 @@ export function normalizeAppPath(route: string) {
 }
 
 export function normalizeRscPath(pathname: string, enabled?: boolean) {
-  return enabled ? pathname.replace(/\.rsc($|\?)/, '') : pathname
+  return enabled
+    ? pathname.replace(
+        /\.rsc($|\?)/,
+        // $1 ensures `?` is preserved
+        '$1'
+      )
+    : pathname
 }

--- a/packages/next/src/shared/lib/router/utils/app-paths.ts
+++ b/packages/next/src/shared/lib/router/utils/app-paths.ts
@@ -50,6 +50,10 @@ export function normalizeAppPath(route: string) {
   )
 }
 
+/**
+ * Strips the `.rsc` extension if it's in the pathname.
+ * Since this function is used on full urls it checks `?` for searchParams handling.
+ */
 export function normalizeRscPath(pathname: string, enabled?: boolean) {
   return enabled
     ? pathname.replace(


### PR DESCRIPTION
Fixes #45883
fix NEXT-541 ([link](https://linear.app/vercel/issue/NEXT-541))

The reason the url after normalization in middleware ended up being `/somethingabc=def` instead of `/something?abc=def` is that the regex matches `?` so the `?` will be removed. Since it's in a capture group the only change needed was applying that by adding `$1` to the replacement.

Added some unit tests for this function, going to add additional integration tests now.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
