### PR TITLE
Polish metadata interface jsdoc

### DIFF
--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -36,13 +36,11 @@ import type { ResolvedTwitterMetadata, Twitter } from './twitter-types'
 interface Metadata {
   /**
    * The base path and origin for absolute urls for various metadata links such as OpenGraph images.
-   * @type {null | URL}
    */
   metadataBase?: null | URL
 
   /**
    * The document title.
-   * @type {null | string | TemplateString}
    * @example
    * "My Blog"
    * <title>My Blog</title>
@@ -58,7 +56,6 @@ interface Metadata {
 
   /**
    * The document description, and optionally the OpenGraph and twitter descriptions.
-   * @type {null | string}
    * @example
    * "My Blog Description"
    * <meta name="description" content="My Blog Description" />
@@ -70,7 +67,6 @@ interface Metadata {
 
   /**
    * The application name.
-   * @type {null | string}
    * @example
    * "My Blog"
    * <meta name="application-name" content="My Blog" />
@@ -79,83 +75,85 @@ interface Metadata {
 
   /**
    * The authors of the document.
-   * @type {null | Author | Array<Author>}
    * @example
+   * ```tsx
    * [{ name: "Next.js Team", url: "https://nextjs.org" }]
+   *
    * <meta name="author" content="Next.js Team" />
    * <link rel="author" href="https://nextjs.org" />
-   *
+   * ```
    */
   authors?: null | Author | Array<Author>
 
   /**
    * The generator used for the document.
-   * @type {null | string}
    * @example
+   * ```tsx
    * "Next.js"
-   * <meta name="generator" content="Next.js" />
    *
+   * <meta name="generator" content="Next.js" />
+   * ```
    */
   generator?: null | string
 
   /**
    * The keywords for the document. If an array is provided, it will be flattened into a single tag with comma separation.
-   * @type {null | string | Array<string>}
    * @example
+   * ```tsx
    * "nextjs, react, blog"
    * <meta name="keywords" content="nextjs, react, blog" />
    *
    * ["react", "server components"]
    * <meta name="keywords" content="react, server components" />
-   *
+   * ```
    */
   keywords?: null | string | Array<string>
 
   /**
    * The referrer setting for the document.
-   * @type {null | ReferrerEnum}
    * @example
+   * ```tsx
    * "origin"
    * <meta name="referrer" content="origin" />
-   *
+   * ```
    */
   referrer?: null | ReferrerEnum
 
   /**
    * The theme color for the document.
-   * @type {null | string}
    * @example
+   * ```tsx
    * "#000000"
    * <meta name="theme-color" content="#000000" />
-   *
+   * ```
    */
   themeColor?: null | string
 
   /**
    * The color scheme for the document.
-   * @type {null | ColorSchemeEnum}
    * @example
+   * ```tsx
    * "dark"
    * <meta name="color-scheme" content="dark" />
+   * ```
    */
   colorScheme?: null | ColorSchemeEnum
 
   /**
    * The viewport setting for the document.
-   * @type {null | string | Viewport}
    * @example
+   * ```tsx
    * "width=device-width, initial-scale=1"
    * <meta name="viewport" content="width=device-width, initial-scale=1" />
    *
    * { width: "device-width", initialScale: 1 }
    * <meta name="viewport" content="width=device-width, initial-scale=1" />
-   *
+   * ```
    */
   viewport?: null | string | Viewport
 
   /**
    * The creator of the document.
-   * @type {null | string}
    * @example
    * "Next.js Team"
    * <meta name="creator" content="Next.js Team" />
@@ -165,7 +163,6 @@ interface Metadata {
 
   /**
    * The publisher of the document.
-   * @type {null | string}
    * @example
    * "Vercel"
    * <meta name="publisher" content="Vercel" />
@@ -177,7 +174,8 @@ interface Metadata {
 
   /**
    * The robots setting for the document.
-   * @type {null | string | Robots}
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Glossary/Robots.txt
    * @example
    * "index, follow"
    * <meta name="robots" content="index, follow" />
@@ -190,7 +188,6 @@ interface Metadata {
 
   /**
    * The canonical and alternate URLs for the document.
-   * @type {null | AlternateURLs}
    * @example
    * { canonical: "https://example.com" }
    * <link rel="canonical" href="https://example.com" />
@@ -204,7 +201,8 @@ interface Metadata {
 
   /**
    * The icons for the document. Defaults to rel="icon".
-   * @type {null | IconURL | Array<Icon> | Icons}
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#attr-icon
    * @example
    * "https://example.com/icon.png"
    * <link rel="icon" href="https://example.com/icon.png" />
@@ -223,7 +221,7 @@ interface Metadata {
   /**
    * The manifest.json file is the only file that every extension using WebExtension APIs must contain
    *
-   * @type {null | string | URL}
+   * @see https://developer.mozilla.org/en-US/docs/Web/Manifest
    * @example
    * "https://example.com/manifest.json"
    * <link rel="manifest" href="https://example.com/manifest.json" />
@@ -232,6 +230,9 @@ interface Metadata {
   manifest?: null | string | URL
 
   /**
+   * The Open Graph metadata for the document.
+   *
+   * @see https://ogp.me
    * @example
    * {
    *   type: "website",
@@ -248,7 +249,6 @@ interface Metadata {
 
   /**
    * The Twitter metadata for the document.
-   * @type {null | Twitter}
    * @example
    * { card: "summary_large_image", site: "@site", creator: "@creator", "images": "https://example.com/og.png" }
    *
@@ -264,7 +264,6 @@ interface Metadata {
 
   /**
    * The common verification tokens for the document.
-   * @type {Verification}
    * @example
    * { verification: { google: "google-site-verification=1234567890", yandex: "1234567890", "me": "1234567890" } }
    * <meta name="google-site-verification" content="1234567890" />
@@ -276,8 +275,8 @@ interface Metadata {
 
   /**
    * The Apple web app metadata for the document.
-   * https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html
-   * @type {null | boolean | AppleWebApp}
+   *
+   * @see https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html
    * @example
    * { capable: true, title: "My Website", statusBarStyle: "black-translucent" }
    * <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -290,7 +289,6 @@ interface Metadata {
   /**
    * Indicates if devices should try to interpret various formats and make actionable links out of them. For example it controles
    * if telephone numbers on mobile that can be clicked to dial or not.
-   * @type {null | FormatDetection}
    * @example
    * { telephone: false }
    * <meta name="format-detection" content="telephone=no" />
@@ -301,7 +299,6 @@ interface Metadata {
   /**
    * The metadata for the iTunes App.
    * It adds the `name="apple-itunes-app"` meta tag.
-   * @type {null | ItunesApp}
    * @example
    * { app: { id: "123456789", affiliateData: "123456789", appArguments: "123456789" } }
    * <meta name="apple-itunes-app" content="app-id=123456789, affiliate-data=123456789, app-arguments=123456789" />
@@ -312,8 +309,8 @@ interface Metadata {
   /**
    * A brief description of what this web-page is about. Not recommended, superseded by description.
    * It adds the `name="abstract"` meta tag.
-   * https://www.metatags.org/all-meta-tags-overview/meta-name-abstract/
-   * @type {null | string}
+   *
+   * @see https://www.metatags.org/all-meta-tags-overview/meta-name-abstract/
    * @example
    * "My Website Description"
    * <meta name="abstract" content="My Website Description" />
@@ -323,7 +320,6 @@ interface Metadata {
 
   /**
    * The Facebook AppLinks metadata for the document.
-   * @type {null | AppLinks}
    * @example
    * { ios: { appStoreId: "123456789", url: "https://example.com" }, android: { packageName: "com.example", url: "https://example.com" } }
    *
@@ -337,7 +333,6 @@ interface Metadata {
 
   /**
    * The archives link rel property.
-   * @type {null | string | Array<string>}
    * @example
    * { archives: "https://example.com/archives" }
    * <link rel="archives" href="https://example.com/archives" />
@@ -347,7 +342,6 @@ interface Metadata {
 
   /**
    * The assets link rel property.
-   * @type {null | string | Array<string>}
    * @example
    * "https://example.com/assets"
    * <link rel="assets" href="https://example.com/assets" />
@@ -357,7 +351,6 @@ interface Metadata {
 
   /**
    * The bookmarks link rel property.
-   * @type {null | string | Array<string>}
    * @example
    * "https://example.com/bookmarks"
    * <link rel="bookmarks" href="https://example.com/bookmarks" />
@@ -369,7 +362,6 @@ interface Metadata {
 
   /**
    * The category meta name property.
-   * @type {null | string}
    * @example
    * "My Category"
    * <meta name="category" content="My Category" />
@@ -378,7 +370,6 @@ interface Metadata {
 
   /**
    * The classification meta name property.
-   * @type {null | string}
    * @example
    * "My Classification"
    * <meta name="classification" content="My Classification" />
@@ -388,7 +379,6 @@ interface Metadata {
 
   /**
    * Arbitrary name/value pairs for the document.
-   * @type {{ [name: string]: string | number | Array<string | number> }}
    */
   other?: {
     [name: string]: string | number | Array<string | number>
@@ -397,7 +387,7 @@ interface Metadata {
   /**
    * Deprecated options that have a preferred method.
    * Use appWebApp to configure apple-mobile-web-app-capable which provides
-   * https://www.appsloveworld.com/coding/iphone/11/difference-between-apple-mobile-web-app-capable-and-apple-touch-fullscreen-ipho
+   * @see https://www.appsloveworld.com/coding/iphone/11/difference-between-apple-mobile-web-app-capable-and-apple-touch-fullscreen-ipho
    * @deprecated
    */
   'apple-touch-fullscreen'?: never
@@ -405,7 +395,7 @@ interface Metadata {
   /**
    * Deprecated options that have a preferred method.
    * Obsolete since iOS 7. use icons.apple or "app-touch-icon" instead
-   * https://web.dev/apple-touch-icon/
+   * @see https://web.dev/apple-touch-icon/
    * @deprecated
    */
   'apple-touch-icon-precomposed'?: never

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -258,14 +258,14 @@ interface Metadata {
    *     url: "https://example.com/og.png",
    *   }],
    * }
-   * ```
+   *
    * <meta property="og:type" content="website" />
    * <meta property="og:url" content="https://example.com" />
    * <meta property="og:site_name" content="My Website" />
    * <meta property="og:title" content="My Website" />
    * <meta property="og:description" content="My Website Description" />
    * <meta property="og:image" content="https://example.com/og.png" />
-   *
+   * ```
    */
   openGraph?: null | OpenGraph
 
@@ -353,7 +353,7 @@ interface Metadata {
   /**
    * The Facebook AppLinks metadata for the document.
    * @example
-   * ```ts
+   * ```tsx
    * { ios: { appStoreId: "123456789", url: "https://example.com" }, android: { packageName: "com.example", url: "https://example.com" } }
    *
    * <meta property="al:ios:app_store_id" content="123456789" />

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -42,6 +42,7 @@ interface Metadata {
   /**
    * The document title.
    * @example
+   * ```tsx
    * "My Blog"
    * <title>My Blog</title>
    *
@@ -50,15 +51,17 @@ interface Metadata {
    *
    * { absolute: "My Blog", template: "%s | My Website" }
    * <title>My Blog</title>
-   *
+   * ```
    */
   title?: null | string | TemplateString
 
   /**
    * The document description, and optionally the OpenGraph and twitter descriptions.
    * @example
+   * ```tsx
    * "My Blog Description"
    * <meta name="description" content="My Blog Description" />
+   * ```
    */
   description?: null | string
 
@@ -68,8 +71,10 @@ interface Metadata {
   /**
    * The application name.
    * @example
+   * ```tsx
    * "My Blog"
    * <meta name="application-name" content="My Blog" />
+   * ```
    */
   applicationName?: null | string
 
@@ -155,18 +160,21 @@ interface Metadata {
   /**
    * The creator of the document.
    * @example
+   * ```tsx
    * "Next.js Team"
    * <meta name="creator" content="Next.js Team" />
-   *
+   * ```
    */
   creator?: null | string
 
   /**
    * The publisher of the document.
    * @example
+   *
+   * ```tsx
    * "Vercel"
    * <meta name="publisher" content="Vercel" />
-   *
+   * ```
    */
   publisher?: null | string
 
@@ -177,25 +185,27 @@ interface Metadata {
    *
    * @see https://developer.mozilla.org/en-US/docs/Glossary/Robots.txt
    * @example
+   * ```tsx
    * "index, follow"
    * <meta name="robots" content="index, follow" />
    *
    * { index: false, follow: false }
    * <meta name="robots" content="noindex, nofollow" />
-   *
+   * ```
    */
   robots?: null | string | Robots
 
   /**
    * The canonical and alternate URLs for the document.
    * @example
+   * ```tsx
    * { canonical: "https://example.com" }
    * <link rel="canonical" href="https://example.com" />
    *
    * { canonical: "https://example.com", hreflang: { "en-US": "https://example.com/en-US" } }
    * <link rel="canonical" href="https://example.com" />
    * <link rel="alternate" href="https://example.com/en-US" hreflang="en-US" />
-   *
+   * ```
    */
   alternates?: null | AlternateURLs
 
@@ -204,6 +214,7 @@ interface Metadata {
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#attr-icon
    * @example
+   * ```tsx
    * "https://example.com/icon.png"
    * <link rel="icon" href="https://example.com/icon.png" />
    *
@@ -214,7 +225,7 @@ interface Metadata {
    * [{ rel: "icon", href: "https://example.com/icon.png" }, { rel: "apple-touch-icon", href: "https://example.com/apple-icon.png" }]
    * <link rel="icon" href="https://example.com/icon.png" />
    * <link rel="apple-touch-icon" href="https://example.com/apple-icon.png" />
-   *
+   * ```
    */
   icons?: null | IconURL | Array<Icon> | Icons
 
@@ -223,8 +234,10 @@ interface Metadata {
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/Manifest
    * @example
+   * ```tsx
    * "https://example.com/manifest.json"
    * <link rel="manifest" href="https://example.com/manifest.json" />
+   * ```
    *
    */
   manifest?: null | string | URL
@@ -234,15 +247,24 @@ interface Metadata {
    *
    * @see https://ogp.me
    * @example
+   * ```tsx
    * {
    *   type: "website",
    *   url: "https://example.com",
-   *   siteName: "My Website",
    *   title: "My Website",
+   *   description: "My Website Description",
+   *   siteName: "My Website",
    *   images: [{
    *     url: "https://example.com/og.png",
    *   }],
    * }
+   * ```
+   * <meta property="og:type" content="website" />
+   * <meta property="og:url" content="https://example.com" />
+   * <meta property="og:site_name" content="My Website" />
+   * <meta property="og:title" content="My Website" />
+   * <meta property="og:description" content="My Website Description" />
+   * <meta property="og:image" content="https://example.com/og.png" />
    *
    */
   openGraph?: null | OpenGraph
@@ -250,6 +272,7 @@ interface Metadata {
   /**
    * The Twitter metadata for the document.
    * @example
+   * ```tsx
    * { card: "summary_large_image", site: "@site", creator: "@creator", "images": "https://example.com/og.png" }
    *
    * <meta name="twitter:card" content="summary_large_image" />
@@ -258,6 +281,7 @@ interface Metadata {
    * <meta name="twitter:title" content="My Website" />
    * <meta name="twitter:description" content="My Website Description" />
    * <meta name="twitter:image" content="https://example.com/og.png" />
+   * ```
    *
    */
   twitter?: null | Twitter
@@ -265,11 +289,12 @@ interface Metadata {
   /**
    * The common verification tokens for the document.
    * @example
+   * ```tsx
    * { verification: { google: "google-site-verification=1234567890", yandex: "1234567890", "me": "1234567890" } }
    * <meta name="google-site-verification" content="1234567890" />
    * <meta name="yandex-verification" content="1234567890" />
    * <meta name="me" content="@me" />
-   *
+   * ```
    */
   verification?: Verification
 
@@ -278,10 +303,12 @@ interface Metadata {
    *
    * @see https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html
    * @example
+   * ```tsx
    * { capable: true, title: "My Website", statusBarStyle: "black-translucent" }
    * <meta name="apple-mobile-web-app-capable" content="yes" />
    * <meta name="apple-mobile-web-app-title" content="My Website" />
    * <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+   * ```
    *
    */
   appleWebApp?: null | boolean | AppleWebApp
@@ -290,8 +317,10 @@ interface Metadata {
    * Indicates if devices should try to interpret various formats and make actionable links out of them. For example it controles
    * if telephone numbers on mobile that can be clicked to dial or not.
    * @example
+   * ```tsx
    * { telephone: false }
    * <meta name="format-detection" content="telephone=no" />
+   * ```
    *
    */
   formatDetection?: null | FormatDetection
@@ -299,10 +328,12 @@ interface Metadata {
   /**
    * The metadata for the iTunes App.
    * It adds the `name="apple-itunes-app"` meta tag.
+   *
    * @example
+   * ```tsx
    * { app: { id: "123456789", affiliateData: "123456789", appArguments: "123456789" } }
    * <meta name="apple-itunes-app" content="app-id=123456789, affiliate-data=123456789, app-arguments=123456789" />
-   *
+   * ```
    */
   itunes?: null | ItunesApp
 
@@ -312,49 +343,54 @@ interface Metadata {
    *
    * @see https://www.metatags.org/all-meta-tags-overview/meta-name-abstract/
    * @example
+   * ```tsx
    * "My Website Description"
    * <meta name="abstract" content="My Website Description" />
-   *
+   * ```
    */
   abstract?: null | string
 
   /**
    * The Facebook AppLinks metadata for the document.
    * @example
+   * ```ts
    * { ios: { appStoreId: "123456789", url: "https://example.com" }, android: { packageName: "com.example", url: "https://example.com" } }
    *
    * <meta property="al:ios:app_store_id" content="123456789" />
    * <meta property="al:ios:url" content="https://example.com" />
    * <meta property="al:android:package" content="com.example" />
    * <meta property="al:android:url" content="https://example.com" />
-   *
+   * ```
    */
   appLinks?: null | AppLinks
 
   /**
    * The archives link rel property.
    * @example
+   * ```tsx
    * { archives: "https://example.com/archives" }
    * <link rel="archives" href="https://example.com/archives" />
-   *
+   * ```
    */
   archives?: null | string | Array<string>
 
   /**
    * The assets link rel property.
    * @example
+   * ```tsx
    * "https://example.com/assets"
    * <link rel="assets" href="https://example.com/assets" />
-   *
+   * ```
    */
   assets?: null | string | Array<string>
 
   /**
    * The bookmarks link rel property.
    * @example
+   * ```tsx
    * "https://example.com/bookmarks"
    * <link rel="bookmarks" href="https://example.com/bookmarks" />
-   *
+   * ```
    */
   bookmarks?: null | string | Array<string> // This is technically against HTML spec but is used in wild
 
@@ -363,17 +399,20 @@ interface Metadata {
   /**
    * The category meta name property.
    * @example
+   * ```tsx
    * "My Category"
    * <meta name="category" content="My Category" />
+   * ```
    */
   category?: null | string
 
   /**
    * The classification meta name property.
    * @example
+   * ```tsx
    * "My Classification"
    * <meta name="classification" content="My Classification" />
-   *
+   * ```
    */
   classification?: null | string
 


### PR DESCRIPTION
* Remove duplicatd `@type` since there's ts type specified already
* Add links with `@see` for external references
* highlight code with tsx syntax