### PR TITLE
Add failing test for navigating from pages to app with dynamic route in pages

### DIFF
--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -520,6 +520,18 @@ function fetchNextData({
           return { dataHref, response, text: '', json: {}, cacheKey }
         }
 
+        // This condition ensures that when navigating from `pages` to `app` the app route is hard navigated to.
+        // It also ensures that when e.g. middleware ends up rewriting to a HTML page it doesn't cause the router to have empty props for a page.
+        if (
+          response.ok &&
+          response.headers.get('Content-Type') !== 'application/json'
+        ) {
+          // TODO: This shouldn't log an error
+          const err = new Error('Different Content-Type returned')
+          markAssetError(err)
+          throw err
+        }
+
         return response.text().then((text) => {
           if (!response.ok) {
             /**

--- a/test/e2e/app-dir/pages-to-app-routing/app/about/page.tsx
+++ b/test/e2e/app-dir/pages-to-app-routing/app/about/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="app-page">About</h1>
+}

--- a/test/e2e/app-dir/pages-to-app-routing/app/layout.tsx
+++ b/test/e2e/app-dir/pages-to-app-routing/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/pages-to-app-routing/middleware.ts
+++ b/test/e2e/app-dir/pages-to-app-routing/middleware.ts
@@ -1,0 +1,3 @@
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {}

--- a/test/e2e/app-dir/pages-to-app-routing/next.config.js
+++ b/test/e2e/app-dir/pages-to-app-routing/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: { appDir: true },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
+++ b/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
@@ -1,0 +1,23 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'pages-to-app-routing',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should work using browser', async () => {
+      const browser = await next.browser('/abc')
+      expect(await browser.elementByCss('#params').text()).toBe(
+        'Params: {"slug":"abc"}'
+      )
+
+      await browser
+        .elementByCss('#to-about-link')
+        .click()
+        .waitForElementByCss('#app-page')
+
+      expect(await browser.elementByCss('#app-page').text()).toBe('About')
+    })
+  }
+)

--- a/test/e2e/app-dir/pages-to-app-routing/pages/[slug].js
+++ b/test/e2e/app-dir/pages-to-app-routing/pages/[slug].js
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export async function getServerSideProps({ params }) {
+  return {
+    props: {
+      params,
+    },
+  }
+}
+
+export default function Page({ params }) {
+  return (
+    <>
+      <h1 id="params">Params: {JSON.stringify(params)}</h1>
+      <Link id="to-about-link" href="/about">
+        To About
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/middleware-redirects/app/pages/dynamic/[slug].js
+++ b/test/e2e/middleware-redirects/app/pages/dynamic/[slug].js
@@ -1,13 +1,15 @@
-export default function Account() {
+export default function Account({ slug }) {
   return (
     <p id="dynamic" className="title">
-      Welcome to a /dynamic/[slug]
+      Welcome to a /dynamic/[slug]: {slug}
     </p>
   )
 }
 
-export function getServerSideProps() {
+export function getServerSideProps({ params }) {
   return {
-    props: {},
+    props: {
+      slug: params.slug,
+    },
   }
 }

--- a/test/e2e/middleware-redirects/test/index.test.ts
+++ b/test/e2e/middleware-redirects/test/index.test.ts
@@ -27,6 +27,9 @@ describe('Middleware Redirect', () => {
       await browser.eval('window.next.router.push("/to-new")')
       await browser.waitForElementByCss('#dynamic')
       expect(await browser.eval('window.beforeNav')).toBe(1)
+      expect(await browser.elementByCss('#dynamic').text()).toBe(
+        'Welcome to a /dynamic/[slug]: new'
+      )
     })
 
     it('does not include the locale in redirects by default', async () => {


### PR DESCRIPTION
When a `_next/data/buildId/path/to/page-name.json` request returns `text/html` instead of JSON that would be handled incorrectly by providing empty `{}` props to the component instead of triggering a hard navigation. This PR changes that to check the response type and hard navigate when it is not JSON. This is similar to the check we do for the new router.

Looking at the router throwing an asset error seemed like the only way to apply it so I'd like to get a review from @ijjk to make sure there isn't a better way.

A benefit of this change is that navigating from `pages` -> `app` will work in more cases. 

fix NEXT-609 ([link](https://linear.app/vercel/issue/NEXT-609))

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
