### PR TITLE
Only check app/ for no-head-element-rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-head-element.ts
+++ b/packages/eslint-plugin-next/src/rules/no-head-element.ts
@@ -20,10 +20,8 @@ export = defineRule({
         const paths = context.getFilename()
 
         const isInAppDir = () =>
-          (paths.includes(`app${path.sep}`) ||
-            paths.includes(`app${path.posix.sep}`)) &&
-          !paths.includes(`pages${path.sep}`) &&
-          !paths.includes(`pages${path.posix.sep}`)
+          paths.includes(`app${path.sep}`) ||
+          paths.includes(`app${path.posix.sep}`)
         // Only lint the <head> element in pages directory
         if (node.name.name !== 'head' || isInAppDir()) {
           return


### PR DESCRIPTION
The reported issue has a `pages` directory above the application directory. We can't detect that in eslint but this rule can just be disabled if the file is in a directory called `app/` which in the worst case disables this rule instead of opts the rule in as with the reported issue.


Fixes NEXT-730
Fixes #46559

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
