### PR TITLE
Reload dev server on change in `/next.config.m?js/`

### DIFF
--- a/packages/next/types/misc.d.ts
+++ b/packages/next/types/misc.d.ts
@@ -431,6 +431,11 @@ declare module 'next/dist/compiled/watchpack' {
       string,
       { safeTime: number; timestamp: number; accuracy?: number }
     >
+
+    getAggregated(): {
+      changes: string[]
+      removals: string[]
+    }
   }
 
   export default Watchpack

--- a/test/development/watch-config-file/index.test.ts
+++ b/test/development/watch-config-file/index.test.ts
@@ -53,6 +53,6 @@ describe('watch-config-file', () => {
       /Found a change in next\.config\.js\. Restarting the server to apply changes\./
     )
 
-    await check(() => next.fetch('/about').then((res) => res.status), '200')
+    await check(() => next.fetch('/about').then((res) => res.status), 200)
   })
 })

--- a/test/development/watch-config-file/index.test.ts
+++ b/test/development/watch-config-file/index.test.ts
@@ -22,27 +22,37 @@ describe('watch-config-file', () => {
         `,
       },
       dependencies: {},
-      skipStart: true,
     })
   })
   afterAll(() => next.destroy())
 
   it('should output config file change', async () => {
-    // next dev test-dir
-    await next.start(true)
     let i = 1
 
-    await check(async () => {
-      await next.patchFile(
-        'next.config.js',
-        `
+    await next.patchFile(
+      'next.config.js',
+      `
           /** changed - ${i} **/  
           const nextConfig = {
             reactStrictMode: true,
+            async redirects() {
+                return [
+                  {
+                    source: '/about',
+                    destination: '/',
+                    permanent: true,
+                  },
+                ]
+              },
           }
           module.exports = nextConfig`
-      )
-      return next.cliOutput
-    }, /Found a change in next.config.js. Restart the server to see the changes in effect./)
+    )
+
+    await check(
+      async () => next.cliOutput,
+      /Found a change in next\.config\.js\. Restarting the server to apply changes\./
+    )
+
+    await check(() => next.fetch('/about').then((res) => res.status), '200')
   })
 })

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -84,7 +84,6 @@ export class NextDevInstance extends NextInstance {
               .pop()
               .trim()
               .split(require('os').EOL)[0]
-            console.log('found new url', this._url)
             try {
               this._parsedUrl = new URL(this._url)
             } catch (err) {

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -84,6 +84,7 @@ export class NextDevInstance extends NextInstance {
               .pop()
               .trim()
               .split(require('os').EOL)[0]
+            console.log('found new url', this._url)
             try {
               this._parsedUrl = new URL(this._url)
             } catch (err) {
@@ -92,7 +93,8 @@ export class NextDevInstance extends NextInstance {
                 msg,
               })
             }
-            this.off('stdout', readyCb)
+            // dev server can reload on next.config.js change and that gets a new port so we want to keep listening and update if needed
+            // this.off('stdout', readyCb)
             resolve()
           }
         }

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -540,7 +540,7 @@ export async function check(contentFn, regex, hardError = true) {
   for (let tries = 0; tries < 30; tries++) {
     try {
       content = await contentFn()
-      if (typeof regex === 'string') {
+      if (typeof regex !== typeof /.*/) {
         if (regex === content) {
           return true
         }


### PR DESCRIPTION
Added automatic server reloading in dev mode when using webpack.

There was an issues with `port=0` which causes randomly generated port number in our tests. Because server reload would change port.

This should happen only when using the default port and the availability of the port `3000` changes or when using `0` (only tests afaik).

I just added a workaround for tests, should be enough.
fix NEXT-639 ([link](https://linear.app/vercel/issue/NEXT-639))