### PR TITLE
Add script to automate updating vendored React version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "debug": "cross-env NEXT_TELEMETRY_DISABLED=1 node --inspect packages/next/dist/bin/next",
     "postinstall": "git config feature.manyFiles true && node scripts/install-native.mjs",
     "version": "npx pnpm@7.24.3 install && IS_PUBLISH=yes ./scripts/check-pre-compiled.sh && git add .",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "sync-react": "node ./scripts/sync-react.js"
   },
   "devDependencies": {
     "@babel/core": "7.18.0",

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -1,0 +1,201 @@
+// @ts-check
+
+const path = require('path')
+const { readJson, writeJson } = require('fs-extra')
+const execa = require('execa')
+
+// Use this script to update Next's vendored copy of React and related packages:
+//
+// Basic usage (defaults to most recent React canary version):
+//   pnpm run sync-react
+//
+// Specify a canary version:
+//   pnpm run sync-react --version 18.3.0-next-41110021f-20230301
+//
+// Update package.json but skip installing the dependencies automatically:
+//   pnpm run sync-react --no-install
+
+async function main() {
+  const noInstall = readBoolArg(process.argv, 'no-install')
+  let newVersionStr = readStringArg(process.argv, 'version')
+  if (newVersionStr === null) {
+    const { stdout, stderr } = await execa('npm', [
+      'view',
+      'react@next',
+      'version',
+    ])
+    if (stderr) {
+      console.error(stderr)
+      throw new Error('Failed to read latest React canary version from npm.')
+    }
+    newVersionStr = stdout.trim()
+  }
+
+  const newVersionInfo = extractInfoFromReactCanaryVersion(newVersionStr)
+  if (!newVersionInfo) {
+    throw new Error(
+      `New react version does not match expected format: ${newVersionStr}
+
+Choose a React canary version from npm: https://www.npmjs.com/package/react?activeTab=versions
+
+Or, run this command with no arguments to use the most recently published version.
+`
+    )
+  }
+
+  const cwd = process.cwd()
+  const pkgJson = await readJson(path.join(cwd, 'package.json'))
+  const devDependencies = pkgJson.devDependencies
+  const baseVersionStr = devDependencies['react-builtin'].replace(
+    /^npm:react@/,
+    ''
+  )
+
+  const baseVersionInfo = extractInfoFromReactCanaryVersion(baseVersionStr)
+  if (!baseVersionInfo) {
+    throw new Error(
+      'Base react version does not match expected format: ' + baseVersionStr
+    )
+  }
+
+  const { sha: newSha, dateString: newDateString } = newVersionInfo
+  const { sha: baseSha, dateString: baseDateString } = baseVersionInfo
+
+  console.log(`Updating React to ${newSha}...\n`)
+  if (newSha === baseSha) {
+    console.log('Already up to date.')
+    return
+  }
+
+  for (const [dep, version] of Object.entries(devDependencies)) {
+    if (version.endsWith(`${baseSha}-${baseDateString}`)) {
+      devDependencies[dep] = version.replace(
+        `${baseSha}-${baseDateString}`,
+        `${newSha}-${newDateString}`
+      )
+    }
+  }
+  await writeJson(path.join(cwd, 'package.json'), pkgJson, { spaces: 2 })
+  console.log('Successfully updated React dependencies in package.json.\n')
+
+  // Install the updated dependencies and build the vendored React files.
+  if (noInstall) {
+    console.log('Skipping install step because --no-install flag was passed.\n')
+  } else {
+    console.log('Installing dependencies...\n')
+
+    const installSubprocess = execa('pnpm', ['install'])
+    if (installSubprocess.stdout) {
+      installSubprocess.stdout.pipe(process.stdout)
+    }
+    try {
+      await installSubprocess
+    } catch (error) {
+      console.error(error)
+      throw new Error('Failed to install updated dependencies.')
+    }
+
+    console.log('Building vendored React files...\n')
+    const nccSubprocess = execa('pnpm', ['taskr', 'ncc'], {
+      cwd: path.join(cwd, 'packages', 'next'),
+    })
+    if (nccSubprocess.stdout) {
+      nccSubprocess.stdout.pipe(process.stdout)
+    }
+    try {
+      await nccSubprocess
+    } catch (error) {
+      console.error(error)
+      throw new Error('Failed to run ncc.')
+    }
+
+    // Print extra newline after ncc output
+    console.log()
+  }
+
+  console.log(`Successfully updated React from ${baseSha} to ${newSha}.\n`)
+
+  // Fetch the changelog from GitHub and print it to the console.
+  try {
+    const changelog = await getChangelogFromGitHub(baseSha, newSha)
+    if (changelog === null) {
+      console.log(
+        `GitHub reported no changes between ${baseSha} and ${newSha}.`
+      )
+    } else {
+      console.log('Includes the following upstream changes:\n\n' + changelog)
+    }
+  } catch (error) {
+    console.error(error)
+    console.log(
+      '\nFailed to fetch changelog from GitHub. Changes were applied, anyway.\n'
+    )
+  }
+
+  if (noInstall) {
+    console.log(
+      `
+To finish upgrading, complete the following steps:
+
+- Install the updated dependencies: pnpm install
+- Build the vendored React files: (inside packages/next dir) pnpm taskr ncc
+
+Or run this command again without the --no-install flag to do both automatically.
+    `
+    )
+  }
+}
+
+function readBoolArg(argv, argName) {
+  return argv.indexOf('--' + argName) !== -1
+}
+
+function readStringArg(argv, argName) {
+  const argIndex = argv.indexOf('--' + argName)
+  return argIndex === -1 ? null : argv[argIndex + 1]
+}
+
+function extractInfoFromReactCanaryVersion(reactCanaryVersion) {
+  const match = reactCanaryVersion.match(
+    /(?<semverVersion>.*)-(?<releaseChannel>.*)-(?<sha>.*)-(?<dateString>.*)$/
+  )
+  return match ? match.groups : null
+}
+
+async function getChangelogFromGitHub(baseSha, newSha) {
+  const pageSize = 50
+  let changelog = []
+  for (let currentPage = 0; ; currentPage++) {
+    const response = await fetch(
+      `https://api.github.com/repos/facebook/react/compare/${baseSha}...${newSha}?per_page=${pageSize}&page=${currentPage}`
+    )
+    if (!response.ok) {
+      throw new Error('Failed to fetch commit log from GitHub.')
+    }
+    const data = await response.json()
+
+    const { commits } = data
+    for (const { commit, sha } of commits) {
+      changelog.push(
+        `-  ${sha.slice(0, 9)} ${commit.message.split('\n')[0]} (${
+          commit.author.name
+        })`
+      )
+    }
+
+    if (commits.length !== pageSize) {
+      // If the number of commits is less than the page size, we've reached
+      // the end. Otherwise we'll keep fetching until we run out.
+      break
+    }
+  }
+
+  changelog.reverse()
+
+  return changelog.length > 0 ? changelog.join('\n') : null
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
Since we intend to update our vendored copy of React frequently, I wrote a script to automate the steps.

Basic usage (defaults to most recent React canary version):

```sh
pnpm run sync-react
```

Specify a canary version:

```sh
pnpm run sync-react --version 18.3.0-next-41110021f-20230301
```

Update package.json but skip installing the dependencies automatically:

```sh
pnpm run sync-react --no-install
```

At the end it will print out a changelog so you can copy/paste it into the PR description.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
