### PR TITLE
fix app dir export when i18n enabled 

### DIFF
--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -178,7 +178,7 @@ export default async function exportPage({
       delete query.__nextLocale
       delete query.__nextSsgPath
 
-      if (renderOpts.locale) {
+      if (renderOpts.locale && !isAppDir) {
         const localePathResult = normalizeLocalePath(path, renderOpts.locales)
 
         if (localePathResult.detectedLocale) {

--- a/test/e2e/app-dir/app-i18n/app-i18n.test.ts
+++ b/test/e2e/app-dir/app-i18n/app-i18n.test.ts
@@ -1,0 +1,26 @@
+import { createNextDescribe } from 'e2e-utils'
+import { fetchViaHTTP } from 'next-test-utils'
+
+createNextDescribe(
+  'app-i18n',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    async function testLocale(lang: string) {
+      const res = await fetchViaHTTP(next.url, `/${lang}/another`)
+      const html = await res.text()
+      expect(html).toContain(`Another page. Lang: <!-- -->${lang}`)
+    }
+
+    it('should export the dynamic [lang] correctly', async () => {
+      await testLocale('en')
+      await testLocale('id')
+    })
+
+    it('returns 404 on missing locale', async () => {
+      const res = await fetchViaHTTP(next.url, `/my/another`)
+      expect(res.status).toBe(404)
+    })
+  }
+)

--- a/test/e2e/app-dir/app-i18n/app/[lang]/another/page.tsx
+++ b/test/e2e/app-dir/app-i18n/app/[lang]/another/page.tsx
@@ -1,0 +1,9 @@
+export const dynamicParams = false
+
+export async function generateStaticParams() {
+  return [{ lang: 'en' }, { lang: 'id' }]
+}
+
+export default function Page({ params }) {
+  return <div>Another page. Lang: {params.lang}</div>
+}

--- a/test/e2e/app-dir/app-i18n/app/layout.tsx
+++ b/test/e2e/app-dir/app-i18n/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-i18n/app/page.tsx
+++ b/test/e2e/app-dir/app-i18n/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/app-i18n/next.config.js
+++ b/test/e2e/app-dir/app-i18n/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: { appDir: true },
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'id', 'my'],
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
fixes #46622

When exporting app dir, ignore any locale info and keep pathname as is

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
