### PR TITLE
Add /route subpath to metadata static routes

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -374,8 +374,6 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
           : bundleFile.slice(1)
       const absolutePagePath = mappings[page]
 
-      const outputServerBundlePath = serverBundlePath
-
       // Handle paths that have aliases
       const pageFilePath = (() => {
         if (absolutePagePath.startsWith(PAGES_DIR_ALIAS) && pagesDir) {
@@ -445,7 +443,7 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
         onServer: () => {
           if (pagesType === 'app' && appDir) {
             const matchedAppPaths = appPathsPerRoute[normalizeAppPath(page)]
-            server[outputServerBundlePath] = getAppEntry({
+            server[serverBundlePath] = getAppEntry({
               name: serverBundlePath,
               pagePath: mappings[page],
               appDir,
@@ -455,13 +453,13 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
             })
           } else {
             if (isInstrumentationHookFile(page) && pagesType === 'root') {
-              server[outputServerBundlePath.replace('src/', '')] = {
+              server[serverBundlePath.replace('src/', '')] = {
                 import: mappings[page],
                 // the '../' is needed to make sure the file is not chunked
                 filename: `../${INSTRUMENTATION_HOOK_FILENAME}.js`,
               }
             } else {
-              server[outputServerBundlePath] = [mappings[page]]
+              server[serverBundlePath] = [mappings[page]]
             }
           }
         },

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -64,17 +64,10 @@ async function createAppRouteCode({
   pagePath: string
   resolver: PathResolver
 }): Promise<string> {
-  // Split based on any specific path separators (both `/` and `\`)...
-  const routePath = name.replace(/^app/, '')
-  const splittedPath = pagePath.split(/[\\/]/)
-  // Then join all but the last part with the same separator, `/`...
-  const segmentPath = splittedPath.slice(0, -1).join('/')
-  // Then add the `/route` suffix...
-  const matchedPagePath = `${segmentPath}/${routePath}`
-
+  const routePath = pagePath.replace(/[\\/]/, '/')
   // This, when used with the resolver will give us the pathname to the built
   // route handler file.
-  let resolvedPagePath = (await resolver(matchedPagePath))!
+  let resolvedPagePath = (await resolver(routePath))!
 
   if (isMetadataRoute(name)) {
     resolvedPagePath = `next-metadata-route-loader!${resolvedPagePath}`

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -65,12 +65,12 @@ async function createAppRouteCode({
   resolver: PathResolver
 }): Promise<string> {
   // Split based on any specific path separators (both `/` and `\`)...
-  const routeName = name.split('/').pop()!
+  const routePath = name.replace(/^app/, '')
   const splittedPath = pagePath.split(/[\\/]/)
   // Then join all but the last part with the same separator, `/`...
   const segmentPath = splittedPath.slice(0, -1).join('/')
   // Then add the `/route` suffix...
-  const matchedPagePath = `${segmentPath}/${routeName}`
+  const matchedPagePath = `${segmentPath}/${routePath}`
 
   // This, when used with the resolver will give us the pathname to the built
   // route handler file.

--- a/packages/next/src/lib/is-app-route-route.ts
+++ b/packages/next/src/lib/is-app-route-route.ts
@@ -1,21 +1,21 @@
-import path from '../shared/lib/isomorphic/path'
-
 export function isAppRouteRoute(route: string): boolean {
   return route.endsWith('/route')
 }
 
 // Match routes that are metadata routes, e.g. /sitemap.xml, /favicon.<ext>, /<icon>.<ext>, etc.
 // TODO-METADATA: support more metadata routes with more extensions
-const staticMetadataRoutes = ['robots.txt', 'sitemap.xml', 'favicon.ico']
+const staticMetadataRoutes = [/robots\.txt/, /sitemap\.xml/, /favicon\.ico/]
 export function isMetadataRoute(route: string): boolean {
   // Remove the 'app/' or '/' prefix, only check the route name since they're only allowed in root app directory
-  const filename = route.replace(/^app\//, '').replace(/^\//, '')
-  return staticMetadataRoutes.includes(filename)
+  const filename = route
+    .replace(/^app\//, '')
+    .replace(/^\//, '')
+    .replace(/\/route$/, '')
+  return staticMetadataRoutes.some((r) => r.test(filename))
 }
 
 // Only match the static metadata files
 // TODO-METADATA: support static metadata files under nested routes folders
 export function isStaticMetadataRoute(resourcePath: string) {
-  const filename = path.basename(resourcePath)
-  return staticMetadataRoutes.includes(filename)
+  return staticMetadataRoutes.some((r) => r.test(resourcePath))
 }

--- a/packages/next/src/server/dev/hot-reloader.ts
+++ b/packages/next/src/server/dev/hot-reloader.ts
@@ -53,6 +53,7 @@ import { getRegistry } from '../../lib/helpers/get-registry'
 import { RouteMatch } from '../future/route-matches/route-match'
 import type { Telemetry } from '../../telemetry/storage'
 import { parseVersionInfo, VersionInfo } from './parse-version-info'
+import { isMetadataRoute } from '../../lib/is-app-route-route'
 
 function diff(a: Set<any>, b: Set<any>) {
   return new Set([...a].filter((v) => !b.has(v)))
@@ -678,6 +679,10 @@ export default class HotReloader {
               )
             const [, key /* pageType*/, , page] = result! // this match should always happen
 
+            const outputBundlePath = isMetadataRoute(page)
+              ? bundlePath
+              : `${bundlePath}/route`
+
             if (key === COMPILER_NAMES.client && !isClientCompilation) return
             if (key === COMPILER_NAMES.server && !isNodeServerCompilation)
               return
@@ -756,14 +761,14 @@ export default class HotReloader {
                   : undefined
 
                 entries[entryKey].status = BUILDING
-                entrypoints[bundlePath] = finalizeEntrypoint({
+                entrypoints[outputBundlePath] = finalizeEntrypoint({
                   compilerType: COMPILER_NAMES.edgeServer,
                   name: bundlePath,
                   value: getEdgeServerEntry({
                     absolutePagePath: entryData.absolutePagePath,
                     rootDir: this.dir,
                     buildId: this.buildId,
-                    bundlePath,
+                    bundlePath: outputBundlePath,
                     config: this.config,
                     isDev: true,
                     page,
@@ -812,7 +817,7 @@ export default class HotReloader {
                 ) {
                   relativeRequest = `./${relativeRequest}`
                 }
-                entrypoints[bundlePath] = finalizeEntrypoint({
+                entrypoints[outputBundlePath] = finalizeEntrypoint({
                   compilerType: COMPILER_NAMES.server,
                   name: bundlePath,
                   isServerComponent,

--- a/packages/next/src/server/dev/hot-reloader.ts
+++ b/packages/next/src/server/dev/hot-reloader.ts
@@ -679,10 +679,6 @@ export default class HotReloader {
               )
             const [, key /* pageType*/, , page] = result! // this match should always happen
 
-            const outputBundlePath = isMetadataRoute(page)
-              ? bundlePath
-              : `${bundlePath}/route`
-
             if (key === COMPILER_NAMES.client && !isClientCompilation) return
             if (key === COMPILER_NAMES.server && !isNodeServerCompilation)
               return
@@ -761,14 +757,14 @@ export default class HotReloader {
                   : undefined
 
                 entries[entryKey].status = BUILDING
-                entrypoints[outputBundlePath] = finalizeEntrypoint({
+                entrypoints[bundlePath] = finalizeEntrypoint({
                   compilerType: COMPILER_NAMES.edgeServer,
                   name: bundlePath,
                   value: getEdgeServerEntry({
                     absolutePagePath: entryData.absolutePagePath,
                     rootDir: this.dir,
                     buildId: this.buildId,
-                    bundlePath: outputBundlePath,
+                    bundlePath: bundlePath,
                     config: this.config,
                     isDev: true,
                     page,
@@ -817,7 +813,7 @@ export default class HotReloader {
                 ) {
                   relativeRequest = `./${relativeRequest}`
                 }
-                entrypoints[outputBundlePath] = finalizeEntrypoint({
+                entrypoints[bundlePath] = finalizeEntrypoint({
                   compilerType: COMPILER_NAMES.server,
                   name: bundlePath,
                   isServerComponent,

--- a/packages/next/src/server/dev/hot-reloader.ts
+++ b/packages/next/src/server/dev/hot-reloader.ts
@@ -53,7 +53,6 @@ import { getRegistry } from '../../lib/helpers/get-registry'
 import { RouteMatch } from '../future/route-matches/route-match'
 import type { Telemetry } from '../../telemetry/storage'
 import { parseVersionInfo, VersionInfo } from './parse-version-info'
-import { isMetadataRoute } from '../../lib/is-app-route-route'
 
 function diff(a: Set<any>, b: Set<any>) {
   return new Set([...a].filter((v) => !b.has(v)))

--- a/test/e2e/app-dir/metadata/app/api/route.ts
+++ b/test/e2e/app-dir/metadata/app/api/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  return new NextResponse('hello api route')
+}

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -7,7 +7,7 @@ createNextDescribe(
   'app dir - metadata',
   {
     files: __dirname,
-    skipDeployment: true,
+    // skipDeployment: true,
   },
   ({ next, isNextDev, isNextStart }) => {
     const getTitle = (browser: BrowserInterface) =>

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -9,7 +9,7 @@ createNextDescribe(
     files: __dirname,
     skipDeployment: true,
   },
-  ({ next, isNextDev }) => {
+  ({ next, isNextDev, isNextStart }) => {
     const getTitle = (browser: BrowserInterface) =>
       browser.elementByCss('title').text()
 
@@ -658,6 +658,20 @@ createNextDescribe(
         const invalidSitemapResponse = await next.fetch('/title/sitemap.xml')
         expect(invalidSitemapResponse.status).toBe(404)
       })
+
+      if (isNextStart) {
+        it('should build favicon.ico as a custom route', async () => {
+          const appPathsManifest = JSON.parse(
+            await next.readFile('.next/app-paths-manifest.json')
+          )
+          expect(appPathsManifest['/robots.txt/route']).toBe(
+            'app/robots.txt/route.js'
+          )
+          expect(appPathsManifest['/sitemap.xml/route']).toBe(
+            'app/sitemap.xml/route.js'
+          )
+        })
+      }
     })
 
     describe('react cache', () => {

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -662,7 +662,7 @@ createNextDescribe(
       if (isNextStart) {
         it('should build favicon.ico as a custom route', async () => {
           const appPathsManifest = JSON.parse(
-            await next.readFile('.next/app-paths-manifest.json')
+            await next.readFile('.next/server/app-paths-manifest.json')
           )
           expect(appPathsManifest['/robots.txt/route']).toBe(
             'app/robots.txt/route.js'


### PR DESCRIPTION
Set the output bundle file path to `/<metadata route>/route.js` to align with other custom app routes, in order to make it easier being handled by app routes in both nextjs and vercel 