### PR TITLE
Fix Link from pages to app folder adds default locale to path

### DIFF
--- a/test/e2e/app-dir/pages-to-app-routing/next.config.js
+++ b/test/e2e/app-dir/pages-to-app-routing/next.config.js
@@ -3,6 +3,10 @@
  */
 const nextConfig = {
   experimental: { appDir: true },
+  i18n: {
+    locales: ['es', 'en'],
+    defaultLocale: 'es',
+  },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
+++ b/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
@@ -19,5 +19,17 @@ createNextDescribe(
 
       expect(await browser.elementByCss('#app-page').text()).toBe('About')
     })
+
+    it('should not add default locale as base path', async () => {
+      const browser = await next.browser('/')
+
+      await browser
+        .elementByCss('#home-to-about')
+        .click()
+        .waitForElementByCss('#app-page')
+
+      expect(await browser.elementByCss('#app-page').text()).toBe('About')
+      expect(await browser.url()).toBe(`${next.url}/about`)
+    })
   }
 )

--- a/test/e2e/app-dir/pages-to-app-routing/pages/index.js
+++ b/test/e2e/app-dir/pages-to-app-routing/pages/index.js
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      <Link id="home-to-about" href="/about">
+        About
+      </Link>
+    </div>
+  )
+}

--- a/test/integration/eslint/test/index.test.js
+++ b/test/integration/eslint/test/index.test.js
@@ -315,6 +315,17 @@ describe('ESLint', () => {
         expect(output).toContain('Cancel')
       })
 
+      test('should generate next-env.d.ts before lint command', async () => {
+        await nextLint(dirBaseDirectories, [], {
+          stdout: true,
+          stderr: true,
+        })
+
+        const files = await fs.readdir(dirBaseDirectories)
+
+        expect(files).toContain('next-env.d.ts')
+      })
+
       for (const { packageManger, lockFile } of [
         { packageManger: 'yarn', lockFile: 'yarn.lock' },
         { packageManger: 'pnpm', lockFile: 'pnpm-lock.yaml' },


### PR DESCRIPTION
related to #46426 

This PR trying to fix wrongly added default locale to path when click a link in pages folder to app folder.

But I have investigated Link component / router / build process, cannot find the root cause, just create the e2e test to reproduce the issue, may need some help for this 😣 

if any one think this PR is useless can kindly create a new one and delete this, I will do some further investigate on this when I have more time ⌛ 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)