### PR TITLE
Prevent ESLint `no-head-element` rule from being checked inside the `app` directory

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-head-element.ts
+++ b/packages/eslint-plugin-next/src/rules/no-head-element.ts
@@ -1,5 +1,6 @@
 import path = require('path')
 import { defineRule } from '../utils/define-rule'
+import { getRootDirs } from '../utils/get-root-dirs'
 
 const url = 'https://nextjs.org/docs/messages/no-head-element'
 
@@ -18,12 +19,23 @@ export = defineRule({
     return {
       JSXOpeningElement(node) {
         const paths = context.getFilename()
+        const rootDirs = getRootDirs(context)
 
-        const isInAppDir = () =>
-          (paths.includes(`app${path.sep}`) ||
-            paths.includes(`app${path.posix.sep}`)) &&
-          !paths.includes(`pages${path.sep}`) &&
-          !paths.includes(`pages${path.posix.sep}`)
+        const isInAppDir = () => {
+          return rootDirs.some(
+            (rootDir) =>
+              paths.includes(`${rootDir}${path.sep}app${path.sep}`) ||
+              paths.includes(
+                `${rootDir}${path.posix.sep}app${path.posix.sep}`
+              ) ||
+              paths.includes(
+                `${rootDir}${path.sep}src${path.sep}app${path.sep}`
+              ) ||
+              paths.includes(
+                `${rootDir}${path.posix.sep}src${path.posix.sep}app${path.posix.sep}`
+              )
+          )
+        }
         // Only lint the <head> element in pages directory
         if (node.name.name !== 'head' || isInAppDir()) {
           return

--- a/packages/eslint-plugin-next/src/rules/no-head-element.ts
+++ b/packages/eslint-plugin-next/src/rules/no-head-element.ts
@@ -22,19 +22,21 @@ export = defineRule({
         const rootDirs = getRootDirs(context)
 
         const isInAppDir = () => {
-          return rootDirs.some(
-            (rootDir) =>
-              paths.includes(`${rootDir}${path.sep}app${path.sep}`) ||
-              paths.includes(
-                `${rootDir}${path.posix.sep}app${path.posix.sep}`
-              ) ||
-              paths.includes(
-                `${rootDir}${path.sep}src${path.sep}app${path.sep}`
-              ) ||
-              paths.includes(
-                `${rootDir}${path.posix.sep}src${path.posix.sep}app${path.posix.sep}`
-              )
-          )
+          return rootDirs
+            .map((rootDir) => path.basename(rootDir))
+            .some(
+              (rootDir) =>
+                paths.includes(`${rootDir}${path.sep}app${path.sep}`) ||
+                paths.includes(
+                  `${rootDir}${path.posix.sep}app${path.posix.sep}`
+                ) ||
+                paths.includes(
+                  `${rootDir}${path.sep}src${path.sep}app${path.sep}`
+                ) ||
+                paths.includes(
+                  `${rootDir}${path.posix.sep}src${path.posix.sep}app${path.posix.sep}`
+                )
+            )
         }
         // Only lint the <head> element in pages directory
         if (node.name.name !== 'head' || isInAppDir()) {

--- a/test/unit/eslint-plugin-next/no-head-element.test.ts
+++ b/test/unit/eslint-plugin-next/no-head-element.test.ts
@@ -61,7 +61,22 @@ ruleTester.run('no-head-element', rule, {
         );
       }
     `,
-      filename: './app/layout.js',
+      filename: 'next.js/app/layout.js',
+    },
+    {
+      code: `
+      export default function Layout({ children }) {
+        return (
+          <html>
+            <head>
+              <title>layout</title>
+            </head>
+            <body>{children}</body>
+          </html>
+        );
+      }
+    `,
+      filename: 'next.js/src/app/layout.js',
     },
   ],
   invalid: [


### PR DESCRIPTION
fixes  #46559

Previously, `isInAppDir` checked the file name to see if it includes `app/` and doesn't include `pages/`.
This is problematic when part of the path, which could be unrelated to the project, includes `pages/`.
e.g. `/Users/foo/pages/projects/my-app/app/layout.js`.

This PR fixes this by using `getRootDirs` to find the Next.js root directory, 
and check if the file name includes `<root-dir>/app/` or `<root-dir>/src/app/`.

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
