### PR TITLE
Improve app-render error log with edge runtime

### DIFF
--- a/packages/next/src/server/app-render.tsx
+++ b/packages/next/src/server/app-render.tsx
@@ -276,7 +276,17 @@ function createErrorHandler({
       if (errorLogger) {
         errorLogger(err).catch(() => {})
       } else {
-        console.error(err)
+        // The error logger is currently not provided in the edge runtime.
+        // Use `log-app-dir-error` instead.
+        // It won't log the source code, but the error will be more useful.
+        if (process.env.NODE_ENV !== 'production') {
+          const { logAppDirError } =
+            require('./dev/log-app-dir-error') as typeof import('./dev/log-app-dir-error')
+          logAppDirError(err)
+        }
+        if (process.env.NODE_ENV === 'production') {
+          console.error(err)
+        }
       }
     }
 

--- a/packages/next/src/server/dev/log-app-dir-error.ts
+++ b/packages/next/src/server/dev/log-app-dir-error.ts
@@ -1,0 +1,27 @@
+import isError from '../../lib/is-error'
+import * as Log from '../../build/output/log'
+
+export function logAppDirError(err: any) {
+  if (isError(err) && err?.stack) {
+    const filteredStack = err.stack
+      .split('\n')
+      .map((line: string) =>
+        // Remove 'webpack-internal:' noise from the path
+        line.replace(/(webpack-internal:\/\/\/|file:\/\/)(\(.*\)\/)?/, '')
+      )
+      // Only display stack frames from the user's code
+      .filter(
+        (line: string) =>
+          !/next[\\/]dist[\\/]compiled/.test(line) &&
+          !/node_modules[\\/]/.test(line) &&
+          !/node:internal[\\/]/.test(line)
+      )
+      .join('\n')
+    Log.error(filteredStack)
+    if (typeof (err as any).digest !== 'undefined') {
+      console.error(`digest: ${JSON.stringify((err as any).digest)}`)
+    }
+  } else {
+    Log.error(err)
+  }
+}

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -92,6 +92,7 @@ import { PagesManifest } from '../../build/webpack/plugins/pages-manifest-plugin
 import { NodeManifestLoader } from '../future/route-matcher-providers/helpers/manifest-loaders/node-manifest-loader'
 import { CachedFileReader } from '../future/route-matcher-providers/dev/helpers/file-reader/cached-file-reader'
 import { DefaultFileReader } from '../future/route-matcher-providers/dev/helpers/file-reader/default-file-reader'
+import { logAppDirError } from './log-app-dir-error'
 
 // Load ReactDevOverlay only when needed
 let ReactDevOverlayImpl: FunctionComponent
@@ -1134,31 +1135,6 @@ export default class DevServer extends Server {
     }
   }
 
