### PR TITLE
Fix turbopack route resolver (#46206

### DIFF
--- a/packages/next/src/server/lib/route-resolver.ts
+++ b/packages/next/src/server/lib/route-resolver.ts
@@ -1,6 +1,10 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { NextConfig } from '../config'
-import type { Route } from '../router'
+import { RouteDefinition } from '../future/route-definitions/route-definition'
+import { RouteKind } from '../future/route-kind'
+import { DefaultRouteMatcherManager } from '../future/route-matcher-managers/default-route-matcher-manager'
+import { RouteMatch } from '../future/route-matches/route-match'
+import type { PageChecker, Route } from '../router'
 
 type RouteResult =
   | {
@@ -12,6 +16,37 @@ type RouteResult =
   | {
       type: 'none'
     }
+
+class DevRouteMatcherManager extends DefaultRouteMatcherManager {
+  private hasPage: PageChecker
+
+  constructor(hasPage: PageChecker) {
+    super()
+    this.hasPage = hasPage
+  }
+
+  async match(
+    pathname: string
+  ): Promise<RouteMatch<RouteDefinition<RouteKind>> | null> {
+    if (await this.hasPage(pathname)) {
+      return {
+        definition: {
+          kind: RouteKind.PAGES,
+          page: '',
+          pathname,
+          filename: '',
+          bundlePath: '',
+        },
+        params: {},
+      }
+    }
+    return null
+  }
+
+  async test(pathname: string) {
+    return (await this.match(pathname)) !== null
+  }
+}
 
 export async function makeResolver(dir: string, nextConfig: NextConfig) {
   const url = require('url') as typeof import('url')
@@ -37,6 +72,12 @@ export async function makeResolver(dir: string, nextConfig: NextConfig) {
 
   const routeResults = new WeakMap<any, string>()
   const routes = devServer.generateRoutes.bind(devServer)()
+
+  routes.matchers = new DevRouteMatcherManager(
+    // @ts-expect-error internal method
+    devServer.hasPage.bind(devServer)
+  )
+
   const router = new Router({
     ...routes,
     catchAllRoute: {
@@ -98,7 +139,7 @@ export async function makeResolver(dir: string, nextConfig: NextConfig) {
               type: 'rewrite',
               url: resolvedUrl,
               statusCode: 200,
-              headers: {},
+              headers: res.originalResponse.getHeaders(),
             }
 
       res.body(JSON.stringify(routeResult)).send()

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -38,8 +38,11 @@ let buildId
 let appPort
 let app
 
-const runTests = (isDev = false) => {
+const runTests = (isDev = false, isTurbo = false) => {
   it('should successfully rewrite a WebSocket request', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const messages = []
     const ws = await new Promise((resolve, reject) => {
       let socket = new WebSocket(`ws://localhost:${appPort}/to-websocket`)
@@ -79,6 +82,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should handle has query encoding correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     for (const expected of [
       {
         post: 'first',
@@ -121,6 +127,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should handle external beforeFiles rewrite correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/overridden')
     const html = await res.text()
 
@@ -139,6 +148,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should handle beforeFiles rewrite to dynamic route correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/nfl')
     const html = await res.text()
 
@@ -165,6 +177,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should handle beforeFiles rewrite to partly dynamic route correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/nfl')
     const html = await res.text()
 
@@ -202,6 +217,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should resolveHref correctly navigating through history', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const browser = await webdriver(appPort, '/')
     await browser.eval('window.beforeNav = 1')
 
@@ -257,6 +275,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should not hang when proxy rewrite fails', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/to-nowhere', undefined, {
       timeout: 5000,
     })
@@ -277,6 +298,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should provide params correctly for rewrite to auto-export non-dynamic page', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const browser = await webdriver(
       appPort,
       '/rewriting-to-another-auto-export/first'
@@ -302,6 +326,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should handle param like headers properly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/my-other-header/my-path')
     expect(res.headers.get('x-path')).toBe('my-path')
     expect(res.headers.get('somemy-path')).toBe('hi')
@@ -320,6 +347,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should not match dynamic route immediately after applying header', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/blog/post-321')
     expect(res.headers.get('x-something')).toBe('applied-everywhere')
 
@@ -486,6 +516,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should have correct encoding for params with catchall rewrite', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const html = await renderViaHTTP(
       appPort,
       '/catchall-rewrite/hello%20world%3Fw%3D24%26focalpoint%3Dcenter?a=b'
@@ -508,6 +541,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should have correct header for catchall rewrite', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/catchall-header/hello/world?a=b')
     const headerValue = res.headers.get('x-value')
     expect(headerValue).toBe('hello/world')
@@ -533,6 +569,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should have correctly encoded params in query for redirect', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(
       appPort,
       '/query-redirect/hello%20world%3Fw%3D24%26focalpoint%3Dcenter/world?a=b',
@@ -640,6 +679,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should work with rewrite when only specifying href', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const browser = await webdriver(appPort, '/nav')
     await browser.eval('window.beforeNav = 1')
     await browser
@@ -656,6 +698,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should work with rewrite when only specifying href and ends in dynamic route', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const browser = await webdriver(appPort, '/nav')
     await browser.eval('window.beforeNav = 1')
     await browser
@@ -685,6 +730,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should match /_next file after rewrite', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     await renderViaHTTP(appPort, '/hello')
     const data = await renderViaHTTP(
       appPort,
@@ -703,34 +751,52 @@ const runTests = (isDev = false) => {
   })
 
   it('should apply headers for exact match', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/add-header')
     expect(res.headers.get('x-custom-header')).toBe('hello world')
     expect(res.headers.get('x-another-header')).toBe('hello again')
   })
 
   it('should apply headers for multi match', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/my-headers/first')
     expect(res.headers.get('x-first-header')).toBe('first')
     expect(res.headers.get('x-second-header')).toBe('second')
   })
 
   it('should apply params for header key/values', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/my-other-header/first')
     expect(res.headers.get('x-path')).toBe('first')
     expect(res.headers.get('somefirst')).toBe('hi')
   })
 
   it('should support URL for header key/values', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/without-params/url')
     expect(res.headers.get('x-origin')).toBe('https://example.com')
   })
 
   it('should apply params header key/values with URL', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/with-params/url/first')
     expect(res.headers.get('x-url')).toBe('https://example.com/first')
   })
 
   it('should apply params header key/values with URL that has port', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/with-params/url2/first')
     expect(res.headers.get('x-url')).toBe(
       'https://example.com:8080?hello=first'
@@ -738,6 +804,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should support named pattern for header key/values', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/named-pattern/hello')
     expect(res.headers.get('x-something')).toBe('value=hello')
     expect(res.headers.get('path-hello')).toBe('end')
@@ -800,6 +869,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should have correctly encoded query in location and refresh headers', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(
       appPort,
       // Query unencoded is ?テスト=あ
@@ -839,6 +911,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should handle encoded value in the pathname correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(
       appPort,
       '/redirect/me/to-about/' + encodeURI('\\google.com'),
@@ -914,6 +989,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should match missing header headers correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/missing-headers-1', undefined, {
       headers: {
         'x-my-header': 'hello world!!',
@@ -929,6 +1007,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should match missing query headers correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/missing-headers-2', {
       'my-query': 'hellooo',
     })
@@ -942,6 +1023,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should match missing cookie headers correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/missing-headers-3', undefined, {
       headers: {
         cookie: 'loggedIn=true',
@@ -1178,6 +1262,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should match has rewrite correctly before files', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res1 = await fetchViaHTTP(appPort, '/hello')
     expect(res1.status).toBe(200)
     const $1 = cheerio.load(await res1.text())
@@ -1345,6 +1432,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should match has header for header correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/has-header-1', undefined, {
       headers: {
         'x-my-header': 'hello world!!',
@@ -1361,6 +1451,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should match has query for header correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(
       appPort,
       '/has-header-2',
@@ -1381,6 +1474,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should match has cookie for header correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/has-header-3', undefined, {
       headers: {
         cookie: 'loggedIn=true',
@@ -1397,6 +1493,9 @@ const runTests = (isDev = false) => {
   })
 
   it('should match has host for header correctly', async () => {
+    // TODO: remove once test failure has been fixed
+    if (isTurbo) return
+
     const res = await fetchViaHTTP(appPort, '/has-header-4', undefined, {
       headers: {
         host: 'example.com',
@@ -2592,6 +2691,38 @@ describe('Custom routes', () => {
       await killApp(app)
     })
     runTests(true)
+  })
+
+  // enable once https://github.com/vercel/turbo/pull/3894 is landed
+  describe.skip('dev mode (turbo)', () => {
+    let nextConfigContent
+
+    beforeAll(async () => {
+      // ensure cache with rewrites disabled doesn't persist
+      // after enabling rewrites
+      await fs.remove(join(appDir, '.next'))
+      nextConfigContent = await fs.readFile(nextConfigPath, 'utf8')
+      await fs.writeFile(
+        nextConfigPath,
+        nextConfigContent.replace('// no-rewrites comment', 'return []')
+      )
+
+      const tempPort = await findPort()
+      const tempApp = await launchApp(appDir, tempPort, { turbo: true })
+      await renderViaHTTP(tempPort, '/')
+
+      await killApp(tempApp)
+      await fs.writeFile(nextConfigPath, nextConfigContent)
+
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort, { turbo: true })
+      buildId = 'development'
+    })
+    afterAll(async () => {
+      await fs.writeFile(nextConfigPath, nextConfigContent)
+      await killApp(app)
+    })
+    runTests(true, true)
   })
 
   describe('no-op rewrite', () => {


### PR DESCRIPTION
This ensures we correctly handle the new route matchers with turbopack. Also updates the custom-routes test suite to allow it to run against turbopack although relies on changes in https://github.com/vercel/turbo/pull/3894 for the tests to run correctly. 