### PR TITLE
fix page cache collision on multiserver configuration

### DIFF
--- a/packages/next/src/server/require.ts
+++ b/packages/next/src/server/require.ts
@@ -32,7 +32,7 @@ export function getMaybePagePath(
   locales?: string[],
   appDirEnabled?: boolean
 ): string | null {
-  const cacheKey = `${page}:${locales}`
+  const cacheKey = `${page}:${distDir}:${locales}`
 
   if (pagePathCache.has(cacheKey)) {
     return pagePathCache.get(cacheKey) as string | null


### PR DESCRIPTION
Hi all,
this fix solves part of the issue in ticket #45852, addressing a problem with caching of pages from different zones that map to the same address.

The docs says that should be avoided but in the specific case of the root index this seems to not be avoidable.

The change constitutes an extension of the cacheKey to incorporate also the value of the distribution directory, which allows to differentiate between indexes from different zones.

Please advise if there is any additional explanation or step that i should comply with.

Regards,

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
