### PR TITLE
Fix(typedRoutes): export createServer from 'next/types/index.d.ts'

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -134,38 +134,36 @@ function createRouteDefinitions() {
   let routeTypes = ''
 
   edgeRouteTypes.forEach((route) => {
-    routeTypes += ` | ${route}\n`
+    routeTypes += `  | ${route}\n  `
   })
   nodeRouteTypes.forEach((route) => {
-    routeTypes += ` | ${route}\n`
+    routeTypes += `  | ${route}\n  `
   })
 
   return `declare module 'next' {
-  export * from 'next/types/index.d.ts';
+  export { default } from 'next/types/index.d.ts'
+  export * from 'next/types/index.d.ts'
+  
   type SearchOrHash = \`?\${string}\` | \`#\${string}\`
 
-  type Suffix = "" | SearchOrHash
+  type Suffix = '' | SearchOrHash
 
-  type SafeSlug<S extends string> = 
-    S extends \`\${string}/\${string}\`
-      ? never
-      : S extends \`\${string}\${SearchOrHash}\`
-      ? never
-      : S extends ''
-      ? never
-      : S
+  type SafeSlug<S extends string> = S extends \`\${string}/\${string}\`
+    ? never
+    : S extends \`\${string}\${SearchOrHash}\`
+    ? never
+    : S extends ''
+    ? never
+    : S
 
-  type CatchAllSlug<S extends string> = 
-    S extends \`\${string}\${SearchOrHash}\`
-      ? never
-      : S extends ''
-      ? never
-      : S
+  type CatchAllSlug<S extends string> = S extends \`\${string}\${SearchOrHash}\`
+    ? never
+    : S extends ''
+    ? never
+    : S
 
-  type OptionalCatchAllSlug<S extends string> = 
-    S extends \`\${string}\${SearchOrHash}\`
-      ? never
-      : S
+  type OptionalCatchAllSlug<S extends string> =
+    S extends \`\${string}\${SearchOrHash}\` ? never : S
 
   export type Route<T extends string = string> = ${fallback}
   ${routeTypes}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

This is a follow-up PR of #46378, which overlooked one thing - I forgot to export `createServer` from `next/types/index.d.ts` in `declare module 'next'`.

I've also reformatted that part as well, so that it matches Next's coding style.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
