### PR TITLE
Ensure config and fetch revalidate are honored

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -11,28 +11,6 @@ export default class FetchCache implements CacheHandler {
   private debug: boolean
 
   constructor(ctx: CacheHandlerContext) {
-    if (ctx.maxMemoryCacheSize && !memoryCache) {
-      memoryCache = new LRUCache({
-        max: ctx.maxMemoryCacheSize,
-        length({ value }) {
-          if (!value) {
-            return 25
-          } else if (value.kind === 'REDIRECT') {
-            return JSON.stringify(value.props).length
-          } else if (value.kind === 'IMAGE') {
-            throw new Error('invariant image should not be incremental-cache')
-          } else if (value.kind === 'FETCH') {
-            return JSON.stringify(value.data || '').length
-          } else if (value.kind === 'ROUTE') {
-            return value.body.length
-          }
-          // rough estimate of size of cache value
-          return (
-            value.html.length + (JSON.stringify(value.pageData)?.length || 0)
-          )
-        },
-      })
-    }
     this.debug = !!process.env.NEXT_PRIVATE_DEBUG_CACHE
     this.headers = {}
     this.headers['Content-Type'] = 'application/json'
@@ -55,6 +33,36 @@ export default class FetchCache implements CacheHandler {
       }
     } else if (this.debug) {
       console.log('no cache endpoint available')
+    }
+
+    if (ctx.maxMemoryCacheSize && !memoryCache) {
+      if (this.debug) {
+        console.log('using memory store for fetch cache')
+      }
+      memoryCache = new LRUCache({
+        max: ctx.maxMemoryCacheSize,
+        length({ value }) {
+          if (!value) {
+            return 25
+          } else if (value.kind === 'REDIRECT') {
+            return JSON.stringify(value.props).length
+          } else if (value.kind === 'IMAGE') {
+            throw new Error('invariant image should not be incremental-cache')
+          } else if (value.kind === 'FETCH') {
+            return JSON.stringify(value.data || '').length
+          } else if (value.kind === 'ROUTE') {
+            return value.body.length
+          }
+          // rough estimate of size of cache value
+          return (
+            value.html.length + (JSON.stringify(value.pageData)?.length || 0)
+          )
+        },
+      })
+    } else {
+      if (this.debug) {
+        console.log('not using memory store for fetch cache')
+      }
     }
   }
 

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -265,7 +265,8 @@ export class IncrementalCache {
   // get data from cache if available
   async get(
     pathname: string,
-    fetchCache?: boolean
+    fetchCache?: boolean,
+    revalidate?: number
   ): Promise<IncrementalCacheEntry | null> {
     // we don't leverage the prerender cache in dev mode
     // so that getStaticProps is always called for easier debugging
@@ -281,7 +282,7 @@ export class IncrementalCache {
     const cacheData = await this.cacheHandler?.get(pathname, fetchCache)
 
     if (cacheData?.value?.kind === 'FETCH') {
-      const revalidate = cacheData.value.revalidate
+      revalidate = revalidate || cacheData.value.revalidate
       const age = Math.round(
         (Date.now() - (cacheData.lastModified || 0)) / 1000
       )

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -218,7 +218,8 @@ export function patchFetch({
       if (cacheKey && staticGenerationStore?.incrementalCache) {
         const entry = await staticGenerationStore.incrementalCache.get(
           cacheKey,
-          true
+          true,
+          revalidate
         )
 
         if (entry?.value && entry.value.kind === 'FETCH') {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -50,6 +50,41 @@ createNextDescribe(
       })
     }
 
+    it('should revalidate correctly with config and fetch revalidate', async () => {
+      const initial$ = await next.render$(
+        '/variable-config-revalidate/revalidate-3'
+      )
+      const initialDate = initial$('#date').text()
+      const initialData = initial$('#data').text()
+
+      expect(initialDate).toBeTruthy()
+      expect(initialData).toBeTruthy()
+
+      let revalidatedDate
+      let revalidatedData
+
+      // wait for a fresh revalidation
+      await check(async () => {
+        const $ = await next.render$('/variable-config-revalidate/revalidate-3')
+
+        revalidatedDate = $('#date').text()
+        revalidatedData = $('#data').text()
+
+        expect(revalidatedData).not.toBe(initialDate)
+        expect(revalidatedDate).not.toBe(initialData)
+        return 'success'
+      }, 'success')
+
+      // the date should revalidate first after 3 seconds
+      // while the fetch data stays in place for 15 seconds
+      await check(async () => {
+        const $ = await next.render$('/variable-config-revalidate/revalidate-3')
+        expect($('#date').text()).not.toBe(revalidatedDate)
+        expect($('#data').text()).toBe(revalidatedData)
+        return 'success'
+      }, 'success')
+    })
+
     it('should include statusCode in cache', async () => {
       const $ = await next.render$('/variable-revalidate/status-code')
       const origData = JSON.parse($('#page-data').text())

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -198,6 +198,9 @@ createNextDescribe(
           'ssr-forced/page.js',
           'static-to-dynamic-error-forced/[id]/page.js',
           'static-to-dynamic-error/[id]/page.js',
+          'variable-config-revalidate/revalidate-3.html',
+          'variable-config-revalidate/revalidate-3.rsc',
+          'variable-config-revalidate/revalidate-3/page.js',
           'variable-revalidate-edge/encoding/page.js',
           'variable-revalidate-edge/no-store/page.js',
           'variable-revalidate-edge/post-method-request/page.js',
@@ -401,6 +404,11 @@ createNextDescribe(
             dataRoute: '/ssg-preview/test-2.rsc',
             initialRevalidateSeconds: false,
             srcRoute: '/ssg-preview/[[...route]]',
+          },
+          '/variable-config-revalidate/revalidate-3': {
+            dataRoute: '/variable-config-revalidate/revalidate-3.rsc',
+            initialRevalidateSeconds: 3,
+            srcRoute: '/variable-config-revalidate/revalidate-3',
           },
           '/variable-revalidate/authorization': {
             dataRoute: '/variable-revalidate/authorization.rsc',

--- a/test/e2e/app-dir/app-static/app/variable-config-revalidate/revalidate-3/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-config-revalidate/revalidate-3/page.js
@@ -1,0 +1,24 @@
+export const revalidate = 3
+
+export const metadata = {
+  title: 'Cache Test',
+}
+
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      next: {
+        revalidate: 15,
+      },
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p>/variable-config-revalidate/revalidate-3</p>
+      <p id="date">{Date.now()}</p>
+      <p id="data">{data}</p>
+    </>
+  )
+}


### PR DESCRIPTION
This ensures revalidate can be fetch specific instead of cache key specific and adds a test case to ensure config based revalidate isn't overridden by fetch based revalidate. 