### PR TITLE
Update client router filter to separate redirects handling

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -850,7 +850,9 @@ export default async function build(
         )
         const clientRouterFilters = createClientRouterFilter(
           appPageKeys,
-          nonInternalRedirects
+          config.experimental.clientRouterFilterRedirects
+            ? nonInternalRedirects
+            : []
         )
 
         NextBuildContext.clientRouterFilters = clientRouterFilters

--- a/packages/next/src/lib/create-client-router-filter.ts
+++ b/packages/next/src/lib/create-client-router-filter.ts
@@ -5,7 +5,7 @@ import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-
 import { Redirect } from './load-custom-routes'
 import { tryToParsePath } from './try-to-parse-path'
 
-const POTENTIAL_ERROR_RATE = 0.02
+const POTENTIAL_ERROR_RATE = 0.01
 
 export function createClientRouterFilter(
   paths: string[],

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -253,6 +253,9 @@ const configSchema = {
         clientRouterFilter: {
           type: 'boolean',
         },
+        clientRouterFilterRedirects: {
+          type: 'boolean',
+        },
         cpus: {
           type: 'number',
         },

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -115,6 +115,7 @@ export interface NextJsWebpackConfig {
 
 export interface ExperimentalConfig {
   clientRouterFilter?: boolean
+  clientRouterFilterRedirects?: boolean
   externalMiddlewareRewritesResolve?: boolean
   extensionAlias?: Record<string, any>
   allowedRevalidateHeaderKeys?: string[]
@@ -621,6 +622,7 @@ export const defaultConfig: NextConfig = {
   modularizeImports: undefined,
   experimental: {
     clientRouterFilter: false,
+    clientRouterFilterRedirects: false,
     preCompiledNextServer: false,
     fetchCacheKeyPrefix: '',
     middlewarePrefetch: 'flexible',

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -585,9 +585,11 @@ export default class DevServer extends Server {
         if (this.nextConfig.experimental.clientRouterFilter) {
           clientRouterFilters = createClientRouterFilter(
             Object.keys(appPaths),
-            ((this.nextConfig as any)._originalRedirects || []).filter(
-              (r: any) => !r.internal
-            )
+            this.nextConfig.experimental.clientRouterFilterRedirects
+              ? ((this.nextConfig as any)._originalRedirects || []).filter(
+                  (r: any) => !r.internal
+                )
+              : []
           )
 
           if (

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -1123,7 +1123,7 @@ export default class Router implements BaseRouter {
     // any time without notice.
     const isQueryUpdating = (options as any)._h === 1
 
-    if (!isQueryUpdating) {
+    if (!isQueryUpdating && !options.shallow) {
       await this._bfl(as, undefined, options.locale)
     }
 
@@ -1509,7 +1509,7 @@ export default class Router implements BaseRouter {
         isMiddlewareRewrite,
       })
 
-      if (!isQueryUpdating) {
+      if (!isQueryUpdating && !options.shallow) {
         await this._bfl(
           as,
           'resolvedAs' in routeInfo ? routeInfo.resolvedAs : undefined,

--- a/test/e2e/app-dir/app-middleware/next.config.js
+++ b/test/e2e/app-dir/app-middleware/next.config.js
@@ -2,5 +2,6 @@ module.exports = {
   experimental: {
     appDir: true,
     clientRouterFilter: true,
+    clientRouterFilterRedirects: true,
   },
 }

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -70,6 +70,16 @@ createNextDescribe(
       }
     )
 
+    it('should not apply client router filter on shallow', async () => {
+      const browser = await next.browser('/')
+      await browser.eval('window.beforeNav = 1')
+      await browser.eval(
+        `window.next.router.push('/', '/redirect-1', { shallow: true })`
+      )
+      await check(() => browser.eval('window.location.pathname'), '/redirect-1')
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+    })
+
     if (isDev) {
       it('should not have duplicate config warnings', async () => {
         await next.fetch('/')

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -73,10 +73,13 @@ createNextDescribe(
     it('should not apply client router filter on shallow', async () => {
       const browser = await next.browser('/')
       await browser.eval('window.beforeNav = 1')
-      await browser.eval(
-        `window.next.router.push('/', '/redirect-1', { shallow: true })`
-      )
-      await check(() => browser.eval('window.location.pathname'), '/redirect-1')
+
+      await check(async () => {
+        await browser.eval(
+          `window.next.router.push('/', '/redirect-1', { shallow: true })`
+        )
+        return await browser.eval('window.location.pathname')
+      }, '/redirect-1')
       expect(await browser.eval('window.beforeNav')).toBe(1)
     })
 

--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   experimental: {
     appDir: true,
+    clientRouterFilterRedirects: true,
     sri: {
       algorithm: 'sha256',
     },

--- a/test/e2e/middleware-redirects/app/next.config.js
+++ b/test/e2e/middleware-redirects/app/next.config.js
@@ -5,6 +5,7 @@ module.exports = {
   },
   experimental: {
     clientRouterFilter: true,
+    clientRouterFilterRedirects: true,
   },
   redirects() {
     return [


### PR DESCRIPTION
x-ref: [slack thread](https://vercel.slack.com/archives/C017QMYC5FB/p1677875647422339)
x-ref: [slack thread](https://vercel.slack.com/archives/C049YV4U2F6/p1677875992732789)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

