### PR TITLE
fix: add media field for icon metadata type definition #45859.

### DIFF
--- a/packages/next/src/lib/metadata/types/metadata-types.ts
+++ b/packages/next/src/lib/metadata/types/metadata-types.ts
@@ -85,6 +85,7 @@ export type IconDescriptor = {
   sizes?: string
   // defaults to rel="icon" unless superceded by Icons map
   rel?: string
+  media?: string
 }
 export type Icons = {
   // rel="icon"


### PR DESCRIPTION
fixes #45859 

add missing type for icon metadata

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
fix NEXT-544 ([link](https://linear.app/vercel/issue/NEXT-544))