### PR TITLE
Fix package name matching

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1255,14 +1255,15 @@ export default async function getBaseWebpackConfig(
           // Built-in modules can be safely ignored.
           if (!builtinModules.includes(request)) {
             // Try to match the package name from the context path:
-            // - /node_modules/package-name/...
             // - /node_modules/.pnpm/package-name@version/...
+            // - /node_modules/package-name/...
             // - /node_modules/@scope/package-name/...
             // - /node_modules/.pnpm/scope+package-name@version/...
             const packageName =
               context.match(
-                /[/\\]node_modules[/\\](\.pnpm[/\\])?([^/\\@]+)/
-              )?.[2] ||
+                /[/\\]node_modules[/\\]\.pnpm[/\\]([^/\\@]+)/
+              )?.[1] ||
+              context.match(/[/\\]node_modules[/\\]([^/\\@]+)/)?.[1] ||
               context.match(
                 /[/\\]node_modules[/\\](@[^/\\]+[/\\][^/\\]+)[/\\]/
               )?.[2] ||


### PR DESCRIPTION
There's a bug in the regex where we use `(\.pnpm)?` that lazily matches the group and causes `([^/\\@]+)` to be `.pnpm`.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
