### PR TITLE
Fix app dynamic route affected by locales

### DIFF
--- a/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.ts
+++ b/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.ts
@@ -10,6 +10,7 @@ import { MatchOptions, RouteMatcherManager } from './route-matcher-manager'
 import { getSortedRoutes } from '../../../shared/lib/router/utils'
 import { LocaleRouteMatcher } from '../route-matchers/locale-route-matcher'
 import { ensureLeadingSlash } from '../../../shared/lib/page-path/ensure-leading-slash'
+import { AppPageRouteMatcher } from '../route-matchers/app-page-route-matcher'
 
 interface RouteMatchers {
   static: ReadonlyArray<RouteMatcher>
@@ -226,6 +227,11 @@ export class DefaultRouteMatcherManager implements RouteMatcherManager {
   ): RouteMatch | null {
     if (matcher instanceof LocaleRouteMatcher) {
       return matcher.match(pathname, options)
+    }
+
+    // For app page routes, we just ignore the locale if it's present.
+    if (matcher instanceof AppPageRouteMatcher) {
+      return matcher.match(options.i18n?.pathname || pathname)
     }
 
     return matcher.match(pathname)

--- a/test/integration/i18n-support/app/[locale]/app-dynamic-locale/[slug]/page.js
+++ b/test/integration/i18n-support/app/[locale]/app-dynamic-locale/[slug]/page.js
@@ -1,0 +1,7 @@
+export default function Page({ params }) {
+  return (
+    <h1>
+      slug = {params.slug}, locale = {params.locale}
+    </h1>
+  )
+}

--- a/test/integration/i18n-support/app/app-dynamic/[slug]/page.js
+++ b/test/integration/i18n-support/app/app-dynamic/[slug]/page.js
@@ -1,0 +1,3 @@
+export default function Page({ params }) {
+  return <h1>{`slug = ` + params.slug}</h1>
+}

--- a/test/integration/i18n-support/app/layout.js
+++ b/test/integration/i18n-support/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/integration/i18n-support/next.config.js
+++ b/test/integration/i18n-support/next.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   // basePath: '/docs',
   // trailingSlash: true,
+  experimental: {
+    appDir: true,
+  },
   i18n: {
     // localeDetection: false,
     locales: [

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -3173,7 +3173,21 @@ export function runTests(ctx) {
   })
 
   it('should not affect app dynamic routes', async () => {
-    const res = await fetchViaHTTP(ctx.appPort, '/app-dynamic/foo')
+    const res = await fetchViaHTTP(
+      ctx.appPort,
+      `${ctx.basePath}/app-dynamic/foo`
+    )
     expect(await res.text()).toContain('slug = foo')
+  })
+
+  it('should resolve app dynamic route correctly', async () => {
+    for (const locale of nonDomainLocales) {
+      const res = await fetchViaHTTP(
+        ctx.appPort,
+        `${ctx.basePath}/${locale}/app-dynamic-locale/bar`
+      )
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain(`slug = bar, locale = ${locale}`)
+    }
   })
 }

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -3171,4 +3171,9 @@ export function runTests(ctx) {
     expect(await browser.elementByCss('#router-pathname').text()).toBe('/')
     expect(await browser.elementByCss('#router-as-path').text()).toBe('/')
   })
+
+  it('should not affect app dynamic routes', async () => {
+    const res = await fetchViaHTTP(ctx.appPort, '/app-dynamic/foo')
+    expect(await res.text()).toContain('slug = foo')
+  })
 }


### PR DESCRIPTION
This PR fixes the problem that when `i18n` is set, dynamic routes in app will never be matched. Related issue: https://vercel.slack.com/archives/C02KC9WQHAQ/p1677089819155839

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
