### PR TITLE
Fix broken link on `node-module-in-edge-runtime.md`

### DIFF
--- a/errors/node-module-in-edge-runtime.md
+++ b/errors/node-module-in-edge-runtime.md
@@ -10,7 +10,7 @@ However, the Edge Runtime does not support [Node.js APIs and globals](https://ne
 
 When running Next.js locally with `next dev`, your application will show in the console, and in your browser, which file is importing and using an unsupported module. This module must be avoided: either by not importing it, or by replacing it with a polyfill.
 
-For example, you might replace the Node.js `crypto` module with the [Web Crypto API](<[https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API](https://nextjs.org/docs/api-reference/edge-runtime#web-crypto-apis)>).
+For example, you might replace the Node.js `crypto` module with the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API).
 
 ### Useful Links
 


### PR DESCRIPTION
I was notified that this link is broken.

Not sure if I'm missing something, but the Markdown doesn't look right, changed it to be a normal link.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
