### PR TITLE
Pass through original matcher source in manifest

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -30,6 +30,7 @@ export interface MiddlewareMatcher {
   locale?: false
   has?: RouteHas[]
   missing?: RouteHas[]
+  originalSource: string
 }
 
 export interface PageStaticInfo {
@@ -197,6 +198,7 @@ export function getMiddlewareMatchers(
     return {
       ...rest,
       regexp: parsedPage.regexStr,
+      originalSource: source,
     }
   })
 }

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -416,7 +416,7 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
 
       if (isMiddlewareFile(page)) {
         middlewareMatchers = staticInfo.middleware?.matchers ?? [
-          { regexp: '.*', originalSource: '/' },
+          { regexp: '.*', originalSource: '/:path*' },
         ]
       }
 

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -416,7 +416,7 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
 
       if (isMiddlewareFile(page)) {
         middlewareMatchers = staticInfo.middleware?.matchers ?? [
-          { regexp: '.*' },
+          { regexp: '.*', originalSource: '/' },
         ]
       }
 

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -175,11 +175,16 @@ function getCreateAssets(params: {
         ? normalizeAppPath(page)
         : page
 
+      const catchAll = !metadata.edgeSSR && !metadata.edgeApiFunction
+
       const { namedRegex } = getNamedMiddlewareRegex(matcherSource, {
-        catchAll: !metadata.edgeSSR && !metadata.edgeApiFunction,
+        catchAll,
       })
       const matchers = metadata?.edgeMiddleware?.matchers ?? [
-        { regexp: namedRegex, originalSource: matcherSource },
+        {
+          regexp: namedRegex,
+          originalSource: page === '/' && catchAll ? '/:path*' : matcherSource,
+        },
       ]
 
       const edgeFunctionDefinition: EdgeFunctionDefinition = {

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -171,14 +171,15 @@ function getCreateAssets(params: {
         continue
       }
 
-      const { namedRegex } = getNamedMiddlewareRegex(
-        metadata.edgeSSR?.isAppDir ? normalizeAppPath(page) : page,
-        {
-          catchAll: !metadata.edgeSSR && !metadata.edgeApiFunction,
-        }
-      )
+      const matcherSource = metadata.edgeSSR?.isAppDir
+        ? normalizeAppPath(page)
+        : page
+
+      const { namedRegex } = getNamedMiddlewareRegex(matcherSource, {
+        catchAll: !metadata.edgeSSR && !metadata.edgeApiFunction,
+      })
       const matchers = metadata?.edgeMiddleware?.matchers ?? [
-        { regexp: namedRegex },
+        { regexp: namedRegex, originalSource: page },
       ]
 
       const edgeFunctionDefinition: EdgeFunctionDefinition = {

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -179,7 +179,7 @@ function getCreateAssets(params: {
         catchAll: !metadata.edgeSSR && !metadata.edgeApiFunction,
       })
       const matchers = metadata?.edgeMiddleware?.matchers ?? [
-        { regexp: namedRegex, originalSource: page },
+        { regexp: namedRegex, originalSource: matcherSource },
       ]
 
       const edgeFunctionDefinition: EdgeFunctionDefinition = {

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -491,7 +491,7 @@ export default class DevServer extends Server {
           if (isMiddlewareFile(rootFile)) {
             this.actualMiddlewareFile = rootFile
             middlewareMatchers = staticInfo.middleware?.matchers || [
-              { regexp: '.*' },
+              { regexp: '.*', originalSource: '/:path*' },
             ]
             continue
           }

--- a/packages/next/src/server/lib/route-resolver.ts
+++ b/packages/next/src/server/lib/route-resolver.ts
@@ -88,7 +88,7 @@ export async function makeResolver(
   if (middleware.files?.length) {
     const matchers = middleware.matcher
       ? getMiddlewareMatchers(middleware.matcher, nextConfig)
-      : [{ regexp: '.*' }]
+      : [{ regexp: '.*', originalSource: '/' }]
     // @ts-expect-error
     devServer.middleware = {
       page: '/',

--- a/packages/next/src/server/lib/route-resolver.ts
+++ b/packages/next/src/server/lib/route-resolver.ts
@@ -88,7 +88,7 @@ export async function makeResolver(
   if (middleware.files?.length) {
     const matchers = middleware.matcher
       ? getMiddlewareMatchers(middleware.matcher, nextConfig)
-      : [{ regexp: '.*', originalSource: '/' }]
+      : [{ regexp: '.*', originalSource: '/:path*' }]
     // @ts-expect-error
     devServer.middleware = {
       page: '/',

--- a/test/e2e/app-dir/app-edge/app-edge.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge.test.ts
@@ -61,6 +61,7 @@ createNextDescribe(
         expect(manifest.functions['/(group)/group/page'].matchers).toEqual([
           {
             regexp: '^/group$',
+            originalSource: '/group',
           },
         ])
       })

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -131,7 +131,7 @@ describe('Middleware Runtime', () => {
             ]),
             name: 'middleware',
             page: '/',
-            matchers: [{ regexp: '^/.*$' }],
+            matchers: [{ regexp: '^/.*$', originalSource: '/' }],
             wasm: [],
             assets: [],
             regions: 'auto',

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -109,7 +109,7 @@ describe('Middleware Runtime', () => {
           `/_next/static/${next.buildId}/_devMiddlewareManifest.json`
         )
         const matchers = await res.json()
-        expect(matchers).toEqual([{ regexp: '.*' }])
+        expect(matchers).toEqual([{ regexp: '.*', originalSource: '/:path*' }])
       })
     }
 

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -131,7 +131,7 @@ describe('Middleware Runtime', () => {
             ]),
             name: 'middleware',
             page: '/',
-            matchers: [{ regexp: '^/.*$', originalSource: '/' }],
+            matchers: [{ regexp: '^/.*$', originalSource: '/:path*' }],
             wasm: [],
             assets: [],
             regions: 'auto',

--- a/test/e2e/middleware-trailing-slash/test/index.test.ts
+++ b/test/e2e/middleware-trailing-slash/test/index.test.ts
@@ -115,7 +115,7 @@ describe('Middleware Runtime trailing slash', () => {
             name: 'middleware',
             env: [],
             page: '/',
-            matchers: [{ regexp: '^/.*$', originalSource: '/' }],
+            matchers: [{ regexp: '^/.*$', originalSource: '/:path*' }],
             wasm: [],
             assets: [],
           },

--- a/test/e2e/middleware-trailing-slash/test/index.test.ts
+++ b/test/e2e/middleware-trailing-slash/test/index.test.ts
@@ -115,7 +115,7 @@ describe('Middleware Runtime trailing slash', () => {
             name: 'middleware',
             env: [],
             page: '/',
-            matchers: [{ regexp: '^/.*$' }],
+            matchers: [{ regexp: '^/.*$', originalSource: '/' }],
             wasm: [],
             assets: [],
           },

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -631,7 +631,7 @@ describe('Switchable runtime', () => {
                 name: 'pages/api/hello',
                 page: '/api/hello',
                 matchers: [
-                  { regexp: '^/api/hello$', originalSource: '/api/edge' },
+                  { regexp: '^/api/hello$', originalSource: '/api/hello' },
                 ],
                 wasm: [],
               },

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -194,7 +194,9 @@ describe('Switchable runtime', () => {
                 ],
                 name: 'pages/api/hello',
                 page: '/api/hello',
-                matchers: [{ regexp: '^/api/hello$' }],
+                matchers: [
+                  { regexp: '^/api/hello$', originalSource: '/api/hello' },
+                ],
                 wasm: [],
               },
               '/api/edge': {
@@ -205,7 +207,9 @@ describe('Switchable runtime', () => {
                 ],
                 name: 'pages/api/edge',
                 page: '/api/edge',
-                matchers: [{ regexp: '^/api/edge$' }],
+                matchers: [
+                  { regexp: '^/api/edge$', originalSource: '/api/edge' },
+                ],
                 wasm: [],
               },
             },
@@ -626,7 +630,9 @@ describe('Switchable runtime', () => {
                 ],
                 name: 'pages/api/hello',
                 page: '/api/hello',
-                matchers: [{ regexp: '^/api/hello$' }],
+                matchers: [
+                  { regexp: '^/api/hello$', originalSource: '/api/edge' },
+                ],
                 wasm: [],
               },
               '/api/edge': {
@@ -637,7 +643,9 @@ describe('Switchable runtime', () => {
                 ],
                 name: 'pages/api/edge',
                 page: '/api/edge',
-                matchers: [{ regexp: '^/api/edge$' }],
+                matchers: [
+                  { regexp: '^/api/edge$', originalSource: '/api/edge' },
+                ],
                 wasm: [],
               },
             },


### PR DESCRIPTION
This ensures we pass through the original matcher source in the middleware manifest for posterity. 

