### PR TITLE
Fix RSC navigation when overriding headers in middleware

### DIFF
--- a/packages/next/src/shared/lib/router/utils/app-paths.test.ts
+++ b/packages/next/src/shared/lib/router/utils/app-paths.test.ts
@@ -1,0 +1,22 @@
+import { normalizeRscPath } from './app-paths'
+
+describe('normalizeRscPath', () => {
+  describe('enabled', () => {
+    it('should normalize url with .rsc', () => {
+      expect(normalizeRscPath('/test.rsc', true)).toBe('/test')
+    })
+    it('should normalize url with .rsc and querystring', () => {
+      expect(normalizeRscPath('/test.rsc?abc=def', true)).toBe('/test?abc=def')
+    })
+  })
+  describe('disabled', () => {
+    it('should normalize url with .rsc', () => {
+      expect(normalizeRscPath('/test.rsc', false)).toBe('/test.rsc')
+    })
+    it('should normalize url with .rsc and querystring', () => {
+      expect(normalizeRscPath('/test.rsc?abc=def', false)).toBe(
+        '/test.rsc?abc=def'
+      )
+    })
+  })
+})

--- a/packages/next/src/shared/lib/router/utils/app-paths.test.ts
+++ b/packages/next/src/shared/lib/router/utils/app-paths.test.ts
@@ -5,7 +5,7 @@ describe('normalizeRscPath', () => {
     it('should normalize url with .rsc', () => {
       expect(normalizeRscPath('/test.rsc', true)).toBe('/test')
     })
-    it('should normalize url with .rsc and querystring', () => {
+    it('should normalize url with .rsc and searchparams', () => {
       expect(normalizeRscPath('/test.rsc?abc=def', true)).toBe('/test?abc=def')
     })
   })
@@ -13,7 +13,7 @@ describe('normalizeRscPath', () => {
     it('should normalize url with .rsc', () => {
       expect(normalizeRscPath('/test.rsc', false)).toBe('/test.rsc')
     })
-    it('should normalize url with .rsc and querystring', () => {
+    it('should normalize url with .rsc and searchparams', () => {
       expect(normalizeRscPath('/test.rsc?abc=def', false)).toBe(
         '/test.rsc?abc=def'
       )

--- a/packages/next/src/shared/lib/router/utils/app-paths.ts
+++ b/packages/next/src/shared/lib/router/utils/app-paths.ts
@@ -51,5 +51,11 @@ export function normalizeAppPath(route: string) {
 }
 
 export function normalizeRscPath(pathname: string, enabled?: boolean) {
-  return enabled ? pathname.replace(/\.rsc($|\?)/, '') : pathname
+  return enabled
+    ? pathname.replace(
+        /\.rsc($|\?)/,
+        // $1 ensures `?` is preserved
+        '$1'
+      )
+    : pathname
 }

--- a/packages/next/src/shared/lib/router/utils/app-paths.ts
+++ b/packages/next/src/shared/lib/router/utils/app-paths.ts
@@ -50,6 +50,10 @@ export function normalizeAppPath(route: string) {
   )
 }
 
+/**
+ * Strips the `.rsc` extension if it's in the pathname.
+ * Since this function is used on full urls it checks `?` for searchParams handling.
+ */
 export function normalizeRscPath(pathname: string, enabled?: boolean) {
   return enabled
     ? pathname.replace(

--- a/test/e2e/app-dir/app/app/searchparams-normalization-bug/client-component.js
+++ b/test/e2e/app-dir/app/app/searchparams-normalization-bug/client-component.js
@@ -1,0 +1,20 @@
+'use client'
+import { usePathname, useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+
+export default function Button({ value, children }) {
+  const router = useRouter()
+  const pathname = usePathname()
+
+  const setSearchParams = useCallback(() => {
+    const params = new URLSearchParams()
+    params.set('val', value)
+    router.replace(`${pathname}?${params}`)
+  }, [router, pathname, value])
+
+  return (
+    <button id={`button-${value}`} onClick={setSearchParams}>
+      {children}
+    </button>
+  )
+}

--- a/test/e2e/app-dir/app/app/searchparams-normalization-bug/page.js
+++ b/test/e2e/app-dir/app/app/searchparams-normalization-bug/page.js
@@ -1,0 +1,15 @@
+import Button from './client-component'
+import { headers } from 'next/headers'
+export default function Page() {
+  const headerStore = headers()
+  const headerValue = headerStore.get('test') || 'empty'
+
+  return (
+    <>
+      <h1 id={`header-${headerValue}`}>Header value: {headerValue}</h1>
+      <Button value="a">Set A</Button>
+      <Button value="b">Set B</Button>
+      <Button value="c">Set C</Button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -1455,6 +1455,36 @@ createNextDescribe(
           const val2 = await browser.elementByCss('#value-2').text()
           expect(val1).toBe(val2)
         })
+
+        it('middleware overriding headers', async () => {
+          const browser = await next.browser('/searchparams-normalization-bug')
+          await browser.eval(`window.didFullPageTransition = 'no'`)
+          expect(await browser.elementByCss('#header-empty').text()).toBe(
+            'Header value: empty'
+          )
+          expect(
+            await browser
+              .elementByCss('#button-a')
+              .click()
+              .waitForElementByCss('#header-a')
+              .text()
+          ).toBe('Header value: a')
+          expect(
+            await browser
+              .elementByCss('#button-b')
+              .click()
+              .waitForElementByCss('#header-b')
+              .text()
+          ).toBe('Header value: b')
+          expect(
+            await browser
+              .elementByCss('#button-c')
+              .click()
+              .waitForElementByCss('#header-c')
+              .text()
+          ).toBe('Header value: c')
+          expect(await browser.eval(`window.didFullPageTransition`)).toBe('no')
+        })
       })
 
       describe('should support React fetch instrumentation', () => {

--- a/test/e2e/app-dir/app/middleware.js
+++ b/test/e2e/app-dir/app/middleware.js
@@ -6,6 +6,17 @@ import { NextResponse } from 'next/server'
  * @returns {NextResponse | undefined}
  */
 export function middleware(request) {
+  if (request.nextUrl.pathname === '/searchparams-normalization-bug') {
+    const headers = new Headers(request.headers)
+    headers.set('test', request.nextUrl.searchParams.get('val') || '')
+    const response = NextResponse.next({
+      request: {
+        headers,
+      },
+    })
+
+    return response
+  }
   if (request.nextUrl.pathname === '/exists-but-not-routed') {
     return NextResponse.rewrite(new URL('/dashboard', request.url))
   }


### PR DESCRIPTION
fix NEXT-583 ([link](https://linear.app/vercel/issue/NEXT-583))

Ran into this when looking into adding an integration test for the RSC normalizing PR.

Middleware has the ability to override `headers` which causes client-side navigation to break as it'll remove the `rsc` header which causes Next.js to respond with the HTML response instead of the RSC payload.

This PR ensures the RSC headers are always copied over as middleware does not get access to them.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
