### PR TITLE
Generate metadata images generation with app routes

### DIFF
--- a/packages/next/src/build/webpack/loaders/metadata/discover.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/discover.ts
@@ -77,11 +77,13 @@ async function enumMetadataFiles(
 export async function discoverStaticMetadataFiles(
   resolvedDir: string,
   {
+    route,
     resolvePath,
     isRootLayer,
     loaderContext,
     loaderOptions,
   }: {
+    route: string
     resolvePath: (pathname: string) => Promise<string>
     isRootLayer: boolean
     loaderContext: webpack.LoaderContext<any>
@@ -121,6 +123,7 @@ export async function discoverStaticMetadataFiles(
         const imageModule = `() => import(/* webpackMode: "eager" */ ${JSON.stringify(
           `next-metadata-image-loader?${stringify({
             ...metadataImageLoaderOptions,
+            route,
             numericSizes:
               type === 'twitter' || type === 'opengraph' ? '1' : undefined,
             type,
@@ -149,7 +152,7 @@ export async function discoverStaticMetadataFiles(
   return hasStaticMetadataFiles ? staticImagesMetadata : null
 }
 
-export function buildMetadata(
+export function createMetadataExportsCode(
   metadata: Awaited<ReturnType<typeof discoverStaticMetadataFiles>>
 ) {
   return metadata

--- a/packages/next/src/build/webpack/loaders/metadata/discover.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/discover.ts
@@ -1,5 +1,4 @@
 import type webpack from 'webpack'
-import type { AppLoaderOptions } from '../next-app-loader'
 import type {
   CollectingMetadata,
   PossibleImageFileNameConvention,

--- a/packages/next/src/build/webpack/loaders/metadata/discover.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/discover.ts
@@ -11,7 +11,7 @@ const METADATA_TYPE = 'metadata'
 
 export const METADATA_RESOURCE_QUERY = '?__next_metadata'
 
-const staticAssetIconsImage = {
+export const STATIC_METADATA_IMAGES = {
   icon: {
     filename: 'icon',
     extensions: ['ico', 'jpg', 'jpeg', 'png', 'svg'],
@@ -111,8 +111,8 @@ export async function discoverStaticMetadataFiles(
   ) {
     const resolvedMetadataFiles = await enumMetadataFiles(
       resolvedDir,
-      staticAssetIconsImage[type].filename,
-      staticAssetIconsImage[type].extensions,
+      STATIC_METADATA_IMAGES[type].filename,
+      STATIC_METADATA_IMAGES[type].extensions,
       opts
     )
     resolvedMetadataFiles

--- a/packages/next/src/build/webpack/loaders/metadata/discover.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/discover.ts
@@ -74,20 +74,18 @@ async function enumMetadataFiles(
   return collectedFiles
 }
 
-export async function discoverStaticMetadataFiles(
+export async function createStaticMetadataFromRoute(
   resolvedDir: string,
   {
     route,
     resolvePath,
     isRootLayer,
     loaderContext,
-    loaderOptions,
   }: {
     route: string
     resolvePath: (pathname: string) => Promise<string>
     isRootLayer: boolean
     loaderContext: webpack.LoaderContext<any>
-    loaderOptions: AppLoaderOptions
   }
 ) {
   let hasStaticMetadataFiles = false
@@ -101,11 +99,6 @@ export async function discoverStaticMetadataFiles(
   const opts = {
     resolvePath,
     loaderContext,
-  }
-
-  const metadataImageLoaderOptions = {
-    isDev: loaderOptions.isDev,
-    assetPrefix: loaderOptions.assetPrefix,
   }
 
   async function collectIconModuleIfExists(
@@ -122,7 +115,6 @@ export async function discoverStaticMetadataFiles(
       .forEach((filepath) => {
         const imageModule = `() => import(/* webpackMode: "eager" */ ${JSON.stringify(
           `next-metadata-image-loader?${stringify({
-            ...metadataImageLoaderOptions,
             route,
             numericSizes:
               type === 'twitter' || type === 'opengraph' ? '1' : undefined,
@@ -153,7 +145,7 @@ export async function discoverStaticMetadataFiles(
 }
 
 export function createMetadataExportsCode(
-  metadata: Awaited<ReturnType<typeof discoverStaticMetadataFiles>>
+  metadata: Awaited<ReturnType<typeof createStaticMetadataFromRoute>>
 ) {
   return metadata
     ? `${METADATA_TYPE}: {

--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
@@ -62,12 +62,12 @@ export function resolveSitemap(data: SitemapFile): string {
 
 export function resolveRouteData(
   data: RobotsFile | SitemapFile,
-  baseName: 'robots' | 'sitemap'
+  fileType: 'robots' | 'sitemap'
 ): string {
-  if (baseName === 'robots') {
+  if (fileType === 'robots') {
     return resolveRobots(data as RobotsFile)
   }
-  if (baseName === 'sitemap') {
+  if (fileType === 'sitemap') {
     return resolveSitemap(data as SitemapFile)
   }
   return ''

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -69,11 +69,12 @@ async function createAppRouteCode({
   resolver: PathResolver
   page: string
 }): Promise<string> {
+  // routePath is the path to the route handler file,
+  // but could be aliased e.g. private-next-app-dir/favicon.ico
   const routePath = pagePath.replace(/[\\/]/, '/')
   // This, when used with the resolver will give us the pathname to the built
   // route handler file.
   let resolvedPagePath = (await resolver(routePath))!
-
   if (isMetadataRoute(name)) {
     resolvedPagePath = `next-metadata-route-loader?${stringify({
       route: page,

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -3,6 +3,7 @@ import type { ValueOf } from '../../../shared/lib/constants'
 import type { ModuleReference, CollectedMetadata } from './metadata/types'
 
 import path from 'path'
+import { stringify } from 'querystring'
 import chalk from 'next/dist/compiled/chalk'
 import { NODE_RESOLVE_OPTIONS } from '../../webpack-config'
 import { getModuleBuildInfo } from './get-module-build-info'
@@ -61,18 +62,21 @@ async function createAppRouteCode({
   name,
   pagePath,
   resolver,
+  appDir,
 }: {
   name: string
   pagePath: string
   resolver: PathResolver
+  appDir: string
 }): Promise<string> {
   const routePath = pagePath.replace(/[\\/]/, '/')
   // This, when used with the resolver will give us the pathname to the built
   // route handler file.
   let resolvedPagePath = (await resolver(routePath))!
 
+  console.log('name', name, '->', isMetadataRoute(name))
   if (isMetadataRoute(name)) {
-    resolvedPagePath = `next-metadata-route-loader!${
+    resolvedPagePath = `next-metadata-route-loader?${stringify({ appDir })}!${
       resolvedPagePath + METADATA_RESOURCE_QUERY
     }`
   }
@@ -355,7 +359,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
   }
 
   if (isAppRouteRoute(name)) {
-    return createAppRouteCode({ name, pagePath, resolver })
+    return createAppRouteCode({ name, pagePath, resolver, appDir })
   }
 
   const {

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -62,12 +62,12 @@ async function createAppRouteCode({
   name,
   pagePath,
   resolver,
-  page,
+  pageExtensions,
 }: {
   name: string
   pagePath: string
   resolver: PathResolver
-  page: string
+  pageExtensions: string[]
 }): Promise<string> {
   // routePath is the path to the route handler file,
   // but could be aliased e.g. private-next-app-dir/favicon.ico
@@ -77,7 +77,7 @@ async function createAppRouteCode({
   let resolvedPagePath = (await resolver(routePath))!
   if (isMetadataRoute(name)) {
     resolvedPagePath = `next-metadata-route-loader?${stringify({
-      route: page,
+      pageExtensions,
     })}!${resolvedPagePath + METADATA_RESOURCE_QUERY}`
   }
 
@@ -359,7 +359,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
   }
 
   if (isAppRouteRoute(name)) {
-    return createAppRouteCode({ name, page, pagePath, resolver })
+    return createAppRouteCode({ name, pagePath, resolver, pageExtensions })
   }
 
   const {

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -12,7 +12,7 @@ import * as Log from '../../../build/output/log'
 import { APP_DIR_ALIAS } from '../../../lib/constants'
 import {
   createMetadataExportsCode,
-  discoverStaticMetadataFiles,
+  createStaticMetadataFromRoute,
   METADATA_RESOURCE_QUERY,
 } from './metadata/discover'
 import { isAppRouteRoute } from '../../../lib/is-app-route-route'
@@ -108,7 +108,6 @@ async function createTreeCodeFromPath(
     resolvePath,
     resolveParallelSegments,
     loaderContext,
-    loaderOptions,
   }: {
     resolver: (
       pathname: string,
@@ -119,7 +118,6 @@ async function createTreeCodeFromPath(
       pathname: string
     ) => [key: string, segment: string | string[]][]
     loaderContext: webpack.LoaderContext<AppLoaderOptions>
-    loaderOptions: AppLoaderOptions
   }
 ) {
   const splittedPath = pagePath.split(/[\\/]/)
@@ -148,18 +146,18 @@ async function createTreeCodeFromPath(
       parallelSegments.push(...resolveParallelSegments(segmentPath))
     }
 
-    let metadata: Awaited<ReturnType<typeof discoverStaticMetadataFiles>> = null
+    let metadata: Awaited<ReturnType<typeof createStaticMetadataFromRoute>> =
+      null
     try {
       const routerDirPath = `${appDirPrefix}${segmentPath}`
       const resolvedRouteDir = await resolver(routerDirPath, true)
 
       if (resolvedRouteDir) {
-        metadata = await discoverStaticMetadataFiles(resolvedRouteDir, {
+        metadata = await createStaticMetadataFromRoute(resolvedRouteDir, {
           route: segmentPath,
           resolvePath,
           isRootLayer,
           loaderContext,
-          loaderOptions,
         })
       }
     } catch (err: any) {
@@ -373,7 +371,6 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
     resolvePath: (pathname: string) => resolve(this.rootContext, pathname),
     resolveParallelSegments,
     loaderContext: this,
-    loaderOptions: loaderOptions,
   })
 
   if (!rootLayout) {

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -5,6 +5,7 @@ import type {
 import loaderUtils from 'next/dist/compiled/loader-utils3'
 import { getImageSize } from '../../../server/image-optimizer'
 import { imageExtMimeTypeMap } from '../../../lib/mime-type'
+
 interface Options {
   route: string
   numericSizes: boolean

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -6,6 +6,7 @@ import loaderUtils from 'next/dist/compiled/loader-utils3'
 import { getImageSize } from '../../../server/image-optimizer'
 
 interface Options {
+  route: string
   isDev: boolean
   assetPrefix: string
   numericSizes: boolean
@@ -21,10 +22,12 @@ const mimeTypeMap = {
 
 async function nextMetadataImageLoader(this: any, content: Buffer) {
   const options: Options = this.getOptions()
-  const { assetPrefix, isDev, numericSizes, type } = options
+  const { resourcePath } = this
+  const { assetPrefix, isDev, route, numericSizes, type } = options
   const context = this.rootContext
 
   const opts = { context, content }
+
   // favicon is the special case, always generate '/favicon.ico'
   const isFavIcon = type === 'favicon'
   // e.g. icon.png -> server/static/media/metadata/icon.399de3b9.png
@@ -34,7 +37,8 @@ async function nextMetadataImageLoader(this: any, content: Buffer) {
     '[name].[ext]',
     opts
   )
-  const outputPath = '/' + interpolatedName
+  // TODO-METADATA: add route into url
+  const outputPath = route + '/' + interpolatedName
   // isFavIcon
   //   ? '/' + interpolatedName
   //   : assetPrefix + '/_next' + interpolatedName

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -30,12 +30,14 @@ async function nextMetadataImageLoader(this: any, content: Buffer) {
   // e.g. icon.png -> server/static/media/metadata/icon.399de3b9.png
   const interpolatedName = loaderUtils.interpolateName(
     this,
-    (isFavIcon ? '' : '/static/media/metadata/') + '[name].[ext]',
+    // (isFavIcon ? '' : '/static/media/metadata/') +
+    '[name].[ext]',
     opts
   )
-  const outputPath = isFavIcon
-    ? '/' + interpolatedName
-    : assetPrefix + '/_next' + interpolatedName
+  const outputPath = '/' + interpolatedName
+  // isFavIcon
+  //   ? '/' + interpolatedName
+  //   : assetPrefix + '/_next' + interpolatedName
 
   let extension = loaderUtils.interpolateName(this, '[ext]', opts)
   if (extension === 'jpg') {
@@ -68,9 +70,9 @@ async function nextMetadataImageLoader(this: any, content: Buffer) {
   const stringifiedData = JSON.stringify(imageData)
 
   // TODO-METADATA: Move image generation to static app routes
-  if (!isFavIcon) {
-    this.emitFile(`../${isDev ? '' : '../'}${interpolatedName}`, content, null)
-  }
+  // if (!isFavIcon) {
+  //   this.emitFile(`../${isDev ? '' : '../'}${interpolatedName}`, content, null)
+  // }
 
   return `export default ${stringifiedData};`
 }

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -14,7 +14,7 @@ interface Options {
 
 async function nextMetadataImageLoader(this: any, content: Buffer) {
   const options: Options = this.getOptions()
-  const { route, numericSizes } = options
+  const { type, route, numericSizes } = options
   const context = this.rootContext
 
   const opts = { context, content }
@@ -25,7 +25,13 @@ async function nextMetadataImageLoader(this: any, content: Buffer) {
     opts
   )
 
-  const outputPath = route + '/' + interpolatedName
+  // No hash query for favicon.ico
+  const contentHash =
+    type === 'favicon'
+      ? ''
+      : loaderUtils.interpolateName(this, '[contenthash]', opts)
+  const outputPath =
+    route + '/' + interpolatedName + (contentHash ? `?${contentHash}` : '')
 
   let extension = loaderUtils.interpolateName(this, '[ext]', opts)
   if (extension === 'jpg') {

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -1,11 +1,10 @@
 import type webpack from 'webpack'
 import path from 'path'
-import { isMetadataRouteFile } from '../../../lib/metadata/is-metadata-route'
 import { METADATA_RESOURCE_QUERY } from './metadata/discover'
 import { imageExtMimeTypeMap } from '../../../lib/mime-type'
 
 type MetadataRouteLoaderOptions = {
-  route: string
+  pageExtensions: string[]
 }
 
 function getFilenameAndExtension(resourcePath: string) {
@@ -85,10 +84,11 @@ export async function GET() {
 const nextMetadataRouterLoader: webpack.LoaderDefinitionFunction<MetadataRouteLoaderOptions> =
   function () {
     const { resourcePath } = this
-    const { route } = this.getOptions()
+    const { pageExtensions } = this.getOptions()
 
-    const appDirRelativePath = route.slice(0, -'/route'.length)
-    const isStatic = isMetadataRouteFile(appDirRelativePath, [])
+    const ext = path.extname(resourcePath).slice(1)
+    const isStatic = !pageExtensions.includes(ext)
+
     const code = isStatic
       ? getStaticRouteCode(resourcePath)
       : getDynamicRouteCode(resourcePath)

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -2,6 +2,7 @@ import type webpack from 'webpack'
 import path from 'path'
 import { isMetadataRouteFile } from '../../../lib/metadata/is-metadata-route'
 import { METADATA_RESOURCE_QUERY } from './metadata/discover'
+import { imageExtMimeTypeMap } from '../../../lib/mime-type'
 
 type MetadataRouteLoaderOptions = {
   route: string
@@ -14,12 +15,16 @@ function getFilenameAndExtension(resourcePath: string) {
 }
 
 function getContentType(resourcePath: string) {
-  const { name, ext } = getFilenameAndExtension(resourcePath)
+  let { name, ext } = getFilenameAndExtension(resourcePath)
+  if (ext === 'jpg') ext = 'jpeg'
+
   if (name === 'favicon' && ext === 'ico') return 'image/x-icon'
   if (name === 'sitemap') return 'application/xml'
   if (name === 'robots') return 'text/plain'
-  // TODO-METADATA: align with next metadata image loader mime type generation
-  if (ext === 'png' || ext === 'jpg') return `image/${ext}`
+
+  if (ext === 'png' || ext === 'jpeg' || ext === 'ico' || ext === 'svg') {
+    return imageExtMimeTypeMap[ext]
+  }
   return 'text/plain'
 }
 

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -35,10 +35,13 @@ import fs from 'fs'
 import { fileURLToPath } from 'url'
 import { NextResponse } from 'next/server'
 
-const resourceUrl = fileURLToPath(import.meta.url).replace(${JSON.stringify(
+console.log('before', import.meta.url)
+const resourceUrl = new URL(import.meta.url)
+console.log('resourceUrl', resourceUrl)
+const filePath = fileURLToPath(resourceUrl).replace(${JSON.stringify(
     METADATA_RESOURCE_QUERY
   )}, '')
-const buffer = fs.readFileSync(resourceUrl)
+const buffer = fs.readFileSync(filePath)
 const contentType = ${JSON.stringify(getContentType(resourcePath))}
 
 export function GET() {

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -35,14 +35,13 @@ import fs from 'fs'
 import { fileURLToPath } from 'url'
 import { NextResponse } from 'next/server'
 
-console.log('before', import.meta.url)
+const contentType = ${JSON.stringify(getContentType(resourcePath))}
 const resourceUrl = new URL(import.meta.url)
-console.log('resourceUrl', resourceUrl)
 const filePath = fileURLToPath(resourceUrl).replace(${JSON.stringify(
     METADATA_RESOURCE_QUERY
   )}, '')
 const buffer = fs.readFileSync(filePath)
-const contentType = ${JSON.stringify(getContentType(resourcePath))}
+
 
 export function GET() {
   return new NextResponse(buffer, {
@@ -64,11 +63,11 @@ import handler from ${JSON.stringify(resourcePath)}
 import { resolveRouteData } from 'next/dist/build/webpack/loaders/metadata/resolve-route-data'
 
 const contentType = ${JSON.stringify(getContentType(resourcePath))}
-const name = ${JSON.stringify(getFilenameAndExtension(resourcePath).name)}
+const fileType = ${JSON.stringify(getFilenameAndExtension(resourcePath).name)}
 
 export async function GET() {
   const data = await handler()
-  const content = resolveRouteData(data, name)
+  const content = resolveRouteData(data, fileType)
 
   return new NextResponse(content, {
     headers: {
@@ -88,7 +87,8 @@ const nextMetadataRouterLoader: webpack.LoaderDefinitionFunction<MetadataRouteLo
     const { resourcePath } = this
     const { route } = this.getOptions()
 
-    const isStatic = isMetadataRouteFile(route, [])
+    const appDirRelativePath = route.slice(0, -'/route'.length)
+    const isStatic = isMetadataRouteFile(appDirRelativePath, [])
     const code = isStatic
       ? getStaticRouteCode(resourcePath)
       : getDynamicRouteCode(resourcePath)

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -4,7 +4,7 @@ import { isMetadataRouteFile } from '../../../lib/metadata/is-metadata-route'
 import { METADATA_RESOURCE_QUERY } from './metadata/discover'
 
 type MetadataRouteLoaderOptions = {
-  appDir: string
+  route: string
 }
 
 function getFilenameAndExtension(resourcePath: string) {
@@ -30,7 +30,6 @@ import fs from 'fs'
 import { fileURLToPath } from 'url'
 import { NextResponse } from 'next/server'
 
-console.log('import.meta.url', import.meta.url)
 const resourceUrl = fileURLToPath(import.meta.url).replace(${JSON.stringify(
     METADATA_RESOURCE_QUERY
   )}, '')
@@ -79,21 +78,13 @@ export async function GET() {
 const nextMetadataRouterLoader: webpack.LoaderDefinitionFunction<MetadataRouteLoaderOptions> =
   function () {
     const { resourcePath } = this
-    const { appDir } = this.getOptions()
+    const { route } = this.getOptions()
 
-    const route = resourcePath.replace(appDir, '')
     const isStatic = isMetadataRouteFile(route, [])
-    console.log(
-      'nextMetadataRouterLoader:relativeAppDirPath',
-      route,
-      'isStatic',
-      isStatic
-    )
     const code = isStatic
       ? getStaticRouteCode(resourcePath)
       : getDynamicRouteCode(resourcePath)
 
-    console.log('code', code)
     return code
   }
 

--- a/packages/next/src/build/webpack/loaders/utils.ts
+++ b/packages/next/src/build/webpack/loaders/utils.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto'
 
 import { RSC_MODULE_TYPES } from '../../../shared/lib/constants'
 
-const imageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'avif']
+const imageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'avif', 'ico', 'svg']
 const imageRegex = new RegExp(`\\.(${imageExtensions.join('|')})$`)
 
 export function isClientComponentModule(mod: {

--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -1,4 +1,4 @@
-import { isMetadataRoute, isStaticMetadataRoute } from './is-metadata-route'
+import { isMetadataRoute } from './is-metadata-route'
 
 /**
  * Map metadata page key to the corresponding route
@@ -12,16 +12,16 @@ import { isMetadataRoute, isStaticMetadataRoute } from './is-metadata-route'
 export function normalizeMetadataRoute(page: string) {
   let route = page
   if (isMetadataRoute(page)) {
-    if (!isStaticMetadataRoute(route)) {
-      if (route === '/sitemap') {
-        route += '.xml'
-      }
-      if (route === '/robots') {
-        route += '.txt'
-      }
-      if (route === '/favicon') {
-        route += '.ico'
-      }
+    // TODO-METADATA: add dynamic routes for metadata images.
+    // Better to move the extension appending to early phase.
+    if (route === '/sitemap') {
+      route += '.xml'
+    }
+    if (route === '/robots') {
+      route += '.txt'
+    }
+    if (route === '/favicon') {
+      route += '.ico'
     }
     route = `${route}/route`
   }

--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -3,8 +3,8 @@ import { isMetadataRoute } from './is-metadata-route'
 /**
  * Map metadata page key to the corresponding route
  *
- * static file page key:    app/robots.txt -> /robots.xml -> /robots.txt/route
- * dynamic route page key:  app/robots.tsx -> /robots -> /robots.txt/route
+ * static file page key:    /app/robots.txt -> /robots.xml -> /robots.txt/route
+ * dynamic route page key:  /app/robots.tsx -> /robots -> /robots.txt/route
  *
  * @param page
  * @returns

--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -20,9 +20,6 @@ export function normalizeMetadataRoute(page: string) {
     if (route === '/robots') {
       route += '.txt'
     }
-    if (route === '/favicon') {
-      route += '.ico'
-    }
     route = `${route}/route`
   }
   return route

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -7,7 +7,10 @@ export function isMetadataRoute(route: string): boolean {
   // Remove the 'app' prefix or '/route' suffix, only check the route name since they're only allowed in root app directory
   const page = route.replace(/^\/?app/, '').replace(/\/route$/, '')
 
-  return !page.endsWith('/page') && isMetadataRouteFile(page, defaultExtensions)
+  return (
+    !page.endsWith('/page') &&
+    isMetadataRouteFile(page, defaultExtensions, false)
+  )
 }
 
 const getExtensionRegexString = (extensions: string[]) =>
@@ -17,44 +20,65 @@ const getExtensionRegexString = (extensions: string[]) =>
 // e.g. /robots.txt, /sitemap.xml, /favicon.ico
 // When you pass the file extension as `['js', 'jsx', 'ts', 'tsx']`, it will also match the dynamic convention files
 // e.g. /robots.js, /sitemap.tsx, /favicon.jsx
+// When `withExtension` is false, it will match the static convention files without the extension, by default it's true
+// e.g. /robots, /sitemap, /favicon, use to match dynamic API routes like app/robots.ts
 export function isMetadataRouteFile(
   appDirRelativePath: string,
-  pageExtensions: string[]
+  pageExtensions: string[],
+  withExtension: boolean
 ) {
   const metadataRouteFilesRegex = [
     new RegExp(
-      `^[\\\\/]robots\\.${getExtensionRegexString(
-        pageExtensions.concat('txt')
-      )}`
+      `^[\\\\/]robots${
+        withExtension
+          ? `\\.${getExtensionRegexString(pageExtensions.concat('txt'))}`
+          : ''
+      }`
     ),
     new RegExp(
-      `^[\\\\/]sitemap\\.${getExtensionRegexString(
-        pageExtensions.concat('xml')
-      )}`
+      `^[\\\\/]sitemap${
+        withExtension
+          ? `\\.${getExtensionRegexString(pageExtensions.concat('xml'))}`
+          : ''
+      }`
     ),
     new RegExp(`^[\\\\/]favicon\\.ico$`),
     // TODO-METADATA: add dynamic routes for metadata images
     new RegExp(
-      `[\\\\/]${
-        STATIC_METADATA_IMAGES.icon.filename
-      }\\.${getExtensionRegexString(STATIC_METADATA_IMAGES.icon.extensions)}`
+      `[\\\\/]${STATIC_METADATA_IMAGES.icon.filename}${
+        withExtension
+          ? `\\.${getExtensionRegexString(
+              STATIC_METADATA_IMAGES.icon.extensions
+            )}`
+          : ''
+      }`
     ),
     new RegExp(
-      `[\\\\/]${
-        STATIC_METADATA_IMAGES.apple.filename
-      }\\.${getExtensionRegexString(STATIC_METADATA_IMAGES.apple.extensions)}`
+      `[\\\\/]${STATIC_METADATA_IMAGES.apple.filename}${
+        withExtension
+          ? `\\.${getExtensionRegexString(
+              STATIC_METADATA_IMAGES.apple.extensions
+            )}`
+          : ''
+      }`
     ),
     new RegExp(
-      `[\\\\/]${
-        STATIC_METADATA_IMAGES.opengraph.filename
-      }\\.${getExtensionRegexString(
-        STATIC_METADATA_IMAGES.opengraph.extensions
-      )}`
+      `[\\\\/]${STATIC_METADATA_IMAGES.opengraph.filename}${
+        withExtension
+          ? `\\.${getExtensionRegexString(
+              STATIC_METADATA_IMAGES.opengraph.extensions
+            )}`
+          : ''
+      }`
     ),
     new RegExp(
-      `[\\\\/]${
-        STATIC_METADATA_IMAGES.twitter.filename
-      }\\.${getExtensionRegexString(STATIC_METADATA_IMAGES.twitter.extensions)}`
+      `[\\\\/]${STATIC_METADATA_IMAGES.twitter.filename}${
+        withExtension
+          ? `\\.${getExtensionRegexString(
+              STATIC_METADATA_IMAGES.twitter.extensions
+            )}`
+          : ''
+      }`
     ),
   ]
 

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -1,34 +1,59 @@
-import path from 'path'
-
-const regexMetadataRoutes = [
-  /^robots(\.txt)?/,
-  /^sitemap(\.xml)?/,
-  /^favicon(\.ico)?/,
-]
-const staticRegexMetadataRoutes = [
-  /^robots\.txt/,
-  /^sitemap\.xml/,
-  /^favicon\.ico/,
-]
+import { STATIC_METADATA_IMAGES } from '../../build/webpack/loaders/metadata/discover'
 
 // Match routes that are metadata routes, e.g. /sitemap.xml, /favicon.<ext>, /<icon>.<ext>, etc.
 // TODO-METADATA: support more metadata routes with more extensions
+const defaultExtensions = ['js', 'jsx', 'ts', 'tsx']
 export function isMetadataRoute(route: string): boolean {
-  // Remove the 'app/' or '/' prefix, only check the route name since they're only allowed in root app directory
-  const baseName = route
-    .replace(/^app\//, '')
-    .replace(/^\//, '')
-    .replace(/\/route$/, '')
+  // Remove the 'app' prefix or '/route' suffix, only check the route name since they're only allowed in root app directory
+  const page = route.replace(/^app/, '').replace(/\/route$/, '')
 
-  return (
-    !baseName.endsWith('/page') &&
-    regexMetadataRoutes.some((r) => r.test(baseName))
-  )
+  return !page.endsWith('/page') && isMetadataRouteFile(page, defaultExtensions)
 }
 
-// Only match the static metadata files
-// TODO-METADATA: support static metadata files under nested routes folders
-export function isStaticMetadataRoute(resourcePath: string) {
-  const filename = path.basename(resourcePath)
-  return staticRegexMetadataRoutes.some((r) => r.test(filename))
+const getExtensionRegexString = (extensions: string[]) =>
+  `(?:${extensions.join('|')})`
+
+// When you only pass the file extension as `[]`, it will only match the static convention files
+// e.g. /robots.txt, /sitemap.xml, /favicon.ico
+// When you pass the file extension as `['js', 'jsx', 'ts', 'tsx']`, it will also match the dynamic convention files
+// e.g. /robots.js, /sitemap.tsx, /favicon.jsx
+export function isMetadataRouteFile(route: string, pageExtensions: string[]) {
+  const metadataRoutesRelativePathRegex = [
+    new RegExp(
+      `^[\\\\/]robots\\.${getExtensionRegexString(
+        pageExtensions.concat('txt')
+      )}`
+    ),
+    new RegExp(
+      `^[\\\\/]sitemap\\.${getExtensionRegexString(
+        pageExtensions.concat('xml')
+      )}`
+    ),
+    new RegExp(`^[\\\\/]favicon\\.ico$`),
+    // TODO-METADATA: add dynamic routes for metadata images
+    new RegExp(
+      `[\\\\/]${
+        STATIC_METADATA_IMAGES.icon.filename
+      }\\.${getExtensionRegexString(STATIC_METADATA_IMAGES.icon.extensions)}`
+    ),
+    new RegExp(
+      `[\\\\/]${
+        STATIC_METADATA_IMAGES.apple.filename
+      }\\.${getExtensionRegexString(STATIC_METADATA_IMAGES.apple.extensions)}`
+    ),
+    new RegExp(
+      `[\\\\/]${
+        STATIC_METADATA_IMAGES.opengraph.filename
+      }\\.${getExtensionRegexString(
+        STATIC_METADATA_IMAGES.opengraph.extensions
+      )}`
+    ),
+    new RegExp(
+      `[\\\\/]${
+        STATIC_METADATA_IMAGES.twitter.filename
+      }\\.${getExtensionRegexString(STATIC_METADATA_IMAGES.twitter.extensions)}`
+    ),
+  ]
+
+  return metadataRoutesRelativePathRegex.some((r) => r.test(route))
 }

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -17,7 +17,10 @@ const getExtensionRegexString = (extensions: string[]) =>
 // e.g. /robots.txt, /sitemap.xml, /favicon.ico
 // When you pass the file extension as `['js', 'jsx', 'ts', 'tsx']`, it will also match the dynamic convention files
 // e.g. /robots.js, /sitemap.tsx, /favicon.jsx
-export function isMetadataRouteFile(route: string, pageExtensions: string[]) {
+export function isMetadataRouteFile(
+  appDirRelativePath: string,
+  pageExtensions: string[]
+) {
   const metadataRoutesRelativePathRegex = [
     new RegExp(
       `^[\\\\/]robots\\.${getExtensionRegexString(
@@ -55,5 +58,5 @@ export function isMetadataRouteFile(route: string, pageExtensions: string[]) {
     ),
   ]
 
-  return metadataRoutesRelativePathRegex.some((r) => r.test(route))
+  return metadataRoutesRelativePathRegex.some((r) => r.test(appDirRelativePath))
 }

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -3,15 +3,6 @@ import { STATIC_METADATA_IMAGES } from '../../build/webpack/loaders/metadata/dis
 // Match routes that are metadata routes, e.g. /sitemap.xml, /favicon.<ext>, /<icon>.<ext>, etc.
 // TODO-METADATA: support more metadata routes with more extensions
 const defaultExtensions = ['js', 'jsx', 'ts', 'tsx']
-export function isMetadataRoute(route: string): boolean {
-  // Remove the 'app' prefix or '/route' suffix, only check the route name since they're only allowed in root app directory
-  const page = route.replace(/^\/?app/, '').replace(/\/route$/, '')
-
-  return (
-    !page.endsWith('/page') &&
-    isMetadataRouteFile(page, defaultExtensions, false)
-  )
-}
 
 const getExtensionRegexString = (extensions: string[]) =>
   `(?:${extensions.join('|')})`
@@ -83,4 +74,14 @@ export function isMetadataRouteFile(
   ]
 
   return metadataRouteFilesRegex.some((r) => r.test(appDirRelativePath))
+}
+
+export function isMetadataRoute(route: string): boolean {
+  // Remove the 'app' prefix or '/route' suffix, only check the route name since they're only allowed in root app directory
+  const page = route.replace(/^\/?app/, '').replace(/\/route$/, '')
+
+  return (
+    !page.endsWith('/page') &&
+    isMetadataRouteFile(page, defaultExtensions, false)
+  )
 }

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -5,7 +5,7 @@ import { STATIC_METADATA_IMAGES } from '../../build/webpack/loaders/metadata/dis
 const defaultExtensions = ['js', 'jsx', 'ts', 'tsx']
 export function isMetadataRoute(route: string): boolean {
   // Remove the 'app' prefix or '/route' suffix, only check the route name since they're only allowed in root app directory
-  const page = route.replace(/^app/, '').replace(/\/route$/, '')
+  const page = route.replace(/^\/?app/, '').replace(/\/route$/, '')
 
   return !page.endsWith('/page') && isMetadataRouteFile(page, defaultExtensions)
 }
@@ -21,7 +21,7 @@ export function isMetadataRouteFile(
   appDirRelativePath: string,
   pageExtensions: string[]
 ) {
-  const metadataRoutesRelativePathRegex = [
+  const metadataRouteFilesRegex = [
     new RegExp(
       `^[\\\\/]robots\\.${getExtensionRegexString(
         pageExtensions.concat('txt')
@@ -58,5 +58,5 @@ export function isMetadataRouteFile(
     ),
   ]
 
-  return metadataRoutesRelativePathRegex.some((r) => r.test(appDirRelativePath))
+  return metadataRouteFilesRegex.some((r) => r.test(appDirRelativePath))
 }

--- a/packages/next/src/lib/mime-type.ts
+++ b/packages/next/src/lib/mime-type.ts
@@ -1,0 +1,9 @@
+/**
+ * Map of images extensions to MIME types
+ */
+export const imageExtMimeTypeMap = {
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  ico: 'image/x-icon',
+  svg: 'image/svg+xml',
+} as const

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
@@ -8,9 +8,9 @@ import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
 import { PrefixingNormalizer } from '../../normalizers/prefixing-normalizer'
 import { RouteKind } from '../../route-kind'
 import { FileCacheRouteMatcherProvider } from './file-cache-route-matcher-provider'
+import { isAppRouteRoute } from '../../../../lib/is-app-route-route'
 
 export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvider<AppRouteRouteMatcher> {
-  private readonly expression: RegExp
   private readonly normalizers: {
     page: Normalizer
     pathname: Normalizer
@@ -23,18 +23,6 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
     reader: FileReader
   ) {
     super(appDir, reader)
-
-    // Match any route file that ends with `/route.${extension}` under the app directory.
-    // Match top level robots file that ends with `/robots.${extension}` under the app directory.
-    this.expression = new RegExp(
-      `[/\\\\]route\\.(?:${extensions.join(
-        '|'
-      )})$|[/\\\\]robots\\.(?:${extensions
-        .concat('txt')
-        .join('|')})?$|[/\\\\]sitemap\\.(?:${extensions
-        .concat('xml')
-        .join('|')})?$|[/\\\\]favicon\\.ico$`
-    )
 
     const pageNormalizer = new AbsoluteFilenameNormalizer(appDir, extensions)
 
@@ -59,10 +47,11 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
   ): Promise<ReadonlyArray<AppRouteRouteMatcher>> {
     const matchers: Array<AppRouteRouteMatcher> = []
     for (const filename of files) {
-      // If the file isn't a match for this matcher, then skip it.
-      if (!this.expression.test(filename)) continue
-
       const page = this.normalizers.page.normalize(filename)
+
+      // If the file isn't a match for this matcher, then skip it.
+      if (!isAppRouteRoute(page)) continue
+
       const pathname = this.normalizers.pathname.normalize(filename)
       const bundlePath = this.normalizers.bundlePath.normalize(filename)
 

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -111,31 +111,18 @@ export function createValidFileMatcher(
    */
   function isMetadataFile(filePath: string) {
     const appDirRelativePath = filePath.replace(appDirPath || '', '')
-    const matched = isMetadataRouteFile(
-      appDirRelativePath,
-      pageExtensions,
-      true
-    )
-    const ext = extname(filePath)
 
-    return {
-      matched,
-      static: !pageExtensions.includes(ext),
-    }
+    return isMetadataRouteFile(appDirRelativePath, pageExtensions, true)
   }
 
   // Determine if the file is leaf node page file or route file under layouts,
   // 'page.<extension>' | 'route.<extension>'
   function isAppRouterPage(filePath: string) {
-    return (
-      leafOnlyPageFileRegex.test(filePath) || isMetadataFile(filePath).matched
-    )
+    return leafOnlyPageFileRegex.test(filePath) || isMetadataFile(filePath)
   }
 
   function isPageFile(filePath: string) {
-    return (
-      validExtensionFileRegex.test(filePath) || isMetadataFile(filePath).matched
-    )
+    return validExtensionFileRegex.test(filePath) || isMetadataFile(filePath)
   }
 
   return {

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -1,11 +1,10 @@
 import { fileExists } from '../../lib/file-exists'
 import { getPagePaths } from '../../shared/lib/page-path/get-page-paths'
 import { nonNullable } from '../../lib/non-nullable'
-import { join, sep, normalize, extname } from 'path'
+import { join, sep, normalize } from 'path'
 import { promises } from 'fs'
 import { warn } from '../../build/output/log'
 import chalk from '../../lib/chalk'
-import { STATIC_METADATA_IMAGES } from '../../build/webpack/loaders/metadata/discover'
 import { isMetadataRouteFile } from '../../lib/metadata/is-metadata-route'
 
 async function isTrueCasePagePath(pagePath: string, pagesDir: string) {
@@ -104,10 +103,8 @@ export function createValidFileMatcher(
    */
 
   /**
+   * Match the file if it's a metadata route file, static: if the file is a static metadata file
    *
-   * @param filePath the absolute path of the file
-   * @returns { matched: boolean, static: boolean }
-   *   matched: if the file is a metadata route file, static: if the file is a static metadata file
    */
   function isMetadataFile(filePath: string) {
     const appDirRelativePath = filePath.replace(appDirPath || '', '')

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -111,7 +111,11 @@ export function createValidFileMatcher(
    */
   function isMetadataFile(filePath: string) {
     const appDirRelativePath = filePath.replace(appDirPath || '', '')
-    const matched = isMetadataRouteFile(appDirRelativePath, pageExtensions)
+    const matched = isMetadataRouteFile(
+      appDirRelativePath,
+      pageExtensions,
+      true
+    )
     const ext = extname(filePath)
 
     return {

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -103,41 +103,6 @@ export function createValidFileMatcher(
    *
    */
 
-  const metadataRoutesRelativePathRegex = [
-    new RegExp(
-      `^[\\\\/]robots\\.${getExtensionRegexString(
-        pageExtensions.concat('txt')
-      )}`
-    ),
-    new RegExp(
-      `^[\\\\/]sitemap\\.${getExtensionRegexString(
-        pageExtensions.concat('xml')
-      )}`
-    ),
-    new RegExp(`^[\\\\/]favicon\\.ico$`),
-    // TODO-METADATA: add dynamic routes for metadata images
-    new RegExp(
-      `[\\\\/]${
-        STATIC_METADATA_IMAGES.icon.filename
-      }\\.${getExtensionRegexString(STATIC_METADATA_IMAGES.icon.extensions)}`
-    ),
-    new RegExp(
-      `[\\\\/]${
-        STATIC_METADATA_IMAGES.apple.filename
-      }\\.${getExtensionRegexString(STATIC_METADATA_IMAGES.apple.extensions)}`
-    ),
-    new RegExp(
-      `[\\\\/]${
-        STATIC_METADATA_IMAGES.apple.filename
-      }\\.${getExtensionRegexString(STATIC_METADATA_IMAGES.apple.extensions)}`
-    ),
-    new RegExp(
-      `[\\\\/]${
-        STATIC_METADATA_IMAGES.apple.filename
-      }\\.${getExtensionRegexString(STATIC_METADATA_IMAGES.apple.extensions)}`
-    ),
-  ]
-
   /**
    *
    * @param filePath the absolute path of the file
@@ -145,7 +110,8 @@ export function createValidFileMatcher(
    *   matched: if the file is a metadata route file, static: if the file is a static metadata file
    */
   function isMetadataFile(filePath: string) {
-    const matched = isMetadataRouteFile(filePath, pageExtensions)
+    const appDirRelativePath = filePath.replace(appDirPath || '', '')
+    const matched = isMetadataRouteFile(appDirRelativePath, pageExtensions)
     const ext = extname(filePath)
 
     return {

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -6,6 +6,7 @@ import { promises } from 'fs'
 import { warn } from '../../build/output/log'
 import chalk from '../../lib/chalk'
 import { STATIC_METADATA_IMAGES } from '../../build/webpack/loaders/metadata/discover'
+import { isMetadataRouteFile } from '../../lib/metadata/is-metadata-route'
 
 async function isTrueCasePagePath(pagePath: string, pagesDir: string) {
   const pageSegments = normalize(pagePath).split(sep).filter(Boolean)
@@ -143,11 +144,9 @@ export function createValidFileMatcher(
    * @returns { matched: boolean, static: boolean }
    *   matched: if the file is a metadata route file, static: if the file is a static metadata file
    */
-  function isMetadataRouteFile(relativeAppDirPath: string) {
-    const matched = metadataRoutesRelativePathRegex.some((r) =>
-      r.test(relativeAppDirPath)
-    )
-    const ext = extname(relativeAppDirPath)
+  function isMetadataFile(filePath: string) {
+    const matched = isMetadataRouteFile(filePath, pageExtensions)
+    const ext = extname(filePath)
 
     return {
       matched,
@@ -158,24 +157,20 @@ export function createValidFileMatcher(
   // Determine if the file is leaf node page file or route file under layouts,
   // 'page.<extension>' | 'route.<extension>'
   function isAppRouterPage(filePath: string) {
-    const relativeAppDirPath = filePath.replace(appDirPath || '', '')
     return (
-      leafOnlyPageFileRegex.test(filePath) ||
-      isMetadataRouteFile(relativeAppDirPath).matched
+      leafOnlyPageFileRegex.test(filePath) || isMetadataFile(filePath).matched
     )
   }
 
   function isPageFile(filePath: string) {
-    const relativeAppDirPath = filePath.replace(appDirPath || '', '')
     return (
-      validExtensionFileRegex.test(filePath) ||
-      isMetadataRouteFile(relativeAppDirPath).matched
+      validExtensionFileRegex.test(filePath) || isMetadataFile(filePath).matched
     )
   }
 
   return {
     isPageFile,
     isAppRouterPage,
-    isMetadataRouteFile,
+    isMetadataFile,
   }
 }

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -428,7 +428,7 @@ createNextDescribe(
       it('should pick up opengraph-image and twitter-image as static metadata files', async () => {
         const $ = await next.render$('/opengraph/static')
         expect($('[property="og:image"]').attr('content')).toBe(
-          'https://example.com/opengraph/static/opengraph-image.png'
+          'https://example.com/opengraph/static/opengraph-image.png?b76e8f0282c93c8e'
         )
         expect($('[property="og:image:type"]').attr('content')).toBe(
           'image/png'
@@ -437,7 +437,7 @@ createNextDescribe(
         expect($('[property="og:image:height"]').attr('content')).toBe('114')
 
         expect($('[name="twitter:image"]').attr('content')).toBe(
-          'https://example.com/opengraph/static/twitter-image.png'
+          'https://example.com/opengraph/static/twitter-image.png?b76e8f0282c93c8e'
         )
         expect($('[name="twitter:card"]').attr('content')).toBe(
           'summary_large_image'
@@ -514,12 +514,12 @@ createNextDescribe(
         const $appleIcon = $('head > link[rel="apple-touch-icon"]')
 
         expect($icon.attr('href')).toMatch(
-          /\/icons\/static\/nested\/icon1\.png/
+          /\/icons\/static\/nested\/icon1\.png\?399de3b94b888afc/
         )
         expect($icon.attr('sizes')).toBe('32x32')
         expect($icon.attr('type')).toBe('image/png')
         expect($appleIcon.attr('href')).toMatch(
-          /\/icons\/static\/nested\/apple-icon\.png/
+          /\/icons\/static\/nested\/apple-icon\.png\?b76e8f0282c93c8e/
         )
         expect($appleIcon.attr('type')).toBe('image/png')
         expect($appleIcon.attr('sizes')).toMatch('114x114')
@@ -529,11 +529,14 @@ createNextDescribe(
         const $ = await next.render$('/icons/static')
 
         const $icon = $('head > link[rel="icon"][type!="image/x-icon"]')
-        const $appleIcon = $('head > link[rel="apple-touch-icon"]')
 
-        expect($icon.attr('href')).toMatch(/\/icons\/static\/icon\.png/)
+        expect($icon.attr('href')).toMatch(
+          /\/icons\/static\/icon\.png\?b76e8f0282c93c8e/
+        )
         expect($icon.attr('sizes')).toBe('114x114')
 
+        // No apple icon if it's not provided
+        const $appleIcon = $('head > link[rel="apple-touch-icon"]')
         expect($appleIcon.length).toBe(0)
       })
 
@@ -548,7 +551,7 @@ createNextDescribe(
             const $ = await next.render$('/icons/static')
             const $icon = $('head > link[rel="icon"][type!="image/x-icon"]')
             return $icon.attr('href')
-          }, /\/icons\/static\/icon2\.png/)
+          }, /\/icons\/static\/icon2\.png\?b76e8f0282c93c8e/)
 
           await next.renameFile(
             'app/icons/static/icon2.png',
@@ -641,6 +644,9 @@ createNextDescribe(
         const res = await next.fetch('/favicon.ico')
         expect(res.status).toBe(200)
         expect(res.headers.get('content-type')).toBe('image/x-icon')
+        expect(res.headers.get('cache-control')).toBe(
+          'public, max-age=0, must-revalidate'
+        )
       })
 
       it('should have icons as route', async () => {
@@ -651,8 +657,14 @@ createNextDescribe(
 
         expect(resAppleIcon.status).toBe(200)
         expect(resAppleIcon.headers.get('content-type')).toBe('image/png')
+        expect(resAppleIcon.headers.get('cache-control')).toBe(
+          'public, max-age=0, must-revalidate'
+        )
         expect(resIcon.status).toBe(200)
         expect(resIcon.headers.get('content-type')).toBe('image/png')
+        expect(resIcon.headers.get('cache-control')).toBe(
+          'public, max-age=0, must-revalidate'
+        )
       })
 
       it('should support root dir robots.txt', async () => {

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -7,7 +7,7 @@ createNextDescribe(
   'app dir - metadata',
   {
     files: __dirname,
-    // skipDeployment: true,
+    skipDeployment: false,
   },
   ({ next, isNextDev, isNextStart }) => {
     const getTitle = (browser: BrowserInterface) =>
@@ -16,7 +16,7 @@ createNextDescribe(
     async function checkMeta(
       browser: BrowserInterface,
       queryValue: string,
-      expected: string | string[],
+      expected: string | string[] | undefined | null,
       queryKey: string = 'property',
       tag: string = 'meta',
       domAttributeField: string = 'content'
@@ -45,7 +45,7 @@ createNextDescribe(
       return async (
         tag: string,
         query: string,
-        expectedObject: Record<string, string>
+        expectedObject: Record<string, string | null | undefined>
       ) => {
         const props = await browser.eval(`
           const el = document.querySelector('${tag}[${query}]');
@@ -118,7 +118,7 @@ createNextDescribe(
         tag: string,
         queryKey: string,
         domAttributeField: string,
-        expected: Record<string, string | string[]>
+        expected: Record<string, string | string[] | undefined | null>
       ) => {
         await Promise.all(
           Object.keys(expected).map(async (key) => {
@@ -427,8 +427,8 @@ createNextDescribe(
 
       it('should pick up opengraph-image and twitter-image as static metadata files', async () => {
         const $ = await next.render$('/opengraph/static')
-        expect($('[property="og:image"]').attr('content')).toMatch(
-          /https:\/\/example.com\/_next\/static\/media\/metadata\/opengraph-image.png/
+        expect($('[property="og:image"]').attr('content')).toBe(
+          'https://example.com/opengraph/static/opengraph-image.png'
         )
         expect($('[property="og:image:type"]').attr('content')).toBe(
           'image/png'
@@ -436,8 +436,8 @@ createNextDescribe(
         expect($('[property="og:image:width"]').attr('content')).toBe('114')
         expect($('[property="og:image:height"]').attr('content')).toBe('114')
 
-        expect($('[name="twitter:image"]').attr('content')).toMatch(
-          /https:\/\/example.com\/_next\/static\/media\/metadata\/twitter-image.png/
+        expect($('[name="twitter:image"]').attr('content')).toBe(
+          'https://example.com/opengraph/static/twitter-image.png'
         )
         expect($('[name="twitter:card"]').attr('content')).toBe(
           'summary_large_image'
@@ -514,12 +514,12 @@ createNextDescribe(
         const $appleIcon = $('head > link[rel="apple-touch-icon"]')
 
         expect($icon.attr('href')).toMatch(
-          /\/_next\/static\/media\/metadata\/icon1\.png/
+          /\/icons\/static\/nested\/icon1\.png/
         )
         expect($icon.attr('sizes')).toBe('32x32')
         expect($icon.attr('type')).toBe('image/png')
         expect($appleIcon.attr('href')).toMatch(
-          /\/_next\/static\/media\/metadata\/apple-icon\.png/
+          /\/icons\/static\/nested\/apple-icon\.png/
         )
         expect($appleIcon.attr('type')).toBe('image/png')
         expect($appleIcon.attr('sizes')).toMatch('114x114')
@@ -531,9 +531,7 @@ createNextDescribe(
         const $icon = $('head > link[rel="icon"][type!="image/x-icon"]')
         const $appleIcon = $('head > link[rel="apple-touch-icon"]')
 
-        expect($icon.attr('href')).toMatch(
-          /\/_next\/static\/media\/metadata\/icon\.png/
-        )
+        expect($icon.attr('href')).toMatch(/\/icons\/static\/icon\.png/)
         expect($icon.attr('sizes')).toBe('114x114')
 
         expect($appleIcon.length).toBe(0)
@@ -550,7 +548,7 @@ createNextDescribe(
             const $ = await next.render$('/icons/static')
             const $icon = $('head > link[rel="icon"][type!="image/x-icon"]')
             return $icon.attr('href')
-          }, /\/_next\/static\/media\/metadata\/icon2\.png/)
+          }, /\/icons\/static\/icon2\.png/)
 
           await next.renameFile(
             'app/icons/static/icon2.png',

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -637,6 +637,24 @@ createNextDescribe(
     })
 
     describe('static routes', () => {
+      it('should have /favicon.ico as route', async () => {
+        const res = await next.fetch('/favicon.ico')
+        expect(res.status).toBe(200)
+        expect(res.headers.get('content-type')).toBe('image/x-icon')
+      })
+
+      it('should have icons as route', async () => {
+        const resIcon = await next.fetch('/icons/static/icon.png')
+        const resAppleIcon = await next.fetch(
+          '/icons/static/nested/apple-icon.png'
+        )
+
+        expect(resAppleIcon.status).toBe(200)
+        expect(resAppleIcon.headers.get('content-type')).toBe('image/png')
+        expect(resIcon.status).toBe(200)
+        expect(resIcon.headers.get('content-type')).toBe('image/png')
+      })
+
       it('should support root dir robots.txt', async () => {
         const res = await next.fetch('/robots.txt')
         expect(res.headers.get('content-type')).toBe('text/plain')

--- a/test/unit/find-page-file.test.ts
+++ b/test/unit/find-page-file.test.ts
@@ -74,17 +74,15 @@ describe('createPageFileMatcher', () => {
     const pageExtensions = ['tsx', 'ts', 'jsx', 'js']
     const fileMatcher = createValidFileMatcher(pageExtensions, 'app')
     it('should determine top level metadata routes', () => {
-      expect(fileMatcher.isMetadataRouteFile('app/route.js')).toBe(false)
-      expect(fileMatcher.isMetadataRouteFile('app/page.js')).toBe(false)
-      expect(fileMatcher.isMetadataRouteFile('pages/index.js')).toBe(false)
+      expect(fileMatcher.isMetadataFile('app/route.js')).toBe(false)
+      expect(fileMatcher.isMetadataFile('app/page.js')).toBe(false)
+      expect(fileMatcher.isMetadataFile('pages/index.js')).toBe(false)
 
-      expect(fileMatcher.isMetadataRouteFile('app/robots.txt')).toBe(true)
-      expect(fileMatcher.isMetadataRouteFile('app/path/robots.txt')).toBe(false)
+      expect(fileMatcher.isMetadataFile('app/robots.txt')).toBe(true)
+      expect(fileMatcher.isMetadataFile('app/path/robots.txt')).toBe(false)
 
-      expect(fileMatcher.isMetadataRouteFile('app/sitemap.xml')).toBe(true)
-      expect(fileMatcher.isMetadataRouteFile('app/path/sitemap.xml')).toBe(
-        false
-      )
+      expect(fileMatcher.isMetadataFile('app/sitemap.xml')).toBe(true)
+      expect(fileMatcher.isMetadataFile('app/path/sitemap.xml')).toBe(false)
     })
   })
 })


### PR DESCRIPTION
Generated metadata icons through api routes instead of using webpack emitting file. Each metadata image file will go through `next-metadata-image-loader` to get the image basic info, and then it will go through `next-metadata-route-loader` to be converted as a routes.

Related to NEXT-264
Closes NEXT-810

