### PR TITLE
Fix custom server error handling in the docs

### DIFF
--- a/docs/advanced-features/custom-server.md
+++ b/docs/advanced-features/custom-server.md
@@ -53,8 +53,9 @@ app.prepare().then(() => {
       res.statusCode = 500
       res.end('internal server error')
     }
-  }).listen(port, (err) => {
-    if (err) throw err
+  }).once('error', (err) => {
+    throw err
+  }).listen(port, () => {
     console.log(`> Ready on http://${hostname}:${port}`)
   })
 })

--- a/docs/advanced-features/custom-server.md
+++ b/docs/advanced-features/custom-server.md
@@ -55,7 +55,8 @@ app.prepare().then(() => {
     }
   })
     .once('error', (err) => {
-      throw err
+      console.error(err)
+      process.exit(1)
     })
     .listen(port, () => {
       console.log(`> Ready on http://${hostname}:${port}`)

--- a/docs/advanced-features/custom-server.md
+++ b/docs/advanced-features/custom-server.md
@@ -53,11 +53,13 @@ app.prepare().then(() => {
       res.statusCode = 500
       res.end('internal server error')
     }
-  }).once('error', (err) => {
-    throw err
-  }).listen(port, () => {
-    console.log(`> Ready on http://${hostname}:${port}`)
   })
+    .once('error', (err) => {
+      throw err
+    })
+    .listen(port, () => {
+      console.log(`> Ready on http://${hostname}:${port}`)
+    })
 })
 ```
 


### PR DESCRIPTION
The `.listen` callback doesn't receive an `error` argument. See https://nodejs.org/api/http.html#serverlisten
