### PR TITLE
test(integration): properly pipe turbopack binary stdouts

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -424,13 +424,17 @@ function loadNative(isCustomTurbopack = false) {
 
               let child = spawn(__INTERNAL_CUSTOM_TURBOPACK_BINARY, args, {
                 stdio: 'pipe',
-                env: {
-                  ...process.env,
-                },
               })
               child.on('message', (message: any) => {
-                console.log(message)
+                require('console').log(message)
               })
+              child.stdout.on('data', (data: any) => {
+                require('console').log(data.toString())
+              })
+              child.stderr.on('data', (data: any) => {
+                require('console').log(data.toString())
+              })
+
               child.on('close', (code: any) => {
                 if (code !== 0) {
                   reject({

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -459,7 +459,9 @@ If you cannot make the changes above, but still want to try out\nNext.js v13 wit
     // Start preflight after server is listening and ignore errors:
     preflight().catch(() => {})
 
-    await telemetry.flush()
+    if (!isCustomTurbopack) {
+      await telemetry.flush()
+    }
     return server
   } else {
     // we're using a sub worker to avoid memory leaks. When memory usage exceeds 90%, we kill the worker and restart it.


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

Partially resolves WEB-628

Starting next-dev relies on some stdout status to grab its devserver url, and this PR correctly bubbles up custom turbopack binary's stdout to make it work.