### PR TITLE
Rewrite action transform in SWC

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -6,7 +6,7 @@ use next_binding::swc::core::{
         comments::{Comment, CommentKind, Comments},
         errors::HANDLER,
         util::take::Take,
-        BytePos, FileName, Span, DUMMY_SP,
+        BytePos, FileName, DUMMY_SP,
     },
     ecma::{
         ast::*,
@@ -37,19 +37,16 @@ pub fn server_actions<C: Comments>(
         in_action_file: false,
         in_export_decl: false,
         in_default_export_decl: false,
-        in_prepass: false,
         has_action: false,
         top_level: false,
 
+        ident_cnt: 0,
         in_module: true,
         in_action_fn: false,
-        action_index: 0,
-        should_add_name: false,
+        in_action_closure: false,
         closure_idents: Default::default(),
         action_idents: Default::default(),
-        async_fn_idents: Default::default(),
         exported_idents: Default::default(),
-        action_arrow_span: Default::default(),
 
         annotations: Default::default(),
         extra_items: Default::default(),
@@ -67,24 +64,18 @@ struct ServerActions<C: Comments> {
     in_action_file: bool,
     in_export_decl: bool,
     in_default_export_decl: bool,
-    in_prepass: bool,
     has_action: bool,
     top_level: bool,
 
+    ident_cnt: u32,
     in_module: bool,
     in_action_fn: bool,
-    action_index: u32,
-    should_add_name: bool,
+    in_action_closure: bool,
     closure_idents: Vec<Id>,
     action_idents: Vec<Name>,
-    async_fn_idents: Vec<Id>,
 
-    // Since arrow functions don't have identifiers, we need to store the span
-    // to find the arrow function later.
-    action_arrow_span: Vec<Span>,
-
-    // (ident, is default export)
-    exported_idents: Vec<(Id, bool)>,
+    // (ident, export name)
+    exported_idents: Vec<(Id, String)>,
 
     annotations: Vec<Stmt>,
     extra_items: Vec<ModuleItem>,
@@ -95,12 +86,10 @@ impl<C: Comments> ServerActions<C> {
     // Check if the function or arrow function is an action function
     fn get_action_info(
         &mut self,
-        maybe_ident: Option<&mut Ident>,
         maybe_body: Option<&mut BlockStmt>,
-    ) -> (bool, bool, bool) {
+        remove_directive: bool,
+    ) -> bool {
         let mut is_action_fn = false;
-        let mut is_exported = self.in_export_decl;
-        let mut is_default_export = self.in_default_export_decl;
 
         if self.in_action_file && self.in_export_decl {
             // All export functions in a server file are actions
@@ -111,44 +100,26 @@ impl<C: Comments> ServerActions<C> {
                 let directive_index = get_server_directive_index_in_fn(&body.stmts);
                 if directive_index >= 0 {
                     is_action_fn = true;
-                    body.stmts.remove(directive_index.try_into().unwrap());
-                }
-            }
-
-            if let Some(ident) = maybe_ident {
-                // If it's exported via named export, it's a valid action.
-                let exported_ident = self
-                    .exported_idents
-                    .iter()
-                    .find(|(id, _)| id == &ident.to_id());
-                if let Some((_, is_default)) = exported_ident {
-                    is_action_fn = true;
-                    is_exported = true;
-                    is_default_export = *is_default;
+                    if remove_directive {
+                        body.stmts.remove(directive_index.try_into().unwrap());
+                    }
                 }
             }
         }
 
-        (is_action_fn, is_exported, is_default_export)
+        is_action_fn
     }
 
-    fn add_action_annotations(
+    fn add_action_annotations_and_maybe_hoist(
         &mut self,
         ident: &Ident,
         function: Option<&mut Box<Function>>,
         arrow: Option<&mut ArrowExpr>,
-        is_exported: bool,
-        is_default_export: bool,
     ) -> (Option<Box<Function>>, Option<Box<ArrowExpr>>) {
-        let need_rename_export = self.in_action_file && (self.in_export_decl || is_exported);
-        let action_name: JsWord = if need_rename_export {
-            ident.sym.clone()
-        } else {
-            format!("$ACTION_{}", ident.sym).into()
-        };
+        let action_name: JsWord = gen_ident(&mut self.ident_cnt).into();
         let action_ident = private_ident!(action_name.clone());
 
-        let export_name: JsWord = if is_default_export {
+        let export_name: JsWord = if self.in_default_export_decl {
             "default".into()
         } else {
             action_name
@@ -157,98 +128,77 @@ impl<C: Comments> ServerActions<C> {
         self.has_action = true;
         self.export_actions.push(export_name.to_string());
 
-        // myAction.$$typeof = Symbol.for('react.server.reference');
-        self.annotations.push(annotate(
-            ident,
-            "$$typeof",
-            CallExpr {
-                span: DUMMY_SP,
-                callee: quote_ident!("Symbol")
-                    .make_member(quote_ident!("for"))
-                    .as_callee(),
-                args: vec!["react.server.reference".as_arg()],
-                type_args: Default::default(),
-            }
-            .into(),
-        ));
-
-        // Attach a checksum to the action using sha1:
-        // myAction.$$id = sha1('file_name' + ':' + 'export_name');
-        let mut hasher = Sha1::new();
-        hasher.update(self.file_name.to_string().as_bytes());
-        hasher.update(b":");
-        hasher.update(export_name.as_bytes());
-        let result = hasher.finalize();
-
-        // Convert result to hex string
-        self.annotations
-            .push(annotate(ident, "$$id", hex_encode(result).into()));
-
+        // If it's already a top level function, we don't need to hoist it.
         if self.top_level && arrow.is_none() {
-            // myAction.$$bound = [];
-            self.annotations.push(annotate(
-                ident,
-                "$$bound",
-                ArrayLit {
+            annotate_ident_as_action(
+                &mut self.annotations,
+                ident.clone(),
+                Vec::new(),
+                self.file_name.to_string(),
+                export_name.to_string(),
+            );
+
+            // export const $ACTION_myAction = myAction;
+            self.extra_items
+                .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
                     span: DUMMY_SP,
-                    elems: Vec::new(),
-                }
-                .into(),
-            ));
-
-            if !need_rename_export {
-                // export const $ACTION_myAction = myAction;
-                self.extra_items
-                    .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::Var(Box::new(VarDecl {
                         span: DUMMY_SP,
-                        decl: Decl::Var(Box::new(VarDecl {
+                        kind: VarDeclKind::Const,
+                        declare: Default::default(),
+                        decls: vec![VarDeclarator {
                             span: DUMMY_SP,
-                            kind: VarDeclKind::Const,
-                            declare: Default::default(),
-                            decls: vec![VarDeclarator {
-                                span: DUMMY_SP,
-                                name: action_ident.into(),
-                                init: Some(ident.clone().into()),
-                                definite: Default::default(),
-                            }],
-                        })),
-                    })));
-            }
+                            name: action_ident.into(),
+                            init: Some(ident.clone().into()),
+                            definite: Default::default(),
+                        }],
+                    })),
+                })));
         } else {
-            // Hoist the function to the top level.
-
+            // Hoist the function to the top level and export it. To hoist it, we need to
+            // first Collect all the identifiers defined in the closure and used
+            // in the action function. Dedup the identifiers.
+            let mut added_ids = Vec::new();
             let mut ids_from_closure = self.action_idents.clone();
-            ids_from_closure.retain(|id| self.closure_idents.contains(&id.0));
+            ids_from_closure.retain(|id| {
+                if added_ids.contains(id) {
+                    false
+                } else if self.closure_idents.contains(&id.0) {
+                    added_ids.push(id.clone());
+                    true
+                } else {
+                    false
+                }
+            });
 
             let closure_arg = private_ident!("closure");
 
+            let call = CallExpr {
+                span: DUMMY_SP,
+                callee: action_ident.clone().as_callee(),
+                args: vec![ident.clone().make_member(quote_ident!("$$bound")).as_arg()],
+                type_args: Default::default(),
+            };
+
+            annotate_ident_as_action(
+                &mut self.annotations,
+                ident.clone(),
+                ids_from_closure
+                    .iter()
+                    .cloned()
+                    .map(|id| Some(id.as_arg()))
+                    .collect(),
+                self.file_name.to_string(),
+                export_name.to_string(),
+            );
+
             if let Some(a) = arrow {
-                a.visit_mut_with(&mut ClosureReplacer {
-                    closure_arg: &closure_arg,
-                    used_ids: &ids_from_closure,
-                });
-
-                // myAction.$$bound = [id1, id2]
-                self.annotations.push(annotate(
-                    ident,
-                    "$$bound",
-                    ArrayLit {
-                        span: DUMMY_SP,
-                        elems: ids_from_closure
-                            .iter()
-                            .cloned()
-                            .map(|id| Some(id.as_arg()))
-                            .collect(),
-                    }
-                    .into(),
-                ));
-
-                let call = CallExpr {
-                    span: DUMMY_SP,
-                    callee: action_ident.clone().as_callee(),
-                    args: vec![ident.clone().make_member(quote_ident!("$$bound")).as_arg()],
-                    type_args: Default::default(),
-                };
+                if let BlockStmtOrExpr::BlockStmt(block) = &mut a.body {
+                    block.visit_mut_with(&mut ClosureReplacer {
+                        closure_arg: &closure_arg,
+                        used_ids: &ids_from_closure,
+                    });
+                }
 
                 let new_arrow = ArrowExpr {
                     span: DUMMY_SP,
@@ -260,18 +210,25 @@ impl<C: Comments> ServerActions<C> {
                     return_type: Default::default(),
                 };
 
+                // export const $ACTION_myAction = async () => {}
                 self.extra_items
-                    .push(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+                    .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
                         span: DUMMY_SP,
-                        kind: VarDeclKind::Var,
-                        declare: Default::default(),
-                        decls: vec![VarDeclarator {
+                        decl: Decl::Var(Box::new(VarDecl {
                             span: DUMMY_SP,
-                            name: action_ident.into(),
-                            init: None,
-                            definite: Default::default(),
-                        }],
-                    })))));
+                            kind: VarDeclKind::Const,
+                            declare: Default::default(),
+                            decls: vec![VarDeclarator {
+                                span: DUMMY_SP,
+                                name: action_ident.into(),
+                                init: Some(Box::new(Expr::Arrow(ArrowExpr {
+                                    params: vec![closure_arg.into()],
+                                    ..a.clone()
+                                }))),
+                                definite: Default::default(),
+                            }],
+                        })),
+                    })));
 
                 return (None, Some(Box::new(new_arrow)));
             } else if let Some(f) = function {
@@ -279,28 +236,6 @@ impl<C: Comments> ServerActions<C> {
                     closure_arg: &closure_arg,
                     used_ids: &ids_from_closure,
                 });
