### PR TITLE
Disallow wildcard export in server entries

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -464,6 +464,9 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                             disallowed_export_span = *span;
                         }
                     },
+                    ModuleItem::ModuleDecl(ModuleDecl::ExportAll(ExportAll { span, .. })) => {
+                        disallowed_export_span = *span;
+                    }
                     _ => {}
                 }
 

--- a/packages/next-swc/crates/core/tests/errors/server-actions/5/input.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/5/input.js
@@ -1,0 +1,3 @@
+'use server';
+
+export * from 'foo'

--- a/packages/next-swc/crates/core/tests/errors/server-actions/5/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/5/output.js
@@ -1,0 +1,1 @@
+/* __next_internal_action_entry_do_not_use__  */ export * from 'foo';

--- a/packages/next-swc/crates/core/tests/errors/server-actions/5/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/5/output.stderr
@@ -1,0 +1,7 @@
+
+  x Only async functions are allowed to be exported in a "use server" file.
+   ,-[input.js:2:1]
+ 2 | 
+ 3 | export * from 'foo'
+   : ^^^^^^^^^^^^^^^^^^^
+   `----


### PR DESCRIPTION
Similar to client entry files, we don't allow `export *` in server entries as well because we can't statically analyze all the export types in SWC.

Fixes NEXT-490

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
