### PR TITLE
Add theme color media support for metadata

### DIFF
--- a/packages/next/src/lib/metadata/generate/basic.tsx
+++ b/packages/next/src/lib/metadata/generate/basic.tsx
@@ -26,7 +26,16 @@ export function BasicMetadata({ metadata }: { metadata: ResolvedMetadata }) {
       <Meta name="generator" content={metadata.generator} />
       <Meta name="keywords" content={metadata.keywords?.join(',')} />
       <Meta name="referrer" content={metadata.referrer} />
-      <Meta name="theme-color" content={metadata.themeColor} />
+      {metadata.themeColor
+        ? metadata.themeColor.map((themeColor, index) => (
+            <Meta
+              key={index}
+              name="theme-color"
+              content={themeColor.color}
+              media={themeColor.media}
+            />
+          ))
+        : null}
       <Meta name="color-scheme" content={metadata.colorScheme} />
       <Meta name="viewport" content={metadata.viewport} />
       <Meta name="creator" content={metadata.creator} />

--- a/packages/next/src/lib/metadata/generate/meta.tsx
+++ b/packages/next/src/lib/metadata/generate/meta.tsx
@@ -4,15 +4,18 @@ export function Meta({
   name,
   property,
   content,
+  media,
 }: {
   name?: string
   property?: string
+  media?: string
   content: string | number | URL | null | undefined
 }): React.ReactElement | null {
   if (typeof content !== 'undefined' && content !== null && content !== '') {
     return (
       <meta
         {...(name ? { name } : { property })}
+        {...(media ? { media } : undefined)}
         content={typeof content === 'string' ? content : content.toString()}
       />
     )

--- a/packages/next/src/lib/metadata/generate/utils.ts
+++ b/packages/next/src/lib/metadata/generate/utils.ts
@@ -1,9 +1,3 @@
-function resolveAsArrayOrUndefined<
-  T extends (null | undefined) | readonly (null | undefined)[]
->(value: T | T[]): undefined
-function resolveAsArrayOrUndefined<T extends unknown | readonly unknown[]>(
-  value: T | T[]
-): T[]
 function resolveAsArrayOrUndefined<T extends unknown | readonly unknown[]>(
   value: T | T[] | undefined | null
 ): undefined | T[] {

--- a/packages/next/src/lib/metadata/generate/utils.ts
+++ b/packages/next/src/lib/metadata/generate/utils.ts
@@ -1,6 +1,12 @@
-export function resolveAsArrayOrUndefined<
-  T extends unknown | readonly unknown[]
->(value: T | T[] | undefined | null): undefined | T[] {
+function resolveAsArrayOrUndefined<
+  T extends (null | undefined) | readonly (null | undefined)[]
+>(value: T | T[]): undefined
+function resolveAsArrayOrUndefined<T extends unknown | readonly unknown[]>(
+  value: T | T[]
+): T[]
+function resolveAsArrayOrUndefined<T extends unknown | readonly unknown[]>(
+  value: T | T[] | undefined | null
+): undefined | T[] {
   if (typeof value === 'undefined' || value === null) {
     return undefined
   }
@@ -9,3 +15,5 @@ export function resolveAsArrayOrUndefined<
   }
   return [value]
 }
+
+export { resolveAsArrayOrUndefined }

--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -54,49 +54,49 @@ describe('accumulateMetadata', () => {
     it('should convert string or URL images field to array, not only for basic og type', async () => {
       const items: [Metadata[], Metadata][] = [
         [
-          [{ openGraph: { type: 'article', images: 'https://test.com' } }],
-          { openGraph: { images: ['https://test.com'] } },
+          [{ openGraph: { type: 'article', images: 'https://test1.com' } }],
+          { openGraph: { images: [{ url: 'https://test1.com' }] } },
         ],
         [
-          [{ openGraph: { type: 'book', images: 'https://test.com' } }],
-          { openGraph: { images: ['https://test.com'] } },
+          [{ openGraph: { type: 'book', images: 'https://test2.com' } }],
+          { openGraph: { images: [{ url: 'https://test2.com' }] } },
         ],
         [
           [
             {
               openGraph: {
                 type: 'music.song',
-                images: new URL('https://test.com'),
+                images: new URL('https://test3.com'),
               },
             },
           ],
-          { openGraph: { images: [new URL('https://test.com')] } },
+          { openGraph: { images: [new URL('https://test3.com')] } },
         ],
         [
           [
             {
               openGraph: {
                 type: 'music.playlist',
-                images: { url: 'https://test.com' },
+                images: { url: 'https://test4.com' },
               },
             },
           ],
-          { openGraph: { images: [{ url: 'https://test.com' }] } },
+          { openGraph: { images: [{ url: 'https://test4.com' }] } },
         ],
         [
           [
             {
               openGraph: {
                 type: 'music.radio_station',
-                images: 'https://test.com',
+                images: 'https://test5.com',
               },
             },
           ],
-          { openGraph: { images: ['https://test.com'] } },
+          { openGraph: { images: [{ url: 'https://test5.com' }] } },
         ],
         [
-          [{ openGraph: { type: 'video.movie', images: 'https://test.com' } }],
-          { openGraph: { images: ['https://test.com'] } },
+          [{ openGraph: { type: 'video.movie', images: 'https://test6.com' } }],
+          { openGraph: { images: [{ url: 'https://test6.com' }] } },
         ],
       ]
 
@@ -106,6 +106,66 @@ describe('accumulateMetadata', () => {
           configuredMetadata.map((m) => [m, null])
         )
         expect(metadata).toMatchObject(result)
+      })
+    })
+  })
+
+  describe('themeColor', () => {
+    it('should support string theme color', async () => {
+      const metadataItems: MetadataItems = [
+        [{ themeColor: '#000' }, null],
+        [{ themeColor: '#fff' }, null],
+      ]
+      const metadata = await accumulateMetadata(metadataItems)
+      console.log('xxmetadata', metadata.themeColor)
+      expect(metadata).toMatchObject({
+        themeColor: [{ color: '#fff' }],
+      })
+    })
+
+    it('should support theme color descriptors', async () => {
+      const metadataItems1: MetadataItems = [
+        [
+          {
+            themeColor: {
+              media: '(prefers-color-scheme: light)',
+              color: '#fff',
+            },
+          },
+          null,
+        ],
+        [
+          {
+            themeColor: {
+              media: '(prefers-color-scheme: dark)',
+              color: 'cyan',
+            },
+          },
+          null,
+        ],
+      ]
+      const metadata1 = await accumulateMetadata(metadataItems1)
+      expect(metadata1).toMatchObject({
+        themeColor: [{ media: '(prefers-color-scheme: dark)', color: 'cyan' }],
+      })
+
+      const metadataItems2: MetadataItems = [
+        [
+          {
+            themeColor: [
+              { media: '(prefers-color-scheme: light)', color: '#fff' },
+              { media: '(prefers-color-scheme: dark)', color: 'cyan' },
+            ],
+          },
+          null,
+        ],
+      ]
+      const metadata2 = await accumulateMetadata(metadataItems2)
+      expect(metadata2).toMatchObject({
+        themeColor: [
+          { media: '(prefers-color-scheme: light)', color: '#fff' },
+          { media: '(prefers-color-scheme: dark)', color: 'cyan' },
+        ],
       })
     })
   })

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -20,6 +20,7 @@ import {
   resolveAppleWebApp,
   resolveAppLinks,
   resolveRobots,
+  resolveThemeColor,
   resolveVerification,
   resolveViewport,
 } from './resolvers/resolve-basics'
@@ -135,6 +136,10 @@ function merge(
         target.robots = resolveRobots(source.robots)
         break
       }
+      case 'themeColor': {
+        target.themeColor = resolveThemeColor(source.themeColor)
+        break
+      }
       case 'archives':
       case 'assets':
       case 'bookmarks':
@@ -149,7 +154,6 @@ function merge(
       case 'applicationName':
       case 'description':
       case 'generator':
-      case 'themeColor':
       case 'creator':
       case 'publisher':
       case 'category':

--- a/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
@@ -22,7 +22,7 @@ export const resolveThemeColor: FieldResolver<'themeColor'> = (themeColor) => {
   if (!themeColor) return null
   const themeColorDescriptors: ResolvedMetadata['themeColor'] = []
 
-  resolveAsArrayOrUndefined(themeColor).map((descriptor) => {
+  resolveAsArrayOrUndefined(themeColor)?.forEach((descriptor) => {
     if (typeof descriptor === 'string')
       themeColorDescriptors.push({ color: descriptor })
     else if (typeof descriptor === 'object')

--- a/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
@@ -18,6 +18,23 @@ const viewPortKeys = {
   viewportFit: 'viewport-fit',
 } as const
 
+export const resolveThemeColor: FieldResolver<'themeColor'> = (themeColor) => {
+  if (!themeColor) return null
+  const themeColorDescriptors: ResolvedMetadata['themeColor'] = []
+
+  resolveAsArrayOrUndefined(themeColor).map((descriptor) => {
+    if (typeof descriptor === 'string')
+      themeColorDescriptors.push({ color: descriptor })
+    else if (typeof descriptor === 'object')
+      themeColorDescriptors.push({
+        color: descriptor.color,
+        media: descriptor.media,
+      })
+  })
+
+  return themeColorDescriptors
+}
+
 export const resolveViewport: FieldResolver<'viewport'> = (viewport) => {
   let resolved: ResolvedMetadata['viewport'] = null
 
@@ -133,14 +150,16 @@ export const resolveAppleWebApp: FieldResolver<'appleWebApp'> = (appWebApp) => {
     }
   }
 
-  const startupImages = resolveAsArrayOrUndefined(appWebApp.startupImage)?.map(
-    (item) => (typeof item === 'string' ? { url: item } : item)
-  )
+  const startupImages = appWebApp.startupImage
+    ? resolveAsArrayOrUndefined(appWebApp.startupImage)?.map((item) =>
+        typeof item === 'string' ? { url: item } : item
+      )
+    : null
 
   return {
     capable: 'capable' in appWebApp ? !!appWebApp.capable : true,
     title: appWebApp.title || null,
-    startupImage: startupImages || null,
+    startupImage: startupImages,
     statusBarStyle: appWebApp.statusBarStyle || 'default',
   }
 }

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -26,6 +26,7 @@ import type {
   ResolvedRobots,
   TemplateString,
   Verification,
+  ThemeColorDescriptor,
 } from './metadata-types'
 import type { OpenGraph, ResolvedOpenGraph } from './opengraph-types'
 import type { ResolvedTwitterMetadata, Twitter } from './twitter-types'
@@ -131,9 +132,19 @@ interface Metadata extends DeprecatedMetadataFields {
    * ```tsx
    * "#000000"
    * <meta name="theme-color" content="#000000" />
+   *
+   * { media: "(prefers-color-scheme: dark)", color: "#000000" }
+   * <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#000000" />
+   *
+   * [
+   *  { media: "(prefers-color-scheme: dark)", color: "#000000" },
+   *  { media: "(prefers-color-scheme: light)", color: "#ffffff" }
+   * ]
+   * <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#000000" />
+   * <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
    * ```
    */
-  themeColor?: null | string
+  themeColor?: null | string | ThemeColorDescriptor | ThemeColorDescriptor[]
 
   /**
    * The color scheme for the document.
@@ -444,7 +455,7 @@ interface ResolvedMetadata extends DeprecatedMetadataFields {
   // if you provide an array it will be flattened into a single tag with comma separation
   keywords: null | Array<string>
   referrer: null | ReferrerEnum
-  themeColor: null | string
+  themeColor: null | ThemeColorDescriptor[]
   colorScheme: null | ColorSchemeEnum
   viewport: null | string
   creator: null | string

--- a/packages/next/src/lib/metadata/types/metadata-types.ts
+++ b/packages/next/src/lib/metadata/types/metadata-types.ts
@@ -150,3 +150,8 @@ export type ResolvedIcons = {
   shortcut?: IconDescriptor[]
   other?: IconDescriptor[]
 }
+
+export type ThemeColorDescriptor = {
+  color: string
+  media?: string
+}

--- a/test/e2e/app-dir/metadata/app/basic/page.tsx
+++ b/test/e2e/app-dir/metadata/app/basic/page.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
   referrer: 'origin-when-cross-origin',
   keywords: ['next.js', 'react', 'javascript'],
   authors: [{ name: 'huozhi' }, { name: 'tree', url: 'https://tree.com' }],
-  themeColor: 'cyan',
+  themeColor: { color: 'cyan', media: '(prefers-color-scheme: dark)' },
   colorScheme: 'dark',
   manifest: 'https://github.com/manifest.json',
   viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no',

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -126,7 +126,17 @@ createNextDescribe(
         )
         await checkMetaNameContentPair(browser, 'author', ['huozhi', 'tree'])
         await checkLink(browser, 'author', 'https://tree.com')
-        await checkMetaNameContentPair(browser, 'theme-color', 'cyan')
+
+        await checkMeta(browser, 'theme-color', 'cyan', 'name')
+        await checkMeta(
+          browser,
+          'theme-color',
+          '(prefers-color-scheme: dark)',
+          'name',
+          'meta',
+          'media'
+        )
+
         await checkMetaNameContentPair(browser, 'color-scheme', 'dark')
         await checkMetaNameContentPair(
           browser,


### PR DESCRIPTION
x-ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color

Resolves NEXT-525



## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [x] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

