### PR TITLE
fix(ts): correctly augment `next` when `typedRoutes: true`

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -128,6 +128,8 @@ function createRouteDefinitions() {
     !edgeRouteTypes.length && !nodeRouteTypes.length ? 'string' : ''
 
   return `
+import "next"
+
 type SearchOrHash = \`?\${string}\` | \`#\${string}\`
 type Suffix = '' | SearchOrHash
 

--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -388,8 +388,6 @@ export class NextTypesPlugin {
               'utf-8'
             )
 
-            console.log(originalNextModule)
-
             pageFiles.forEach((file) => {
               this.collectPage(file)
             })

--- a/test/integration/app-types/src/app/layout.tsx
+++ b/test/integration/app-types/src/app/layout.tsx
@@ -1,3 +1,9 @@
+import { Metadata } from 'next'
+
+export const meta: Metadata = {
+  title: 'My App',
+}
+
 export default function Root({ children }: { children: React.ReactNode }) {
   return (
     <html>


### PR DESCRIPTION
Fixes #46320

[Slack thread](https://vercel.slack.com/archives/C035J346QQL/p1677197813467609)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

fix NEXT-627 ([link](https://linear.app/vercel/issue/NEXT-627))