### PR TITLE
Fix: only apply metadata dynamic image routes convention for app dir

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -111,7 +111,8 @@ export function createPagesMapping({
         )
       )
 
-      const route = normalizeMetadataRoute(pageKey)
+      const route =
+        pagesType === 'app' ? normalizeMetadataRoute(pageKey) : pageKey
       result[route] = normalizedPath
       return result
     },

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -492,9 +492,10 @@ export default class DevServer extends Server {
           devPageFiles.add(fileName)
 
           const rootFile = absolutePathToPage(fileName, {
-            pagesDir: this.dir,
+            dir: this.dir,
             extensions: this.nextConfig.pageExtensions,
             keepIndex: false,
+            pagesType: 'root',
           })
 
           const staticInfo = await getPageStaticInfo({
@@ -531,9 +532,10 @@ export default class DevServer extends Server {
           }
 
           let pageName = absolutePathToPage(fileName, {
-            pagesDir: isAppPath ? this.appDir! : this.pagesDir!,
+            dir: isAppPath ? this.appDir! : this.pagesDir!,
             extensions: this.nextConfig.pageExtensions,
             keepIndex: isAppPath,
+            pagesType: isAppPath ? 'app' : 'pages',
           })
 
           if (

--- a/packages/next/src/server/future/normalizers/absolute-filename-normalizer.test.ts
+++ b/packages/next/src/server/future/normalizers/absolute-filename-normalizer.test.ts
@@ -20,12 +20,11 @@ describe('AbsoluteFilenameNormalizer', () => {
   ])(
     "normalizes '$pathname' to '$expected'",
     ({ pathname, expected, name }) => {
-      const normalizer = new AbsoluteFilenameNormalizer(`<root>/${name}`, [
-        'ts',
-        'tsx',
-        'js',
-        'jsx',
-      ])
+      const normalizer = new AbsoluteFilenameNormalizer(
+        `<root>/${name}`,
+        ['ts', 'tsx', 'js', 'jsx'],
+        name as 'app' | 'pages' | 'root'
+      )
 
       expect(normalizer.normalize(pathname)).toEqual(expected)
     }

--- a/packages/next/src/server/future/normalizers/absolute-filename-normalizer.ts
+++ b/packages/next/src/server/future/normalizers/absolute-filename-normalizer.ts
@@ -14,14 +14,16 @@ export class AbsoluteFilenameNormalizer implements Normalizer {
    */
   constructor(
     private readonly dir: string,
-    private readonly extensions: ReadonlyArray<string>
+    private readonly extensions: ReadonlyArray<string>,
+    private readonly pagesType: 'pages' | 'app' | 'root'
   ) {}
 
   public normalize(pathname: string): string {
     return absolutePathToPage(pathname, {
       extensions: this.extensions,
       keepIndex: false,
-      pagesDir: this.dir,
+      dir: this.dir,
+      pagesType: this.pagesType,
     })
   }
 }

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-app-page-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-app-page-route-matcher-provider.ts
@@ -28,7 +28,11 @@ export class DevAppPageRouteMatcherProvider extends FileCacheRouteMatcherProvide
     // directory.
     this.expression = new RegExp(`[/\\\\]page\\.(?:${extensions.join('|')})$`)
 
-    const pageNormalizer = new AbsoluteFilenameNormalizer(appDir, extensions)
+    const pageNormalizer = new AbsoluteFilenameNormalizer(
+      appDir,
+      extensions,
+      'app'
+    )
 
     this.normalizers = {
       page: pageNormalizer,

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
@@ -24,7 +24,11 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
   ) {
     super(appDir, reader)
 
-    const pageNormalizer = new AbsoluteFilenameNormalizer(appDir, extensions)
+    const pageNormalizer = new AbsoluteFilenameNormalizer(
+      appDir,
+      extensions,
+      'app'
+    )
 
     this.normalizers = {
       page: pageNormalizer,

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.ts
@@ -34,7 +34,11 @@ export class DevPagesAPIRouteMatcherProvider extends FileCacheRouteMatcherProvid
     // pages directory.
     this.expression = new RegExp(`\\.(?:${extensions.join('|')})$`)
 
-    const pageNormalizer = new AbsoluteFilenameNormalizer(pagesDir, extensions)
+    const pageNormalizer = new AbsoluteFilenameNormalizer(
+      pagesDir,
+      extensions,
+      'pages'
+    )
 
     const bundlePathNormalizer = new Normalizers([
       pageNormalizer,

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-pages-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-pages-route-matcher-provider.ts
@@ -34,7 +34,11 @@ export class DevPagesRouteMatcherProvider extends FileCacheRouteMatcherProvider<
     // pages directory.
     this.expression = new RegExp(`\\.(?:${extensions.join('|')})$`)
 
-    const pageNormalizer = new AbsoluteFilenameNormalizer(pagesDir, extensions)
+    const pageNormalizer = new AbsoluteFilenameNormalizer(
+      pagesDir,
+      extensions,
+      'pages'
+    )
 
     this.normalizers = {
       page: pageNormalizer,

--- a/packages/next/src/shared/lib/page-path/absolute-path-to-page.ts
+++ b/packages/next/src/shared/lib/page-path/absolute-path-to-page.ts
@@ -14,26 +14,27 @@ import { normalizeMetadataRoute } from '../../../lib/metadata/get-metadata-route
  * - `/Users/rick/my-project/app/sitemap.js` -> `/sitemap/route`
  *
  * @param filepath Absolute path to the page.
- * @param opts.pagesDir Absolute path to the pages folder.
+ * @param opts.dir Absolute path to the pages/app folder.
  * @param opts.extensions Extensions allowed for the page.
  * @param opts.keepIndex When true the trailing `index` kept in the path.
+ * @param opts.pagesType Whether the page is in the pages or app directory.
  */
 export function absolutePathToPage(
   pagePath: string,
   options: {
     extensions: string[] | readonly string[]
     keepIndex: boolean
-    pagesDir: string
+    dir: string
+    pagesType: 'pages' | 'app' | 'root'
   }
 ) {
+  const isAppDir = options.pagesType === 'app'
   const page = removePagePathTail(
-    normalizePathSep(
-      ensureLeadingSlash(path.relative(options.pagesDir, pagePath))
-    ),
+    normalizePathSep(ensureLeadingSlash(path.relative(options.dir, pagePath))),
     {
       extensions: options.extensions,
       keepIndex: options.keepIndex,
     }
   )
-  return normalizeMetadataRoute(page)
+  return isAppDir ? normalizeMetadataRoute(page) : page
 }

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -756,5 +756,12 @@ createNextDescribe(
         }
       })
     })
+
+    it('should not effect metadata images convention like files under pages directory', async () => {
+      const iconHtml = await next.render('/blog/icon')
+      const ogHtml = await next.render('/blog/opengraph-image')
+      expect(iconHtml).toContain('pages-icon-page')
+      expect(ogHtml).toContain('pages-opengraph-image-page')
+    })
   }
 )

--- a/test/e2e/app-dir/metadata/pages/blog/icon.tsx
+++ b/test/e2e/app-dir/metadata/pages/blog/icon.tsx
@@ -1,0 +1,3 @@
+export default function page() {
+  return <>pages-icon-page</>
+}

--- a/test/e2e/app-dir/metadata/pages/blog/opengraph-image.tsx
+++ b/test/e2e/app-dir/metadata/pages/blog/opengraph-image.tsx
@@ -1,0 +1,3 @@
+export default function page() {
+  return <>pages-opengraph-image-page</>
+}

--- a/test/e2e/app-dir/metadata/tsconfig.json
+++ b/test/e2e/app-dir/metadata/tsconfig.json
@@ -17,7 +17,8 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "strictNullChecks": true
   },
   "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
We shouldn't detect icon/og/etc. metadata image convention as image dynamic routes under `pages/` dir, they should be only apply in `app/` dir. This PR changed the normalization rule that we only apply them when page is from `app/`. So when you're using `icon.js` under `pages/` it won't get effected.