### PR TITLE
Support static file robots.txt and sitemap.xml as metadata route

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -132,8 +132,9 @@ import {
 import { webpackBuild } from './webpack-build'
 import { NextBuildContext } from './build-context'
 import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
-import { isAppRouteRoute } from '../lib/is-app-route-route'
+import { isAppRouteRoute, isMetadataRoute } from '../lib/is-app-route-route'
 import { createClientRouterFilter } from '../lib/create-client-router-filter'
+import { createValidFileMatcher } from '../server/lib/find-page-file'
 
 export type SsgRoute = {
   initialRevalidateSeconds: number | false
@@ -491,15 +492,17 @@ export default async function build(
 
       NextBuildContext.buildSpinner = buildSpinner
 
+      const validFileMatcher = createValidFileMatcher(
+        config.pageExtensions,
+        appDir
+      )
+
       const pagesPaths =
         !appDirOnly && pagesDir
           ? await nextBuildSpan
               .traceChild('collect-pages')
               .traceAsyncFn(() =>
-                recursiveReadDir(
-                  pagesDir,
-                  new RegExp(`\\.(?:${config.pageExtensions.join('|')})$`)
-                )
+                recursiveReadDir(pagesDir, validFileMatcher.isPageFile)
               )
           : []
 
@@ -509,12 +512,7 @@ export default async function build(
         appPaths = await nextBuildSpan
           .traceChild('collect-app-paths')
           .traceAsyncFn(() =>
-            recursiveReadDir(
-              appDir,
-              new RegExp(
-                `^(page|route)\\.(?:${config.pageExtensions.join('|')})$`
-              )
-            )
+            recursiveReadDir(appDir, validFileMatcher.isAppRouterPage)
           )
       }
 
@@ -2442,7 +2440,9 @@ export default async function build(
               appConfig.revalidate === 0 ||
               exportConfig.initialPageRevalidationMap[page] === 0
 
-            const isRouteHandler = isAppRouteRoute(originalAppPath)
+            const isRouteHandler =
+              isAppRouteRoute(originalAppPath) ||
+              isMetadataRoute(originalAppPath)
 
             routes.forEach((route) => {
               if (isDynamicRoute(page) && route === page) return

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1708,6 +1708,7 @@ export default async function getBaseWebpackConfig(
         'next-app-loader',
         'next-font-loader',
         'next-invalid-import-error-loader',
+        'next-metadata-route-loader',
       ].reduce((alias, loader) => {
         // using multiple aliases to replace `resolveLoader.modules`
         alias[loader] = path.join(__dirname, 'webpack', 'loaders', loader)

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -1,8 +1,18 @@
 import type webpack from 'webpack'
+import path from 'path'
 
 const staticFileRegex = /[\\/](robots\.txt|sitemap\.xml)/
+
 function isStaticRoute(resourcePath: string) {
   return staticFileRegex.test(resourcePath)
+}
+
+function getContentType(resourcePath: string) {
+  const filename = path.basename(resourcePath)
+  const [name] = filename.split('.')
+  if (name === 'sitemap') return 'application/xml'
+  if (name === 'robots') return 'text/plain'
+  return 'text/plain'
 }
 
 const nextMetadataRouterLoader: webpack.LoaderDefinitionFunction = function (
@@ -14,9 +24,13 @@ const nextMetadataRouterLoader: webpack.LoaderDefinitionFunction = function (
     ? `import { NextResponse } from 'next/server'
 
 const content = ${JSON.stringify(content)}
+const contentType = ${JSON.stringify(getContentType(resourcePath))}
 export function GET() {
   return new NextResponse(content, {
     status: 200,
+    headers: {
+      'Content-Type': contentType,
+    },
   })
 }
 

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -1,0 +1,31 @@
+import type webpack from 'webpack'
+
+const staticFileRegex = /[\\/](robots\.txt|sitemap\.xml)/
+function isStaticRoute(resourcePath: string) {
+  return staticFileRegex.test(resourcePath)
+}
+
+const nextMetadataRouterLoader: webpack.LoaderDefinitionFunction = function (
+  content: string
+) {
+  const { resourcePath } = this
+
+  const code = isStaticRoute(resourcePath)
+    ? `import { NextResponse } from 'next/server'
+
+const content = ${JSON.stringify(content)}
+export function GET() {
+  return new NextResponse(content, {
+    status: 200,
+  })
+}
+
+export const dynamic = 'force-static'
+`
+    : // TODO: handle the defined configs in routes file
+      `export { default as GET } from ${JSON.stringify(resourcePath)}`
+
+  return code
+}
+
+export default nextMetadataRouterLoader

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -31,7 +31,10 @@ import {
 } from '../loaders/utils'
 import { traverseModules } from '../utils'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
-import { isAppRouteRoute } from '../../../lib/is-app-route-route'
+import {
+  isAppRouteRoute,
+  isMetadataRoute,
+} from '../../../lib/is-app-route-route'
 import { getProxiedPluginState } from '../../build-context'
 
 interface Options {
@@ -181,7 +184,8 @@ export class FlightClientEntryPlugin {
         if (
           name.startsWith('pages/') ||
           // Skip for route.js entries
-          (name.startsWith('app/') && isAppRouteRoute(name))
+          (name.startsWith('app/') &&
+            (isAppRouteRoute(name) || isMetadataRoute(name)))
         ) {
           continue
         }

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -40,7 +40,7 @@ import { mockRequest } from '../server/lib/mock-request'
 import { RouteKind } from '../server/future/route-kind'
 import { NodeNextRequest, NodeNextResponse } from '../server/base-http/node'
 import { StaticGenerationContext } from '../server/future/route-handlers/app-route-route-handler'
-import { isAppRouteRoute } from '../lib/is-app-route-route'
+import { isAppRouteRoute, isMetadataRoute } from '../lib/is-app-route-route'
 
 loadRequireHook()
 
@@ -167,7 +167,8 @@ export default async function exportPage({
       let renderAmpPath = ampPath
       let query = { ...originalQuery }
       let params: { [key: string]: string | string[] } | undefined
-      const isRouteHandler = isAppDir && isAppRouteRoute(page)
+      const isRouteHandler =
+        isAppDir && (isAppRouteRoute(page) || isMetadataRoute(page))
 
       if (isAppDir) {
         outDir = join(distDir, 'server/app')

--- a/packages/next/src/lib/is-app-route-route.ts
+++ b/packages/next/src/lib/is-app-route-route.ts
@@ -1,3 +1,11 @@
 export function isAppRouteRoute(route: string): boolean {
   return route.endsWith('/route')
 }
+
+// TODO: support more metadata routes
+const staticMetadataRoutes = ['robots.txt', 'sitemap.xml']
+export function isMetadataRoute(route: string): boolean {
+  // Remove the 'app/' or '/' prefix, only check the route name since they're only allowed in root app directory
+  const filename = route.replace(/^app\//, '').replace(/^\//, '')
+  return staticMetadataRoutes.includes(filename)
+}

--- a/packages/next/src/lib/recursive-readdir.ts
+++ b/packages/next/src/lib/recursive-readdir.ts
@@ -8,10 +8,10 @@ import { join } from 'path'
 export async function recursiveReadDir(
   /** Directory to read */
   dir: string,
-  /** Filter for the file name, only the name part is considered, not the full path */
-  filter: RegExp,
-  /** Filter for the file name, only the name part is considered, not the full path */
-  ignore?: RegExp,
+  /** Filter for the file path */
+  filter: (absoluteFilePath: string) => boolean,
+  /** Filter for the file path */
+  ignore?: (absoluteFilePath: string) => boolean,
   /** This doesn't have to be provided, it's used for the recursion */
   arr: string[] = [],
   /** Used to replace the initial path, only the relative path is left, it's faster than path.relative. */
@@ -22,7 +22,8 @@ export async function recursiveReadDir(
   await Promise.all(
     result.map(async (part: Dirent) => {
       const absolutePath = join(dir, part.name)
-      if (ignore && ignore.test(part.name)) return
+      const relativePath = absolutePath.replace(rootDir, '')
+      if (ignore && ignore(absolutePath)) return
 
       // readdir does not follow symbolic links
       // if part is a symbolic link, follow it using stat
@@ -37,11 +38,11 @@ export async function recursiveReadDir(
         return
       }
 
-      if (!filter.test(part.name)) {
+      if (!filter(absolutePath)) {
         return
       }
 
-      arr.push(absolutePath.replace(rootDir, ''))
+      arr.push(relativePath)
     })
   )
 

--- a/packages/next/src/lib/typescript/getTypeScriptIntent.ts
+++ b/packages/next/src/lib/typescript/getTypeScriptIntent.ts
@@ -29,11 +29,13 @@ export async function getTypeScriptIntent(
   // project for the user when we detect TypeScript files. So, we need to check
   // the `pages/` directory for a TypeScript file.
   // Checking all directories is too slow, so this is a happy medium.
+  const tsFilesRegex = /.*\.(ts|tsx)$/
+  const excludedRegex = /(node_modules|.*\.d\.ts$)/
   for (const dir of intentDirs) {
     const typescriptFiles = await recursiveReadDir(
       dir,
-      /.*\.(ts|tsx)$/,
-      /(node_modules|.*\.d\.ts)/
+      (name) => tsFilesRegex.test(name),
+      (name) => excludedRegex.test(name)
     )
     if (typescriptFiles.length) {
       return { firstTimeSetup: true }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -48,7 +48,7 @@ import { eventCliSession } from '../../telemetry/events'
 import { Telemetry } from '../../telemetry/storage'
 import { setGlobal } from '../../trace'
 import HotReloader from './hot-reloader'
-import { findPageFile, isLayoutsLeafPage } from '../lib/find-page-file'
+import { createValidFileMatcher, findPageFile } from '../lib/find-page-file'
 import { getNodeOptionsWithoutInspect } from '../lib/utils'
 import {
   UnwrapPromise,
@@ -358,8 +358,9 @@ export default class DevServer extends Server {
       return
     }
 
-    const regexPageExtension = new RegExp(
-      `\\.+(?:${this.nextConfig.pageExtensions.join('|')})$`
+    const validFileMatcher = createValidFileMatcher(
+      this.nextConfig.pageExtensions,
+      this.appDir
     )
 
     let resolved = false
@@ -474,7 +475,7 @@ export default class DevServer extends Server {
 
           if (
             meta?.accuracy === undefined ||
-            !regexPageExtension.test(fileName)
+            !validFileMatcher.isPageFile(fileName)
           ) {
             continue
           }
@@ -543,7 +544,7 @@ export default class DevServer extends Server {
           }
 
           if (isAppPath) {
-            if (!isLayoutsLeafPage(fileName, this.nextConfig.pageExtensions)) {
+            if (!validFileMatcher.isAppRouterPage(fileName)) {
               continue
             }
 

--- a/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
+++ b/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
@@ -337,8 +337,8 @@ export class AppRouteRouteHandler implements RouteHandler<AppRouteRouteMatch> {
       RequestStore,
       RequestContext
     > = new RequestAsyncStorageWrapper(),
-    private readonly staticAsyncLocalStorageWrapper = new StaticGenerationAsyncStorageWrapper(),
-    private readonly moduleLoader: ModuleLoader = new NodeModuleLoader()
+    protected readonly staticAsyncLocalStorageWrapper = new StaticGenerationAsyncStorageWrapper(),
+    protected readonly moduleLoader: ModuleLoader = new NodeModuleLoader()
   ) {}
 
   private resolve(method: string, mod: AppRouteModule): AppRouteHandlerFn {
@@ -427,11 +427,11 @@ export class AppRouteRouteHandler implements RouteHandler<AppRouteRouteMatch> {
     // TODO-APP: this is temporarily used for edge.
     request?: Request
   ): Promise<Response> {
-    // This is added by the webpack loader, we load it directly from the module.
-    const { requestAsyncStorage, staticGenerationAsyncStorage } = module
-
     // Get the handler function for the given method.
     const handle = this.resolve(req.method, module)
+
+    // This is added by the webpack loader, we load it directly from the module.
+    const { requestAsyncStorage, staticGenerationAsyncStorage } = module
 
     const requestContext: RequestContext =
       process.env.NEXT_RUNTIME === 'edge'

--- a/packages/next/src/server/future/route-kind.ts
+++ b/packages/next/src/server/future/route-kind.ts
@@ -13,8 +13,8 @@ export const enum RouteKind {
    */
   APP_PAGE = 'APP_PAGE',
   /**
-   * `APP_ROUTE` represents all the API routes that are under `app/` with the
-   * filename of `route.{j,t}s{,x}`.
+   * `APP_ROUTE` represents all the API routes and metadata routes that are under `app/` with the
+   * filename of `route.{j,t}s{,x}` or `^(robots).({j,t}s{,x}|txt)`
    */
   APP_ROUTE = 'APP_ROUTE',
 }

--- a/packages/next/src/server/future/route-kind.ts
+++ b/packages/next/src/server/future/route-kind.ts
@@ -14,7 +14,7 @@ export const enum RouteKind {
   APP_PAGE = 'APP_PAGE',
   /**
    * `APP_ROUTE` represents all the API routes and metadata routes that are under `app/` with the
-   * filename of `route.{j,t}s{,x}` or `^(robots).({j,t}s{,x}|txt)`
+   * filename of `route.{j,t}s{,x}`.
    */
   APP_ROUTE = 'APP_ROUTE',
 }

--- a/packages/next/src/server/future/route-matcher-providers/app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/app-route-route-matcher-provider.ts
@@ -1,5 +1,8 @@
 import path from '../../../shared/lib/isomorphic/path'
-import { isAppRouteRoute } from '../../../lib/is-app-route-route'
+import {
+  isAppRouteRoute,
+  isMetadataRoute,
+} from '../../../lib/is-app-route-route'
 import {
   APP_PATHS_MANIFEST,
   SERVER_DIRECTORY,
@@ -25,7 +28,9 @@ export class AppRouteRouteMatcherProvider extends ManifestRouteMatcherProvider<A
     manifest: Manifest
   ): Promise<ReadonlyArray<AppRouteRouteMatcher>> {
     // This matcher only matches app routes.
-    const pages = Object.keys(manifest).filter((page) => isAppRouteRoute(page))
+    const pages = Object.keys(manifest).filter(
+      (page) => isAppRouteRoute(page) || isMetadataRoute(page)
+    )
 
     // Format the routes.
     const matchers: Array<AppRouteRouteMatcher> = []

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
@@ -24,9 +24,13 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
   ) {
     super(appDir, reader)
 
-    // Match any route file that ends with `/route.${extension}` under the app
-    // directory.
-    this.expression = new RegExp(`[/\\\\]route\\.(?:${extensions.join('|')})$`)
+    // Match any route file that ends with `/route.${extension}` under the app directory.
+    // Match top level robots file that ends with `/robots.${extension}` under the app directory.
+    this.expression = new RegExp(
+      `[/\\\\]route\\.(?:${extensions.join(
+        '|'
+      )})$|[/\\\\]robots\\.(?:${extensions.concat('txt').join('|')})?$`
+    )
 
     const pageNormalizer = new AbsoluteFilenameNormalizer(appDir, extensions)
 

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
@@ -29,7 +29,11 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
     this.expression = new RegExp(
       `[/\\\\]route\\.(?:${extensions.join(
         '|'
-      )})$|[/\\\\]robots\\.(?:${extensions.concat('txt').join('|')})?$`
+      )})$|[/\\\\]robots\\.(?:${extensions
+        .concat('txt')
+        .join('|')})?$|[/\\\\]sitemap\\.(?:${extensions
+        .concat('xml')
+        .join('|')})?$`
     )
 
     const pageNormalizer = new AbsoluteFilenameNormalizer(appDir, extensions)

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -87,8 +87,11 @@ export function createValidFileMatcher(
   )
   // TODO: support other metadata routes
   // regex for /robots.txt|((j|t)sx?)
+  // regex for /sitemap.xml|((j|t)sx?)
   const metadataRoutesRelativePathRegex = new RegExp(
-    `^[\\\\/](robots)\\.(?:${pageExtensions.concat('txt').join('|')})$`
+    `^[\\\\/](robots)\\.(?:${pageExtensions.concat('txt').join('|')})$` +
+      '|' +
+      `^[\\\\/](sitemap)\\.(?:${pageExtensions.concat('xml').join('|')})$`
   )
 
   function isMetadataRouteFile(filePath: string) {

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -1,7 +1,7 @@
 import { fileExists } from '../../lib/file-exists'
 import { getPagePaths } from '../../shared/lib/page-path/get-page-paths'
 import { nonNullable } from '../../lib/non-nullable'
-import { join, sep, normalize, basename } from 'path'
+import { join, sep, normalize } from 'path'
 import { promises } from 'fs'
 import { warn } from '../../build/output/log'
 import chalk from '../../lib/chalk'

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -68,10 +68,49 @@ export async function findPageFile(
   return existingPath
 }
 
-// Determine if the file is leaf node page file under layouts,
-// The filename should start with 'page' and end with one of the allowed extensions
-export function isLayoutsLeafPage(filePath: string, pageExtensions: string[]) {
-  return new RegExp(
-    `(^page|[\\\\/]page|^route|[\\\\/]route)\\.(?:${pageExtensions.join('|')})$`
-  ).test(filePath)
+/**
+ *
+ * createValidFileMatcher receives configured page extensions and return helpers to determine:
+ * `isLayoutsLeafPage`: if a file is a valid page file or routes file under app directory
+ * `isTrackedFiles`: if it's a tracked file for webpack watcher
+ *
+ */
+export function createValidFileMatcher(
+  pageExtensions: string[],
+  appDirPath: string | undefined
+) {
+  const validExtensionFileRegex = new RegExp(
+    `\\.+(?:${pageExtensions.join('|')})$`
+  )
+  const leafOnlyPageFileRegex = new RegExp(
+    `[\\\\/](page|route)\\.(?:${pageExtensions.join('|')})$`
+  )
+  // TODO: support other metadata routes
+  // regex for /robots.txt|((j|t)sx?)
+  const metadataRoutesRelativePathRegex = new RegExp(
+    `^[\\\\/](robots)\\.(?:${pageExtensions.concat('txt').join('|')})$`
+  )
+
+  function isMetadataRouteFile(filePath: string) {
+    if (!appDirPath) return false
+    const relativePath = filePath.replace(appDirPath, '')
+    return metadataRoutesRelativePathRegex.test(relativePath)
+  }
+
+  // Determine if the file is leaf node page file or route file under layouts,
+  // 'page.<extension>' | 'route.<extension>'
+  function isAppRouterPage(filePath: string) {
+    return leafOnlyPageFileRegex.test(filePath) || isMetadataRouteFile(filePath)
+  }
+
+  function isPageFile(filePath: string) {
+    return (
+      validExtensionFileRegex.test(filePath) || isMetadataRouteFile(filePath)
+    )
+  }
+
+  return {
+    isAppRouterPage,
+    isPageFile,
+  }
 }

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -1,7 +1,7 @@
 import { fileExists } from '../../lib/file-exists'
 import { getPagePaths } from '../../shared/lib/page-path/get-page-paths'
 import { nonNullable } from '../../lib/non-nullable'
-import { join, sep, normalize } from 'path'
+import { join, sep, normalize, basename } from 'path'
 import { promises } from 'fs'
 import { warn } from '../../build/output/log'
 import chalk from '../../lib/chalk'
@@ -83,7 +83,7 @@ export function createValidFileMatcher(
     `\\.+(?:${pageExtensions.join('|')})$`
   )
   const leafOnlyPageFileRegex = new RegExp(
-    `[\\\\/](page|route)\\.(?:${pageExtensions.join('|')})$`
+    `(^(page|route)|[\\\\/](page|route))\\.(?:${pageExtensions.join('|')})$`
   )
   // TODO: support other metadata routes
   // regex for /robots.txt|((j|t)sx?)
@@ -113,7 +113,8 @@ export function createValidFileMatcher(
   }
 
   return {
-    isAppRouterPage,
     isPageFile,
+    isAppRouterPage,
+    isMetadataRouteFile,
   }
 }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1277,6 +1277,10 @@ export default class NextNodeServer extends BaseServer {
             )
             if (handled) return { finished: true }
           }
+          // else if (match.definition.kind === RouteKind.METADATA_ROUTE) {
+          //   handled = await this.handlers.handle(match, req, res)
+          //   if (handled) return { finished: true }
+          // }
         }
 
         try {

--- a/test/e2e/app-dir/metadata/app/robots.txt
+++ b/test/e2e/app-dir/metadata/app/robots.txt
@@ -1,0 +1,2 @@
+User-Agent: *
+Disallow:

--- a/test/e2e/app-dir/metadata/app/sitemap.xml
+++ b/test/e2e/app-dir/metadata/app/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://vercel.com/</loc>
+    <lastmod>2023-03-06T18:04:14.008Z</lastmod>
+  </url>
+</urlset>

--- a/test/e2e/app-dir/metadata/app/title/robots.txt
+++ b/test/e2e/app-dir/metadata/app/title/robots.txt
@@ -1,0 +1,6 @@
+# This robots.txt not in root app dir should never be triggered
+User-Agent: *
+Disallow:
+
+Disallow: /pocket
+Allow: /blog/*

--- a/test/e2e/app-dir/metadata/app/title/sitemap.xml
+++ b/test/e2e/app-dir/metadata/app/title/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://vercel.com/</loc>
+    <lastmod>2023-03-06T18:04:14.008Z</lastmod>
+  </url>
+</urlset>

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -644,6 +644,17 @@ createNextDescribe(
       })
     })
 
+    describe('static routes', () => {
+      it('should support root dir robots.txt', async () => {
+        const content = await next.render('/robots.txt')
+        expect(content).toContain('User-Agent: *\nDisallow:')
+        const res = await next.fetch('/title/robots.txt')
+        expect(res.status).toBe(404)
+      })
+
+      it('should support root dir robots.txt', async () => {})
+    })
+
     describe('react cache', () => {
       it('should have same title and page value on initial load', async () => {
         const browser = await next.browser('/cache-deduping')

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -646,13 +646,24 @@ createNextDescribe(
 
     describe('static routes', () => {
       it('should support root dir robots.txt', async () => {
-        const content = await next.render('/robots.txt')
-        expect(content).toContain('User-Agent: *\nDisallow:')
-        const res = await next.fetch('/title/robots.txt')
-        expect(res.status).toBe(404)
+        const res = await next.fetch('/robots.txt')
+        expect(res.headers.get('content-type')).toBe('text/plain')
+        expect(await res.text()).toContain('User-Agent: *\nDisallow:')
+        const invalidRobotsResponse = await next.fetch('/title/robots.txt')
+        expect(invalidRobotsResponse.status).toBe(404)
       })
 
-      it('should support root dir robots.txt', async () => {})
+      it('should support root dir sitemap.xml', async () => {
+        const res = await next.fetch('/sitemap.xml')
+        expect(res.headers.get('content-type')).toBe('application/xml')
+        const sitemap = await res.text()
+        expect(sitemap).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+        expect(sitemap).toContain(
+          '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        )
+        const invalidSitemapResponse = await next.fetch('/title/sitemap.xml')
+        expect(invalidSitemapResponse.status).toBe(404)
+      })
     })
 
     describe('react cache', () => {

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -187,9 +187,8 @@ describe('Build Output', () => {
       })
 
       it('should not emit extracted comments', async () => {
-        const files = await recursiveReadDir(
-          join(appDir, '.next'),
-          /\.txt|\.LICENSE\./
+        const files = await recursiveReadDir(join(appDir, '.next'), (f) =>
+          /\.txt|\.LICENSE\./.test(f)
         )
         expect(files).toEqual([])
       })

--- a/test/integration/production-browser-sourcemaps/test/index.test.js
+++ b/test/integration/production-browser-sourcemaps/test/index.test.js
@@ -10,7 +10,7 @@ function runTests() {
   it('includes sourcemaps for all browser files', async () => {
     const browserFiles = await recursiveReadDir(
       join(appDir, '.next', 'static'),
-      /.*/
+      (f) => /.*/.test(f)
     )
     const jsFiles = browserFiles.filter(
       (file) => file.endsWith('.js') && file.includes('/pages/')

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -645,13 +645,13 @@ describe('Production Usage', () => {
 
       const cssStaticAssets = await recursiveReadDir(
         join(__dirname, '..', '.next', 'static'),
-        /\.css$/
+        (f) => /\.css$/.test(f)
       )
       expect(cssStaticAssets.length).toBeGreaterThanOrEqual(1)
       expect(cssStaticAssets[0]).toMatch(/[\\/]css[\\/]/)
       const mediaStaticAssets = await recursiveReadDir(
         join(__dirname, '..', '.next', 'static'),
-        /\.svg$/
+        (f) => /\.svg$/.test(f)
       )
       expect(mediaStaticAssets.length).toBeGreaterThanOrEqual(1)
       expect(mediaStaticAssets[0]).toMatch(/[\\/]media[\\/]/)

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -98,7 +98,9 @@ module.exports = (context) => {
       const buildId = readFileSync(join(__dirname, '../.next/BUILD_ID'), 'utf8')
 
       const readPath = join(__dirname, `../.next/static/${buildId}`)
-      const buildFiles = await recursiveReadDir(readPath, /\.js$/)
+      const buildFiles = await recursiveReadDir(readPath, (f) =>
+        /\.js$/.test(f)
+      )
 
       if (buildFiles.length < 1) {
         throw new Error('Could not locate any build files')

--- a/test/unit/recursive-delete.test.ts
+++ b/test/unit/recursive-delete.test.ts
@@ -16,7 +16,9 @@ describe('recursiveDelete', () => {
       await recursiveCopy(resolveDataDir, testResolveDataDir)
       await fs.symlink('./aa', join(testResolveDataDir, 'symlink'))
       await recursiveDelete(testResolveDataDir)
-      const result = await recursiveReadDir(testResolveDataDir, /.*/)
+      const result = await recursiveReadDir(testResolveDataDir, (f) =>
+        /.*/.test(f)
+      )
       expect(result.length).toBe(0)
     } finally {
       await recursiveDelete(testResolveDataDir)
@@ -32,13 +34,17 @@ describe('recursiveDelete', () => {
       // preserve cache dir
       await recursiveDelete(testpreservefileDir, /^cache/)
 
-      const result = await recursiveReadDir(testpreservefileDir, /.*/)
+      const result = await recursiveReadDir(testpreservefileDir, (f) =>
+        /.*/.test(f)
+      )
       expect(result.length).toBe(1)
     } finally {
       // Ensure test cleanup
       await recursiveDelete(testpreservefileDir)
 
-      const cleanupResult = await recursiveReadDir(testpreservefileDir, /.*/)
+      const cleanupResult = await recursiveReadDir(testpreservefileDir, (f) =>
+        /.*/.test(f)
+      )
       expect(cleanupResult.length).toBe(0)
     }
   })

--- a/test/unit/recursive-readdir.test.ts
+++ b/test/unit/recursive-readdir.test.ts
@@ -8,7 +8,7 @@ const dirWithPages = join(resolveDataDir, 'readdir', 'pages')
 
 describe('recursiveReadDir', () => {
   it('should work', async () => {
-    const result = await recursiveReadDir(dirWithPages, /\.js/)
+    const result = await recursiveReadDir(dirWithPages, (f) => /\.js/.test(f))
     const pages = [
       /^[\\/]index\.js/,
       /^[\\/]prefered\.js/,


### PR DESCRIPTION
Support top level static `robots.txt` and `sitemap.xml` as metadata route in app directory. When those files are placed in top root directory

Refactored a bit the page files matching logic, to reuse it between dev server and build

Closes NEXT-267