### PR TITLE
Update flakey instrumentation test cases

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -206,7 +206,7 @@ export default class NextNodeServer extends BaseServer {
       this.imageResponseCache = new ResponseCache(this.minimalMode)
     }
 
-    if (!options.dev) {
+    if (!options.dev && this.nextConfig.experimental.instrumentationHook) {
       try {
         const instrumentationHook = require(join(
           options.dir || '.',


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/46002 this fixes the flakey test cases by not relying on the timestamp to restart the dev server