### PR TITLE
Fix async generateMetadata type in ts plugin

### DIFF
--- a/packages/next/src/server/typescript/rules/metadata.ts
+++ b/packages/next/src/server/typescript/rules/metadata.ts
@@ -8,7 +8,7 @@ import {
 } from '../utils'
 
 const TYPE_ANOTATION = ': Metadata'
-const TYPE_ANOTATION_ASYNC = ': Promise<Metadata> | Metadata'
+const TYPE_ANOTATION_ASYNC = ': Promise<Metadata>'
 const TYPE_IMPORT = `\n\nimport type { Metadata } from 'next'`
 
 // Find the `export const metadata = ...` node.


### PR DESCRIPTION
Corrects async return type for `generateMetadata`

x-ref: https://github.com/vercel/next.js/pull/45723/files#r1121140364

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

