### PR TITLE
Fix adding-exmaples.md doc

### DIFF
--- a/contributing/examples/adding-examples.md
+++ b/contributing/examples/adding-examples.md
@@ -12,7 +12,7 @@ When you add an example to the [examples](https://github.com/vercel/next.js/tree
 - Use `export default function` for page components and API Routes instead of `const`/`let` (The exception is if the page has `getInitialProps`, in which case [`NextPage`](https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#typescript) could be useful)
 - CMS example directories should be prefixed with `cms-`
 - Example directories should not be prefixed with `with-`
-- Make sure linting passes (you can run `pnpm build && pnpm lint`)
+- Make sure linting passes (you can run `pnpm build && pnpm lint` to verify and `pnpm lint-fix` for automatic fixes)
 
 Also, don’t forget to add a `README.md` file with the following format:
 

--- a/contributing/examples/adding-examples.md
+++ b/contributing/examples/adding-examples.md
@@ -12,7 +12,7 @@ When you add an example to the [examples](https://github.com/vercel/next.js/tree
 - Use `export default function` for page components and API Routes instead of `const`/`let` (The exception is if the page has `getInitialProps`, in which case [`NextPage`](https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#typescript) could be useful)
 - CMS example directories should be prefixed with `cms-`
 - Example directories should not be prefixed with `with-`
-- Make sure linting passes (you can run `pnpm lint-fix`)
+- Make sure linting passes (you can run `pnpm build && pnpm lint`)
 
 Also, don’t forget to add a `README.md` file with the following format:
 

--- a/contributing/examples/adding-examples.md
+++ b/contributing/examples/adding-examples.md
@@ -1,6 +1,6 @@
 ## Adding examples
 
-When you add an example to the [examples](examples) directory, please follow these guidelines to ensure high-quality examples:
+When you add an example to the [examples](https://github.com/vercel/next.js/tree/canary/examples) directory, please follow these guidelines to ensure high-quality examples:
 
 - TypeScript should be leveraged for new examples (no need for separate JavaScript and TypeScript examples, converting old JavaScript examples is preferred)
 - Examples should not add custom ESLint configuration (we have specific templates for ESLint)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

There are two edit point

First, The url in the doc directed wrong URL.

Second, The instruction in the doc says "Make sure linting passes (you can run pnpm lint-fix)"
But PR request user to check "Make sure the linting passes by running `pnpm build && pnpm lint`"
I thought that it need unity and if i run pnpm lint-fix, lots of errors appear.
So i edit instruction from `pnpm lint-fix` to `pnpm build & pnpm lit`


## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
