### PR TITLE
turbopack: Implement streamed middleware

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "serde",
 ]
@@ -3261,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6580,7 +6580,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "mimalloc",
 ]
@@ -6588,7 +6588,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6618,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6630,7 +6630,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6645,7 +6645,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6659,7 +6659,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6676,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6705,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "base16",
  "hex",
@@ -6717,7 +6717,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -6731,7 +6731,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6741,7 +6741,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6763,7 +6763,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6801,7 +6801,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6817,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6857,7 +6857,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6879,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6898,7 +6898,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6932,7 +6932,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6967,7 +6967,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "serde",
@@ -6982,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "serde",
@@ -6997,7 +6997,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7012,7 +7012,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7041,7 +7041,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "serde",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7068,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230323.1#40ba20ba0939a19598a25d435b7c9396ecfb15c1"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli 0.27.1",
+ "gimli 0.27.2",
 ]
 
 [[package]]
@@ -74,18 +74,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 dependencies = [
  "backtrace",
 ]
 
 [[package]]
 name = "arrayref"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
@@ -114,7 +114,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -172,22 +172,22 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
  "async-lock",
  "autocfg",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "futures-lite",
- "libc",
  "log",
  "parking",
  "polling",
+ "rustix 0.37.3",
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -228,13 +228,13 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
+checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.7",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -294,13 +294,13 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.7",
 ]
 
 [[package]]
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "serde",
 ]
@@ -351,7 +351,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -362,13 +362,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.7"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
+checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -384,7 +384,6 @@ dependencies = [
  "serde",
  "sync_wrapper",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -456,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.44.10"
+version = "0.44.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a038911a0bafe08b6872e7da37360ea9939b58778b4169eb7156dca9855c5de0"
+checksum = "ecc1f7ebb45c51627084dd823c48a396c67f28c42ad3543f4ecc066979e5e996"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -482,6 +481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+
+[[package]]
 name = "blake3"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -550,23 +555,24 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+checksum = "13fe11640a23eb24562225322cd3e452b93a3d4091d62fab69c70542fcd17d1f"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
+ "simdutf8",
 ]
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -587,7 +593,7 @@ version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
 dependencies = [
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
  "toml",
  "url",
@@ -695,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -741,7 +747,7 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.2.4",
  "indexmap",
  "textwrap 0.16.0",
@@ -749,13 +755,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.8"
+version = "4.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
+checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.2",
  "clap_derive",
- "clap_lex 0.3.1",
+ "clap_lex 0.3.3",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -764,15 +770,15 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.8"
+version = "4.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
+checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -786,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
 ]
@@ -799,7 +805,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -885,9 +891,9 @@ checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
+checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "convert_case"
@@ -1065,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -1075,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
@@ -1086,22 +1092,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1112,7 +1118,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
  "mio 0.8.6",
@@ -1148,7 +1154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1174,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.60+curl-7.88.1"
+version = "0.4.61+curl-8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "717abe2cb465a5da6ce06617388a3980c9a2844196734bec8ccb8e575250f13f"
+checksum = "14d05c10f541ae6f3bc5b3d923c20001f47db7d5f0b2bc6ad16490133842db79"
 dependencies = [
  "cc",
  "libc",
@@ -1190,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.90"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90d59d9acd2a682b4e40605a242f6670eaa58c5957471cbf85e8aa6a0b97a5e8"
+checksum = "a9c00419335c41018365ddf7e4d5f1c12ee3659ddcf3e01974650ba1de73d038"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1202,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.90"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfa40bda659dd5c864e65f4c9a2b0aff19bea56b017b9b77c73d3766a453a38"
+checksum = "fb8307ad413a98fff033c8545ecf133e3257747b3bae935e7602aab8aa92d4ca"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1212,24 +1218,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.7",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.90"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457ce6757c5c70dc6ecdbda6925b958aae7f959bda7d8fb9bde889e34a09dc03"
+checksum = "edc52e2eb08915cb12596d29d55f0b5384f00d697a646dbd269b6ecb0fbd9d31"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.90"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf883b7aacd7b2aeb2a7b338648ee19f57c140d4ee8e52c68979c6b2f7f2263"
+checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.7",
 ]
 
 [[package]]
@@ -1244,12 +1250,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core 0.14.3",
- "darling_macro 0.14.3",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
 ]
 
 [[package]]
@@ -1263,20 +1269,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1287,18 +1293,18 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core 0.14.3",
+ "darling_core 0.14.4",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1313,6 +1319,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core 0.9.7",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "debugid"
@@ -1375,9 +1387,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dotenvy"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"
@@ -1417,11 +1429,11 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea166b3f7dc1032f7866d13f8d8e02c8d87507b61750176b86554964dc6a7bf"
+checksum = "706d9e7cf1c7664859d79cd524e4e53ea2b67ea03c98cc2870c5e539695d597e"
 dependencies = [
- "enum-iterator-derive 1.1.0",
+ "enum-iterator-derive 1.2.0",
 ]
 
 [[package]]
@@ -1432,18 +1444,18 @@ checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "enum-iterator-derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+checksum = "355f93763ef7b0ae1c43c4d8eccc9d5848d84ad1a1d8ce61c421d1ac85a19d05"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1455,7 +1467,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1473,10 +1485,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
 dependencies = [
- "darling 0.14.3",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1494,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
+checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
 dependencies = [
  "serde",
 ]
@@ -1510,6 +1522,17 @@ dependencies = [
  "errno-dragonfly",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1610,7 +1633,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1625,7 +1648,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fsevent-sys",
 ]
 
@@ -1644,7 +1667,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fuchsia-zircon-sys",
 ]
 
@@ -1656,9 +1679,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1671,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1681,15 +1704,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1698,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-lite"
@@ -1719,13 +1742,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1741,15 +1764,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-timer"
@@ -1759,9 +1782,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1825,7 +1848,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1841,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glob"
@@ -1865,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1982,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -2001,12 +2024,6 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
@@ -2030,7 +2047,7 @@ dependencies = [
  "async-object-pool",
  "async-trait",
  "base64 0.13.1",
- "clap 4.1.8",
+ "clap 4.1.11",
  "crossbeam-utils",
  "env_logger",
  "form_urlencoded",
@@ -2058,9 +2075,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2133,16 +2150,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi 0.3.9",
+ "windows",
 ]
 
 [[package]]
@@ -2220,7 +2237,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -2245,10 +2262,11 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.45.0",
 ]
@@ -2270,26 +2288,26 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-macro"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c068d4c6b922cd6284c609cfa6dec0e41615c9c5a1a4ba729a970d8daba05fb"
+checksum = "8a7d079e129b77477a49c5c4f1cfe9ce6c2c909ef52520693e8e811a714c7b20"
 dependencies = [
  "Inflector",
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.36.11",
  "windows-sys 0.45.0",
 ]
 
@@ -2337,22 +2355,24 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jni"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039022cdf4d7b1cf548d31f60ae783138e5fd42013f6271049d7df7afadef96c"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
+ "cfg-if 1.0.0",
  "combine",
  "jni-sys",
  "log",
  "thiserror",
  "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2503,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libloading"
