### PR TITLE
Add build debug logs behind debug flag

### DIFF
--- a/packages/next/src/build/build-context.ts
+++ b/packages/next/src/build/build-context.ts
@@ -12,6 +12,7 @@ import type { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
 // to pass it through function arguments.
 // Not exhaustive, but should be extended to as needed whilst refactoring
 export const NextBuildContext: Partial<{
+  debugOutput?: boolean
   // core fields
   dir: string
   buildId: string

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -260,6 +260,7 @@ export default async function build(
       version: process.env.__NEXT_VERSION as string,
     })
 
+    NextBuildContext.debugOutput = debugOutput
     NextBuildContext.nextBuildSpan = nextBuildSpan
     NextBuildContext.dir = dir
     NextBuildContext.appDirOnly = appDirOnly

--- a/packages/next/src/build/webpack-build.ts
+++ b/packages/next/src/build/webpack-build.ts
@@ -47,10 +47,6 @@ function isTraceEntryPointsPlugin(
   return plugin instanceof TraceEntryPointsPlugin
 }
 
-interface BuildOptions {
-  debugOutput?: boolean
-}
-
 async function webpackBuildImpl(): Promise<{
   duration: number
   turbotraceContext?: TurbotraceContext

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -2621,6 +2621,11 @@ const runTests = (isDev = false, isTurbo = false) => {
           expect(cleanStdout).toContain(header.value)
         }
       }
+
+      // build compilation debug logs should be present as well
+      expect(cleanStdout).toContain('starting webpack compilation')
+      expect(cleanStdout).toContain('finished server compilation')
+      expect(cleanStdout).toContain('finished client compilation')
     })
   }
 }


### PR DESCRIPTION
x-ref: [slack thread](https://vercel.slack.com/archives/C04S835KUC9)

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

