### PR TITLE
Change App Route Route Handler signature

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/handle.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/handle.ts
@@ -3,7 +3,10 @@ import {
   WebNextResponse,
 } from '../../../../server/base-http/web'
 import { NextConfig } from '../../../../server/config-shared'
-import { AppRouteRouteHandler } from '../../../../server/future/route-handlers/app-route-route-handler'
+import {
+  AppRouteModule,
+  AppRouteRouteHandler,
+} from '../../../../server/future/route-handlers/app-route-route-handler'
 import { RouteKind } from '../../../../server/future/route-kind'
 import { AppRouteRouteMatcher } from '../../../../server/future/route-matchers/app-route-route-matcher'
 import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
@@ -11,13 +14,17 @@ import { removeTrailingSlash } from '../../../../shared/lib/router/utils/remove-
 
 type HandleProps = {
   page: string
-  mod: any
+  mod: AppRouteModule
   nextConfigOutput: NextConfig['output']
 }
 
 export function getHandle({ page, mod, nextConfigOutput }: HandleProps) {
-  const appRouteRouteHandler = new AppRouteRouteHandler(nextConfigOutput)
-  const appRouteRouteMatcher = new AppRouteRouteMatcher({
+  const handler = new AppRouteRouteHandler(nextConfigOutput)
+
+  // Set the module on the handler so it can be used when we handle the request.
+  handler.module = mod
+
+  const matcher = new AppRouteRouteMatcher({
     kind: RouteKind.APP_ROUTE,
     pathname: normalizeAppPath(page),
     page: '',
@@ -28,17 +35,16 @@ export function getHandle({ page, mod, nextConfigOutput }: HandleProps) {
   return async function handle(request: Request) {
     const extendedReq = new WebNextRequest(request)
     const extendedRes = new WebNextResponse()
-    const match = appRouteRouteMatcher.match(
+    const match = matcher.match(
       removeTrailingSlash(new URL(request.url).pathname)
     )!
-    const response = await appRouteRouteHandler.execute(
+
+    const response = await handler.handle(
       match,
-      mod,
       extendedReq,
       extendedRes,
       // TODO: pass incrementalCache here
-      { supportsDynamicHTML: true },
-      request
+      { supportsDynamicHTML: true }
     )
 
     return response

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -41,6 +41,7 @@ import { RouteKind } from '../server/future/route-kind'
 import { NodeNextRequest, NodeNextResponse } from '../server/base-http/node'
 import { StaticGenerationContext } from '../server/future/route-handlers/app-route-route-handler'
 import { isAppRouteRoute } from '../lib/is-app-route-route'
+import { AppRouteRouteMatch } from '../server/future/route-matches/app-route-route-match'
 
 loadRequireHook()
 
@@ -393,24 +394,26 @@ export default async function exportPage({
             incrementalCache: curRenderOpts.incrementalCache,
           }
 
+          const match: AppRouteRouteMatch = {
+            params: query,
+            definition: {
+              filename: posix.join(distDir, 'server', 'app', page),
+              bundlePath: posix.join('app', page),
+              kind: RouteKind.APP_ROUTE,
+              page,
+              pathname: path,
+            },
+          }
+
           try {
-            const routeHandler = new AppRouteRouteHandler(nextConfigOuput)
-            const response: Response = await routeHandler.handle(
-              {
-                params: query,
-                definition: {
-                  filename: posix.join(distDir, 'server', 'app', page),
-                  bundlePath: posix.join('app', page),
-                  kind: RouteKind.APP_ROUTE,
-                  page,
-                  pathname: path,
-                },
-              },
+            const handler = new AppRouteRouteHandler(nextConfigOuput)
+            const response = await handler.handle(
+              match,
               nodeReq,
               nodeRes,
-              staticContext,
-              true
+              staticContext
             )
+
             // we don't consider error status for static generation
             // except for 404
             // TODO: do we want to cache other status codes?

--- a/packages/next/src/server/future/route-handler-managers/route-handler-manager.ts
+++ b/packages/next/src/server/future/route-handler-managers/route-handler-manager.ts
@@ -26,17 +26,14 @@ export class RouteHandlerManager {
     match: RouteMatch,
     req: BaseNextRequest,
     res: BaseNextResponse,
-    context?: any,
-    bubbleResult?: boolean
-  ): Promise<boolean> {
+    context?: any
+  ): Promise<Response | undefined> {
     const handler = this.handlers[match.definition.kind]
-    if (!handler) return false
+    if (!handler) return
 
-    const result = await handler.handle(match, req, res, context, bubbleResult)
+    // Get the response from the handler.
+    const response = await handler.handle(match, req, res, context)
 
-    if (bubbleResult) {
-      return result as any
-    }
-    return true
+    return response
   }
 }

--- a/packages/next/src/server/future/route-handlers/app-page-route-handler.ts
+++ b/packages/next/src/server/future/route-handlers/app-page-route-handler.ts
@@ -2,7 +2,7 @@ import { AppPageRouteMatch } from '../route-matches/app-page-route-match'
 import { RouteHandler } from './route-handler'
 
 export class AppPageRouteHandler implements RouteHandler<AppPageRouteMatch> {
-  public async handle(): Promise<void> {
+  public async handle(): Promise<Response> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
+++ b/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
@@ -13,8 +13,8 @@ import {
   RequestAsyncStorageWrapper,
   type RequestContext,
 } from '../../async-storage/request-async-storage-wrapper'
-import type { BaseNextRequest, BaseNextResponse } from '../../base-http'
-import type { NodeNextRequest, NodeNextResponse } from '../../base-http/node'
+import { BaseNextRequest, BaseNextResponse } from '../../base-http'
+import { NodeNextRequest, NodeNextResponse } from '../../base-http/node'
 import { getRequestMeta } from '../../request-meta'
 import {
   handleBadRequestResponse,
@@ -38,6 +38,8 @@ import { AppConfig } from '../../../build/utils'
 import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies'
 import { NextURL } from '../../web/next-url'
 import { NextConfig } from '../../config-shared'
+import { AppRouteRouteDefinition } from '../route-definitions/app-route-route-definition'
+import { WebNextRequest } from '../../base-http/web'
 
 // TODO-APP: This module has a dynamic require so when bundling for edge it causes issues.
 const NodeModuleLoader =
@@ -104,7 +106,7 @@ export type StaticGenerationContext = {
  * @param req base request to adapt for use with app routes
  * @returns the wrapped request.
  */
-function wrapRequest(req: BaseNextRequest): Request {
+function wrapRequest(req: BaseNextRequest): NextRequest {
   const { originalRequest } = req as NodeNextRequest
 
   const url = getRequestMeta(originalRequest, '__NEXT_INIT_URL')
@@ -123,7 +125,7 @@ function wrapRequest(req: BaseNextRequest): Request {
   })
 }
 
-function resolveHandlerError(err: any, bubbleResult?: boolean): Response {
+function resolveHandlerError(err: any): Response | false {
   if (isRedirectError(err)) {
     const redirect = getURLFromRedirectError(err)
     if (!redirect) {
@@ -139,60 +141,8 @@ function resolveHandlerError(err: any, bubbleResult?: boolean): Response {
     return handleNotFoundResponse()
   }
 
-  if (bubbleResult) {
-    throw err
-  }
-  // TODO: validate the correct handling behavior
-  Log.error(err)
-  return handleInternalServerErrorResponse()
-}
-
-export async function sendResponse(
-  req: BaseNextRequest,
-  res: BaseNextResponse,
-  response: Response
-): Promise<void> {
-  // Don't use in edge runtime
-  if (process.env.NEXT_RUNTIME !== 'edge') {
-    // Copy over the response status.
-    res.statusCode = response.status
-    res.statusMessage = response.statusText
-
-    // Copy over the response headers.
-    response.headers?.forEach((value, name) => {
-      // The append handling is special cased for `set-cookie`.
-      if (name.toLowerCase() === 'set-cookie') {
-        res.setHeader(name, value)
-      } else {
-        res.appendHeader(name, value)
-      }
-    })
-
-    /**
-     * The response can't be directly piped to the underlying response. The
-     * following is duplicated from the edge runtime handler.
-     *
-     * See packages/next/server/next-server.ts
-     */
-
-    const originalResponse = (res as NodeNextResponse).originalResponse
-
-    // A response body must not be sent for HEAD requests. See https://httpwg.org/specs/rfc9110.html#HEAD
-    if (response.body && req.method !== 'HEAD') {
-      const { consumeUint8ArrayReadableStream } =
-        require('next/dist/compiled/edge-runtime') as typeof import('next/dist/compiled/edge-runtime')
-      const iterator = consumeUint8ArrayReadableStream(response.body)
-      try {
-        for await (const chunk of iterator) {
-          originalResponse.write(chunk)
-        }
-      } finally {
-        originalResponse.end()
-      }
-    } else {
-      originalResponse.end()
-    }
-  }
+  // Return false to indicate that this is not a handled error.
+  return false
 }
 
 function cleanURL(urlString: string): string {
@@ -203,7 +153,10 @@ function cleanURL(urlString: string): string {
   return url.toString()
 }
 
-function proxyRequest(req: NextRequest, module: AppRouteModule): NextRequest {
+function proxyRequest(
+  req: NextRequest | Request,
+  module: AppRouteModule
+): Request {
   function handleNextUrlBailout(prop: string | symbol) {
     switch (prop) {
       case 'search':
@@ -263,30 +216,33 @@ function proxyRequest(req: NextRequest, module: AppRouteModule): NextRequest {
     }
   }
 
-  const wrappedNextUrl = new Proxy(req.nextUrl, {
-    get(target, prop) {
-      handleNextUrlBailout(prop)
+  const wrappedNextUrl =
+    'nextUrl' in req
+      ? new Proxy(req.nextUrl, {
+          get(target, prop) {
+            handleNextUrlBailout(prop)
 
-      if (
-        module.handlers.dynamic === 'force-static' &&
-        typeof prop === 'string'
-      ) {
-        const result = handleForceStatic(target.href, prop)
-        if (result !== undefined) return result
-      }
-      const value = (target as any)[prop]
+            if (
+              module.handlers.dynamic === 'force-static' &&
+              typeof prop === 'string'
+            ) {
+              const result = handleForceStatic(target.href, prop)
+              if (result !== undefined) return result
+            }
+            const value = (target as any)[prop]
 
-      if (typeof value === 'function') {
-        return value.bind(target)
-      }
-      return value
-    },
-    set(target, prop, value) {
-      handleNextUrlBailout(prop)
-      ;(target as any)[prop] = value
-      return true
-    },
-  })
+            if (typeof value === 'function') {
+              return value.bind(target)
+            }
+            return value
+          },
+          set(target, prop, value) {
+            handleNextUrlBailout(prop)
+            ;(target as any)[prop] = value
+            return true
+          },
+        })
+      : undefined
 
   const handleReqBailout = (prop: string | symbol) => {
     switch (prop) {
@@ -341,6 +297,12 @@ function proxyRequest(req: NextRequest, module: AppRouteModule): NextRequest {
 }
 
 export class AppRouteRouteHandler implements RouteHandler<AppRouteRouteMatch> {
+  /**
+   * The module for this handler. When set, this will be used instead of loading
+   * the module from the loader.
+   */
+  public module: AppRouteModule | undefined
+
   constructor(
     private readonly nextConfigOutput: NextConfig['output'] = undefined,
     private readonly requestAsyncLocalStorageWrapper: AsyncStorageWrapper<
@@ -427,16 +389,38 @@ export class AppRouteRouteHandler implements RouteHandler<AppRouteRouteMatch> {
     return handleMethodNotAllowedResponse
   }
 
+  /**
+   * Loads and patches the module for the given route definition unless it's
+   * already been loaded.
+   *
+   * @param definition the route definition to load the module for
+   * @returns the loaded and patched module
+   */
+  private async load(
+    definition: AppRouteRouteDefinition
+  ): Promise<AppRouteModule> {
+    // Modules that have been provided by the user are already patched.
+    if (this.module) return this.module
+
+    // Load the module using the module loader.
+    const module = await this.moduleLoader.load(definition.filename)
+
+    // Patch the module with the fetch polyfill.
+    patchFetch(module)
+
+    return module
+  }
+
   // TODO-APP: this is temporarily used for edge.
   public async execute(
     { params, definition }: AppRouteRouteMatch,
-    module: AppRouteModule,
     req: BaseNextRequest,
     res: BaseNextResponse,
-    context?: StaticGenerationContext,
-    // TODO-APP: this is temporarily used for edge.
-    request?: Request
+    context?: StaticGenerationContext
   ): Promise<Response> {
+    // Load the module.
+    const module = await this.load(definition)
+
     // Get the handler function for the given method.
     const handle = this.resolve(req.method, module)
 
@@ -522,8 +506,7 @@ export class AppRouteRouteHandler implements RouteHandler<AppRouteRouteMatch> {
             // Wrap the request so we can add additional functionality to cases
             // that might change it's output or affect the rendering.
             const wrappedRequest = proxyRequest(
-              // TODO: investigate why/how this cast is necessary/possible
-              (request ? request : wrapRequest(req)) as NextRequest,
+              req instanceof WebNextRequest ? req.request : wrapRequest(req),
               module
             )
 
@@ -579,38 +562,21 @@ export class AppRouteRouteHandler implements RouteHandler<AppRouteRouteMatch> {
     match: AppRouteRouteMatch,
     req: BaseNextRequest,
     res: BaseNextResponse,
-    context?: StaticGenerationContext,
-    bubbleResult?: boolean
-  ): Promise<any> {
+    context?: StaticGenerationContext
+  ): Promise<Response> {
     try {
-      // Load the module using the module loader.
-      const appRouteModule: AppRouteModule = await this.moduleLoader.load(
-        match.definition.filename
-      )
-      patchFetch(appRouteModule)
-
       // Execute the route to get the response.
-      const response = await this.execute(
-        match,
-        appRouteModule,
-        req,
-        res,
-        context
-      )
+      const response = await this.execute(match, req, res, context)
 
-      if (bubbleResult) {
-        return response
-      }
-      // Send the response back to the response.
-      await sendResponse(req, res, response)
+      // The response was handled, return it.
+      return response
     } catch (err) {
-      const response = resolveHandlerError(err, bubbleResult)
+      // Try to resolve the error to a response, else throw it again.
+      const response = resolveHandlerError(err)
+      if (!response) throw err
 
-      if (bubbleResult) {
-        return response
-      }
-      // Get the correct response based on the error.
-      await sendResponse(req, res, response)
+      // The response was resolved, return it.
+      return response
     }
   }
 }

--- a/packages/next/src/server/future/route-handlers/pages-api-route-handler.ts
+++ b/packages/next/src/server/future/route-handlers/pages-api-route-handler.ts
@@ -2,7 +2,7 @@ import { PagesAPIRouteMatch } from '../route-matches/pages-api-route-match'
 import { RouteHandler } from './route-handler'
 
 export class PagesAPIRouteHandler implements RouteHandler<PagesAPIRouteMatch> {
-  public async handle(): Promise<void> {
+  public async handle(): Promise<Response> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/next/src/server/future/route-handlers/pages-route-handler.ts
+++ b/packages/next/src/server/future/route-handlers/pages-route-handler.ts
@@ -2,7 +2,7 @@ import { PagesRouteMatch } from '../route-matches/pages-route-match'
 import { RouteHandler } from './route-handler'
 
 export class PagesRouteHandler implements RouteHandler<PagesRouteMatch> {
-  public async handle(): Promise<void> {
+  public async handle(): Promise<Response> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/next/src/server/future/route-handlers/route-handler.ts
+++ b/packages/next/src/server/future/route-handlers/route-handler.ts
@@ -6,7 +6,6 @@ export interface RouteHandler<M extends RouteMatch = RouteMatch> {
     match: M,
     req: BaseNextRequest,
     res: BaseNextResponse,
-    context?: any,
-    bubbleResult?: boolean
-  ): Promise<any>
+    context?: any
+  ): Promise<Response>
 }

--- a/packages/next/src/server/send-response.ts
+++ b/packages/next/src/server/send-response.ts
@@ -1,0 +1,59 @@
+import type { BaseNextRequest, BaseNextResponse } from './base-http'
+import type { NodeNextResponse } from './base-http/node'
+
+/**
+ * Sends the response on the underlying next response object.
+ *
+ * @param req the underlying request object
+ * @param res the underlying response object
+ * @param response the response to send
+ */
+export async function sendResponse(
+  req: BaseNextRequest,
+  res: BaseNextResponse,
+  response: Response
+): Promise<void> {
+  // Don't use in edge runtime
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    return
+  }
+
+  // Copy over the response status.
+  res.statusCode = response.status
+  res.statusMessage = response.statusText
+
+  // Copy over the response headers.
+  response.headers?.forEach((value, name) => {
+    // The append handling is special cased for `set-cookie`.
+    if (name.toLowerCase() === 'set-cookie') {
+      res.setHeader(name, value)
+    } else {
+      res.appendHeader(name, value)
+    }
+  })
+
+  /**
+   * The response can't be directly piped to the underlying response. The
+   * following is duplicated from the edge runtime handler.
+   *
+   * See packages/next/server/next-server.ts
+   */
+
+  const originalResponse = (res as NodeNextResponse).originalResponse
+
+  // A response body must not be sent for HEAD requests. See https://httpwg.org/specs/rfc9110.html#HEAD
+  if (response.body && req.method !== 'HEAD') {
+    const { consumeUint8ArrayReadableStream } =
+      require('next/dist/compiled/edge-runtime') as typeof import('next/dist/compiled/edge-runtime')
+    const iterator = consumeUint8ArrayReadableStream(response.body)
+    try {
+      for await (const chunk of iterator) {
+        originalResponse.write(chunk)
+      }
+    } finally {
+      originalResponse.end()
+    }
+  } else {
+    originalResponse.end()
+  }
+}

--- a/packages/next/src/server/send-response.ts
+++ b/packages/next/src/server/send-response.ts
@@ -14,46 +14,44 @@ export async function sendResponse(
   response: Response
 ): Promise<void> {
   // Don't use in edge runtime
-  if (process.env.NEXT_RUNTIME === 'edge') {
-    return
-  }
+  if (process.env.NEXT_RUNTIME !== 'edge') {
+    // Copy over the response status.
+    res.statusCode = response.status
+    res.statusMessage = response.statusText
 
-  // Copy over the response status.
-  res.statusCode = response.status
-  res.statusMessage = response.statusText
-
-  // Copy over the response headers.
-  response.headers?.forEach((value, name) => {
-    // The append handling is special cased for `set-cookie`.
-    if (name.toLowerCase() === 'set-cookie') {
-      res.setHeader(name, value)
-    } else {
-      res.appendHeader(name, value)
-    }
-  })
-
-  /**
-   * The response can't be directly piped to the underlying response. The
-   * following is duplicated from the edge runtime handler.
-   *
-   * See packages/next/server/next-server.ts
-   */
-
-  const originalResponse = (res as NodeNextResponse).originalResponse
-
-  // A response body must not be sent for HEAD requests. See https://httpwg.org/specs/rfc9110.html#HEAD
-  if (response.body && req.method !== 'HEAD') {
-    const { consumeUint8ArrayReadableStream } =
-      require('next/dist/compiled/edge-runtime') as typeof import('next/dist/compiled/edge-runtime')
-    const iterator = consumeUint8ArrayReadableStream(response.body)
-    try {
-      for await (const chunk of iterator) {
-        originalResponse.write(chunk)
+    // Copy over the response headers.
+    response.headers?.forEach((value, name) => {
+      // The append handling is special cased for `set-cookie`.
+      if (name.toLowerCase() === 'set-cookie') {
+        res.setHeader(name, value)
+      } else {
+        res.appendHeader(name, value)
       }
-    } finally {
+    })
+
+    /**
+     * The response can't be directly piped to the underlying response. The
+     * following is duplicated from the edge runtime handler.
+     *
+     * See packages/next/server/next-server.ts
+     */
+
+    const originalResponse = (res as NodeNextResponse).originalResponse
+
+    // A response body must not be sent for HEAD requests. See https://httpwg.org/specs/rfc9110.html#HEAD
+    if (response.body && req.method !== 'HEAD') {
+      const { consumeUint8ArrayReadableStream } =
+        require('next/dist/compiled/edge-runtime') as typeof import('next/dist/compiled/edge-runtime')
+      const iterator = consumeUint8ArrayReadableStream(response.body)
+      try {
+        for await (const chunk of iterator) {
+          originalResponse.write(chunk)
+        }
+      } finally {
+        originalResponse.end()
+      }
+    } else {
       originalResponse.end()
     }
-  } else {
-    originalResponse.end()
   }
 }


### PR DESCRIPTION
In preparation for improvements for the runtime support, this changes the handle signature to _always_ return a response object.
fix NEXT-679 ([link](https://linear.app/vercel/issue/NEXT-679))