### PR TITLE
Print command for current packet manager in @next/font warning

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -22,6 +22,7 @@ import Watchpack from 'next/dist/compiled/watchpack'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { warn } from '../build/output/log'
 import { getPossibleInstrumentationHookFilenames } from '../build/utils'
+import { getNpxCommand } from '../lib/helpers/get-npx-command'
 
 let isTurboSession = false
 let sessionStopHandled = false
@@ -197,10 +198,11 @@ const nextDev: CliCommand = async (argv) => {
       (devDependencies['@next/font'] &&
         devDependencies['@next/font'] !== 'workspace:*')
     ) {
+      const command = getNpxCommand(dir)
       Log.warn(
         'Your project has `@next/font` installed as a dependency, please use the built-in `next/font` instead. ' +
           'The `@next/font` package will be removed in Next.js 14. ' +
-          'You can migrate by running `npx @next/codemod built-in-next-font .`. Read more: https://nextjs.org/docs/messages/built-in-next-font'
+          `You can migrate by running \`${command} @next/codemod built-in-next-font .\`. Read more: https://nextjs.org/docs/messages/built-in-next-font`
       )
     }
   }

--- a/packages/next/src/lib/helpers/get-npx-command.ts
+++ b/packages/next/src/lib/helpers/get-npx-command.ts
@@ -1,0 +1,17 @@
+import { execSync } from 'child_process'
+import { getPkgManager } from './get-pkg-manager'
+
+export function getNpxCommand(baseDir: string) {
+  const pkgManager = getPkgManager(baseDir)
+  let command = 'npx'
+  if (pkgManager === 'pnpm') {
+    command = 'pnpm dlx'
+  } else if (pkgManager === 'yarn') {
+    try {
+      execSync('yarn dlx --help', { stdio: 'ignore' })
+      command = 'yarn dlx'
+    } catch {}
+  }
+
+  return command
+}


### PR DESCRIPTION
The warning that tells you to uninstall `@next/font` always prints `npx` as the command to run the codemod. This makes it look for the current packet manager and print a more relevant command.

npm
![image](https://user-images.githubusercontent.com/25056922/221159311-daf6ac01-a3e9-4c09-8f86-159ea2ac178b.png)

Yarn version where `yarn dlx` command is available, otherwise `npx`
![image](https://user-images.githubusercontent.com/25056922/221159598-51cb5818-ba2b-4cd8-aaf9-4cc2ef874039.png)

pnpm
![image](https://user-images.githubusercontent.com/25056922/221167672-56425112-48b6-4c77-aafd-0b20134f0aee.png)


## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
