### PR TITLE
Support unnamed default export expression (#46888

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -135,7 +135,7 @@ impl<C: Comments> ServerActions<C> {
         let export_name: JsWord = if self.in_default_export_decl {
             "default".into()
         } else {
-            action_name.clone()
+            action_name
         };
 
         self.has_action = true;
@@ -165,7 +165,7 @@ impl<C: Comments> ServerActions<C> {
 
         // myAction.$$name = '$ACTION_myAction';
         self.annotations
-            .push(annotate(ident, "$$name", action_name.into()));
+            .push(annotate(ident, "$$name", export_name.into()));
 
         if self.top_level {
             // myAction.$$bound = [];

--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -34,12 +34,14 @@ pub fn server_actions<C: Comments>(
         start_pos: BytePos(0),
         in_action_file: false,
         in_export_decl: false,
+        in_default_export_decl: false,
         in_prepass: false,
         has_action: false,
         top_level: false,
 
         in_module: true,
         in_action_fn: false,
+        action_index: 0,
         should_add_name: false,
         closure_idents: Default::default(),
         action_idents: Default::default(),
@@ -61,12 +63,14 @@ struct ServerActions<C: Comments> {
     start_pos: BytePos,
     in_action_file: bool,
     in_export_decl: bool,
+    in_default_export_decl: bool,
     in_prepass: bool,
     has_action: bool,
     top_level: bool,
 
     in_module: bool,
     in_action_fn: bool,
+    action_index: u32,
     should_add_name: bool,
     closure_idents: Vec<Id>,
     action_idents: Vec<Name>,
@@ -128,8 +132,14 @@ impl<C: Comments> ServerActions<C> {
         };
         let action_ident = private_ident!(action_name.clone());
 
+        let export_name: JsWord = if self.in_default_export_decl {
+            "default".into()
+        } else {
+            action_name.clone()
+        };
+
         self.has_action = true;
-        self.export_actions.push(action_name.to_string());
+        self.export_actions.push(export_name.to_string());
 
         // myAction.$$typeof = Symbol.for('react.server.reference');
         self.annotations.push(annotate(
@@ -270,9 +280,12 @@ impl<C: Comments> VisitMut for ServerActions<C> {
 
     fn visit_mut_export_default_decl(&mut self, decl: &mut ExportDefaultDecl) {
         let old = self.in_export_decl;
+        let old_default = self.in_default_export_decl;
         self.in_export_decl = true;
+        self.in_default_export_decl = true;
         decl.decl.visit_mut_with(self);
         self.in_export_decl = old;
+        self.in_default_export_decl = old_default;
     }
 
     fn visit_mut_fn_expr(&mut self, f: &mut FnExpr) {
@@ -288,8 +301,15 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         }
 
         if f.ident.is_none() {
-            f.visit_mut_children_with(self);
-            return;
+            // Exported anonymous async functions need to have a name assigned.
+            if self.in_action_file && self.in_export_decl && f.function.is_async {
+                let action_name: JsWord = format!("$ACTION_default_{}", self.action_index).into();
+                self.action_index += 1;
+                f.ident = Some(Ident::new(action_name, DUMMY_SP));
+            } else {
+                f.visit_mut_children_with(self);
+                return;
+            }
         }
 
         let (is_action_fn, is_exported) =

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/10/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/10/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ foo */ export default async function foo() {}
+/* __next_internal_action_entry_do_not_use__ default */ export default async function foo() {}
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$filepath = "/app/item.js";
 foo.$$name = "foo";

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/10/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/10/output.js
@@ -1,5 +1,5 @@
 /* __next_internal_action_entry_do_not_use__ default */ export default async function foo() {}
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$filepath = "/app/item.js";
-foo.$$name = "foo";
+foo.$$name = "default";
 foo.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/11/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/11/input.js
@@ -1,0 +1,2 @@
+'use server'
+export default async function () {}

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/11/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/11/output.js
@@ -1,0 +1,5 @@
+/* __next_internal_action_entry_do_not_use__ default */ export default async function $ACTION_default_0() {}
+$ACTION_default_0.$$typeof = Symbol.for("react.server.reference");
+$ACTION_default_0.$$filepath = "/app/item.js";
+$ACTION_default_0.$$name = "$ACTION_default_0";
+$ACTION_default_0.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/11/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/11/output.js
@@ -1,5 +1,5 @@
 /* __next_internal_action_entry_do_not_use__ default */ export default async function $ACTION_default_0() {}
 $ACTION_default_0.$$typeof = Symbol.for("react.server.reference");
 $ACTION_default_0.$$filepath = "/app/item.js";
-$ACTION_default_0.$$name = "$ACTION_default_0";
+$ACTION_default_0.$$name = "default";
 $ACTION_default_0.$$bound = [];

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -17,8 +17,14 @@ createNextDescribe(
       await browser.elementByCss('#inc').click()
       await check(() => browser.elementByCss('h1').text(), '1')
 
+      await browser.elementByCss('#inc').click()
+      await check(() => browser.elementByCss('h1').text(), '2')
+
+      await browser.elementByCss('#double').click()
+      await check(() => browser.elementByCss('h1').text(), '4')
+
       await browser.elementByCss('#dec').click()
-      await check(() => browser.elementByCss('h1').text(), '0')
+      await check(() => browser.elementByCss('h1').text(), '3')
     })
 
     it('should support headers and cookies', async () => {

--- a/test/e2e/app-dir/actions/app/server/actions.js
+++ b/test/e2e/app-dir/actions/app/server/actions.js
@@ -8,6 +8,6 @@ export async function dec(value) {
   return value - 1
 }
 
-export default async function double(value) {
+export default async function (value) {
   return value * 2
 }

--- a/test/e2e/app-dir/actions/app/server/actions.js
+++ b/test/e2e/app-dir/actions/app/server/actions.js
@@ -7,3 +7,7 @@ export async function inc(value) {
 export async function dec(value) {
   return value - 1
 }
+
+export default async function double(value) {
+  return value * 2
+}

--- a/test/e2e/app-dir/actions/app/server/counter.js
+++ b/test/e2e/app-dir/actions/app/server/counter.js
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 
-export default function Counter({ inc, dec }) {
+export default function Counter({ inc, dec, double }) {
   const [count, setCount] = useState(0)
 
   return (
@@ -25,6 +25,15 @@ export default function Counter({ inc, dec }) {
         }}
       >
         -1
+      </button>
+      <button
+        id="double"
+        onClick={async () => {
+          const newCount = await double(count)
+          setCount(newCount)
+        }}
+      >
+        *2
       </button>
     </div>
   )

--- a/test/e2e/app-dir/actions/app/server/page.js
+++ b/test/e2e/app-dir/actions/app/server/page.js
@@ -1,7 +1,7 @@
 import Counter from './counter'
 
-import { inc, dec } from './actions'
+import double, { inc, dec } from './actions'
 
 export default function Page() {
-  return <Counter inc={inc} dec={dec} />
+  return <Counter inc={inc} dec={dec} double={double} />
 }


### PR DESCRIPTION
This PR adds the support for unnamed default export expression support `export default async function () {}` in a "use server" entry, with corresponding test.

Also fixed an existing bug that the default exported action's name should be aligned with the export name, which is `"default"`.

Closes NEXT-769.