-
-                // myAction.$$bound = [id1, id2]
-                self.annotations.push(annotate(
-                    ident,
-                    "$$bound",
-                    ArrayLit {
-                        span: DUMMY_SP,
-                        elems: ids_from_closure
-                            .iter()
-                            .cloned()
-                            .map(|id| Some(id.as_arg()))
-                            .collect(),
-                    }
-                    .into(),
-                ));
-
-                let call = CallExpr {
-                    span: DUMMY_SP,
-                    callee: action_ident.clone().as_callee(),
-                    args: vec![ident.clone().make_member(quote_ident!("$$bound")).as_arg()],
-                    type_args: Default::default(),
-                };
 
                 let new_fn = Function {
                     params: f.params.clone(),
@@ -319,6 +254,7 @@ impl<C: Comments> ServerActions<C> {
                     return_type: Default::default(),
                 };
 
+                // export async function $ACTION_myAction () {}
                 self.extra_items
                     .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
                         span: DUMMY_SP,
@@ -370,48 +306,24 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     fn visit_mut_fn_expr(&mut self, f: &mut FnExpr) {
-        // Need to collect all async function identifiers if we are in a server
-        // file, because it can be exported later.
-        if self.in_action_file && self.in_prepass {
-            if f.function.is_async {
-                if let Some(ident) = &f.ident {
-                    self.async_fn_idents.push(ident.to_id());
-                }
-            }
-            return;
-        }
-
-        if f.ident.is_none() {
-            // Exported anonymous async functions need to have a name assigned.
-            if self.in_action_file && self.in_export_decl && f.function.is_async {
-                let action_name: JsWord = format!("$ACTION_default_{}", self.action_index).into();
-                self.action_index += 1;
-                f.ident = Some(Ident::new(action_name, DUMMY_SP));
-            } else {
-                f.visit_mut_children_with(self);
-                return;
-            }
-        }
-
-        let (is_action_fn, is_exported, is_default_export) =
-            self.get_action_info(f.ident.as_mut(), f.function.body.as_mut());
+        let is_action_fn = self.get_action_info(f.function.body.as_mut(), true);
 
         {
             // Visit children
             let old_in_action_fn = self.in_action_fn;
             let old_in_module = self.in_module;
-            let old_should_add_name = self.should_add_name;
+            let old_in_action_closure = self.in_action_closure;
             let old_in_export_decl = self.in_export_decl;
             let old_in_default_export_decl = self.in_default_export_decl;
             self.in_action_fn = is_action_fn;
             self.in_module = false;
-            self.should_add_name = true;
+            self.in_action_closure = true;
             self.in_export_decl = false;
             self.in_default_export_decl = false;
             f.visit_mut_children_with(self);
             self.in_action_fn = old_in_action_fn;
             self.in_module = old_in_module;
-            self.should_add_name = old_should_add_name;
+            self.in_action_closure = old_in_action_closure;
             self.in_export_decl = old_in_export_decl;
             self.in_default_export_decl = old_in_default_export_decl;
         }
@@ -423,56 +335,48 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         if !f.function.is_async {
             HANDLER.with(|handler| {
                 handler
-                    .struct_span_err(
-                        f.ident.as_mut().unwrap().span,
-                        "Server actions must be async functions",
-                    )
+                    .struct_span_err(f.function.span, "Server actions must be async functions")
                     .emit();
             });
         } else {
-            let (maybe_new_fn, _) = self.add_action_annotations(
-                f.ident.as_mut().unwrap(),
-                Some(&mut f.function),
-                None,
-                is_exported,
-                is_default_export,
-            );
+            if !self.in_action_file {
+                if f.ident.is_none() {
+                    let action_name = gen_ident(&mut self.ident_cnt);
+                    f.ident = Some(Ident::new(action_name, DUMMY_SP));
+                }
 
-            if let Some(new_fn) = maybe_new_fn {
-                f.function = new_fn;
+                let (maybe_new_fn, _) = self.add_action_annotations_and_maybe_hoist(
+                    f.ident.as_mut().unwrap(),
+                    Some(&mut f.function),
+                    None,
+                );
+
+                if let Some(new_fn) = maybe_new_fn {
+                    f.function = new_fn;
+                }
             }
         }
     }
 
     fn visit_mut_fn_decl(&mut self, f: &mut FnDecl) {
-        // Need to collect all async function identifiers if we are in a server
-        // file, because it can be exported later.
-        if self.in_action_file && self.in_prepass {
-            if f.function.is_async {
-                self.async_fn_idents.push(f.ident.to_id());
-            }
-            return;
-        }
-
-        let (is_action_fn, is_exported, is_default_export) =
-            self.get_action_info(Some(&mut f.ident), f.function.body.as_mut());
+        let is_action_fn = self.get_action_info(f.function.body.as_mut(), true);
 
         {
             // Visit children
             let old_in_action_fn = self.in_action_fn;
             let old_in_module = self.in_module;
-            let old_should_add_name = self.should_add_name;
+            let old_in_action_closure = self.in_action_closure;
             let old_in_export_decl = self.in_export_decl;
             let old_in_default_export_decl = self.in_default_export_decl;
             self.in_action_fn = is_action_fn;
             self.in_module = false;
-            self.should_add_name = true;
+            self.in_action_closure = true;
             self.in_export_decl = false;
             self.in_default_export_decl = false;
             f.visit_mut_children_with(self);
             self.in_action_fn = old_in_action_fn;
             self.in_module = old_in_module;
-            self.should_add_name = old_should_add_name;
+            self.in_action_closure = old_in_action_closure;
             self.in_export_decl = old_in_export_decl;
             self.in_default_export_decl = old_in_default_export_decl;
         }
@@ -488,16 +392,16 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                     .emit();
             });
         } else {
-            let (maybe_new_fn, _) = self.add_action_annotations(
-                &f.ident,
-                Some(&mut f.function),
-                None,
-                is_exported,
-                is_default_export,
-            );
+            if !self.in_action_file {
+                let (maybe_new_fn, _) = self.add_action_annotations_and_maybe_hoist(
+                    &f.ident,
+                    Some(&mut f.function),
+                    None,
+                );
 
-            if let Some(new_fn) = maybe_new_fn {
-                f.function = new_fn;
+                if let Some(new_fn) = maybe_new_fn {
+                    f.function = new_fn;
+                }
             }
         }
     }
