### PR TITLE
Update generateStaticParams handling with fetch cache

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1463,6 +1463,11 @@ export default async function build(
                           edgeInfo,
                           pageType,
                           hasServerComponents: !!appDir,
+                          incrementalCacheHandlerPath:
+                            config.experimental.incrementalCacheHandlerPath,
+                          isrFlushToDisk: config.experimental.isrFlushToDisk,
+                          maxMemoryCacheSize:
+                            config.experimental.isrMemoryCacheSize,
                         })
                       }
                     )

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -55,6 +55,10 @@ import {
   overrideBuiltInReactPackages,
 } from './webpack/require-hook'
 import { isClientReference } from './is-client-reference'
+import { StaticGenerationAsyncStorageWrapper } from '../server/async-storage/static-generation-async-storage-wrapper'
+import { IncrementalCache } from '../server/lib/incremental-cache'
+import { patchFetch } from '../server/lib/patch-fetch'
+import { nodeFs } from '../server/lib/node-fs-methods'
 
 loadRequireHook()
 if (process.env.NEXT_PREBUNDLED_REACT) {
@@ -998,6 +1002,15 @@ export async function buildStaticPaths({
           (repeat && !Array.isArray(paramValue)) ||
           (!repeat && typeof paramValue !== 'string')
         ) {
+          // If from appDir and not all params were provided from
+          // generateStaticParams we can just filter this entry out
+          // as it's meant to be generated at runtime
+          if (appDir) {
+            builtPage = ''
+            encodedBuiltPage = ''
+            return
+          }
+
           throw new Error(
             `A required parameter (${validParamKey}) was not provided as ${
               repeat ? 'an array' : 'a string'
@@ -1030,6 +1043,10 @@ export async function buildStaticPaths({
           )
           .replace(/(?!^)\/$/, '')
       })
+
+      if (!builtPage && !encodedBuiltPage) {
+        return
+      }
 
       if (entry.locale && !locales?.includes(entry.locale)) {
         throw new Error(
@@ -1143,89 +1160,155 @@ export const collectGenerateParams = async (
 
 export async function buildAppStaticPaths({
   page,
+  distDir,
   configFileName,
   generateParams,
+  isrFlushToDisk,
+  incrementalCacheHandlerPath,
+  requestHeaders,
+  maxMemoryCacheSize,
+  fetchCacheKeyPrefix,
+  staticGenerationAsyncStorage,
+  serverHooks,
 }: {
   page: string
   configFileName: string
   generateParams: GenerateParams
+  incrementalCacheHandlerPath?: string
+  distDir: string
+  isrFlushToDisk?: boolean
+  fetchCacheKeyPrefix?: string
+  maxMemoryCacheSize?: number
+  requestHeaders: IncrementalCache['requestHeaders']
+  staticGenerationAsyncStorage: Parameters<
+    typeof patchFetch
+  >[0]['staticGenerationAsyncStorage']
+  serverHooks: Parameters<typeof patchFetch>[0]['serverHooks']
 }) {
-  const pageEntry = generateParams[generateParams.length - 1]
+  patchFetch({
+    staticGenerationAsyncStorage,
+    serverHooks,
+  })
+  let CacheHandler: any
 
-  // if the page has legacy getStaticPaths we call it like normal
-  if (typeof pageEntry?.getStaticPaths === 'function') {
-    return buildStaticPaths({
-      page,
-      configFileName,
-      getStaticPaths: pageEntry.getStaticPaths,
-    })
-  } else {
-    // if generateStaticParams is being used we iterate over them
-    // collecting them from each level
-    type Params = Array<Record<string, string | string[]>>
-    let hadGenerateParams = false
-
-    const buildParams = async (
-      paramsItems: Params = [{}],
-      idx = 0
-    ): Promise<Params> => {
-      const curGenerate = generateParams[idx]
-
-      if (idx === generateParams.length) {
-        return paramsItems
-      }
-      if (
-        typeof curGenerate.generateStaticParams !== 'function' &&
-        idx < generateParams.length
-      ) {
-        return buildParams(paramsItems, idx + 1)
-      }
-      hadGenerateParams = true
-
-      const newParams = []
-
-      for (const params of paramsItems) {
-        const result = await curGenerate.generateStaticParams({ params })
-        // TODO: validate the result is valid here or wait for
-        // buildStaticPaths to validate?
-        for (const item of result) {
-          newParams.push({ ...params, ...item })
-        }
-      }
-
-      if (idx < generateParams.length) {
-        return buildParams(newParams, idx + 1)
-      }
-      return newParams
-    }
-    const builtParams = await buildParams()
-    const fallback = !generateParams.some(
-      // TODO: check complementary configs that can impact
-      // dynamicParams behavior
-      (generate) => generate.config?.dynamicParams === false
-    )
-
-    if (!hadGenerateParams) {
-      return {
-        paths: undefined,
-        fallback:
-          process.env.NODE_ENV === 'production' && isDynamicRoute(page)
-            ? true
-            : undefined,
-        encodedPaths: undefined,
-      }
-    }
-
-    return buildStaticPaths({
-      staticPathsResult: {
-        fallback,
-        paths: builtParams.map((params) => ({ params })),
-      },
-      page,
-      configFileName,
-      appDir: true,
-    })
+  if (incrementalCacheHandlerPath) {
+    CacheHandler = require(incrementalCacheHandlerPath)
+    CacheHandler = CacheHandler.default || CacheHandler
   }
+
+  const incrementalCache = new IncrementalCache({
+    fs: nodeFs,
+    dev: true,
+    appDir: true,
+    flushToDisk: isrFlushToDisk,
+    serverDistDir: path.join(distDir, 'server'),
+    fetchCacheKeyPrefix,
+    maxMemoryCacheSize,
+    getPrerenderManifest: () => ({
+      version: -1 as any, // letting us know this doesn't conform to spec
+      routes: {},
+      dynamicRoutes: {},
+      notFoundRoutes: [],
+      preview: null as any, // `preview` is special case read in next-dev-server
+    }),
+    CurCacheHandler: CacheHandler,
+    requestHeaders,
+  })
+
+  const wrapper = new StaticGenerationAsyncStorageWrapper()
+
+  return wrapper.wrap(
+    staticGenerationAsyncStorage,
+    {
+      pathname: page,
+      renderOpts: {
+        incrementalCache,
+        supportsDynamicHTML: true,
+        isRevalidate: false,
+        isBot: false,
+      },
+    },
+    async () => {
+      const pageEntry = generateParams[generateParams.length - 1]
+
+      // if the page has legacy getStaticPaths we call it like normal
+      if (typeof pageEntry?.getStaticPaths === 'function') {
+        return buildStaticPaths({
+          page,
+          configFileName,
+          getStaticPaths: pageEntry.getStaticPaths,
+        })
+      } else {
+        // if generateStaticParams is being used we iterate over them
+        // collecting them from each level
+        type Params = Array<Record<string, string | string[]>>
+        let hadGenerateParams = false
+
+        const buildParams = async (
+          paramsItems: Params = [{}],
+          idx = 0
+        ): Promise<Params> => {
+          const curGenerate = generateParams[idx]
+
+          if (idx === generateParams.length) {
+            return paramsItems
+          }
+          if (
+            typeof curGenerate.generateStaticParams !== 'function' &&
+            idx < generateParams.length
+          ) {
+            return buildParams(paramsItems, idx + 1)
+          }
+          hadGenerateParams = true
+
+          const newParams = []
+
+          for (const params of paramsItems) {
+            const result = await curGenerate.generateStaticParams({ params })
+            // TODO: validate the result is valid here or wait for
+            // buildStaticPaths to validate?
+            for (const item of result) {
+              newParams.push({ ...params, ...item })
+            }
+          }
+
+          if (idx < generateParams.length) {
+            return buildParams(newParams, idx + 1)
+          }
+          return newParams
+        }
+        const builtParams = await buildParams()
+        const fallback = !generateParams.some(
+          // TODO: dynamic params should be allowed
+          // to be granular per segment but we need
+          // additional information stored/leveraged in
+          // the prerender-manifest to allow this behavior
+          (generate) => generate.config?.dynamicParams === false
+        )
+
+        if (!hadGenerateParams) {
+          return {
+            paths: undefined,
+            fallback:
+              process.env.NODE_ENV === 'production' && isDynamicRoute(page)
+                ? true
+                : undefined,
+            encodedPaths: undefined,
+          }
+        }
+
+        return buildStaticPaths({
+          staticPathsResult: {
+            fallback,
+            paths: builtParams.map((params) => ({ params })),
+          },
+          page,
+          configFileName,
+          appDir: true,
+        })
+      }
+    }
+  )
 }
 
 export async function isPageStatic({
@@ -1243,6 +1326,9 @@ export async function isPageStatic({
   pageType,
   hasServerComponents,
   originalAppPath,
+  isrFlushToDisk,
+  maxMemoryCacheSize,
+  incrementalCacheHandlerPath,
 }: {
   page: string
   distDir: string
@@ -1258,6 +1344,9 @@ export async function isPageStatic({
   pageRuntime?: ServerRuntime
   hasServerComponents?: boolean
   originalAppPath?: string
+  isrFlushToDisk?: boolean
+  maxMemoryCacheSize?: number
+  incrementalCacheHandlerPath?: string
 }): Promise<{
   isStatic?: boolean
   isAmpOnly?: boolean
@@ -1335,6 +1424,9 @@ export async function isPageStatic({
         isClientComponent = isClientReference(componentsResult.ComponentMod)
         const tree = componentsResult.ComponentMod.tree
         const handlers = componentsResult.ComponentMod.handlers
+        const staticGenerationAsyncStorage =
+          componentsResult.ComponentMod.staticGenerationAsyncStorage
+        const serverHooks = componentsResult.ComponentMod.serverHooks
 
         const generateParams: GenerateParams = handlers
           ? [
@@ -1399,8 +1491,15 @@ export async function isPageStatic({
             encodedPaths: encodedPrerenderRoutes,
           } = await buildAppStaticPaths({
             page,
+            serverHooks,
+            staticGenerationAsyncStorage,
             configFileName,
             generateParams,
+            distDir,
+            requestHeaders: {},
+            isrFlushToDisk,
+            maxMemoryCacheSize,
+            incrementalCacheHandlerPath,
           }))
         }
       } else {

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -49,7 +49,8 @@ export class Worker {
         _child: ChildProcess
       }[]) {
         worker._child.on('exit', (code, signal) => {
-          if (code || signal) {
+          // log unexpected exit if .end() wasn't called
+          if ((code || signal) && this._worker) {
             console.error(
               `Static worker unexpectedly exited with code: ${code} and signal: ${signal}`
             )

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1096,6 +1096,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     pathname,
   }: {
     pathname: string
+    requestHeaders: import('./lib/incremental-cache').IncrementalCache['requestHeaders']
     originalAppPath?: string
   }): Promise<{
     staticPaths?: string[]
@@ -1162,6 +1163,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       const pathsResult = await this.getStaticPaths({
         pathname,
         originalAppPath: components.pathname,
+        requestHeaders: req.headers,
       })
 
       staticPaths = pathsResult.staticPaths
@@ -1607,7 +1609,10 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
         if (!staticPaths) {
           ;({ staticPaths, fallbackMode } = hasStaticPaths
-            ? await this.getStaticPaths({ pathname })
+            ? await this.getStaticPaths({
+                pathname,
+                requestHeaders: req.headers,
+              })
             : { staticPaths: undefined, fallbackMode: false })
         }
 

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -97,6 +97,7 @@ import { DefaultFileReader } from '../future/route-matcher-providers/dev/helpers
 import { NextBuildContext } from '../../build/build-context'
 import { logAppDirError } from './log-app-dir-error'
 import { createClientRouterFilter } from '../../lib/create-client-router-filter'
+import { IncrementalCache } from '../lib/incremental-cache'
 
 // Load ReactDevOverlay only when needed
 let ReactDevOverlayImpl: FunctionComponent
@@ -1511,9 +1512,11 @@ export default class DevServer extends Server {
   protected async getStaticPaths({
     pathname,
     originalAppPath,
+    requestHeaders,
   }: {
     pathname: string
     originalAppPath?: string
+    requestHeaders: IncrementalCache['requestHeaders']
   }): Promise<{
     staticPaths?: string[]
     fallbackMode?: false | 'static' | 'blocking'
@@ -1545,6 +1548,12 @@ export default class DevServer extends Server {
         defaultLocale,
         originalAppPath,
         isAppPath: !!originalAppPath,
+        requestHeaders,
+        incrementalCacheHandlerPath:
+          this.nextConfig.experimental.incrementalCacheHandlerPath,
+        fetchCacheKeyPrefix: this.nextConfig.experimental.fetchCacheKeyPrefix,
+        isrFlushToDisk: this.nextConfig.experimental.isrFlushToDisk,
+        maxMemoryCacheSize: this.nextConfig.experimental.isrMemoryCacheSize,
       })
       return pathsResult
     }

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -13,6 +13,9 @@ import {
   loadRequireHook,
   overrideBuiltInReactPackages,
 } from '../../build/webpack/require-hook'
+import { IncrementalCache } from '../lib/incremental-cache'
+import * as serverHooks from '../../client/components/hooks-server-context'
+import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage'
 
 type RuntimeConfig = any
 
@@ -40,6 +43,11 @@ export async function loadStaticPaths({
   defaultLocale,
   isAppPath,
   originalAppPath,
+  isrFlushToDisk,
+  fetchCacheKeyPrefix,
+  maxMemoryCacheSize,
+  requestHeaders,
+  incrementalCacheHandlerPath,
 }: {
   distDir: string
   pathname: string
@@ -50,6 +58,11 @@ export async function loadStaticPaths({
   defaultLocale?: string
   isAppPath?: boolean
   originalAppPath?: string
+  isrFlushToDisk?: boolean
+  fetchCacheKeyPrefix?: string
+  maxMemoryCacheSize?: number
+  requestHeaders: IncrementalCache['requestHeaders']
+  incrementalCacheHandlerPath?: string
 }): Promise<{
   paths?: string[]
   encodedPaths?: string[]
@@ -104,6 +117,14 @@ export async function loadStaticPaths({
       page: pathname,
       generateParams,
       configFileName: config.configFileName,
+      distDir,
+      requestHeaders,
+      incrementalCacheHandlerPath,
+      serverHooks,
+      staticGenerationAsyncStorage,
+      isrFlushToDisk,
+      fetchCacheKeyPrefix,
+      maxMemoryCacheSize,
     })
   }
 

--- a/packages/next/src/server/lib/node-fs-methods.ts
+++ b/packages/next/src/server/lib/node-fs-methods.ts
@@ -1,0 +1,10 @@
+import _fs from 'fs'
+import { CacheFs } from '../../shared/lib/utils'
+
+export const nodeFs: CacheFs = {
+  readFile: (f) => _fs.promises.readFile(f, 'utf8'),
+  readFileSync: (f) => _fs.readFileSync(f, 'utf8'),
+  writeFile: (f, d) => _fs.promises.writeFile(f, d, 'utf8'),
+  mkdir: (dir) => _fs.promises.mkdir(dir, { recursive: true }),
+  stat: (f) => _fs.promises.stat(f),
+}

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -99,6 +99,7 @@ import { MatchOptions } from './future/route-matcher-managers/route-matcher-mana
 import { INSTRUMENTATION_HOOK_FILENAME } from '../lib/constants'
 import { getTracer } from './lib/trace/tracer'
 import { NextNodeServerSpan } from './lib/trace/constants'
+import { nodeFs } from './lib/node-fs-methods'
 
 export * from './base-server'
 
@@ -1336,13 +1337,7 @@ export default class NextNodeServer extends BaseServer {
   }
 
   protected getCacheFilesystem(): CacheFs {
-    return {
-      readFile: (f) => fs.promises.readFile(f, 'utf8'),
-      readFileSync: (f) => fs.readFileSync(f, 'utf8'),
-      writeFile: (f, d) => fs.promises.writeFile(f, d, 'utf8'),
-      mkdir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
-      stat: (f) => fs.promises.stat(f),
-    }
+    return nodeFs
   }
 
   private normalizeReq(

--- a/test/e2e/app-dir/app-static/app/partial-gen-params-no-additional-lang/[lang]/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/partial-gen-params-no-additional-lang/[lang]/[slug]/page.js
@@ -1,0 +1,32 @@
+export const dynamicParams = true
+
+export async function generateStaticParams() {
+  const res = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?staticGen'
+  )
+
+  const data = await res.text()
+  const fetchSlug = Math.round(Number(data) * 100)
+  console.log('partial-gen-params fetch', fetchSlug)
+
+  return [
+    {
+      slug: 'first',
+    },
+    {
+      slug: 'second',
+    },
+    {
+      slug: fetchSlug + '',
+    },
+  ]
+}
+
+export default function Page({ params }) {
+  return (
+    <>
+      <p id="page">/partial-gen-params/[lang]/[slug]</p>
+      <p id="params">{JSON.stringify(params)}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/partial-gen-params-no-additional-lang/[lang]/layout.js
+++ b/test/e2e/app-dir/app-static/app/partial-gen-params-no-additional-lang/[lang]/layout.js
@@ -1,0 +1,9 @@
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return [{ lang: 'en' }, { lang: 'fr' }]
+}
+
+export default function Layout({ children }) {
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/app-static/app/partial-gen-params-no-additional-slug/[lang]/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/partial-gen-params-no-additional-slug/[lang]/[slug]/page.js
@@ -1,0 +1,32 @@
+export const dynamicParams = false
+
+export async function generateStaticParams() {
+  const res = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?staticGen'
+  )
+
+  const data = await res.text()
+  const fetchSlug = Math.round(Number(data) * 100)
+  console.log('partial-gen-params fetch', fetchSlug)
+
+  return [
+    {
+      slug: 'first',
+    },
+    {
+      slug: 'second',
+    },
+    {
+      slug: fetchSlug + '',
+    },
+  ]
+}
+
+export default function Page({ params }) {
+  return (
+    <>
+      <p id="page">/partial-gen-params/[lang]/[slug]</p>
+      <p id="params">{JSON.stringify(params)}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/partial-gen-params-no-additional-slug/[lang]/layout.js
+++ b/test/e2e/app-dir/app-static/app/partial-gen-params-no-additional-slug/[lang]/layout.js
@@ -1,0 +1,9 @@
+export const dynamicParams = true
+
+export function generateStaticParams() {
+  return [{ lang: 'en' }, { lang: 'fr' }]
+}
+
+export default function Layout({ children }) {
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/app-static/app/partial-gen-params/[lang]/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/partial-gen-params/[lang]/[slug]/page.js
@@ -1,0 +1,8 @@
+export default function Page({ params }) {
+  return (
+    <>
+      <p id="page">/partial-gen-params/[lang]/[slug]</p>
+      <p id="params">{JSON.stringify(params)}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/partial-gen-params/[lang]/layout.js
+++ b/test/e2e/app-dir/app-static/app/partial-gen-params/[lang]/layout.js
@@ -1,0 +1,7 @@
+export function generateStaticParams() {
+  return [{ lang: 'en' }, { lang: 'fr' }]
+}
+
+export default function Layout({ children }) {
+  return <>{children}</>
+}


### PR DESCRIPTION
This ensures we leverage the fetch cache when calling `generateStaticParams` and also ensures paths with `generateStaticParams` without `dynamicParams = false` don't error when only partial params are provided. 

x-ref: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1678149362238089)