### PR TITLE
parallel routes: fix nested routes

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -186,7 +186,6 @@ async function createTreeCodeFromPath(
         continue
       }
 
-      const parallelSegmentPath = segmentPath + '/' + parallelSegment
       const { treeCode: subtreeCode } = await createSubtreePropsFromSegmentPath(
         [
           ...segments,
@@ -194,6 +193,12 @@ async function createTreeCodeFromPath(
           Array.isArray(parallelSegment) ? parallelSegment[0] : parallelSegment,
         ]
       )
+
+      const parallelSegmentPath =
+        segmentPath +
+        '/' +
+        (parallelKey === 'children' ? '' : `@${parallelKey}/`) +
+        (Array.isArray(parallelSegment) ? parallelSegment[0] : parallelSegment)
 
       // `page` is not included here as it's added above.
       const filePaths = await Promise.all(

--- a/packages/next/src/server/future/route-matchers/app-page-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/app-page-route-matcher.ts
@@ -3,6 +3,6 @@ import { AppPageRouteDefinition } from '../route-definitions/app-page-route-defi
 
 export class AppPageRouteMatcher extends RouteMatcher<AppPageRouteDefinition> {
   public get identity(): string {
-    return `${this.definition.pathname}?__nextPage=${this.definition.page}}`
+    return `${this.definition.pathname}?__nextParallelPath=${this.definition.page}}`
   }
 }

--- a/packages/next/src/server/future/route-matchers/app-page-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/app-page-route-matcher.ts
@@ -3,6 +3,6 @@ import { AppPageRouteDefinition } from '../route-definitions/app-page-route-defi
 
 export class AppPageRouteMatcher extends RouteMatcher<AppPageRouteDefinition> {
   public get identity(): string {
-    return `${this.definition.pathname}?__nextParallelPath=${this.definition.page}}`
+    return `${this.definition.pathname}?__nextPage=${this.definition.page}}`
   }
 }


### PR DESCRIPTION
### What?

There was a bug with supporting nested routes in the parallel routes with named slots that made the request hang

### Why?

The request was hanging suspended on the router because the `next-app-loader` was not finding the layout component and thus, it was falling back to a component that returned null, tripping a bit of code in the app router that suspended.

### How?

The fix was to fix the next-app-loader loader tree generation to account for parallel routes

Closes NEXT-
Fixes #


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?


### Why?

### How?

Closes NEXT-
Fixes #

-->

fix NEXT-854 ([link](https://linear.app/vercel/issue/NEXT-854))