### PR TITLE
fix: don't append domain to absolute urls when using i18n (#46201

### DIFF
--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -10,6 +10,7 @@ import { UrlObject } from 'url'
 import { resolveHref } from '../shared/lib/router/utils/resolve-href'
 import { isLocalURL } from '../shared/lib/router/utils/is-local-url'
 import { formatUrl } from '../shared/lib/router/utils/format-url'
+import { isAbsoluteUrl } from '../shared/lib/utils'
 import { addLocale } from './add-locale'
 import { RouterContext } from '../shared/lib/router-context'
 import {
@@ -679,8 +680,11 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     }
 
     // If child is an <a> tag and doesn't have a href attribute, or if the 'passHref' property is
-    // defined, we specify the current 'href', so that repetition is not needed by the user
-    if (
+    // defined, we specify the current 'href', so that repetition is not needed by the user.
+    // If the url is absolute, we can bypass the logic to prepend the domain and locale.
+    if (isAbsoluteUrl(as)) {
+      childProps.href = as
+    } else if (
       !legacyBehavior ||
       passHref ||
       (child.type === 'a' && !('href' in child.props))

--- a/test/integration/i18n-support-base-path/pages/index.js
+++ b/test/integration/i18n-support-base-path/pages/index.js
@@ -60,6 +60,9 @@ export default function Page(props) {
       <Link href="/api/post/asdf" id="to-api-post">
         to /api/post/[slug]
       </Link>
+      <Link href="https://nextjs.org/" id="to-external">
+        to https://nextjs.org/
+      </Link>
       <br />
     </>
   )

--- a/test/integration/i18n-support/pages/index.js
+++ b/test/integration/i18n-support/pages/index.js
@@ -60,6 +60,9 @@ export default function Page(props) {
       <Link href="/api/post/asdf" id="to-api-post">
         to /api/post/[slug]
       </Link>
+      <Link href="https://nextjs.org/" id="to-external">
+        to https://nextjs.org/
+      </Link>
       <br />
     </>
   )

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -386,6 +386,9 @@ export function runTests(ctx) {
       const href = await browser.elementByCss(element).getAttribute('href')
       expect(href).toBe(`https://example.com${ctx.basePath || ''}${pathname}`)
     }
+    expect(
+      await browser.elementByCss('#to-external').getAttribute('href')
+    ).toBe('https://nextjs.org/')
 
     browser = await webdriver(
       ctx.appPort,
@@ -405,6 +408,9 @@ export function runTests(ctx) {
         `https://example.com${ctx.basePath || ''}/go-BE${pathname}`
       )
     }
+    expect(
+      await browser.elementByCss('#to-external').getAttribute('href')
+    ).toBe('https://nextjs.org/')
   })
 
   // The page is accessible on subpath as well as on the domain url without subpath.
@@ -428,6 +434,9 @@ export function runTests(ctx) {
         expect(href).toBe(`https://example.com${ctx.basePath || ''}${pathname}`)
       }
     }
+    expect(
+      await browser.elementByCss('#to-external').getAttribute('href')
+    ).toBe('https://nextjs.org/')
 
     browser = await webdriver(ctx.appPort, `${ctx.basePath || ''}/go-BE`)
 
@@ -448,6 +457,9 @@ export function runTests(ctx) {
         )
       }
     }
+    expect(
+      await browser.elementByCss('#to-external').getAttribute('href')
+    ).toBe('https://nextjs.org/')
   })
 
   it('should render the correct href with locale domains but not on a locale domain', async () => {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

When passing absolute URLs to `<Link>` on a Next.js site using Internationalized Routing, the site's domain will be prepended to the URL, causing broken links. This PR checks if the provided URL is an absolute URL, and if so, skips the logic that prepends the domain.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
