### PR TITLE
test(utils): support turbopack-based overlay error text lookup

### DIFF
--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -669,16 +669,27 @@ export async function hasRedbox(browser, expected = true) {
 
 export async function getRedboxHeader(browser) {
   return retry(
-    () =>
-      evaluate(browser, () => {
+    () => {
+      if (shouldRunTurboDevTest()) {
         const portal = [].slice
           .call(document.querySelectorAll('nextjs-portal'))
           .find((p) =>
-            p.shadowRoot.querySelector('[data-nextjs-dialog-header]')
+            p.shadowRoot.querySelector('[data-nextjs-turbo-dialog-body]')
           )
         const root = portal.shadowRoot
-        return root.querySelector('[data-nextjs-dialog-header]').innerText
-      }),
+        return root.querySelector('[data-nextjs-turbo-dialog-body]').innerText
+      } else {
+        return evaluate(browser, () => {
+          const portal = [].slice
+            .call(document.querySelectorAll('nextjs-portal'))
+            .find((p) =>
+              p.shadowRoot.querySelector('[data-nextjs-dialog-header]')
+            )
+          const root = portal.shadowRoot
+          return root.querySelector('[data-nextjs-dialog-header]').innerText
+        })
+      }
+    },
     10000,
     500,
     'getRedboxHeader'


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

- closes WEB-672. 

Due to differences of error overlay layout between turbopack and normal next-dev, test fixtures cannot lookup corresponding error text with same data-* tag. Companion PR https://github.com/vercel/turbo/pull/4015 added new tag for the turbopack specific, and this PR utilizes those if test runs against --turbo.

## Bug

- [x] Related issues linked using `fixes #number`
