### PR TITLE
Allow users to use webpack config types in `next.config.js`

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -100,7 +100,7 @@ export interface WebpackConfigContext {
   /** Number of total Next.js pages */
   totalPages: number
   /** The webpack configuration */
-  webpack: any
+  webpack: typeof webpack
   /** The current server runtime */
   nextRuntime?: 'nodejs' | 'edge'
 }
@@ -108,7 +108,7 @@ export interface WebpackConfigContext {
 export interface NextJsWebpackConfig {
   (
     /** Existing Webpack config */
-    config: any,
+    config: webpack.Configuration,
     context: WebpackConfigContext
   ): any
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
