### PR TITLE
Update app dir searchParams handling on deploy

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -768,7 +768,18 @@ export default abstract class Server<ServerOptions extends Options = Options> {
               matchedPath = utils.interpolateDynamicPath(srcPathname, params)
               req.url = utils.interpolateDynamicPath(req.url!, params)
             }
-            Object.assign(parsedUrl.query, params)
+
+            if (this.hasAppDir) {
+              // params should not be present in the query
+              // for appDir. TODO: we should prefix routeKeys
+              // so that they don't overlap with actual query
+              // values passed through
+              for (const key of Object.keys(params)) {
+                delete parsedUrl.query[key]
+              }
+            } else {
+              Object.assign(parsedUrl.query, params)
+            }
           }
 
           if (pageIsDynamic || didRewrite) {

--- a/test/e2e/app-dir/app/app/dynamic-client/[category]/[id]/page.js
+++ b/test/e2e/app-dir/app/app/dynamic-client/[category]/[id]/page.js
@@ -1,6 +1,9 @@
 'use client'
+import { useSearchParams } from 'next/navigation'
 
 export default function IdPage({ children, params }) {
+  const searchParams = useSearchParams()
+
   return (
     <>
       <p>
@@ -8,6 +11,10 @@ export default function IdPage({ children, params }) {
         <span id="id-page-params">{JSON.stringify(params)}</span>
       </p>
       {children}
+
+      <p id="search-params">
+        {JSON.stringify(Object.fromEntries(searchParams))}
+      </p>
     </>
   )
 }

--- a/test/e2e/app-dir/app/app/dynamic/[category]/[id]/page.js
+++ b/test/e2e/app-dir/app/app/dynamic/[category]/[id]/page.js
@@ -1,4 +1,4 @@
-export default function IdPage({ children, params }) {
+export default function IdPage({ children, params, searchParams }) {
   return (
     <>
       <p>
@@ -6,6 +6,8 @@ export default function IdPage({ children, params }) {
         <span id="id-page-params">{JSON.stringify(params)}</span>
       </p>
       {children}
+
+      <p id="search-params">{JSON.stringify(searchParams)}</p>
     </>
   )
 }

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -16,6 +16,35 @@ createNextDescribe(
     },
   },
   ({ next, isNextDev: isDev, isNextStart, isNextDeploy }) => {
+    it('should have correct searchParams and params (server)', async () => {
+      const html = await next.render('/dynamic/category-1/id-2?query1=value2')
+      const $ = cheerio.load(html)
+
+      expect(JSON.parse($('#id-page-params').text())).toEqual({
+        category: 'category-1',
+        id: 'id-2',
+      })
+      expect(JSON.parse($('#search-params').text())).toEqual({
+        query1: 'value2',
+      })
+    })
+
+    it('should have correct searchParams and params (client)', async () => {
+      const browser = await next.browser(
+        '/dynamic-client/category-1/id-2?query1=value2'
+      )
+      const html = await browser.eval('document.documentElement.innerHTML')
+      const $ = cheerio.load(html)
+
+      expect(JSON.parse($('#id-page-params').text())).toEqual({
+        category: 'category-1',
+        id: 'id-2',
+      })
+      expect(JSON.parse($('#search-params').text())).toEqual({
+        query1: 'value2',
+      })
+    })
+
     it('should encode chunk path correctly', async () => {
       const browser = await next.browser('/')
       const requests = []


### PR DESCRIPTION
This prevents dynamic params from being present in searchParams when deployed, in a follow-up we can investigate allowing searchParams with the same names to be present alongside the dynamic params by prefixing the route keys. 

Closes: https://github.com/vercel/next.js/issues/43139