### PR TITLE
Fix flaky invalid import test

### DIFF
--- a/test/development/acceptance-app/invalid-imports.test.ts
+++ b/test/development/acceptance-app/invalid-imports.test.ts
@@ -188,7 +188,6 @@ createNextDescribe(
           [
             'app/comp2.js',
             `
-            import "server-only-package"
             export function Comp2() {
               return (
                 <div>Hello world</div>
@@ -210,9 +209,9 @@ createNextDescribe(
         ])
       )
 
-      const pageFile = 'app/page.js'
-      const content = await next.readFile(pageFile)
-      await session.patch(pageFile, '"use client"\n' + content)
+      const file = 'app/comp2.js'
+      const content = await next.readFile(file)
+      await session.patch(file, 'import "server-only-package"\n' + content)
 
       expect(await session.hasRedbox(true)).toBe(true)
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
@@ -222,9 +221,9 @@ createNextDescribe(
         The error was caused by importing 'server-only-package/index.js' in 'app/comp2.js'.
 
         Import trace for requested module:
-          app/comp2.js
-          app/comp1.js
-          app/page.js"
+        app/comp2.js
+        app/comp1.js
+        app/page.js"
       `)
 
       await cleanup()


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
