### PR TITLE
Fix redundant TS plugin warning

### DIFF
--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -196,10 +196,17 @@ export async function writeConfigurationDefaults(
   // Enable the Next.js typescript plugin.
   if (isAppDirEnabled) {
     if (userTsConfig.compilerOptions) {
+      // Check if the config or the resolved config has the plugin already.
+      const hasNextPlugin = [
+        ...(tsOptions.plugins as { name: string }[]),
+        ...userTsConfig.compilerOptions.plugins,
+      ].some(({ name }: { name: string }) => name === 'next')
+
       // If the TS config extends on another config, we can't add the `plugin` field
       // because that will override the parent config's plugins.
       // Instead we have to show a message to the user to add the plugin manually.
       if (
+        !hasNextPlugin &&
         'extends' in userTsConfig &&
         !('plugins' in userTsConfig.compilerOptions)
       ) {
@@ -210,22 +217,16 @@ export async function writeConfigurationDefaults(
             '"plugins": [{ "name": "next" }]'
           )}\`) manually to your TypeScript configuration. Learn more: https://beta.nextjs.org/docs/configuring/typescript#using-the-typescript-plugin\n`
         )
-      } else {
+      } else if (!hasNextPlugin) {
         if (!('plugins' in userTsConfig.compilerOptions)) {
           userTsConfig.compilerOptions.plugins = []
         }
-        if (
-          !userTsConfig.compilerOptions.plugins.some(
-            (plugin: { name: string }) => plugin.name === 'next'
-          )
-        ) {
-          userTsConfig.compilerOptions.plugins.push({ name: 'next' })
-          suggestedActions.push(
-            chalk.cyan('plugins') +
-              ' was updated to add ' +
-              chalk.bold(`{ name: 'next' }`)
-          )
-        }
+        userTsConfig.compilerOptions.plugins.push({ name: 'next' })
+        suggestedActions.push(
+          chalk.cyan('plugins') +
+            ' was updated to add ' +
+            chalk.bold(`{ name: 'next' }`)
+        )
       }
 
       // If `strict` is set to `false` or `strictNullChecks` is set to `false`,

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -198,8 +198,10 @@ export async function writeConfigurationDefaults(
     if (userTsConfig.compilerOptions) {
       // Check if the config or the resolved config has the plugin already.
       const hasNextPlugin = [
-        ...(tsOptions.plugins as { name: string }[]),
-        ...userTsConfig.compilerOptions.plugins,
+        ...(Array.isArray(tsOptions.plugins) ? tsOptions.plugins : []),
+        ...(Array.isArray(userTsConfig.compilerOptions.plugins)
+          ? userTsConfig.compilerOptions.plugins
+          : []),
       ].some(({ name }: { name: string }) => name === 'next')
 
       // If the TS config extends on another config, we can't add the `plugin` field


### PR DESCRIPTION
When the project's TS config extends another base configuration, and the Next.js TS plugin was configured there, we always output this message:

![CleanShot-2023-03-04-F5TcATto@2x](https://user-images.githubusercontent.com/3676859/222918715-6c2026f4-a96a-4c6b-9440-fc3d6075abb3.png)

This PR fixes that by checking the resolved TS options which contains plugins from parent configurations too.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
