### PR TITLE
Send correct stats in hot reloader sync event

### DIFF
--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -498,6 +498,18 @@ for (const variant of ['default', 'turbo']) {
 
           await cleanup()
         })
+
+        test('displays build error on initial page load', async () => {
+          const { session, cleanup } = await sandbox(
+            next,
+            new Map([['app/page.js', '{{{']])
+          )
+
+          expect(await session.hasRedbox(true)).toBe(true)
+          await check(() => session.getRedboxSource(true), /Failed to compile/)
+
+          await cleanup()
+        })
       }
     )
   })


### PR DESCRIPTION
If there's a build error on initial page load, the error is sometimes displayed as a server error instead of a build error:
![image](https://user-images.githubusercontent.com/25056922/220099125-5f538551-342f-4bca-a670-a04d8428de2d.png)

When the hot reloader sends the `sync` event to the client, it always picks the latest compilation. The problem occurs if only the server has errors and the client is the latest. In that case the server errors are ignored and the client stats are sent instead.

This PR makes it check if the server compilation has errors, if that's the case we use those stats. `built` events acts the same, new client builds are [ignored if the server has errors](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/dev/hot-middleware.ts#L123.): 
```ts
onClientDone = (statsResult: webpack.Stats) => {
  this.clientLatestStats = { ts: Date.now(), stats: statsResult }
  if (this.closed || this.serverLatestStats?.stats.hasErrors()) return
  this.publishStats('built', statsResult)
}
```

fix NEXT-403 ([link](https://linear.app/vercel/issue/NEXT-403))

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