@@ -2565,6 +2585,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,7 +2628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2690,9 +2716,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
@@ -2711,6 +2737,15 @@ name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -2743,7 +2778,7 @@ checksum = "6b5bc45b761bcf1b5e6e6c4128cd93b84c218721a8d9b894aa0aff4ed180174c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2777,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
@@ -2889,18 +2924,18 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "napi"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2412d19892730f62fd592f8af41606ca6717ea1eca026103cd44b447829f00c1"
+checksum = "564ad12389dd08b0f5e95b9e8b5e88e5e42a234d326639cfa7b0fe643562e0d7"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.0.2",
  "ctor",
+ "napi-derive",
  "napi-sys",
  "once_cell",
  "serde",
  "serde_json",
- "thread_local",
  "tokio",
 ]
 
@@ -2912,29 +2947,30 @@ checksum = "882a73d9ef23e8dc2ebbffb6a6ae2ef467c0f18ac10711e4cc59c5485d41df0e"
 
 [[package]]
 name = "napi-derive"
-version = "2.11.0"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f15c1ac0eac01eca2a24c27905ab47f7411acefd829d0d01fb131dc39befd7"
+checksum = "a6bd0beb0ac7e8576bc92d293361a461b42eaf41740bbdec7e0cbf64d8dc89f7"
 dependencies = [
  "convert_case 0.6.0",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.44"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4930d5fa70f5663b9e7d6b4f0816b70d095574ee7f3c865fdb8c43b0f7e6406d"
+checksum = "c713ff9ff5baa6d6ad9aedc46fad73c91e2f16ebe5ece0f41983d4e70e020c7c"
 dependencies = [
  "convert_case 0.6.0",
  "once_cell",
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "semver 1.0.17",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3022,6 +3058,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
+ "futures",
  "indexmap",
  "indoc",
  "mime",
@@ -3036,6 +3073,7 @@ dependencies = [
  "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
+ "turbo-tasks-bytes",
  "turbo-tasks-env",
  "turbo-tasks-fetch",
  "turbo-tasks-fs",
@@ -3055,7 +3093,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chromiumoxide",
- "clap 4.1.8",
+ "clap 4.1.11",
  "console-subscriber",
  "criterion",
  "dunce",
@@ -3212,7 +3250,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.7.1",
@@ -3223,10 +3261,10 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
- "clap 4.1.8",
+ "clap 4.1.11",
  "serde",
  "serde_json",
  "tokio",
@@ -3271,7 +3309,7 @@ version = "4.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "filetime",
  "fsevent",
  "fsevent-sys",
@@ -3378,11 +3416,11 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -3399,7 +3437,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3410,9 +3448,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
 dependencies = [
  "autocfg",
  "cc",
@@ -3423,9 +3461,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "output_vt100"
@@ -3510,7 +3548,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "062a6297f2cd3969a780156ccb288eafb34bb5ed0f3c9a2b4500dbde869d4b86"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3521,9 +3559,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
+checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3531,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac3922aac69a40733080f53c1ce7f91dcf57e1a5f6c52f421fadec7fbdc4b69"
+checksum = "a81186863f3d0a27340815be8f2078dd8050b14cd71913db9fbda795e5f707d7"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3541,22 +3579,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06646e185566b5961b4058dd107e0a7f56e77c3f484549fb119867773c0f202"
+checksum = "75a1ef20bf3193c15ac345acb32e26b3dc3223aff4d77ae4fc5359567683796b"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f60b2ba541577e2a0c307c8f39d1439108120eb7903adeb6497fa880c59616"
+checksum = "5e3b284b1f13a20dc5ebc90aff59a51b8d7137c221131b52a7260c08cbc1cc80"
 dependencies = [
  "once_cell",
  "pest",
@@ -3605,7 +3643,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3634,7 +3672,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3691,7 +3729,7 @@ checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3701,7 +3739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "concurrent-queue",
  "libc",
@@ -3743,7 +3781,7 @@ dependencies = [
  "dashmap",
  "from_variant",
  "once_cell",
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
  "st-map",
  "tracing",
@@ -3780,7 +3818,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -3803,9 +3841,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]
@@ -3830,7 +3868,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3868,7 +3906,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3882,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3927,18 +3965,15 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
-dependencies = [
- "cty",
-]
+checksum = "4f851a03551ceefd30132e447f07f96cb7011d6b658374f3aed847333adb5559"
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -3946,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -3968,7 +4003,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3995,9 +4030,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4015,9 +4050,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "region"
@@ -4025,7 +4060,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "mach",
  "winapi 0.3.9",
@@ -4033,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "relative-path"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3bf6b372449361333ac1f498b7edae4dd5e70dccd7c0c2a7c7bce8f05ede648"
+checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
 
 [[package]]
 name = "rend"
@@ -4048,9 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "0ba30cc2c0cd02af1222ed216ba659cdb2f879dfe3181852fe7c50b1d0005949"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4125,7 +4160,7 @@ checksum = "e289706df51226e84814bf6ba1a9e1013112ae29bc7a9878f73fce360520c403"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4155,20 +4190,34 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.16",
+ "semver 1.0.17",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
- "bitflags",
- "errno",
+ "bitflags 1.3.2",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno 0.3.0",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.0",
  "windows-sys 0.45.0",
 ]
 
@@ -4195,15 +4244,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "ryu-js"
@@ -4243,9 +4292,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -4269,7 +4318,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4297,9 +4346,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
@@ -4385,16 +4434,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
  "url",
  "uuid",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
@@ -4421,20 +4470,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.7",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "indexmap",
  "itoa",
@@ -4444,9 +4493,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
 dependencies = [
  "serde",
 ]
@@ -4585,6 +4634,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4598,9 +4653,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -4641,9 +4696,9 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -4651,11 +4706,11 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "6.2.1"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebe057d110ddba043708da3fb010bf562ff6e9d4d60c9ee92860527bcbeccd6"
+checksum = "eed16231c92d0a6f0388f56e0ab2be24ecff1173f8e22f0ea5e074d0525631cb"
 dependencies = [
- "base64 0.13.1",
+ "data-encoding",
  "if_chain",
  "rustc_version 0.2.3",
  "serde",
@@ -4717,7 +4772,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4750,7 +4805,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_derive",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4766,7 +4821,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1 0.6.1",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4811,7 +4866,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4881,9 +4936,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.255.10"
+version = "0.255.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08774e54fabd2394cbc0da9636c769b1ab9e65c1686268b97c815395a818679"
+checksum = "630a74e8f8b5345225ea4829c588fde46c5031ac06a32e5a0425573746bcc902"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4948,9 +5003,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.208.8"
+version = "0.208.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1fb437dd26e1a128136f6e342c1648a934b10f3c98b3fc9bc91ad4710027bb"
+checksum = "06d3a1a590a46a8ffbbdf8c9a14ba7c62304b7f09edb318536ac90fd8cdccac8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5048,14 +5103,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "swc_core"
-version = "0.69.11"
+version = "0.69.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5de5c999b4c92d181b79097647b73b173bd3f017a0fe56b3b681cdbbc4fef4"
+checksum = "9d13d1df11c7a0c2876ccf36bda91da3686310fb0ab853a22aac5496e02e5e9f"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5118,7 +5173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa6ae6065fa3a75c3bd9d4e8747d692a57ab5ac3259c5b3e5811965cce92d4"
 dependencies = [
  "auto_impl",
- "bitflags",
+ "bitflags 1.3.2",
  "rustc-hash",
  "serde",
  "swc_atoms",
@@ -5138,7 +5193,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5147,7 +5202,7 @@ version = "0.20.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608c5e294e2fcbea240831e02863c68e765d2508c42cc3bda492a18198e3081f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "once_cell",
  "serde",
  "serde_json",
@@ -5180,7 +5235,7 @@ version = "0.143.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4dc464bb7b97db5cb057164af91d1a374bffa48170d67604c7f3158639ed27"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "lexical",
  "serde",
  "swc_atoms",
@@ -5235,11 +5290,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.100.1"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dbfdbe05dde274473a6030dcf5e52e579516aea761d25d7a8d128f2ab597f09"
+checksum = "5e636d10ea834f572d8e1b5e87eb9eae830f2e9fa1ebdad24d75501753351bea"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "is-macro",
  "num-bigint",
  "rkyv",
@@ -5253,9 +5308,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.135.4"
+version = "0.135.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5280ef3bfa40a8ab3fa16ceba1bac038957c835a8d3742d3bd9bb067f3e427"
+checksum = "2ebb4d7ab6fc44de75644847314390517c3a9ee2e8e548498de1e2d3fe67bf3b"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -5280,14 +5335,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.99.4"
+version = "0.99.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38e93d4c2593c16693521863df1be40a731479b51622f031d89f696de5028d9"
+checksum = "75b36dabcf256f051da0dbf85bd8f21f9676225f339cf2f5e7024ac9797d3b91"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -5299,9 +5354,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.77.5"
+version = "0.77.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aff33c34012b2d43ba6716aa233e36db8486715a696cc6aea44ab61c682b0cd"
+checksum = "0bfa431594cf0aeaf183e2044cda25a34d9d956b8259d681de2de36b624ffc3a"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -5342,9 +5397,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.175.8"
+version = "0.175.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "204f60e7f17f944d4d6fc059bec0659004c5c2ecc5f0fe8e1d015acb68d8489b"
+checksum = "ba83fba738f445e9dd5b053e8eb9d6296590df7aa4b27b43bd83dd76d72dd471"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -5378,9 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.130.3"
+version = "0.130.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace449290ab97f779573b8c9f5de43ce414a7c49043f0a61bd6e9a22173b2482"
+checksum = "9d9734a65e45f866fb35a89a340fedb4405d23ecd33e6c565065d47bc8af86ba"
 dependencies = [
  "either",
  "enum_kind",
@@ -5399,9 +5454,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.189.7"
+version = "0.189.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1632c57e30d4b805f30a72a36603336f211dbefd7396ee33209d84f0bc7922"
+checksum = "32245446715276f550043f832c6b97b9150ddb1673438e069f2284ea165c7c4b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5409,7 +5464,7 @@ dependencies = [
  "indexmap",
  "once_cell",
  "preset_env_base",
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
  "serde_json",
  "st-map",
@@ -5424,9 +5479,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.41.3"
+version = "0.41.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2103be5c172525c2001be6392d257de7bad3b0ec17e1ad9abf05e4adff4f0b5f"
+checksum = "4a67a54c53456110664db461edbe3954ca372827048369306a825386c9186795"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -5437,7 +5492,7 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5454,9 +5509,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.212.7"
+version = "0.212.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4fb67fcbfd44d5d8b2ba28454ff0ab3ef4e57a545c8fbd4c796e0243b78d11"
+checksum = "9a4450231e31c1aa5c7c45db367bc0ef1ad6d81952b011ce7fd672897624cf6e"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5474,12 +5529,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.122.5"
+version = "0.122.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2063b150343891e8f6eaccd67f546a3cd3c1c4b1ec6a0958681aa766d8d04993"
+checksum = "476c98b881033f14d66f4217a27e13749faf901960a798886ccc3dea70f291db"
 dependencies = [
  "better_scoped_tls",
- "bitflags",
+ "bitflags 1.3.2",
+ "indexmap",
  "once_cell",
  "phf",
  "rayon",
@@ -5497,9 +5553,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.111.5"
+version = "0.111.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b32dd8c0c1411d933fbf268205637d3668761b58694c8b9ceb4e1ee271f6af6"
+checksum = "3554cfcf434703f324683f9b6d13777d1fbdcd87d1db8f8c8cfc33bc400d819d"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5511,9 +5567,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.148.6"
+version = "0.148.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d876c0f73579657c12c4f3efc55bea0fd78839d4de03d6b5809685e9577ecf1"
+checksum = "3cbe71e817be88a85899b8891fbeac36c68749b02e454c4c529001e39e7dbfcc"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -5546,19 +5602,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.165.6"
+version = "0.165.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2680f2b8a9b2ced927c7a2f787a43793e5f5fe2eb0a7fd8bd554352106eddeb7"
+checksum = "a91b9f29345a403d287a8fc36120d32b5c632a234148db94e214a33dacd445bd"
 dependencies = [
  "Inflector",
  "ahash",
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "indexmap",
  "is-macro",
  "path-clean",
@@ -5579,9 +5635,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.181.7"
+version = "0.181.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af72bda74e48705a053a5b7198f3dbca2b4c75343f1d0af5f9c8180303be5ce7"
+checksum = "4a4d72e0552f6d81f9903a282b00ab4f1747d488c0574450698d1b4aa9b284e4"
 dependencies = [
  "ahash",
  "dashmap",
@@ -5605,9 +5661,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.156.6"
+version = "0.156.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ebd1c133fd4da55715c5957fdd831e639d9affaeb83660462e02cbf5225ff1"
+checksum = "d2bfd6afb5a17c971dbfb82a4675e1e33aab2bce6deba2dfc499cc468f9d6940"
 dependencies = [
  "either",
  "serde",
@@ -5624,9 +5680,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.167.7"
+version = "0.167.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d1f8c586abc99ab052e60e647e6a2ea8b62bf30c1bbacd16eced2157e190c1"
+checksum = "589df42a8ff3681f81fef1487e2ee9ed90da7826d24bddce7dd5e65e43b31946"
 dependencies = [
  "ahash",
  "base64 0.13.1",
@@ -5651,9 +5707,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.125.5"
+version = "0.125.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04a4b965b755cf9701c572d91f84908f2e0f75bca65dd8b94f5b4bffb672700"
+checksum = "5263a184443e798c90db91a2d49e93c062627931e692ee4d691ce32ebad720d9"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -5677,9 +5733,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.171.7"
+version = "0.171.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033082e0f39e04ceeef6f07ec453aa045d8b909fa8ff01cd23e333d0f153a6c8"
+checksum = "89e8710b64100c931450acfe2a04cee6c31dee43e38b7695b6d69b9572bc67c7"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5693,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.9.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14f5ea9df6057d2f2ab2ac69309f21b84ba42172fcfa124ae279bf0f6ef23e9"
+checksum = "1d0be7ba013e93d1907522e76205af72a00b91120c6d328ba89e64fea7bfca1e"
 dependencies = [
  "ahash",
  "indexmap",
@@ -5711,9 +5767,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.113.4"
+version = "0.113.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd48f4c207b9dc261d4f7ce88571a0b26f53f5bd16b3b147ea536bf02e41f90"
+checksum = "3aa6814656d8ff0f6afe8133bcb89e43d7907d2d8ac939e9ccd88372cd2f8b97"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -5730,9 +5786,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.86.1"
+version = "0.86.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147cf9137da6fe2704a5defd29a1cde849961978f8c92911e6790d50df475fef"
+checksum = "2bdd22762d52cf9bd3ea56429e1a39e0200632861bbbbd02e6e0b300a0be0fb8"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -5769,7 +5825,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5819,7 +5875,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5860,9 +5916,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.29.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e93c0ad5ec20f6d9d275fc26bd4236511727a569c638a31381a37c58934d54"
+checksum = "686b0830dda2e063168170b4cfde1dfda2bde6167a5acf7df0351c21cd27454f"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -5874,9 +5930,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.91.3"
+version = "0.91.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970c8dd16f5b8083345d2c4ea86d945d5abd6c08ffe1419cd72ac02cf01fdf3d"
+checksum = "a516f50b22af99ace3d7149a644d9dd9f06d84bff07c1474072b90d0e47ddcde"
 dependencies = [
  "anyhow",
  "enumset",
@@ -5912,7 +5968,7 @@ checksum = "a4795c8d23e0de62eef9cac0a20ae52429ee2ffc719768e838490f195b7d7267"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5936,14 +5992,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9a90d19f27bb60792270bb90225f96d97fc5705395134b2ca1dcbb3acc27f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5971,7 +6038,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.2.16",
- "rustix",
+ "rustix 0.36.11",
  "windows-sys 0.42.0",
 ]
 
@@ -6027,7 +6094,7 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6049,22 +6116,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.7",
 ]
 
 [[package]]
@@ -6126,14 +6193,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "serde",
  "time-core",
- "time-macros 0.2.6",
+ "time-macros 0.2.8",
 ]
 
 [[package]]
@@ -6154,9 +6221,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -6171,7 +6238,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "standback",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6201,9 +6268,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -6217,7 +6284,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -6238,7 +6305,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6264,9 +6331,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -6361,25 +6428,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-layer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6412,7 +6460,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6532,7 +6580,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "mimalloc",
 ]
@@ -6540,7 +6588,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6570,19 +6618,34 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "cargo-lock",
  "glob",
- "syn",
+ "syn 1.0.109",
  "turbo-tasks-macros-shared",
+]
+
+[[package]]
+name = "turbo-tasks-bytes"
+version = "0.1.0"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "serde",
+ "serde_bytes",
+ "tokio",
+ "turbo-tasks",
+ "turbo-tasks-build",
 ]
 
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6596,7 +6659,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6613,11 +6676,11 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "auto-hash-map",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "concurrent-queue",
  "dashmap",
@@ -6642,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "base16",
  "hex",
@@ -6654,31 +6717,31 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "turbo-tasks-macros-shared",
 ]
 
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6700,7 +6763,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6712,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6738,10 +6801,10 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
- "clap 4.1.8",
+ "clap 4.1.11",
  "crossterm",
  "owo-colors",
  "serde",
@@ -6754,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6781,10 +6844,10 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
- "clap 4.1.8",
+ "clap 4.1.11",
  "indoc",
  "pathdiff",
  "serde_json",
@@ -6794,7 +6857,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6816,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6835,7 +6898,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6851,11 +6914,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "turbo-tasks",
  "turbo-tasks-build",
+ "turbo-tasks-bytes",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
  "turbopack-cli-utils",
@@ -6867,7 +6932,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6902,7 +6967,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "serde",
@@ -6917,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "serde",
@@ -6932,7 +6997,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -6947,9 +7012,11 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
+ "async-stream",
+ "bytes",
  "futures",
  "futures-retry",
  "indexmap",
@@ -6960,6 +7027,7 @@ dependencies = [
  "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
+ "turbo-tasks-bytes",
  "turbo-tasks-env",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
@@ -6973,7 +7041,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "serde",
@@ -6989,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7000,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230322.2#abc1f63953ea48046ff3fbab3bf5b51db6288385"
+source = "git+https://github.com/vercel/turbo.git?branch=jrl-node-eval-stream#5ad3155ed941843fbf93d60e47695543d480e4ef"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -7061,9 +7129,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-id"
@@ -7073,9 +7141,9 @@ checksum = "d70b6494226b36008c8366c288d77190b3fad2eb4c10533139c1c1f461127f1a"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-linebreak"
@@ -7184,11 +7252,11 @@ checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
- "enum-iterator 1.3.0",
+ "enum-iterator 1.4.0",
  "getset",
  "rustversion",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -7205,12 +7273,11 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -7278,7 +7345,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -7312,7 +7379,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7325,9 +7392,9 @@ checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c3e4bc09095436c8e7584d86d33e6c3ee67045af8fb262cbb9cc321de553428"
+checksum = "4eff853c4f09eec94d76af527eddad4e9de13b11d6286a1ef7134bc30135a2b7"
 dependencies = [
  "leb128",
 ]
@@ -7432,7 +7499,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7626,9 +7693,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
-version = "53.0.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8244fa24196b1d8fd3ca4a96a3a164c40f846498c5deab6caf414c67340ca4af"
+checksum = "4984d3e1406571f4930ba5cf79bd70f75f41d0e87e17506e0bd19b0e5d085f05"
 dependencies = [
  "leb128",
  "memchr",
@@ -7638,9 +7705,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4620f1059add6dad511decb9d5d88b4a0a0d3e2e315ed34f79b0dc0dce18aa4b"
+checksum = "af2b53f4da14db05d32e70e9c617abdf6620c575bd5dd972b7400037b4df2091"
 dependencies = [
  "wast",
 ]
@@ -7657,9 +7724,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d1fa1e5c829b2bf9eb1e28fb950248b797cd6a04866fbdfa8bc31e5eef4c78"
+checksum = "579cc485bd5ce5bfa0d738e4921dd0b956eca9800be1fd2e5257ebe95bc4617e"
 dependencies = [
  "core-foundation",
  "dirs",
@@ -7746,6 +7813,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7765,12 +7841,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7784,24 +7860,24 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7811,9 +7887,9 @@ checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7823,9 +7899,9 @@ checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7835,9 +7911,9 @@ checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7847,15 +7923,15 @@ checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7865,9 +7941,9 @@ checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"

--- a/packages/next-swc/Cargo.toml
+++ b/packages/next-swc/Cargo.toml
@@ -46,37 +46,38 @@ swc_emotion = { version = "0.29.10" }
 testing = { version = "0.31.31" }
 
 # Turbo crates
-auto-hash-map = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-node-file-trace = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-swc-ast-explorer = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbo-malloc = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2", default-features = false }
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbo-tasks-build = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbo-tasks-env = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbo-tasks-fetch = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2", default-features = false }
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbo-tasks-hash = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbo-tasks-macros = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbo-tasks-macros-shared = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbo-tasks-memory = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbo-tasks-testing = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbo-updater = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-cli-utils = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-core = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-create-test-app = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-css = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-dev = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-dev-server = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-ecmascript = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-env = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-json = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-mdx = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-node = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-static = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-swc-utils = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-test-utils = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
-turbopack-tests = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230322.2" }
+auto-hash-map = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+node-file-trace = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+swc-ast-explorer = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbo-malloc = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream", default-features = false }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbo-tasks-build = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbo-tasks-bytes = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbo-tasks-env = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbo-tasks-fetch = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream", default-features = false }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbo-tasks-hash = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbo-tasks-macros = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbo-tasks-macros-shared = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbo-tasks-memory = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbo-tasks-testing = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbo-updater = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-cli-utils = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-core = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-create-test-app = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-css = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-dev = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-dev-server = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-ecmascript = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-env = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-json = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-mdx = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-node = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-static = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-swc-utils = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-test-utils = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+turbopack-tests = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
 
 # General Deps
 

--- a/packages/next-swc/Cargo.toml
+++ b/packages/next-swc/Cargo.toml
@@ -46,38 +46,38 @@ swc_emotion = { version = "0.29.10" }
 testing = { version = "0.31.31" }
 
 # Turbo crates
-auto-hash-map = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-node-file-trace = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-swc-ast-explorer = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbo-malloc = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream", default-features = false }
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbo-tasks-build = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbo-tasks-bytes = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbo-tasks-env = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbo-tasks-fetch = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream", default-features = false }
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbo-tasks-hash = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbo-tasks-macros = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbo-tasks-macros-shared = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbo-tasks-memory = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbo-tasks-testing = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbo-updater = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-cli-utils = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-core = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-create-test-app = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-css = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-dev = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-dev-server = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-ecmascript = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-env = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-json = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-mdx = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-node = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-static = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-swc-utils = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-test-utils = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
-turbopack-tests = { git = "https://github.com/vercel/turbo.git", branch = "jrl-node-eval-stream" }
+auto-hash-map = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+node-file-trace = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+swc-ast-explorer = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbo-malloc = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1", default-features = false }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbo-tasks-build = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbo-tasks-bytes = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbo-tasks-env = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbo-tasks-fetch = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1", default-features = false }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbo-tasks-hash = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbo-tasks-macros = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbo-tasks-macros-shared = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbo-tasks-memory = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbo-tasks-testing = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbo-updater = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-cli-utils = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-core = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-create-test-app = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-css = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-dev = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-dev-server = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-ecmascript = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-env = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-json = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-mdx = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-node = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-static = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-swc-utils = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-test-utils = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
+turbopack-tests = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230323.1" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/Cargo.toml
+++ b/packages/next-swc/crates/next-core/Cargo.toml
@@ -11,6 +11,7 @@ bench = false
 [dependencies]
 anyhow = { workspace = true }
 auto-hash-map = { workspace = true }
+futures = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 indoc = { workspace = true }
 mime = { workspace = true }
@@ -20,6 +21,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 turbo-tasks = { workspace = true }
+turbo-tasks-bytes = { workspace = true }
 turbo-tasks-env = { workspace = true }
 turbo-tasks-fetch = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/packages/next-swc/crates/next-core/js/.prettierrc.json
+++ b/packages/next-swc/crates/next-core/js/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": false,
+  "semi": true
+}

--- a/packages/next-swc/crates/next-core/js/src/entry/router.ts
+++ b/packages/next-swc/crates/next-core/js/src/entry/router.ts
@@ -1,70 +1,69 @@
-import type { Ipc } from "@vercel/turbopack-next/ipc/index";
-import type { IncomingMessage, ServerResponse } from "node:http";
-import { Buffer } from "node:buffer";
-import { createServer, makeRequest } from "@vercel/turbopack-next/ipc/server";
-import { toPairs } from "@vercel/turbopack-next/internal/headers";
-import { makeResolver } from "next/dist/server/lib/route-resolver";
-import loadConfig from "next/dist/server/config";
-import { PHASE_DEVELOPMENT_SERVER } from "next/dist/shared/lib/constants";
+import type { Ipc } from '@vercel/turbopack-next/ipc/index'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { Buffer } from 'node:buffer'
+import { createServer, makeRequest } from '@vercel/turbopack-next/ipc/server'
+import { toPairs } from '@vercel/turbopack-next/internal/headers'
+import { makeResolver } from 'next/dist/server/lib/route-resolver'
+import loadConfig from 'next/dist/server/config'
+import { PHASE_DEVELOPMENT_SERVER } from 'next/dist/shared/lib/constants'
 
-import "next/dist/server/node-polyfill-fetch.js";
+import 'next/dist/server/node-polyfill-fetch.js'
 
-import middlewareChunkGroup from "MIDDLEWARE_CHUNK_GROUP";
-import middlewareConfig from "MIDDLEWARE_CONFIG";
+// @ts-expect-error internal package is injected by Rust
+import middlewareChunkGroup from 'MIDDLEWARE_CHUNK_GROUP'
+
+// @ts-expect-error internal package is injected by Rust
+import middlewareConfig from 'MIDDLEWARE_CONFIG'
 
 type RouterRequest = {
-  method: string;
-  pathname: string;
-  rawHeaders: [string, string][];
-  rawQuery: string;
-};
+  method: string
+  pathname: string
+  rawHeaders: [string, string][]
+  rawQuery: string
+}
 
 type RouteResult =
   | {
-      type: "rewrite";
-      url: string;
-      headers: Record<string, string>;
+      type: 'rewrite'
+      url: string
+      headers: Record<string, string>
     }
   | {
-      type: "none";
-    };
+      type: 'none'
+    }
 
 type IpcOutgoingMessage = {
-  type: "jsonValue";
-  data: string;
-};
+  type: 'value'
+  data: string | Buffer
+}
 
 type MessageData =
-  | { type: "middleware-headers"; data: MiddlewareHeadersResponse }
-  | { type: "middleware-body"; data: Uint8Array }
+  | { type: 'middleware-headers'; data: MiddlewareHeadersResponse }
+  | { type: 'middleware-body'; data: Uint8Array }
   | {
-      type: "full-middleware";
-      data: { headers: MiddlewareHeadersResponse; body: number[] };
+      type: 'rewrite'
+      data: RewriteResponse
     }
-  | {
-      type: "rewrite";
-      data: RewriteResponse;
-    }
-  | { type: "none" };
+  | { type: 'none' }
 
 type RewriteResponse = {
-  url: string;
-  headers: [string, string][];
-};
+  url: string
+  headers: [string, string][]
+}
 
 type MiddlewareHeadersResponse = {
-  statusCode: number;
-  headers: [string, string][];
-};
+  statusCode: number
+  headers: [string, string][]
+}
 
 let resolveRouteMemo: Promise<
   (req: IncomingMessage, res: ServerResponse) => Promise<void>
->;
+>
 
 async function getResolveRoute(
   dir: string
 ): ReturnType<
-  typeof import("next/dist/server/lib/route-resolver").makeResolver
+  typeof import('next/dist/server/lib/route-resolver').makeResolver
 > {
   const nextConfig = await loadConfig(
     PHASE_DEVELOPMENT_SERVER,
@@ -72,12 +71,14 @@ async function getResolveRoute(
     undefined,
     undefined,
     true
-  );
+  )
 
   return await makeResolver(dir, nextConfig, {
-    files: middlewareChunkGroup.filter((f) => /\.[mc]?js$/.test(f)),
-    matcher: middlewareConfig.matcher,
-  });
+    files: (middlewareChunkGroup as string[]).filter((f) =>
+      /\.[mc]?js$/.test(f)
+    ),
+    matcher: (middlewareConfig as { matcher: string[] }).matcher,
+  })
 }
 
 export default async function route(
@@ -88,7 +89,7 @@ export default async function route(
   const [resolveRoute, server] = await Promise.all([
     (resolveRouteMemo ??= getResolveRoute(dir)),
     createServer(),
-  ]);
+  ])
 
   try {
     const {
@@ -102,16 +103,16 @@ export default async function route(
       routerRequest.pathname,
       routerRequest.rawQuery,
       routerRequest.rawHeaders
-    );
+    )
 
     // Send the clientRequest, so the server parses everything. We can then pass
     // the serverRequest to Next.js to handle.
-    clientRequest.end();
+    clientRequest.end()
 
     // The route promise must not block us from starting the client response
     // handling, so we cannot await it yet. By making the call, we allow
     // Next.js to start writing to the response whenever it's ready.
-    const routePromise = resolveRoute(serverRequest, serverResponse);
+    const routePromise = resolveRoute(serverRequest, serverResponse)
 
     // Now that the Next.js has started processing the route, the
     // clientResponsePromise will resolve once they write data and then we can
@@ -120,82 +121,72 @@ export default async function route(
     // occur in the routePromise while we're waiting.
     const responsePromise = clientResponsePromise.then((c) =>
       handleClientResponse(ipc, c)
-    );
+    )
 
     // Now that both promises are in progress, we await both so that a
     // rejection in either will end the routing.
-    const [response] = await Promise.all([responsePromise, routePromise]);
+    const [response] = await Promise.all([responsePromise, routePromise])
 
-    server.close();
-    return response;
+    server.close()
+    return response
   } catch (e) {
     // Server doesn't need to be closed, because the sendError will terminate
     // the process.
-    ipc.sendError(e as Error);
+    ipc.sendError(e as Error)
   }
 }
 
 async function handleClientResponse(
-  _ipc: Ipc<RouterRequest, IpcOutgoingMessage>,
+  ipc: Ipc<RouterRequest, IpcOutgoingMessage>,
   clientResponse: IncomingMessage
-): Promise<MessageData> {
-  if (clientResponse.headers["x-nextjs-route-result"] === "1") {
-    clientResponse.setEncoding("utf8");
+): Promise<MessageData | void> {
+  if (clientResponse.headers['x-nextjs-route-result'] === '1') {
+    clientResponse.setEncoding('utf8')
     // We're either a redirect or a rewrite
-    let buffer = "";
+    let buffer = ''
     for await (const chunk of clientResponse) {
-      buffer += chunk;
+      buffer += chunk
     }
 
-    const data = JSON.parse(buffer) as RouteResult;
+    const data = JSON.parse(buffer) as RouteResult
 
     switch (data.type) {
-      case "none":
+      case 'none':
         return {
-          type: "none",
-        };
-      case "rewrite":
+          type: 'none',
+        }
+      case 'rewrite':
       default:
         return {
-          type: "rewrite",
+          type: 'rewrite',
           data: {
             url: data.url,
             headers: Object.entries(data.headers),
           },
-        };
+        }
     }
   }
 
   const responseHeaders: MiddlewareHeadersResponse = {
     statusCode: clientResponse.statusCode!,
     headers: toPairs(clientResponse.rawHeaders),
-  };
-
-  // TODO: support streaming middleware
-  // ipc.send({
-  //   type: "jsonValue",
-  //   data: JSON.stringify({
-  //     type: "middleware-headers",
-  //     data: responseHeaders,
-  //   }),
-  // });
-  // ipc.send({
-  //   type: "jsonValue",
-  //   data: JSON.stringify({
-  //     type: "middleware-body",
-  //     data: chunk as Buffer,
-  //   }),
-  // });
-
-  const buffers = [];
-  for await (const chunk of clientResponse) {
-    buffers.push(chunk as Buffer);
   }
