### PR TITLE
Fix static to dynamic on revalidate

### DIFF
--- a/packages/next/src/client/components/static-generation-async-storage.ts
+++ b/packages/next/src/client/components/static-generation-async-storage.ts
@@ -6,6 +6,7 @@ export interface StaticGenerationStore {
   readonly pathname: string
   readonly incrementalCache?: import('../../server/lib/incremental-cache').IncrementalCache
   readonly isRevalidate?: boolean
+  readonly isPrerendering?: boolean
 
   forceDynamic?: boolean
   revalidate?: false | number

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -385,6 +385,7 @@ export default async function exportPage({
             `http://localhost:3000${req.url}`
           )
           const staticContext: StaticGenerationContext = {
+            nextExport: true,
             supportsDynamicHTML: false,
             incrementalCache: curRenderOpts.incrementalCache,
           }

--- a/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
@@ -10,6 +10,7 @@ export type RequestContext = {
     supportsDynamicHTML: boolean
     isRevalidate?: boolean
     isBot?: boolean
+    nextExport?: boolean
   }
 }
 
@@ -53,6 +54,7 @@ export class StaticGenerationAsyncStorageWrapper
       pathname,
       incrementalCache: renderOpts.incrementalCache,
       isRevalidate: renderOpts.isRevalidate,
+      isPrerendering: renderOpts.nextExport,
     }
     ;(renderOpts as any).store = store
 

