### PR TITLE
Match getter/setter behavior of real-world fetch

### DIFF
--- a/packages/next/src/server/node-polyfill-fetch.ts
+++ b/packages/next/src/server/node-polyfill-fetch.ts
@@ -21,7 +21,7 @@ if (!(global as any).fetch) {
   }
 
   // Due to limitation of global configuration, we have to do this resolution at runtime
-  impl.fetch = (...args: any[]) => {
+  ;(global as any).fetch = (...args: any[]) => {
     const fetchImpl = getFetchImpl()
 
     if ((global as any).__NEXT_USE_UNDICI) {
@@ -51,14 +51,6 @@ if (!(global as any).fetch) {
   }
 
   Object.defineProperties(global, {
-    fetch: {
-      set(fetch) {
-        impl.fetch = fetch
-      },
-      get() {
-        return impl.fetch
-      },
-    },
     Headers: {
       set(Headers) {
         impl.Headers = Headers

--- a/packages/next/src/server/node-polyfill-fetch.ts
+++ b/packages/next/src/server/node-polyfill-fetch.ts
@@ -56,7 +56,7 @@ if (!(global as any).fetch) {
         impl.Headers = Headers
       },
       get() {
-        return impl.Headers
+        return impl.Headers ?? (impl.Headers = getFetchImpl().Headers)
       },
     },
     Request: {
@@ -64,7 +64,7 @@ if (!(global as any).fetch) {
         impl.Request = Request
       },
       get() {
-        return getRequestImpl().Request
+        return getRequestImpl()
       },
     },
     Response: {
@@ -72,7 +72,7 @@ if (!(global as any).fetch) {
         impl.Response = Response
       },
       get() {
-        return impl.Response
+        return impl.Response ?? (impl.Response = getFetchImpl().Response)
       },
     },
   })


### PR DESCRIPTION
When upgrading to Next 13, unit tests which use tools like Pretender or Mirage, which overwrite the global.{fetch,Headers,etc.} to mock them, start to fail with "unable to set window#Headers, no getter" (or something like that). This creates an underlying `impl` object which we can set to, enabling these to be polyfilled again.