### PR TITLE
[edge] support Node.js core modules in edge runtime

### DIFF
--- a/packages/next/src/build/polyfills/edge/node-buffer.ts
+++ b/packages/next/src/build/polyfills/edge/node-buffer.ts
@@ -1,0 +1,7 @@
+// @ts-ignore will be populated by context.ts
+const fromGlobal = global.__nextjs__node_compat__.buffer
+
+module.exports = {
+  ...fromGlobal,
+  default: fromGlobal,
+}

--- a/packages/next/src/build/polyfills/edge/node-buffer.ts
+++ b/packages/next/src/build/polyfills/edge/node-buffer.ts
@@ -1,7 +1,0 @@
-// @ts-ignore will be populated by context.ts
-const fromGlobal = global.__nextjs__node_compat__.buffer
-
-module.exports = {
-  ...fromGlobal,
-  default: fromGlobal,
-}

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -35,6 +35,7 @@ import { finalizeEntrypoint } from './entries'
 import * as Log from './output/log'
 import { buildConfiguration } from './webpack/config'
 import MiddlewarePlugin, {
+  getEdgePolyfilledModules,
   handleWebpackExternalForEdgeRuntime,
 } from './webpack/plugins/middleware-plugin'
 import BuildManifestPlugin from './webpack/plugins/build-manifest-plugin'
@@ -1450,6 +1451,7 @@ export default async function getBaseWebpackConfig(
                     './cjs/react-dom-server-legacy.browser.development.js':
                       '{}',
                   },
+                  getEdgePolyfilledModules(),
                   handleWebpackExternalForEdgeRuntime,
                 ]
               : []),
