### PR TITLE
Fix originalRequest not available for edge requests

### DIFF
--- a/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
@@ -10,6 +10,7 @@ import {
 } from '../app-render'
 import { AsyncStorageWrapper } from './async-storage-wrapper'
 import type { tryGetPreviewData } from '../api-utils/node'
+import type { BaseNextRequest, BaseNextResponse } from '../base-http'
 
 function headersWithoutFlight(headers: IncomingHttpHeaders) {
   const newHeaders = { ...headers }
@@ -20,8 +21,8 @@ function headersWithoutFlight(headers: IncomingHttpHeaders) {
 }
 
 export type RequestContext = {
-  req: IncomingMessage
-  res: ServerResponse
+  req: IncomingMessage | BaseNextRequest
+  res: ServerResponse | BaseNextResponse
   renderOpts?: RenderOpts
 }
 

--- a/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
+++ b/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
@@ -433,14 +433,19 @@ export class AppRouteRouteHandler implements RouteHandler<AppRouteRouteMatch> {
     // Get the handler function for the given method.
     const handle = this.resolve(req.method, module)
 
+    const requestContext: RequestContext =
+      process.env.NEXT_RUNTIME === 'edge'
+        ? { req, res }
+        : {
+            req: (req as NodeNextRequest).originalRequest,
+            res: (res as NodeNextResponse).originalResponse,
+          }
+
     // Run the handler with the request AsyncLocalStorage to inject the helper
     // support.
     const response = await this.requestAsyncLocalStorageWrapper.wrap(
       requestAsyncStorage,
-      {
-        req: (req as NodeNextRequest).originalRequest ?? request,
-        res: (res as NodeNextResponse).originalResponse,
-      },
+      requestContext,
       () =>
         this.staticAsyncLocalStorageWrapper.wrap(
           staticGenerationAsyncStorage,

--- a/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
+++ b/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
@@ -438,7 +438,7 @@ export class AppRouteRouteHandler implements RouteHandler<AppRouteRouteMatch> {
     const response = await this.requestAsyncLocalStorageWrapper.wrap(
       requestAsyncStorage,
       {
-        req: (req as NodeNextRequest).originalRequest,
+        req: (req as NodeNextRequest).originalRequest ?? request,
         res: (res as NodeNextResponse).originalResponse,
       },
       () =>

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -405,6 +405,16 @@ createNextDescribe(
         expect(res.status).toEqual(200)
         expect(await res.text()).toContain('hello, world')
       })
+
+      it('returns a response when headers are accessed', async () => {
+        const meta = { ping: 'pong' }
+        const res = await next.fetch('/edge/headers', {
+          headers: withRequestMeta(meta),
+        })
+
+        expect(res.status).toEqual(200)
+        expect(await res.json()).toEqual(meta)
+      })
     })
 
     describe('dynamic = "force-static"', () => {

--- a/test/e2e/app-dir/app-routes/app/edge/headers/route.ts
+++ b/test/e2e/app-dir/app-routes/app/edge/headers/route.ts
@@ -1,0 +1,10 @@
+import { headers } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { getRequestMeta } from '../../../helpers'
+
+export const runtime = 'experimental-edge'
+
+export function GET() {
+  const meta = getRequestMeta(headers())
+  return NextResponse.json(meta)
+}


### PR DESCRIPTION
For requests made via the edge runtime, they will not contain the `originalRequest` object used by the request storage to enable headers/cookie access. This uses the request object passed when in the edge runtime.
fix NEXT-763