### PR TITLE
Render og:image instead of og:image:url

### DIFF
--- a/packages/next/src/lib/metadata/generate/meta.tsx
+++ b/packages/next/src/lib/metadata/generate/meta.tsx
@@ -32,7 +32,7 @@ type MultiMetaContent =
   | null
   | undefined
 
-function ExtendMeta({
+export function ExtendMeta({
   content,
   namePrefix,
   propertyPrefix,

--- a/packages/next/src/lib/metadata/generate/opengraph.tsx
+++ b/packages/next/src/lib/metadata/generate/opengraph.tsx
@@ -2,7 +2,8 @@ import type { ResolvedMetadata } from '../types/metadata-interface'
 import type { TwitterAppDescriptor } from '../types/twitter-types'
 
 import React from 'react'
-import { Meta, MultiMeta } from './meta'
+import { isStringOrURL } from '../resolvers/resolve-url'
+import { Meta, MultiMeta, ExtendMeta } from './meta'
 
 export function OpenGraphMetadata({
   openGraph,
@@ -202,7 +203,20 @@ export function OpenGraphMetadata({
       <Meta property="og:locale" content={openGraph.locale} />
       <Meta property="og:country_name" content={openGraph.countryName} />
       <Meta property="og:ttl" content={openGraph.ttl?.toString()} />
-      <MultiMeta propertyPrefix="og:image" contents={openGraph.images} />
+      {openGraph.images?.map((image, index) => (
+        <React.Fragment key={index}>
+          <Meta
+            property="og:image"
+            content={isStringOrURL(image) ? image : image.url}
+          />
+          {!isStringOrURL(image) && (
+            <ExtendMeta
+              propertyPrefix="og:image"
+              content={{ ...image, url: null }}
+            />
+          )}
+        </React.Fragment>
+      ))}
       <MultiMeta propertyPrefix="og:video" contents={openGraph.videos} />
       <MultiMeta propertyPrefix="og:audio" contents={openGraph.audio} />
       <MultiMeta propertyPrefix="og:email" contents={openGraph.emails} />

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -418,7 +418,7 @@ createNextDescribe(
         )
         await checkMetaPropertyContentPair(browser, 'og:locale', 'en-US')
         await checkMetaPropertyContentPair(browser, 'og:type', 'website')
-        await checkMetaPropertyContentPair(browser, 'og:image:url', [
+        await checkMetaPropertyContentPair(browser, 'og:image', [
           'https://example.com/image.png',
           'https://example.com/image2.png',
         ])
@@ -464,7 +464,7 @@ createNextDescribe(
 
       it('should pick up opengraph-image and twitter-image as static metadata files', async () => {
         const $ = await next.render$('/opengraph/static')
-        expect($('[property="og:image:url"]').attr('content')).toMatch(
+        expect($('[property="og:image"]').attr('content')).toMatch(
           /https:\/\/example.com\/_next\/static\/media\/metadata\/opengraph-image.\w+.png/
         )
         expect($('[property="og:image:type"]').attr('content')).toBe(


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

Render `og:image` instead of `og:image:url`.
Other structured properties such as `og:image:type` and `og:image:alt` will still be rendered.

Fixes #46545

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