@@ -505,66 +409,48 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     fn visit_mut_arrow_expr(&mut self, a: &mut ArrowExpr) {
         // Arrow expressions need to be visited in prepass to determine if it's
         // an action function or not.
-        if self.in_prepass {
-            let (is_action_fn, _, _) = self.get_action_info(
-                None,
-                if let BlockStmtOrExpr::BlockStmt(block) = &mut a.body {
-                    Some(block)
-                } else {
-                    None
-                },
-            );
+        let is_action_fn = self.get_action_info(
+            if let BlockStmtOrExpr::BlockStmt(block) = &mut a.body {
+                Some(block)
+            } else {
+                None
+            },
+            false,
+        );
 
-            // Store the span of the arrow expression if it's an action function.
-            if is_action_fn && a.is_async {
-                self.action_arrow_span.push(a.span);
-            }
+        {
+            // Visit children
+            let old_in_action_fn = self.in_action_fn;
+            let old_in_module = self.in_module;
+            let old_in_action_closure = self.in_action_closure;
+            let old_in_export_decl = self.in_export_decl;
+            let old_in_default_export_decl = self.in_default_export_decl;
+            self.in_action_fn = is_action_fn;
+            self.in_module = false;
+            self.in_action_closure = true;
+            self.in_export_decl = false;
+            self.in_default_export_decl = false;
+            a.visit_mut_children_with(self);
+            self.in_action_fn = old_in_action_fn;
+            self.in_module = old_in_module;
+            self.in_action_closure = old_in_action_closure;
+            self.in_export_decl = old_in_export_decl;
+            self.in_default_export_decl = old_in_default_export_decl;
+        }
+
+        if !is_action_fn {
             return;
         }
 
-        a.visit_mut_children_with(self);
-    }
-
-    fn visit_mut_var_decl(&mut self, n: &mut VarDecl) {
-        if self.in_action_file {
-            for decl in n.decls.iter_mut() {
-                if decl.init.is_none() {
-                    continue;
-                }
-
-                let init = decl.init.as_mut().unwrap();
-                if let Pat::Ident(ident) = &mut decl.name {
-                    if let Some(fn_expr) = init.as_mut_fn_expr() {
-                        // Collect `const foo = async function () {}` declarations. For now we
-                        // just ignore other types of assignments.
-                        if fn_expr.function.is_async {
-                            if self.in_prepass {
-                                self.async_fn_idents.push(ident.id.to_id());
-                            } else if let Some(exported_ident) = self
-                                .exported_idents
-                                .iter()
-                                .find(|(id, _)| id == &ident.id.to_id())
-                            {
-                                // It's an action function, we need to add the
-                                // name to the function if missing.
-                                if fn_expr.ident.is_none() {
-                                    let action_name: JsWord =
-                                        format!("$ACTION_fn_{}", self.action_index).into();
-                                    self.action_index += 1;
-                                    fn_expr.ident = Some(Ident::new(action_name, DUMMY_SP));
-                                }
-                                self.exported_idents.push((
-                                    fn_expr.ident.as_ref().unwrap().to_id(),
-                                    exported_ident.1,
-                                ));
-                            }
-                        }
-                    }
-                }
+        if !a.is_async {
+            if !self.in_action_file {
+                HANDLER.with(|handler| {
+                    handler
+                        .struct_span_err(a.span, "Server actions must be async functions")
+                        .emit();
+                });
             }
         }
-
-        n.visit_mut_children_with(self);
     }
 
     fn visit_mut_module(&mut self, m: &mut Module) {
@@ -587,10 +473,6 @@ impl<C: Comments> VisitMut for ServerActions<C> {
 
     fn visit_mut_param(&mut self, n: &mut Param) {
         n.visit_mut_children_with(self);
-
-        if self.in_prepass {
-            return;
-        }
 
         if !self.in_action_fn && !self.in_action_file {
             match &n.pat {
@@ -616,19 +498,52 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     fn visit_mut_expr(&mut self, n: &mut Expr) {
-        if self.in_action_fn && self.should_add_name {
+        if self.in_action_fn && self.in_action_closure {
             if let Ok(name) = Name::try_from(&*n) {
-                self.should_add_name = false;
-                if !self.in_prepass {
-                    self.action_idents.push(name);
-                }
+                self.in_action_closure = false;
+                self.action_idents.push(name);
                 n.visit_mut_children_with(self);
-                self.should_add_name = true;
+                self.in_action_closure = true;
                 return;
             }
         }
 
         n.visit_mut_children_with(self);
+
+        if !self.in_action_file {
+            if let Expr::Arrow(a) = n {
+                let is_action_fn = self.get_action_info(
+                    if let BlockStmtOrExpr::BlockStmt(block) = &mut a.body {
+                        Some(block)
+                    } else {
+                        None
+                    },
+                    true,
+                );
+
+                if is_action_fn {
+                    // We need to give a name to the arrow function
+                    // action and hoist it to the top.
+                    let action_name = gen_ident(&mut self.ident_cnt);
+                    let ident = private_ident!(action_name);
+
+                    let (_, maybe_new_arrow) =
+                        self.add_action_annotations_and_maybe_hoist(&ident, None, Some(a));
+
+                    *n = attach_name_to_arrow(
+                        ident,
+                        if let Some(new_arrow) = maybe_new_arrow {
+                            *new_arrow
+                        } else {
+                            a.clone()
+                        },
+                        &mut self.extra_items,
+                    );
+
+                    return;
+                }
+            }
+        }
     }
 
     fn visit_mut_module_items(&mut self, stmts: &mut Vec<ModuleItem>) {
@@ -640,51 +555,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         }
 
         let old_annotations = self.annotations.take();
-
         let mut new = Vec::with_capacity(stmts.len());
-
-        // We need a second pass to collect all async function idents and exports
-        // so we can handle the named export cases if it's in the "use server" file.
-        if self.in_action_file {
-            self.in_prepass = true;
-            for stmt in stmts.iter_mut() {
-                match &*stmt {
-                    ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                        decl: Decl::Var(var),
-                        ..
-                    })) => {
-                        let ids: Vec<Id> = collect_idents_in_var_decls(&var.decls);
-                        self.exported_idents
-                            .extend(ids.into_iter().map(|id| (id, false)));
-                    }
-                    ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) => {
-                        for spec in &named.specifiers {
-                            if let ExportSpecifier::Named(ExportNamedSpecifier {
-                                orig: ModuleExportName::Ident(ident),
-                                ..
-                            }) = spec
-                            {
-                                // export { foo, foo as bar }
-                                self.exported_idents.push((ident.to_id(), false));
-                            }
-                        }
-                    }
-                    ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(ExportDefaultExpr {
-                        expr,
-                        ..
-                    })) => {
-                        if let Expr::Ident(ident) = &**expr {
-                            // export default foo
-                            self.exported_idents.push((ident.to_id(), true));
-                        }
-                    }
-                    _ => {}
-                }
-
-                stmt.visit_mut_with(self);
-            }
-            self.in_prepass = false;
-        }
 
         for mut stmt in stmts.take() {
             self.top_level = true;
@@ -698,8 +569,18 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                 match &mut stmt {
                     ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl { decl, span })) => {
                         match decl {
-                            Decl::Fn(_f) => {}
+                            Decl::Fn(f) => {
+                                // export function foo() {}
+                                self.exported_idents
+                                    .push((f.ident.to_id(), f.ident.sym.to_string()));
+                            }
                             Decl::Var(var) => {
+                                // export const foo = 1
+                                let ids: Vec<Id> = collect_idents_in_var_decls(&var.decls);
+                                self.exported_idents.extend(
+                                    ids.into_iter().map(|id| (id.clone(), id.0.to_string())),
+                                );
+
                                 for decl in &mut var.decls {
                                     if let Some(init) = &decl.init {
                                         match &**init {
@@ -724,11 +605,26 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                             for spec in &mut named.specifiers {
                                 if let ExportSpecifier::Named(ExportNamedSpecifier {
                                     orig: ModuleExportName::Ident(ident),
+                                    exported,
                                     ..
                                 }) = spec
                                 {
-                                    if !self.async_fn_idents.contains(&ident.to_id()) {
-                                        disallowed_export_span = named.span;
+                                    if let Some(export_name) = exported {
+                                        if let ModuleExportName::Ident(Ident { sym, .. }) =
+                                            export_name
+                                        {
+                                            // export { foo as bar }
+                                            self.exported_idents
+                                                .push((ident.to_id(), sym.to_string()));
+                                        } else if let ModuleExportName::Str(str) = export_name {
+                                            // export { foo as "bar" }
+                                            self.exported_idents
+                                                .push((ident.to_id(), str.value.to_string()));
+                                        }
+                                    } else {
+                                        // export { foo }
+                                        self.exported_idents
+                                            .push((ident.to_id(), ident.sym.to_string()));
                                     }
                                 } else {
                                     disallowed_export_span = named.span;
@@ -741,7 +637,19 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                         span,
                         ..
                     })) => match decl {
-                        DefaultDecl::Fn(_f) => {}
+                        DefaultDecl::Fn(f) => {
+                            if let Some(ident) = &f.ident {
+                                // export default function foo() {}
+                                self.exported_idents.push((ident.to_id(), "default".into()));
+                            } else {
+                                // export default function() {}
+                                let new_ident =
+                                    Ident::new(gen_ident(&mut self.ident_cnt), DUMMY_SP);
+                                f.ident = Some(new_ident.clone());
+                                self.exported_idents
+                                    .push((new_ident.to_id(), "default".into()));
+                            }
+                        }
                         _ => {
                             disallowed_export_span = *span;
                         }
@@ -749,29 +657,27 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                     ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(default_expr)) => {
                         match &mut *default_expr.expr {
                             Expr::Fn(_f) => {}
-                            Expr::Arrow(a) => {
-                                if !self.action_arrow_span.contains(&a.span) {
+                            Expr::Arrow(arrow) => {
+                                if !arrow.is_async {
                                     disallowed_export_span = default_expr.span;
                                 } else {
-                                    // We need to give a name to the arrow function
-                                    // action and hoist it to the top.
-                                    let action_name: JsWord =
-                                        format!("$ACTION_default_{}", self.action_index).into();
-                                    self.action_index += 1;
-                                    let ident = Ident::new(action_name, DUMMY_SP);
-                                    self.add_action_annotations(&ident, None, Some(a), true, true);
-                                    default_expr.expr = Box::new(Expr::Assign(AssignExpr {
-                                        span: DUMMY_SP,
-                                        left: PatOrExpr::Pat(Box::new(Pat::Ident(ident.into()))),
-                                        op: op!("="),
-                                        right: Box::new(Expr::Arrow(a.clone())),
-                                    }));
+                                    // export default async () => {}
+                                    let new_ident =
+                                        Ident::new(gen_ident(&mut self.ident_cnt), DUMMY_SP);
+
+                                    self.exported_idents
+                                        .push((new_ident.to_id(), "default".into()));
+
+                                    *default_expr.expr = attach_name_to_arrow(
+                                        new_ident,
+                                        arrow.clone(),
+                                        &mut self.extra_items,
+                                    );
                                 }
                             }
                             Expr::Ident(ident) => {
-                                if !self.async_fn_idents.contains(&ident.to_id()) {
-                                    disallowed_export_span = default_expr.span;
-                                }
+                                // export default foo
+                                self.exported_idents.push((ident.to_id(), "default".into()));
                             }
                             _ => {
                                 disallowed_export_span = default_expr.span;
@@ -804,6 +710,22 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             new.append(&mut self.extra_items);
         }
 
+        // If it's a "use server" file, all exports need to be annotated as actions.
+        if self.in_action_file {
+            for (id, export_name) in self.exported_idents.iter() {
+                let ident = Ident::new(id.0.clone(), DUMMY_SP.with_ctxt(id.1));
+                annotate_ident_as_action(
+                    &mut self.annotations,
+                    ident,
+                    Vec::new(),
+                    self.file_name.to_string(),
+                    export_name.to_string(),
+                );
+            }
+            new.extend(self.annotations.drain(..).map(ModuleItem::Stmt));
+            new.append(&mut self.extra_items);
+        }
+
         *stmts = new;
 
         self.annotations = old_annotations;
@@ -818,7 +740,15 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                     // Append a list of exported actions.
                     text: format!(
                         " __next_internal_action_entry_do_not_use__ {} ",
-                        self.export_actions.join(",")
+                        if self.in_action_file {
+                            self.exported_idents
+                                .iter()
+                                .map(|e| e.1.to_string())
+                                .collect::<Vec<_>>()
+                                .join(",")
+                        } else {
+                            self.export_actions.join(",")
+                        }
                     )
                     .into(),
                 },
@@ -859,6 +789,83 @@ fn annotate(fn_name: &Ident, field_name: &str, value: Box<Expr>) -> Stmt {
         }
         .into(),
     })
+}
+
+fn gen_ident(cnt: &mut u32) -> JsWord {
+    let id: JsWord = format!("$$ACTION_{}", cnt).into();
+    *cnt += 1;
+    id
+}
+
+fn attach_name_to_arrow(ident: Ident, arrow: ArrowExpr, extra_items: &mut Vec<ModuleItem>) -> Expr {
+    // Create the variable `var $$ACTION_0;`
+    extra_items.push(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+        span: DUMMY_SP,
+        kind: VarDeclKind::Var,
+        declare: Default::default(),
+        decls: vec![VarDeclarator {
+            span: DUMMY_SP,
+            name: ident.clone().into(),
+            init: None,
+            definite: Default::default(),
+        }],
+    })))));
+
+    // Create the assignment `($$ACTION_0 = arrow)`
+    Expr::Paren(ParenExpr {
+        span: DUMMY_SP,
+        expr: Box::new(Expr::Assign(AssignExpr {
+            span: DUMMY_SP,
+            left: PatOrExpr::Pat(Box::new(Pat::Ident(ident.into()))),
+            op: op!("="),
+            right: Box::new(Expr::Arrow(arrow.clone())),
+        })),
+    })
+}
+
+fn annotate_ident_as_action(
+    annotations: &mut Vec<Stmt>,
+    ident: Ident,
+    bound: Vec<Option<ExprOrSpread>>,
+    file_name: String,
+    export_name: String,
+) {
+    // myAction.$$typeof = Symbol.for('react.server.reference');
+    annotations.push(annotate(
+        &ident,
+        "$$typeof",
+        CallExpr {
+            span: DUMMY_SP,
+            callee: quote_ident!("Symbol")
+                .make_member(quote_ident!("for"))
+                .as_callee(),
+            args: vec!["react.server.reference".as_arg()],
+            type_args: Default::default(),
+        }
+        .into(),
+    ));
+
+    // Attach a checksum to the action using sha1:
+    // myAction.$$id = sha1('file_name' + ':' + 'export_name');
+    let mut hasher = Sha1::new();
+    hasher.update(file_name.as_bytes());
+    hasher.update(b":");
+    hasher.update(export_name.as_bytes());
+    let result = hasher.finalize();
+
+    // Convert result to hex string
+    annotations.push(annotate(&ident, "$$id", hex_encode(result).into()));
+
+    // myAction.$$bound = [];
+    annotations.push(annotate(
+        &ident,
+        "$$bound",
+        ArrayLit {
+            span: DUMMY_SP,
+            elems: bound,
+        }
+        .into(),
+    ));
 }
 
 fn get_server_directive_index_in_module(stmts: &[ModuleItem]) -> i32 {

--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -116,7 +116,7 @@ impl<C: Comments> ServerActions<C> {
         function: Option<&mut Box<Function>>,
         arrow: Option<&mut ArrowExpr>,
     ) -> (Option<Box<Function>>, Option<Box<ArrowExpr>>) {
-        let action_name: JsWord = gen_ident(&mut self.ident_cnt).into();
+        let action_name: JsWord = gen_ident(&mut self.ident_cnt);
         let action_ident = private_ident!(action_name.clone());
 
         let export_name: JsWord = if self.in_default_export_decl {
@@ -338,22 +338,20 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                     .struct_span_err(f.function.span, "Server actions must be async functions")
                     .emit();
             });
-        } else {
-            if !self.in_action_file {
-                if f.ident.is_none() {
-                    let action_name = gen_ident(&mut self.ident_cnt);
-                    f.ident = Some(Ident::new(action_name, DUMMY_SP));
-                }
+        } else if !self.in_action_file {
+            if f.ident.is_none() {
+                let action_name = gen_ident(&mut self.ident_cnt);
+                f.ident = Some(Ident::new(action_name, DUMMY_SP));
+            }
 
-                let (maybe_new_fn, _) = self.add_action_annotations_and_maybe_hoist(
-                    f.ident.as_mut().unwrap(),
-                    Some(&mut f.function),
-                    None,
-                );
+            let (maybe_new_fn, _) = self.add_action_annotations_and_maybe_hoist(
+                f.ident.as_mut().unwrap(),
+                Some(&mut f.function),
+                None,
+            );
 
-                if let Some(new_fn) = maybe_new_fn {
-                    f.function = new_fn;
-                }
+            if let Some(new_fn) = maybe_new_fn {
+                f.function = new_fn;
             }
         }
     }
@@ -391,17 +389,12 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                     .struct_span_err(f.ident.span, "Server actions must be async functions")
                     .emit();
             });
-        } else {
-            if !self.in_action_file {
-                let (maybe_new_fn, _) = self.add_action_annotations_and_maybe_hoist(
-                    &f.ident,
-                    Some(&mut f.function),
-                    None,
-                );
+        } else if !self.in_action_file {
+            let (maybe_new_fn, _) =
+                self.add_action_annotations_and_maybe_hoist(&f.ident, Some(&mut f.function), None);
 
-                if let Some(new_fn) = maybe_new_fn {
-                    f.function = new_fn;
-                }
+            if let Some(new_fn) = maybe_new_fn {
+                f.function = new_fn;
             }
         }
     }
@@ -442,14 +435,12 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             return;
         }
 
-        if !a.is_async {
-            if !self.in_action_file {
-                HANDLER.with(|handler| {
-                    handler
-                        .struct_span_err(a.span, "Server actions must be async functions")
-                        .emit();
-                });
-            }
+        if !a.is_async && !self.in_action_file {
+            HANDLER.with(|handler| {
+                handler
+                    .struct_span_err(a.span, "Server actions must be async functions")
+                    .emit();
+            });
         }
     }
 
@@ -539,8 +530,6 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                         },
                         &mut self.extra_items,
                     );