-  return {
-    type: "full-middleware",
-    data: {
-      headers: responseHeaders,
-      body: Buffer.concat(buffers).toJSON().data,
-    },
-  };
+
+  ipc.send({
+    type: 'value',
+    data: JSON.stringify({
+      type: 'middleware-headers',
+      data: responseHeaders,
+    }),
+  })
+
+  for await (const chunk of clientResponse) {
+    ipc.send({
+      type: 'value',
+      data: JSON.stringify({
+        type: 'middleware-body',
+        data: (chunk as Buffer).toJSON().data,
+      }),
+    })
+  }
 }

--- a/packages/next-swc/crates/next-core/js/src/entry/router.ts
+++ b/packages/next-swc/crates/next-core/js/src/entry/router.ts
@@ -1,69 +1,69 @@
-import type { Ipc } from '@vercel/turbopack-next/ipc/index'
-import type { IncomingMessage, ServerResponse } from 'node:http'
-import { Buffer } from 'node:buffer'
-import { createServer, makeRequest } from '@vercel/turbopack-next/ipc/server'
-import { toPairs } from '@vercel/turbopack-next/internal/headers'
-import { makeResolver } from 'next/dist/server/lib/route-resolver'
-import loadConfig from 'next/dist/server/config'
-import { PHASE_DEVELOPMENT_SERVER } from 'next/dist/shared/lib/constants'
+import type { Ipc } from "@vercel/turbopack-next/ipc/index";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Buffer } from "node:buffer";
+import { createServer, makeRequest } from "@vercel/turbopack-next/ipc/server";
+import { toPairs } from "@vercel/turbopack-next/internal/headers";
+import { makeResolver } from "next/dist/server/lib/route-resolver";
+import loadConfig from "next/dist/server/config";
+import { PHASE_DEVELOPMENT_SERVER } from "next/dist/shared/lib/constants";
 
