### PR TITLE
Support mdx-components file in src directory

### DIFF
--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -22,6 +22,7 @@ module.exports =
     return Object.assign({}, nextConfig, {
       webpack(config, options) {
         config.resolve.alias['next-mdx-import-source-file'] = [
+          'private-next-root-dir/src/mdx-components',
           'private-next-root-dir/mdx-components',
           '@mdx-js/react',
         ]


### PR DESCRIPTION
Adds additional alias for `/src/mdx-components` which makes the resolving:

- `/src/mdx-components`
- `/mdx-components`
- `@mdx-js/react` (this one doesn't support server components)

Fixes NEXT-515
Fixes #45748

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
