### PR TITLE
Update server reference syntax and tests

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -166,6 +166,17 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             .push(annotate(&f.ident, "$$name", action_name.into()));
 
         if self.top_level {
+            // myAction.$$bound = [];
+            self.annotations.push(annotate(
+                &f.ident,
+                "$$bound",
+                ArrayLit {
+                    span: DUMMY_SP,
+                    elems: Vec::new(),
+                }
+                .into(),
+            ));
+
             if !(self.in_action_file && self.in_export_decl) {
                 // export const $ACTION_myAction = myAction;
                 self.extra_items
@@ -197,10 +208,10 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                 used_ids: &ids_from_closure,
             });
 
-            // myAction.$$closure = [id1, id2]
+            // myAction.$$bound = [id1, id2]
             self.annotations.push(annotate(
                 &f.ident,
-                "$$closure",
+                "$$bound",
                 ArrayLit {
                     span: DUMMY_SP,
                     elems: ids_from_closure
@@ -218,7 +229,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                 args: vec![f
                     .ident
                     .clone()
-                    .make_member(quote_ident!("$$closure"))
+                    .make_member(quote_ident!("$$bound"))
                     .as_arg()],
                 type_args: Default::default(),
             };

--- a/packages/next-swc/crates/core/tests/errors/server-actions/1/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/1/output.js
@@ -2,3 +2,4 @@
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$filepath = "/app/item.js";
 foo.$$name = "foo";
+foo.$$bound = [];

--- a/packages/next-swc/crates/core/tests/errors/server-actions/2/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/2/output.js
@@ -3,3 +3,4 @@ export function bar() {}
 bar.$$typeof = Symbol.for("react.server.reference");
 bar.$$filepath = "/app/item.js";
 bar.$$name = "bar";
+bar.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/1/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/1/output.js
@@ -1,12 +1,12 @@
 /* __next_internal_action_entry_do_not_use__ $ACTION_deleteItem */ import deleteFromDb from 'db'
 export function Item({ id1 , id2  }) {
     async function deleteItem() {
-        return $ACTION_deleteItem(deleteItem.$$closure);
+        return $ACTION_deleteItem(deleteItem.$$bound);
     }
     deleteItem.$$typeof = Symbol.for("react.server.reference");
     deleteItem.$$filepath = "/app/item.js";
     deleteItem.$$name = "$ACTION_deleteItem";
-    deleteItem.$$closure = [
+    deleteItem.$$bound = [
         id1,
         id2
     ];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/2/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/2/output.js
@@ -4,6 +4,7 @@
 myAction.$$typeof = Symbol.for("react.server.reference");
 myAction.$$filepath = "/app/item.js";
 myAction.$$name = "$ACTION_myAction";
+myAction.$$bound = [];
 export const $ACTION_myAction = myAction;
 export default function Page() {
     return <Button action={myAction}>Delete</Button>;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/3/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/3/output.js
@@ -5,3 +5,4 @@
 myAction.$$typeof = Symbol.for("react.server.reference");
 myAction.$$filepath = "/app/item.js";
 myAction.$$name = "myAction";
+myAction.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/4/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/4/output.js
@@ -2,22 +2,25 @@
 a.$$typeof = Symbol.for("react.server.reference");
 a.$$filepath = "/app/item.js";
 a.$$name = "a";
+a.$$bound = [];
 export async function b() {}
 b.$$typeof = Symbol.for("react.server.reference");
 b.$$filepath = "/app/item.js";
 b.$$name = "b";
+b.$$bound = [];
 export async function c() {}
 c.$$typeof = Symbol.for("react.server.reference");
 c.$$filepath = "/app/item.js";
 c.$$name = "c";
+c.$$bound = [];
 function d() {}
 function Foo() {
     async function e() {
-        return $ACTION_e(e.$$closure);
+        return $ACTION_e(e.$$bound);
     }
     e.$$typeof = Symbol.for("react.server.reference");
     e.$$filepath = "/app/item.js";
     e.$$name = "$ACTION_e";
-    e.$$closure = [];
+    e.$$bound = [];
 }
 export async function $ACTION_e(closure) {}

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/5/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/5/output.js
@@ -3,12 +3,12 @@ const v1 = 'v1';
 export function Item({ id1 , id2  }) {
     const v2 = id2;
     async function deleteItem() {
-        return $ACTION_deleteItem(deleteItem.$$closure);
+        return $ACTION_deleteItem(deleteItem.$$bound);
     }
     deleteItem.$$typeof = Symbol.for("react.server.reference");
     deleteItem.$$filepath = "/app/item.js";
     deleteItem.$$name = "$ACTION_deleteItem";
-    deleteItem.$$closure = [
+    deleteItem.$$bound = [
         id1,
         v2
     ];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/6/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/6/output.js
@@ -18,12 +18,12 @@ export function y(p, [p1, { p2  }], ...p3) {
         const f8 = 1;
     }
     async function action() {
-        return $ACTION_action(action.$$closure);
+        return $ACTION_action(action.$$bound);
     }
     action.$$typeof = Symbol.for("react.server.reference");
     action.$$filepath = "/app/item.js";
     action.$$name = "$ACTION_action";
-    action.$$closure = [
+    action.$$bound = [
         f2,
         f2,
         f11,

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/7/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/7/output.js
@@ -1,12 +1,12 @@
 /* __next_internal_action_entry_do_not_use__ $ACTION_deleteItem */ import deleteFromDb from 'db';
 export function Item(product, foo, bar) {
     async function deleteItem() {
-        return $ACTION_deleteItem(deleteItem.$$closure);
+        return $ACTION_deleteItem(deleteItem.$$bound);
     }
     deleteItem.$$typeof = Symbol.for("react.server.reference");
     deleteItem.$$filepath = "/app/item.js";
     deleteItem.$$name = "$ACTION_deleteItem";
-    deleteItem.$$closure = [
+    deleteItem.$$bound = [
         product.id,
         product?.foo,
         product.bar.baz,

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/8/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/8/output.js
@@ -6,6 +6,7 @@
 myAction.$$typeof = Symbol.for("react.server.reference");
 myAction.$$filepath = "/app/item.js";
 myAction.$$name = "$ACTION_myAction";
+myAction.$$bound = [];
 export const $ACTION_myAction = myAction;
 export default function Page() {
     return <Button action={myAction}>Delete</Button>;


### PR DESCRIPTION
`$$closure` was renamed to `$$bound` and it's always required.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
