### PR TITLE
Improve generic namings

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -9,16 +9,16 @@ import type { PreviewData } from 'next/types'
 import { COMPILER_NAMES } from './constants'
 
 export type NextComponentType<
-  C extends BaseContext = NextPageContext,
-  IP = {},
-  P = {}
-> = ComponentType<P> & {
+  Context extends BaseContext = NextPageContext,
+  InitialProps = {},
+  Props = {}
+> = ComponentType<Props> & {
   /**
    * Used for initial page load data population. Data returned from `getInitialProps` is serialized when server rendered.
    * Make sure to return plain `Object` without using `Date`, `Map`, `Set`.
-   * @param ctx Context of `page`
+   * @param context Context of `page`
    */
-  getInitialProps?(context: C): IP | Promise<IP>
+  getInitialProps?(context: Context): InitialProps | Promise<InitialProps>
 }
 
 export type DocumentType = NextComponentType<
@@ -159,23 +159,23 @@ export interface NextPageContext {
   AppTree: AppTreeType
 }
 
-export type AppContextType<R extends NextRouter = NextRouter> = {
+export type AppContextType<Router extends NextRouter = NextRouter> = {
   Component: NextComponentType<NextPageContext>
   AppTree: AppTreeType
   ctx: NextPageContext
-  router: R
+  router: Router
 }
 
-export type AppInitialProps<P = any> = {
-  pageProps: P
+export type AppInitialProps<PageProps = any> = {
+  pageProps: PageProps
 }
 
 export type AppPropsType<
-  R extends NextRouter = NextRouter,
-  P = {}
-> = AppInitialProps<P> & {
+  Router extends NextRouter = NextRouter,
+  PageProps = {}
+> = AppInitialProps<PageProps> & {
   Component: NextComponentType<NextPageContext, any, any>
-  router: R
+  router: Router
   __N_SSG?: boolean
   __N_SSP?: boolean
 }
@@ -230,18 +230,18 @@ type Send<T> = (body: T) => void
 /**
  * Next `API` route response
  */
-export type NextApiResponse<T = any> = ServerResponse & {
+export type NextApiResponse<Data = any> = ServerResponse & {
   /**
    * Send data `any` data in response
    */
-  send: Send<T>
+  send: Send<Data>
   /**
    * Send data `json` data in response
    */
-  json: Send<T>
-  status: (statusCode: number) => NextApiResponse<T>
-  redirect(url: string): NextApiResponse<T>
-  redirect(status: number, url: string): NextApiResponse<T>
+  json: Send<Data>
+  status: (statusCode: number) => NextApiResponse<Data>
+  redirect(url: string): NextApiResponse<Data>
+  redirect(status: number, url: string): NextApiResponse<Data>
 
   /**
    * Set preview data for Next.js' prerender mode
@@ -262,13 +262,20 @@ export type NextApiResponse<T = any> = ServerResponse & {
        */
       path?: string
     }
-  ) => NextApiResponse<T>
+  ) => NextApiResponse<Data>
 
   /**
    * Clear preview data for Next.js' prerender mode
    */
-  clearPreviewData: (options?: { path?: string }) => NextApiResponse<T>
+  clearPreviewData: (options?: { path?: string }) => NextApiResponse<Data>
 
+  /**
+   * Revalidate a specific page and regenerate it using On-Demand Incremental
+   * Static Regeneration.
+   * The path should be an actual path, not a rewritten path. E.g. for
+   * "/blog/[slug]" this should be "/blog/post-1".
+   * @link https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#on-demand-revalidation
+   */
   revalidate: (
     urlPath: string,
     opts?: {

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -62,7 +62,11 @@ export type Redirect =
 /**
  * `Page` type, use it as a guide to create `pages`.
  */
-export type NextPage<P = {}, IP = P> = NextComponentType<NextPageContext, IP, P>
+export type NextPage<Props = {}, InitialProps = Props> = NextComponentType<
+  NextPageContext,
+  InitialProps,
+  Props
+>
 
 export type FileSizeSuffix = `${
   | 'k'
@@ -135,29 +139,29 @@ export {
 export type PreviewData = string | false | object | undefined
 
 export type GetStaticPropsContext<
-  Q extends ParsedUrlQuery = ParsedUrlQuery,
-  D extends PreviewData = PreviewData
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData
 > = {
-  params?: Q
+  params?: Params
   preview?: boolean
-  previewData?: D
+  previewData?: Preview
   locale?: string
   locales?: string[]
   defaultLocale?: string
 }
 
-export type GetStaticPropsResult<P> =
-  | { props: P; revalidate?: number | boolean }
+export type GetStaticPropsResult<Props> =
+  | { props: Props; revalidate?: number | boolean }
   | { redirect: Redirect; revalidate?: number | boolean }
   | { notFound: true; revalidate?: number | boolean }
 
 export type GetStaticProps<
-  P extends { [key: string]: any } = { [key: string]: any },
-  Q extends ParsedUrlQuery = ParsedUrlQuery,
-  D extends PreviewData = PreviewData
+  Props extends { [key: string]: any } = { [key: string]: any },
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData
 > = (
-  context: GetStaticPropsContext<Q, D>
-) => Promise<GetStaticPropsResult<P>> | GetStaticPropsResult<P>
+  context: GetStaticPropsContext<Params, Preview>
+) => Promise<GetStaticPropsResult<Props>> | GetStaticPropsResult<Props>
 
 export type InferGetStaticPropsType<T extends (args: any) => any> = Extract<
   Awaited<ReturnType<T>>,
@@ -169,45 +173,47 @@ export type GetStaticPathsContext = {
   defaultLocale?: string
 }
 
-export type GetStaticPathsResult<P extends ParsedUrlQuery = ParsedUrlQuery> = {
-  paths: Array<string | { params: P; locale?: string }>
+export type GetStaticPathsResult<
+  Params extends ParsedUrlQuery = ParsedUrlQuery
+> = {
+  paths: Array<string | { params: Params; locale?: string }>
   fallback: boolean | 'blocking'
 }
 
-export type GetStaticPaths<P extends ParsedUrlQuery = ParsedUrlQuery> = (
+export type GetStaticPaths<Params extends ParsedUrlQuery = ParsedUrlQuery> = (
   context: GetStaticPathsContext
-) => Promise<GetStaticPathsResult<P>> | GetStaticPathsResult<P>
+) => Promise<GetStaticPathsResult<Params>> | GetStaticPathsResult<Params>
 
 export type GetServerSidePropsContext<
-  Q extends ParsedUrlQuery = ParsedUrlQuery,
-  D extends PreviewData = PreviewData
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData
 > = {
   req: IncomingMessage & {
     cookies: NextApiRequestCookies
   }
   res: ServerResponse
-  params?: Q
+  params?: Params
   query: ParsedUrlQuery
   preview?: boolean
-  previewData?: D
+  previewData?: Preview
   resolvedUrl: string
   locale?: string
   locales?: string[]
   defaultLocale?: string
 }
 
-export type GetServerSidePropsResult<P> =
-  | { props: P | Promise<P> }
+export type GetServerSidePropsResult<Props> =
+  | { props: Props | Promise<Props> }
   | { redirect: Redirect }
   | { notFound: true }
 
 export type GetServerSideProps<
-  P extends { [key: string]: any } = { [key: string]: any },
-  Q extends ParsedUrlQuery = ParsedUrlQuery,
-  D extends PreviewData = PreviewData
+  Props extends { [key: string]: any } = { [key: string]: any },
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData
 > = (
-  context: GetServerSidePropsContext<Q, D>
-) => Promise<GetServerSidePropsResult<P>>
+  context: GetServerSidePropsContext<Params, Preview>
+) => Promise<GetServerSidePropsResult<Props>>
 
 export type InferGetServerSidePropsType<T extends (args: any) => any> = Awaited<
   Extract<Awaited<ReturnType<T>>, { props: any }>['props']


### PR DESCRIPTION
Improves the naming of some generics to be more explicit. This feedback was reported by some community members on Twitter.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
