### PR TITLE
fix: Export StaticRequire interface in Image.tsx to avoid TS emit issues

### DIFF
--- a/packages/next/src/client/image.tsx
+++ b/packages/next/src/client/image.tsx
@@ -67,7 +67,7 @@ export interface StaticImageData {
   blurHeight?: number
 }
 
-interface StaticRequire {
+export interface StaticRequire {
   default: StaticImageData
 }
 


### PR DESCRIPTION
### What?

export the interface for `next/image`'s `StaticRequire`

### Why?

Some context:

While working on a library that tries to provide a unified API for `next/image` and `expo/image`, I discovered that any library that to build on top of `next/image` cannot emit types in the latest typescript versions.

Not entirely sure why tbh, but can confirm that this tiny fix worked locally for me with `npx patch-package`

If there are other / better solutions to fix such issues, please let me know 🙏

### How?

export the interface for `next/image`'s `StaticRequire`