-  private logAppDirError(err: any) {
-    if (isError(err) && err?.stack) {
-      const filteredStack = err.stack
-        .split('\n')
-        .map((line: string) =>
-          // Remove 'webpack-internal:' noise from the path
-          line.replace(/(webpack-internal:\/\/\/|file:\/\/)(\(.*\)\/)?/, '')
-        )
-        // Only display stack frames from the user's code
-        .filter(
-          (line: string) =>
-            !/next[\\/]dist[\\/]compiled/.test(line) &&
-            !/node_modules[\\/]/.test(line) &&
-            !/node:internal[\\/]/.test(line)
-        )
-        .join('\n')
-      Log.error(filteredStack)
-      if (typeof (err as any).digest !== 'undefined') {
-        console.error(`digest: ${JSON.stringify((err as any).digest)}`)
-      }
-    } else {
-      Log.error(err)
-    }
-  }
-
   private async logErrorWithOriginalStack(
     err?: unknown,
     type?: 'unhandledRejection' | 'uncaughtException' | 'warning' | 'app-dir'
@@ -1230,7 +1206,7 @@ export default class DevServer extends Server {
             if (type === 'warning') {
               Log.warn(err)
             } else if (type === 'app-dir') {
-              this.logAppDirError(err)
+              logAppDirError(err)
             } else if (type) {
               Log.error(`${type}:`, err)
             } else {
@@ -1251,7 +1227,7 @@ export default class DevServer extends Server {
       if (type === 'warning') {
         Log.warn(err)
       } else if (type === 'app-dir') {
-        this.logAppDirError(err)
+        logAppDirError(err)
       } else if (type) {
         Log.error(`${type}:`, err)
       } else {

--- a/test/development/app-render-error-log/app-render-error-log.test.ts
+++ b/test/development/app-render-error-log/app-render-error-log.test.ts
@@ -7,18 +7,36 @@ createNextDescribe(
     files: __dirname,
   },
   ({ next }) => {
-    it('should log the correct values on app-render error ', async () => {
+    it('should log the correct values on app-render error', async () => {
+      const outputIndex = next.cliOutput.length
       await next.fetch('/')
 
-      await check(() => next.cliOutput, /Error: boom/)
+      await check(() => next.cliOutput.slice(outputIndex), /at Page/)
+      const cliOutput = next.cliOutput.slice(outputIndex)
 
-      expect(next.cliOutput).toInclude('Error: boom')
-      expect(next.cliOutput).toInclude('at fn2 (./app/fn.ts:6:11)')
-      expect(next.cliOutput).toInclude('at fn1 (./app/fn.ts:9:5')
-      expect(next.cliOutput).toInclude('at Page (./app/page.tsx:10:45)')
-      expect(next.cliOutput).toInclude('digest: ')
+      expect(cliOutput).toInclude('Error: boom')
+      expect(cliOutput).toInclude('at fn2 (./app/fn.ts:6:11)')
+      expect(cliOutput).toInclude('at fn1 (./app/fn.ts:9:5')
+      expect(cliOutput).toInclude('at Page (./app/page.tsx:10:45)')
+      expect(cliOutput).toInclude('digest: ')
 
-      expect(next.cliOutput).not.toInclude('webpack-internal')
+      expect(cliOutput).not.toInclude('webpack-internal')
+    })
+
+    it('should log the correct values on app-render error with edge runtime', async () => {
+      const outputIndex = next.cliOutput.length
+      await next.fetch('/edge')
+
+      await check(() => next.cliOutput.slice(outputIndex), /at EdgePage/)
+      const cliOutput = next.cliOutput.slice(outputIndex)
+
+      expect(cliOutput).toInclude('Error: boom')
+      expect(cliOutput).toInclude('at fn2 (./app/fn.ts:6:11)')
+      expect(cliOutput).toInclude('at fn1 (./app/fn.ts:9:5')
+      expect(cliOutput).toInclude('at EdgePage (./app/edge/page.tsx:12:45)')
+      expect(cliOutput).toInclude('digest: ')
+
+      expect(cliOutput).not.toInclude('webpack-internal')
     })
   }
 )

--- a/test/development/app-render-error-log/app/edge/page.tsx
+++ b/test/development/app-render-error-log/app/edge/page.tsx
@@ -1,0 +1,8 @@
+export const runtime = 'edge'
+
+import { fn1 } from '../fn'
+
+export default function EdgePage() {
+  fn1()
+  return <p>hello world</p>
+}


### PR DESCRIPTION
`app-render` server errors aren't logged correctly with the edge runtime. This adds logging of a filtered stack trace.

Before
![image](https://user-images.githubusercontent.com/25056922/220144922-06aba048-0166-4114-8421-8f61e6137d5e.png)

After
![image](https://user-images.githubusercontent.com/25056922/220145019-83c1cf80-d6c7-4ce0-b76f-201265c7fafb.png)

Still some improvements left to figure out. This change doesn't log the original stack frame, and the `Log.error` is not printed with a red text like it should be.

fix NEXT-593 ([link](https://linear.app/vercel/issue/NEXT-593))

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
