### PR TITLE
Update static build workers

### DIFF
--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -1,5 +1,5 @@
+import { ChildProcess } from 'child_process'
 import { Worker as JestWorker } from 'next/dist/compiled/jest-worker'
-
 type FarmOptions = ConstructorParameters<typeof JestWorker>[1]
 
 const RESTARTED = Symbol('restarted')
@@ -24,10 +24,35 @@ export class Worker {
     this._worker = undefined
 
     const createWorker = () => {
-      this._worker = new JestWorker(workerPath, farmOptions) as JestWorker
+      this._worker = new JestWorker(workerPath, {
+        ...farmOptions,
+        forkOptions: {
+          ...farmOptions.forkOptions,
+          env: {
+            ...((farmOptions.forkOptions?.env || {}) as any),
+            ...process.env,
+            // we don't pass down NODE_OPTIONS as it can
+            // extra memory usage
+            NODE_OPTIONS: '',
+          } as any,
+        },
+      }) as JestWorker
       restartPromise = new Promise(
         (resolve) => (resolveRestartPromise = resolve)
       )
+
+      for (const worker of ((this._worker as any)._workerPool?._workers ||
+        []) as {
+        _child: ChildProcess
+      }[]) {
+        worker._child.on('exit', (code, signal) => {
+          if (code || signal) {
+            console.error(
+              `Static worker unexpectedly exited with code: ${code} and signal: ${signal}`
+            )
+          }
+        })
+      }
 
       this._worker.getStdout().pipe(process.stdout)
       this._worker.getStderr().pipe(process.stderr)

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -1,5 +1,6 @@
 import { ChildProcess } from 'child_process'
 import { Worker as JestWorker } from 'next/dist/compiled/jest-worker'
+import { getNodeOptionsWithoutInspect } from '../server/lib/utils'
 type FarmOptions = ConstructorParameters<typeof JestWorker>[1]
 
 const RESTARTED = Symbol('restarted')
@@ -33,7 +34,9 @@ export class Worker {
             ...process.env,
             // we don't pass down NODE_OPTIONS as it can
             // extra memory usage
-            NODE_OPTIONS: '',
+            NODE_OPTIONS: getNodeOptionsWithoutInspect()
+              .replace(/--max-old-space-size=[\d]{1,}/, '')
+              .trim(),
           } as any,
         },
       }) as JestWorker


### PR DESCRIPTION
Ensures we log when a static build worker exits unexpectedly and fixes passing down `NODE_OPTIONS` unconditionally as this can cause too much memory to be leveraged when it shouldn't be. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04S835KUC9/p1677788484200189)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

