### PR TITLE
Ensure fetch fields are detected with RequestInit

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -8,6 +8,7 @@ import {
   IncrementalCacheValue,
   IncrementalCacheEntry,
 } from '../../response-cache'
+import { encode } from '../../../shared/lib/bloom-filter/base64-arraybuffer'
 
 function toRoute(pathname: string): string {
   return pathname.replace(/\/$/, '').replace(/\/index$/, '') || '/'
@@ -146,6 +147,71 @@ export class IncrementalCache {
 
   // x-ref: https://github.com/facebook/react/blob/2655c9354d8e1c54ba888444220f63e836925caa/packages/react/src/ReactFetch.js#L23
   async fetchCacheKey(url: string, init: RequestInit = {}): Promise<string> {
+    let cacheKey: string
+    const bodyChunks: string[] = []
+
+    try {
+      if (init.body) {
+        // handle ReadableStream body
+        if (typeof (init.body as any).getReader === 'function') {
+          const readableBody = init.body as ReadableStream
+          const [origBody, newBody] = readableBody.tee()
+          init.body = origBody
+
+          const reader = newBody.getReader()
+
+          function processValue({
+            done,
+            value,
+          }: {
+            done?: boolean
+            value?: ArrayBuffer | string
+          }): any {
+            if (done) {
+              return
+            }
+            if (value) {
+              try {
+                bodyChunks.push(
+                  typeof value === 'string' ? value : encode(value)
+                )
+              } catch (err) {
+                console.error(err)
+              }
+            }
+            return reader.read().then(processValue)
+          }
+          await reader.read().then(processValue)
+          // handle FormData or URLSearchParams bodies
+        } else if (typeof (init.body as any).keys === 'function') {
+          const formData = init.body as FormData
+          for (const key of new Set([...formData.keys()])) {
+            const values = formData.getAll(key)
+            bodyChunks.push(
+              `${key}=${(
+                await Promise.all(
+                  values.map(async (val) => {
+                    if (typeof val === 'string') {
+                      return val
+                    } else {
+                      return await val.text()
+                    }
+                  })
+                )
+              ).join(',')}`
+            )
+          }
+          // handle blob body
+        } else if (typeof (init.body as any).arrayBuffer === 'function') {
+          bodyChunks.push(encode(await (init.body as Blob).arrayBuffer()))
+        } else if (typeof init.body === 'string') {
+          bodyChunks.push(init.body)
+        }
+      }
+    } catch (err) {
+      console.error(err)
+    }
+
     const cacheString = JSON.stringify([
       this.fetchCacheKey || '',
       url,
@@ -159,8 +225,8 @@ export class IncrementalCache {
       init.integrity,
       init.next,
       init.cache,
+      bodyChunks,
     ])
-    let cacheKey: string
 
     if (process.env.NEXT_RUNTIME === 'edge') {
       function bufferToHex(buffer: ArrayBuffer): string {

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -203,7 +203,10 @@ export class IncrementalCache {
           }
           // handle blob body
         } else if (typeof (init.body as any).arrayBuffer === 'function') {
+          const blob = init.body as Blob
+          const arrayBuffer = await blob.arrayBuffer()
           bodyChunks.push(encode(await (init.body as Blob).arrayBuffer()))
+          init.body = new Blob([arrayBuffer], { type: blob.type })
         } else if (typeof init.body === 'string') {
           bodyChunks.push(init.body)
         }

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -98,6 +98,16 @@ export function patchFetch({
       }
 
       let cacheKey: string | undefined
+      if (
+        staticGenerationStore.incrementalCache &&
+        typeof revalidate === 'number' &&
+        revalidate > 0
+      ) {
+        cacheKey = await staticGenerationStore.incrementalCache.fetchCacheKey(
+          isRequestInput ? (input as Request).url : input.toString(),
+          isRequestInput ? (input as RequestInit) : init
+        )
+      }
 
       const doOriginalFetch = async () => {
         return originFetch(input, init).then(async (res) => {
@@ -144,15 +154,7 @@ export function patchFetch({
         })
       }
 
-      if (
-        staticGenerationStore.incrementalCache &&
-        typeof revalidate === 'number' &&
-        revalidate > 0
-      ) {
-        cacheKey = await staticGenerationStore.incrementalCache.fetchCacheKey(
-          isRequestInput ? (input as Request).url : input.toString(),
-          isRequestInput ? (input as RequestInit) : init
-        )
+      if (cacheKey && staticGenerationStore?.incrementalCache) {
         const entry = await staticGenerationStore.incrementalCache.get(
           cacheKey,
           true

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -149,10 +149,8 @@ export function patchFetch({
         revalidate > 0
       ) {
         cacheKey = await staticGenerationStore.incrementalCache.fetchCacheKey(
-          input && typeof input === 'object'
-            ? (input as Request).url
-            : input.toString(),
-          init
+          isRequestInput ? (input as Request).url : input.toString(),
+          isRequestInput ? (input as RequestInit) : init
         )
         const entry = await staticGenerationStore.incrementalCache.get(
           cacheKey,

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -100,6 +100,7 @@ createNextDescribe(
           'variable-revalidate/post-method-cached.html',
           'variable-revalidate/post-method-cached.rsc',
           'variable-revalidate/post-method-cached/page.js',
+          'variable-revalidate/post-method-request/page.js',
           'variable-revalidate/post-method/page.js',
           'variable-revalidate/revalidate-3.html',
           'variable-revalidate/revalidate-3.rsc',

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -84,6 +84,7 @@ createNextDescribe(
           'static-to-dynamic-error/[id]/page.js',
           'variable-revalidate-edge/encoding/page.js',
           'variable-revalidate-edge/no-store/page.js',
+          'variable-revalidate-edge/post-method-cached/page.js',
           'variable-revalidate-edge/revalidate-3/page.js',
           'variable-revalidate/authorization-cached.html',
           'variable-revalidate/authorization-cached.rsc',
@@ -223,7 +224,7 @@ createNextDescribe(
           },
           '/variable-revalidate/post-method-cached': {
             dataRoute: '/variable-revalidate/post-method-cached.rsc',
-            initialRevalidateSeconds: 3,
+            initialRevalidateSeconds: 10,
             srcRoute: '/variable-revalidate/post-method-cached',
           },
           '/variable-revalidate/revalidate-3': {
@@ -525,6 +526,76 @@ createNextDescribe(
 
         expect($2('#page-data').text()).not.toBe(pageData)
       }
+    })
+
+    it('should cache correctly with post method and revalidate', async () => {
+      await check(async () => {
+        const res = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/post-method-cached'
+        )
+        expect(res.status).toBe(200)
+        const html = await res.text()
+        const $ = cheerio.load(html)
+
+        const layoutData = $('#layout-data').text()
+        const pageData = $('#page-data').text()
+        const dataBody1 = $('#data-body1').text()
+        const dataBody2 = $('#data-body2').text()
+        const dataBody3 = $('#data-body3').text()
+        const dataBody4 = $('#data-body4').text()
+
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/post-method-cached'
+        )
+        expect(res2.status).toBe(200)
+        const html2 = await res2.text()
+        const $2 = cheerio.load(html2)
+
+        expect($2('#layout-data').text()).toBe(layoutData)
+        expect($2('#page-data').text()).toBe(pageData)
+        expect($2('#data-body1').text()).toBe(dataBody1)
+        expect($2('#data-body2').text()).toBe(dataBody2)
+        expect($2('#data-body3').text()).toBe(dataBody3)
+        expect($2('#data-body4').text()).toBe(dataBody4)
+        return 'success'
+      }, 'success')
+    })
+
+    it('should cache correctly with post method and revalidate edge', async () => {
+      await check(async () => {
+        const res = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate-edge/post-method-cached'
+        )
+        expect(res.status).toBe(200)
+        const html = await res.text()
+        const $ = cheerio.load(html)
+
+        const layoutData = $('#layout-data').text()
+        const pageData = $('#page-data').text()
+        const dataBody1 = $('#data-body1').text()
+        const dataBody2 = $('#data-body2').text()
+        const dataBody3 = $('#data-body3').text()
+        const dataBody4 = $('#data-body4').text()
+
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate-edge/post-method-cached'
+        )
+        expect(res2.status).toBe(200)
+        const html2 = await res2.text()
+        const $2 = cheerio.load(html2)
+
+        expect($2('#layout-data').text()).toBe(layoutData)
+        expect($2('#page-data').text()).toBe(pageData)
+        expect($2('#data-body1').text()).toBe(dataBody1)
+        expect($2('#data-body2').text()).toBe(dataBody2)
+        expect($2('#data-body3').text()).toBe(dataBody3)
+        expect($2('#data-body4').text()).toBe(dataBody4)
+        return 'success'
+      }, 'success')
     })
 
     it('should cache correctly with POST method and revalidate', async () => {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -85,6 +85,7 @@ createNextDescribe(
           'variable-revalidate-edge/encoding/page.js',
           'variable-revalidate-edge/no-store/page.js',
           'variable-revalidate-edge/post-method-cached/page.js',
+          'variable-revalidate-edge/post-method-request/page.js',
           'variable-revalidate-edge/revalidate-3/page.js',
           'variable-revalidate/authorization-cached.html',
           'variable-revalidate/authorization-cached.rsc',
@@ -101,7 +102,6 @@ createNextDescribe(
           'variable-revalidate/post-method-cached.html',
           'variable-revalidate/post-method-cached.rsc',
           'variable-revalidate/post-method-cached/page.js',
-          'variable-revalidate/post-method-request/page.js',
           'variable-revalidate/post-method/page.js',
           'variable-revalidate/revalidate-3.html',
           'variable-revalidate/revalidate-3.rsc',
@@ -507,7 +507,7 @@ createNextDescribe(
     it('should not cache correctly with POST method request init', async () => {
       const res = await fetchViaHTTP(
         next.url,
-        '/variable-revalidate/post-method-request'
+        '/variable-revalidate-edge/post-method-request'
       )
       expect(res.status).toBe(200)
       const html = await res.text()
@@ -518,7 +518,7 @@ createNextDescribe(
       for (let i = 0; i < 3; i++) {
         const res2 = await fetchViaHTTP(
           next.url,
-          '/variable-revalidate/post-method-request'
+          '/variable-revalidate-edge/post-method-request'
         )
         expect(res2.status).toBe(200)
         const html2 = await res2.text()
@@ -544,6 +544,10 @@ createNextDescribe(
         const dataBody2 = $('#data-body2').text()
         const dataBody3 = $('#data-body3').text()
         const dataBody4 = $('#data-body4').text()
+
+        expect(dataBody1).not.toBe(dataBody2)
+        expect(dataBody2).not.toBe(dataBody3)
+        expect(dataBody3).not.toBe(dataBody4)
 
         const res2 = await fetchViaHTTP(
           next.url,

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -502,6 +502,30 @@ createNextDescribe(
       }
     })
 
+    it('should not cache correctly with POST method request init', async () => {
+      const res = await fetchViaHTTP(
+        next.url,
+        '/variable-revalidate/post-method-request'
+      )
+      expect(res.status).toBe(200)
+      const html = await res.text()
+      const $ = cheerio.load(html)
+
+      const pageData = $('#page-data').text()
+
+      for (let i = 0; i < 3; i++) {
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/variable-revalidate/post-method-request'
+        )
+        expect(res2.status).toBe(200)
+        const html2 = await res2.text()
+        const $2 = cheerio.load(html2)
+
+        expect($2('#page-data').text()).not.toBe(pageData)
+      }
+    })
+
     it('should cache correctly with POST method and revalidate', async () => {
       await check(async () => {
         const res = await fetchViaHTTP(

--- a/test/e2e/app-dir/app-static/app/variable-revalidate-edge/post-method-cached/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate-edge/post-method-cached/page.js
@@ -1,4 +1,4 @@
-import { FormData, Blob } from 'next/dist/compiled/@edge-runtime/primitives'
+export const runtime = 'experimental-edge'
 
 export default async function Page() {
   const data = await fetch(

--- a/test/e2e/app-dir/app-static/app/variable-revalidate-edge/post-method-cached/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate-edge/post-method-cached/page.js
@@ -1,7 +1,20 @@
 export const runtime = 'experimental-edge'
 
+const fetchRetry = async (url, init) => {
+  for (let i = 0; i < 5; i++) {
+    try {
+      return await fetch(url, init)
+    } catch (err) {
+      if (i === 4) {
+        throw err
+      }
+      console.log(`Failed to fetch`, err, `retrying...`)
+    }
+  }
+}
+
 export default async function Page() {
-  const data = await fetch(
+  const data = await fetchRetry(
     'https://next-data-api-endpoint.vercel.app/api/random',
     {
       method: 'POST',
@@ -11,7 +24,7 @@ export default async function Page() {
     }
   ).then((res) => res.text())
 
-  const dataWithBody1 = await fetch(
+  const dataWithBody1 = await fetchRetry(
     'https://next-data-api-endpoint.vercel.app/api/random',
     {
       method: 'POST',
@@ -22,7 +35,7 @@ export default async function Page() {
     }
   ).then((res) => res.text())
 
-  const dataWithBody2 = await fetch(
+  const dataWithBody2 = await fetchRetry(
     'https://next-data-api-endpoint.vercel.app/api/random',
     {
       method: 'POST',
@@ -44,7 +57,7 @@ export default async function Page() {
   formData.append('another', new Blob(['some text'], { type: 'text/plain' }))
   formData.append('another', 'text')
 
-  const dataWithBody3 = await fetch(
+  const dataWithBody3 = await fetchRetry(
     'https://next-data-api-endpoint.vercel.app/api/random',
     {
       method: 'POST',
@@ -55,7 +68,7 @@ export default async function Page() {
     }
   ).then((res) => res.text())
 
-  const dataWithBody4 = await fetch(
+  const dataWithBody4 = await fetchRetry(
     'https://next-data-api-endpoint.vercel.app/api/random',
     {
       method: 'POST',

--- a/test/e2e/app-dir/app-static/app/variable-revalidate-edge/post-method-request/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate-edge/post-method-request/page.js
@@ -1,3 +1,5 @@
+export const runtime = 'experimental-edge'
+
 export default async function Page() {
   const data = await fetch(
     new Request('https://next-data-api-endpoint.vercel.app/api/random', {

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/post-method-cached/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/post-method-cached/page.js
@@ -1,7 +1,20 @@
 import { FormData, Blob } from 'next/dist/compiled/@edge-runtime/primitives'
 
+const fetchRetry = async (url, init) => {
+  for (let i = 0; i < 5; i++) {
+    try {
+      return await fetch(url, init)
+    } catch (err) {
+      if (i === 4) {
+        throw err
+      }
+      console.log(`Failed to fetch`, err, `retrying...`)
+    }
+  }
+}
+
 export default async function Page() {
-  const data = await fetch(
+  const data = await fetchRetry(
     'https://next-data-api-endpoint.vercel.app/api/random',
     {
       method: 'POST',
@@ -11,7 +24,7 @@ export default async function Page() {
     }
   ).then((res) => res.text())
 
-  const dataWithBody1 = await fetch(
+  const dataWithBody1 = await fetchRetry(
     'https://next-data-api-endpoint.vercel.app/api/random',
     {
       method: 'POST',
@@ -22,7 +35,7 @@ export default async function Page() {
     }
   ).then((res) => res.text())
 
-  const dataWithBody2 = await fetch(
+  const dataWithBody2 = await fetchRetry(
     'https://next-data-api-endpoint.vercel.app/api/random',
     {
       method: 'POST',
@@ -44,7 +57,7 @@ export default async function Page() {
   formData.append('another', new Blob(['some text'], { type: 'text/plain' }))
   formData.append('another', 'text')
 
-  const dataWithBody3 = await fetch(
+  const dataWithBody3 = await fetchRetry(
     'https://next-data-api-endpoint.vercel.app/api/random',
     {
       method: 'POST',
@@ -55,7 +68,7 @@ export default async function Page() {
     }
   ).then((res) => res.text())
 
-  const dataWithBody4 = await fetch(
+  const dataWithBody4 = await fetchRetry(
     'https://next-data-api-endpoint.vercel.app/api/random',
     {
       method: 'POST',

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/post-method-request/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/post-method-request/page.js
@@ -1,0 +1,14 @@
+export default async function Page() {
+  const data = await fetch(
+    new Request('https://next-data-api-endpoint.vercel.app/api/random', {
+      method: 'POST',
+    })
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="page">/variable-revalidate/post-method</p>
+      <p id="page-data">{data}</p>
+    </>
+  )
+}


### PR DESCRIPTION
This ensures we properly detect fetch fields when a `new Request()` is passed to fetch instead of a separate `init` param. 

Fixes: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1677264109548949)
Closes: https://github.com/vercel/next.js/issues/46349

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

