### PR TITLE
docs(mdx): add example with overriding app.js

### DIFF
--- a/docs/advanced-features/using-mdx.md
+++ b/docs/advanced-features/using-mdx.md
@@ -214,6 +214,32 @@ export default function Post(props) {
 
 If you use it across the site you may want to add the provider to `_app.js` so all MDX pages pick up the custom element config.
 
+```jsx
+import Image from 'next/image'
+import { Heading, InlineCode, Pre, Table, Text } from 'my-components'
+
+const ResponsiveImage = (props) => (
+  <Image alt={props.alt} layout="responsive" {...props} />
+)
+
+const components = {
+  img: ResponsiveImage,
+  h1: Heading.H1,
+  h2: Heading.H2,
+  p: Text,
+  pre: Pre,
+  code: InlineCode,
+}
+
+
+function MyApp({ Component, pageProps }: AppProps) {
+  // You can directly pass custom components to the page props
+  return <Component {...pageProps} components={components} />;
+}
+
+export default MyApp;
+```
+
 ## Using rust based MDX compiler (experimental)
 
 Next.js supports a new MDX compiler written in Rust. This compiler is still experimental and is not recommended for production use. To use the new compiler, you need to configure `next.config.js` when you pass it to `withMDX`:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->
## Why

I wanted to use Mdx on one of the website I work on and I came across an error when I tryed to pass the `<MDXProvider/>` in the app wrapper.  This doesn't seem to work as expected and generate a client/server diff as overrided components does not seems to be passed in the server rendered component.

After some investiguation, I found out that passing components directly in the pageProps work nicely and [it is what is recommanded in Mdx/React documentation.](https://mdxjs.com/packages/react/#use)

## How

- Add an example of how overriding MdxProvider directly with page props

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
