### PR TITLE
Docs: change image path to absolute path from "../public/png" to "public/png"

### DIFF
--- a/docs/basic-features/image-optimization.md
+++ b/docs/basic-features/image-optimization.md
@@ -44,7 +44,7 @@ Next.js will automatically determine the `width` and `height` of your image base
 
 ```js
 import Image from 'next/image'
-import profilePic from '../public/me.png'
+import profilePic from 'public/me.png'
 
 function Home() {
   return (


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Documentation / Examples

- [x] Docs improvement

From my understanding, having a relative path to the public folder is unnecessary since an absolute path will always lead to the right path, seems kind of silly, but I lost some good 5m because my image preview extension showed the right picture I assumed the path was correct.