### PR TITLE
Skip build step for docs only change (#46225

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -90,6 +90,7 @@ jobs:
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
 
       - run: pnpm run build
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
 
       - id: check-release
         run: |


### PR DESCRIPTION
Since we don't need to run type-checking for docs only changes we can skip the build step and speed up docs PRs a bit 

x-ref: https://github.com/vercel/next.js/actions/runs/4238129393/jobs/7364888664