### PR TITLE
Change @next/font to next/font in examples

### DIFF
--- a/examples/app-dir-mdx/app/page.tsx
+++ b/examples/app-dir-mdx/app/page.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image'
-import { Inter } from '@next/font/google'
+import { Inter } from 'next/font/google'
 import styles from './page.module.css'
 import Content from './message.mdx'
 

--- a/examples/app-dir-mdx/package.json
+++ b/examples/app-dir-mdx/package.json
@@ -6,7 +6,6 @@
     "start": "next start"
   },
   "dependencies": {
-    "@next/font": "latest",
     "@next/mdx": "latest",
     "@types/mdx": "2.0.3",
     "@types/node": "18.11.18",

--- a/examples/with-sfcc/package.json
+++ b/examples/with-sfcc/package.json
@@ -6,7 +6,6 @@
     "start": "next start"
   },
   "dependencies": {
-    "@next/font": "latest",
     "commerce-sdk": "^2.8.0",
     "next": "latest",
     "react": "^18.2.0",

--- a/examples/with-sfcc/pages/_app.tsx
+++ b/examples/with-sfcc/pages/_app.tsx
@@ -1,7 +1,7 @@
 import '../styles/globals.css'
 import Footer from '../components/Footer'
 import Head from 'next/head'
-import { Montserrat } from '@next/font/google'
+import { Montserrat } from 'next/font/google'
 
 const montserrat = Montserrat({
   subsets: ['latin'],


### PR DESCRIPTION
Migrate examples using `@next/font` to `next/font`.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
