### PR TITLE
Add support for scrolling to hash fragment

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -239,6 +239,7 @@ export function hydrate() {
             changeByServerResponse: () => {},
             focusAndScrollRef: {
               apply: false,
+              hashFragment: null,
             },
           }}
         >

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -114,11 +114,24 @@ function topOfElementInViewport(element: HTMLElement, viewportHeight: number) {
   return rect.top >= 0 && rect.top <= viewportHeight
 }
 
+/**
+ * Find the DOM node for a hash fragment.
+ * If `top` the page has to scroll to the top of the page. This mirrors the browser's behavior.
+ * If the hash fragment is an id, the page has to scroll to the element with that id.
+ * If the hash fragment is a name, the page has to scroll to the first element with that name.
+ */
 function getHashFragmentDomNode(hashFragment: string) {
+  // If the hash fragment is `top` the page has to scroll to the top of the page.
   if (hashFragment === 'top') {
     return document.body
   }
-  return document.getElementById(hashFragment)
+
+  // If the hash fragment is an id, the page has to scroll to the element with that id.
+  return (
+    document.getElementById(hashFragment) ??
+    // If the hash fragment is a name, the page has to scroll to the first element with that name.
+    document.getElementsByName(hashFragment)[0]
+  )
 }
 interface ScrollAndFocusHandlerProps {
   focusAndScrollRef: FocusAndScrollRef

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -146,11 +146,10 @@ class ScrollAndFocusHandler extends React.Component<ScrollAndFocusHandlerProps> 
       let domNode:
         | ReturnType<typeof getHashFragmentDomNode>
         | ReturnType<typeof findDOMNode> = null
-      let isHashScroll = false
+      const hashFragment = focusAndScrollRef.hashFragment
 
-      if (focusAndScrollRef.hashFragment) {
-        domNode = getHashFragmentDomNode(focusAndScrollRef.hashFragment)
-        isHashScroll = true
+      if (hashFragment) {
+        domNode = getHashFragmentDomNode(hashFragment)
       }
 
       // `findDOMNode` is tricky because it returns just the first child if the component is a fragment.
@@ -171,7 +170,7 @@ class ScrollAndFocusHandler extends React.Component<ScrollAndFocusHandlerProps> 
       handleSmoothScroll(
         () => {
           // In case of hash scroll we need to scroll to the top of the element
-          if (isHashScroll) {
+          if (hashFragment) {
             window.scrollTo(0, (domNode as HTMLElement).offsetTop)
             return
           }

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -156,7 +156,6 @@ class ScrollAndFocusHandler extends React.Component<ScrollAndFocusHandlerProps> 
       // This already caused a bug where the first child was a <link/> in head.
       if (!domNode) {
         domNode = findDOMNode(this)
-        console.log('layoutDomNode', domNode)
       }
 
       // If there is no DOMNode this layout-router level is skipped. It'll be handled higher-up in the tree.

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -133,10 +133,11 @@ class ScrollAndFocusHandler extends React.Component<ScrollAndFocusHandlerProps> 
       let domNode:
         | ReturnType<typeof getHashFragmentDomNode>
         | ReturnType<typeof findDOMNode> = null
+      let isHashScroll = false
 
       if (focusAndScrollRef.hashFragment) {
         domNode = getHashFragmentDomNode(focusAndScrollRef.hashFragment)
-        console.log('hashFragment', domNode)
+        isHashScroll = true
       }
 
       // `findDOMNode` is tricky because it returns just the first child if the component is a fragment.
@@ -156,6 +157,11 @@ class ScrollAndFocusHandler extends React.Component<ScrollAndFocusHandlerProps> 
 
       handleSmoothScroll(
         () => {
+          // In case of hash scroll we need to scroll to the top of the element
+          if (isHashScroll) {
+            window.scrollTo(0, (domNode as HTMLElement).offsetTop)
+            return
+          }
           // Store the current viewport height because reading `clientHeight` causes a reflow,
           // and it won't change during this function.
           const htmlElement = document.documentElement

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -95,7 +95,7 @@ describe('createInitialRouterState', () => {
       canonicalUrl: initialCanonicalUrl,
       prefetchCache: new Map(),
       pushRef: { pendingPush: false, mpaNavigation: false },
-      focusAndScrollRef: { apply: false },
+      focusAndScrollRef: { apply: false, hashFragment: null },
       cache: expectedCache,
     }
 

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -43,7 +43,7 @@ export function createInitialRouterState({
     cache,
     prefetchCache: new Map(),
     pushRef: { pendingPush: false, mpaNavigation: false },
-    focusAndScrollRef: { apply: false },
+    focusAndScrollRef: { apply: false, hashFragment: null },
     canonicalUrl:
       // location.href is read as the initial value for canonicalUrl in the browser
       // This is safe to do as canonicalUrl can't be rendered, it's only used to control the history updates in the useEffect further down in this file.

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
@@ -191,6 +191,7 @@ describe('navigateReducer', () => {
       },
       focusAndScrollRef: {
         apply: true,
+        hashFragment: null,
       },
       canonicalUrl: '/linking/about',
       cache: {
@@ -373,6 +374,7 @@ describe('navigateReducer', () => {
       },
       focusAndScrollRef: {
         apply: true,
+        hashFragment: null,
       },
       canonicalUrl: '/linking/about',
       cache: {
@@ -558,6 +560,7 @@ describe('navigateReducer', () => {
       },
       focusAndScrollRef: {
         apply: false,
+        hashFragment: null,
       },
       canonicalUrl: 'https://example.vercel.sh/',
       cache: {
@@ -714,6 +717,7 @@ describe('navigateReducer', () => {
       },
       focusAndScrollRef: {
         apply: false,
+        hashFragment: null,
       },
       canonicalUrl: 'https://example.vercel.sh/',
       cache: {
@@ -867,6 +871,7 @@ describe('navigateReducer', () => {
       },
       focusAndScrollRef: {
         apply: true,
+        hashFragment: null,
       },
       canonicalUrl: '/linking/about',
       cache: {
@@ -1088,6 +1093,7 @@ describe('navigateReducer', () => {
       },
       focusAndScrollRef: {
         apply: true,
+        hashFragment: null,
       },
       canonicalUrl: '/linking/about',
       cache: {
@@ -1314,6 +1320,7 @@ describe('navigateReducer', () => {
       },
       focusAndScrollRef: {
         apply: true,
+        hashFragment: null,
       },
       canonicalUrl: '/parallel-tab-bar/demographics',
       cache: {

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -57,8 +57,8 @@ export function handleMutable(
         // Empty hash should trigger default behavior of scrolling layout into view.
         // #top is handled in layout-router.
         mutable.hashFragment && mutable.hashFragment !== ''
-          ? // Remove leading #.
-            mutable.hashFragment.slice(1)
+          ? // Remove leading # and decode hash to make non-latin hashes work.
+            decodeURIComponent(mutable.hashFragment.slice(1))
           : null,
     },
     // Apply cache.

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -53,6 +53,13 @@ export function handleMutable(
         typeof mutable.applyFocusAndScroll !== 'undefined'
           ? mutable.applyFocusAndScroll
           : state.focusAndScrollRef.apply,
+      hashFragment:
+        // Empty hash should trigger default behavior of scrolling layout into view.
+        // #top is handled in layout-router.
+        mutable.hashFragment && mutable.hashFragment !== ''
+          ? // Remove leading #.
+            mutable.hashFragment.slice(1)
+          : null,
     },
     // Apply cache.
     cache: mutable.cache ? mutable.cache : state.cache,
@@ -121,7 +128,7 @@ export function navigateReducer(
     mutable,
     forceOptimisticNavigation,
   } = action
-  const { pathname, search } = url
+  const { pathname, search, hash } = url
   const href = createHrefFromUrl(url)
   const pendingPush = navigateType === 'push'
 
@@ -192,6 +199,7 @@ export function navigateReducer(
         ? createHrefFromUrl(canonicalUrlOverride)
         : href
       mutable.pendingPush = pendingPush
+      mutable.hashFragment = hash
 
       return handleMutable(state, mutable)
     }
@@ -230,6 +238,7 @@ export function navigateReducer(
       mutable.previousTree = state.tree
       mutable.patchedTree = optimisticTree
       mutable.pendingPush = pendingPush
+      mutable.hashFragment = hash
       mutable.applyFocusAndScroll = true
       mutable.cache = cache
       mutable.canonicalUrl = href
@@ -289,6 +298,7 @@ export function navigateReducer(
   mutable.patchedTree = newTree
   mutable.applyFocusAndScroll = true
   mutable.pendingPush = pendingPush
+  mutable.hashFragment = hash
 
   const applied = applyFlightData(state, cache, flightDataPath)
   if (applied) {

--- a/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
@@ -170,6 +170,7 @@ describe('prefetchReducer', () => {
       },
       focusAndScrollRef: {
         apply: false,
+        hashFragment: null,
       },
       canonicalUrl: '/linking',
       cache: {
@@ -313,6 +314,7 @@ describe('prefetchReducer', () => {
       },
       focusAndScrollRef: {
         apply: false,
+        hashFragment: null,
       },
       canonicalUrl: '/linking',
       cache: {

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
@@ -151,6 +151,7 @@ describe('refreshReducer', () => {
       },
       focusAndScrollRef: {
         apply: false,
+        hashFragment: null,
       },
       canonicalUrl: '/linking',
       cache: {
@@ -307,6 +308,7 @@ describe('refreshReducer', () => {
       },
       focusAndScrollRef: {
         apply: false,
+        hashFragment: null,
       },
       canonicalUrl: '/linking',
       cache: {
@@ -487,6 +489,7 @@ describe('refreshReducer', () => {
       },
       focusAndScrollRef: {
         apply: false,
+        hashFragment: null,
       },
       canonicalUrl: '/linking',
       cache: {

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.test.tsx
@@ -123,6 +123,7 @@ describe('serverPatchReducer', () => {
       },
       focusAndScrollRef: {
         apply: false,
+        hashFragment: null,
       },
       canonicalUrl: '/linking/about',
       cache: {
@@ -283,6 +284,7 @@ describe('serverPatchReducer', () => {
       },
       focusAndScrollRef: {
         apply: false,
+        hashFragment: null,
       },
       canonicalUrl: '/linking/about',
       cache: {

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
@@ -186,6 +186,7 @@ describe('serverPatchReducer', () => {
       },
       focusAndScrollRef: {
         apply: false,
+        hashFragment: null,
       },
       canonicalUrl: '/linking/about',
       cache: {
@@ -379,6 +380,7 @@ describe('serverPatchReducer', () => {
       },
       focusAndScrollRef: {
         apply: false,
+        hashFragment: null,
       },
       canonicalUrl: '/linking/about',
       cache: {
@@ -551,6 +553,7 @@ describe('serverPatchReducer', () => {
       },
       focusAndScrollRef: {
         apply: true,
+        hashFragment: null,
       },
       canonicalUrl: '/linking/about',
       cache: {

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -16,6 +16,7 @@ export interface Mutable {
   applyFocusAndScroll?: boolean
   pendingPush?: boolean
   cache?: CacheNode
+  hashFragment?: string
 }
 
 /**
@@ -132,6 +133,10 @@ export type FocusAndScrollRef = {
    * If focus and scroll should be set in the layout-router's useEffect()
    */
   apply: boolean
+  /**
+   * The hash fragment that should be scrolled to.
+   */
+  hashFragment: string | null
 }
 
 /**

--- a/test/e2e/app-dir/navigation/app/hash/global.css
+++ b/test/e2e/app-dir/navigation/app/hash/global.css
@@ -1,0 +1,5 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}

--- a/test/e2e/app-dir/navigation/app/hash/global.css
+++ b/test/e2e/app-dir/navigation/app/hash/global.css
@@ -2,4 +2,5 @@
   margin: 0;
   padding: 0;
   box-sizing: border-box;
+  font-size: 14px;
 }

--- a/test/e2e/app-dir/navigation/app/hash/global.css
+++ b/test/e2e/app-dir/navigation/app/hash/global.css
@@ -3,4 +3,5 @@
   padding: 0;
   box-sizing: border-box;
   font-size: 14px;
+  line-height: 1;
 }

--- a/test/e2e/app-dir/navigation/app/hash/page.js
+++ b/test/e2e/app-dir/navigation/app/hash/page.js
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 export default function HashPage() {
   // Create list of 5000 items that all have unique id
   const items = Array.from({ length: 5000 }, (_, i) => ({ id: i }))
@@ -5,6 +7,24 @@ export default function HashPage() {
   return (
     <div>
       <h1>Hash Page</h1>
+      <Link href="/hash#hash-6" id="link-to-6">
+        To 6
+      </Link>
+      <Link href="/hash#hash-50" id="link-to-50">
+        To 50
+      </Link>
+      <Link href="/hash#hash-160" id="link-to-160">
+        To 160
+      </Link>
+      <Link href="/hash#hash-300" id="link-to-300">
+        To 300
+      </Link>
+      <Link href="/hash#top" id="link-to-top">
+        To Top
+      </Link>
+      <Link href="/hash#non-existent" id="link-to-non-existent">
+        To non-existent
+      </Link>
       <ul>
         {items.map((item) => (
           <li key={item.id}>

--- a/test/e2e/app-dir/navigation/app/hash/page.js
+++ b/test/e2e/app-dir/navigation/app/hash/page.js
@@ -26,13 +26,13 @@ export default function HashPage() {
       <Link href="/hash#non-existent" id="link-to-non-existent">
         To non-existent
       </Link>
-      <ul>
+      <div>
         {items.map((item) => (
-          <li key={item.id}>
+          <div key={item.id}>
             <div id={`hash-${item.id}`}>{item.id}</div>
-          </li>
+          </div>
         ))}
-      </ul>
+      </div>
     </div>
   )
 }

--- a/test/e2e/app-dir/navigation/app/hash/page.js
+++ b/test/e2e/app-dir/navigation/app/hash/page.js
@@ -7,7 +7,7 @@ export default function HashPage() {
 
   return (
     <div style={{ fontFamily: 'sans-serif', fontSize: '16px' }}>
-      <h1>Hash Page</h1>
+      <p>Hash Page</p>
       <Link href="/hash#hash-6" id="link-to-6">
         To 6
       </Link>

--- a/test/e2e/app-dir/navigation/app/hash/page.js
+++ b/test/e2e/app-dir/navigation/app/hash/page.js
@@ -1,0 +1,17 @@
+export default function HashPage() {
+  // Create list of 5000 items that all have unique id
+  const items = Array.from({ length: 5000 }, (_, i) => ({ id: i }))
+
+  return (
+    <div>
+      <h1>Hash Page</h1>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>
+            <div id={`hash-${item.id}`}>{item.id}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/app/hash/page.js
+++ b/test/e2e/app-dir/navigation/app/hash/page.js
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import './global.css'
 
 export default function HashPage() {
   // Create list of 5000 items that all have unique id

--- a/test/e2e/app-dir/navigation/app/hash/page.js
+++ b/test/e2e/app-dir/navigation/app/hash/page.js
@@ -5,7 +5,7 @@ export default function HashPage() {
   const items = Array.from({ length: 5000 }, (_, i) => ({ id: i }))
 
   return (
-    <div>
+    <div style={{ fontFamily: 'sans-serif' }}>
       <h1>Hash Page</h1>
       <Link href="/hash#hash-6" id="link-to-6">
         To 6

--- a/test/e2e/app-dir/navigation/app/hash/page.js
+++ b/test/e2e/app-dir/navigation/app/hash/page.js
@@ -6,7 +6,7 @@ export default function HashPage() {
   const items = Array.from({ length: 5000 }, (_, i) => ({ id: i }))
 
   return (
-    <div style={{ fontFamily: 'sans-serif' }}>
+    <div style={{ fontFamily: 'sans-serif', fontSize: '16px' }}>
       <h1>Hash Page</h1>
       <Link href="/hash#hash-6" id="link-to-6">
         To 6

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -42,18 +42,24 @@ createNextDescribe(
           expectedScroll: number
         ) => {
           await browser.elementByCss(`#link-to-${val.toString()}`).click()
-          await check(async () => {
-            const val = await browser.eval('window.pageYOffset')
-            return val.toString()
-          }, expectedScroll.toString())
+          await check(
+            async () => {
+              const val = await browser.eval('window.pageYOffset')
+              return val.toString()
+            },
+            expectedScroll.toString(),
+            true,
+            // Try maximum of 15 seconds
+            15
+          )
         }
 
-        await checkLink(6, 222)
-        await checkLink(50, 1039)
-        await checkLink(160, 3074)
-        await checkLink(300, 5664)
+        await checkLink(6, 167)
+        await checkLink(50, 981)
+        await checkLink(160, 3016)
+        await checkLink(300, 5606)
         await checkLink('top', 0)
-        await checkLink('non-existent', 21)
+        await checkLink('non-existent', 0)
       })
     })
 

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -55,10 +55,10 @@ createNextDescribe(
           )
         }
 
-        await checkLink(6, 131)
-        await checkLink(50, 835)
-        await checkLink(160, 2595)
-        await checkLink(300, 4835)
+        await checkLink(6, 114)
+        await checkLink(50, 730)
+        await checkLink(160, 2270)
+        await checkLink(300, 4230)
         await checkLink('top', 0)
         await checkLink('non-existent', 0)
       })

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -48,7 +48,7 @@ createNextDescribe(
           }, expectedScroll.toString())
         }
 
-        await checkLink(6, 225)
+        await checkLink(6, 222)
         await checkLink(50, 1039)
         await checkLink(160, 3074)
         await checkLink(300, 5664)

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -45,6 +45,7 @@ createNextDescribe(
           await check(
             async () => {
               const val = await browser.eval('window.pageYOffset')
+              require('console').error({ val })
               return val.toString()
             },
             expectedScroll.toString(),
@@ -54,10 +55,10 @@ createNextDescribe(
           )
         }
 
-        await checkLink(6, 167)
-        await checkLink(50, 981)
-        await checkLink(160, 3016)
-        await checkLink(300, 5606)
+        await checkLink(6, 131)
+        await checkLink(50, 835)
+        await checkLink(160, 2595)
+        await checkLink(300, 4835)
         await checkLink('top', 0)
         await checkLink('non-existent', 0)
       })

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -33,6 +33,30 @@ createNextDescribe(
       })
     })
 
+    describe('hash', () => {
+      it('should scroll to the specified hash', async () => {
+        const browser = await next.browser('/hash')
+
+        const checkLink = async (
+          val: number | string,
+          expectedScroll: number
+        ) => {
+          await browser.elementByCss(`#link-to-${val.toString()}`).click()
+          await check(async () => {
+            const val = await browser.eval('window.pageYOffset')
+            return val.toString()
+          }, expectedScroll.toString())
+        }
+
+        await checkLink(6, 225)
+        await checkLink(50, 1039)
+        await checkLink(160, 3074)
+        await checkLink(300, 5664)
+        await checkLink('top', 0)
+        await checkLink('non-existent', 21)
+      })
+    })
+
     describe('not-found', () => {
       it('should trigger not-found in a server component', async () => {
         const browser = await next.browser('/not-found/servercomponent')

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -533,11 +533,16 @@ export async function startCleanStaticServer(dir) {
 
 // check for content in 1 second intervals timing out after
 // 30 seconds
-export async function check(contentFn, regex, hardError = true) {
+export async function check(
+  contentFn,
+  regex,
+  hardError = true,
+  maxRetries = 30
+) {
   let content
   let lastErr
 
-  for (let tries = 0; tries < 30; tries++) {
+  for (let tries = 0; tries < maxRetries; tries++) {
     try {
       content = await contentFn()
       if (typeof regex === 'string') {


### PR DESCRIPTION
Adds support for scrolling based on the [hash fragment](https://en.wikipedia.org/wiki/URI_fragment) in client-side navigations for the App Router, mirroring browser behavior. 

- `#main-content` → scrolls to `id="main-content"` or `name="main-content"` property 
- `#top` → scrolls to the top of the page, this is a special case in browsers.
- no hash → default scroll behavior, layout that changed

Fixes NEXT-658

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

fixes #44295