### PR TITLE
Improve type checking

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -75,7 +75,7 @@ export interface PageProps {
   searchParams?: any
 }
 export interface LayoutProps {
-  children: React.ReactNode
+  children?: React.ReactNode
 ${
   options.slots
     ? options.slots.map((slot) => `  ${slot}: React.ReactNode`).join('\n')

--- a/packages/next/src/lib/typescript/diagnosticFormatter.ts
+++ b/packages/next/src/lib/typescript/diagnosticFormatter.ts
@@ -41,27 +41,26 @@ function getFormattedLinkDiagnosticMessageText(
 }
 
 function getFormattedLayoutAndPageDiagnosticMessageText(
-  baseDir: string,
+  relativeSourceFilepath: string,
   diagnostic: import('typescript').Diagnostic
 ) {
-  const message = diagnostic.messageText
-  const sourceFilepath =
-    diagnostic.file?.text.trim().match(/^\/\/ File: (.+)\n/)?.[1] || ''
+  const message =
+    typeof diagnostic.messageText === 'string'
+      ? diagnostic
+      : diagnostic.messageText
+  const messageText = message.messageText
 
-  if (sourceFilepath && typeof message !== 'string') {
-    const relativeSourceFile = path.relative(baseDir, sourceFilepath)
-    const type = /page\.[^.]+$/.test(relativeSourceFile) ? 'Page' : 'Layout'
+  if (typeof messageText === 'string') {
+    const type = /page\.[^.]+$/.test(relativeSourceFilepath) ? 'Page' : 'Layout'
 
     // Reference of error codes:
     // https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json
     switch (message.code) {
       case 2344:
-        const filepathAndType = message.messageText.match(
-          /typeof import\("(.+)"\)/
-        )
+        const filepathAndType = messageText.match(/typeof import\("(.+)"\)/)
         if (filepathAndType) {
           let main = `${type} "${chalk.bold(
-            relativeSourceFile
+            relativeSourceFilepath
           )}" does not match the required types of a Next.js ${type}.`
 
           function processNext(
@@ -173,16 +172,16 @@ function getFormattedLayoutAndPageDiagnosticMessageText(
             }
           }
 
-          processNext(1, message.next)
+          if ('next' in message) processNext(1, message.next)
           return main
         }
 
-        const invalidExportFnArg = message.messageText.match(
+        const invalidExportFnArg = messageText.match(
           /Type 'OmitWithTag<(.+), .+, "(.+)">' does not satisfy the constraint/
         )
         if (invalidExportFnArg) {
           const main = `${type} "${chalk.bold(
-            relativeSourceFile
+            relativeSourceFilepath
           )}" has an invalid "${chalk.bold(
             invalidExportFnArg[2]
           )}" export:\n  Type "${chalk.bold(
@@ -191,12 +190,12 @@ function getFormattedLayoutAndPageDiagnosticMessageText(
           return main
         }
 
-        const invalidExportFnReturn = message.messageText.match(
+        const invalidExportFnReturn = messageText.match(
           /Type '{ __tag__: "(.+)"; __return_type__: (.+); }' does not satisfy/
         )
         if (invalidExportFnReturn) {
           let main = `${type} "${chalk.bold(
-            relativeSourceFile
+            relativeSourceFilepath
           )}" has an invalid export:\n  "${chalk.bold(
             invalidExportFnReturn[2]
           )}" is not a valid ${invalidExportFnReturn[1]} return type:`
@@ -226,27 +225,50 @@ function getFormattedLayoutAndPageDiagnosticMessageText(
             }
           }
 
-          processNext(1, message.next)
+          if ('next' in message) processNext(1, message.next)
           return main
         }
 
         break
       case 2345:
-        const filepathAndInvalidExport = message.messageText.match(
+        const filepathAndInvalidExport = messageText.match(
           /'typeof import\("(.+)"\)'.+Impossible<"(.+)">/
         )
         if (filepathAndInvalidExport) {
           const main = `${type} "${chalk.bold(
-            relativeSourceFile
+            relativeSourceFilepath
           )}" exports an invalid "${chalk.bold(
             filepathAndInvalidExport[2]
           )}" field. ${type} should only export a default React component and configuration options. Learn more: https://nextjs.org/docs/messages/invalid-segment-export`
           return main
         }
         break
+      case 2559:
+        const invalid = messageText.match(
+          /Type '(.+)' has no properties in common with type '(.+)'/
+        )
+        if (invalid) {
+          const main = `${type} "${chalk.bold(
+            relativeSourceFilepath
+          )}" contains an invalid type "${chalk.bold(invalid[1])}" as ${
+            invalid[2]
+          }.`
+          return main
+        }
+        break
       default:
     }
   }
+}
+
+function getAppEntrySourceFilePath(
+  baseDir: string,
+  diagnostic: import('typescript').Diagnostic
+) {
+  const sourceFilepath =
+    diagnostic.file?.text.trim().match(/^\/\/ File: (.+)\n/)?.[1] || ''
+
+  return path.relative(baseDir, sourceFilepath)
 }
 
 export function getFormattedDiagnostic(
@@ -263,14 +285,18 @@ export function getFormattedDiagnostic(
 
   let message = ''
 
+  const appPath = isLayoutOrPageError
+    ? getAppEntrySourceFilePath(baseDir, diagnostic)
+    : null
   const linkReason = getFormattedLinkDiagnosticMessageText(diagnostic)
-  const layoutReason =
-    !linkReason && isLayoutOrPageError
-      ? getFormattedLayoutAndPageDiagnosticMessageText(baseDir, diagnostic)
+  const appReason =
+    !linkReason && isLayoutOrPageError && appPath
+      ? getFormattedLayoutAndPageDiagnosticMessageText(appPath, diagnostic)
       : null
+
   const reason =
     linkReason ||
-    layoutReason ||
+    appReason ||
     ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
   const category = diagnostic.category
   switch (category) {
@@ -325,6 +351,8 @@ export function getFormattedDiagnostic(
         },
         { forceColor: true }
       )
+  } else if (isLayoutOrPageError && appPath) {
+    message = chalk.cyan(appPath) + '\n' + message
   }
 
   return message

--- a/test/integration/app-types/src/app/type-checks/layout/layout.tsx
+++ b/test/integration/app-types/src/app/type-checks/layout/layout.tsx
@@ -1,0 +1,7 @@
+import type { PropsWithChildren } from 'react'
+
+type LayoutProps = PropsWithChildren<{}>
+
+export default function Layout(props: LayoutProps) {
+  return <div>{props.children}</div>
+}

--- a/test/integration/app-types/tsconfig.json
+++ b/test/integration/app-types/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Fixes the case where some errors don't have the filepath attached, and other minor improvements.

Related: https://vercel.slack.com/archives/C035J346QQL/p1677092482452709

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
