### PR TITLE
Fix loader rule with wrong matching conditions (#47261

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1921,6 +1921,10 @@ export default async function getBaseWebpackConfig(
                     issuerLayer: {
                       or: [WEBPACK_LAYERS.client, WEBPACK_LAYERS.appClient],
                     },
+                    exclude: [
+                      staticGenerationAsyncStorageRegex,
+                      codeCondition.exclude,
+                    ],
                     use: [
                       ...(dev && isClient
                         ? [

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1917,18 +1917,16 @@ export default async function getBaseWebpackConfig(
                     use: swcLoaderForServerLayer,
                   },
                   {
-                    test: codeCondition.test,
+                    ...codeCondition,
                     issuerLayer: {
                       or: [WEBPACK_LAYERS.client, WEBPACK_LAYERS.appClient],
                     },
-                    exclude: [staticGenerationAsyncStorageRegex],
                     use: [
                       ...(dev && isClient
                         ? [
                             require.resolve(
                               'next/dist/compiled/@next/react-refresh-utils/dist/loader'
                             ),
-                            defaultLoaders.babel,
                           ]
                         : []),
                       {

--- a/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox-builtins.test.ts.snap
+++ b/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox-builtins.test.ts.snap
@@ -41,7 +41,7 @@ https://nextjs.org/docs/messages/module-not-found"
 `;
 
 exports[`ReactRefreshLogBox app default Node.js builtins 1`] = `
-"./node_modules/my-package/index.js:2:22
+"./node_modules/my-package/index.js:2:0
 Module not found: Can't resolve 'dns'
 
 https://nextjs.org/docs/messages/module-not-found


### PR DESCRIPTION
This Webpack loader rule should have the exactly same conditions as

https://github.com/vercel/next.js/blob/828fd5a162b02c41cbfbef539688ae454594f24c/packages/next/src/build/webpack-config.ts#L1940-L1951

Except that it matches 2 special layers and an extra loader.