### PR TITLE
Add searchParams to leaf cache key

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -177,7 +177,7 @@ async function createTreeCodeFromPath(
         if (resolvedPagePath) pages.push(resolvedPagePath)
 
         // Use '' for segment as it's the page. There can't be a segment called '' so this is the safest way to add it.
-        props[parallelKey] = `['', {}, {
+        props[parallelKey] = `['__PAGE__', {}, {
           page: [() => import(/* webpackMode: "eager" */ ${JSON.stringify(
             resolvedPagePath
           )}), ${JSON.stringify(resolvedPagePath)}],

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -152,7 +152,7 @@ function getSelectedLayoutSegmentPath(
   if (!node) return segmentPath
   const segment = node[0]
   const segmentValue = Array.isArray(segment) ? segment[1] : segment
-  if (!segmentValue) return segmentPath
+  if (!segmentValue || segmentValue === '__PAGE__') return segmentPath
 
   segmentPath.push(segmentValue)
 

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -110,14 +110,11 @@ export function navigateReducer(
 
       const applied = applyFlightData(state, cache, flightDataPath)
 
-      const hardNavigate =
-        // TODO-APP: Revisit searchParams support
-        search !== locationSearch ||
-        shouldHardNavigate(
-          // TODO-APP: remove ''
-          ['', ...flightSegmentPath],
-          state.tree
-        )
+      const hardNavigate = shouldHardNavigate(
+        // TODO-APP: remove ''
+        ['', ...flightSegmentPath],
+        state.tree
+      )
 
       if (hardNavigate) {
         cache.status = CacheStates.READY

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -41,13 +41,12 @@ export function navigateReducer(
   const {
     url,
     isExternalUrl,
-    locationSearch,
     navigateType,
     cache,
     mutable,
     forceOptimisticNavigation,
   } = action
-  const { pathname, search, hash } = url
+  const { pathname, hash } = url
   const href = createHrefFromUrl(url)
   const pendingPush = navigateType === 'push'
 

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -1,0 +1,43 @@
+import { LoaderTree } from '../lib/app-dir-module'
+import { FlightRouterState } from './types'
+import { GetDynamicParamFromSegment } from './app-render'
+import { stringify } from 'querystring'
+
+export function createFlightRouterStateFromLoaderTree(
+  [segment, parallelRoutes, { layout }]: LoaderTree,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  searchParams: any,
+  rootLayoutIncluded = false
+): FlightRouterState {
+  const dynamicParam = getDynamicParamFromSegment(segment)
+
+  const treeSegment = dynamicParam ? dynamicParam.treeSegment : segment
+  const isPageSegment = segment === '__PAGE__'
+  const stringifiedQuery = stringify(searchParams)
+
+  const segmentTree: FlightRouterState = [
+    treeSegment +
+      (isPageSegment && stringifiedQuery !== '' ? '?' + stringifiedQuery : ''),
+    {},
+  ]
+
+  if (!rootLayoutIncluded && typeof layout !== 'undefined') {
+    rootLayoutIncluded = true
+    segmentTree[4] = true
+  }
+
+  segmentTree[1] = Object.keys(parallelRoutes).reduce(
+    (existingValue, currentValue) => {
+      existingValue[currentValue] = createFlightRouterStateFromLoaderTree(
+        parallelRoutes[currentValue],
+        getDynamicParamFromSegment,
+        searchParams,
+        rootLayoutIncluded
+      )
+      return existingValue
+    },
+    {} as FlightRouterState[1]
+  )
+
+  return segmentTree
+}

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -1,7 +1,6 @@
 import { LoaderTree } from '../lib/app-dir-module'
 import { FlightRouterState, Segment } from './types'
 import { GetDynamicParamFromSegment } from './index'
-import { stringify } from 'querystring'
 
 // TODO-APP: Move __PAGE__ to a shared constant
 const PAGE_SEGMENT_KEY = '__PAGE__'
@@ -13,7 +12,7 @@ export function addSearchParamsIfPageSegment(
   const isPageSegment = segment === PAGE_SEGMENT_KEY
 
   if (isPageSegment) {
-    const stringifiedQuery = stringify(searchParams)
+    const stringifiedQuery = JSON.stringify(searchParams)
     return stringifiedQuery !== '' ? segment + '?' + stringifiedQuery : segment
   }
 

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -1,6 +1,6 @@
 import { LoaderTree } from '../lib/app-dir-module'
 import { FlightRouterState } from './types'
-import { GetDynamicParamFromSegment } from './app-render'
+import { GetDynamicParamFromSegment } from './index'
 import { stringify } from 'querystring'
 
 export function createFlightRouterStateFromLoaderTree(

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -13,7 +13,9 @@ export function addSearchParamsIfPageSegment(
 
   if (isPageSegment) {
     const stringifiedQuery = JSON.stringify(searchParams)
-    return stringifiedQuery !== '' ? segment + '?' + stringifiedQuery : segment
+    return stringifiedQuery !== '{}'
+      ? segment + '?' + stringifiedQuery
+      : segment
   }
 
   return segment

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -1,7 +1,24 @@
 import { LoaderTree } from '../lib/app-dir-module'
-import { FlightRouterState } from './types'
+import { FlightRouterState, Segment } from './types'
 import { GetDynamicParamFromSegment } from './index'
 import { stringify } from 'querystring'
+
+// TODO-APP: Move __PAGE__ to a shared constant
+const PAGE_SEGMENT_KEY = '__PAGE__'
+
+export function addSearchParamsIfPageSegment(
+  segment: Segment,
+  searchParams: any
+) {
+  const isPageSegment = segment === PAGE_SEGMENT_KEY
+
+  if (isPageSegment) {
+    const stringifiedQuery = stringify(searchParams)
+    return stringifiedQuery !== '' ? segment + '?' + stringifiedQuery : segment
+  }
+
+  return segment
+}
 
 export function createFlightRouterStateFromLoaderTree(
   [segment, parallelRoutes, { layout }]: LoaderTree,
@@ -10,14 +27,10 @@ export function createFlightRouterStateFromLoaderTree(
   rootLayoutIncluded = false
 ): FlightRouterState {
   const dynamicParam = getDynamicParamFromSegment(segment)
-
   const treeSegment = dynamicParam ? dynamicParam.treeSegment : segment
-  const isPageSegment = segment === '__PAGE__'
-  const stringifiedQuery = stringify(searchParams)
 
   const segmentTree: FlightRouterState = [
-    treeSegment +
-      (isPageSegment && stringifiedQuery !== '' ? '?' + stringifiedQuery : ''),
+    addSearchParamsIfPageSegment(treeSegment, searchParams),
     {},
   ]
 

--- a/packages/next/src/server/app-render/index.tsx
+++ b/packages/next/src/server/app-render/index.tsx
@@ -12,7 +12,6 @@ import type {
 import type { StaticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage'
 import type { RequestAsyncStorage } from '../../client/components/request-async-storage'
 import type { MetadataItems } from '../../lib/metadata/resolve-metadata'
-import { stringify } from 'querystring'
 // Import builtin react directly to avoid require cache conflicts
 import React from 'next/dist/compiled/react'
 import ReactDOMServer from 'next/dist/compiled/react-dom/server.browser'

--- a/packages/next/src/server/app-render/index.tsx
+++ b/packages/next/src/server/app-render/index.tsx
@@ -841,10 +841,7 @@ export async function renderToHTMLOrFlight(
         injectedFontPreloadTags: Set<string>
         rootLayoutIncluded: boolean
       }): Promise<FlightDataPath> => {
-        const [loaderTreeSegment, parallelRoutes, components] =
-          loaderTreeToFilter
-
-        const segment = addSearchParamsIfPageSegment(loaderTreeSegment, query)
+        const [segment, parallelRoutes, components] = loaderTreeToFilter
 
         const parallelRoutesKeys = Object.keys(parallelRoutes)
         const { layout } = components
@@ -870,9 +867,10 @@ export async function renderToHTMLOrFlight(
                 [segmentParam.param]: segmentParam.value,
               }
             : parentParams
-        const actualSegment: Segment = segmentParam
-          ? segmentParam.treeSegment
-          : segment
+        const actualSegment: Segment = addSearchParamsIfPageSegment(
+          segmentParam ? segmentParam.treeSegment : segment,
+          query
+        )
 
         /**
          * Decide if the current segment is where rendering has to start.

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -123,7 +123,7 @@ function getEntrypointsFromTree(
 
   const currentPath = [...parentPath, currentSegment]
 
-  if (!isFirst && currentSegment === '') {
+  if (!isFirst && currentSegment === '__PAGE__') {
     // TODO get rid of '' at the start of tree
     return [treePathToEntrypoint(currentPath.slice(1))]
   }

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -121,9 +121,11 @@ function getEntrypointsFromTree(
     ? convertDynamicParamTypeToSyntax(segment[2], segment[0])
     : segment
 
-  const currentPath = [...parentPath, currentSegment]
+  const isPageSegment = currentSegment.startsWith('__PAGE')
 
-  if (!isFirst && currentSegment === '__PAGE__') {
+  const currentPath = [...parentPath, isPageSegment ? '' : currentSegment]
+
+  if (!isFirst && isPageSegment) {
     // TODO get rid of '' at the start of tree
     return [treePathToEntrypoint(currentPath.slice(1))]
   }

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -121,7 +121,7 @@ function getEntrypointsFromTree(
     ? convertDynamicParamTypeToSyntax(segment[2], segment[0])
     : segment
 
-  const isPageSegment = currentSegment.startsWith('__PAGE')
+  const isPageSegment = currentSegment.startsWith('__PAGE__')
 
   const currentPath = [...parentPath, isPageSegment ? '' : currentSegment]
 

--- a/test/e2e/app-dir/app/app/navigation/searchparams/page.js
+++ b/test/e2e/app-dir/app/app/navigation/searchparams/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+export default function Page({ searchParams }) {
+  return (
+    <>
+      <h1 id="result">{JSON.stringify(searchParams)}</h1>
+      <div>
+        <Link href="/navigation/searchparams?a=a">To A</Link>
+      </div>
+      <div>
+        <Link href="/navigation/searchparams?b=b">To B</Link>
+      </div>
+      <div>
+        <Link href="/navigation/searchparams?a=a&b=b">To A&B</Link>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
### What?

Makes searchParams part of the cache key for dynamic rendering responses.

### Why?

Current the cache key only includes the pathname and not the searchParams. This causes issues in a few cases:
- Navigation to `/dashboard` then clicking a link to `/dashboard?sort=asc` works, but then when navigating back the cache node for `/dashboard?sort=asc` is used instead of the content for `/dashboard`.
- Navigation between different searchParams always had to be a hard navigation as reusing a cache node would result in the wrong result.

### How?

Changed the leaf node's name from `''` to `'__PAGE__'` so that it can be distinguished. Then used that `__PAGE__` marker to include the searchParams into the cache key for that leaf node in all places it's used.

Ideally the `__PAGE__` key becomes something that can't be addressed in the pathname, since it still has to be serializable I'm thinking a number would be best.

Given that the server just provides the cache key and the client only reasons about rendering the tree the current approach of stringifying  the searchParams and making that part of the cache key could be replaced with a hash of the stringified result instead.

fix NEXT-685 ([link](https://linear.app/vercel/issue/NEXT-685))
Fixes #45026
fix NEXT-688 ([link](https://linear.app/vercel/issue/NEXT-688))
Fixes #46503
fix NEXT-698 ([link](https://linear.app/vercel/issue/NEXT-698))
Fixes #46257