### PR TITLE
fix: show error for api route handler with `output: export`

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -181,6 +181,7 @@ export function getEdgeServerEntry(opts: {
       absolutePagePath: opts.absolutePagePath,
       page: opts.page,
       appDirLoader: Buffer.from(opts.appDirLoader || '').toString('base64'),
+      nextConfigOutput: opts.config.output,
     }
 
     return `next-edge-app-route-loader?${stringify(loaderParams)}!`

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/handle.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/handle.ts
@@ -2,14 +2,21 @@ import {
   WebNextRequest,
   WebNextResponse,
 } from '../../../../server/base-http/web'
+import { NextConfig } from '../../../../server/config-shared'
 import { AppRouteRouteHandler } from '../../../../server/future/route-handlers/app-route-route-handler'
 import { RouteKind } from '../../../../server/future/route-kind'
 import { AppRouteRouteMatcher } from '../../../../server/future/route-matchers/app-route-route-matcher'
 import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
 import { removeTrailingSlash } from '../../../../shared/lib/router/utils/remove-trailing-slash'
 
-export function getHandle({ page, mod }: any) {
-  const appRouteRouteHandler = new AppRouteRouteHandler()
+type HandleProps = {
+  page: string
+  mod: any
+  nextConfigOutput: NextConfig['output']
+}
+
+export function getHandle({ page, mod, nextConfigOutput }: HandleProps) {
+  const appRouteRouteHandler = new AppRouteRouteHandler(nextConfigOutput)
   const appRouteRouteMatcher = new AppRouteRouteMatcher({
     kind: RouteKind.APP_ROUTE,
     pathname: normalizeAppPath(page),

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
@@ -1,10 +1,12 @@
 import { getModuleBuildInfo } from '../get-module-build-info'
 import { stringifyRequest } from '../../stringify-request'
+import { NextConfig } from '../../../../server/config-shared'
 
 export type EdgeAppRouteLoaderQuery = {
   absolutePagePath: string
   page: string
   appDirLoader: string
+  nextConfigOutput: NextConfig['output']
 }
 
 export default async function edgeAppRouteLoader(this: any) {
@@ -12,7 +14,8 @@ export default async function edgeAppRouteLoader(this: any) {
     page,
     absolutePagePath,
     appDirLoader: appDirLoaderBase64,
-  } = this.getOptions()
+    nextConfigOutput,
+  } = this.getOptions() as EdgeAppRouteLoaderQuery
 
   const appDirLoader = Buffer.from(
     appDirLoaderBase64 || '',
@@ -48,6 +51,9 @@ export default async function edgeAppRouteLoader(this: any) {
     const render = getHandle({
       mod,
       page: ${JSON.stringify(page)},
+      nextConfigOuput: ${
+        nextConfigOutput ? JSON.stringify(nextConfigOutput) : 'undefined'
+      }
     })
 
     export const ComponentMod = mod

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -85,6 +85,7 @@ interface ExportPageInput {
   isrMemoryCacheSize?: NextConfigComplete['experimental']['isrMemoryCacheSize']
   fetchCache?: boolean
   incrementalCacheHandlerPath?: string
+  nextConfigOuput?: NextConfigComplete['output']
 }
 
 interface ExportPageResults {
@@ -143,6 +144,7 @@ export default async function exportPage({
   isrMemoryCacheSize,
   fetchCache,
   incrementalCacheHandlerPath,
+  nextConfigOuput,
 }: ExportPageInput): Promise<ExportPageResults> {
   setHttpClientAndAgentOptions({
     httpAgentOptions,
@@ -392,7 +394,7 @@ export default async function exportPage({
           }
 
           try {
-            const routeHandler = new AppRouteRouteHandler()
+            const routeHandler = new AppRouteRouteHandler(nextConfigOuput)
             const response: Response = await routeHandler.handle(
               {
                 params: query,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -254,9 +254,13 @@ export default class NextNodeServer extends BaseServer {
 
   protected getRoutes() {
     const routes = super.getRoutes()
+    const nextConfigOutput = this.nextConfig.output
 
     if (this.hasAppDir) {
-      routes.handlers.set(RouteKind.APP_ROUTE, new AppRouteRouteHandler())
+      routes.handlers.set(
+        RouteKind.APP_ROUTE,
+        new AppRouteRouteHandler(nextConfigOutput)
+      )
     }
 
     return routes

--- a/test/integration/app-dir-export/app/api/json/route.js
+++ b/test/integration/app-dir-export/app/api/json/route.js
@@ -1,3 +1,5 @@
+export const dynamic = 'force-static'
+
 export async function GET() {
   return Response.json({ answer: 42 })
 }

--- a/test/integration/app-dir-export/test/index.test.ts
+++ b/test/integration/app-dir-export/test/index.test.ts
@@ -6,6 +6,7 @@ import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
 import globOrig from 'glob'
 import {
+  fetchViaHTTP,
   File,
   findPort,
   killApp,
@@ -70,7 +71,6 @@ async function runTests({
   }
   try {
     const a = (n: number) => `li:nth-child(${n}) a`
-    console.log('[navigate]')
     const browser = await webdriver(appPort, '/')
     expect(await browser.elementByCss('h1').text()).toBe('Home')
     expect(await browser.elementByCss(a(1)).text()).toBe(
@@ -126,6 +126,13 @@ async function runTests({
     expect(await browser.elementByCss(a(2)).getAttribute('href')).toContain(
       '/test.3f1a293b.png'
     )
+    const res1 = await fetchViaHTTP(appPort, '/api/json')
+    expect(res1.status).toBe(200)
+    expect(await res1.json()).toEqual({ answer: 42 })
+
+    const res2 = await fetchViaHTTP(appPort, '/api/txt')
+    expect(res2.status).toBe(200)
+    expect(await res2.text()).toEqual('this is plain text')
   } finally {
     await stopOrKill()
     nextConfig.restore()


### PR DESCRIPTION
In the case when the user configured `output: export` and used an API Route Handler that cannot be converted to static, Next.js must throw an error.

fix NEXT-823 ([link](https://linear.app/vercel/issue/NEXT-823))