### PR TITLE
chore: add App Router template to bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -51,7 +51,9 @@ body:
   - type: input
     attributes:
       label: Link to the code that reproduces this issue
-      description: A link to a GitHub repository, a [StackBlitz](https://stackblitz.com/fork/github/vercel/next.js/tree/canary/examples/reproduction-template), or a [CodeSandbox](https://codesandbox.io/p/sandbox/github/vercel/next.js/tree/canary/examples/reproduction-template) minimal reproduction. Minimal reproductions should be created from our [bug report template with `npx create-next-app -e reproduction-template`](https://github.com/vercel/next.js/tree/canary/examples/reproduction-template) and should include only changes that contribute to the issue.
+      description: |
+        A link to a GitHub repository, a [CodeSandbox](https://codesandbox.io/p/sandbox/github/vercel/next.js/tree/canary/examples/reproduction-template) or a [StackBlitz](https://stackblitz.com/fork/github/vercel/next.js/tree/canary/examples/reproduction-template) minimal reproduction. Minimal reproductions should be created from our [bug report template with `npx create-next-app -e reproduction-template`](https://github.com/vercel/next.js/tree/canary/examples/reproduction-template) and should include only changes that contribute to the issue.
+        To report an App Router related issue, you can use these templates: [CodeSandbox](https://codesandbox.io/p/sandbox/github/vercel/next.js/tree/canary/examples/reproduction-template-app-dir), [StackBlitz](https://stackblitz.com/fork/github/vercel/next.js/tree/canary/examples/reproduction-template-app-dir) or [`npx create-next-app -e reproduction-template-app-dir`](https://github.com/vercel/next.js/tree/canary/examples/reproduction-template-app-dir)
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
### What?

Link to https://github.com/vercel/next.js/tree/canary/examples/reproduction-template-app-dir from our bug report template.

### Why?

To lower the barrier to adding a reproduction even when reporting an App Router-related issue, which is currently behind a flag. (Pointed out in #46852)

### How?

Added a link in the issue template. The remaining question is, should we add anything else to https://github.com/vercel/next.js/tree/canary/examples/reproduction-template-app-dir to make creating a reproduction easier? 

Closes NEXT-789
Related #46852