### PR TITLE
Fix export conditions in Webpack config

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -903,7 +903,13 @@ export default async function getBaseWebpackConfig(
   const mainFieldsPerCompiler: Record<typeof compilerType, string[]> = {
     [COMPILER_NAMES.server]: ['main', 'module'],
     [COMPILER_NAMES.client]: ['browser', 'module', 'main'],
-    [COMPILER_NAMES.edgeServer]: ['edge-light', 'browser', 'module', 'main'],
+    [COMPILER_NAMES.edgeServer]: [
+      'edge-light',
+      'browser',
+      'worker',
+      'module',
+      'main',
+    ],
   }
 
   const reactDir = path.dirname(require.resolve('react/package.json'))
@@ -1022,7 +1028,9 @@ export default async function getBaseWebpackConfig(
         }
       : undefined),
     mainFields: mainFieldsPerCompiler[compilerType],
-    ...(isEdgeServer && { conditionNames: ['edge-light', 'import', 'node'] }),
+    ...(isEdgeServer && {
+      conditionNames: mainFieldsPerCompiler[COMPILER_NAMES.edgeServer],
+    }),
     plugins: [],
   }
 
@@ -1724,7 +1732,11 @@ export default async function getBaseWebpackConfig(
                 resolve: {
                   conditionNames: [
                     'react-server',
-                    ...(!isEdgeServer ? [] : ['edge-light']),
+                    ...mainFieldsPerCompiler[
+                      isEdgeServer
+                        ? COMPILER_NAMES.edgeServer
+                        : COMPILER_NAMES.server
+                    ],
                     'node',
                     'import',
                     'require',

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1028,7 +1028,11 @@ export default async function getBaseWebpackConfig(
       : undefined),
     mainFields: mainFieldsPerCompiler[compilerType],
     ...(isEdgeServer && {
-      conditionNames: mainFieldsPerCompiler[COMPILER_NAMES.edgeServer],
+      conditionNames: [
+        ...mainFieldsPerCompiler[COMPILER_NAMES.edgeServer],
+        'import',
+        'node',
+      ],
     }),
     plugins: [],
   }

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -905,8 +905,8 @@ export default async function getBaseWebpackConfig(
     [COMPILER_NAMES.client]: ['browser', 'module', 'main'],
     [COMPILER_NAMES.edgeServer]: [
       'edge-light',
-      'browser',
       'worker',
+      'browser',
       'module',
       'main',
     ],


### PR DESCRIPTION
Currently the export conditions we use for certain runtime, in different places of the config are totally random. This PR unifies them by referring to the single constant.

Also adds `worker` as a condition of the edge runtime.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
