### PR TITLE
Fix typo from next-font

### DIFF
--- a/packages/font/src/google/utils.ts
+++ b/packages/font/src/google/utils.ts
@@ -164,14 +164,14 @@ export function getUrl(
   // Variants are all combinations of weight and style, each variant will result in a separate font file
   const variants: Array<[string, string][]> = []
   if (axes.wght) {
-    for (const wgth of axes.wght) {
+    for (const wght of axes.wght) {
       if (!axes.ital) {
-        variants.push([['wght', wgth], ...(axes.variableAxes ?? [])])
+        variants.push([['wght', wght], ...(axes.variableAxes ?? [])])
       } else {
         for (const ital of axes.ital) {
           variants.push([
             ['ital', ital],
-            ['wght', wgth],
+            ['wght', wght],
             ...(axes.variableAxes ?? []),
           ])
         }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

Abbreviation for weight was `wgth` on axes iteration while other part was `wght`.