### PR TITLE
test(next-script): teardown next-dev instance via jest hooks

### DIFF
--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -253,6 +253,18 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
 })
 
 describe('experimental.nextScriptWorkers: true with required Partytown dependency for inline script', () => {
+  let next: NextInstance
+
+  // Note: previously we were using `finally` cluase inside of test assertion. However, if the test times out
+  // exceeding jest.setTimeout() value, the finally clause is not executed and subsequent tests will fail due to
+  // hanging next instance.
+  afterEach(async () => {
+    if (next) {
+      await next.destroy()
+      next = undefined
+    }
+  })
+
   const createNextApp = async (script) =>
     await createNext({
       nextConfig: {
@@ -282,7 +294,6 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
     })
 
   it('Inline worker script through children is modified by Partytown to execute on a worker thread', async () => {
-    let next: NextInstance
     let browser: BrowserInterface
 
     next = await createNextApp(
@@ -304,12 +315,10 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
       expect(text).toBe('abc')
     } finally {
       if (browser) await browser.close()
-      await next.destroy()
     }
   })
 
   it('Inline worker script through dangerouslySetInnerHtml is modified by Partytown to execute on a worker thread', async () => {
-    let next: NextInstance
     let browser: BrowserInterface
 
     next = await createNextApp(
@@ -331,7 +340,6 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
       expect(text).toBe('abcd')
     } finally {
       if (browser) await browser.close()
-      await next.destroy()
     }
   })
 })


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

Partially resolves WEB-628

This PR is minor improvement to the fixture setup for next-script test: if one of test assertion using `finally` to teardown next instance (next.destroy) times out, those clause won't be called so next instance will leak, makes subsequent test fail. PR moves teardown to `afterEach` hook instead. This relies on the assumption we run test in band (serial), but internals of nextdevinstance already assumes it via its own singleton.