### PR TITLE
chore: tweak PR labeler pattern

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -3,14 +3,6 @@
     "area: create-next-app": ["packages/create-next-app/**"],
     "area: documentation": ["docs/**", "errors/**"],
     "area: examples": ["examples/**"],
-    "area: next/image": [
-      "packages/**/*image*",
-      "packages/**/*image*/**",
-      "packages/next/src/client/use-intersection.tsx",
-      "packages/next/src/server/lib/squoosh/",
-      "packages/next/src/server/serve-static.ts",
-      "test/**/*next-image*"
-    ],
     "area: Font Optimization": ["**/*font*"],
     "area: tests": ["test/**", "bench/**"],
     "created-by: Chrome Aurora": [

--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -4,8 +4,8 @@
     "area: documentation": ["docs/**", "errors/**"],
     "area: examples": ["examples/**"],
     "area: next/image": [
-      "packages/*image*",
-      "packages/*image*/**",
+      "packages/**/*image*",
+      "packages/**/*image*/**",
       "packages/next/src/client/use-intersection.tsx",
       "packages/next/src/server/lib/squoosh/",
       "packages/next/src/server/serve-static.ts",

--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -4,11 +4,12 @@
     "area: documentation": ["docs/**", "errors/**"],
     "area: examples": ["examples/**"],
     "area: next/image": [
-      "**/*image*",
-      "**/*image*/**",
+      "packages/*image*",
+      "packages/*image*/**",
       "packages/next/src/client/use-intersection.tsx",
       "packages/next/src/server/lib/squoosh/",
-      "packages/next/src/server/serve-static.ts"
+      "packages/next/src/server/serve-static.ts",
+      "test/**/*next-image*"
     ],
     "area: Font Optimization": ["**/*font*"],
     "area: tests": ["test/**", "bench/**"],


### PR DESCRIPTION
### What?

Scope down what is being matched when labeling PRs

### Why?

In #47367 the labeler added `area: next/image` because a test file name contained `image`

### How?

Removing Next Image component labeling as it provided no value for us.

Related: [Slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1679421353696549), #46675
