### PR TITLE
chore(ci): remove `needs: build-native-test` from codemod test

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -666,7 +666,7 @@ jobs:
   testCodemods:
     name: Test Codemods
     runs-on: ubuntu-latest
-    needs: [build, build-native-test]
+    needs: [build]
     timeout-minutes: 5
     env:
       NEXT_TELEMETRY_DISABLED: 1


### PR DESCRIPTION
Follow up to https://github.com/vercel/next.js/pull/46068