### PR TITLE
fix: OpenGraph metadata images rendering

### DIFF
--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -1,4 +1,5 @@
 import { accumulateMetadata, MetadataItems } from './resolve-metadata'
+import { Metadata, ResolvedMetadata } from './types/metadata-interface'
 
 describe('accumulateMetadata', () => {
   describe('typing', () => {
@@ -47,21 +48,65 @@ describe('accumulateMetadata', () => {
         title: { absolute: '2nd parent layout page', template: null },
       })
     })
+  })
 
-    it.each`
-      metadataItems                                                                         | result
-      ${[[{ openGraph: { type: 'article', images: 'https://test.com' } }, null]]}           | ${{ openGraph: { images: ['https://test.com'] } }}
-      ${[[{ openGraph: { type: 'book', images: 'https://test.com' } }, null]]}              | ${{ openGraph: { images: ['https://test.com'] } }}
-      ${[[{ openGraph: { type: 'song', images: new URL('https://test.com') } }, null]]}     | ${{ openGraph: { images: [new URL('https://test.com')] } }}
-      ${[[{ openGraph: { type: 'playlist', images: { url: 'https://test.com' } } }, null]]} | ${{ openGraph: { images: [{ url: 'https://test.com' }] } }}
-      ${[[{ openGraph: { type: 'radio', images: 'https://test.com' } }, null]]}             | ${{ openGraph: { images: ['https://test.com'] } }}
-      ${[[{ openGraph: { type: 'video', images: 'https://test.com' } }, null]]}             | ${{ openGraph: { images: ['https://test.com'] } }}
-    `(
-      'should convert string or URL images field to array, not only for basic og type',
-      async ({ metadataItems, result }) => {
-        const metadata = await accumulateMetadata(metadataItems)
+  describe('openGraph', () => {
+    it('should convert string or URL images field to array, not only for basic og type', async () => {
+      const items: [Metadata[], Metadata][] = [
+        [
+          [{ openGraph: { type: 'article', images: 'https://test.com' } }],
+          { openGraph: { images: ['https://test.com'] } },
+        ],
+        [
+          [{ openGraph: { type: 'book', images: 'https://test.com' } }],
+          { openGraph: { images: ['https://test.com'] } },
+        ],
+        [
+          [
+            {
+              openGraph: {
+                type: 'music.song',
+                images: new URL('https://test.com'),
+              },
+            },
+          ],
+          { openGraph: { images: [new URL('https://test.com')] } },
+        ],
+        [
+          [
+            {
+              openGraph: {
+                type: 'music.playlist',
+                images: { url: 'https://test.com' },
+              },
+            },
+          ],
+          { openGraph: { images: [{ url: 'https://test.com' }] } },
+        ],
+        [
+          [
+            {
+              openGraph: {
+                type: 'music.radio_station',
+                images: 'https://test.com',
+              },
+            },
+          ],
+          { openGraph: { images: ['https://test.com'] } },
+        ],
+        [
+          [{ openGraph: { type: 'video.movie', images: 'https://test.com' } }],
+          { openGraph: { images: ['https://test.com'] } },
+        ],
+      ]
+
+      items.forEach(async (item) => {
+        const [configuredMetadata, result] = item
+        const metadata = await accumulateMetadata(
+          configuredMetadata.map((m) => [m, null])
+        )
         expect(metadata).toMatchObject(result)
-      }
-    )
+      })
+    })
   })
 })

--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -1,5 +1,5 @@
 import { accumulateMetadata, MetadataItems } from './resolve-metadata'
-import { Metadata, ResolvedMetadata } from './types/metadata-interface'
+import { Metadata } from './types/metadata-interface'
 
 describe('accumulateMetadata', () => {
   describe('typing', () => {

--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -47,5 +47,21 @@ describe('accumulateMetadata', () => {
         title: { absolute: '2nd parent layout page', template: null },
       })
     })
+
+    it.each`
+      metadataItems                                                                         | result
+      ${[[{ openGraph: { type: 'article', images: 'https://test.com' } }, null]]}           | ${{ openGraph: { images: ['https://test.com'] } }}
+      ${[[{ openGraph: { type: 'book', images: 'https://test.com' } }, null]]}              | ${{ openGraph: { images: ['https://test.com'] } }}
+      ${[[{ openGraph: { type: 'song', images: new URL('https://test.com') } }, null]]}     | ${{ openGraph: { images: [new URL('https://test.com')] } }}
+      ${[[{ openGraph: { type: 'playlist', images: { url: 'https://test.com' } } }, null]]} | ${{ openGraph: { images: [{ url: 'https://test.com' }] } }}
+      ${[[{ openGraph: { type: 'radio', images: 'https://test.com' } }, null]]}             | ${{ openGraph: { images: ['https://test.com'] } }}
+      ${[[{ openGraph: { type: 'video', images: 'https://test.com' } }, null]]}             | ${{ openGraph: { images: ['https://test.com'] } }}
+    `(
+      'should convert string or URL images field to array, not only for basic og type',
+      async ({ metadataItems, result }) => {
+        const metadata = await accumulateMetadata(metadataItems)
+        expect(metadata).toMatchObject(result)
+      }
+    )
   })
 })

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
@@ -10,11 +10,11 @@ import { resolveAsArrayOrUndefined } from '../generate/utils'
 import { isStringOrURL, resolveUrl } from './resolve-url'
 
 const OgTypFields = {
-  article: ['authors', 'tags'],
-  song: ['albums', 'musicians'],
-  playlist: ['albums', 'musicians'],
-  radio: ['creators'],
-  video: ['actors', 'directors', 'writers', 'tags'],
+  article: ['authors', 'tags', 'images'],
+  song: ['albums', 'musicians', 'images'],
+  playlist: ['albums', 'musicians', 'images'],
+  radio: ['creators', 'images'],
+  video: ['actors', 'directors', 'writers', 'tags', 'images'],
   basic: [
     'emails',
     'phoneNumbers',

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
@@ -10,17 +10,16 @@ import { resolveAsArrayOrUndefined } from '../generate/utils'
 import { isStringOrURL, resolveUrl } from './resolve-url'
 
 const OgTypFields = {
-  article: ['authors', 'tags', 'images'],
-  song: ['albums', 'musicians', 'images'],
-  playlist: ['albums', 'musicians', 'images'],
-  radio: ['creators', 'images'],
-  video: ['actors', 'directors', 'writers', 'tags', 'images'],
+  article: ['authors', 'tags'],
+  song: ['albums', 'musicians'],
+  playlist: ['albums', 'musicians'],
+  radio: ['creators'],
+  video: ['actors', 'directors', 'writers', 'tags'],
   basic: [
     'emails',
     'phoneNumbers',
     'faxNumbers',
     'alternateLocale',
-    'images',
     'audio',
     'videos',
   ],
@@ -69,6 +68,7 @@ export function resolveOpenGraph(
         }
       }
     }
+    resolved.images = resolveAsArrayOrUndefined(og.images)
   }
 
   assignProps(openGraph)


### PR DESCRIPTION
fixes #46152.

image urls will be convert to array and map to meta tags.

https://stackblitz.com/edit/vercel-next-js-kc2ejf?file=next.config.js,app%2Flayout.tsx,app%2Fpage.tsx

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
