### PR TITLE
Enable NextTypesPlugin for non-appDir projects

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -49,7 +49,7 @@ import { regexLikeCss } from './webpack/config/blocks/css'
 import { CopyFilePlugin } from './webpack/plugins/copy-file-plugin'
 import { FlightManifestPlugin } from './webpack/plugins/flight-manifest-plugin'
 import { FlightClientEntryPlugin } from './webpack/plugins/flight-client-entry-plugin'
-import { FlightTypesPlugin } from './webpack/plugins/flight-types-plugin'
+import { NextTypesPlugin } from './webpack/plugins/next-types-plugin'
 import type {
   Feature,
   SWC_TARGET_TRIPLE,
@@ -650,7 +650,7 @@ export default async function getBaseWebpackConfig(
   const hasAppDir = !!config.experimental.appDir && !!appDir
   const hasServerComponents = hasAppDir
   const disableOptimizedLoading = true
-  const enableTypedRoutes = !!config.experimental.typedRoutes && hasAppDir
+  const enableTypedRoutes = !!config.experimental.typedRoutes
 
   if (isClient) {
     if (isEdgeRuntime(config.experimental.runtime)) {
@@ -661,11 +661,6 @@ export default async function getBaseWebpackConfig(
     if (config.experimental.runtime === 'nodejs') {
       Log.warn(
         'You are using the experimental Node.js Runtime with `experimental.runtime`.'
-      )
-    }
-    if (config.experimental.typedRoutes && !hasAppDir) {
-      Log.warn(
-        '`experimental.typedRoutes` requires `experimental.appDir` to be enabled.'
       )
     }
   }
@@ -2193,11 +2188,12 @@ export default async function getBaseWebpackConfig(
               dev,
               isEdgeServer,
             })),
-      hasAppDir &&
-        !isClient &&
-        new FlightTypesPlugin({
+      // Only enable the plugin in the Node server and Edge server compilers.
+      !isClient &&
+        new NextTypesPlugin({
           dir,
           distDir: config.distDir,
+          pagesDir,
           appDir,
           dev,
           isEdgeServer,

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -169,31 +169,33 @@ export async function writeConfigurationDefaults(
     }
   }
 
-  const nextAppTypes = `${distDir}/types/**/*.ts`
+  // Include Next.js generated types.
+  const nextGeneratedTypes = `${distDir}/types/**/*.ts`
 
   if (!('include' in rawConfig)) {
-    userTsConfig.include = isAppDirEnabled
-      ? ['next-env.d.ts', nextAppTypes, '**/*.ts', '**/*.tsx']
-      : ['next-env.d.ts', '**/*.ts', '**/*.tsx']
+    userTsConfig.include = [
+      'next-env.d.ts',
+      nextGeneratedTypes,
+      '**/*.ts',
+      '**/*.tsx',
+    ]
     suggestedActions.push(
       chalk.cyan('include') +
         ' was set to ' +
         chalk.bold(
-          isAppDirEnabled
-            ? `['next-env.d.ts', '${nextAppTypes}', '**/*.ts', '**/*.tsx']`
-            : `['next-env.d.ts', '**/*.ts', '**/*.tsx']`
+          `['next-env.d.ts', '${nextGeneratedTypes}', '**/*.ts', '**/*.tsx']`
         )
     )
-  } else if (isAppDirEnabled && !rawConfig.include.includes(nextAppTypes)) {
-    userTsConfig.include.push(nextAppTypes)
+  } else if (!rawConfig.include.includes(nextGeneratedTypes)) {
+    userTsConfig.include.push(nextGeneratedTypes)
     suggestedActions.push(
       chalk.cyan('include') +
         ' was updated to add ' +
-        chalk.bold(`'${nextAppTypes}'`)
+        chalk.bold(`'${nextGeneratedTypes}'`)
     )
   }
 
-  // Enable the Next.js typescript plugin.
+  // Enable the Next.js typescript plugin for app dir.
   if (isAppDirEnabled) {
     if (userTsConfig.compilerOptions) {
       // If the TS config extends on another config, we can't add the `plugin` field

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -79,7 +79,7 @@ import {
 import { getDefineEnv } from '../../build/webpack-config'
 import loadJsConfig from '../../build/load-jsconfig'
 import { formatServerError } from '../../lib/format-server-error'
-import { pageFiles } from '../../build/webpack/plugins/flight-types-plugin'
+import { pageFiles } from '../../build/webpack/plugins/next-types-plugin'
 import {
   DevRouteMatcherManager,
   RouteEnsurer,

--- a/test/integration/app-types/tsconfig.json
+++ b/test/integration/app-types/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
There's no technical limitation that blocks static link types to be enabled without `appDir: true`, the only consideration is one changed behavior (writing `".next/types/**/*.ts"` into `tsconfig.json`).

TODO: This changes the order of type checking and builds, is it good?

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
