### PR TITLE
Create sentry.edge.config.js

### DIFF
--- a/examples/with-sentry/sentry.edge.config.js
+++ b/examples/with-sentry/sentry.edge.config.js
@@ -1,0 +1,15 @@
+// This file configures the initialization of Sentry on the edge runtime.
+// The config you add here will be used whenever the server handles a request.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+
+import * as Sentry from '@sentry/nextjs'
+
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
+
+Sentry.init({
+  dsn: SENTRY_DSN,
+  tracesSampleRate: 1.0,
+  // Note: if you want to override the automatic release value, do not set a
+  // `release` value here - use the environment variable `SENTRY_RELEASE`, so
+  // that it will also get attached to your source maps
+})


### PR DESCRIPTION
The Sentry SDK now supports middleware and edge routes running in Vercel's edge runtime.

The with-sentry example repo requires this config file to fix and run in edge runtime, users will receive this error during build

<img width="833" alt="image" src="https://user-images.githubusercontent.com/47563310/224503912-1a06a956-f834-4247-a397-1b1026d19d68.png">

confirmed fix with this PR on my repo

https://github.com/smeubank/nextjs-sentry-example-2/pull/1

edit:

tested golden path: option 1 deploy from this branch

successful deploy: https://nextjs-sentry-example-edge-69y8yvnt4-smeubank.vercel.app/

https://github.com/smeubank/nextjs-sentry-example-edge

https://vercel.com/smeubank/nextjs-sentry-example-edge