-import 'next/dist/server/node-polyfill-fetch.js'
-
-// @ts-expect-error internal package is injected by Rust
-import middlewareChunkGroup from 'MIDDLEWARE_CHUNK_GROUP'
+import "next/dist/server/node-polyfill-fetch.js";
 
 // @ts-expect-error internal package is injected by Rust
-import middlewareConfig from 'MIDDLEWARE_CONFIG'
+import middlewareChunkGroup from "MIDDLEWARE_CHUNK_GROUP";
+
+// @ts-expect-error internal package is injected by Rust
+import middlewareConfig from "MIDDLEWARE_CONFIG";
 
 type RouterRequest = {
-  method: string
-  pathname: string
-  rawHeaders: [string, string][]
-  rawQuery: string
-}
+  method: string;
+  pathname: string;
+  rawHeaders: [string, string][];
+  rawQuery: string;
+};
 
 type RouteResult =
   | {
-      type: 'rewrite'
-      url: string
-      headers: Record<string, string>
+      type: "rewrite";
+      url: string;
+      headers: Record<string, string>;
     }
   | {
-      type: 'none'
-    }
+      type: "none";
+    };
 
 type IpcOutgoingMessage = {
-  type: 'value'
-  data: string | Buffer
-}
+  type: "value";
+  data: string | Buffer;
+};
 
 type MessageData =
