### PR TITLE
Fix Request and NextRequest creation from existing Request instance.

### DIFF
--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -378,13 +378,13 @@ Learn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation`),
       const __Request = context.Request
       context.Request = class extends __Request {
         next?: NextFetchRequestConfig | undefined
-        constructor(input: URL | RequestInfo, init?: RequestInit | undefined) {
+        constructor(input: RequestInfo | URL, init?: RequestInit | undefined) {
           const url =
             typeof input !== 'string' && 'url' in input
               ? input.url
               : String(input)
           validateURL(url)
-          super(url, init)
+          super(input, init)
           this.next = init?.next
         }
       }

--- a/packages/next/src/server/web/spec-extension/request.ts
+++ b/packages/next/src/server/web/spec-extension/request.ts
@@ -20,7 +20,7 @@ export class NextRequest extends Request {
     const url =
       typeof input !== 'string' && 'url' in input ? input.url : String(input)
     validateURL(url)
-    super(url, init)
+    super(input, init)
     const nextUrl = new NextURL(url, {
       headers: toNodeHeaders(this.headers),
       nextConfig: init.nextConfig,

--- a/test/e2e/edge-can-create-request-from-request-instance/app/pages/api/edge.js
+++ b/test/e2e/edge-can-create-request-from-request-instance/app/pages/api/edge.js
@@ -1,0 +1,18 @@
+export default async () => {
+  const self = new Request('http://localhost:3000', { method: 'POST' })
+  const other = new Request(self, { body: JSON.stringify('test') })
+
+  if (self.method === other.method && await other.json() === 'test') {
+    return new Response('Created Request from Request instance', {
+      status: 200,
+    })
+  }
+
+  return new Response('Could not create Request from Request instance', {
+    status: 418,
+  })
+}
+
+export const config = {
+  runtime: 'edge',
+}

--- a/test/e2e/edge-can-create-request-from-request-instance/app/pages/api/edge.js
+++ b/test/e2e/edge-can-create-request-from-request-instance/app/pages/api/edge.js
@@ -2,7 +2,7 @@ export default async () => {
   const self = new Request('http://localhost:3000', { method: 'POST' })
   const other = new Request(self, { body: JSON.stringify('test') })
 
-  if (self.method === other.method && await other.json() === 'test') {
+  if (self.method === other.method && (await other.json()) === 'test') {
     return new Response('Created Request from Request instance', {
       status: 200,
     })

--- a/test/e2e/edge-can-create-request-from-request-instance/index.test.ts
+++ b/test/e2e/edge-can-create-request-from-request-instance/index.test.ts
@@ -1,0 +1,27 @@
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { fetchViaHTTP } from 'next-test-utils'
+import path from 'path'
+
+describe('Edge runtime creates request form request instance', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/api/edge.js': new FileRef(
+          path.resolve(__dirname, './app/pages/api/edge.js')
+        ),
+      },
+      dependencies: {},
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('creates correct request from request', async () => {
+    const res = await fetchViaHTTP(next.url, '/api/edge', {}, { method: 'GET' })
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('Created Request from Request instanced')
+  })
+})

--- a/test/e2e/edge-can-create-request-from-request-instance/index.test.ts
+++ b/test/e2e/edge-can-create-request-from-request-instance/index.test.ts
@@ -22,6 +22,6 @@ describe('Edge runtime creates request form request instance', () => {
     const res = await fetchViaHTTP(next.url, '/api/edge', {}, { method: 'GET' })
 
     expect(res.status).toBe(200)
-    expect(await res.text()).toBe('Created Request from Request instanced')
+    expect(await res.text()).toBe('Created Request from Request instance')
   })
 })

--- a/test/unit/web-runtime/next-request.test.ts
+++ b/test/unit/web-runtime/next-request.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+
+import { NextRequest } from 'next/src/server/web/spec-extension/request'
+
+describe('NextRequest', () => {
+  const urlStr = 'http://localhost:3000/'
+  const url = new URL(urlStr)
+  const body = JSON.stringify('test')
+  const requestInstance = new Request(urlStr, {
+    method: 'POST',
+    body,
+  })
+
+  const cases: readonly [RequestInfo | URL, RequestInit][] = [
+    [requestInstance, {}],
+    [url, { method: 'POST', body }],
+    [urlStr, { method: 'POST', body }],
+  ]
+
+  it.each(cases)('creates request from %o', async (input, init) => {
+    const actual = new NextRequest(input, init)
+
+    expect(actual.method).toBe('POST')
+    expect(actual.url).toBe(urlStr)
+    expect(await actual.json()).toBe('test')
+  })
+
+  it('throws if provider url is invalid', () => {
+    const wrongUrl = 'wrong_url'
+    expect(() => new NextRequest(wrongUrl)).toThrow(
+      new Error(
+        `URL is malformed "${wrongUrl}". Please use only absolute URLs - https://nextjs.org/docs/messages/middleware-relative-urls`,
+        { cause: expect.any(Error) }
+      )
+    )
+  })
+})


### PR DESCRIPTION
…he Request constructor

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

Repro [sandbox](https://codesandbox.io/p/sandbox/keen-frost-pi2zl9?file=%2Fpages%2Fapi%2Fhello.ts&selection=%5B%7B%22endColumn%22%3A49%2C%22endLineNumber%22%3A6%2C%22startColumn%22%3A49%2C%22startLineNumber%22%3A6%7D%5D)

The current implementation only takes the `URL` from the `Request` instance and passes is to the `super()`. This PR uses extracted `URL` only for validation and passes the entire input as a param to the superclass constructor.

I found out today that `NextRequest`, was also broken. I've fixed that with additional unit tests.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [x] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