--- a/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
+++ b/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
@@ -94,6 +94,7 @@ export type AppRouteModule = {
 export type StaticGenerationContext = {
   incrementalCache?: IncrementalCache
   supportsDynamicHTML: boolean
+  nextExport?: boolean
 }
 
 /**

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -78,10 +78,12 @@ export function patchFetch({
         getRequestMeta('method')?.toLowerCase() || 'get'
       )
 
+      const autoNoCache = hasUnCacheableHeader || isUnCacheableMethod
+
       if (typeof revalidate === 'undefined') {
         // if there are uncacheable headers and the cache value
         // wasn't overridden then we must bail static generation
-        if (hasUnCacheableHeader || isUnCacheableMethod) {
+        if (autoNoCache) {
           revalidate = 0
         } else {
           revalidate =
@@ -93,9 +95,12 @@ export function patchFetch({
       }
 
       if (
-        typeof staticGenerationStore.revalidate === 'undefined' ||
-        (typeof revalidate === 'number' &&
-          revalidate < staticGenerationStore.revalidate)
+        // we don't consider autoNoCache to switch to dynamic during
+        // revalidate although if it occurs during build we do
+        (!autoNoCache || !staticGenerationStore.isRevalidate) &&
+        (typeof staticGenerationStore.revalidate === 'undefined' ||
+          (typeof revalidate === 'number' &&
+            revalidate < staticGenerationStore.revalidate))
       ) {
         staticGenerationStore.revalidate = revalidate
       }

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -97,7 +97,7 @@ export function patchFetch({
       if (
         // we don't consider autoNoCache to switch to dynamic during
         // revalidate although if it occurs during build we do
-        (!autoNoCache || !staticGenerationStore.isRevalidate) &&
+        (!autoNoCache || staticGenerationStore.isPrerendering) &&
         (typeof staticGenerationStore.revalidate === 'undefined' ||
           (typeof revalidate === 'number' &&
             revalidate < staticGenerationStore.revalidate))

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -58,6 +58,9 @@ createNextDescribe(
           'force-static/page.js',
           'force-static/second.html',
           'force-static/second.rsc',
+          'gen-params-dynamic-revalidate/[slug]/page.js',
+          'gen-params-dynamic-revalidate/one.html',
+          'gen-params-dynamic-revalidate/one.rsc',
           'gen-params-dynamic/[slug]/page.js',
           'hooks/use-pathname/[slug]/page.js',
           'hooks/use-pathname/slug.html',
@@ -191,6 +194,11 @@ createNextDescribe(
             initialRevalidateSeconds: false,
             srcRoute: '/force-static/[slug]',
           },
+          '/gen-params-dynamic-revalidate/one': {
+            dataRoute: '/gen-params-dynamic-revalidate/one.rsc',
+            initialRevalidateSeconds: 3,
+            srcRoute: '/gen-params-dynamic-revalidate/[slug]',
+          },
           '/ssg-preview': {
             dataRoute: '/ssg-preview.rsc',
             initialRevalidateSeconds: false,
@@ -245,6 +253,16 @@ createNextDescribe(
             dataRouteRegex: '^\\/dynamic\\-error\\/([^\\/]+?)\\.rsc$',
             fallback: null,
             routeRegex: '^\\/dynamic\\-error\\/([^\\/]+?)(?:\\/)?$',
+          },
+          '/gen-params-dynamic-revalidate/[slug]': {
+            dataRoute: '/gen-params-dynamic-revalidate/[slug].rsc',
+            dataRouteRegex: normalizeRegEx(
+              '^\\/gen\\-params\\-dynamic\\-revalidate\\/([^\\/]+?)\\.rsc$'
+            ),
+            fallback: null,
+            routeRegex: normalizeRegEx(
+              '^\\/gen\\-params\\-dynamic\\-revalidate\\/([^\\/]+?)(?:\\/)?$'
+            ),
           },
           '/hooks/use-pathname/[slug]': {
             dataRoute: '/hooks/use-pathname/[slug].rsc',
@@ -791,6 +809,26 @@ createNextDescribe(
             .text()
         ).not.toBe(data)
       }
+    })
+
+    it('should not error with generateStaticParams and authed data on revalidate', async () => {
+      const res = await next.fetch('/gen-params-dynamic-revalidate/one')
+      const html = await res.text()
+      expect(res.status).toBe(200)
+      expect(html).toContain('gen-params-dynamic/[slug]')
+      expect(html).toContain('one')
+      const initData = cheerio.load(html)('#data').text()
+
+      await check(async () => {
+        const res2 = await next.fetch('/gen-params-dynamic-revalidate/one')
+
+        expect(res2.status).toBe(200)
+
+        const $ = cheerio.load(await res2.text())
+        expect($('#data').text()).toBeTruthy()
+        expect($('#data').text()).not.toBe(initData)
+        return 'success'
+      }, 'success')
     })
 
     it('should honor dynamic = "force-static" correctly', async () => {

--- a/test/e2e/app-dir/app-static/app/gen-params-dynamic-revalidate/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/gen-params-dynamic-revalidate/[slug]/page.js
@@ -1,0 +1,42 @@
+export const revalidate = 3
+
+export async function generateStaticParams() {
+  return [{ slug: 'one' }]
+}
+
+const fetchRetry = async (url, init) => {
+  for (let i = 0; i < 5; i++) {
+    try {
+      return await fetch(url, init)
+    } catch (err) {
+      if (i === 4) {
+        throw err
+      }
+      console.log(`Failed to fetch`, err, `retrying...`)
+    }
+  }
+}
+
+export default async function page({ params }) {
+  const { slug } = params
+  let data
+
+  if (process.env.NEXT_PHASE !== 'phase-production-build') {
+    data = await fetchRetry(
+      'https://next-data-api-endpoint.vercel.app/api/random',
+      {
+        headers: {
+          Authorization: 'Bearer my-token',
+        },
+      }
+    ).then((res) => res.text())
+  }
+
+  return (
+    <>
+      <p id="page">/gen-params-dynamic/[slug]</p>
+      <p id="slug">{slug}</p>
+      <p id="data">{data}</p>
+    </>
+  )
+}


### PR DESCRIPTION
Since it's perfectly valid to do an authorized request during revalidate we shouldn't consider this a reason to throw the static to dynamic error during runtime. If an authorized request is done during build and caching isn't enabled for a path it will still bail from being turned into a Prerender. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1677734108126679)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

