### PR TITLE
fix(mdx): export NextMDXOptions interface

### DIFF
--- a/packages/next-mdx/index.d.ts
+++ b/packages/next-mdx/index.d.ts
@@ -5,7 +5,7 @@ import { RuleSetConditionAbsolute } from 'webpack'
 
 type WithMDX = (config: NextConfig) => NextConfig
 
-interface NextMDXOptions {
+export interface NextMDXOptions {
   /**
    * A webpack rule test to match files to treat as MDX.
    *


### PR DESCRIPTION
## Description

This allow to type mdx option externaly

```js
/** @type {import('@next/mdx').NextMDXOptions} */
export const options = {}
```

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
