### PR TITLE
Fix(typedRoutes): fixed 'next' imports on TS < 5.0

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -141,8 +141,8 @@ function createRouteDefinitions() {
   })
 
   return `declare module 'next' {
-  export { default } from 'next/types/index.d.ts'
-  export * from 'next/types/index.d.ts'
+  export { default } from 'next/types'
+  export * from 'next/types'
   
   type SearchOrHash = \`?\${string}\` | \`#\${string}\`
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

This is yet another follow-up PR of #46378...
In my discussion with the author of PR 46457, I figured out that exporting with the .d.ts extension doesn't work in TS < 5.0, which I didn't really notice because my projects were already using TS 5.0 and Next's tests were passing. This PR just deletes the extension from the export path. 


## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
