### PR TITLE
Fix hot-reloading of tailwind css on Firefox

### DIFF
--- a/packages/next/src/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/index.ts
@@ -546,6 +546,18 @@ export const css = curry(async function css(
           chunkFilename: ctx.isProduction
             ? 'static/css/[contenthash].css'
             : 'static/css/[name].css',
+          insert: function (link) {
+            var found = false
+            for (var i = 0; i < document.head.children.length; i++) {
+              var current = document.head.children.item(i)
+              if (current.href === link.href) {
+                found = true
+                current.insertAdjacentElement('beforebegin', link)
+                break
+              }
+            }
+            if (!found) document.head.appendChild(link)
+          },
           // Next.js guarantees that CSS order "doesn't matter", due to imposed
           // restrictions:
           // 1. Global CSS can only be defined in a single entrypoint (_app)


### PR DESCRIPTION
## Bug

- [x] Related issues linked using fixes #43878 and fixes #43396

Browsers do weird things. This works around the fact that if you append a stylesheet in firefox to the end of head, firefox sees it as a duplicate and ignores it. But only at the end apparently. This fix changes the MiniCssExtractPlugin to not use the default insert that just appends to the end of head.

This has another advantage: the css files remain in the same order.

NOTE: the plugin takes the function `insert` and does a `.toString()` on it, so for best compat, best to use old JS as it will not get transpiled.
fix NEXT-684 ([link](https://linear.app/vercel/issue/NEXT-684))

I messed up my git history and so started over, sorry for new PR @shuding 