### PR TITLE
fix(webpack): support cacheGroups for virtual fs(yarn berry)

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1575,7 +1575,7 @@ export default async function getBaseWebpackConfig(
               }): boolean {
                 return (
                   module.size() > 160000 &&
-                  /node_modules[/\\]/.test(module.nameForCondition() || '')
+                  /(?:node_modules|__virtual__)[/\\]/.test(module.nameForCondition() || '')
                 )
               },
               name(module: {

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1575,7 +1575,9 @@ export default async function getBaseWebpackConfig(
               }): boolean {
                 return (
                   module.size() > 160000 &&
-                  /(?:node_modules|__virtual__)[/\\]/.test(module.nameForCondition() || '')
+                  /(?:node_modules|__virtual__)[/\\]/.test(
+                    module.nameForCondition() || ''
+                  )
                 )
               },
               name(module: {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
