### PR TITLE
Align on next-transform-font

### DIFF
--- a/packages/font/src/google/validate-google-font-function-call.ts
+++ b/packages/font/src/google/validate-google-font-function-call.ts
@@ -16,7 +16,7 @@ type FontOptions = {
   subsets: string[]
 }
 /**
- * Validate the data recieved from next-swc next_font_loaders on next/font/google calls
+ * Validate the data recieved from next-swc next-transform-font on next/font/google calls
  */
 export function validateGoogleFontFunctionCall(
   functionName: string,

--- a/packages/font/src/local/get-fallback-metrics-from-font-file.ts
+++ b/packages/font/src/local/get-fallback-metrics-from-font-file.ts
@@ -80,6 +80,17 @@ export function getFallbackMetricsFromFontFile(
   const azAvgWidth = calcAverageWidth(font)
   const { ascent, descent, lineGap, unitsPerEm } = font
 
+  console.log(
+    'ascent',
+    ascent,
+    'descent',
+    descent,
+    'lineGap',
+    lineGap,
+    'unitsPerEm',
+    unitsPerEm
+  )
+
   const fallbackFontAvgWidth = fallbackFont.azAvgWidth / fallbackFont.unitsPerEm
   let sizeAdjust = azAvgWidth
     ? azAvgWidth / unitsPerEm / fallbackFontAvgWidth

--- a/packages/font/src/local/get-fallback-metrics-from-font-file.ts
+++ b/packages/font/src/local/get-fallback-metrics-from-font-file.ts
@@ -80,17 +80,6 @@ export function getFallbackMetricsFromFontFile(
   const azAvgWidth = calcAverageWidth(font)
   const { ascent, descent, lineGap, unitsPerEm } = font
 
-  console.log(
-    'ascent',
-    ascent,
-    'descent',
-    descent,
-    'lineGap',
-    lineGap,
-    'unitsPerEm',
-    unitsPerEm
-  )
-
   const fallbackFontAvgWidth = fallbackFont.azAvgWidth / fallbackFont.unitsPerEm
   let sizeAdjust = azAvgWidth
     ? azAvgWidth / unitsPerEm / fallbackFontAvgWidth

--- a/packages/font/src/local/validate-local-font-function-call.ts
+++ b/packages/font/src/local/validate-local-font-function-call.ts
@@ -29,7 +29,7 @@ type FontOptions = {
 }
 
 /**
- * Validate the data recieved from next-swc next_font_loaders on next/font/local calls
+ * Validate the data recieved from next-swc next-transform-font on next/font/local calls
  */
 export function validateLocalFontFunctionCall(
   functionName: string,

--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -3130,8 +3130,8 @@ dependencies = [
  "indexmap",
  "indoc",
  "mime",
- "next-font",
  "next-transform-dynamic",
+ "next-transform-font",
  "next-transform-strip-page-exports",
  "once_cell",
  "qstring",
@@ -3233,16 +3233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "next-font"
-version = "0.1.0"
-dependencies = [
- "rustc-hash",
- "serde",
- "serde_json",
- "swc_core",
-]
-
-[[package]]
 name = "next-swc"
 version = "0.0.0"
 dependencies = [
@@ -3252,6 +3242,7 @@ dependencies = [
  "fxhash",
  "hex",
  "next-binding",
+ "next-transform-font",
  "once_cell",
  "pathdiff",
  "regex",
@@ -3295,6 +3286,16 @@ dependencies = [
  "pathdiff",
  "swc_core",
  "testing",
+]
+
+[[package]]
+name = "next-transform-font"
+version = "0.1.0"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "swc_core",
 ]
 
 [[package]]

--- a/packages/next-swc/Cargo.toml
+++ b/packages/next-swc/Cargo.toml
@@ -8,7 +8,7 @@ members = [
   "crates/next-core",
   "crates/next-dev",
   "crates/next-dev-tests",
-  "crates/next-font",
+  "crates/next-transform-font",
   "crates/next-transform-dynamic",
   "crates/next-transform-strip-page-exports",
 ]
@@ -29,7 +29,7 @@ next-binding = { path = "crates/next-binding" }
 next-core = { path = "crates/next-core", default-features = false }
 next-dev = { path = "crates/next-dev" }
 next-dev-tests = { path = "crates/next-dev-tests" }
-next-font = { path = "crates/next-font" }
+next-transform-font = { path = "crates/next-transform-font" }
 next-transform-dynamic = { path = "crates/next-transform-dynamic" }
 next-transform-strip-page-exports = { path = "crates/next-transform-strip-page-exports" }
 

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -14,6 +14,7 @@ either = "1"
 fxhash = "0.2.1"
 hex = "0.4.3"
 once_cell = "1.13.0"
+next-transform-font = {"workspace" = true}
 pathdiff = "0.2.0"
 regex = "1.5"
 serde = "1"

--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -34,6 +34,7 @@ use auto_cjs::contains_cjs;
 use either::Either;
 use fxhash::FxHashSet;
 
+use next_transform_font::next_font_loaders;
 use serde::Deserialize;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -51,7 +52,6 @@ pub mod amp_attributes;
 mod auto_cjs;
 pub mod disallow_re_export_all_in_page;
 pub mod next_dynamic;
-pub mod next_font_loaders;
 pub mod next_ssg;
 pub mod page_config;
 pub mod react_remove_properties;
@@ -125,7 +125,7 @@ pub struct TransformOptions {
     pub modularize_imports: Option<next_binding::swc::custom_transform::modularize_imports::Config>,
 
     #[serde(default)]
-    pub font_loaders: Option<next_font_loaders::Config>,
+    pub font_loaders: Option<next_transform_font::Config>,
 
     #[serde(default)]
     pub server_actions: Option<server_actions::Config>,
@@ -257,7 +257,7 @@ where
             None => Either::Right(noop()),
         },
         match &opts.font_loaders {
-            Some(config) => Either::Left(next_font_loaders::next_font_loaders(config.clone())),
+            Some(config) => Either::Left(next_font_loaders(config.clone())),
             None => Either::Right(noop()),
         },
         match &opts.server_actions {

--- a/packages/next-swc/crates/core/tests/errors.rs
+++ b/packages/next-swc/crates/core/tests/errors.rs
@@ -14,11 +14,11 @@ use next_binding::swc::{
 use next_swc::{
     disallow_re_export_all_in_page::disallow_re_export_all_in_page,
     next_dynamic::next_dynamic,
-    next_font_loaders::{next_font_loaders, Config as FontLoaderConfig},
     next_ssg::next_ssg,
     react_server_components::server_components,
     server_actions::{self, server_actions},
 };
+use next_transform_font::{next_font_loaders, Config as FontLoaderConfig};
 use std::path::PathBuf;
 
 fn syntax() -> Syntax {

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -11,7 +11,6 @@ use next_binding::swc::{
 use next_swc::{
     amp_attributes::amp_attributes,
     next_dynamic::next_dynamic,
-    next_font_loaders::{next_font_loaders, Config as FontLoaderConfig},
     next_ssg::next_ssg,
     page_config::page_config_test,
     react_remove_properties::remove_properties,
@@ -21,6 +20,7 @@ use next_swc::{
     server_actions::{self, server_actions},
     shake_exports::{shake_exports, Config as ShakeExportsConfig},
 };
+use next_transform_font::{next_font_loaders, Config as FontLoaderConfig};
 use std::path::PathBuf;
 
 fn syntax() -> Syntax {

--- a/packages/next-swc/crates/next-core/Cargo.toml
+++ b/packages/next-swc/crates/next-core/Cargo.toml
@@ -31,7 +31,7 @@ turbopack-ecmascript = { workspace = true }
 turbopack-env = { workspace = true }
 turbopack-node = { workspace = true }
 next-transform-strip-page-exports = { workspace = true }
-next-font = { workspace = true }
+next-transform-font = { workspace = true }
 next-transform-dynamic = { workspace = true }
 
 swc_core = { workspace = true, features = ["ecma_ast", "common"] }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms.rs
@@ -147,7 +147,7 @@ struct NextJsFont {
 
 impl CustomTransformer for NextJsFont {
     fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Option<Program> {
-        let mut next_font = next_font::next_font_loaders(next_font::Config {
+        let mut next_font = next_transform_font::next_font_loaders(next_transform_font::Config {
             font_loaders: self.font_loaders.clone(),
             relative_file_path_from_root: ctx.file_name_str.into(),
         });

--- a/packages/next-swc/crates/next-transform-font/Cargo.toml
+++ b/packages/next-swc/crates/next-transform-font/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "next-transform-font"
+version = "0.1.0"
+description = "TBD"
+license = "MPL-2.0"
+edition = "2021"
+
+[lib]
+bench = false
+
+[dependencies]
+rustc-hash = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+swc_core = { workspace = true }

--- a/packages/next-swc/crates/next-transform-font/src/find_functions_outside_module_scope.rs
+++ b/packages/next-swc/crates/next-transform-font/src/find_functions_outside_module_scope.rs
@@ -1,8 +1,10 @@
-use next_binding::swc::core::common::errors::HANDLER;
-use next_binding::swc::core::ecma::ast::*;
-use next_binding::swc::core::ecma::visit::noop_visit_type;
-use next_binding::swc::core::ecma::visit::Visit;
-
+use swc_core::{
+    common::errors::HANDLER,
+    ecma::{
+        ast::*,
+        visit::{noop_visit_type, Visit},
+    },
+};
 pub struct FindFunctionsOutsideModuleScope<'a> {
     pub state: &'a super::State,
 }

--- a/packages/next-swc/crates/next-transform-font/src/font_functions_collector.rs
+++ b/packages/next-swc/crates/next-transform-font/src/font_functions_collector.rs
@@ -1,8 +1,11 @@
-use next_binding::swc::core::common::errors::HANDLER;
-use next_binding::swc::core::ecma::ast::*;
-use next_binding::swc::core::ecma::atoms::JsWord;
-use next_binding::swc::core::ecma::visit::noop_visit_type;
-use next_binding::swc::core::ecma::visit::Visit;
+use swc_core::{
+    common::errors::HANDLER,
+    ecma::{
+        ast::*,
+        atoms::JsWord,
+        visit::{noop_visit_type, Visit},
+    },
+};
 
 pub struct FontFunctionsCollector<'a> {
     pub font_loaders: &'a [JsWord],

--- a/packages/next-swc/crates/next-transform-font/src/font_imports_generator.rs
+++ b/packages/next-swc/crates/next-transform-font/src/font_imports_generator.rs
@@ -1,9 +1,12 @@
-use next_binding::swc::core::common::errors::HANDLER;
-use next_binding::swc::core::common::{Spanned, DUMMY_SP};
-use next_binding::swc::core::ecma::ast::*;
-use next_binding::swc::core::ecma::atoms::JsWord;
-use next_binding::swc::core::ecma::visit::{noop_visit_type, Visit};
 use serde_json::Value;
+use swc_core::{
+    common::{errors::HANDLER, Spanned, DUMMY_SP},
+    ecma::{
+        ast::*,
+        atoms::JsWord,
+        visit::{noop_visit_type, Visit},
+    },
+};
 
 pub struct FontImportsGenerator<'a> {
     pub state: &'a mut super::State,

--- a/packages/next-swc/crates/next-transform-font/src/lib.rs
+++ b/packages/next-swc/crates/next-transform-font/src/lib.rs
@@ -1,13 +1,13 @@
-use fxhash::FxHashSet;
-use next_binding::swc::core::{
+use rustc_hash::FxHashSet;
+use serde::Deserialize;
+use swc_core::{
     common::{collections::AHashMap, BytePos, Spanned},
     ecma::{
-        ast::Id,
+        ast::{Id, ModuleItem},
+        atoms::JsWord,
         visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitWith},
     },
-    ecma::{ast::ModuleItem, atoms::JsWord},
 };
-use serde::Deserialize;
 
 mod find_functions_outside_module_scope;
 mod font_functions_collector;

--- a/packages/next/src/build/webpack/loaders/next-font-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-font-loader/index.ts
@@ -13,7 +13,7 @@ export default async function nextFontLoader(this: any) {
     const callback = this.async()
 
     /**
-     * The next-swc plugin next_font_loaders turns font function calls into CSS imports.
+     * The next-swc plugin next-transform-font turns font function calls into CSS imports.
      * At the end of the import, it adds the call arguments and some additional data as a resourceQuery.
      * e.g:
      * const inter = Inter({ subset: ['latin'] })

--- a/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNextFontError.ts
+++ b/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNextFontError.ts
@@ -15,7 +15,7 @@ export function getNextFontError(
     }
 
     // Parse the query and get the path of the file where the font function was called.
-    // provided by next-swc next_font_loaders
+    // provided by next-swc next-transform-font
     const file = JSON.parse(resourceResolveData.query.slice(1)).path
 
     if (err.name === 'NextFontError') {

--- a/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
+++ b/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
@@ -87,7 +87,7 @@ function getFormattedFileName(
     )
   ) {
     // Parse the query and get the path of the file where the font function was called.
-    // provided by next-swc next_font_loaders
+    // provided by next-swc next-transform-font
     return JSON.parse(module.resourceResolveData.query.slice(1)).path
   } else {
     let formattedFileName: string = chalk.cyan(fileName)


### PR DESCRIPTION
fix NEXT-827 ([link](https://linear.app/vercel/issue/NEXT-827))

This aligns use of the next/font transform across the workspace under a single crate, now called `next-transform-font`.
