### PR TITLE
fix(typedRoutes): overriding next types

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -140,7 +140,9 @@ function createRouteDefinitions() {
     routeTypes += ` | ${route}\n`
   })
 
-  return `declare module 'next' {
+  return `import 'next'
+  
+  declare module 'next' {
   export * from 'next/types/index.d.ts';
   type SearchOrHash = \`?\${string}\` | \`#\${string}\`
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

Without importing the original `next` typings, `declare module "next"` will overwrite all of the typings

Before this change
![image](https://user-images.githubusercontent.com/42935195/221442659-6af1e485-9e70-482c-b7bc-c99c24c3c294.png)

After this change
![image](https://user-images.githubusercontent.com/42935195/221442673-8ce85770-3bcb-4d6f-8c0d-df096d8d5447.png)



## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
