### PR TITLE
Refactor app-render to decouple type definitions (#47128

### DIFF
--- a/packages/next/src/client/components/app-router-announcer.tsx
+++ b/packages/next/src/client/components/app-router-announcer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import type { FlightRouterState } from '../../server/app-render'
+import type { FlightRouterState } from '../../server/app-render/types'
 
 const ANNOUNCER_TYPE = 'next-route-announcer'
 const ANNOUNCER_ID = '__next-route-announcer__'

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -12,7 +12,10 @@ import type {
   CacheNode,
   AppRouterInstance,
 } from '../../shared/lib/app-router-context'
-import type { FlightRouterState, FlightData } from '../../server/app-render'
+import type {
+  FlightRouterState,
+  FlightData,
+} from '../../server/app-render/types'
 import type { ErrorComponent } from './error-boundary'
 import { reducer } from './router-reducer/router-reducer'
 import {

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -8,7 +8,7 @@ import type {
   FlightRouterState,
   FlightSegmentPath,
   ChildProp,
-} from '../../server/app-render'
+} from '../../server/app-render/types'
 import type { ErrorComponent } from './error-boundary'
 import { FocusAndScrollRef } from './router-reducer/router-reducer-types'
 

--- a/packages/next/src/client/components/match-segments.ts
+++ b/packages/next/src/client/components/match-segments.ts
@@ -1,4 +1,4 @@
-import type { Segment } from '../../server/app-render'
+import type { Segment } from '../../server/app-render/types'
 
 export const matchSegment = (
   existingSegment: Segment,

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -1,7 +1,7 @@
 // useLayoutSegments() // Only the segments for the current place. ['children', 'dashboard', 'children', 'integrations'] -> /dashboard/integrations (/dashboard/layout.js would get ['children', 'dashboard', 'children', 'integrations'])
 
 import { useContext, useMemo } from 'react'
-import type { FlightRouterState } from '../../server/app-render'
+import type { FlightRouterState } from '../../server/app-render/types'
 import {
   AppRouterContext,
   LayoutRouterContext,

--- a/packages/next/src/client/components/request-async-storage.ts
+++ b/packages/next/src/client/components/request-async-storage.ts
@@ -1,9 +1,7 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 import { PreviewData } from '../../../types'
-import type {
-  ReadonlyHeaders,
-  ReadonlyRequestCookies,
-} from '../../server/app-render'
+import type { ReadonlyHeaders } from '../../server/app-render/readonly-headers'
+import type { ReadonlyRequestCookies } from '../../server/app-render/readonly-request-cookies'
 import { createAsyncLocalStorage } from './async-local-storage'
 
 export interface RequestStore {

--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.test.tsx
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.test.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
-import type { FlightData, FlightRouterState } from '../../../server/app-render'
+import type {
+  FlightData,
+  FlightRouterState,
+} from '../../../server/app-render/types'
 import { applyRouterStatePatchToTree } from './apply-router-state-patch-to-tree'
 
 const getInitialRouterStateTree = (): FlightRouterState => [

--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
@@ -1,7 +1,7 @@
 import type {
   FlightRouterState,
   FlightSegmentPath,
-} from '../../../server/app-render'
+} from '../../../server/app-render/types'
 import { matchSegment } from '../match-segments'
 
 /**

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FlightRouterState } from '../../../server/app-render'
+import type { FlightRouterState } from '../../../server/app-render/types'
 import { CacheNode, CacheStates } from '../../../shared/lib/app-router-context'
 import { createInitialRouterState } from './create-initial-router-state'
 

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import type { CacheNode } from '../../../shared/lib/app-router-context'
-import type { FlightRouterState } from '../../../server/app-render'
+import type { FlightRouterState } from '../../../server/app-render/types'
 
 import { CacheStates } from '../../../shared/lib/app-router-context'
 import { createHrefFromUrl } from './create-href-from-url'

--- a/packages/next/src/client/components/router-reducer/create-optimistic-tree.test.ts
+++ b/packages/next/src/client/components/router-reducer/create-optimistic-tree.test.ts
@@ -1,5 +1,5 @@
 import { createOptimisticTree } from './create-optimistic-tree'
-import type { FlightRouterState } from '../../../server/app-render'
+import type { FlightRouterState } from '../../../server/app-render/types'
 
 const getInitialRouterStateTree = (): FlightRouterState => [
   '',

--- a/packages/next/src/client/components/router-reducer/create-optimistic-tree.ts
+++ b/packages/next/src/client/components/router-reducer/create-optimistic-tree.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../../server/app-render'
+import type { FlightRouterState } from '../../../server/app-render/types'
 import { matchSegment } from '../match-segments'
 
 /**

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -1,7 +1,10 @@
 'use client'
 
 import { createFromFetch } from 'next/dist/compiled/react-server-dom-webpack/client'
-import type { FlightRouterState, FlightData } from '../../../server/app-render'
+import type {
+  FlightRouterState,
+  FlightData,
+} from '../../../server/app-render/types'
 import {
   NEXT_ROUTER_PREFETCH,
   NEXT_ROUTER_STATE_TREE,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fillCacheWithNewSubTreeData } from './fill-cache-with-new-subtree-data'
 import { CacheStates, CacheNode } from '../../../shared/lib/app-router-context'
-import { FlightData } from '../../../server/app-render'
+import type { FlightData } from '../../../server/app-render/types'
 
 const getFlightData = (): FlightData => {
   return [

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -1,5 +1,5 @@
 import { CacheNode, CacheStates } from '../../../shared/lib/app-router-context'
-import type { FlightDataPath } from '../../../server/app-render'
+import type { FlightDataPath } from '../../../server/app-render/types'
 import { invalidateCacheByRouterState } from './invalidate-cache-by-router-state'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { CacheStates, CacheNode } from '../../../shared/lib/app-router-context'
-import { FlightData } from '../../../server/app-render'
+import type { FlightData } from '../../../server/app-render/types'
 
 const getFlightData = (): FlightData => {
   return [

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -1,5 +1,5 @@
 import { CacheNode, CacheStates } from '../../../shared/lib/app-router-context'
-import type { FlightRouterState } from '../../../server/app-render'
+import type { FlightRouterState } from '../../../server/app-render/types'
 
 export function fillLazyItemsTillLeafWithHead(
   newCache: CacheNode,

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { FlightData } from '../../../server/app-render'
+import type { FlightData } from '../../../server/app-render/types'
 import { invalidateCacheBelowFlightSegmentPath } from './invalidate-cache-below-flight-segmentpath'
 import { CacheStates, CacheNode } from '../../../shared/lib/app-router-context'
 import { fillCacheWithNewSubTreeData } from './fill-cache-with-new-subtree-data'

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
@@ -1,5 +1,5 @@
 import type { CacheNode } from '../../../shared/lib/app-router-context'
-import type { FlightSegmentPath } from '../../../server/app-render'
+import type { FlightSegmentPath } from '../../../server/app-render/types'
 
 /**
  * Fill cache up to the end of the flightSegmentPath, invalidating anything below it.

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { invalidateCacheByRouterState } from './invalidate-cache-by-router-state'
 import { CacheStates, CacheNode } from '../../../shared/lib/app-router-context'
-import { FlightRouterState } from '../../../server/app-render'
+import type { FlightRouterState } from '../../../server/app-render/types'
 
 describe('invalidateCacheByRouterState', () => {
   it('should invalidate the cache by router state', () => {

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.ts
@@ -1,5 +1,5 @@
 import type { CacheNode } from '../../../shared/lib/app-router-context'
-import type { FlightRouterState } from '../../../server/app-render'
+import type { FlightRouterState } from '../../../server/app-render/types'
 
 /**
  * Invalidate cache one level down from the router state.

--- a/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.test.ts
+++ b/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.test.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../../server/app-render'
+import type { FlightRouterState } from '../../../server/app-render/types'
 import { isNavigatingToNewRootLayout } from './is-navigating-to-new-root-layout'
 
 describe('shouldHardNavigate', () => {

--- a/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.ts
+++ b/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../../server/app-render'
+import type { FlightRouterState } from '../../../server/app-render/types'
 
 export function isNavigatingToNewRootLayout(
   currentTree: FlightRouterState,

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FlightRouterState } from '../../../../server/app-render'
+import type { FlightRouterState } from '../../../../server/app-render/types'
 import {
   CacheNode,
   CacheStates,

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../../../server/app-render'
+import type { FlightRouterState } from '../../../../server/app-render/types'
 import type { ChildSegmentMap } from '../../../../shared/lib/app-router-context'
 
 export function findHeadInCache(

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { fetchServerResponse as fetchServerResponseType } from '../fetch-server-response'
-import type { FlightData } from '../../../../server/app-render'
+import type { FlightData } from '../../../../server/app-render/types'
 const flightData: FlightData = [
   [
     'children',
@@ -68,7 +68,7 @@ jest.mock('../fetch-server-response', () => {
     },
   }
 })
-import { FlightRouterState } from '../../../../server/app-render'
+import { FlightRouterState } from '../../../../server/app-render/types'
 import {
   CacheNode,
   CacheStates,

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -5,7 +5,7 @@ import {
 import type {
   FlightDataPath,
   FlightSegmentPath,
-} from '../../../../server/app-render'
+} from '../../../../server/app-render/types'
 import { fetchServerResponse } from '../fetch-server-response'
 import { createRecordFromThenable } from '../create-record-from-thenable'
 import { readRecordValue } from '../read-record-value'

--- a/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { fetchServerResponse as fetchServerResponseType } from '../fetch-server-response'
-import type { FlightData } from '../../../../server/app-render'
+import type { FlightData } from '../../../../server/app-render/types'
 jest.mock('../fetch-server-response', () => {
   const flightData: FlightData = [
     [
@@ -32,7 +32,7 @@ jest.mock('../fetch-server-response', () => {
     },
   }
 })
-import { FlightRouterState } from '../../../../server/app-render'
+import { FlightRouterState } from '../../../../server/app-render/types'
 import {
   CacheNode,
   CacheStates,

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { fetchServerResponse } from '../fetch-server-response'
-import type { FlightData } from '../../../../server/app-render'
+import type { FlightData } from '../../../../server/app-render/types'
 jest.mock('../fetch-server-response', () => {
   const flightData: FlightData = [
     [
@@ -39,7 +39,7 @@ jest.mock('../fetch-server-response', () => {
     },
   }
 })
-import { FlightRouterState } from '../../../../server/app-render'
+import { FlightRouterState } from '../../../../server/app-render/types'
 import {
   CacheNode,
   CacheStates,

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FlightRouterState } from '../../../../server/app-render'
+import type { FlightRouterState } from '../../../../server/app-render/types'
 import {
   CacheNode,
   CacheStates,

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
@@ -3,7 +3,7 @@ import type { fetchServerResponse as fetchServerResponseType } from '../fetch-se
 import type {
   FlightData,
   FlightRouterState,
-} from '../../../../server/app-render'
+} from '../../../../server/app-render/types'
 jest.mock('../fetch-server-response', () => {
   const flightData: FlightData = [
     [

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -1,5 +1,8 @@
 import type { CacheNode } from '../../../shared/lib/app-router-context'
-import type { FlightRouterState, FlightData } from '../../../server/app-render'
+import type {
+  FlightRouterState,
+  FlightData,
+} from '../../../server/app-render/types'
 import { fetchServerResponse } from './fetch-server-response'
 
 export const ACTION_REFRESH = 'refresh'

--- a/packages/next/src/client/components/router-reducer/should-hard-navigate.test.tsx
+++ b/packages/next/src/client/components/router-reducer/should-hard-navigate.test.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
-import type { FlightData, FlightRouterState } from '../../../server/app-render'
+import type {
+  FlightData,
+  FlightRouterState,
+} from '../../../server/app-render/types'
 import { shouldHardNavigate } from './should-hard-navigate'
 
 describe('shouldHardNavigate', () => {

--- a/packages/next/src/client/components/router-reducer/should-hard-navigate.ts
+++ b/packages/next/src/client/components/router-reducer/should-hard-navigate.ts
@@ -2,7 +2,7 @@ import type {
   FlightRouterState,
   FlightDataPath,
   Segment,
-} from '../../../server/app-render'
+} from '../../../server/app-render/types'
 import { matchSegment } from '../match-segments'
 
 // TODO-APP: flightSegmentPath will be empty in case of static response, needs to be handled.

--- a/packages/next/src/server/app-render/index.tsx
+++ b/packages/next/src/server/app-render/index.tsx
@@ -191,7 +191,7 @@ function createErrorHandler({
         // It won't log the source code, but the error will be more useful.
         if (process.env.NODE_ENV !== 'production') {
           const { logAppDirError } =
-            require('./dev/log-app-dir-error') as typeof import('../dev/log-app-dir-error')
+            require('../dev/log-app-dir-error') as typeof import('../dev/log-app-dir-error')
           logAppDirError(err)
         }
         if (process.env.NODE_ENV === 'production') {

--- a/packages/next/src/server/app-render/index.tsx
+++ b/packages/next/src/server/app-render/index.tsx
@@ -1819,7 +1819,7 @@ export async function renderToHTMLOrFlight(
     if (isFetchAction || isFormAction) {
       if (process.env.NEXT_RUNTIME !== 'edge') {
         const { parseBody } =
-          require('./api-utils/node') as typeof import('../api-utils/node')
+          require('../api-utils/node') as typeof import('../api-utils/node')
         const actionData = (await parseBody(req, '1mb')) || {}
         let bound = []
 

--- a/packages/next/src/server/app-render/index.tsx
+++ b/packages/next/src/server/app-render/index.tsx
@@ -1,18 +1,34 @@
-import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from 'http'
-import type { LoadComponentsReturnType } from './load-components'
-import type { ServerRuntime } from '../../types'
-import type { NextFontManifest } from '../build/webpack/plugins/next-font-manifest-plugin'
+import type { IncomingMessage, ServerResponse } from 'http'
+import type { NextFontManifest } from '../../build/webpack/plugins/next-font-manifest-plugin'
+import type {
+  FlightCSSManifest,
+  FlightManifest,
+} from '../../build/webpack/plugins/flight-manifest-plugin'
+import type {
+  ChildProp,
+  DynamicParamTypes,
+  DynamicParamTypesShort,
+  FlightData,
+  FlightDataPath,
+  FlightRouterState,
+  FlightSegmentPath,
+  RenderOpts,
+  Segment,
+} from './types'
+import type { StaticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage'
+import type { RequestAsyncStorage } from '../../client/components/request-async-storage'
+import type { MetadataItems } from '../../lib/metadata/resolve-metadata'
 
 // Import builtin react directly to avoid require cache conflicts
 import React, { use } from 'next/dist/compiled/react'
-import { NotFound as DefaultNotFound } from '../client/components/error'
+import { NotFound as DefaultNotFound } from '../../client/components/error'
 
 // this needs to be required lazily so that `next-server` can set
 // the env before we require
 import ReactDOMServer from 'next/dist/compiled/react-dom/server.browser'
 import { ParsedUrlQuery } from 'querystring'
-import { NextParsedUrlQuery } from './request-meta'
-import RenderResult, { type RenderResultMetadata } from './render-result'
+import { NextParsedUrlQuery } from '../request-meta'
+import RenderResult, { type RenderResultMetadata } from '../render-result'
 import {
   readableStreamTee,
   encodeText,
@@ -22,18 +38,13 @@ import {
   continueFromInitialStream,
   streamToString,
   streamToBufferedResult,
-} from './node-web-streams-helper'
-import { ESCAPE_REGEX, htmlEscapeJsonString } from './htmlescape'
-import { matchSegment } from '../client/components/match-segments'
-import {
-  FlightCSSManifest,
-  FlightManifest,
-} from '../build/webpack/plugins/flight-manifest-plugin'
-import { ServerInsertedHTMLContext } from '../shared/lib/server-inserted-html'
-import { stripInternalQueries } from './internal-utils'
-import { RequestCookies } from './web/spec-extension/cookies'
-import { DYNAMIC_ERROR_CODE } from '../client/components/hooks-server-context'
-import { HeadManagerContext } from '../shared/lib/head-manager-context'
+} from '../node-web-streams-helper'
+import { ESCAPE_REGEX, htmlEscapeJsonString } from '../htmlescape'
+import { matchSegment } from '../../client/components/match-segments'
+import { ServerInsertedHTMLContext } from '../../shared/lib/server-inserted-html'
+import { stripInternalQueries } from '../internal-utils'
+import { DYNAMIC_ERROR_CODE } from '../../client/components/hooks-server-context'
+import { HeadManagerContext } from '../../shared/lib/head-manager-context'
 import stringHash from 'next/dist/compiled/string-hash'
 import {
   ACTION,
@@ -41,28 +52,25 @@ import {
   NEXT_ROUTER_STATE_TREE,
   RSC,
   RSC_CONTENT_TYPE_HEADER,
-} from '../client/components/app-router-headers'
-import type { StaticGenerationAsyncStorage } from '../client/components/static-generation-async-storage'
-import type { RequestAsyncStorage } from '../client/components/request-async-storage'
-import { formatServerError } from '../lib/format-server-error'
-import { MetadataTree } from '../lib/metadata/metadata'
-import { RequestAsyncStorageWrapper } from './async-storage/request-async-storage-wrapper'
-import { StaticGenerationAsyncStorageWrapper } from './async-storage/static-generation-async-storage-wrapper'
-import { collectMetadata } from '../lib/metadata/resolve-metadata'
-import type { MetadataItems } from '../lib/metadata/resolve-metadata'
-import { isClientReference } from '../build/is-client-reference'
-import { getLayoutOrPageModule, LoaderTree } from './lib/app-dir-module'
-import { warnOnce } from '../shared/lib/utils/warn-once'
-import { isNotFoundError } from '../client/components/not-found'
+} from '../../client/components/app-router-headers'
+import { formatServerError } from '../../lib/format-server-error'
+import { MetadataTree } from '../../lib/metadata/metadata'
+import { RequestAsyncStorageWrapper } from '../async-storage/request-async-storage-wrapper'
+import { StaticGenerationAsyncStorageWrapper } from '../async-storage/static-generation-async-storage-wrapper'
+import { collectMetadata } from '../../lib/metadata/resolve-metadata'
+import { isClientReference } from '../../build/is-client-reference'
+import { getLayoutOrPageModule, LoaderTree } from '../lib/app-dir-module'
+import { warnOnce } from '../../shared/lib/utils/warn-once'
+import { isNotFoundError } from '../../client/components/not-found'
 import {
   getURLFromRedirectError,
   isRedirectError,
-} from '../client/components/redirect'
-import { NEXT_DYNAMIC_NO_SSR_CODE } from '../shared/lib/lazy-dynamic/no-ssr-error'
-import { patchFetch } from './lib/patch-fetch'
-import { AppRenderSpan } from './lib/trace/constants'
-import { getTracer } from './lib/trace/tracer'
-import zod from 'next/dist/compiled/zod'
+} from '../../client/components/redirect'
+import { NEXT_DYNAMIC_NO_SSR_CODE } from '../../shared/lib/lazy-dynamic/no-ssr-error'
+import { patchFetch } from '../lib/patch-fetch'
+import { AppRenderSpan } from '../lib/trace/constants'
+import { getTracer } from '../lib/trace/tracer'
+import { flightRouterStateSchema } from './types'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 
@@ -97,111 +105,6 @@ function preloadComponent(Component: any, props: any) {
   }
   return Component
 }
-
-const INTERNAL_HEADERS_INSTANCE = Symbol('internal for headers readonly')
-
-function readonlyHeadersError() {
-  return new Error('ReadonlyHeaders cannot be modified')
-}
-
-export class ReadonlyHeaders {
-  [INTERNAL_HEADERS_INSTANCE]: Headers
-
-  entries: Headers['entries']
-  forEach: Headers['forEach']
-  get: Headers['get']
-  has: Headers['has']
-  keys: Headers['keys']
-  values: Headers['values']
-
-  constructor(headers: IncomingHttpHeaders) {
-    // Since `new Headers` uses `this.append()` to fill the headers object ReadonlyHeaders can't extend from Headers directly as it would throw.
-    const headersInstance = new Headers(headers as any)
-    this[INTERNAL_HEADERS_INSTANCE] = headersInstance
-
-    this.entries = headersInstance.entries.bind(headersInstance)
-    this.forEach = headersInstance.forEach.bind(headersInstance)
-    this.get = headersInstance.get.bind(headersInstance)
-    this.has = headersInstance.has.bind(headersInstance)
-    this.keys = headersInstance.keys.bind(headersInstance)
-    this.values = headersInstance.values.bind(headersInstance)
-  }
-  [Symbol.iterator]() {
-    return this[INTERNAL_HEADERS_INSTANCE][Symbol.iterator]()
-  }
-
-  append() {
-    throw readonlyHeadersError()
-  }
-  delete() {
-    throw readonlyHeadersError()
-  }
-  set() {
-    throw readonlyHeadersError()
-  }
-}
-
-const INTERNAL_COOKIES_INSTANCE = Symbol('internal for cookies readonly')
-class ReadonlyRequestCookiesError extends Error {
-  message =
-    'ReadonlyRequestCookies cannot be modified. Read more: https://nextjs.org/api-reference/cookies'
-}
-
-export class ReadonlyRequestCookies {
-  [INTERNAL_COOKIES_INSTANCE]: RequestCookies
-
-  get: RequestCookies['get']
-  getAll: RequestCookies['getAll']
-  has: RequestCookies['has']
-
-  constructor(request: {
-    headers: {
-      get(key: 'cookie'): string | null | undefined
-    }
-  }) {
-    // Since `new Headers` uses `this.append()` to fill the headers object ReadonlyHeaders can't extend from Headers directly as it would throw.
-    // Request overridden to not have to provide a fully request object.
-    const cookiesInstance = new RequestCookies(request.headers as Headers)
-    this[INTERNAL_COOKIES_INSTANCE] = cookiesInstance
-
-    this.get = cookiesInstance.get.bind(cookiesInstance)
-    this.getAll = cookiesInstance.getAll.bind(cookiesInstance)
-    this.has = cookiesInstance.has.bind(cookiesInstance)
-  }
-
-  [Symbol.iterator]() {
-    return (this[INTERNAL_COOKIES_INSTANCE] as any)[Symbol.iterator]()
-  }
-
-  clear() {
-    throw new ReadonlyRequestCookiesError()
-  }
-  delete() {
-    throw new ReadonlyRequestCookiesError()
-  }
-  set() {
-    throw new ReadonlyRequestCookiesError()
-  }
-}
-
-export type RenderOptsPartial = {
-  err?: Error | null
-  dev?: boolean
-  serverComponentManifest?: FlightManifest
-  serverCSSManifest?: FlightCSSManifest
-  supportsDynamicHTML: boolean
-  runtime?: ServerRuntime
-  serverComponents?: boolean
-  assetPrefix?: string
-  nextFontManifest?: NextFontManifest
-  isBot?: boolean
-  incrementalCache?: import('./lib/incremental-cache').IncrementalCache
-  isRevalidate?: boolean
-  nextExport?: boolean
-  appDirDevErrorLogger?: (err: any) => Promise<void>
-}
-
-export type RenderOpts = LoadComponentsReturnType & RenderOptsPartial
 
 /**
  * Flight Response is always set to RSC_CONTENT_TYPE_HEADER to ensure it does not get interpreted as HTML.
@@ -288,7 +191,7 @@ function createErrorHandler({
         // It won't log the source code, but the error will be more useful.
         if (process.env.NODE_ENV !== 'production') {
           const { logAppDirError } =
-            require('./dev/log-app-dir-error') as typeof import('./dev/log-app-dir-error')
+            require('./dev/log-app-dir-error') as typeof import('../dev/log-app-dir-error')
           logAppDirError(err)
         }
         if (process.env.NODE_ENV === 'production') {
@@ -446,16 +349,6 @@ function createServerComponentRenderer<Props>(
   }
 }
 
-type DynamicParamTypes = 'catchall' | 'optional-catchall' | 'dynamic'
-
-const dynamicParamTypesSchema = zod.enum(['c', 'oc', 'd'])
-/**
- * c = catchall
- * oc = optional catchall
- * d = dynamic
- */
-export type DynamicParamTypesShort = zod.infer<typeof dynamicParamTypesSchema>
-
 /**
  * Shorten the dynamic param in order to make it smaller when transmitted to the browser.
  */
@@ -472,92 +365,6 @@ function getShortDynamicParamType(
     default:
       throw new Error('Unknown dynamic param type')
   }
-}
-
-const segmentSchema = zod.union([
-  zod.string(),
-  zod.tuple([zod.string(), zod.string(), dynamicParamTypesSchema]),
-])
-/**
- * Segment in the router state.
- */
-export type Segment = zod.infer<typeof segmentSchema>
-
-const flightRouterStateSchema: zod.ZodType<FlightRouterState> = zod.lazy(() => {
-  const parallelRoutesSchema = zod.record(flightRouterStateSchema)
-  const urlSchema = zod.string().nullable().optional()
-  const refreshSchema = zod.literal('refetch').nullable().optional()
-  const isRootLayoutSchema = zod.boolean().optional()
-
-  // Due to the lack of optional tuple types in Zod, we need to use union here.
-  // https://github.com/colinhacks/zod/issues/1465
-  return zod.union([
-    zod.tuple([
-      segmentSchema,
-      parallelRoutesSchema,
-      urlSchema,
-      refreshSchema,
-      isRootLayoutSchema,
-    ]),
-    zod.tuple([segmentSchema, parallelRoutesSchema, urlSchema, refreshSchema]),
-    zod.tuple([segmentSchema, parallelRoutesSchema, urlSchema]),
-    zod.tuple([segmentSchema, parallelRoutesSchema]),
-  ])
-})
-/**
- * Router state
- */
-export type FlightRouterState = [
-  segment: Segment,
-  parallelRoutes: { [parallelRouterKey: string]: FlightRouterState },
-  url?: string | null,
-  refresh?: 'refetch' | null,
-  isRootLayout?: boolean
-]
-
-/**
- * Individual Flight response path
- */
-export type FlightSegmentPath =
-  // Uses `any` as repeating pattern can't be typed.
-  | any[]
-  // Looks somewhat like this
-  | [
-      segment: Segment,
-      parallelRouterKey: string,
-      segment: Segment,
-      parallelRouterKey: string,
-      segment: Segment,
-      parallelRouterKey: string
-    ]
-
-export type FlightDataPath =
-  // Uses `any` as repeating pattern can't be typed.
-  | any[]
-  // Looks somewhat like this
-  | [
-      // Holds full path to the segment.
-      ...FlightSegmentPath[],
-      /* segment of the rendered slice: */ Segment,
-      /* treePatch */ FlightRouterState,
-      /* subTreeData: */ React.ReactNode | null, // Can be null during prefetch if there's no loading component
-      /* head */ React.ReactNode | null
-    ]
-
-/**
- * The Flight response data
- */
-export type FlightData = Array<FlightDataPath> | string
-
-/**
- * Property holding the current subTreeData.
- */
-export type ChildProp = {
-  /**
-   * Null indicates that the tree is partial
-   */
-  current: React.ReactNode | null
-  segment: Segment
 }
 
 /**
@@ -923,9 +730,9 @@ export async function renderToHTMLOrFlight(
     const searchParamsProps = { searchParams: query }
 
     const LayoutRouter =
-      ComponentMod.LayoutRouter as typeof import('../client/components/layout-router').default
+      ComponentMod.LayoutRouter as typeof import('../../client/components/layout-router').default
     const RenderFromTemplateContext =
-      ComponentMod.RenderFromTemplateContext as typeof import('../client/components/render-from-template-context').default
+      ComponentMod.RenderFromTemplateContext as typeof import('../../client/components/render-from-template-context').default
 
     /**
      * Server Context is specifically only available in Server Components.
@@ -1278,7 +1085,7 @@ export async function renderToHTMLOrFlight(
           defaultRevalidate === 0
         ) {
           const { DynamicServerError } =
-            ComponentMod.serverHooks as typeof import('../client/components/hooks-server-context')
+            ComponentMod.serverHooks as typeof import('../../client/components/hooks-server-context')
 
           const dynamicUsageDescription = `revalidate: 0 configured ${segment}`
           staticGenerationStore.dynamicUsageDescription =
@@ -1755,11 +1562,11 @@ export async function renderToHTMLOrFlight(
 
     // AppRouter is provided by next-app-loader
     const AppRouter =
-      ComponentMod.AppRouter as typeof import('../client/components/app-router').default
+      ComponentMod.AppRouter as typeof import('../../client/components/app-router').default
 
     const GlobalError = interopDefault(
       /** GlobalError can be either the default error boundary or the overwritten app/global-error.js **/
-      ComponentMod.GlobalError as typeof import('../client/components/error-boundary').default
+      ComponentMod.GlobalError as typeof import('../../client/components/error-boundary').default
     )
 
     let serverComponentsInlinedTransformStream: TransformStream<
@@ -2012,7 +1819,7 @@ export async function renderToHTMLOrFlight(
     if (isFetchAction || isFormAction) {
       if (process.env.NEXT_RUNTIME !== 'edge') {
         const { parseBody } =
-          require('./api-utils/node') as typeof import('./api-utils/node')
+          require('./api-utils/node') as typeof import('../api-utils/node')
         const actionData = (await parseBody(req, '1mb')) || {}
         let bound = []
 

--- a/packages/next/src/server/app-render/readonly-headers.ts
+++ b/packages/next/src/server/app-render/readonly-headers.ts
@@ -1,0 +1,44 @@
+import type { IncomingHttpHeaders } from 'http'
+
+const INTERNAL_HEADERS_INSTANCE = Symbol('internal for headers readonly')
+
+function readonlyHeadersError() {
+  return new Error('ReadonlyHeaders cannot be modified')
+}
+
+export class ReadonlyHeaders {
+  [INTERNAL_HEADERS_INSTANCE]: Headers
+
+  entries: Headers['entries']
+  forEach: Headers['forEach']
+  get: Headers['get']
+  has: Headers['has']
+  keys: Headers['keys']
+  values: Headers['values']
+
+  constructor(headers: IncomingHttpHeaders) {
+    // Since `new Headers` uses `this.append()` to fill the headers object ReadonlyHeaders can't extend from Headers directly as it would throw.
+    const headersInstance = new Headers(headers as any)
+    this[INTERNAL_HEADERS_INSTANCE] = headersInstance
+
+    this.entries = headersInstance.entries.bind(headersInstance)
+    this.forEach = headersInstance.forEach.bind(headersInstance)
+    this.get = headersInstance.get.bind(headersInstance)
+    this.has = headersInstance.has.bind(headersInstance)
+    this.keys = headersInstance.keys.bind(headersInstance)
+    this.values = headersInstance.values.bind(headersInstance)
+  }
+  [Symbol.iterator]() {
+    return this[INTERNAL_HEADERS_INSTANCE][Symbol.iterator]()
+  }
+
+  append() {
+    throw readonlyHeadersError()
+  }
+  delete() {
+    throw readonlyHeadersError()
+  }
+  set() {
+    throw readonlyHeadersError()
+  }
+}

--- a/packages/next/src/server/app-render/readonly-request-cookies.ts
+++ b/packages/next/src/server/app-render/readonly-request-cookies.ts
@@ -1,0 +1,44 @@
+import { RequestCookies } from '../web/spec-extension/cookies'
+
+const INTERNAL_COOKIES_INSTANCE = Symbol('internal for cookies readonly')
+class ReadonlyRequestCookiesError extends Error {
+  message =
+    'ReadonlyRequestCookies cannot be modified. Read more: https://nextjs.org/api-reference/cookies'
+}
+
+export class ReadonlyRequestCookies {
+  [INTERNAL_COOKIES_INSTANCE]: RequestCookies
+
+  get: RequestCookies['get']
+  getAll: RequestCookies['getAll']
+  has: RequestCookies['has']
+
+  constructor(request: {
+    headers: {
+      get(key: 'cookie'): string | null | undefined
+    }
+  }) {
+    // Since `new Headers` uses `this.append()` to fill the headers object ReadonlyHeaders can't extend from Headers directly as it would throw.
+    // Request overridden to not have to provide a fully request object.
+    const cookiesInstance = new RequestCookies(request.headers as Headers)
+    this[INTERNAL_COOKIES_INSTANCE] = cookiesInstance
+
+    this.get = cookiesInstance.get.bind(cookiesInstance)
+    this.getAll = cookiesInstance.getAll.bind(cookiesInstance)
+    this.has = cookiesInstance.has.bind(cookiesInstance)
+  }
+
+  [Symbol.iterator]() {
+    return (this[INTERNAL_COOKIES_INSTANCE] as any)[Symbol.iterator]()
+  }
+
+  clear() {
+    throw new ReadonlyRequestCookiesError()
+  }
+  delete() {
+    throw new ReadonlyRequestCookiesError()
+  }
+  set() {
+    throw new ReadonlyRequestCookiesError()
+  }
+}

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -1,0 +1,131 @@
+import type { LoadComponentsReturnType } from '../load-components'
+import type { ServerRuntime } from '../../../types'
+import type {
+  FlightCSSManifest,
+  FlightManifest,
+} from '../../build/webpack/plugins/flight-manifest-plugin'
+import type { NextFontManifest } from '../../build/webpack/plugins/next-font-manifest-plugin'
+
+import zod from 'next/dist/compiled/zod'
+
+export type DynamicParamTypes = 'catchall' | 'optional-catchall' | 'dynamic'
+
+const dynamicParamTypesSchema = zod.enum(['c', 'oc', 'd'])
+/**
+ * c = catchall
+ * oc = optional catchall
+ * d = dynamic
+ */
+export type DynamicParamTypesShort = zod.infer<typeof dynamicParamTypesSchema>
+
+const segmentSchema = zod.union([
+  zod.string(),
+  zod.tuple([zod.string(), zod.string(), dynamicParamTypesSchema]),
+])
+/**
+ * Segment in the router state.
+ */
+export type Segment = zod.infer<typeof segmentSchema>
+
+export const flightRouterStateSchema: zod.ZodType<FlightRouterState> = zod.lazy(
+  () => {
+    const parallelRoutesSchema = zod.record(flightRouterStateSchema)
+    const urlSchema = zod.string().nullable().optional()
+    const refreshSchema = zod.literal('refetch').nullable().optional()
+    const isRootLayoutSchema = zod.boolean().optional()
+
+    // Due to the lack of optional tuple types in Zod, we need to use union here.
+    // https://github.com/colinhacks/zod/issues/1465
+    return zod.union([
+      zod.tuple([
+        segmentSchema,
+        parallelRoutesSchema,
+        urlSchema,
+        refreshSchema,
+        isRootLayoutSchema,
+      ]),
+      zod.tuple([
+        segmentSchema,
+        parallelRoutesSchema,
+        urlSchema,
+        refreshSchema,
+      ]),
+      zod.tuple([segmentSchema, parallelRoutesSchema, urlSchema]),
+      zod.tuple([segmentSchema, parallelRoutesSchema]),
+    ])
+  }
+)
+/**
+ * Router state
+ */
+export type FlightRouterState = [
+  segment: Segment,
+  parallelRoutes: { [parallelRouterKey: string]: FlightRouterState },
+  url?: string | null,
+  refresh?: 'refetch' | null,
+  isRootLayout?: boolean
+]
+
+/**
+ * Individual Flight response path
+ */
+export type FlightSegmentPath =
+  // Uses `any` as repeating pattern can't be typed.
+  | any[]
+  // Looks somewhat like this
+  | [
+      segment: Segment,
+      parallelRouterKey: string,
+      segment: Segment,
+      parallelRouterKey: string,
+      segment: Segment,
+      parallelRouterKey: string
+    ]
+
+export type FlightDataPath =
+  // Uses `any` as repeating pattern can't be typed.
+  | any[]
+  // Looks somewhat like this
+  | [
+      // Holds full path to the segment.
+      ...FlightSegmentPath[],
+      /* segment of the rendered slice: */ Segment,
+      /* treePatch */ FlightRouterState,
+      /* subTreeData: */ React.ReactNode | null, // Can be null during prefetch if there's no loading component
+      /* head */ React.ReactNode | null
+    ]
+
+/**
+ * The Flight response data
+ */
+export type FlightData = Array<FlightDataPath> | string
+
+/**
+ * Property holding the current subTreeData.
+ */
+export type ChildProp = {
+  /**
+   * Null indicates that the tree is partial
+   */
+  current: React.ReactNode | null
+  segment: Segment
+}
+
+export type RenderOptsPartial = {
+  err?: Error | null
+  dev?: boolean
+  serverComponentManifest?: FlightManifest
+  serverCSSManifest?: FlightCSSManifest
+  supportsDynamicHTML: boolean
+  runtime?: ServerRuntime
+  serverComponents?: boolean
+  assetPrefix?: string
+  nextFontManifest?: NextFontManifest
+  isBot?: boolean
+  incrementalCache?: import('../lib/incremental-cache').IncrementalCache
+  isRevalidate?: boolean
+  nextExport?: boolean
+  appDirDevErrorLogger?: (err: any) => Promise<void>
+}
+
+export type RenderOpts = LoadComponentsReturnType & RenderOptsPartial

--- a/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
@@ -3,11 +3,9 @@ import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from 'http'
 import type { AsyncLocalStorage } from 'async_hooks'
 import type { PreviewData } from '../../../types'
 import type { RequestStore } from '../../client/components/request-async-storage'
-import {
-  ReadonlyHeaders,
-  ReadonlyRequestCookies,
-  type RenderOpts,
-} from '../app-render'
+import type { RenderOpts } from '../app-render/types'
+import { ReadonlyHeaders } from '../app-render/readonly-headers'
+import { ReadonlyRequestCookies } from '../app-render/readonly-request-cookies'
 import { AsyncStorageWrapper } from './async-storage-wrapper'
 import type { tryGetPreviewData } from '../api-utils/node'
 import type { BaseNextRequest, BaseNextResponse } from '../base-http'

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -2,7 +2,10 @@ import type ws from 'ws'
 import origDebug from 'next/dist/compiled/debug'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type { NextConfigComplete } from '../config-shared'
-import type { DynamicParamTypesShort, FlightRouterState } from '../app-render'
+import type {
+  DynamicParamTypesShort,
+  FlightRouterState,
+} from '../app-render/types'
 
 import { EventEmitter } from 'events'
 import { findPageFile } from '../lib/find-page-file'

--- a/packages/next/src/server/node-web-streams-helper.ts
+++ b/packages/next/src/server/node-web-streams-helper.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from './app-render'
+import type { FlightRouterState } from './app-render/types'
 import { nonNullable } from '../lib/non-nullable'
 import { getTracer } from './lib/trace/tracer'
 import { AppRenderSpan } from './lib/trace/constants'

--- a/packages/next/src/shared/lib/app-router-context.ts
+++ b/packages/next/src/shared/lib/app-router-context.ts
@@ -2,7 +2,10 @@
 
 import { FocusAndScrollRef } from '../../client/components/router-reducer/router-reducer-types'
 import type { fetchServerResponse } from '../../client/components/router-reducer/fetch-server-response'
-import type { FlightRouterState, FlightData } from '../../server/app-render'
+import type {
+  FlightRouterState,
+  FlightData,
+} from '../../server/app-render/types'
 import React from 'react'
 
 export type ChildSegmentMap = Map<string, CacheNode>


### PR DESCRIPTION
This changes make sure that the `app-render` module isn't being imported by too many unnecessary places, as we'll later move the renderer into a worker.