### PR TITLE
Ensure chained middleware rewrites work properly

### DIFF
--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -152,11 +152,22 @@ export async function adapter(params: {
      * with an internal header so the client knows which component to load
      * from the data request.
      */
-    if (isDataReq) {
-      response.headers.set(
-        'x-nextjs-rewrite',
-        relativizeURL(String(rewriteUrl), String(requestUrl))
+    const relativizedRewrite = relativizeURL(
+      String(rewriteUrl),
+      String(requestUrl)
+    )
+
+    if (
+      isDataReq &&
+      // if the rewrite is external and external rewrite
+      // resolving config is enabled don't add this header
+      // so the upstream app can set it instead
+      !(
+        process.env.__NEXT_EXTERNAL_MIDDLEWARE_REWRITE_RESOLVE &&
+        relativizedRewrite.match(/http(s)?:\/\//)
       )
+    ) {
+      response.headers.set('x-nextjs-rewrite', relativizedRewrite)
     }
   }
 

--- a/test/e2e/skip-trailing-slash-redirect/app/next.config.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/next.config.js
@@ -2,6 +2,9 @@
 const nextConfig = {
   skipMiddlewareUrlNormalize: true,
   skipTrailingSlashRedirect: true,
+  experimental: {
+    externalMiddlewareRewritesResolve: true,
+  },
   async redirects() {
     return [
       {

--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -17,10 +17,9 @@ describe('skip-trailing-slash-redirect', () => {
   afterAll(() => next.destroy())
 
   it.each([
-    // TODO: should these cases be supported
-    // { pathname: '/chained-rewrite-ssg' },
-    // { pathname: '/chained-rewrite-static' },
-    // { pathname: '/chained-rewrite-ssr' },
+    { pathname: '/chained-rewrite-ssg' },
+    { pathname: '/chained-rewrite-static' },
+    { pathname: '/chained-rewrite-ssr' },
     { pathname: '/docs/first' },
     { pathname: '/docs-auto-static/first' },
     { pathname: '/docs-ssr/first' },


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/45772 this ensures the rewrite header can be correctly set when a chained middleware rewrite is occurring. 

x-ref: [slack thread](https://vercel.slack.com/archives/C01RGMANU9Y/p1678074803731489)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)


