### PR TITLE
Use set to track CSS imports

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -474,7 +474,7 @@ export class FlightClientEntryPlugin {
     const visitedBySegment: { [segment: string]: Set<string> } = {}
     const clientComponentImports: ClientComponentImports = []
     const actionImports: [string, string[]][] = []
-    const CSSImports: CssImports = {}
+    const CSSImports = new Set<string>()
 
     const filterClientComponents = (
       dependencyToFilter: any,
@@ -527,8 +527,7 @@ export class FlightClientEntryPlugin {
           }
         }
 
-        CSSImports[entryRequest] = CSSImports[entryRequest] || []
-        CSSImports[entryRequest].push(modRequest)
+        CSSImports.add(modRequest)
       }
 
       // Check if request is for css file.
@@ -567,7 +566,11 @@ export class FlightClientEntryPlugin {
 
     return {
       clientImports: clientComponentImports,
-      cssImports: CSSImports,
+      cssImports: CSSImports.size
+        ? {
+            [entryRequest]: Array.from(CSSImports),
+          }
+        : {},
       actionImports,
     }
   }


### PR DESCRIPTION
Noticed some duplicated CSS resources in a large application and confirmed that this fixes it.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
