### PR TITLE
Fix missing metadataBase for static tw,og image resolving

### DIFF
--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -52,7 +52,7 @@ function mergeStaticMetadata(
         card: 'summary_large_image',
         images: twitter,
       },
-      null
+      metadata.metadataBase
     )
     metadata.twitter = { ...metadata.twitter, ...resolvedTwitter! }
   }
@@ -62,7 +62,7 @@ function mergeStaticMetadata(
       {
         images: opengraph,
       },
-      null
+      metadata.metadataBase
     )
     metadata.openGraph = { ...metadata.openGraph, ...resolvedOg! }
   }
@@ -81,7 +81,7 @@ function merge(
     openGraph: string | null
   }
 ) {
-  const metadataBase = source?.metadataBase || null
+  const metadataBase = source?.metadataBase || target.metadataBase
   for (const key_ in source) {
     const key = key_ as keyof Metadata
 

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
@@ -69,6 +69,16 @@ export function resolveOpenGraph(
       }
     }
     resolved.images = resolveAsArrayOrUndefined(og.images)
+    resolved.images?.forEach((item, index, array) => {
+      if (isStringOrURL(item)) {
+        array[index] = {
+          url: metadataBase ? resolveUrl(item, metadataBase)! : item,
+        }
+      } else {
+        // Update image descriptor url
+        item.url = metadataBase ? resolveUrl(item.url, metadataBase)! : item.url
+      }
+    })
   }
 
   assignProps(openGraph)

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
@@ -9,7 +9,7 @@ describe('metadata: resolveUrl', () => {
   })
 
   it('should error when metadataBase is not provided but url is not valid URL', () => {
-    expect(() => resolveUrl('/abc', null)).toThrow('missing metadataBase')
+    expect(() => resolveUrl('/abc', null)).toThrow()
   })
 
   it('should return url itself when metadataBase is null or url is valid URL', () => {

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -18,7 +18,10 @@ function resolveUrl(
     return parsedUrl
   } catch (_) {}
 
-  if (!metadataBase) throw new Error('missing metadataBase')
+  if (!metadataBase)
+    throw new Error(
+      `metadata.metadataBase needs to be provided for resolving absolute URLs: ${url}`
+    )
 
   // Handle relative or absolute paths
   const basePath = metadataBase.pathname || '/'

--- a/packages/next/src/lib/metadata/types/twitter-types.ts
+++ b/packages/next/src/lib/metadata/types/twitter-types.ts
@@ -64,8 +64,12 @@ type TwitterPlayerDescriptor = {
 }
 
 type ResolvedTwitterImage = {
-  url: null | URL | string
+  url: string | URL
   alt?: string
+  secureUrl?: string | URL
+  type?: string
+  width?: string | number
+  height?: string | number
 }
 type ResolvedTwitterSummary = {
   site: string | null

--- a/test/e2e/app-dir/metadata/app/opengraph/layout.tsx
+++ b/test/e2e/app-dir/metadata/app/opengraph/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return children
+}
+
+export const metadata = {
+  metadataBase: new URL('https://example.com/'),
+}

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -450,7 +450,7 @@ createNextDescribe(
       it('should pick up opengraph-image and twitter-image as static metadata files', async () => {
         const $ = await next.render$('/opengraph/static')
         expect($('[property="og:image:url"]').attr('content')).toMatch(
-          /_next\/static\/media\/metadata\/opengraph-image.\w+.png/
+          /https:\/\/example.com\/_next\/static\/media\/metadata\/opengraph-image.\w+.png/
         )
         expect($('[property="og:image:type"]').attr('content')).toBe(
           'image/png'
@@ -459,7 +459,7 @@ createNextDescribe(
         expect($('[property="og:image:height"]').attr('content')).toBe('114')
 
         expect($('[name="twitter:image"]').attr('content')).toMatch(
-          /_next\/static\/media\/metadata\/twitter-image.\w+.png/
+          /https:\/\/example.com\/_next\/static\/media\/metadata\/twitter-image.\w+.png/
         )
         expect($('[name="twitter:card"]').attr('content')).toBe(
           'summary_large_image'


### PR DESCRIPTION
Replacement for #46156
Closes NEXT-587

* `metadataBase` will always need to be provided for twitter image and opengraph image
* Fixing the metadataBase isn't picked up by static og/twitter images

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