-
-                    return;
                 }
             }
         }
@@ -818,7 +807,7 @@ fn attach_name_to_arrow(ident: Ident, arrow: ArrowExpr, extra_items: &mut Vec<Mo
             span: DUMMY_SP,
             left: PatOrExpr::Pat(Box::new(Pat::Ident(ident.into()))),
             op: op!("="),
-            right: Box::new(Expr::Arrow(arrow.clone())),
+            right: Box::new(Expr::Arrow(arrow)),
         })),
     })
 }

--- a/packages/next-swc/crates/core/tests/errors/server-actions/1/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/1/output.js
@@ -1,1 +1,4 @@
-/* __next_internal_action_entry_do_not_use__  */ export function foo() {}
+/* __next_internal_action_entry_do_not_use__ foo */ export function foo() {}
+foo.$$typeof = Symbol.for("react.server.reference");
+foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
+foo.$$bound = [];

--- a/packages/next-swc/crates/core/tests/errors/server-actions/2/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/2/output.js
@@ -1,2 +1,5 @@
-/* __next_internal_action_entry_do_not_use__  */ 'use strict';
+/* __next_internal_action_entry_do_not_use__ bar */ 'use strict';
 export function bar() {}
+bar.$$typeof = Symbol.for("react.server.reference");
+bar.$$id = "ac840dcaf5e8197cb02b7f3a43c119b7a770b272";
+bar.$$bound = [];

