### PR TITLE
Fix(typedRoutes): fixed StaticRoutes and DynamicRoutes being empty causing invalid syntax

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -205,6 +205,9 @@ function createRouteDefinitions(
   let staticRouteTypes = ''
   let dynamicRouteTypes = ''
 
+  const staticRouteTypesFallback = staticRouteTypes ? '' : 'string'
+  const dynamicRouteTypesFallback = dynamicRouteTypes ? '' : 'string'
+
   function addRouteToRouteTypes(route: string) {
     const isDynamic = isDynamicRoute(route)
     if (isDynamic) {
@@ -267,8 +270,8 @@ declare namespace __next_route_internal_types__ {
   type OptionalCatchAllSlug<S extends string> =
     S extends \`\${string}\${SearchOrHash}\` ? never : S
 
-  type StaticRoutes = ${staticRouteTypes}
-  type DynamicRoutes<T extends string = string> = ${dynamicRouteTypes}
+  type StaticRoutes = ${staticRouteTypesFallback}${staticRouteTypes}
+  type DynamicRoutes<T extends string = string> = ${dynamicRouteTypesFallback}${dynamicRouteTypes}
 
   type RouteImpl<T> = ${fallback}
     | StaticRoutes

--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -205,9 +205,6 @@ function createRouteDefinitions(
   let staticRouteTypes = ''
   let dynamicRouteTypes = ''
 
-  const staticRouteTypesFallback = staticRouteTypes ? '' : 'string'
-  const dynamicRouteTypesFallback = dynamicRouteTypes ? '' : 'string'
-
   function addRouteToRouteTypes(route: string) {
     const isDynamic = isDynamicRoute(route)
     if (isDynamic) {
@@ -240,6 +237,9 @@ function createRouteDefinitions(
   for (const route of routes) {
     addRouteToRouteTypes(route)
   }
+
+  const staticRouteTypesFallback = staticRouteTypes ? '' : 'string'
+  const dynamicRouteTypesFallback = dynamicRouteTypes ? '' : 'string'
 
   return `// Type definitions for Next.js routes
 

--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -237,9 +237,6 @@ function createRouteDefinitions(
     addRouteToRouteTypes(route)
   }
 
-  const staticRouteTypesFallback = staticRouteTypes ? '' : 'string'
-  const dynamicRouteTypesFallback = dynamicRouteTypes ? '' : 'string'
-
   return `// Type definitions for Next.js routes
 
 /**
@@ -269,8 +266,8 @@ declare namespace __next_route_internal_types__ {
   type OptionalCatchAllSlug<S extends string> =
     S extends \`\${string}\${SearchOrHash}\` ? never : S
 
-  type StaticRoutes = ${staticRouteTypesFallback}${staticRouteTypes}
-  type DynamicRoutes<T extends string = string> = ${dynamicRouteTypesFallback}${dynamicRouteTypes}
+  type StaticRoutes = ${staticRouteTypes || ''}
+  type DynamicRoutes<T extends string = string> = ${dynamicRouteTypes || ''}
 
   type RouteImpl<T> =
     | StaticRoutes

--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -196,7 +196,6 @@ function createRouteDefinitions(
     }
   }
 
-  const fallback = !edgeRoutes.length && !nodeRoutes.length ? 'string' : ''
   const routes = [...edgeRoutes, ...nodeRoutes, ...extraRoutes]
 
   // By exposing the static route types separately as string literals,
@@ -273,7 +272,7 @@ declare namespace __next_route_internal_types__ {
   type StaticRoutes = ${staticRouteTypesFallback}${staticRouteTypes}
   type DynamicRoutes<T extends string = string> = ${dynamicRouteTypesFallback}${dynamicRouteTypes}
 
-  type RouteImpl<T> = ${fallback}
+  type RouteImpl<T> =
     | StaticRoutes
     | \`\${StaticRoutes}\${Suffix}\`
     | (T extends \`\${DynamicRoutes<infer _>}\${Suffix}\` ? T : never)

--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -266,8 +266,10 @@ declare namespace __next_route_internal_types__ {
   type OptionalCatchAllSlug<S extends string> =
     S extends \`\${string}\${SearchOrHash}\` ? never : S
 
-  type StaticRoutes = ${staticRouteTypes || ''}
-  type DynamicRoutes<T extends string = string> = ${dynamicRouteTypes || ''}
+  type StaticRoutes = ${staticRouteTypes || 'string'}
+  type DynamicRoutes<T extends string = string> = ${
+    dynamicRouteTypes || 'string'
+  }
 
   type RouteImpl<T> =
     | StaticRoutes


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

When `dynamicRouteTypes`/`staticRouteTypes` is empty, an invalid `link.d.ts` is generated. This just handles that case.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
