### PR TITLE
Ensure SERVER_REFERENCE_MANIFEST is included in output files

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -68,6 +68,7 @@ import {
   MIDDLEWARE_REACT_LOADABLE_MANIFEST,
   TURBO_TRACE_DEFAULT_MEMORY_LIMIT,
   TRACE_OUTPUT_VERSION,
+  SERVER_REFERENCE_MANIFEST,
 } from '../shared/lib/constants'
 import { getSortedRoutes, isDynamicRoute } from '../shared/lib/router/utils'
 import { __ApiPreviewProps } from '../server/api-utils'
@@ -969,6 +970,14 @@ export default async function build(
                   path.join(
                     SERVER_DIRECTORY,
                     FLIGHT_SERVER_CSS_MANIFEST + '.json'
+                  ),
+                  path.join(
+                    SERVER_DIRECTORY,
+                    SERVER_REFERENCE_MANIFEST + '.js'
+                  ),
+                  path.join(
+                    SERVER_DIRECTORY,
+                    SERVER_REFERENCE_MANIFEST + '.json'
                   ),
                 ]
               : []),

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -130,6 +130,7 @@ export default async function edgeSSRLoader(this: any) {
     const reactLoadableManifest = self.__REACT_LOADABLE_MANIFEST
     const rscManifest = self.__RSC_MANIFEST
     const rscCssManifest = self.__RSC_CSS_MANIFEST
+    const rscServerManifest = self.__RSC_SERVER_MANIFEST
     const subresourceIntegrityManifest = ${
       sriEnabled ? 'self.__SUBRESOURCE_INTEGRITY_MANIFEST' : 'undefined'
     }
@@ -150,6 +151,7 @@ export default async function edgeSSRLoader(this: any) {
       reactLoadableManifest,
       serverComponentManifest: ${isServerComponent} ? rscManifest : null,
       serverCSSManifest: ${isServerComponent} ? rscCssManifest : null,
+      serverActionsManifest: ${isServerComponent} ? rscServerManifest : null,
       subresourceIntegrityManifest,
       config: ${stringifiedConfig},
       buildId: ${JSON.stringify(buildId)},

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -28,6 +28,7 @@ export function getRender({
   serverComponentManifest,
   subresourceIntegrityManifest,
   serverCSSManifest,
+  serverActionsManifest,
   config,
   buildId,
   fontLoaderManifest,
@@ -48,6 +49,7 @@ export function getRender({
   subresourceIntegrityManifest?: Record<string, string>
   serverComponentManifest: any
   serverCSSManifest: any
+  serverActionsManifest: any
   appServerMod: any
   config: NextConfigComplete
   buildId: string
@@ -79,6 +81,7 @@ export function getRender({
         disableOptimizedLoading: true,
         serverComponentManifest,
         serverCSSManifest,
+        serverActionsManifest,
       },
       appRenderToHTML,
       pagesRenderToHTML,

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -767,6 +767,9 @@ export class FlightClientEntryPlugin {
     }
 
     const json = JSON.stringify(serverActions, null, this.dev ? 2 : undefined)
+    assets[SERVER_REFERENCE_MANIFEST + '.js'] = new sources.RawSource(
+      'self.__RSC_SERVER_MANIFEST=' + json
+    ) as unknown as webpack.sources.RawSource
     assets[SERVER_REFERENCE_MANIFEST + '.json'] = new sources.RawSource(
       json
     ) as unknown as webpack.sources.RawSource

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -20,6 +20,7 @@ import {
   FLIGHT_SERVER_CSS_MANIFEST,
   SUBRESOURCE_INTEGRITY_MANIFEST,
   FONT_LOADER_MANIFEST,
+  SERVER_REFERENCE_MANIFEST,
 } from '../../../shared/lib/constants'
 import {
   getPageStaticInfo,
@@ -99,6 +100,7 @@ function getEntryFiles(
   const files: string[] = []
   if (meta.edgeSSR) {
     if (meta.edgeSSR.isServerComponent) {
+      files.push(`server/${SERVER_REFERENCE_MANIFEST}.js`)
       files.push(`server/${CLIENT_REFERENCE_MANIFEST}.js`)
       files.push(`server/${FLIGHT_SERVER_CSS_MANIFEST}.js`)
       if (opts.sriEnabled) {

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -30,6 +30,7 @@ import {
   PHASE_EXPORT,
   PRERENDER_MANIFEST,
   SERVER_DIRECTORY,
+  SERVER_REFERENCE_MANIFEST,
 } from '../shared/lib/constants'
 import loadConfig from '../server/config'
 import { ExportPathMap, NextConfigComplete } from '../server/config-shared'
@@ -443,13 +444,19 @@ export default async function exportApp(
       renderOpts.serverComponentManifest = require(join(
         distDir,
         SERVER_DIRECTORY,
-        `${CLIENT_REFERENCE_MANIFEST}.json`
+        CLIENT_REFERENCE_MANIFEST + '.json'
       )) as PagesManifest
       // @ts-expect-error untyped
       renderOpts.serverCSSManifest = require(join(
         distDir,
         SERVER_DIRECTORY,
         FLIGHT_SERVER_CSS_MANIFEST + '.json'
+      )) as PagesManifest
+      // @ts-expect-error untyped
+      renderOpts.serverActionsManifest = require(join(
+        distDir,
+        SERVER_DIRECTORY,
+        SERVER_REFERENCE_MANIFEST + '.json'
       )) as PagesManifest
     }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -228,6 +228,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     isBot?: boolean
     serverComponentManifest?: any
     serverCSSManifest?: any
+    serverActionsManifest?: any
     fontLoaderManifest?: FontLoaderManifest
     renderServerComponentData?: boolean
     serverComponentProps?: any


### PR DESCRIPTION
Fixes #46419.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
