### PR TITLE
Fix IntelliSense for generateMetadata

### DIFF
--- a/packages/next/src/server/typescript/rules/metadata.ts
+++ b/packages/next/src/server/typescript/rules/metadata.ts
@@ -158,7 +158,10 @@ function updateVirtualFileWithType(
   if (ts.isFunctionDeclaration(node)) {
     if (isGenerateMetadata) {
       nodeEnd = node.body!.getFullStart()
-      annotation = TYPE_ANOTATION_ASYNC
+      const isAsync = node.modifiers?.some(
+        (m) => m.kind === ts.SyntaxKind.AsyncKeyword
+      )
+      annotation = isAsync ? TYPE_ANOTATION_ASYNC : TYPE_ANOTATION
     } else {
       return
     }

--- a/test/e2e/app-dir/metadata/app/type-checking/generate-async/page.tsx
+++ b/test/e2e/app-dir/metadata/app/type-checking/generate-async/page.tsx
@@ -1,0 +1,9 @@
+export default function Page() {
+  return null
+}
+
+export async function generateMetadata() {
+  return {
+    title: 'foo',
+  }
+}

--- a/test/e2e/app-dir/metadata/app/type-checking/generate-sync/page.tsx
+++ b/test/e2e/app-dir/metadata/app/type-checking/generate-sync/page.tsx
@@ -1,0 +1,9 @@
+export default function Page() {
+  return null
+}
+
+export function generateMetadata() {
+  return {
+    title: 'foo',
+  }
+}


### PR DESCRIPTION
Related to #46431, this makes sure the IntelliSense for both sync and async `generateMetadata` is correct.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
