### PR TITLE
Dedupe next/font preload tags

### DIFF
--- a/test/e2e/app-dir/next-font/app-old/navigation/font.js
+++ b/test/e2e/app-dir/next-font/app-old/navigation/font.js
@@ -1,0 +1,3 @@
+import localFont from '@next/font/local'
+
+export const font = localFont({ src: './font.woff2' })

--- a/test/e2e/app-dir/next-font/app-old/navigation/font.woff2
+++ b/test/e2e/app-dir/next-font/app-old/navigation/font.woff2
@@ -1,0 +1,1 @@
+font.woff2

--- a/test/e2e/app-dir/next-font/app-old/navigation/layout.js
+++ b/test/e2e/app-dir/next-font/app-old/navigation/layout.js
@@ -1,0 +1,12 @@
+import { font } from './font'
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        <p className={font.className}>LAYOUT1</p>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/next-font/app-old/navigation/page-with-same-font/page.js
+++ b/test/e2e/app-dir/next-font/app-old/navigation/page-with-same-font/page.js
@@ -1,0 +1,9 @@
+import { font } from '../font'
+
+export default function Page() {
+  return (
+    <p id="page-with-same-font" className={font.className}>
+      Page with same font
+    </p>
+  )
+}

--- a/test/e2e/app-dir/next-font/app-old/navigation/page.js
+++ b/test/e2e/app-dir/next-font/app-old/navigation/page.js
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <>
+      <Link href="/navigation/page-with-same-font">
+        Go to page with same font
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/next-font/app/navigation/font.js
+++ b/test/e2e/app-dir/next-font/app/navigation/font.js
@@ -1,0 +1,3 @@
+import localFont from 'next/font/local'
+
+export const font = localFont({ src: './font.woff2' })

--- a/test/e2e/app-dir/next-font/app/navigation/font.woff2
+++ b/test/e2e/app-dir/next-font/app/navigation/font.woff2
@@ -1,0 +1,1 @@
+font.woff2

--- a/test/e2e/app-dir/next-font/app/navigation/layout.js
+++ b/test/e2e/app-dir/next-font/app/navigation/layout.js
@@ -1,0 +1,12 @@
+import { font } from './font'
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        <p className={font.className}>LAYOUT1</p>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/next-font/app/navigation/page-with-same-font/page.js
+++ b/test/e2e/app-dir/next-font/app/navigation/page-with-same-font/page.js
@@ -1,0 +1,9 @@
+import { font } from '../font'
+
+export default function Page() {
+  return (
+    <p id="page-with-same-font" className={font.className}>
+      Page with same font
+    </p>
+  )
+}

--- a/test/e2e/app-dir/next-font/app/navigation/page.js
+++ b/test/e2e/app-dir/next-font/app/navigation/page.js
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <>
+      <Link href="/navigation/page-with-same-font">
+        Go to page with same font
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/next-font/next-font.test.ts
+++ b/test/e2e/app-dir/next-font/next-font.test.ts
@@ -9,7 +9,7 @@ const getAttrs = (elems: Cheerio) =>
     // My machine behaves differently to CI
     .sort((a, b) => (a.href < b.href ? -1 : 1))
 
-describe.each([['app']])('%s', (fixture: string) => {
+describe.each([['app'], ['app-old']])('%s', (fixture: string) => {
   createNextDescribe(
     'app dir next-font',
     {


### PR DESCRIPTION
Just like https://github.com/vercel/next.js/pull/44938 did for CSS tags, this makes sure `app-render` will only render one preload tag per font file by keeping track of the rendered files in a set while building the component tree.

Tested locally with react, react-dom and react-server-dom-webpack with version  `18.3.0-next-4fcc9184a-20230217`.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
