### PR TITLE
Generate stats.json file by default when analyzing the bundle

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -1,5 +1,5 @@
 module.exports =
-  ({ enabled = true, openAnalyzer = true } = {}) =>
+  ({ enabled = true, openAnalyzer = true, generateStatsFile = true } = {}) =>
   (nextConfig = {}) => {
     return Object.assign({}, nextConfig, {
       webpack(config, options) {
@@ -9,6 +9,7 @@ module.exports =
             new BundleAnalyzerPlugin({
               analyzerMode: 'static',
               openAnalyzer,
+              generateStatsFile,
               reportFilename: !options.nextRuntime
                 ? `./analyze/client.html`
                 : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${


### PR DESCRIPTION
stats.json is essential when analyzing the size of a bundle. In complement to the sizes of the modules, it allows to know why a module has been required.  Having it by default to true can be opiniated : at least we could pass the option to the BundleAnalyzerPlugin

I opened a feature request : https://github.com/vercel/next.js/issues/46234 

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [X] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
