### PR TITLE
Cleanup remove directive logic to reduce allocate

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -337,16 +337,17 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                     .emit();
             });
         } else if !self.in_action_file {
-            if f.ident.is_none() {
-                let action_name = gen_ident(&mut self.ident_cnt);
-                f.ident = Some(Ident::new(action_name, DUMMY_SP));
-            }
+            let ident = match f.ident.as_mut() {
+                None => {
+                    let action_name = gen_ident(&mut self.ident_cnt);
+                    let ident = Ident::new(action_name, DUMMY_SP);
+                    f.ident.insert(ident)
+                }
+                Some(i) => i,
+            };
 
-            let (maybe_new_fn, _) = self.add_action_annotations_and_maybe_hoist(
-                f.ident.as_mut().unwrap(),
-                Some(&mut f.function),
-                None,
-            );
+            let (maybe_new_fn, _) =
+                self.add_action_annotations_and_maybe_hoist(ident, Some(&mut f.function), None);
 
             if let Some(new_fn) = maybe_new_fn {
                 f.function = new_fn;

--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -97,13 +97,11 @@ impl<C: Comments> ServerActions<C> {
         } else {
             // Check if the function has `"use server"`
             if let Some(body) = maybe_body {
-                let directive_index = get_server_directive_index_in_fn(&body.stmts);
-                if directive_index >= 0 {
-                    is_action_fn = true;
-                    if remove_directive {
-                        body.stmts.remove(directive_index.try_into().unwrap());
-                    }
-                }
+                remove_server_directive_index_in_fn(
+                    &mut body.stmts,
+                    remove_directive,
+                    &mut is_action_fn,
+                );
             }
         }
 
@@ -536,12 +534,11 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     fn visit_mut_module_items(&mut self, stmts: &mut Vec<ModuleItem>) {
-        let directive_index = get_server_directive_index_in_module(stmts);
-        if directive_index >= 0 {
-            self.in_action_file = true;
-            self.has_action = true;
-            stmts.remove(directive_index.try_into().unwrap());
-        }
+        remove_server_directive_index_in_module(
+            stmts,
+            &mut self.in_action_file,
+            &mut self.has_action,
+        );
 
         let old_annotations = self.annotations.take();
         let mut new = Vec::with_capacity(stmts.len());
@@ -857,40 +854,47 @@ fn annotate_ident_as_action(
     ));
 }
 
-fn get_server_directive_index_in_module(stmts: &[ModuleItem]) -> i32 {
-    for (i, stmt) in stmts.iter().enumerate() {
-        if let ModuleItem::Stmt(Stmt::Expr(first)) = stmt {
-            match &*first.expr {
-                Expr::Lit(Lit::Str(Str { value, .. })) => {
-                    if value == "use server" {
-                        return i as i32;
-                    }
-                }
-                _ => return -1,
+fn remove_server_directive_index_in_module(
+    stmts: &mut Vec<ModuleItem>,
+    in_action_file: &mut bool,
+    has_action: &mut bool,
+) {
+    stmts.retain(|stmt| {
+        if let ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+            expr: box Expr::Lit(Lit::Str(Str { value, .. })),
+            ..
+        })) = stmt
+        {
+            if value == "use server" {
+                *in_action_file = true;
+                *has_action = true;
+                return false;
             }
-        } else {
-            return -1;
         }
-    }
-    -1
+        true
+    });
 }
 
-fn get_server_directive_index_in_fn(stmts: &[Stmt]) -> i32 {
-    for (i, stmt) in stmts.iter().enumerate() {
-        if let Stmt::Expr(first) = stmt {
-            match &*first.expr {
-                Expr::Lit(Lit::Str(Str { value, .. })) => {
-                    if value == "use server" {
-                        return i as i32;
-                    }
+fn remove_server_directive_index_in_fn(
+    stmts: &mut Vec<Stmt>,
+    remove_directive: bool,
+    is_action_fn: &mut bool,
+) {
+    stmts.retain(|stmt| {
+        if let Stmt::Expr(ExprStmt {
+            expr: box Expr::Lit(Lit::Str(Str { value, .. })),
+            ..
+        }) = stmt
+        {
+            if value == "use server" {
+                *is_action_fn = true;
+                if remove_directive {
+                    return false;
                 }
-                _ => return -1,
             }
-        } else {
-            return -1;
         }
-    }
-    -1
+        true
+    });
 }
 
 fn collect_idents_in_array_pat(elems: &[Option<Pat>]) -> Vec<Id> {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Reduce `unwrap` and `clone` usages