### PR TITLE
Wrong function name

### DIFF
--- a/errors/middleware-parse-user-agent.md
+++ b/errors/middleware-parse-user-agent.md
@@ -29,6 +29,6 @@ export function middleware(request: NextRequest) {
   const viewport = device.type === 'mobile' ? 'mobile' : 'desktop'
 
   request.nextUrl.searchParams.set('viewport', viewport)
-  return NextResponse.rewrites(request.nextUrl)
+  return NextResponse.rewrite(request.nextUrl)
 }
 ```


### PR DESCRIPTION
The function name was written incorrectly. Property 'rewrites' does not exist on type NextResponse.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
