### PR TITLE
Revert "Support `server-only` inside pages/api"

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -786,11 +786,6 @@ export default async function getBaseWebpackConfig(
         [getSwcLoader({ isServerLayer: true }), getBabelLoader()]
     : []
 
-  const loaderForAPI =
-    hasServerComponents && useSWCLoader
-      ? getSwcLoader({ isServerLayer: true })
-      : defaultLoaders.babel
-
   const pageExtensions = config.pageExtensions
 
   const outputPath =
@@ -1414,16 +1409,6 @@ export default async function getBaseWebpackConfig(
     },
   }
 
-  const serverCondition = [
-    'react-server',
-    ...mainFieldsPerCompiler[
-      isEdgeServer ? COMPILER_NAMES.edgeServer : COMPILER_NAMES.server
-    ],
-    'node',
-    'import',
-    'require',
-  ]
-
   let webpackConfig: webpack.Configuration = {
     parallelism: Number(process.env.NEXT_WEBPACK_PARALLELISM) || undefined,
     ...(isNodeServer ? { externalsPresets: { node: true } } : {}),
@@ -1736,7 +1721,17 @@ export default async function getBaseWebpackConfig(
                   ],
                 },
                 resolve: {
-                  conditionNames: serverCondition,
+                  conditionNames: [
+                    'react-server',
+                    ...mainFieldsPerCompiler[
+                      isEdgeServer
+                        ? COMPILER_NAMES.edgeServer
+                        : COMPILER_NAMES.server
+                    ],
+                    'node',
+                    'import',
+                    'require',
+                  ],
                   alias: {
                     // If missing the alias override here, the default alias will be used which aliases
                     // react to the direct file path, not the package name. In that case the condition
@@ -1863,6 +1858,14 @@ export default async function getBaseWebpackConfig(
             ]
           : []),
         {
+          test: /\.(js|cjs|mjs)$/,
+          issuerLayer: WEBPACK_LAYERS.api,
+          parser: {
+            // Switch back to normal URL handling
+            url: true,
+          },
+        },
+        {
           oneOf: [
             {
               ...codeCondition,
@@ -1871,12 +1874,7 @@ export default async function getBaseWebpackConfig(
                 // Switch back to normal URL handling
                 url: true,
               },
-              resolve: {
-                alias: {
-                  'server-only': 'next/dist/compiled/server-only/empty',
-                },
-              },
-              use: loaderForAPI,
+              use: defaultLoaders.babel,
             },
             {
               ...codeCondition,

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -13,7 +13,6 @@ createNextDescribe(
       react: 'latest',
       'react-dom': 'latest',
       sass: 'latest',
-      'server-only': 'latest',
     },
   },
   ({ next, isNextDev: isDev, isNextStart, isNextDeploy }) => {
@@ -67,11 +66,6 @@ createNextDescribe(
         ).toBe(1)
       })
     }
-
-    it('should support server-only in pages/api', async () => {
-      const res = await next.fetch('/api/server-only')
-      expect(await res.text()).toBe('Hello from server-only.js')
-    })
 
     if (!isNextDeploy) {
       it('should not share edge workers', async () => {

--- a/test/e2e/app-dir/app/pages/api/server-only.js
+++ b/test/e2e/app-dir/app/pages/api/server-only.js
@@ -1,5 +1,0 @@
-import 'server-only'
-
-export default function (_, res) {
-  res.end('Hello from server-only.js')
-}


### PR DESCRIPTION
Looks like this is breaking when run against `vercel-site`, going to revert temporarily to allow investigating further without blocking canary. 

Reverts vercel/next.js#46328
fix NEXT-625 ([link](https://linear.app/vercel/issue/NEXT-625))