### PR TITLE
parallel routes: fix duplicate dev warning

### DIFF
--- a/packages/next/src/server/future/route-matchers/app-page-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/app-page-route-matcher.ts
@@ -3,8 +3,6 @@ import { AppPageRouteDefinition } from '../route-definitions/app-page-route-defi
 
 export class AppPageRouteMatcher extends RouteMatcher<AppPageRouteDefinition> {
   public get identity(): string {
-    return `${
-      this.definition.pathname
-    }?__nextParallelPaths=${this.definition.appPaths.join(',')}}`
+    return `${this.definition.pathname}?__nextParallelPath=${this.definition.page}}`
   }
 }

--- a/packages/next/src/server/future/route-matchers/app-page-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/app-page-route-matcher.ts
@@ -3,6 +3,6 @@ import { AppPageRouteDefinition } from '../route-definitions/app-page-route-defi
 
 export class AppPageRouteMatcher extends RouteMatcher<AppPageRouteDefinition> {
   public get identity(): string {
-    return `${this.definition.pathname}?__nextParallelPath=${this.definition.page}}`
+    return `${this.definition.pathname}?__nextPage=${this.definition.page}}`
   }
 }


### PR DESCRIPTION
- there's a warning that happens currently when compiling parallel routes in dev because they all resolve to the same pathname and their identity function is all the same
- I'm repurposing their identity fn to include the actual segment it's referring to, instead of all of them

the `__next_prallelPaths` string doesn't seem to be used otherwise so I think it's alright to rename


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- there's a warning that happens currently when compiling parallel routes in dev because they all resolve to the same pathname
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-831
Fixes #

-->

fix NEXT-831 ([link](https://linear.app/vercel/issue/NEXT-831))