-  | { type: 'middleware-headers'; data: MiddlewareHeadersResponse }
-  | { type: 'middleware-body'; data: Uint8Array }
+  | { type: "middleware-headers"; data: MiddlewareHeadersResponse }
+  | { type: "middleware-body"; data: Uint8Array }
   | {
-      type: 'rewrite'
-      data: RewriteResponse
+      type: "rewrite";
+      data: RewriteResponse;
     }
-  | { type: 'none' }
+  | { type: "none" };
 
 type RewriteResponse = {
-  url: string
-  headers: [string, string][]
-}
+  url: string;
+  headers: [string, string][];
+};
 
 type MiddlewareHeadersResponse = {
-  statusCode: number
-  headers: [string, string][]
-}
+  statusCode: number;
+  headers: [string, string][];
+};
 
 let resolveRouteMemo: Promise<
   (req: IncomingMessage, res: ServerResponse) => Promise<void>
->
+>;
 
 async function getResolveRoute(
   dir: string
 ): ReturnType<
-  typeof import('next/dist/server/lib/route-resolver').makeResolver
+  typeof import("next/dist/server/lib/route-resolver").makeResolver
 > {
   const nextConfig = await loadConfig(
     PHASE_DEVELOPMENT_SERVER,
@@ -71,14 +71,14 @@ async function getResolveRoute(
     undefined,
     undefined,
     true
-  )
+  );
 
   return await makeResolver(dir, nextConfig, {
     files: (middlewareChunkGroup as string[]).filter((f) =>
       /\.[mc]?js$/.test(f)
     ),
     matcher: (middlewareConfig as { matcher: string[] }).matcher,
-  })
+  });
 }
 
 export default async function route(
@@ -89,7 +89,7 @@ export default async function route(
   const [resolveRoute, server] = await Promise.all([
     (resolveRouteMemo ??= getResolveRoute(dir)),
     createServer(),
-  ])
+  ]);
 
   try {
     const {
@@ -103,16 +103,16 @@ export default async function route(
       routerRequest.pathname,
       routerRequest.rawQuery,
       routerRequest.rawHeaders
-    )
+    );
 
     // Send the clientRequest, so the server parses everything. We can then pass
     // the serverRequest to Next.js to handle.
-    clientRequest.end()
+    clientRequest.end();
 
     // The route promise must not block us from starting the client response
     // handling, so we cannot await it yet. By making the call, we allow
     // Next.js to start writing to the response whenever it's ready.
-    const routePromise = resolveRoute(serverRequest, serverResponse)
+    const routePromise = resolveRoute(serverRequest, serverResponse);
 
     // Now that the Next.js has started processing the route, the
     // clientResponsePromise will resolve once they write data and then we can
@@ -121,18 +121,18 @@ export default async function route(
     // occur in the routePromise while we're waiting.
     const responsePromise = clientResponsePromise.then((c) =>
       handleClientResponse(ipc, c)
-    )
+    );
 
     // Now that both promises are in progress, we await both so that a
     // rejection in either will end the routing.
-    const [response] = await Promise.all([responsePromise, routePromise])
+    const [response] = await Promise.all([responsePromise, routePromise]);
 
-    server.close()
-    return response
+    server.close();
+    return response;
   } catch (e) {
     // Server doesn't need to be closed, because the sendError will terminate
     // the process.
-    ipc.sendError(e as Error)
+    ipc.sendError(e as Error);
   }
 }
 
