### PR TITLE
Add build worker exit tracking and enable tests

### DIFF
--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -4,6 +4,7 @@ module.exports = {
     sri: {
       algorithm: 'sha256',
     },
+    webpackBuildWorker: true,
   },
   // output: 'standalone',
   rewrites: async () => {

--- a/test/e2e/middleware-general/app/next.config.js
+++ b/test/e2e/middleware-general/app/next.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  experimental: {
+    webpackBuildWorker: true,
+  },
   i18n: {
     locales: ['en', 'fr', 'nl'],
     defaultLocale: 'en',


### PR DESCRIPTION
Ensures we properly log when a compilation worker unexpectedly exits and ensures we enable the flag for some test suites to ensure it's covered. 

x-ref: https://github.com/vercel/next.js/pull/46666
x-ref: [slack thread](https://vercel.slack.com/archives/C04S835KUC9/p1677777414887749?thread_ts=1677775341.172509&cid=C04S835KUC9)

