### PR TITLE
fix: add pretty error for `exportPathMap` with `app` dir

### DIFF
--- a/docs/advanced-features/static-html-export.md
+++ b/docs/advanced-features/static-html-export.md
@@ -46,7 +46,7 @@ Running `npm run build` will generate an `out` directory.
 
 For more advanced scenarios, you can define a parameter called [`exportPathMap`](/docs/api-reference/next.config.js/exportPathMap.md) in your [`next.config.js`](/docs/api-reference/next.config.js/introduction.md) file to configure exactly which pages will be generated.
 
-> **Warning**: Using `exportPathMap` for defining routes with any `getStaticPaths` powered page is now ignored and gets overridden. We recommend not to use them together.
+> **Warning**: Using `exportPathMap` is deprecated and is overridden by `getStaticPaths` inside `pages`. We recommend not to use them together.
 
 ## Supported Features
 

--- a/docs/api-reference/next.config.js/exportPathMap.md
+++ b/docs/api-reference/next.config.js/exportPathMap.md
@@ -4,7 +4,7 @@ description: Customize the pages that will be exported as HTML files when using 
 
 # exportPathMap
 
-> This feature is exclusive to `next export`. Please refer to [Static HTML export](/docs/advanced-features/static-html-export.md) if you want to learn more about it.
+> This feature is exclusive to `next export` and currently **deprecated** in favor of `getStaticPaths` with `pages` or `generateStaticParams` with `app`.
 
 <details>
   <summary><b>Examples</b></summary>
@@ -79,7 +79,7 @@ module.exports = {
 next export -o outdir
 ```
 
-> **Warning**: Using `exportPathMap` for defining routes with any `getStaticPaths` powered page is now ignored and gets overridden. We recommend not to use them together.
+> **Warning**: Using `exportPathMap` is deprecated and is overridden by `getStaticPaths` inside `pages`. We recommend not to use them together.
 
 ## Related
 

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -143,7 +143,7 @@ const createProgress = (total: number, label: string) => {
   }
 }
 
-interface ExportOptions {
+export interface ExportOptions {
   outdir: string
   silent?: boolean
   threads?: number
@@ -369,11 +369,6 @@ export default async function exportApp(
 
     // Get the exportPathMap from the config file
     if (typeof nextConfig.exportPathMap !== 'function') {
-      if (!options.silent) {
-        Log.info(
-          `No "exportPathMap" found in "${nextConfig.configFile}". Generating map from "./pages"`
-        )
-      }
       nextConfig.exportPathMap = async (defaultMap) => {
         return defaultMap
       }

--- a/test/integration/app-dir-export/test/index.test.ts
+++ b/test/integration/app-dir-export/test/index.test.ts
@@ -235,4 +235,25 @@ describe('app dir with output export', () => {
       'export const dynamic = "force-dynamic" on page "/api/json" cannot be used with "output: export".'
     )
   })
+  it('should throw when exportPathMap configured', async () => {
+    nextConfig.replace(
+      'trailingSlash: true,',
+      `trailingSlash: true,
+       exportPathMap: async function (map) {
+        return map
+      },`
+    )
+    await fs.remove(distDir)
+    await fs.remove(exportDir)
+    let result = { code: 0, stderr: '' }
+    try {
+      result = await nextBuild(appDir, [], { stderr: true })
+    } finally {
+      nextConfig.restore()
+    }
+    expect(result.code).toBe(1)
+    expect(result.stderr).toContain(
+      'The "exportPathMap" configuration cannot be used with the "app" directory. Please use generateStaticParams() instead.'
+    )
+  })
 })


### PR DESCRIPTION
The `exportPathMap` feature has been unofficially deprecated for a long time since introducing `getStaticPaths()`.

For the `app` dir, the same can be accomplished with `generateStaticParams()`.

This PR adds a pretty error when using `exportPathMap` with `app` and updates documentation to reflect the current status.


fix NEXT-836 ([link](https://linear.app/vercel/issue/NEXT-836))