### PR TITLE
Add logging-route-events examples

### DIFF
--- a/examples/logging-route-events/.gitignore
+++ b/examples/logging-route-events/.gitignore
@@ -1,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/logging-route-events/README.md
+++ b/examples/logging-route-events/README.md
@@ -1,0 +1,27 @@
+# Example app logging route events
+
+This example features logs about the execution order of route events and the path information when navigating
+
+## Deploy your own
+
+Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/logging-route-events&project-name=logging-route-events&repository-name=logging-route-events)
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
+
+```bash
+npx create-next-app --example logging-route-events logging-route-events-app
+```
+
+```bash
+yarn create next-app --example logging-route-events logging-route-events-app
+```
+
+```bash
+pnpm create next-app --example logging-route-events logging-route-events-app
+```
+
+Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/logging-route-events/package.json
+++ b/examples/logging-route-events/package.json
@@ -1,0 +1,18 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "18.13.0",
+    "@types/react": "18.0.28",
+    "typescript": "4.9.5"
+  }
+}

--- a/examples/logging-route-events/pages/[itemId].tsx
+++ b/examples/logging-route-events/pages/[itemId].tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+export default function ItemPage() {
+  const { query, asPath } = useRouter()
+  const hash = asPath.split('#')[1]
+
+  return (
+    <ul>
+      <li>
+        <Link href="/">Route To Index Page</Link>
+      </li>
+      <li>
+        <Link href={`/${Number(query.itemId) + 1}`}>
+          Route To Next Item Page
+        </Link>
+      </li>
+      <li>
+        <Link href={hash ? asPath.replace(`#${hash}`, '') : asPath + '#hash'}>
+          {hash ? 'Remove hash' : 'Append hash'}
+        </Link>
+      </li>
+    </ul>
+  )
+}

--- a/examples/logging-route-events/pages/_app.tsx
+++ b/examples/logging-route-events/pages/_app.tsx
@@ -1,0 +1,75 @@
+import type { AppProps } from 'next/app'
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export default function App({ Component, pageProps }: AppProps) {
+  const router = useRouter()
+  const { pathname, asPath, query } = router
+
+  useEffect(() => {
+    const handleRouteChangeStart = (url: string) => {
+      console.log(
+        'event: routeChangeStart, ',
+        `url: ${url}, `,
+        `asPath: ${asPath}`
+      )
+    }
+    const handleBeforeHistoryChange = (url: string) => {
+      console.log(
+        'event: beforeHistoryChange, ',
+        `url: ${url}, `,
+        `asPath: ${asPath}`
+      )
+    }
+    const handleRouteChangeComplete = (url: string) => {
+      console.log(
+        'event: routeChangeComplete, ',
+        `url: ${url}, `,
+        `asPath: ${asPath}`
+      )
+    }
+    const handleHashChangeStart = (url: string) => {
+      console.log(
+        'event: hashChangeStart, ',
+        `url: ${url}, `,
+        `asPath: ${asPath}`
+      )
+    }
+    const handleHashChangeComplete = (url: string) => {
+      console.log(
+        'event:hashChangeComplete, ',
+        `url: ${url}, `,
+        `asPath:${asPath}`
+      )
+    }
+    const handleBeforePopState = ({ url, as }: { url: string; as: string }) => {
+      console.log(
+        'event: beforePopState, ',
+        `url: ${url}, `,
+        `as: ${as}, `,
+        `asPath: ${asPath}`
+      )
+
+      return true
+    }
+
+    router.beforePopState(handleBeforePopState)
+    router.events.on('routeChangeStart', handleRouteChangeStart)
+    router.events.on('routeChangeComplete', handleRouteChangeComplete)
+    router.events.on('beforeHistoryChange', handleBeforeHistoryChange)
+    router.events.on('hashChangeStart', handleHashChangeStart)
+    router.events.on('hashChangeComplete', handleHashChangeComplete)
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart)
+      router.events.off('routeChangeComplete', handleRouteChangeComplete)
+      router.events.off('beforeHistoryChange', handleBeforeHistoryChange)
+      router.events.off('hashChangeStart', handleHashChangeStart)
+      router.events.off('hashChangeComplete', handleHashChangeComplete)
+    }
+  }, [router])
+
+  console.log('🟢 render!, ', `asPath: ${asPath}`)
+
+  return <Component {...pageProps} />
+}

--- a/examples/logging-route-events/pages/index.tsx
+++ b/examples/logging-route-events/pages/index.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+export default function IndexPage() {
+  const { asPath } = useRouter()
+  const hash = asPath.split('#')[1]
+
+  return (
+    <ul>
+      <li>
+        <Link href="/">Route To Index Page</Link>
+      </li>
+      <li>
+        <Link href={`/1`}>Route To First Item Page</Link>
+      </li>
+      <li>
+        <Link href={hash ? asPath.replace(`#${hash}`, '') : asPath + '#hash'}>
+          {hash ? 'Remove hash' : 'Append hash'}
+        </Link>
+      </li>
+    </ul>
+  )
+}

--- a/examples/logging-route-events/tsconfig.json
+++ b/examples/logging-route-events/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
I had time to implement saving a scroll position of an element when navigating by push state and restoring the scroll position when navigating back or forward.

So i should understand router events but there are no explanation about the order of events and URL when navigating.

I guess there might be people like me. so i made this example.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
