### PR TITLE
fix: lazy load dynamically generated `next/image` in Safari Firefox

### DIFF
--- a/packages/next/src/client/image.tsx
+++ b/packages/next/src/client/image.tsx
@@ -396,15 +396,18 @@ const ImageElement = forwardRef<HTMLImageElement | null, ImageElementProps>(
       <>
         <img
           {...rest}
-          {...imgAttributes}
+          // @ts-ignore - TODO: upgrade to `@types/react@17`
+          loading={loading}
           width={widthInt}
           height={heightInt}
           decoding="async"
           data-nimg={fill ? 'fill' : '1'}
           className={className}
-          // @ts-ignore - TODO: upgrade to `@types/react@17`
-          loading={loading}
           style={{ ...imgStyle, ...blurStyle }}
+          // It's intended to keep `loading` before `src` because React updates
+          // props in order which causes Safari/Firefox to not lazy load properly.
+          // See https://github.com/facebook/react/issues/25883
+          {...imgAttributes}
           ref={useCallback(
             (img: ImgElementWithDataProp | null) => {
               if (forwardedRef) {

--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -559,6 +559,15 @@ const ImageElement = ({
         <noscript>
           <img
             {...rest}
+            // @ts-ignore - TODO: upgrade to `@types/react@17`
+            loading={loading}
+            decoding="async"
+            data-nimg={layout}
+            style={imgStyle}
+            className={className}
+            // It's intended to keep `loading` before `src` because React updates
+            // props in order which causes Safari/Firefox to not lazy load properly.
+            // See https://github.com/facebook/react/issues/25883
             {...generateImgAttrs({
               config,
               src: srcString,
@@ -569,12 +578,6 @@ const ImageElement = ({
               sizes: noscriptSizes,
               loader,
             })}
-            decoding="async"
-            data-nimg={layout}
-            style={imgStyle}
-            className={className}
-            // @ts-ignore - TODO: upgrade to `@types/react@17`
-            loading={loading}
           />
         </noscript>
       )}

--- a/test/unit/next-image-new.test.ts
+++ b/test/unit/next-image-new.test.ts
@@ -7,7 +7,7 @@ import cheerio from 'cheerio'
 describe('Image rendering', () => {
   it('should render Image on its own', async () => {
     const element = React.createElement(Image, {
-      alt: 'unit-image',
+      alt: 'a nice image',
       id: 'unit-image',
       src: '/test.png',
       width: 100,
@@ -17,9 +17,20 @@ describe('Image rendering', () => {
     const html = ReactDOM.renderToString(element)
     const $ = cheerio.load(html)
     const img = $('#unit-image')
-    expect(img.attr('id')).toBe('unit-image')
-    expect(img.attr('src')).toContain('test.png')
-    expect(img.attr('srcset')).toContain('test.png')
+    // order matters here
+    expect(img.attr()).toStrictEqual({
+      alt: 'a nice image',
+      id: 'unit-image',
+      loading: 'eager',
+      width: '100',
+      height: '100',
+      decoding: 'async',
+      'data-nimg': '1',
+      style: 'color:transparent',
+      srcset:
+        '/_next/image?url=%2Ftest.png&w=128&q=75 1x, /_next/image?url=%2Ftest.png&w=256&q=75 2x',
+      src: '/_next/image?url=%2Ftest.png&w=256&q=75',
+    })
   })
 
   it('should only render noscript element when lazy loading', async () => {


### PR DESCRIPTION
- Fixes https://github.com/vercel/next.js/issues/46019
- Related to https://github.com/facebook/react/issues/25883