### PR TITLE
fix typo

### DIFF
--- a/docs/api-routes/edge-api-routes.md
+++ b/docs/api-routes/edge-api-routes.md
@@ -88,7 +88,7 @@ export default async function handler(req: NextRequest) {
 ### Forwarding Headers
 
 ```typescript
-import { type NextRequest } from 'next/server'
+import type { NextRequest } from 'next/server'
 
 export const config = {
   runtime: 'edge',


### PR DESCRIPTION
`import { type` to `import type {`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
