### PR TITLE
Simplify moduleProxy alias

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -11,7 +11,6 @@ import {
   ROOT_DIR_ALIAS,
   APP_DIR_ALIAS,
   WEBPACK_LAYERS,
-  RSC_MOD_REF_PROXY_ALIAS,
   RSC_ACTION_PROXY_ALIAS,
 } from '../lib/constants'
 import { fileExists } from '../lib/file-exists'
@@ -1051,9 +1050,6 @@ export default async function getBaseWebpackConfig(
       ...(isClient || isEdgeServer ? getOptimizedAliases() : {}),
       ...getReactProfilingInProduction(),
 
-      [RSC_MOD_REF_PROXY_ALIAS]:
-        'next/dist/build/webpack/loaders/next-flight-loader/module-proxy',
-
       [RSC_ACTION_PROXY_ALIAS]:
         'next/dist/build/webpack/loaders/next-flight-loader/action-proxy',
 
@@ -1241,7 +1237,7 @@ export default async function getBaseWebpackConfig(
       }
 
       const notExternalModules =
-        /^(?:private-next-pages\/|next\/(?:dist\/pages\/|(?:app|document|link|image|legacy\/image|constants|dynamic|script|navigation|headers)$)|string-hash|private-next-rsc-mod-ref-proxy|private-next-rsc-action-proxy$)/
+        /^(?:private-next-pages\/|next\/(?:dist\/pages\/|(?:app|document|link|image|legacy\/image|constants|dynamic|script|navigation|headers)$)|string-hash|private-next-rsc-action-proxy$)/
       if (notExternalModules.test(request)) {
         return
       }

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -1,9 +1,12 @@
+import { RSC_MOD_REF_PROXY_ALIAS } from '../../../../lib/constants'
 import { RSC_MODULE_TYPES } from '../../../../shared/lib/constants'
 import { warnOnce } from '../../../../shared/lib/utils/warn-once'
 import { getRSCModuleInformation } from '../../../analysis/get-page-static-info'
 import { getModuleBuildInfo } from '../get-module-build-info'
 
 const noopHeadPath = require.resolve('next/dist/client/components/noop-head')
+const moduleProxy =
+  'next/dist/build/webpack/loaders/next-flight-loader/module-proxy'
 
 export default async function transformSource(
   this: any,
@@ -47,7 +50,7 @@ export default async function transformSource(
     }
 
     let esmSource = `
-    import { createProxy } from "private-next-rsc-mod-ref-proxy"
+    import { createProxy } from "${moduleProxy}"
     const proxy = createProxy(${proxyFilepath})
     `
     let cnt = 0
@@ -70,5 +73,9 @@ export default async function transformSource(
     }
   }
 
-  return callback(null, source, sourceMap)
+  return callback(
+    null,
+    source.replace(RSC_MOD_REF_PROXY_ALIAS, moduleProxy),
+    sourceMap
+  )
 }


### PR DESCRIPTION
Currently, the client entry loader creates the code of `import { createProxy } from "private-next-rsc-mod-ref-proxy"` and then we alias it to the target file. This process is redundant and risky. If the loader-created code is somehow marked as external (due to the effect of both our complex external handling and `transpilePackages`), that alias can't be correctly resolved.

Hence this PR simplifies it by creating the target import path directly from the loader.

**Note that in the future we should change it directly on the SWC side, and convert this loader to Rust.**