@@ -2061,7 +2063,7 @@ export default async function getBaseWebpackConfig(
           // Buffer is used by getInlineScriptSource
           Buffer: [require.resolve('buffer'), 'Buffer'],
           // Avoid process being overridden when in web run time
-          ...(isClient && { process: [require.resolve('process')] }),
+          process: [require.resolve('process')],
         }),
       new webpack.DefinePlugin(
         getDefineEnv({
@@ -2076,11 +2078,6 @@ export default async function getBaseWebpackConfig(
           clientRouterFilters,
         })
       ),
-      isEdgeServer &&
-        new webpack.NormalModuleReplacementPlugin(
-          /^(node:)?buffer$/,
-          require.resolve('./polyfills/edge/node-buffer')
-        ),
       isClient &&
         new ReactLoadablePlugin({
           filename: REACT_LOADABLE_MANIFEST,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2078,7 +2078,7 @@ export default async function getBaseWebpackConfig(
       ),
       isEdgeServer &&
         new webpack.NormalModuleReplacementPlugin(
-          /^node:buffer$/,
+          /^(node:)?buffer$/,
           require.resolve('./polyfills/edge/node-buffer')
         ),
       isClient &&

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2076,6 +2076,11 @@ export default async function getBaseWebpackConfig(
           clientRouterFilters,
         })
       ),
+      isEdgeServer &&
+        new webpack.NormalModuleReplacementPlugin(
+          /^node:buffer$/,
+          require.resolve('./polyfills/edge/node-buffer')
+        ),
       isClient &&
         new ReactLoadablePlugin({
           filename: REACT_LOADABLE_MANIFEST,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2063,7 +2063,7 @@ export default async function getBaseWebpackConfig(
           // Buffer is used by getInlineScriptSource
           Buffer: [require.resolve('buffer'), 'Buffer'],
           // Avoid process being overridden when in web run time
-          process: [require.resolve('process')],
+          ...(isClient && { process: [require.resolve('process')] }),
         }),
       new webpack.DefinePlugin(
         getDefineEnv({

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -858,6 +858,17 @@ export default class MiddlewarePlugin {
   }
 }
 
+const supportedEdgePolyfills = new Set(['buffer'])
+
+export function getEdgePolyfilledModules() {
+  const records: Record<string, string> = {}
+  for (const mod of supportedEdgePolyfills) {
+    records[mod] = `commonjs node:${mod}`
+    records[`node:${mod}`] = `commonjs node:${mod}`
+  }
+  return records
+}
+
 export async function handleWebpackExternalForEdgeRuntime({
   request,
   context,
@@ -869,7 +880,11 @@ export async function handleWebpackExternalForEdgeRuntime({
   contextInfo: any
   getResolve: () => any
 }) {
-  if (contextInfo.issuerLayer === 'middleware' && isNodeJsModule(request)) {
+  if (
+    contextInfo.issuerLayer === 'middleware' &&
+    isNodeJsModule(request) &&
+    !supportedEdgePolyfills.has(request)
+  ) {
     // allows user to provide and use their polyfills, as we do with buffer.
     try {
       await getResolve()(context, request)

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -858,7 +858,13 @@ export default class MiddlewarePlugin {
   }
 }
 
-const supportedEdgePolyfills = new Set(['buffer'])
+const supportedEdgePolyfills = new Set([
+  'buffer',
+  'events',
+  'assert',
+  'util',
+  'async_hooks',
+])
 
 export function getEdgePolyfilledModules() {
   const records: Record<string, string> = {}

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -16,6 +16,7 @@ import { fetchInlineAsset } from './fetch-inline-assets'
 import type { EdgeFunctionDefinition } from '../../../build/webpack/plugins/middleware-plugin'
 import { UnwrapPromise } from '../../../lib/coalesced-function'
 import { runInContext } from 'vm'
+import * as BufferImplementation from 'node:buffer'
 
 const WEBPACK_HASH_REGEX =
   /__webpack_require__\.h = function\(\) \{ return "[0-9a-f]+"; \}/g
@@ -154,6 +155,19 @@ async function createModuleContext(options: ModuleContextOptions) {
         : undefined,
     extend: (context) => {
       context.process = createProcessPolyfill(options)
+
+      Object.defineProperty(context, '__nextjs__node_compat__', {
+        enumerable: false,
+        value: {
+          buffer: pick(BufferImplementation, [
+            'constants',
+            'kMaxLength',
+            'kStringMaxLength',
+            'Buffer',
+            'SlowBuffer',
+          ]),
+        },
+      })
 
       context.__next_eval__ = function __next_eval__(fn: Function) {
         const key = fn.toString()

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -16,7 +16,11 @@ import { fetchInlineAsset } from './fetch-inline-assets'
 import type { EdgeFunctionDefinition } from '../../../build/webpack/plugins/middleware-plugin'
 import { UnwrapPromise } from '../../../lib/coalesced-function'
 import { runInContext } from 'vm'
-import * as BufferImplementation from 'node:buffer'
+import BufferImplementation from 'node:buffer'
+import EventsImplementation from 'node:events'
+import AssertImplementation from 'node:assert'
+import UtilImplementation from 'node:util'
+import AsyncHooksImplementation from 'node:async_hooks'
 
 const WEBPACK_HASH_REGEX =
   /__webpack_require__\.h = function\(\) \{ return "[0-9a-f]+"; \}/g
@@ -140,18 +144,42 @@ function getDecorateUnhandledRejection(runtime: EdgeRuntime) {
   }
 }
 
-const NativeModuleMap = new Map([
+const NativeModuleMap = new Map<string, unknown>([
   [
     'node:buffer',
-    {
-      ...pick(BufferImplementation, [
-        'constants',
-        'kMaxLength',
-        'kStringMaxLength',
-        'Buffer',
-        'SlowBuffer',
-      ]),
-    },
+    pick(BufferImplementation, [
+      'constants',
+      'kMaxLength',
+      'kStringMaxLength',
+      'Buffer',
+      'SlowBuffer',
+    ]),
+  ],
+  [
+    'node:events',
+    pick(EventsImplementation, [
+      'EventEmitter',
+      'captureRejectionSymbol',
+      'defaultMaxListeners',
+      'errorMonitor',
+      'listenerCount',
+      'on',
+      'once',
+    ]),
+  ],
+  [
+    'node:async_hooks',
+    pick(AsyncHooksImplementation, ['AsyncLocalStorage', 'AsyncResource']),
+  ],
+  [
+    'node:assert',
+    // TODO: check if need to pick specific properties
+    AssertImplementation,
+  ],
+  [
+    'node:util',
+    // TODO: check if need to pick specific properties
+    UtilImplementation,
   ],
 ])
 

--- a/test/e2e/app-dir/edge-runtime-node-compatibility/app/buffer/route.js
+++ b/test/e2e/app-dir/edge-runtime-node-compatibility/app/buffer/route.js
@@ -1,4 +1,5 @@
 import B from 'node:buffer'
+import { NextResponse } from 'next/server'
 
 /**
  * @param {Request} req
@@ -6,12 +7,11 @@ import B from 'node:buffer'
 export async function POST(req) {
   const text = await req.text()
   const buf = B.Buffer.from(text)
-  return new Response(
-    JSON.stringify({
-      encoded: buf.toString('base64'),
-      exposedKeys: Object.keys(B),
-    })
-  )
+  return NextResponse.json({
+    'Buffer === B.Buffer': B.Buffer === Buffer,
+    encoded: buf.toString('base64'),
+    exposedKeys: Object.keys(B),
+  })
 }
 
 export const runtime = 'edge'

--- a/test/e2e/app-dir/edge-runtime-node-compatibility/app/buffer/route.js
+++ b/test/e2e/app-dir/edge-runtime-node-compatibility/app/buffer/route.js
@@ -1,0 +1,17 @@
+import B from 'node:buffer'
+
+/**
+ * @param {Request} req
+ */
+export async function POST(req) {
+  const text = await req.text()
+  const buf = B.Buffer.from(text)
+  return new Response(
+    JSON.stringify({
+      encoded: buf.toString('base64'),
+      exposedKeys: Object.keys(B),
+    })
+  )
+}
+
+export const runtime = 'edge'

--- a/test/e2e/app-dir/edge-runtime-node-compatibility/app/layout.tsx
+++ b/test/e2e/app-dir/edge-runtime-node-compatibility/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/edge-runtime-node-compatibility/edge-runtime-node-compatibility.test.ts
+++ b/test/e2e/app-dir/edge-runtime-node-compatibility/edge-runtime-node-compatibility.test.ts
@@ -13,6 +13,7 @@ createNextDescribe(
       })
       const json = await res.json()
       expect(json).toEqual({
+        'Buffer === B.Buffer': true,
         encoded: Buffer.from('Hello, world!').toString('base64'),
         exposedKeys: [
           'constants',

--- a/test/e2e/app-dir/edge-runtime-node-compatibility/edge-runtime-node-compatibility.test.ts
+++ b/test/e2e/app-dir/edge-runtime-node-compatibility/edge-runtime-node-compatibility.test.ts
@@ -6,7 +6,7 @@ createNextDescribe(
     files: __dirname,
   },
   ({ next }) => {
-    it('supports node:buffer', async () => {
+    it('[app] supports node:buffer', async () => {
       const res = await next.fetch('/buffer', {
         method: 'POST',
         body: 'Hello, world!',
@@ -21,7 +21,29 @@ createNextDescribe(
           'kStringMaxLength',
           'Buffer',
           'SlowBuffer',
-          'default',
+        ],
+      })
+    })
+
+    it('[pages/api] supports node:buffer', async () => {
+      const res = await next.fetch('/api/buffer', {
+        method: 'POST',
+        body: 'Hello, world!',
+      })
+      const json = await res.json()
+      expect(json).toEqual({
+        'B2.Buffer === B.Buffer': true,
+        'Buffer === B.Buffer': true,
+        'typeof B.Buffer': 'function',
+        'typeof B2.Buffer': 'function',
+        'typeof Buffer': 'function',
+        encoded: 'SGVsbG8sIHdvcmxkIQ==',
+        exposedKeys: [
+          'constants',
+          'kMaxLength',
+          'kStringMaxLength',
+          'Buffer',
+          'SlowBuffer',
         ],
       })
     })

--- a/test/e2e/app-dir/edge-runtime-node-compatibility/edge-runtime-node-compatibility.test.ts
+++ b/test/e2e/app-dir/edge-runtime-node-compatibility/edge-runtime-node-compatibility.test.ts
@@ -1,0 +1,28 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'edge runtime node compatibility',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('supports node:buffer', async () => {
+      const res = await next.fetch('/buffer', {
+        method: 'POST',
+        body: 'Hello, world!',
+      })
+      const json = await res.json()
+      expect(json).toEqual({
+        encoded: Buffer.from('Hello, world!').toString('base64'),
+        exposedKeys: [
+          'constants',
+          'kMaxLength',
+          'kStringMaxLength',
+          'Buffer',
+          'SlowBuffer',
+          'default',
+        ],
+      })
+    })
+  }
+)

--- a/test/e2e/app-dir/edge-runtime-node-compatibility/next.config.js
+++ b/test/e2e/app-dir/edge-runtime-node-compatibility/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: { appDir: true },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/edge-runtime-node-compatibility/pages/api/buffer.js
+++ b/test/e2e/app-dir/edge-runtime-node-compatibility/pages/api/buffer.js
@@ -1,0 +1,22 @@
+import B from 'node:buffer'
+import B2 from 'buffer'
+import { NextResponse } from 'next/server'
+
+export const config = { runtime: 'edge' }
+
+/**
+ * @param {Request} req
+ */
+export default async function (req) {
+  const text = await req.text()
+  const buf = B.Buffer.from(text)
+  return NextResponse.json({
+    'Buffer === B.Buffer': B.Buffer === Buffer,
+    'B2.Buffer === B.Buffer': B.Buffer === B2.Buffer,
+    'typeof Buffer': typeof Buffer,
+    'typeof B.Buffer': typeof B.Buffer,
+    'typeof B2.Buffer': typeof B2.Buffer,
+    encoded: buf.toString('base64'),
+    exposedKeys: Object.keys(B),
+  })
+}

--- a/test/e2e/app-dir/edge-runtime-node-compatibility/tsconfig.json
+++ b/test/e2e/app-dir/edge-runtime-node-compatibility/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/test/e2e/app-dir/edge-runtime-node-compatibility/tsconfig.json
+++ b/test/e2e/app-dir/edge-runtime-node-compatibility/tsconfig.json
@@ -17,7 +17,8 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "strictNullChecks": true
   },
   "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This PR enables Node.js core modules in edge runtime by leaving a `require` statement in the output source as externals

- [x] buffer
- [ ] async_hooks
- [ ] util 
- [ ] assert
- [ ] events