### PR TITLE
fix(ts): Fix navigation types

### DIFF
--- a/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
@@ -49,16 +49,14 @@ export async function writeAppTypeDeclarations({
     directives.push('/// <reference types="next/image-types/global" />')
   }
 
-  if (isAppDirEnabled) {
-    if (hasPagesDir) {
-      directives.push(
-        '/// <reference types="next/navigation-types/compat/navigation" />'
-      )
-    } else {
-      directives.push(
-        '/// <reference types="next/navigation-types/navigation" />'
-      )
-    }
+  if (isAppDirEnabled && hasPagesDir) {
+    directives.push(
+      '/// <reference types="next/navigation-types/compat/navigation" />'
+    )
+  } else {
+    directives.push(
+      '/// <reference types="next/navigation-types/navigation" />'
+    )
   }
 
   // Push the notice in.

--- a/test/unit/write-app-declarations.test.ts
+++ b/test/unit/write-app-declarations.test.ts
@@ -19,6 +19,8 @@ describe('find config', () => {
     const content =
       '/// <reference types="next" />' +
       eol +
+      '/// <reference types="next/navigation-types/navigation" />' +
+      eol +
       (imageImportsEnabled
         ? '/// <reference types="next/image-types/global" />' + eol
         : '') +
@@ -44,6 +46,8 @@ describe('find config', () => {
     const content =
       '/// <reference types="next" />' +
       eol +
+      '/// <reference types="next/navigation-types/navigation" />' +
+      eol +
       (imageImportsEnabled
         ? '/// <reference types="next/image-types/global" />' + eol
         : '') +
@@ -68,6 +72,8 @@ describe('find config', () => {
     const eol = os.EOL
     const content =
       '/// <reference types="next" />' +
+      eol +
+      '/// <reference types="next/navigation-types/navigation" />' +
       eol +
       (imageImportsEnabled
         ? '/// <reference types="next/image-types/global" />' + eol


### PR DESCRIPTION
PR fixes([#46360](https://github.com/vercel/next.js/issues/46360)) typescript errors `Module '"next/navigation"' has no exported member 'usePathname'.` and `Module '"next/navigation"' has no exported member 'useSearchParams'.`

The issue appeared inside [#45919](https://github.com/vercel/next.js/pull/45919/files#diff-77f06665ebc0df2289daa6fb683f5d2c160bbfdf90a9f3ba9cf6b02bd0b7d57aR104) when types changed to `@internal` and condition to append types inside `writeAppTypeDeclarations` was wrongly set.