--- a/packages/next-swc/crates/core/tests/errors/server-actions/3/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/3/output.js
@@ -1,1 +1,4 @@
-/* __next_internal_action_entry_do_not_use__  */ export const x = 1;
+/* __next_internal_action_entry_do_not_use__ x */ export const x = 1;
+x.$$typeof = Symbol.for("react.server.reference");
+x.$$id = "b78c261f135a7a852508c2920bd7228020ff4bd7";
+x.$$bound = [];

--- a/packages/next-swc/crates/core/tests/errors/server-actions/7/input.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/7/input.js
@@ -1,0 +1,3 @@
+const foo = () => {
+  'use server'
+}

--- a/packages/next-swc/crates/core/tests/errors/server-actions/7/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/7/output.js
@@ -1,0 +1,6 @@
+/* __next_internal_action_entry_do_not_use__ $$ACTION_1 */ const foo = $$ACTION_0 = ()=>$$ACTION_1($$ACTION_0.$$bound);
+$$ACTION_0.$$typeof = Symbol.for("react.server.reference");
+$$ACTION_0.$$id = "188d5d945750dc32e2c842b93c75a65763d4a922";
+$$ACTION_0.$$bound = [];
+export const $$ACTION_1 = (closure)=>{};
+var $$ACTION_0;