@@ -140,53 +140,53 @@ async function handleClientResponse(
   ipc: Ipc<RouterRequest, IpcOutgoingMessage>,
   clientResponse: IncomingMessage
 ): Promise<MessageData | void> {
-  if (clientResponse.headers['x-nextjs-route-result'] === '1') {
-    clientResponse.setEncoding('utf8')
+  if (clientResponse.headers["x-nextjs-route-result"] === "1") {
+    clientResponse.setEncoding("utf8");
     // We're either a redirect or a rewrite
-    let buffer = ''
+    let buffer = "";
     for await (const chunk of clientResponse) {
-      buffer += chunk
+      buffer += chunk;
     }
 
-    const data = JSON.parse(buffer) as RouteResult
+    const data = JSON.parse(buffer) as RouteResult;
 
     switch (data.type) {
-      case 'none':
+      case "none":
         return {
-          type: 'none',
-        }
-      case 'rewrite':
+          type: "none",
+        };
+      case "rewrite":
       default:
         return {
-          type: 'rewrite',
+          type: "rewrite",
           data: {
             url: data.url,
             headers: Object.entries(data.headers),
           },
-        }
+        };
     }
   }
 
   const responseHeaders: MiddlewareHeadersResponse = {
     statusCode: clientResponse.statusCode!,
     headers: toPairs(clientResponse.rawHeaders),
-  }
+  };
 
   ipc.send({
-    type: 'value',
+    type: "value",
     data: JSON.stringify({
-      type: 'middleware-headers',
+      type: "middleware-headers",
       data: responseHeaders,
     }),
-  })
+  });
 
   for await (const chunk of clientResponse) {
     ipc.send({
-      type: 'value',
+      type: "value",
       data: JSON.stringify({
-        type: 'middleware-body',
+        type: "middleware-body",
         data: (chunk as Buffer).toJSON().data,
       }),
-    })
+    });
   }
 }

