### PR TITLE
chore: add checkout step to issue labeler action

### DIFF
--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -13,6 +13,7 @@ jobs:
     name: Triage
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
### What?

Fixes the Issue Labeler action, because it is currently failing:

https://github.com/vercel/next.js/actions/runs/4477855927/jobs/7869905336

This works now, verified on my fork: https://github.com/balazsorban44/next.js/actions/runs/4479173427, https://github.com/balazsorban44/next.js/issues/19

### Why?

Local actions need to check out the repo to be able to run. See this other action:

https://github.com/vercel/next.js/blob/ed539c5dca7bd4d1c9cc9cd99c4b3d947e54c88e/.github/workflows/issue_validator.yml#L10

### How?

Adding `actions/checkout` to Issue Labeler workflow


Related: #47206