### PR TITLE
Fix edge runtime path slashes mismatch on windows

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -595,8 +595,8 @@ export class FlightClientEntryPlugin {
       modules: this.isEdgeServer
         ? clientImports.map((importPath) =>
             importPath.replace(
-              /next[\\/]dist[\\/]esm[\\/]/,
-              'next/dist/'.replace(/\//g, path.sep)
+              /[\\/]next[\\/]dist[\\/]esm[\\/]/,
+              '/next/dist/'.replace(/\//g, path.sep)
             )
           )
         : clientImports,

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -594,7 +594,10 @@ export class FlightClientEntryPlugin {
     const clientLoader = `next-flight-client-entry-loader?${stringify({
       modules: this.isEdgeServer
         ? clientImports.map((importPath) =>
-            importPath.replace('next/dist/esm/', 'next/dist/')
+            importPath.replace(
+              /next[\\/]dist[\\/]esm[\\/]/,
+              path.join('next', 'dist')
+            )
           )
         : clientImports,
       server: false,

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -596,7 +596,7 @@ export class FlightClientEntryPlugin {
         ? clientImports.map((importPath) =>
             importPath.replace(
               /next[\\/]dist[\\/]esm[\\/]/,
-              path.join('next', 'dist')
+              'next/dist/'.replace(/\//g, path.sep)
             )
           )
         : clientImports,

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -329,8 +329,8 @@ export class FlightManifestPlugin {
         if (/[\\/]next[\\/]dist[\\/]/.test(resource)) {
           manifest[
             resource.replace(
-              /next[\\/]dist[\\/]/,
-              path.join('next', 'dist', 'esm')
+              /[\\/]next[\\/]dist[\\/]/,
+              path.sep + path.join('next', 'dist', 'esm') + path.sep
             )
           ] = moduleExports
         }

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -330,7 +330,7 @@ export class FlightManifestPlugin {
           manifest[
             resource.replace(
               /[\\/]next[\\/]dist[\\/]/,
-              path.sep + path.join('next', 'dist', 'esm') + path.sep
+              '/next/dist/esm/'.replace(/\//g, path.sep)
             )
           ] = moduleExports
         }

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import path from 'path'
 import { webpack, sources } from 'next/dist/compiled/webpack/webpack'
 import {
   CLIENT_REFERENCE_MANIFEST,
@@ -325,9 +326,13 @@ export class FlightManifestPlugin {
 
         // The client compiler will always use the CJS Next.js build, so here we
         // also add the mapping for the ESM build (Edge runtime) to consume.
-        if (/\/next\/dist\//.test(resource)) {
-          manifest[resource.replace(/\/next\/dist\//, '/next/dist/esm/')] =
-            moduleExports
+        if (/[\\/]next[\\/]dist[\\/]/.test(resource)) {
+          manifest[
+            resource.replace(
+              /next[\\/]dist[\\/]/,
+              path.join('next', 'dist', 'esm')
+            )
+          ] = moduleExports
         }
 
         manifest.__ssr_module_mapping__ = moduleIdMapping


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

Closes NEXT-620

Test with app-playground locally on windows VM

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

