### PR TITLE
chore: Add modularizeImports to config schema

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -311,6 +311,9 @@ const configSchema = {
         largePageDataBytes: {
           type: 'number',
         },
+        modularizeImports: {
+          type: 'object',
+        },
         legacyBrowsers: {
           type: 'boolean',
         },


### PR DESCRIPTION
I'm gettting the warning that `modularizeImports` is not allowed config value but it's documented:

https://nextjs.org/docs/advanced-features/compiler

```
warn  - Invalid next.config.js options detected:
  - The value at .experimental has an unexpected property, modularizeImports, which is not in the list of allowed properties...
```

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
