### PR TITLE
chore: update with-xata example

### DIFF
--- a/examples/with-xata/README.md
+++ b/examples/with-xata/README.md
@@ -38,18 +38,16 @@ pnpm create next-app --example with-xata with-xata-app
 
 ### Link With Your Xata Workspace And Update Types
 
-> 💡 We recommend installing the [Xata CLI](https://xata.io/docs/cli/getting-started) globally, but you can also use `npx @xata.io/cli` instead of `xata` in the commands below.
-
 You can link your project with a Xata workspace by running the following command:
 
 ```sh
-xata init
+npm run xata:init
 ```
 
 To update your types, run the following command:
 
 ```sh
-xata codegen
+npm run xata:codegen
 ```
 
 ### Start Coding

--- a/examples/with-xata/package.json
+++ b/examples/with-xata/package.json
@@ -4,19 +4,21 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "xata": "xata codegen",
-    "postinstall": "npx @xata.io/cli@latest schema upload schema.template.json --branch main --create-only --yes"
+    "xata": "xata",
+    "xata:codegen": "xata codegen",
+    "xata:init": "xata init --schema=schema.template.json --codegen utils/xata.codegen.ts"
   },
   "devDependencies": {
     "@types/node": "18.11.10",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",
+    "@xata.io/cli": "latest",
     "eslint": "8.28.0",
     "eslint-config-next": "latest",
     "typescript": "4.9.3"
   },
   "dependencies": {
-    "@xata.io/client": "^0.21.3",
+    "@xata.io/client": "latest",
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
Update `with-xata` example with `xata:init` command to follow the latest convention.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
