### PR TITLE
Not apply image loader to metadata images

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -61,7 +61,7 @@ import { AppBuildManifestPlugin } from './webpack/plugins/app-build-manifest-plu
 import { SubresourceIntegrityPlugin } from './webpack/plugins/subresource-integrity-plugin'
 import { NextFontManifestPlugin } from './webpack/plugins/next-font-manifest-plugin'
 import { getSupportedBrowsers } from './utils'
-import { METADATA_IMAGE_RESOURCE_QUERY } from './webpack/loaders/metadata/discover'
+import { METADATA_RESOURCE_QUERY } from './webpack/loaders/metadata/discover'
 
 const EXTERNAL_PACKAGES =
   require('../lib/server-external-packages.json') as string[]
@@ -1958,8 +1958,7 @@ export default async function getBaseWebpackConfig(
                 loader: 'next-image-loader',
                 issuer: { not: regexLikeCss },
                 dependency: { not: ['url'] },
-                resourceQuery: (queryString: string) =>
-                  queryString !== METADATA_IMAGE_RESOURCE_QUERY,
+                resourceQuery: { not: [METADATA_RESOURCE_QUERY] },
                 options: {
                   isServer: isNodeServer || isEdgeServer,
                   isDev: dev,

--- a/packages/next/src/build/webpack/loaders/metadata/discover.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/discover.ts
@@ -9,7 +9,7 @@ import { stringify } from 'querystring'
 
 const METADATA_TYPE = 'metadata'
 
-export const METADATA_IMAGE_RESOURCE_QUERY = '?__next_metadata'
+export const METADATA_RESOURCE_QUERY = '?__next_metadata'
 
 const staticAssetIconsImage = {
   icon: {
@@ -126,7 +126,7 @@ export async function discoverStaticMetadataFiles(
             type,
           })}!` +
             filepath +
-            METADATA_IMAGE_RESOURCE_QUERY
+            METADATA_RESOURCE_QUERY
         )})`
 
         hasStaticMetadataFiles = true

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -9,7 +9,11 @@ import { getModuleBuildInfo } from './get-module-build-info'
 import { verifyRootLayout } from '../../../lib/verifyRootLayout'
 import * as Log from '../../../build/output/log'
 import { APP_DIR_ALIAS } from '../../../lib/constants'
-import { buildMetadata, discoverStaticMetadataFiles } from './metadata/discover'
+import {
+  buildMetadata,
+  discoverStaticMetadataFiles,
+  METADATA_RESOURCE_QUERY,
+} from './metadata/discover'
 import { isAppRouteRoute } from '../../../lib/is-app-route-route'
 import { isMetadataRoute } from '../../../lib/metadata/is-metadata-route'
 
@@ -68,7 +72,9 @@ async function createAppRouteCode({
   let resolvedPagePath = (await resolver(routePath))!
 
   if (isMetadataRoute(name)) {
-    resolvedPagePath = `next-metadata-route-loader!${resolvedPagePath}`
+    resolvedPagePath = `next-metadata-route-loader!${
+      resolvedPagePath + METADATA_RESOURCE_QUERY
+    }`
   }
 
   // TODO: verify if other methods need to be injected

--- a/test/integration/app-dir-export/test/index.test.ts
+++ b/test/integration/app-dir-export/test/index.test.ts
@@ -149,8 +149,6 @@ describe('app dir with output export', () => {
     expect(files).toEqual([
       '404.html',
       '404/index.html',
-      // TODO-METADATA: favicon.ico should not be here
-      '_next/static/media/favicon.603d046c.ico',
       '_next/static/media/test.3f1a293b.png',
       '_next/static/test-build-id/_buildManifest.js',
       '_next/static/test-build-id/_ssgManifest.js',


### PR DESCRIPTION
Previously when we move to metadata images to custom app routes, when the image files get imported, it matches the `next-image-loader` rule which accidentally generate a static file into media.

This PR appends the metadata reource query to the imported rerource, and then skip in the `next-metadata-route-loader` so they won't get applied by image loader or emit any unexpected assets
