### PR TITLE
Adjust API route loader (#46726

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -792,7 +792,7 @@ export default async function getBaseWebpackConfig(
     babel: useSWCLoader ? getSwcLoader() : getBabelLoader(),
   }
 
-  const swcLoaderForRSC = hasServerComponents
+  const swcLoaderForServerLayer = hasServerComponents
     ? useSWCLoader
       ? getSwcLoader({ isServerLayer: true })
       : // When using Babel, we will have to add the SWC loader
@@ -804,14 +804,13 @@ export default async function getBaseWebpackConfig(
 
   // Loader for API routes needs to be differently configured as it shouldn't
   // have RSC transpiler enabled, so syntax checks such as invalid imports won't
-  // be performed. However, it still needs to use the "react-server" condition
-  // to make isomorphic dependencies work.
+  // be performed.
   const loaderForAPIRoutes =
     hasServerComponents && useSWCLoader
       ? {
           loader: 'next-swc-loader',
           options: {
-            ...getSwcLoader({ isServerLayer: true }).options,
+            ...getSwcLoader().options,
             hasServerComponents: false,
           },
         }
@@ -1886,9 +1885,6 @@ export default async function getBaseWebpackConfig(
                 url: true,
               },
               use: loaderForAPIRoutes,
-              resolve: {
-                conditionNames: reactServerCondition,
-              },
             },
             {
               ...codeCondition,
@@ -1901,12 +1897,12 @@ export default async function getBaseWebpackConfig(
                     test: codeCondition.test,
                     issuerLayer: WEBPACK_LAYERS.server,
                     exclude: [staticGenerationAsyncStorageRegex],
-                    use: swcLoaderForRSC,
+                    use: swcLoaderForServerLayer,
                   },
                   {
                     test: codeCondition.test,
                     resourceQuery: /__edge_ssr_entry__/,
-                    use: swcLoaderForRSC,
+                    use: swcLoaderForServerLayer,
                   },
                 ]
               : []),

--- a/test/e2e/app-dir/rsc-basic/pages/api/import-test.js
+++ b/test/e2e/app-dir/rsc-basic/pages/api/import-test.js
@@ -1,0 +1,9 @@
+// You can still import React and Next's client component APIs from the server
+// they won't be poisoned by the environment.
+// eslint-disable-next-line no-unused-vars
+import { useState } from 'react'
+import 'next/headers'
+
+export default function (_, res) {
+  res.end('Hello from import-test.js')
+}

--- a/test/e2e/app-dir/rsc-basic/pages/api/server-only.js
+++ b/test/e2e/app-dir/rsc-basic/pages/api/server-only.js
@@ -1,0 +1,9 @@
+import 'server-only'
+
+// You can still import React's client component APIs from the server - it won't
+// be poisoned by the environment.
+import { useState } from 'react'
+
+export default function (_, res) {
+  res.end('Hello from server-only.js')
+}

--- a/test/e2e/app-dir/rsc-basic/pages/api/server-only.js
+++ b/test/e2e/app-dir/rsc-basic/pages/api/server-only.js
@@ -1,9 +1,0 @@
-import 'server-only'
-
-// You can still import React's client component APIs from the server - it won't
-// be poisoned by the environment.
-import { useState } from 'react'
-
-export default function (_, res) {
-  res.end('Hello from server-only.js')
-}

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -431,9 +431,9 @@ describe('app dir - rsc basics', () => {
     })
   })
 
-  it('should support server-only in pages/api', async () => {
-    const res = await next.fetch('/api/server-only')
-    expect(await res.text()).toBe('Hello from server-only.js')
+  it('should not apply rsc syntax checks in pages/api', async () => {
+    const res = await next.fetch('/api/import-test')
+    expect(await res.text()).toBe('Hello from import-test.js')
   })
 
   // disable this flaky test

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -35,6 +35,7 @@ describe('app dir - rsc basics', () => {
         'styled-components': '6.0.0-beta.5',
         react: 'latest',
         'react-dom': 'latest',
+        'server-only': 'latest',
       },
       packageJson: {
         scripts: {
@@ -428,6 +429,11 @@ describe('app dir - rsc basics', () => {
       expect(gotData).toBe(true)
       expect(gotInlinedData).toBe(true)
     })
+  })
+
+  it('should support server-only in pages/api', async () => {
+    const res = await next.fetch('/api/server-only')
+    expect(await res.text()).toBe('Hello from server-only.js')
   })
 
   // disable this flaky test


### PR DESCRIPTION
Similar to #46328 but with `hasServerComponents: false` for the compiler so RSC syntax constrains don't apply here.

Note that since we don’t bundle external modules in API routes, we can't resolve to `react-server` so that one will be tricky.

Fixes NEXT-625

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
