### PR TITLE
Fix fetch cache key inputs and encoding (#46392

### DIFF
--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -82,6 +82,7 @@ createNextDescribe(
           'ssr-forced/page.js',
           'static-to-dynamic-error-forced/[id]/page.js',
           'static-to-dynamic-error/[id]/page.js',
+          'variable-revalidate-edge/encoding/page.js',
           'variable-revalidate-edge/no-store/page.js',
           'variable-revalidate-edge/revalidate-3/page.js',
           'variable-revalidate/authorization-cached.html',
@@ -92,7 +93,14 @@ createNextDescribe(
           'variable-revalidate/cookie-cached.rsc',
           'variable-revalidate/cookie-cached/page.js',
           'variable-revalidate/cookie/page.js',
+          'variable-revalidate/encoding.html',
+          'variable-revalidate/encoding.rsc',
+          'variable-revalidate/encoding/page.js',
           'variable-revalidate/no-store/page.js',
+          'variable-revalidate/post-method-cached.html',
+          'variable-revalidate/post-method-cached.rsc',
+          'variable-revalidate/post-method-cached/page.js',
+          'variable-revalidate/post-method/page.js',
           'variable-revalidate/revalidate-3.html',
           'variable-revalidate/revalidate-3.rsc',
           'variable-revalidate/revalidate-3/page.js',
@@ -206,6 +214,16 @@ createNextDescribe(
             dataRoute: '/variable-revalidate/cookie-cached.rsc',
             initialRevalidateSeconds: 3,
             srcRoute: '/variable-revalidate/cookie-cached',
+          },
+          '/variable-revalidate/encoding': {
+            dataRoute: '/variable-revalidate/encoding.rsc',
+            initialRevalidateSeconds: 3,
+            srcRoute: '/variable-revalidate/encoding',
+          },
+          '/variable-revalidate/post-method-cached': {
+            dataRoute: '/variable-revalidate/post-method-cached.rsc',
+            initialRevalidateSeconds: 3,
+            srcRoute: '/variable-revalidate/post-method-cached',
           },
           '/variable-revalidate/revalidate-3': {
             dataRoute: '/variable-revalidate/revalidate-3.rsc',
@@ -460,6 +478,57 @@ createNextDescribe(
       }, 'success')
     })
 
+    it('should not cache correctly with POST method', async () => {
+      const res = await fetchViaHTTP(
+        next.url,
+        '/variable-revalidate/post-method'
+      )
+      expect(res.status).toBe(200)
+      const html = await res.text()
+      const $ = cheerio.load(html)
+
+      const pageData = $('#page-data').text()
+
+      for (let i = 0; i < 3; i++) {
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/post-method'
+        )
+        expect(res2.status).toBe(200)
+        const html2 = await res2.text()
+        const $2 = cheerio.load(html2)
+
+        expect($2('#page-data').text()).not.toBe(pageData)
+      }
+    })
+
+    it('should cache correctly with POST method and revalidate', async () => {
+      await check(async () => {
+        const res = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/post-method-cached'
+        )
+        expect(res.status).toBe(200)
+        const html = await res.text()
+        const $ = cheerio.load(html)
+
+        const layoutData = $('#layout-data').text()
+        const pageData = $('#page-data').text()
+
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/post-method-cached'
+        )
+        expect(res2.status).toBe(200)
+        const html2 = await res2.text()
+        const $2 = cheerio.load(html2)
+
+        expect($2('#layout-data').text()).toBe(layoutData)
+        expect($2('#page-data').text()).toBe(pageData)
+        return 'success'
+      }, 'success')
+    })
+
     it('should not cache correctly with cookie header', async () => {
       const res = await fetchViaHTTP(next.url, '/variable-revalidate/cookie')
       expect(res.status).toBe(200)
@@ -494,6 +563,68 @@ createNextDescribe(
         const res2 = await fetchViaHTTP(
           next.url,
           '/variable-revalidate/cookie-cached'
+        )
+        expect(res2.status).toBe(200)
+        const html2 = await res2.text()
+        const $2 = cheerio.load(html2)
+
+        expect($2('#layout-data').text()).toBe(layoutData)
+        expect($2('#page-data').text()).toBe(pageData)
+        return 'success'
+      }, 'success')
+    })
+
+    it('should cache correctly with utf8 encoding', async () => {
+      await check(async () => {
+        const res = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/encoding'
+        )
+        expect(res.status).toBe(200)
+        const html = await res.text()
+        const $ = cheerio.load(html)
+
+        const layoutData = $('#layout-data').text()
+        const pageData = $('#page-data').text()
+
+        expect(JSON.parse(pageData).jp).toBe(
+          '超鬼畜！激辛ボム兵スピンジャンプ　Bomb Spin Jump'
+        )
+
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/encoding'
+        )
+        expect(res2.status).toBe(200)
+        const html2 = await res2.text()
+        const $2 = cheerio.load(html2)
+
+        expect($2('#layout-data').text()).toBe(layoutData)
+        expect($2('#page-data').text()).toBe(pageData)
+        return 'success'
+      }, 'success')
+    })
+
+    it('should cache correctly with utf8 encoding edge', async () => {
+      await check(async () => {
+        const res = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate-edge/encoding'
+        )
+        expect(res.status).toBe(200)
+        const html = await res.text()
+        const $ = cheerio.load(html)
+
+        const layoutData = $('#layout-data').text()
+        const pageData = $('#page-data').text()
+
+        expect(JSON.parse(pageData).jp).toBe(
+          '超鬼畜！激辛ボム兵スピンジャンプ　Bomb Spin Jump'
+        )
+
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/encoding'
         )
         expect(res2.status).toBe(200)
         const html2 = await res2.text()

--- a/test/e2e/app-dir/app-static/app/variable-revalidate-edge/encoding/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate-edge/encoding/page.js
@@ -1,0 +1,19 @@
+export const runtime = 'experimental-edge'
+
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/utf8-encoding',
+    {
+      next: {
+        revalidate: 3,
+      },
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="page">/variable-revalidate-edge/encoding</p>
+      <p id="page-data">{data}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/encoding/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/encoding/page.js
@@ -1,0 +1,17 @@
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/utf8-encoding',
+    {
+      next: {
+        revalidate: 3,
+      },
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="page">/variable-revalidate/encoding</p>
+      <p id="page-data">{data}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/post-method-cached/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/post-method-cached/page.js
@@ -1,0 +1,18 @@
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      method: 'POST',
+      next: {
+        revalidate: 3,
+      },
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="page">/variable-revalidate/post-method-cached</p>
+      <p id="page-data">{data}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/post-method/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/post-method/page.js
@@ -1,0 +1,15 @@
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      method: 'POST',
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="page">/variable-revalidate/post-method</p>
+      <p id="page-data">{data}</p>
+    </>
+  )
+}


### PR DESCRIPTION
This ensures we properly filter caching on uncachable request methods by default and correct encoding handling in edge runtime. 

Fixes: https://github.com/vercel/next.js/issues/46349
x-ref: [slack thread](https://vercel.slack.com/archives/C042LHPJ1NX/p1677253242022489)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