--- a/packages/next-swc/crates/next-core/src/lib.rs
+++ b/packages/next-swc/crates/next-core/src/lib.rs
@@ -40,6 +40,7 @@ pub use web_entry_source::create_web_entry_source;
 
 pub fn register() {
     turbo_tasks::register();
+    turbo_tasks_bytes::register();
     turbo_tasks_fs::register();
     turbo_tasks_fetch::register();
     turbopack_dev::register();

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -8,7 +8,7 @@ use turbo_tasks::{
     CompletionVc, Value,
 };
 use turbo_tasks_env::EnvMapVc;
-use turbo_tasks_fs::{json::parse_json_rope_with_source_context, FileSystemPathVc};
+use turbo_tasks_fs::{json::parse_json_with_source_context, FileSystemPathVc};
 use turbopack::evaluate_context::node_evaluate_asset_context;
 use turbopack_core::{
     asset::Asset,
@@ -29,7 +29,7 @@ use turbopack_ecmascript::{
     EcmascriptInputTransformsVc, EcmascriptModuleAssetType, EcmascriptModuleAssetVc,
 };
 use turbopack_node::{
-    evaluate::{evaluate, JavaScriptValue},
+    evaluate::{evaluate, JavaScriptEvaluation},
     execution_context::{ExecutionContext, ExecutionContextVc},
     transforms::webpack::{WebpackLoaderConfigItems, WebpackLoaderConfigItemsVc},
 };
@@ -603,16 +603,13 @@ pub async fn load_next_config_internal(
     )
     .await?;
     match &*config_value {
-        JavaScriptValue::Value(val) => {
-            let next_config: NextConfig = parse_json_rope_with_source_context(val)?;
+        JavaScriptEvaluation::Single(Ok(val)) => {
+            let next_config: NextConfig = parse_json_with_source_context(&val.to_str()?)?;
             let next_config = next_config.cell();
 
             Ok(next_config)
         }
-        JavaScriptValue::Error => Ok(NextConfig::default().cell()),
-        JavaScriptValue::Stream(_) => {
-            unimplemented!("Stream not supported now");
-        }
+        _ => Ok(NextConfig::default().cell()),
     }
 }
 

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -604,7 +604,7 @@ pub async fn load_next_config_internal(
     .await?;
     match &*config_value {
         JavaScriptEvaluation::Single(Ok(val)) => {
-            let next_config: NextConfig = parse_json_with_source_context(&val.to_str()?)?;
+            let next_config: NextConfig = parse_json_with_source_context(val.to_str()?)?;
             let next_config = next_config.cell();
 
             Ok(next_config)

--- a/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
@@ -377,7 +377,7 @@ async fn get_mock_stylesheet(
     use turbo_tasks::{CompletionVc, Value};
     use turbo_tasks_env::{CommandLineProcessEnvVc, ProcessEnv};
     use turbo_tasks_fs::{
-        json::parse_json_rope_with_source_context, DiskFileSystemVc, File, FileSystem,
+        json::parse_json_with_source_context, DiskFileSystemVc, File, FileSystem,
     };
     use turbopack::evaluate_context::node_evaluate_asset_context;
     use turbopack_core::{context::AssetContext, ident::AssetIdentVc};
@@ -452,7 +452,7 @@ async fn get_mock_stylesheet(
     match &*val {
         JavaScriptValue::Value(val) => {
             let mock_map: HashMap<String, Option<String>> =
-                parse_json_rope_with_source_context(val)?;
+                parse_json_with_source_context(&val.to_str()?)?;
             Ok((mock_map.get(url).context("url not found")?).clone())
         }
         JavaScriptValue::Error => panic!("Unexpected error evaluating JS"),

--- a/packages/next-swc/crates/next-core/src/router.rs
+++ b/packages/next-swc/crates/next-core/src/router.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{
     primitives::{JsonValueVc, StringsVc},
     CompletionVc, CompletionsVc, Value,
 };
-use turbo_tasks_bytes::{bytes::Bytes, stream::Stream};
+use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_fs::{json::parse_json_with_source_context, to_sys_path, File, FileSystemPathVc};
 use turbopack::{evaluate_context::node_evaluate_asset_context, transition::TransitionsByNameVc};
 use turbopack_core::{

--- a/packages/next-swc/crates/next-core/src/router.rs
+++ b/packages/next-swc/crates/next-core/src/router.rs
@@ -402,11 +402,7 @@ async fn route_internal(
                     // a buffer directly into the IPC message without having to wrap it in an
                     // object.
                     let body = read.map(|data| {
-                        let chunk = match data {
-                            Ok(c) => c,
-                            Err(e) => return Err(e.message),
-                        };
-                        let chunk: RouterIncomingMessage = match chunk
+                        let chunk: RouterIncomingMessage = match data?
                             .to_str()
                             .context("error decoding string")
                             .and_then(parse_json_with_source_context)
@@ -424,7 +420,7 @@ async fn route_internal(
                         RouterIncomingMessage::MiddlewareHeaders { data } => MiddlewareResponse {
                             status_code: data.status_code,
                             headers: data.headers,
-                            body: Stream::from_stream(body),
+                            body: Stream::from(body),
                         },
                         _ => return Ok(RouterResult::Error.cell()),
                     }

--- a/packages/next-swc/crates/next-core/src/router.rs
+++ b/packages/next-swc/crates/next-core/src/router.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{
     primitives::{JsonValueVc, StringsVc},
     CompletionVc, CompletionsVc, Value,
 };
-use turbo_tasks_bytes::{bytes::BytesValue, stream::Stream};
+use turbo_tasks_bytes::{bytes::Bytes, stream::Stream};
 use turbo_tasks_fs::{json::parse_json_with_source_context, to_sys_path, File, FileSystemPathVc};
 use turbopack::{evaluate_context::node_evaluate_asset_context, transition::TransitionsByNameVc};
 use turbopack_core::{
@@ -98,7 +98,7 @@ pub struct MiddlewareHeadersResponse {
 
 #[turbo_tasks::value(shared)]
 #[derive(Debug, Clone, Default)]
-pub struct MiddlewareBodyResponse(BytesValue);
+pub struct MiddlewareBodyResponse(Bytes);
 
 #[derive(Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "kebab-case")]
@@ -116,7 +116,7 @@ pub struct MiddlewareResponse {
     pub status_code: u16,
     pub headers: Vec<(String, String)>,
     #[turbo_tasks(trace_ignore)]
-    pub body: Stream<Result<BytesValue, String>>,
+    pub body: Stream<Result<Bytes, String>>,
 }
 
 #[derive(Debug)]
@@ -414,9 +414,7 @@ async fn route_internal(
                             Err(e) => return Err(e.to_string()),
                         };
                         match chunk {
-                            RouterIncomingMessage::MiddlewareBody { data } => {
-                                Ok(BytesValue::from(data))
-                            }
+                            RouterIncomingMessage::MiddlewareBody { data } => Ok(Bytes::from(data)),
                             m => Err(format!("unexpected message type: {:#?}", m)),
                         }
                     });

--- a/packages/next-swc/crates/next-core/src/router_source.rs
+++ b/packages/next-swc/crates/next-core/src/router_source.rs
@@ -153,9 +153,10 @@ impl ContentSource for NextRouterContentSource {
                         headers: data.headers.clone(),
                         body: Body::from_stream(data.body.read().map(|chunk| {
                             chunk.map_err(|e| {
-                                BodyError::new(
-                                    "error streaming proxied contents: ".to_string() + e.as_str(),
-                                )
+                                BodyError::new(format!(
+                                    "error streaming proxied contents: {}",
+                                    e.as_str()
+                                ))
                             })
                         })),
                     }

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/headers/input/next.config.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/headers/input/next.config.js
@@ -1,0 +1,16 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: "/foo",
+        headers: [
+          {
+            key: "x-foo",
+            value: "bar",
+          },
+        ],
+      },
+    ];
+  },
+};

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/headers/input/pages/foo.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/headers/input/pages/foo.js
@@ -1,0 +1,3 @@
+export default function Foo() {
+  return "check x-foo header";
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/headers/input/pages/index.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/headers/input/pages/index.js
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+export default function Foo() {
+  useEffect(() => {
+    // Only run on client
+    import("@turbo/pack-test-harness").then(runTests);
+  });
+
+  return "index";
+}
+
+function runTests() {
+  it("should set header onto response", async () => {
+    const res = await fetch("/foo");
+    expect(res.headers.get("x-foo")).toBe("bar");
+  });
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware/input/middleware.ts
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware/input/middleware.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+function iteratorToStream<T>(iterator: AsyncIterator<T>) {
+  return new ReadableStream({
+    async pull(controller) {
+      const { value, done } = await iterator.next()
+
+      if (done) {
+        controller.close()
+      } else {
+        controller.enqueue(value)
+      }
+    },
+  })
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+async function* count(n: number) {
+  for (let i = 0; i < n; i++) {
+    yield String(i)
+    await sleep(100)
+  }
+}
+
+export function middleware(_request: NextRequest) {
+  return new NextResponse(iteratorToStream(count(10)))
+}
+
+export const config = {
+  matcher: '/stream',
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware/input/next.config.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware/input/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = {}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware/input/pages/index.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware/input/pages/index.js
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+
+export default function Foo() {
+  useEffect(() => {
+    // Only run on client
+    import('@turbo/pack-test-harness').then(runTests)
+  })
+
+  return 'index'
+}
+
+function runTests() {
+  it('should set header onto response', async () => {
+    let start = Date.now()
+    const res = await fetch('/stream')
+    const reader = res.body.getReader()
+
+    // we're only testing the timing
+    const { value, done } = await reader.read()
+
+    // The body still stream for 1 second, we just want the first chunk
+    // to be delivered within 500ms.
+    expect(Date.now()).toBeGreaterThan(start + 50)
+    expect(Date.now()).toBeLessThan(start + 500)
+    console.log({ duration: Date.now() - start })
+
+    // The value is a Uint8Array of the bytes
+    expect(value).toContain('0'.charCodeAt(0))
+
+    expect(done).toBe(false)
+  })
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware/input/pages/index.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware/input/pages/index.js
@@ -38,7 +38,9 @@ function runTests() {
       if (done) break
     }
 
-    console.log({ data })
     expect(data).toBe('0123456789')
+
+    const second = await fetch('/stream').then((r) => r.text())
+    expect(data).toBe(second)
   })
 }


### PR DESCRIPTION
Fun! This depends on https://github.com/vercel/turbo/pull/4251 to implement streamed Node evaluations, giving us the ability to support streamed middleware responses.

This is just the first step to supporting RSC streaming in Turbopack. I chose to start with this because it requires all the same base logic, and I understand the full router->middleware->HTTP server code path, so it's a lot easier to work on.

Fixes WEB-738