### PR TITLE
Add `vary` header to responses from pages and Edge SSR

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -82,6 +82,7 @@ export function getRender({
       pagesRenderToHTML,
       loadComponent: async (pathname) => {
         if (isAppPath) return null
+
         if (pathname === page) {
           return {
             ...baseLoadComponentResult,
@@ -91,6 +92,7 @@ export function getRender({
             getServerSideProps: pageMod.getServerSideProps,
             getStaticPaths: pageMod.getStaticPaths,
             ComponentMod: pageMod,
+            isAppPath: !!pageMod.__next_app_webpack_require__,
             pathname,
           }
         }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1139,6 +1139,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         }
       }
     }
+
     delete query.__nextDataReq
 
     // normalize req.url for SSG paths as it is not exposed
@@ -1166,6 +1167,12 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     const isFlightRequest = Boolean(
       this.serverComponentManifest && req.headers[RSC.toLowerCase()]
     )
+
+    // For pages we need to ensure the correct Vary header is set too, to avoid
+    // caching issues when navigating between pages and app
+    if (!isAppPath && isFlightRequest) {
+      res.setHeader('vary', RSC_VARY_HEADER)
+    }
 
     // we need to ensure the status code if /404 is visited directly
     if (is404Page && !isDataReq && !isFlightRequest) {

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -115,7 +115,7 @@ createNextDescribe(
         },
       })
       expect(res.headers.get('vary')).toBe(
-        'RSC, Next-Router-State-Tree, Next-Router-Prefetch'
+        'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Accept-Encoding'
       )
     })
 

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -108,6 +108,17 @@ createNextDescribe(
       )
     })
 
+    it('should return the `vary` header from pages for flight requests', async () => {
+      const res = await next.fetch('/', {
+        headers: {
+          ['RSC'.toString()]: '1',
+        },
+      })
+      expect(res.headers.get('vary')).toBe(
+        'RSC, Next-Router-State-Tree, Next-Router-Prefetch'
+      )
+    })
+
     it('should pass props from getServerSideProps in root layout', async () => {
       const $ = await next.render$('/dashboard')
       expect($('title').first().text()).toBe('hello world')

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -100,6 +100,14 @@ createNextDescribe(
       expect(res.headers.get('Content-Type')).toBe('text/x-component')
     })
 
+    it('should return the `vary` header from edge runtime', async () => {
+      const res = await next.fetch('/dashboard')
+      expect(res.headers.get('x-edge-runtime')).toBe('1')
+      expect(res.headers.get('vary')).toBe(
+        'RSC, Next-Router-State-Tree, Next-Router-Prefetch'
+      )
+    })
+
     it('should pass props from getServerSideProps in root layout', async () => {
       const $ = await next.render$('/dashboard')
       expect($('title').first().text()).toBe('hello world')


### PR DESCRIPTION
This PR ensures that the `vary` header is set for pages responses and Edge SSR responses too, to avoid potential caching problems when navigating between them.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

fix NEXT-382 ([link](https://linear.app/vercel/issue/NEXT-382))