### PR TITLE
Fix static to dynamic error in dev

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1550,7 +1550,10 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       isNotFound = (renderOpts as any).isNotFound
       isRedirect = (renderOpts as any).isRedirect
 
-      if (isAppPath && isSSG && isrRevalidate === 0) {
+      // we don't throw static to dynamic errors in dev as isSSG
+      // is a best guess in dev since we don't have the prerender pass
+      // to know whether the path is actually static or not
+      if (isAppPath && isSSG && isrRevalidate === 0 && !this.renderOpts.dev) {
         const staticBailoutInfo: {
           stack?: string
           description?: string

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -58,6 +58,7 @@ createNextDescribe(
           'force-static/page.js',
           'force-static/second.html',
           'force-static/second.rsc',
+          'gen-params-dynamic/[slug]/page.js',
           'hooks/use-pathname/[slug]/page.js',
           'hooks/use-pathname/slug.html',
           'hooks/use-pathname/slug.rsc',
@@ -769,6 +770,26 @@ createNextDescribe(
 
         const $2 = cheerio.load(await res2.text())
         expect(firstTime).not.toBe($2('#now').text())
+      }
+    })
+
+    it('should not error with generateStaticParams and dynamic data', async () => {
+      const res = await next.fetch('/gen-params-dynamic/one')
+      const html = await res.text()
+      expect(res.status).toBe(200)
+      expect(html).toContain('gen-params-dynamic/[slug]')
+      expect(html).toContain('one')
+
+      const data = cheerio.load(html)('#data').text()
+
+      for (let i = 0; i < 5; i++) {
+        const res2 = await next.fetch('/gen-params-dynamic/one')
+        expect(res2.status).toBe(200)
+        expect(
+          cheerio
+            .load(await res2.text())('#data')
+            .text()
+        ).not.toBe(data)
       }
     })
 

--- a/test/e2e/app-dir/app-static/app/gen-params-dynamic/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/gen-params-dynamic/[slug]/page.js
@@ -1,0 +1,35 @@
+export async function generateStaticParams() {
+  return [{ slug: 'one' }]
+}
+
+const fetchRetry = async (url, init) => {
+  for (let i = 0; i < 5; i++) {
+    try {
+      return await fetch(url, init)
+    } catch (err) {
+      if (i === 4) {
+        throw err
+      }
+      console.log(`Failed to fetch`, err, `retrying...`)
+    }
+  }
+}
+
+export default async function page({ params }) {
+  const { slug } = params
+  const data = await fetchRetry(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      method: 'POST',
+      body: JSON.stringify({ hello: 'world' }),
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="page">/gen-params-dynamic/[slug]</p>
+      <p id="slug">{slug}</p>
+      <p id="data">{data}</p>
+    </>
+  )
+}


### PR DESCRIPTION
This corrects the static to dynamic error incorrectly showing in development since we don't have enough information to accurately know if this error should be thrown or not unless a build has been done. 

Fixes: https://github.com/vercel/next.js/issues/46436
x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1677637140906959)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
