### PR TITLE
Improve OpenTelemetry spans

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1924,7 +1924,11 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   private async renderToResponse(
     ctx: RequestContext
   ): Promise<ResponsePayload | null> {
-    return getTracer().trace(BaseServerSpan.renderToResponse, async () => {
+    return getTracer().trace(BaseServerSpan.renderToResponse, async (span) => {
+      if (span) {
+        span.setAttribute('path', ctx.pathname)
+      }
+
       return this.renderToResponseImpl(ctx)
     })
   }

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -24,6 +24,9 @@ const isPromise = <T>(p: any): p is Promise<T> => {
 }
 
 const closeSpanWithError = (span: Span, error?: Error) => {
+  if (error) {
+    span.recordException(error)
+  }
   span.setStatus({ code: SpanStatusCode.ERROR, message: error?.message })
   span.end()
 }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -958,9 +958,13 @@ export default class NextNodeServer extends BaseServer {
     params: Params | null
     isAppPath: boolean
   }): Promise<FindComponentsResult | null> {
-    return getTracer().trace(NextNodeServerSpan.findPageComponents, () =>
-      this.findPageComponentsImpl({ pathname, query, params, isAppPath })
-    )
+    return getTracer().trace(NextNodeServerSpan.findPageComponents, (span) => {
+      if (span) {
+        span.setAttribute('filename', pathname)
+      }
+
+      return this.findPageComponentsImpl({ pathname, query, params, isAppPath })
+    })
   }
 
   private async findPageComponentsImpl({

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -64,10 +64,21 @@ export class NextServer {
       res: ServerResponse,
       parsedUrl?: UrlWithParsedQuery
     ) => {
-      return getTracer().trace(NextServerSpan.getRequestHandler, async () => {
-        const requestHandler = await this.getServerRequestHandler()
-        return requestHandler(req, res, parsedUrl)
-      })
+      return getTracer().trace(
+        NextServerSpan.getRequestHandler,
+        async (span) => {
+          if (span && req.method) {
+            span.setAttribute('method', req.method)
+          }
+
+          const requestHandler = await this.getServerRequestHandler()
+          await requestHandler(req, res, parsedUrl)
+
+          if (span) {
+            span.setAttribute('status', res.statusCode)
+          }
+        }
+      )
     }
   }
 


### PR DESCRIPTION
I didn't add any of the checklists suggested as it didn't seem that any of them were relevant to this improvement. Please let me know if there's anything that needs to be done in order to move this issue forward.

## What?

The currently reported spans provide information about the performance of specific parts of the request serving pipeline, but it's missing context about the specific action being performed when serving that request. For example, rendering a response may take more or less time depending on the complexity of the components in the response being rendered -- knowing which component was being rendered is useful information to have.

This PR adds attributes to the spans that provide context about the request itself, such as the URL path being handled, the method of the request, and the status code of the response. It also adds an attribute that identifies the file that implements a specific request handler. This is particularly valuable, as it provides a low-cardinality attribute by which to group traces in a way that is relevant to our users.

Finally, it also updates the existing tracing's error reporting, in order to add the full error to the span, including its backtrace, as an exception event. This is in compliance with the [OpenTelemetry Semantic Conventions for Exceptions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/exceptions/#recording-an-exception).

## Why?

At AppSignal, we're looking to improve our support for Next.js in our Node.js integration, which uses OpenTelemetry under the hood. Currently, we recommend the use of a custom server, which provides a bare minimum of instrumentation for the server itself, but lacks useful information relating to the actual structure of your Next.js application. We'd like to use your OpenTelemetry tracing support to provide better Next.js support for our users.

By adding these attributes, we should be able to display relevant performance traces for our users, grouped by the file implementing the specific handler whose performance is being measured. And by using exception events, we'd be able to report errors taking place in `getServerSideProps` with a full backtrace.

## How?

### [Record errors as exception events](https://github.com/vercel/next.js/commit/feaa0fb1a026a745fe87797fc7d7562f13b01ca2)

The currently recommended way to report an error in OpenTelemetry is to,
in addition to setting the span status, adding the error information as
an exception event in the span in which it happens.

### [Add span attributes to vanilla spans](https://github.com/vercel/next.js/commit/bcbbc34a331abc35c5b5fc16994c862dcc14d0e8)

Adds a `filename` span attribute to the `NextNodeServer.findPageComponents`
span, with the path to the file for the route (i.e. `/post/[id]/route`)

Adds a `path` span attribute to the `BaseServer.renderToResponse` span,
with the URL path handled by this request (i.e. `/post/123`)

Adds `status` and `method` attributes to the `NextServer.getRequestHandler`
span, with the method of the request and the status code of the response.

## Notes

The code sprinkles `if (span)` everywhere because, when tracing is not being used, the function given to `getTracer().trace()` as an argument will not be passed a span. I believe the OpenTelemetry-idiomatic way to handle this would be for `getTracer().trace()` to pass a `NonRecordingSpan` to the function when tracing is not active or desired, and/or to call `suppressTracing` on the context. It felt to me that changing this was outside the scope of this PR.