--- a/packages/next-swc/crates/core/tests/errors/server-actions/7/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/7/output.stderr
@@ -1,0 +1,7 @@
+
+  x Server actions must be async functions
+   ,-[input.js:1:1]
+ 1 | ,-> const foo = () => {
+ 2 | |     'use server'
+ 3 | `-> }
+   `----

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/1/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/1/output.js
@@ -1,17 +1,17 @@
-/* __next_internal_action_entry_do_not_use__ $ACTION_deleteItem */ import deleteFromDb from 'db'
+/* __next_internal_action_entry_do_not_use__ $$ACTION_0 */ import deleteFromDb from 'db';
 export function Item({ id1 , id2  }) {
     async function deleteItem() {
-        return $ACTION_deleteItem(deleteItem.$$bound);
+        return $$ACTION_0(deleteItem.$$bound);
     }
     deleteItem.$$typeof = Symbol.for("react.server.reference");
-    deleteItem.$$id = "de52fdc8536c533b05b2e525bd43b18cf019cbb3";
+    deleteItem.$$id = "6d53ce510b2e36499b8f56038817b9bad86cabb4";
     deleteItem.$$bound = [
         id1,
         id2
     ];
     return <Button action={deleteItem}>Delete</Button>;
 }
-export async function $ACTION_deleteItem(closure) {
+export async function $$ACTION_0(closure) {
     await deleteFromDb(closure[0]);
     await deleteFromDb(closure[1]);
 }

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/11/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/11/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ default */ export default async function $ACTION_default_0() {}
-$ACTION_default_0.$$typeof = Symbol.for("react.server.reference");
-$ACTION_default_0.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
-$ACTION_default_0.$$bound = [];
+/* __next_internal_action_entry_do_not_use__ default */ export default async function $$ACTION_0() {}
+$$ACTION_0.$$typeof = Symbol.for("react.server.reference");
+$$ACTION_0.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
+$$ACTION_0.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/12/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/12/output.js
@@ -1,5 +1,5 @@
 /* __next_internal_action_entry_do_not_use__ default */ async function foo() {}
+export default foo;
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
 foo.$$bound = [];
-export default foo;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/13/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/13/output.js
@@ -1,10 +1,10 @@
-/* __next_internal_action_entry_do_not_use__ default,$ACTION_fn_1 */ const foo = async function $ACTION_fn_0() {};
-$ACTION_fn_0.$$typeof = Symbol.for("react.server.reference");
-$ACTION_fn_0.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
-$ACTION_fn_0.$$bound = [];
+/* __next_internal_action_entry_do_not_use__ default,bar */ const foo = async function() {};
 export default foo;
-const bar = async function $ACTION_fn_1() {};
-$ACTION_fn_1.$$typeof = Symbol.for("react.server.reference");
-$ACTION_fn_1.$$id = "5bde18329eb1c98fc2d6dea0a22639861a18ce65";
-$ACTION_fn_1.$$bound = [];
+const bar = async function() {};
 export { bar };
+foo.$$typeof = Symbol.for("react.server.reference");
+foo.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
+foo.$$bound = [];
+bar.$$typeof = Symbol.for("react.server.reference");
+bar.$$id = "ac840dcaf5e8197cb02b7f3a43c119b7a770b272";
+bar.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/15/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/15/output.js
@@ -1,7 +1,7 @@
-/* __next_internal_action_entry_do_not_use__ default */ export default $ACTION_default_0 = async (a, b)=>{
+/* __next_internal_action_entry_do_not_use__ default */ export default $$ACTION_0 = async (a, b)=>{
   console.log(a, b);
 };
-$ACTION_default_0.$$typeof = Symbol.for("react.server.reference");
-$ACTION_default_0.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
-$ACTION_default_0.$$bound = [];
-var $ACTION_default_0;
+var $$ACTION_0;
+$$ACTION_0.$$typeof = Symbol.for("react.server.reference");
+$$ACTION_0.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
+$$ACTION_0.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/16/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/16/input.js
@@ -1,0 +1,14 @@
+import deleteFromDb from 'db'
+
+const v1 = 'v1';
+
+export function Item({ id1, id2 }) {
+    const v2 = id2;
+    const deleteItem = async () => {
+        "use server";
+        await deleteFromDb(id1);
+        await deleteFromDb(v1);
+        await deleteFromDb(v2);
+    }
+    return <Button action={deleteItem}>Delete</Button>;
+}

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/16/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/16/output.js
@@ -1,0 +1,19 @@
+/* __next_internal_action_entry_do_not_use__ $$ACTION_1 */ import deleteFromDb from 'db';
+const v1 = 'v1';
+export function Item({ id1 , id2  }) {
+    const v2 = id2;
+    const deleteItem = $$ACTION_0 = async ()=>$$ACTION_1($$ACTION_0.$$bound);
+    $$ACTION_0.$$typeof = Symbol.for("react.server.reference");
+    $$ACTION_0.$$id = "188d5d945750dc32e2c842b93c75a65763d4a922";
+    $$ACTION_0.$$bound = [
+        id1,
+        v2
+    ];
+    return <Button action={deleteItem}>Delete</Button>;
+}
+export const $$ACTION_1 = async (closure)=>{
+    await deleteFromDb(closure[0]);
+    await deleteFromDb(v1);
+    await deleteFromDb(closure[1]);
+};
+var $$ACTION_0;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/17/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/17/input.js
@@ -1,0 +1,6 @@
+'use server'
+
+export const foo = async () => {}
+
+const bar = async () => {}
+export { bar }

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/17/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/17/output.js
@@ -1,0 +1,9 @@
+/* __next_internal_action_entry_do_not_use__ foo,bar */ export const foo = async ()=>{};
+const bar = async ()=>{};
+export { bar };
+foo.$$typeof = Symbol.for("react.server.reference");
+foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
+foo.$$bound = [];
+bar.$$typeof = Symbol.for("react.server.reference");
+bar.$$id = "ac840dcaf5e8197cb02b7f3a43c119b7a770b272";
+bar.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/18/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/18/input.js
@@ -1,0 +1,23 @@
+import deleteFromDb from 'db'
+
+const v1 = 'v1';
+
+export function Item({ id1, id2 }) {
+    const v2 = id2;
+    
+    // TODO: Fix the inline function cases.
+    return <>
+        <Button action={async () => {
+            "use server";
+            await deleteFromDb(id1);
+            await deleteFromDb(v1);
+            await deleteFromDb(v2);
+        }}>Delete</Button>
+        <Button action={async function () {
+            "use server";
+            await deleteFromDb(id1);
+            await deleteFromDb(v1);
+            await deleteFromDb(v2);
+        }}>Delete</Button>
+    </>
+}

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/18/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/18/output.js
@@ -1,0 +1,38 @@
+/* __next_internal_action_entry_do_not_use__ $$ACTION_1,$$ACTION_3 */ import deleteFromDb from 'db';
+const v1 = 'v1';
+export function Item({ id1 , id2  }) {
+    const v2 = id2;
+    // TODO: Fix the inline function cases.
+    return <>
+
+        <Button action={$$ACTION_0 = async ()=>$$ACTION_1($$ACTION_0.$$bound)}>Delete</Button>
+
+        <Button action={async function $$ACTION_2() {
+        return $$ACTION_3($$ACTION_2.$$bound);
+    }}>Delete</Button>
+
+    </>;
+    $$ACTION_0.$$typeof = Symbol.for("react.server.reference");
+    $$ACTION_0.$$id = "188d5d945750dc32e2c842b93c75a65763d4a922";
+    $$ACTION_0.$$bound = [
+        id1,
+        v2
+    ];
+    $$ACTION_2.$$typeof = Symbol.for("react.server.reference");
+    $$ACTION_2.$$id = "56a859f462d35a297c46a1bbd1e6a9058c104ab8";
+    $$ACTION_2.$$bound = [
+        id1,
+        v2
+    ];
+}
+export const $$ACTION_1 = async (closure)=>{
+    await deleteFromDb(closure[0]);
+    await deleteFromDb(v1);
+    await deleteFromDb(closure[1]);
+};
+var $$ACTION_0;
+export async function $$ACTION_3(closure) {
+    await deleteFromDb(closure[0]);
+    await deleteFromDb(v1);
+    await deleteFromDb(closure[1]);
+}

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/2/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/2/output.js
@@ -1,10 +1,10 @@
-/* __next_internal_action_entry_do_not_use__ $ACTION_myAction */ async function myAction(a, b, c) {
+/* __next_internal_action_entry_do_not_use__ $$ACTION_0 */ async function myAction(a, b, c) {
     console.log('a');
 }
 myAction.$$typeof = Symbol.for("react.server.reference");
-myAction.$$id = "c67fa6a80e65945a14b1fac181d282d79bba49b7";
+myAction.$$id = "6d53ce510b2e36499b8f56038817b9bad86cabb4";
 myAction.$$bound = [];
-export const $ACTION_myAction = myAction;
+export const $$ACTION_0 = myAction;
 export default function Page() {
     return <Button action={myAction}>Delete</Button>;
 }

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/4/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/4/output.js
@@ -1,22 +1,16 @@
-/* __next_internal_action_entry_do_not_use__ a,b,c,$ACTION_e */ export async function a() {}
+/* __next_internal_action_entry_do_not_use__ a,b,c */ export async function a() {}
+export async function b() {}
+export async function c() {}
+function d() {}
+function Foo() {
+    async function e() {}
+}
 a.$$typeof = Symbol.for("react.server.reference");
 a.$$id = "6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d";
 a.$$bound = [];
-export async function b() {}
 b.$$typeof = Symbol.for("react.server.reference");
 b.$$id = "d1f7eb64271d7c601dfef7d4d7053de1c2ca4338";
 b.$$bound = [];
-export async function c() {}
 c.$$typeof = Symbol.for("react.server.reference");
 c.$$id = "1ab723c80dcca470e0410b4b2a2fc2bf21f41476";
 c.$$bound = [];
-function d() {}
-function Foo() {
-    async function e() {
-        return $ACTION_e(e.$$bound);
-    }
-    e.$$typeof = Symbol.for("react.server.reference");
-    e.$$id = "b6c8c6754aefb804cf95f444931ba7e955c0701d";
-    e.$$bound = [];
-}
-export async function $ACTION_e(closure) {}

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/5/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/5/output.js
@@ -1,19 +1,19 @@
-/* __next_internal_action_entry_do_not_use__ $ACTION_deleteItem */ import deleteFromDb from 'db';
+/* __next_internal_action_entry_do_not_use__ $$ACTION_0 */ import deleteFromDb from 'db';
 const v1 = 'v1';
 export function Item({ id1 , id2  }) {
     const v2 = id2;
     async function deleteItem() {
-        return $ACTION_deleteItem(deleteItem.$$bound);
+        return $$ACTION_0(deleteItem.$$bound);
     }
     deleteItem.$$typeof = Symbol.for("react.server.reference");
-    deleteItem.$$id = "de52fdc8536c533b05b2e525bd43b18cf019cbb3";
+    deleteItem.$$id = "6d53ce510b2e36499b8f56038817b9bad86cabb4";
     deleteItem.$$bound = [
         id1,
         v2
     ];
     return <Button action={deleteItem}>Delete</Button>;
 }
-export async function $ACTION_deleteItem(closure) {
+export async function $$ACTION_0(closure) {
     await deleteFromDb(closure[0]);
     await deleteFromDb(v1);
     await deleteFromDb(closure[1]);

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/6/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/6/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ $ACTION_action */ import f, { f1, f2 } from 'foo';
+/* __next_internal_action_entry_do_not_use__ $$ACTION_0 */ import f, { f1, f2 } from 'foo';
 const f3 = 1;
 var f4;
 let f5;
@@ -18,12 +18,11 @@ export function y(p, [p1, { p2  }], ...p3) {
         const f8 = 1;
     }
     async function action() {
-        return $ACTION_action(action.$$bound);
+        return $$ACTION_0(action.$$bound);
     }
     action.$$typeof = Symbol.for("react.server.reference");
-    action.$$id = "b3d2707f04906fa37fdc7bee4f53e41053034751";
+    action.$$id = "6d53ce510b2e36499b8f56038817b9bad86cabb4";
     action.$$bound = [
-        f2,
         f2,
         f11,
         p,
@@ -33,11 +32,11 @@ export function y(p, [p1, { p2  }], ...p3) {
     ];
     return <Button action={action}>Delete</Button>;
 }
-export async function $ACTION_action(closure) {
+export async function $$ACTION_0(closure) {
     const f17 = 1;
     if (true) {
         const f18 = 1;
         const f19 = 1;
     }
-    console.log(f, f1, closure[0], f3, f4, f5, f6, f7, f8, closure[0](f9), f12, closure[2], f16.x, f17, f18, closure[3], closure[4], closure[5], closure[6], g19, g20, globalThis);
+    console.log(f, f1, closure[0], f3, f4, f5, f6, f7, f8, closure[0](f9), f12, closure[1], f16.x, f17, f18, closure[2], closure[3], closure[4], closure[5], g19, g20, globalThis);
 }

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/7/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/7/output.js
@@ -1,10 +1,10 @@
-/* __next_internal_action_entry_do_not_use__ $ACTION_deleteItem */ import deleteFromDb from 'db';
+/* __next_internal_action_entry_do_not_use__ $$ACTION_0 */ import deleteFromDb from 'db';
 export function Item(product, foo, bar) {
     async function deleteItem() {
-        return $ACTION_deleteItem(deleteItem.$$bound);
+        return $$ACTION_0(deleteItem.$$bound);
     }
     deleteItem.$$typeof = Symbol.for("react.server.reference");
-    deleteItem.$$id = "de52fdc8536c533b05b2e525bd43b18cf019cbb3";
+    deleteItem.$$id = "6d53ce510b2e36499b8f56038817b9bad86cabb4";
     deleteItem.$$bound = [
         product.id,
         product?.foo,
@@ -15,6 +15,6 @@ export function Item(product, foo, bar) {
     ];
     return <Button action={deleteItem}>Delete</Button>;
 }
-export async function $ACTION_deleteItem(closure) {
+export async function $$ACTION_0(closure) {
     await deleteFromDb(closure[3].id, closure[3]?.foo, closure[3].bar.baz, closure[3][closure[4], closure[5]]);
 }

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/8/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/8/output.js
@@ -1,12 +1,12 @@
-/* __next_internal_action_entry_do_not_use__ $ACTION_myAction */ async function myAction(a, b, c) {
+/* __next_internal_action_entry_do_not_use__ $$ACTION_0 */ async function myAction(a, b, c) {
     // comment
     "use strict";
     console.log('a');
 }
 myAction.$$typeof = Symbol.for("react.server.reference");
-myAction.$$id = "c67fa6a80e65945a14b1fac181d282d79bba49b7";
+myAction.$$id = "6d53ce510b2e36499b8f56038817b9bad86cabb4";
 myAction.$$bound = [];
-export const $ACTION_myAction = myAction;
+export const $$ACTION_0 = myAction;
 export default function Page() {
     return <Button action={myAction}>Delete</Button>;
 }

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/9/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/9/output.js
@@ -1,16 +1,16 @@
 // app/send.ts
-/* __next_internal_action_entry_do_not_use__ foo,bar,qux */ async function foo() {}
+/* __next_internal_action_entry_do_not_use__ foo,baz,default */ async function foo() {}
+export { foo };
+async function bar() {}
+export { bar as baz };
+async function qux() {}
+export { qux as default };
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
 foo.$$bound = [];
-export { foo };
-async function bar() {}
 bar.$$typeof = Symbol.for("react.server.reference");
-bar.$$id = "ac840dcaf5e8197cb02b7f3a43c119b7a770b272";
+bar.$$id = "050e3854b72b19e3c7e3966a67535543a90bf7e0";
 bar.$$bound = [];
-export { bar as baz };
-async function qux() {}
 qux.$$typeof = Symbol.for("react.server.reference");
-qux.$$id = "3c8ed39a99caf636869d076cc7cae786a4053164";
+qux.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
 qux.$$bound = [];
-export { qux as default };


### PR DESCRIPTION
This is almost a rewrite of the transform to simply some logic. For a `"use server"` file we now simply annotate every exported identifier and will later do runtime checks. This is because that we can't statically know the source of exported values.

This rewrite also makes it possible to annotate anonymous arrow functions.

Thanks to @kdy1 for some of the suggestions here.

Closes NEXT-708, closes NEXT-421.