### PR TITLE
Fix generateStaticParams check in app dir

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1005,7 +1005,7 @@ export async function buildStaticPaths({
           // If from appDir and not all params were provided from
           // generateStaticParams we can just filter this entry out
           // as it's meant to be generated at runtime
-          if (appDir) {
+          if (appDir && typeof paramValue === 'undefined') {
             builtPage = ''
             encodedBuiltPage = ''
             return
@@ -1014,7 +1014,7 @@ export async function buildStaticPaths({
           throw new Error(
             `A required parameter (${validParamKey}) was not provided as ${
               repeat ? 'an array' : 'a string'
-            } in ${
+            } received ${typeof paramValue} in ${
               appDir ? 'generateStaticParams' : 'getStaticPaths'
             } for ${page}`
           )

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -32,6 +32,24 @@ createNextDescribe(
       }
     })
 
+    if (isDev) {
+      it('should error correctly for invalid params from generateStaticParams', async () => {
+        await next.patchFile(
+          'app/invalid/[slug]/page.js',
+          `
+            export function generateStaticParams() {
+              return [{slug: { invalid: true }}]
+            }
+          `
+        )
+        const html = await next.render('/invalid/first')
+        await next.deleteFile('app/invalid/[slug]/page.js')
+        expect(html).toContain(
+          'A required parameter (slug) was not provided as a string received object'
+        )
+      })
+    }
+
     if (isNextStart) {
       it('should output HTML/RSC files for static paths', async () => {
         const files = (

--- a/test/integration/dynamic-optional-routing/test/index.test.js
+++ b/test/integration/dynamic-optional-routing/test/index.test.js
@@ -305,7 +305,7 @@ describe('Dynamic Optional Routing', () => {
         )
         const { stderr } = await nextBuild(appDir, [], { stderr: true })
         await expect(stderr).toMatch(
-          'A required parameter (slug) was not provided as an array  received undefined in getStaticPaths for /invalid/[[...slug]]'
+          'A required parameter (slug) was not provided as an array received undefined in getStaticPaths for /invalid/[[...slug]]'
         )
       } finally {
         await fs.unlink(invalidRoute)

--- a/test/integration/dynamic-optional-routing/test/index.test.js
+++ b/test/integration/dynamic-optional-routing/test/index.test.js
@@ -305,7 +305,7 @@ describe('Dynamic Optional Routing', () => {
         )
         const { stderr } = await nextBuild(appDir, [], { stderr: true })
         await expect(stderr).toMatch(
-          'A required parameter (slug) was not provided as an array in getStaticPaths for /invalid/[[...slug]]'
+          'A required parameter (slug) was not provided as an array  received undefined in getStaticPaths for /invalid/[[...slug]]'
         )
       } finally {
         await fs.unlink(invalidRoute)

--- a/test/integration/prerender-invalid-catchall-params/test/index.test.js
+++ b/test/integration/prerender-invalid-catchall-params/test/index.test.js
@@ -10,7 +10,7 @@ describe('Invalid Prerender Catchall Params', () => {
     const out = await nextBuild(appDir, [], { stderr: true })
     expect(out.stderr).toMatch(`Build error occurred`)
     expect(out.stderr).toMatch(
-      'A required parameter (slug) was not provided as an array in getStaticPaths for /[...slug]'
+      'A required parameter (slug) was not provided as an array received string in getStaticPaths for /[...slug]'
     )
   })
 })


### PR DESCRIPTION
This ensures our `params` checking works properly with `app` dir. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1678659475821299)