### PR TITLE
Fix missing option in `createFromFetch`

### DIFF
--- a/packages/next-swc/crates/next-core/js/src/entry/app/hydrate.tsx
+++ b/packages/next-swc/crates/next-core/js/src/entry/app/hydrate.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from "react";
 // @ts-expect-error
 import { version } from "next/package.json";
 import { createFromReadableStream } from "next/dist/compiled/react-server-dom-webpack/client";
+import { callServer } from 'next/dist/client/app-call-server';
 
 import { HeadManagerContext } from "next/dist/shared/lib/head-manager-context";
 
@@ -109,7 +110,7 @@ function useInitialServerResponse(cacheKey: string) {
     },
   });
 
-  const newResponse = createFromReadableStream(readable);
+  const newResponse = createFromReadableStream(readable, { callServer });
 
   rscCache.set(cacheKey, newResponse);
   return newResponse;

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -12,6 +12,7 @@ import {
   RSC_CONTENT_TYPE_HEADER,
 } from '../app-router-headers'
 import { urlToUrlWithoutFlightMarker } from '../app-router'
+import { callServer } from '../../app-call-server'
 
 /**
  * Fetch the flight data for the provided url. Takes in the current router state to decide what to render server-side.
@@ -75,7 +76,9 @@ export async function fetchServerResponse(
     }
 
     // Handle the `fetch` readable stream that can be unwrapped by `React.use`.
-    const flightData: FlightData = await createFromFetch(Promise.resolve(res))
+    const flightData: FlightData = await createFromFetch(Promise.resolve(res), {
+      callServer,
+    })
     return [flightData, canonicalUrl]
   } catch (err) {
     console.error(


### PR DESCRIPTION
This PR makes sure that `callServer` is specified in all Flight response creation calls. Added a test to cover HMR.

https://vercel.slack.com/archives/C03KAR5DCKC/p1678997184339409