### PR TITLE
Check for windows paths in server matchers

### DIFF
--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-app-page-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-app-page-route-matcher-provider.ts
@@ -26,7 +26,7 @@ export class DevAppPageRouteMatcherProvider extends FileCacheRouteMatcherProvide
 
     // Match any page file that ends with `/page.${extension}` under the app
     // directory.
-    this.expression = new RegExp(`\\/page\\.(?:${extensions.join('|')})$`)
+    this.expression = new RegExp(`[/\\\\]page\\.(?:${extensions.join('|')})$`)
 
     const pageNormalizer = new AbsoluteFilenameNormalizer(appDir, extensions)
 

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
@@ -26,7 +26,7 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
 
     // Match any route file that ends with `/route.${extension}` under the app
     // directory.
-    this.expression = new RegExp(`\\/route\\.(?:${extensions.join('|')})$`)
+    this.expression = new RegExp(`[/\\\\]route\\.(?:${extensions.join('|')})$`)
 
     const pageNormalizer = new AbsoluteFilenameNormalizer(appDir, extensions)
 


### PR DESCRIPTION
Check for Windows paths in the dev server router matchers.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
