### PR TITLE
Fix build and server logic of handling special entires

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1475,14 +1475,6 @@ export default async function build(
                         isStatic = false
                         isSsg = false
                       } else {
-                        // If a page has action and it is static, we need to
-                        // change it to SSG to keep the worker created.
-                        // TODO: This is a workaround for now, we should have a
-                        // dedicated worker defined in a heuristic way.
-                        const hasAction = entriesWithAction?.has(
-                          'app' + originalAppPath
-                        )
-
                         if (
                           workerResult.encodedPrerenderRoutes &&
                           workerResult.prerenderRoutes
@@ -1500,7 +1492,7 @@ export default async function build(
                         }
 
                         const appConfig = workerResult.appConfig || {}
-                        if (appConfig.revalidate !== 0 && !hasAction) {
+                        if (appConfig.revalidate !== 0) {
                           const isDynamic = isDynamicRoute(page)
                           const hasGenerateStaticParams =
                             !!workerResult.prerenderRoutes?.length

--- a/packages/next/src/server/app-render.tsx
+++ b/packages/next/src/server/app-render.tsx
@@ -2020,7 +2020,15 @@ export async function renderToHTMLOrFlight(
     () =>
       StaticGenerationAsyncStorageWrapper.wrap(
         staticGenerationAsyncStorage,
-        { pathname, renderOpts },
+        {
+          pathname,
+          renderOpts: isAction
+            ? {
+                supportsDynamicHTML: true,
+                isBot: false,
+              }
+            : renderOpts,
+        },
         () => wrappedRender()
       )
   )

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -958,7 +958,12 @@ export default class NextNodeServer extends BaseServer {
     isAppPath: boolean
   }): Promise<FindComponentsResult | null> {
     return getTracer().trace(NextNodeServerSpan.findPageComponents, () =>
-      this.findPageComponentsImpl({ pathname, query, params, isAppPath })
+      this.findPageComponentsImpl({
+        pathname,
+        query,
+        params,
+        isAppPath,
+      })
     )
   }
 


### PR DESCRIPTION
This PR updates the build conditions to not specially handle entries with actions so they can still be built as static pages. And in the server these requests will always be passed to the renderer instead of handled as page.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

fix NEXT-786