### PR TITLE
Don't set git config `features.manyFiles` on post install

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "next-no-sourcemaps": "cross-env NEXT_TELEMETRY_DISABLED=1 node --trace-deprecation packages/next/dist/bin/next",
     "clean-trace-jaeger": "rm -rf test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",
     "debug": "cross-env NEXT_TELEMETRY_DISABLED=1 node --inspect packages/next/dist/bin/next",
-    "postinstall": "git config feature.manyFiles true && node scripts/install-native.mjs",
+    "postinstall": "node scripts/install-native.mjs",
     "version": "npx pnpm@7.24.3 install && IS_PUBLISH=yes ./scripts/check-pre-compiled.sh && git add .",
     "prepare": "husky install",
     "sync-react": "node ./scripts/sync-react.js"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "next-no-sourcemaps": "cross-env NEXT_TELEMETRY_DISABLED=1 node --trace-deprecation packages/next/dist/bin/next",
     "clean-trace-jaeger": "rm -rf test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",
     "debug": "cross-env NEXT_TELEMETRY_DISABLED=1 node --inspect packages/next/dist/bin/next",
-    "postinstall": "node scripts/install-native.mjs",
+    "postinstall": "git config index.skipHash false && node scripts/install-native.mjs",
     "version": "npx pnpm@7.24.3 install && IS_PUBLISH=yes ./scripts/check-pre-compiled.sh && git add .",
     "prepare": "husky install",
     "sync-react": "node ./scripts/sync-react.js"


### PR DESCRIPTION
This reverts #31408, as it also sets the git config value `index.skipHash` which breaks cargo at the moment: https://github.com/rust-lang/cargo/issues/11857

Contributors docs have been updated to recommend a shallow clone in #44158, which should alleviate some of the issues that manyFiles addresses.
