### PR TITLE
Ensure all server entry exports are functions (#47364)

### DIFF
--- a/packages/next-swc/crates/core/tests/errors/server-actions/1/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/1/output.js
@@ -1,4 +1,8 @@
 /* __next_internal_action_entry_do_not_use__ foo */ export function foo() {}
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    foo
+]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
 foo.$$bound = [];

--- a/packages/next-swc/crates/core/tests/errors/server-actions/2/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/2/output.js
@@ -1,5 +1,9 @@
 /* __next_internal_action_entry_do_not_use__ bar */ 'use strict';
 export function bar() {}
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    bar
+]);
 bar.$$typeof = Symbol.for("react.server.reference");
 bar.$$id = "ac840dcaf5e8197cb02b7f3a43c119b7a770b272";
 bar.$$bound = [];

--- a/packages/next-swc/crates/core/tests/errors/server-actions/3/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/3/output.js
@@ -1,4 +1,8 @@
 /* __next_internal_action_entry_do_not_use__ x */ export const x = 1;
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    x
+]);
 x.$$typeof = Symbol.for("react.server.reference");
 x.$$id = "b78c261f135a7a852508c2920bd7228020ff4bd7";
 x.$$bound = [];

--- a/packages/next-swc/crates/core/tests/errors/server-actions/4/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/4/output.js
@@ -3,3 +3,5 @@
     return null;
 }
 }
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([]);

--- a/packages/next-swc/crates/core/tests/errors/server-actions/5/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/5/output.js
@@ -1,1 +1,3 @@
 /* __next_internal_action_entry_do_not_use__  */ export * from 'foo';
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([]);

--- a/packages/next-swc/crates/core/tests/errors/server-actions/6/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/6/output.js
@@ -1,1 +1,3 @@
 /* __next_internal_action_entry_do_not_use__  */ export default (()=>{});
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([]);

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/client/1/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/client/1/output.js
@@ -5,6 +5,11 @@
 export default async function $$ACTION_0(...args) {
     return __build_action__($$ACTION_0, args);
 };
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    myAction,
+    $$ACTION_0
+]);
 myAction.$$typeof = Symbol.for("react.server.reference");
 myAction.$$id = "e10665baac148856374b2789aceb970f66fec33e";
 myAction.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/10/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/10/output.js
@@ -1,4 +1,8 @@
 /* __next_internal_action_entry_do_not_use__ default */ export default async function foo() {}
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    foo
+]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
 foo.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/11/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/11/output.js
@@ -1,4 +1,8 @@
 /* __next_internal_action_entry_do_not_use__ default */ export default async function $$ACTION_0() {}
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    $$ACTION_0
+]);
 $$ACTION_0.$$typeof = Symbol.for("react.server.reference");
 $$ACTION_0.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
 $$ACTION_0.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/12/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/12/output.js
@@ -1,5 +1,9 @@
 /* __next_internal_action_entry_do_not_use__ default */ async function foo() {}
 export default foo;
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    foo
+]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
 foo.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/13/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/13/output.js
@@ -2,6 +2,11 @@
 export default foo;
 const bar = async function() {};
 export { bar };
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    foo,
+    bar
+]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
 foo.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/14/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/14/output.js
@@ -1,6 +1,10 @@
 /* __next_internal_action_entry_do_not_use__ foo */ export async function foo() {
   async function bar() {}
 }
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    foo
+]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
 foo.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/15/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/15/output.js
@@ -2,6 +2,10 @@
   console.log(a, b);
 };
 var $$ACTION_0;
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    $$ACTION_0
+]);
 $$ACTION_0.$$typeof = Symbol.for("react.server.reference");
 $$ACTION_0.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
 $$ACTION_0.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/17/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/17/output.js
@@ -1,6 +1,11 @@
 /* __next_internal_action_entry_do_not_use__ foo,bar */ export const foo = async ()=>{};
 const bar = async ()=>{};
 export { bar };
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    foo,
+    bar
+]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
 foo.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/20/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/20/input.js
@@ -1,0 +1,4 @@
+'use server'
+
+const [foo] = [null]
+export default foo

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/20/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/20/output.js
@@ -1,12 +1,12 @@
-// app/send.ts
-/* __next_internal_action_entry_do_not_use__ foo */ export async function foo(...args) {
-  return __build_action__(foo, args);
-}
+/* __next_internal_action_entry_do_not_use__ default */ const [foo] = [
+  null
+];
+export default foo;
 import ensureServerEntryExports from "private-next-rsc-action-proxy";
 ensureServerEntryExports([
     foo
 ]);
 foo.$$typeof = Symbol.for("react.server.reference");
-foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
+foo.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
 foo.$$bound = [];
 foo.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/3/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/3/output.js
@@ -2,6 +2,10 @@
 /* __next_internal_action_entry_do_not_use__ myAction */ export async function myAction(a, b, c) {
     console.log('a');
 }
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    myAction
+]);
 myAction.$$typeof = Symbol.for("react.server.reference");
 myAction.$$id = "e10665baac148856374b2789aceb970f66fec33e";
 myAction.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/4/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/4/output.js
@@ -5,6 +5,12 @@ function d() {}
 function Foo() {
     async function e() {}
 }
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    a,
+    b,
+    c
+]);
 a.$$typeof = Symbol.for("react.server.reference");
 a.$$id = "6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d";
 a.$$bound = [];

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/9/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/9/output.js
@@ -5,6 +5,12 @@ async function bar() {}
 export { bar as baz };
 async function qux() {}
 export { qux as default };
+import ensureServerEntryExports from "private-next-rsc-action-proxy";
+ensureServerEntryExports([
+    foo,
+    bar,
+    qux
+]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
 foo.$$bound = [];

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -12,6 +12,7 @@ import {
   APP_DIR_ALIAS,
   WEBPACK_LAYERS,
   RSC_MOD_REF_PROXY_ALIAS,
+  RSC_ACTION_PROXY_ALIAS,
 } from '../lib/constants'
 import { fileExists } from '../lib/file-exists'
 import { CustomRoutes } from '../lib/load-custom-routes.js'
@@ -1053,6 +1054,9 @@ export default async function getBaseWebpackConfig(
       [RSC_MOD_REF_PROXY_ALIAS]:
         'next/dist/build/webpack/loaders/next-flight-loader/module-proxy',
 
+      [RSC_ACTION_PROXY_ALIAS]:
+        'next/dist/build/webpack/loaders/next-flight-loader/action-proxy',
+
       ...(isClient || isEdgeServer
         ? {
             [clientResolveRewrites]: hasRewrites
@@ -1237,7 +1241,7 @@ export default async function getBaseWebpackConfig(
       }
 
       const notExternalModules =
-        /^(?:private-next-pages\/|next\/(?:dist\/pages\/|(?:app|document|link|image|legacy\/image|constants|dynamic|script|navigation|headers)$)|string-hash|private-next-rsc-mod-ref-proxy$)/
+        /^(?:private-next-pages\/|next\/(?:dist\/pages\/|(?:app|document|link|image|legacy\/image|constants|dynamic|script|navigation|headers)$)|string-hash|private-next-rsc-mod-ref-proxy|private-next-rsc-action-proxy$)/
       if (notExternalModules.test(request)) {
         return
       }

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
@@ -1,0 +1,10 @@
+export default function ensureServerEntryExports(actions: any[]) {
+  for (let i = 0; i < actions.length; i++) {
+    const action = actions[i]
+    if (typeof action !== 'function') {
+      throw new Error(
+        `A "use server" file can only export async functions, found ${typeof action}.`
+      )
+    }
+  }
+}

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -18,6 +18,7 @@ export const DOT_NEXT_ALIAS = 'private-dot-next'
 export const ROOT_DIR_ALIAS = 'private-next-root-dir'
 export const APP_DIR_ALIAS = 'private-next-app-dir'
 export const RSC_MOD_REF_PROXY_ALIAS = 'private-next-rsc-mod-ref-proxy'
+export const RSC_ACTION_PROXY_ALIAS = 'private-next-rsc-action-proxy'
 
 export const PUBLIC_DIR_MIDDLEWARE_CONFLICT = `You can not have a '_next' folder inside of your public folder. This conflicts with the internal '/_next' route. https://nextjs.org/docs/messages/public-next-folder-conflict`
 


### PR DESCRIPTION
When using a "use server" module, only exporting async functions is permitted. However, since we cannot perform static analysis on all exported value types (e.g., `export const foo = condition ? A : B`), we have added a runtime ensure function to validate that these are indeed valid functions.

By implementing this, we can prevent any strange errors like "Can't access $$typeof of undefined or null" that may arise when exporting `undefined` or `null` from a server entry. Moreover, this measure helps avoid any potential mistakes that may occur.

fix NEXT-865 ([link](https://linear.app/vercel/issue/NEXT-865))