### PR TITLE
Fix SWC error wrongly formatted 

### DIFF
--- a/packages/next-swc/crates/core/src/react_server_components.rs
+++ b/packages/next-swc/crates/core/src/react_server_components.rs
@@ -484,11 +484,7 @@ impl<C: Comments> ReactServerComponents<C> {
                 if has_gm_export && has_metadata_export {
                     HANDLER.with(|handler| {
                         handler
-                            .struct_span_err(
-                                span,
-                                "NEXT_RSC_ERR_INVALID_API: export generateMetadata and metadata \
-                                 together",
-                            )
+                            .struct_span_err(span, "NEXT_RSC_ERR_CONFLICT_METADATA_EXPORT")
                             .emit()
                     })
                 }

--- a/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseRSC.ts
+++ b/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseRSC.ts
@@ -18,6 +18,8 @@ function formatRSCErrorMessage(
   const NEXT_RSC_ERR_CLIENT_IMPORT = /.+NEXT_RSC_ERR_CLIENT_IMPORT: (.*?)\n/s
   const NEXT_RSC_ERR_CLIENT_METADATA_EXPORT =
     /.+NEXT_RSC_ERR_CLIENT_METADATA_EXPORT: (.*?)\n/s
+  const NEXT_RSC_ERR_CONFLICT_METADATA_EXPORT =
+    /NEXT_RSC_ERR_CONFLICT_METADATA_EXPORT/s
   const NEXT_RSC_ERR_CLIENT_DIRECTIVE = /.+NEXT_RSC_ERR_CLIENT_DIRECTIVE\n/s
   const NEXT_RSC_ERR_CLIENT_DIRECTIVE_PAREN =
     /.+NEXT_RSC_ERR_CLIENT_DIRECTIVE_PAREN\n/s
@@ -99,6 +101,13 @@ function formatRSCErrorMessage(
     formattedMessage = message.replace(
       NEXT_RSC_ERR_CLIENT_METADATA_EXPORT,
       `\n\nYou are attempting to export "$1" from a component marked with "use client", which is disallowed. Either remove the export, or the "use client" directive. Read more: https://beta.nextjs.org/docs/api-reference/metadata\n\n`
+    )
+
+    formattedVerboseMessage = '\n\nFile path:\n'
+  } else if (NEXT_RSC_ERR_CONFLICT_METADATA_EXPORT.test(message)) {
+    formattedMessage = message.replace(
+      NEXT_RSC_ERR_CONFLICT_METADATA_EXPORT,
+      `\n\n"metadata" and "generateMetadata" cannot be exported at the same time, please keep one of them. Read more: https://beta.nextjs.org/docs/api-reference/metadata\n\n`
     )
 
     formattedVerboseMessage = '\n\nFile path:\n'

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -93,7 +93,7 @@ createNextDescribe(
       await session.patch(pageFile, uncomment)
       expect(await session.hasRedbox(true)).toBe(true)
       expect(await session.getRedboxSource()).toInclude(
-        'export generateMetadata and metadata together'
+        '"metadata" and "generateMetadata" cannot be exported at the same time, please keep one of them.'
       )
 
       await cleanup()


### PR DESCRIPTION
We currently use the `NEXT_RSC_ERR_INVALID_API` error code for metadata API conflicts which is wrong. The format should be `NEXT_RSC_ERR_INVALID_API: foo` and then the formatter transforms it into `foo isn't supported in app/`.

This PR adds a new `NEXT_RSC_ERR_CONFLICT_METADATA_EXPORT` error code and improves the message. Closes #46406.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
