### PR TITLE
fix: codemod `next/image` within monorepo

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/many-keys/input/next.config.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/many-keys/input/next.config.js
@@ -1,0 +1,21 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+module.exports = {
+  reactStrictMode: true,
+
+  images: {
+    loader: "cloudinary",
+    path: "https://example.com/"
+  },
+
+  async redirects() {
+    return [
+      {
+        source: '/source',
+        destination: '/dest',
+        permanent: true,
+      },
+    ];
+  },
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/many-keys/output/cloudinary-loader.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/many-keys/output/cloudinary-loader.js
@@ -1,0 +1,6 @@
+const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src
+export default function cloudinaryLoader({ src, width, quality }) {
+const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
+const paramsString = params.join(',') + '/'
+return 'https://example.com/' + paramsString + normalizeSrc(src)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/many-keys/output/next.config.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/many-keys/output/next.config.js
@@ -1,0 +1,21 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+module.exports = {
+  reactStrictMode: true,
+
+  images: {
+    loader: "custom",
+    loaderFile: "./cloudinary-loader.js"
+  },
+
+  async redirects() {
+    return [
+      {
+        source: '/source',
+        destination: '/dest',
+        permanent: true,
+      },
+    ];
+  },
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/input/app1/next.config.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/input/app1/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  images: {
+    loader: "imgix",
+    path: "https://example.com/"
+  },
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/input/app2/next.config.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/input/app2/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  images: {
+    loader: "cloudinary",
+    path: "https://example.com/"
+  },
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/output/app1/imgix-loader.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/output/app1/imgix-loader.js
@@ -1,0 +1,10 @@
+const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src
+export default function imgixLoader({ src, width, quality }) {
+const url = new URL('https://example.com/' + normalizeSrc(src))
+const params = url.searchParams
+params.set('auto', params.getAll('auto').join(',') || 'format')
+params.set('fit', params.get('fit') || 'max')
+params.set('w', params.get('w') || width.toString())
+if (quality) { params.set('q', quality.toString()) }
+return url.href
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/output/app1/next.config.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/output/app1/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  images: {
+    loader: "custom",
+    loaderFile: "./imgix-loader.js"
+  },
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/output/app2/cloudinary-loader.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/output/app2/cloudinary-loader.js
@@ -1,0 +1,6 @@
+const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src
+export default function cloudinaryLoader({ src, width, quality }) {
+const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
+const paramsString = params.join(',') + '/'
+return 'https://example.com/' + paramsString + normalizeSrc(src)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/output/app2/next.config.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-image-experimental-loader/monorepo/output/app2/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  images: {
+    loader: "custom",
+    loaderFile: "./cloudinary-loader.js"
+  },
+}

--- a/packages/next-codemod/transforms/__tests__/next-image-experimental-loader.test.js
+++ b/packages/next-codemod/transforms/__tests__/next-image-experimental-loader.test.js
@@ -2,12 +2,13 @@
 jest.autoMockOff()
 const Runner = require('jscodeshift/dist/Runner');
 const { cp, mkdir, rm, readdir, readFile } = require('fs/promises')
-const { readdirSync } = require('fs')
+const { mkdtempSync, readdirSync } = require('fs')
+const { tmpdir } = require('os')
 const { join } = require('path')
 
 const fixtureDir = join(__dirname, '..', '__testfixtures__', 'next-image-experimental-loader')
 const transform = join(__dirname, '..', 'next-image-experimental.js')
-const opts = { recursive: true }
+const opts = { recursive: true, force: true }
 
 async function toObj(dir) {
   const obj = {}
@@ -19,18 +20,21 @@ async function toObj(dir) {
 }
 
 it.each(readdirSync(fixtureDir))('should transform loader %s', async (loader) => {
+  const tmp = mkdtempSync(join(tmpdir(), `next-image-experimental-${loader}-`))
+  const originalCwd = process.cwd()
   try {
-    await mkdir(join(fixtureDir, 'tmp'), opts)
-    await cp(join(fixtureDir, loader, 'input'), join(fixtureDir, 'tmp'), opts)
-    process.chdir(join(fixtureDir, 'tmp'))
+    await mkdir(tmp, opts)
+    await cp(join(fixtureDir, loader, 'input'), tmp, opts)
+    process.chdir(tmp)
     const result = await Runner.run(transform, [`.`], {})
     expect(result.error).toBe(0)
     expect(
-      await toObj(join(fixtureDir, 'tmp'))
+      await toObj(tmp)
     ).toStrictEqual(
       await toObj(join(fixtureDir, loader, 'output'))
     )
   } finally {
-    await rm(join(fixtureDir, 'tmp'), opts)
+    await rm(tmp, opts)
+    process.chdir(originalCwd)
   }
 })

--- a/packages/next-codemod/transforms/next-image-experimental.ts
+++ b/packages/next-codemod/transforms/next-image-experimental.ts
@@ -193,15 +193,20 @@ function nextConfigTransformer(
         return true
       })
       if (loaderType && pathPrefix) {
-        let filename = `./${loaderType}-loader.js`
+        const importSpecifier = `./${loaderType}-loader.js`
+        const filePath = join(appDir, importSpecifier)
         properties.push(
-          j.property('init', j.identifier('loaderFile'), j.literal(filename))
+          j.property(
+            'init',
+            j.identifier('loaderFile'),
+            j.literal(importSpecifier)
+          )
         )
         images.value.properties = properties
         const normalizeSrc = `const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src`
         if (loaderType === 'imgix') {
           writeFileSync(
-            join(appDir, filename),
+            filePath,
             `${normalizeSrc}
             export default function imgixLoader({ src, width, quality }) {
               const url = new URL('${pathPrefix}' + normalizeSrc(src))
@@ -218,7 +223,7 @@ function nextConfigTransformer(
           )
         } else if (loaderType === 'cloudinary') {
           writeFileSync(
-            filename,
+            filePath,
             `${normalizeSrc}
             export default function cloudinaryLoader({ src, width, quality }) {
               const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
@@ -231,7 +236,7 @@ function nextConfigTransformer(
           )
         } else if (loaderType === 'akamai') {
           writeFileSync(
-            filename,
+            filePath,
             `${normalizeSrc}
             export default function akamaiLoader({ src, width, quality }) {
               return '${pathPrefix}' + normalizeSrc(src) + '?imwidth=' + width
@@ -255,7 +260,7 @@ export default function transformer(
   const j = api.jscodeshift.withParser('tsx')
   const root = j(file.source)
 
-  const parsed = parse(file.path)
+  const parsed = parse(file.path || '/')
   const isConfig =
     parsed.base === 'next.config.js' ||
     parsed.base === 'next.config.ts' ||


### PR DESCRIPTION
Fix for running the `next/image` codemod within a monorepo

Related to https://twitter.com/codercatdev/status/1625972398448078848
