### PR TITLE
Improve static export documentation

### DIFF
--- a/docs/advanced-features/static-html-export.md
+++ b/docs/advanced-features/static-html-export.md
@@ -11,7 +11,7 @@ description: Export your Next.js app to static HTML, and run it standalone witho
   </ul>
 </details>
 
-Next.js can be used to generatic static applications, including using React in the browser without the need for a server.
+Next.js can be used to generate static applications, including using React in the browser without the need for a Node.js server.
 
 The core of Next.js has been designed to enable starting as a static site (or Single-Page Application), if desired, and later upgrade to use powerful, dynamic features that require a server. For example, [Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md), [Internationalized Routing](/docs/advanced-features/i18n-routing.md), [and more](#unsupported-features).
 

--- a/docs/advanced-features/static-html-export.md
+++ b/docs/advanced-features/static-html-export.md
@@ -15,7 +15,7 @@ Next.js can be used to generate static applications, including using React in th
 
 The core of Next.js has been designed to enable starting as a static site (or Single-Page Application), if desired, and later upgrade to use powerful, dynamic features that require a server. For example, [Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md), [Internationalized Routing](/docs/advanced-features/i18n-routing.md), [and more](#unsupported-features).
 
-Since Next.js supports this static export, it can be deployed and hosted anywhere you prefer.
+Since Next.js supports this static export, it can be deployed and hosted on any web server that can serve HTML/CSS/JS static assets.
 
 ## `next export`
 

--- a/docs/advanced-features/static-html-export.md
+++ b/docs/advanced-features/static-html-export.md
@@ -11,9 +11,11 @@ description: Export your Next.js app to static HTML, and run it standalone witho
   </ul>
 </details>
 
-`next export` allows you to export your Next.js application to static HTML, which can render without the need of a Node.js server. It is recommended to only use `next export` if you don't need any of the [unsupported features](#unsupported-features) requiring a server.
+Next.js can be used to generatic static applications, including using React in the browser without the need for a server.
 
-If you're looking to build a hybrid site where only _some_ pages are prerendered to static HTML, Next.js already does that automatically. Learn more about [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) and [Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md).
+The core of Next.js has been designed to enable starting as a static site (or Single-Page Application), if desired, and later upgrade to use powerful, dynamic features that require a server. For example, [Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md), [Internationalized Routing](/docs/advanced-features/i18n-routing.md), [and more](#unsupported-features).
+
+Since Next.js supports this static export, it can be deployed and hosted anywhere you prefer.
 
 ## `next export`
 


### PR DESCRIPTION
There has been some helpful [discussion on Twitter](https://twitter.com/dan_abramov/status/1636778278882099216) around this page of documentation. I refactored the introduction to make it more clear that you also get to use SPA features when doing a static export, and underscoring the value of being able to deploy/host virtually anywhere with this approach.