### PR TITLE
Error.getInitialProps dose not work when hydrating if there is only a server side exception in production build

### DIFF
--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -411,8 +411,9 @@ function renderError(renderErrorProps: RenderErrorProps): Promise<any> {
           AppTree,
         },
       }
+
       return Promise.resolve(
-        renderErrorProps.props?.err
+        renderErrorProps.props
           ? renderErrorProps.props
           : loadGetInitialProps(App, appCtx)
       ).then((initProps) =>
@@ -901,7 +902,20 @@ export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
     App: CachedApp,
     initial: true,
     Component: CachedComponent,
-    props: initialData.props,
+    /**
+     * Initial props from server is invalid when server has no error(initialData.err)
+     * but client has error(initialErr), such that loadGetInitialProps would be called
+     * in the client side.
+     *
+     * Moreover, For the reference @see https://github.com/vercel/next.js/pull/21240
+     *
+     * The old fix introduced a new bug, the renderErrorProps.props never has an `err`
+     * property, which means server side error.getInitialProps's result will never be used
+     * as a client initial props(client will always call the error.getInitialProps).
+     *
+     * This fix can also resolve top module error issue(#21240).
+     */
+    props: initialErr && !initialData.err ? undefined : initialData.props,
     err: initialErr,
   }
 

--- a/test/integration/render-error-on-page-error/pages/_error.js
+++ b/test/integration/render-error-on-page-error/pages/_error.js
@@ -1,0 +1,11 @@
+const Error = ({ message }) => {
+  return <p id="error-p">Error Rendered with: {message}</p>
+}
+
+Error.getInitialProps = ({ err }) => {
+  return {
+    message: err && err.message,
+  }
+}
+
+export default Error

--- a/test/integration/render-error-on-page-error/pages/err.js
+++ b/test/integration/render-error-on-page-error/pages/err.js
@@ -1,0 +1,12 @@
+const Index = () => {
+  if (typeof window === 'undefined') {
+    throw new Error('server side render error')
+  }
+  return 'Hi'
+}
+
+export function getServerSideProps() {
+  return { props: {} }
+}
+
+export default Index

--- a/test/integration/render-error-on-page-error/pages/index.js
+++ b/test/integration/render-error-on-page-error/pages/index.js
@@ -1,0 +1,9 @@
+const Index = () => {
+  return 'Hi'
+}
+
+export function getServerSideProps() {
+  throw new Error('server side props error')
+}
+
+export default Index

--- a/test/integration/render-error-on-page-error/test/index.test.js
+++ b/test/integration/render-error-on-page-error/test/index.test.js
@@ -1,0 +1,66 @@
+/* eslint-env jest */
+
+import {
+  nextBuild,
+  nextServer,
+  startApp,
+  stopApp,
+  waitFor,
+} from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { join } from 'path'
+
+const appDir = join(__dirname, '..')
+
+let appPort
+let app
+let server
+
+describe('Render page error with Error.getInitialProps', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    app = nextServer({
+      dir: join(__dirname, '../'),
+      dev: false,
+      quiet: true,
+    })
+
+    server = await startApp(app)
+    appPort = server.address().port
+  })
+  afterAll(() => stopApp(server))
+
+  it('should render error page when gssr throws', async () => {
+    const browser = await webdriver(appPort, '/')
+    try {
+      await waitFor(2000)
+      // SSR
+      let text = await browser.elementByCss('#error-p').text()
+      expect(text).toBe('Error Rendered with: server side props error')
+
+      // HYDRATION
+      await waitFor(1000)
+      text = await browser.elementByCss('#error-p').text()
+      expect(text).toBe('Error Rendered with: server side props error')
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('should render error page when render throws', async () => {
+    const browser = await webdriver(appPort, '/err')
+    try {
+      await waitFor(2000)
+      // SSR
+      let text = await browser.elementByCss('#error-p').text()
+      expect(text).toBe('Error Rendered with: server side render error')
+
+      // HYDRATION
+      await waitFor(1000)
+      text = await browser.elementByCss('#error-p').text()
+      expect(text).toBe('Error Rendered with: server side render error')
+    } finally {
+      await browser.close()
+    }
+  })
+})


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] fixes #44844
- [x] Integration tests added
- [x] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
