### PR TITLE
Update isStale checking for fetch cache (#46331

### DIFF
--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -1,5 +1,8 @@
 import type { ServerRuntime } from '../../types'
 
+// in seconds
+export const CACHE_ONE_YEAR = 31536000
+
 // Patterns to detect middleware files
 export const MIDDLEWARE_FILENAME = 'middleware'
 export const MIDDLEWARE_LOCATION_REGEXP = `(?:src/)?${MIDDLEWARE_FILENAME}`

--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -99,13 +99,11 @@ export default class FetchCache implements CacheHandler {
           throw new Error(`invalid cache value`)
         }
 
-        const cacheState = res.headers.get('x-vercel-cache-state')
         const age = res.headers.get('age')
 
         data = {
-          age: age === null ? undefined : parseInt(age, 10),
-          cacheState: cacheState || undefined,
           value: cached,
+          lastModified: Date.now() - parseInt(age || '0', 10) * 1000,
         }
         if (this.debug) {
           console.log(
@@ -146,7 +144,11 @@ export default class FetchCache implements CacheHandler {
         if (data !== null && 'revalidate' in data) {
           this.headers['x-vercel-revalidate'] = data.revalidate.toString()
         }
-        if (data !== null && 'data' in data) {
+        if (
+          !this.headers['x-vercel-revalidate'] &&
+          data !== null &&
+          'data' in data
+        ) {
           this.headers['x-vercel-cache-control'] =
             data.data.headers['cache-control']
         }

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -197,13 +197,11 @@ export class IncrementalCache {
 
     if (cacheData?.value?.kind === 'FETCH') {
       const revalidate = cacheData.value.revalidate
-      const age =
-        cacheData.age ||
-        Math.round((Date.now() - (cacheData.lastModified || 0)) / 1000)
+      const age = Math.round(
+        (Date.now() - (cacheData.lastModified || 0)) / 1000
+      )
 
-      const isStale = cacheData.cacheState
-        ? cacheData.cacheState !== 'fresh'
-        : age > revalidate
+      const isStale = age > revalidate
       const data = cacheData.value.data
 
       return {

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -1,9 +1,9 @@
 import type { StaticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage'
 import { AppRenderSpan } from './trace/constants'
 import { getTracer, SpanKind } from './trace/tracer'
+import { CACHE_ONE_YEAR } from '../../lib/constants'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
-const CACHE_ONE_YEAR = 31536000
 
 // we patch fetch to collect cache information used for
 // determining if a page is static or not


### PR DESCRIPTION
This ensures we set `lastModified` when pulling from upstream cache instead of using `isStale` on the cache entry since once it's stored to the memory cache the `isStale` field would never be updated. 