### PR TITLE
List unsupported Turbopack config keys

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -270,7 +270,7 @@ const nextDev: CliCommand = async (argv) => {
     let babelrc = await getBabelConfigFile(dir)
     if (babelrc) babelrc = path.basename(babelrc)
 
-    let hasNonDefaultConfig
+    let nonSupportedConfig: string[] = []
     let rawNextConfig: NextConfig = {}
 
     try {
@@ -317,14 +317,14 @@ const nextDev: CliCommand = async (argv) => {
         }
       }
 
-      hasNonDefaultConfig = Object.keys(rawNextConfig).some((key) =>
+      nonSupportedConfig = Object.keys(rawNextConfig).filter((key) =>
         checkUnsupportedCustomConfig(key, rawNextConfig, defaultConfig)
       )
     } catch (e) {
       console.error('Unexpected error occurred while checking config', e)
     }
 
-    const hasWarningOrError = babelrc || hasNonDefaultConfig
+    const hasWarningOrError = babelrc || nonSupportedConfig.length
     if (!hasWarningOrError) {
       thankYouMsg = chalk.dim(thankYouMsg)
     }
@@ -349,13 +349,17 @@ const nextDev: CliCommand = async (argv) => {
         `Babel is not yet supported. To use Turbopack at the moment,\n  you'll need to remove your usage of Babel.`
       )}`
     }
-    if (hasNonDefaultConfig) {
+    if (nonSupportedConfig.length) {
       unsupportedParts += `\n\n- Unsupported Next.js configuration option(s) (${chalk.cyan(
         'next.config.js'
       )})\n  ${chalk.dim(
         `The only configurations options supported are:\n${supportedTurbopackNextConfigOptions
           .map((name) => `    - ${chalk.cyan(name)}\n`)
-          .join('')}  To use Turbopack, remove other configuration options.`
+          .join(
+            ''
+          )}  To use Turbopack, remove the following configuration options:\n${nonSupportedConfig.map(
+          (name) => `    - ${chalk.red(name)}\n`
+        )}`
       )}   `
     }
 


### PR DESCRIPTION
A small DX improvement, this will list any unsupported keys when one is found:

<img width="538" alt="Screen Shot 2023-02-28 at 5 23 58 PM" src="https://user-images.githubusercontent.com/112982/221995232-cb798084-4b6a-4733-99b7-0f599fdec315.png">
