### PR TITLE
update dynamic-import.md example

### DIFF
--- a/docs/advanced-features/dynamic-import.md
+++ b/docs/advanced-features/dynamic-import.md
@@ -23,7 +23,7 @@ By using `next/dynamic`, the header component will not be included in the page's
 import dynamic from 'next/dynamic'
 
 const DynamicHeader = dynamic(() => import('../components/header'), {
-  loading: () => 'Loading...',
+  loading: () => <p>Loading...</p>,
 })
 
 export default function Home() {


### PR DESCRIPTION
Because there is a TS error when is set just a string:
`TS2322: Type '() => string' is not assignable to type '(loadingProps: DynamicOptionsLoadingProps) => Element | null'.   Type 'string' is not assignable to type 'Element'.`
