### PR TITLE
prettier-plugin-tailwindcss addition to `create-next-app` template with tailwindcss configured

### DIFF
--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -56,7 +56,7 @@ const program = new Commander.Command(packageJson.name)
     '--tailwind',
     `
 
-  Initialize with Tailwind CSS config. (default)
+  Initialize with Tailwind CSS and prettier plugin for tailwindcss config. (default)
 `
   )
   .option(
@@ -302,7 +302,7 @@ async function run(): Promise<void> {
       if (ciInfo.isCI) {
         program.tailwind = false
       } else {
-        const tw = chalk.hex('#007acc')('Tailwind CSS')
+        const tw = chalk.hex('#007acc')('Tailwind CSS with prettier plugin')
         const { tailwind } = await prompts({
           onState: onPromptState,
           type: 'toggle',

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -215,7 +215,7 @@ export const installTemplate = async ({
    * Add Tailwind CSS dependencies.
    */
   if (tailwind) {
-    dependencies.push('tailwindcss', 'postcss', 'autoprefixer')
+    dependencies.push('tailwindcss', 'postcss', 'autoprefixer','prettier','prettier-plugin-tailwindcss')
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
The idea is to add prettier plugin as dependency when creating the new project using `npx create-next-app` with tailwind.
1. Ask the user if they want to use tailwind with prettier plugin.
2. Add the prettier-plugin for tailwind as one of the dependency in `package.json` file.