### PR TITLE
Use separate workers for webpackBuildWorker

### DIFF
--- a/packages/next/src/build/build-context.ts
+++ b/packages/next/src/build/build-context.ts
@@ -19,6 +19,9 @@ export const NextBuildContext: Partial<{
     serverModuleIds?: any
     edgeServerModuleIds?: any
     asyncClientModules?: any
+    serverActions?: any
+    serverCSSManifest?: any
+    edgeServerCSSManifest?: any
   }
   serializedPagesManifestEntries: {
     edgeServerPages?: PagesManifest

--- a/packages/next/src/build/build-context.ts
+++ b/packages/next/src/build/build-context.ts
@@ -5,6 +5,7 @@ import type { __ApiPreviewProps } from '../server/api-utils'
 import type { NextConfigComplete } from '../server/config-shared'
 import type { Span } from '../trace'
 import type getBaseWebpackConfig from './webpack-config'
+import { PagesManifest } from './webpack/plugins/pages-manifest-plugin'
 import type { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
 
 // a global object to store context for the current build
@@ -12,6 +13,19 @@ import type { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
 // to pass it through function arguments.
 // Not exhaustive, but should be extended to as needed whilst refactoring
 export const NextBuildContext: Partial<{
+  compilerIdx?: number
+  serializedFlightMaps?: {
+    injectedClientEntries?: any
+    serverModuleIds?: any
+    edgeServerModuleIds?: any
+    asyncClientModules?: any
+  }
+  serializedPagesManifestEntries: {
+    edgeServerPages?: PagesManifest
+    nodeServerPages?: PagesManifest
+    edgeServerAppPaths?: PagesManifest
+    nodeServerAppPaths?: PagesManifest
+  }
   // core fields
   dir: string
   buildId: string

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1068,7 +1068,9 @@ export default async function build(
             if (filesTracedFromEntries.length) {
               // The turbo trace doesn't provide the traced file type and reason at present
               // let's write the traced files into the first [entry].nft.json
+              // @ts-expect-error types
               const [[, entryName]] = Array.from(entryNameMap.entries()).filter(
+                // @ts-expect-error types
                 ([k]) => k.startsWith(turbotraceContextAppDir)
               )
               const traceOutputPath = path.join(
@@ -1085,7 +1087,7 @@ export default async function build(
           }
           if (chunksTrace) {
             const { action, outputPath } = chunksTrace
-            action.input = action.input.filter((f) => {
+            action.input = action.input.filter((f: any) => {
               const outputPagesPath = path.join(outputPath, '..', 'pages')
               return (
                 !f.startsWith(outputPagesPath) ||

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -16,6 +16,13 @@ const ArchName = arch()
 const PlatformName = platform()
 const triples = platformArchTriples[PlatformName][ArchName] || []
 
+const infoLog = (...args: any[]) => {
+  if (process.env.NEXT_PRIVATE_BUILD_WORKER) {
+    return
+  }
+  Log.info(...args)
+}
+
 // Allow to specify an absolute path to the custom turbopack binary to load.
 // If one of env variables is set, `loadNative` will try to use any turbo-* interfaces from specified
 // binary instead. This will not affect existing swc's transform, or other interfaces. This is thin,
@@ -213,7 +220,7 @@ async function loadWasm(importPath = '') {
       if (pkg === '@next/swc-wasm-web') {
         bindings = await bindings.default()
       }
-      Log.info('Using wasm build of next-swc')
+      infoLog('Using wasm build of next-swc')
 
       // Note wasm binary does not support async intefaces yet, all async
       // interface coereces to sync interfaces.
@@ -292,7 +299,7 @@ function loadNative(isCustomTurbopack = false) {
   for (const triple of triples) {
     try {
       bindings = require(`@next/swc/native/next-swc.${triple.platformArchABI}.node`)
-      Log.info('Using locally built binary of @next/swc')
+      infoLog('Using locally built binary of @next/swc')
       break
     } catch (e) {}
   }

--- a/packages/next/src/build/webpack-build.ts
+++ b/packages/next/src/build/webpack-build.ts
@@ -12,10 +12,8 @@ import { runCompiler } from './compiler'
 import * as Log from './output/log'
 import getBaseWebpackConfig, { loadProjectInfo } from './webpack-config'
 import { NextError } from '../lib/is-error'
-import { injectedClientEntries } from './webpack/plugins/flight-client-entry-plugin'
 import { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
 import { NextBuildContext } from './build-context'
-import { isMainThread, parentPort, Worker, workerData } from 'worker_threads'
 import { createEntrypoints } from './entries'
 import loadConfig from '../server/config'
 import { trace } from '../trace'
@@ -24,6 +22,14 @@ import {
   TraceEntryPointsPlugin,
   TurbotraceContext,
 } from './webpack/plugins/next-trace-entrypoints-plugin'
+import { UnwrapPromise } from '../lib/coalesced-function'
+import * as flightPluginModule from './webpack/plugins/flight-client-entry-plugin'
+import * as flightManifestPluginModule from './webpack/plugins/flight-manifest-plugin'
+import * as pagesPluginModule from './webpack/plugins/pages-manifest-plugin'
+import { Worker } from 'next/dist/compiled/jest-worker'
+import origDebug from 'next/dist/compiled/debug'
+
+const debug = origDebug('next:build:webpack-build')
 
 type CompilerResult = {
   errors: webpack.StatsError[]
@@ -47,9 +53,11 @@ function isTraceEntryPointsPlugin(
   return plugin instanceof TraceEntryPointsPlugin
 }
 
-async function webpackBuildImpl(): Promise<{
+async function webpackBuildImpl(compilerIdx?: number): Promise<{
   duration: number
   turbotraceContext?: TurbotraceContext
+  serializedFlightMaps?: typeof NextBuildContext['serializedFlightMaps']
+  serializedPagesManifestEntries?: typeof NextBuildContext['serializedPagesManifestEntries']
 }> {
   let result: CompilerResult | null = {
     warnings: [],
@@ -58,7 +66,6 @@ async function webpackBuildImpl(): Promise<{
   }
   let webpackBuildStart
   const nextBuildSpan = NextBuildContext.nextBuildSpan!
-  const buildSpinner = NextBuildContext.buildSpinner
   const dir = NextBuildContext.dir!
   const config = NextBuildContext.config!
 
@@ -150,6 +157,7 @@ async function webpackBuildImpl(): Promise<{
 
   webpackBuildStart = process.hrtime()
 
+  debug(`starting compiler`, compilerIdx)
   // We run client and server compilation separately to optimize for memory usage
   await runWebpackSpan.traceAsyncFn(async () => {
     // Run the server compilers first and then the client
@@ -158,18 +166,28 @@ async function webpackBuildImpl(): Promise<{
 
     // During the server compilations, entries of client components will be
     // injected to this set and then will be consumed by the client compiler.
-    injectedClientEntries.clear()
+    let serverResult: UnwrapPromise<ReturnType<typeof runCompiler>> | null =
+      null
+    let edgeServerResult: UnwrapPromise<ReturnType<typeof runCompiler>> | null =
+      null
 
-    const serverResult = await runCompiler(serverConfig, {
-      runWebpackSpan,
-    })
-    const edgeServerResult = configs[2]
-      ? await runCompiler(configs[2], { runWebpackSpan })
-      : null
+    if (!compilerIdx || compilerIdx == 1) {
+      serverResult = await runCompiler(serverConfig, {
+        runWebpackSpan,
+      })
+      debug('server result', serverResult)
+    }
+
+    if (!compilerIdx || compilerIdx === 2) {
+      edgeServerResult = configs[2]
+        ? await runCompiler(configs[2], { runWebpackSpan })
+        : null
+      debug('edge server result', edgeServerResult)
+    }
 
     // Only continue if there were no errors
-    if (!serverResult.errors.length && !edgeServerResult?.errors.length) {
-      injectedClientEntries.forEach((value, key) => {
+    if (!serverResult?.errors.length && !edgeServerResult?.errors.length) {
+      flightPluginModule.injectedClientEntries.forEach((value, key) => {
         const clientEntry = clientConfig.entry as webpack.EntryObject
         if (key === APP_CLIENT_INTERNALS) {
           clientEntry[CLIENT_STATIC_FILES_RUNTIME_MAIN_APP] = {
@@ -190,9 +208,12 @@ async function webpackBuildImpl(): Promise<{
         }
       })
 
-      clientResult = await runCompiler(clientConfig, {
-        runWebpackSpan,
-      })
+      if (!compilerIdx || compilerIdx === 3) {
+        clientResult = await runCompiler(clientConfig, {
+          runWebpackSpan,
+        })
+        debug('client result', clientResult)
+      }
     }
 
     result = {
@@ -230,9 +251,6 @@ async function webpackBuildImpl(): Promise<{
   ).plugins?.find(isTraceEntryPointsPlugin)
 
   const webpackBuildEnd = process.hrtime(webpackBuildStart)
-  if (buildSpinner) {
-    buildSpinner.stopAndPersist()
-  }
 
   if (result.errors.length > 0) {
     // Only keep the first few errors. Others are often indicative
@@ -277,21 +295,71 @@ async function webpackBuildImpl(): Promise<{
       Log.warn('Compiled with warnings\n')
       console.warn(result.warnings.filter(Boolean).join('\n\n'))
       console.warn()
-    } else {
+    } else if (!compilerIdx) {
       Log.info('Compiled successfully')
     }
+
     return {
       duration: webpackBuildEnd[0],
       turbotraceContext: traceEntryPointsPlugin?.turbotraceContext,
+      serializedFlightMaps: {
+        injectedClientEntries: Array.from(
+          flightPluginModule.injectedClientEntries.entries()
+        ),
+        serverModuleIds: Array.from(
+          flightPluginModule.serverModuleIds.entries()
+        ),
+        edgeServerModuleIds: Array.from(
+          flightPluginModule.edgeServerModuleIds.entries()
+        ),
+        asyncClientModules: Array.from(
+          flightManifestPluginModule.ASYNC_CLIENT_MODULES
+        ),
+      },
+      serializedPagesManifestEntries: {
+        edgeServerPages: pagesPluginModule.edgeServerPages,
+        edgeServerAppPaths: pagesPluginModule.edgeServerAppPaths,
+        nodeServerPages: pagesPluginModule.nodeServerPages,
+        nodeServerAppPaths: pagesPluginModule.nodeServerAppPaths,
+      },
     }
   }
 }
 
 // the main function when this file is run as a worker
-async function workerMain() {
-  const { buildContext } = workerData
+export async function workerMain(workerData: {
+  compilerIdx?: number
+  buildContext: typeof NextBuildContext
+}) {
   // setup new build context from the serialized data passed from the parent
-  Object.assign(NextBuildContext, buildContext)
+  Object.assign(NextBuildContext, workerData.buildContext)
+
+  // restore module scope maps for flight plugins
+  const { serializedFlightMaps, serializedPagesManifestEntries } =
+    NextBuildContext
+
+  for (const key of Object.keys(serializedPagesManifestEntries || {})) {
+    Object.assign(
+      (pagesPluginModule as any)[key],
+      (serializedPagesManifestEntries as any)?.[key]
+    )
+  }
+
+  if (serializedFlightMaps) {
+    serializedFlightMaps.asyncClientModules?.forEach((item: any) =>
+      flightManifestPluginModule.ASYNC_CLIENT_MODULES.add(item)
+    )
+
+    for (const field of [
+      'injectedClientEntries',
+      'serverModuleIds',
+      'edgeServerModuleIds',
+    ]) {
+      for (const [key, value] of (serializedFlightMaps as any)[field] || []) {
+        ;(flightPluginModule as any)[field].set(key, value)
+      }
+    }
+  }
 
   /// load the config because it's not serializable
   NextBuildContext.config = await loadConfig(
@@ -303,30 +371,20 @@ async function workerMain() {
   )
   NextBuildContext.nextBuildSpan = trace('next-build')
 
-  try {
-    const result = await webpackBuildImpl()
-    const { entriesTrace } = result.turbotraceContext ?? {}
-    if (entriesTrace) {
-      const { entryNameMap, depModArray } = entriesTrace
-      if (depModArray) {
-        result.turbotraceContext!.entriesTrace!.depModArray = depModArray
-      }
-      if (entryNameMap) {
-        const entryEntries = Array.from(entryNameMap?.entries() ?? [])
-        // @ts-expect-error
-        result.turbotraceContext.entriesTrace.entryNameMap = entryEntries
-      }
+  const result = await webpackBuildImpl(workerData.compilerIdx)
+  const { entriesTrace } = result.turbotraceContext ?? {}
+  if (entriesTrace) {
+    const { entryNameMap, depModArray } = entriesTrace
+    if (depModArray) {
+      result.turbotraceContext!.entriesTrace!.depModArray = depModArray
     }
-    parentPort!.postMessage(JSON.stringify(result))
-  } catch (e) {
-    parentPort!.postMessage(e)
-  } finally {
-    process.exit(0)
+    if (entryNameMap) {
+      const entryEntries = Array.from(entryNameMap?.entries() ?? [])
+      // @ts-expect-error
+      result.turbotraceContext.entriesTrace.entryNameMap = entryEntries
+    }
   }
-}
-
-if (!isMainThread) {
-  workerMain()
+  return result
 }
 
 async function webpackBuildWithWorker() {
@@ -337,49 +395,94 @@ async function webpackBuildWithWorker() {
     nextBuildSpan,
     ...prunedBuildContext
   } = NextBuildContext
-  const worker = new Worker(new URL(import.meta.url), {
-    workerData: {
-      buildContext: prunedBuildContext,
-    },
-  })
 
-  const result = JSON.parse(
-    await new Promise((resolve, reject) => {
-      worker.on('message', (data) => {
-        if (data instanceof Error) {
-          reject(data)
-        } else {
-          resolve(data)
-        }
-      })
-      worker.on('error', reject)
-      worker.on('exit', (code) => {
-        if (code !== 0) {
-          reject(new Error(`Worker stopped with exit code ${code}`))
-        }
-      })
-    })
-  ) as {
-    duration: number
-    turbotraceContext?: TurbotraceContext
+  const getWorker = () => {
+    const _worker = new Worker(__filename, {
+      exposedMethods: ['workerMain'],
+      numWorkers: 1,
+      forkOptions: {
+        env: {
+          ...process.env,
+          NEXT_PRIVATE_BUILD_WORKER: '1',
+        },
+      },
+    }) as Worker & { workerMain: typeof workerMain }
+    _worker.getStderr().pipe(process.stderr)
+    _worker.getStdout().pipe(process.stdout)
+    return _worker
   }
 
-  if (result.turbotraceContext?.entriesTrace) {
-    const { entryNameMap } = result.turbotraceContext.entriesTrace
-    if (entryNameMap) {
-      result.turbotraceContext.entriesTrace.entryNameMap = new Map(entryNameMap)
+  const combinedResult = {
+    duration: 0,
+    turbotraceContext: {} as any,
+  }
+
+  for (let i = 1; i < 4; i++) {
+    const worker = getWorker()
+    const curResult = await worker.workerMain({
+      buildContext: prunedBuildContext,
+      compilerIdx: i,
+    })
+    // destroy worker so it's not sticking around using memory
+    await worker.end()
+
+    prunedBuildContext.serializedFlightMaps = {
+      injectedClientEntries: [
+        ...(prunedBuildContext.serializedFlightMaps?.injectedClientEntries ||
+          []),
+        ...curResult.serializedFlightMaps?.injectedClientEntries,
+      ],
+      serverModuleIds: [
+        ...(prunedBuildContext.serializedFlightMaps?.serverModuleIds || []),
+        ...curResult.serializedFlightMaps?.serverModuleIds,
+      ],
+      edgeServerModuleIds: [
+        ...(prunedBuildContext.serializedFlightMaps?.edgeServerModuleIds || []),
+        ...curResult.serializedFlightMaps?.edgeServerModuleIds,
+      ],
+      asyncClientModules: [
+        ...(prunedBuildContext.serializedFlightMaps?.asyncClientModules || []),
+        ...curResult.serializedFlightMaps?.asyncClientModules,
+      ],
+    }
+    prunedBuildContext.serializedPagesManifestEntries = {
+      edgeServerAppPaths:
+        curResult.serializedPagesManifestEntries?.edgeServerAppPaths,
+      edgeServerPages:
+        curResult.serializedPagesManifestEntries?.edgeServerPages,
+      nodeServerAppPaths:
+        curResult.serializedPagesManifestEntries?.nodeServerAppPaths,
+      nodeServerPages:
+        curResult.serializedPagesManifestEntries?.nodeServerPages,
+    }
+
+    combinedResult.duration += curResult.duration
+
+    if (curResult.turbotraceContext?.entriesTrace) {
+      combinedResult.turbotraceContext = curResult.turbotraceContext
+
+      const { entryNameMap } = combinedResult.turbotraceContext.entriesTrace
+      if (entryNameMap) {
+        combinedResult.turbotraceContext.entriesTrace.entryNameMap = new Map(
+          entryNameMap
+        )
+      }
     }
   }
+  buildSpinner?.stopAndPersist()
+  Log.info('Compiled successfully')
 
-  return result
+  return combinedResult
 }
 
 export async function webpackBuild() {
   const config = NextBuildContext.config!
 
   if (config.experimental.webpackBuildWorker) {
+    debug('using separate compiler workers')
     return await webpackBuildWithWorker()
   } else {
+    debug('building all compilers in same process')
     return await webpackBuildImpl()
   }
 }

--- a/packages/next/src/build/webpack-build.ts
+++ b/packages/next/src/build/webpack-build.ts
@@ -368,7 +368,10 @@ export async function workerMain(workerData: {
       'serverCSSManifest',
       'edgeServerCSSManifest',
     ]) {
-      ;(flightPluginModule as any)[field] = (serializedFlightMaps as any)[field]
+      Object.assign(
+        (flightPluginModule as any)[field],
+        (serializedFlightMaps as any)[field]
+      )
     }
   }
 
@@ -455,10 +458,18 @@ async function webpackBuildWithWorker() {
         ...(prunedBuildContext.serializedFlightMaps?.asyncClientModules || []),
         ...curResult.serializedFlightMaps?.asyncClientModules,
       ],
-      serverActions: curResult.serializedFlightMaps?.serverActions,
-      serverCSSManifest: curResult.serializedFlightMaps?.serverCSSManifest,
-      edgeServerCSSManifest:
-        curResult.serializedFlightMaps?.edgeServerCSSManifest,
+      serverActions: {
+        ...prunedBuildContext.serializedFlightMaps?.serverActions,
+        ...curResult.serializedFlightMaps?.serverActions,
+      },
+      serverCSSManifest: {
+        ...prunedBuildContext.serializedFlightMaps?.serverCSSManifest,
+        ...curResult.serializedFlightMaps?.serverCSSManifest,
+      },
+      edgeServerCSSManifest: {
+        ...prunedBuildContext.serializedFlightMaps?.edgeServerCSSManifest,
+        ...curResult.serializedFlightMaps?.edgeServerCSSManifest,
+      },
     }
     prunedBuildContext.serializedPagesManifestEntries = {
       edgeServerAppPaths:

--- a/packages/next/src/build/webpack-build.ts
+++ b/packages/next/src/build/webpack-build.ts
@@ -171,7 +171,7 @@ async function webpackBuildImpl(compilerIdx?: number): Promise<{
     let edgeServerResult: UnwrapPromise<ReturnType<typeof runCompiler>> | null =
       null
 
-    if (!compilerIdx || compilerIdx == 1) {
+    if (!compilerIdx || compilerIdx === 1) {
       serverResult = await runCompiler(serverConfig, {
         runWebpackSpan,
       })

--- a/packages/next/src/build/webpack-build.ts
+++ b/packages/next/src/build/webpack-build.ts
@@ -315,6 +315,9 @@ async function webpackBuildImpl(compilerIdx?: number): Promise<{
         asyncClientModules: Array.from(
           flightManifestPluginModule.ASYNC_CLIENT_MODULES
         ),
+        serverActions: flightPluginModule.serverActions,
+        serverCSSManifest: flightPluginModule.serverCSSManifest,
+        edgeServerCSSManifest: flightPluginModule.edgeServerCSSManifest,
       },
       serializedPagesManifestEntries: {
         edgeServerPages: pagesPluginModule.edgeServerPages,
@@ -358,6 +361,14 @@ export async function workerMain(workerData: {
       for (const [key, value] of (serializedFlightMaps as any)[field] || []) {
         ;(flightPluginModule as any)[field].set(key, value)
       }
+    }
+
+    for (const field of [
+      'serverActions',
+      'serverCSSManifest',
+      'edgeServerCSSManifest',
+    ]) {
+      ;(flightPluginModule as any)[field] = (serializedFlightMaps as any)[field]
     }
   }
 
@@ -444,6 +455,10 @@ async function webpackBuildWithWorker() {
         ...(prunedBuildContext.serializedFlightMaps?.asyncClientModules || []),
         ...curResult.serializedFlightMaps?.asyncClientModules,
       ],
+      serverActions: curResult.serializedFlightMaps?.serverActions,
+      serverCSSManifest: curResult.serializedFlightMaps?.serverCSSManifest,
+      edgeServerCSSManifest:
+        curResult.serializedFlightMaps?.edgeServerCSSManifest,
     }
     prunedBuildContext.serializedPagesManifestEntries = {
       edgeServerAppPaths:

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -41,7 +41,7 @@ interface Options {
 
 const PLUGIN_NAME = 'ClientEntryPlugin'
 
-export const injectedClientEntries = new Map()
+export const injectedClientEntries = new Map<string, string>()
 
 export const serverModuleIds = new Map<string, string | number>()
 export const edgeServerModuleIds = new Map<string, string | number>()

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -55,9 +55,9 @@ export type ActionManifest = {
 }
 
 // A map to track "action" -> "list of bundles".
-let serverActions: ActionManifest = {}
-let serverCSSManifest: FlightCSSManifest = {}
-let edgeServerCSSManifest: FlightCSSManifest = {}
+export let serverActions: ActionManifest = {}
+export let serverCSSManifest: FlightCSSManifest = {}
+export let edgeServerCSSManifest: FlightCSSManifest = {}
 
 export class FlightClientEntryPlugin {
   dev: boolean

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -55,9 +55,9 @@ export type ActionManifest = {
 }
 
 // A map to track "action" -> "list of bundles".
-export let serverActions: ActionManifest = {}
-export let serverCSSManifest: FlightCSSManifest = {}
-export let edgeServerCSSManifest: FlightCSSManifest = {}
+export const serverActions: ActionManifest = {}
+export const serverCSSManifest: FlightCSSManifest = {}
+export const edgeServerCSSManifest: FlightCSSManifest = {}
 
 export class FlightClientEntryPlugin {
   dev: boolean
@@ -274,7 +274,6 @@ export class FlightClientEntryPlugin {
       )
 
       // Create action entry
-      serverActions = {}
       if (actionEntryImports.size > 0) {
         addActionEntryList.push(
           this.injectActionEntry({
@@ -292,11 +291,6 @@ export class FlightClientEntryPlugin {
     // by the certain chunk.
     compilation.hooks.afterOptimizeModules.tap(PLUGIN_NAME, () => {
       const cssImportsForChunk: Record<string, Set<string>> = {}
-      if (this.isEdgeServer) {
-        edgeServerCSSManifest = {}
-      } else {
-        serverCSSManifest = {}
-      }
 
       let cssManifest = this.isEdgeServer
         ? edgeServerCSSManifest

--- a/packages/next/src/build/webpack/plugins/pages-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/pages-manifest-plugin.ts
@@ -8,10 +8,10 @@ import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-s
 
 export type PagesManifest = { [page: string]: string }
 
-let edgeServerPages = {}
-let nodeServerPages = {}
-let edgeServerAppPaths = {}
-let nodeServerAppPaths = {}
+export let edgeServerPages = {}
+export let nodeServerPages = {}
+export let edgeServerAppPaths = {}
+export let nodeServerAppPaths = {}
 
 // This plugin creates a pages-manifest.json from page entrypoints.
 // This is used for mapping paths like `/` to `.next/server/static/<buildid>/pages/index.js` when doing SSR


### PR DESCRIPTION
This updates our experimental `webpackBuildWorker` config to use separate process for each compilation to reduce memory usage building up from all compilers sharing same process. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04S835KUC9)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

