### PR TITLE
parallel routes: implement default route + fix bugs on navigation

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -110,6 +110,15 @@ async function createAppRouteCode({
 const normalizeParallelKey = (key: string) =>
   key.startsWith('@') ? key.slice(1) : key
 
+const isDirectory = async (path: string) => {
+  try {
+    const stat = await fs.stat(path)
+    return stat.isDirectory()
+  } catch (err) {
+    return false
+  }
+}
+
 async function createTreeCodeFromPath(
   pagePath: string,
   {
@@ -147,6 +156,12 @@ async function createTreeCodeFromPath(
     )
 
     if (!absoluteSegmentPath) {
+      return []
+    }
+
+    const segmentIsDirectory = await isDirectory(absoluteSegmentPath)
+
+    if (!segmentIsDirectory) {
       return []
     }
 

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -110,9 +110,9 @@ async function createAppRouteCode({
 const normalizeParallelKey = (key: string) =>
   key.startsWith('@') ? key.slice(1) : key
 
-const isDirectory = async (path: string) => {
+const isDirectory = async (pathname: string) => {
   try {
-    const stat = await fs.stat(path)
+    const stat = await fs.stat(pathname)
     return stat.isDirectory()
   } catch (err) {
     return false

--- a/packages/next/src/client/components/parallel-route-default.tsx
+++ b/packages/next/src/client/components/parallel-route-default.tsx
@@ -1,0 +1,3 @@
+export default function NoopParallelRouteDefault() {
+  return null
+}

--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
@@ -14,6 +14,12 @@ function applyPatch(
   const [initialSegment, initialParallelRoutes] = initialTree
   const [patchSegment, patchParallelRoutes] = patchTree
 
+  // if the applied patch segment is __DEFAULT__ then we can ignore it and return the initial tree
+  // this is because the __DEFAULT__ segment is used as a placeholder on navigation
+  if (patchSegment === '__DEFAULT__') {
+    return initialTree
+  }
+
   if (matchSegment(initialSegment, patchSegment)) {
     const newParallelRoutes: FlightRouterState[1] = {}
     for (const key in initialParallelRoutes) {
@@ -85,7 +91,7 @@ export function applyRouterStatePatchToTree(
 
   let parallelRoutePatch
   if (lastSegment) {
-    parallelRoutePatch = applyPatch(treePatch, parallelRoutes[parallelRouteKey])
+    parallelRoutePatch = applyPatch(parallelRoutes[parallelRouteKey], treePatch)
   } else {
     parallelRoutePatch = applyRouterStatePatchToTree(
       flightSegmentPath.slice(2),

--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
@@ -11,32 +11,33 @@ function applyPatch(
   initialTree: FlightRouterState,
   patchTree: FlightRouterState
 ): FlightRouterState {
-  const [segment, parallelRoutes] = initialTree
+  const [initialSegment, initialParallelRoutes] = initialTree
+  const [patchSegment, patchParallelRoutes] = patchTree
 
-  if (matchSegment(segment, patchTree[0])) {
+  if (matchSegment(initialSegment, patchSegment)) {
     const newParallelRoutes: FlightRouterState[1] = {}
-    for (const key in parallelRoutes) {
+    for (const key in initialParallelRoutes) {
       const isInPatchTreeParallelRoutes =
-        typeof patchTree[1][key] !== 'undefined'
+        typeof patchParallelRoutes[key] !== 'undefined'
       if (isInPatchTreeParallelRoutes) {
         newParallelRoutes[key] = applyPatch(
-          parallelRoutes[key],
-          patchTree[1][key]
+          initialParallelRoutes[key],
+          patchParallelRoutes[key]
         )
       } else {
-        newParallelRoutes[key] = parallelRoutes[key]
+        newParallelRoutes[key] = initialParallelRoutes[key]
       }
     }
 
-    for (const key in patchTree[1]) {
+    for (const key in patchParallelRoutes) {
       if (newParallelRoutes[key]) {
         continue
       }
 
-      newParallelRoutes[key] = patchTree[1][key]
+      newParallelRoutes[key] = patchParallelRoutes[key]
     }
 
-    const tree: FlightRouterState = [segment, newParallelRoutes]
+    const tree: FlightRouterState = [initialSegment, newParallelRoutes]
 
     if (initialTree[2]) {
       tree[2] = initialTree[2]

--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
@@ -55,6 +55,7 @@ function applyPatch(
 
   return patchTree
 }
+
 /**
  * Apply the router state from the Flight response. Creates a new router state tree.
  */
@@ -83,7 +84,7 @@ export function applyRouterStatePatchToTree(
 
   let parallelRoutePatch
   if (lastSegment) {
-    parallelRoutePatch = treePatch
+    parallelRoutePatch = applyPatch(treePatch, parallelRoutes[parallelRouteKey])
   } else {
     parallelRoutePatch = applyRouterStatePatchToTree(
       flightSegmentPath.slice(2),

--- a/packages/next/src/server/app-render/index.tsx
+++ b/packages/next/src/server/app-render/index.tsx
@@ -927,10 +927,7 @@ export async function renderToHTMLOrFlight(
           // Last item in the tree
           parallelRoutesKeys.length === 0 ||
           // Explicit refresh
-          flightRouterState[3] === 'refetch' ||
-          // The layout needs to be re-rendered because the parallel slots differ,
-          // so that the layout can render the correct components in the new slots.
-          !arrayEquals(parallelRoutesKeys, Object.keys(flightRouterState[1]))
+          flightRouterState[3] === 'refetch'
 
         if (!parentRendered && renderComponentsOnThisLevel) {
           return [

--- a/packages/next/src/server/app-render/index.tsx
+++ b/packages/next/src/server/app-render/index.tsx
@@ -437,7 +437,8 @@ export async function renderToHTMLOrFlight(
         template,
         error,
         loading,
-        page,
+        defaultPage,
+        page = defaultPage,
         'not-found': notFound,
       } = components
       const layoutOrPagePath = layout?.[1] || page?.[1]

--- a/packages/next/src/server/app-render/index.tsx
+++ b/packages/next/src/server/app-render/index.tsx
@@ -74,9 +74,6 @@ import { handleAction } from './action-handler'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/constants'
 import { DEFAULT_METADATA_TAGS } from '../../lib/metadata/default-metadata'
 
-const arrayEquals = (a: any[], b: any[]) =>
-  a.length === b.length && a.every((v, i) => v === b[i])
-
 export const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 
 export type GetDynamicParamFromSegment = (

--- a/packages/next/src/server/app-render/index.tsx
+++ b/packages/next/src/server/app-render/index.tsx
@@ -434,10 +434,14 @@ export async function renderToHTMLOrFlight(
         template,
         error,
         loading,
-        defaultPage,
-        page = defaultPage,
         'not-found': notFound,
       } = components
+      let { page } = components
+      // a __DEFAULT__ segment means that this route didn't match any of the
+      // segments in the route, so we should use the default page
+
+      page = segment === '__DEFAULT__' ? components.defaultPage : page
+
       const layoutOrPagePath = layout?.[1] || page?.[1]
 
       const injectedCSSWithCurrentLayout = new Set(injectedCSS)

--- a/packages/next/src/server/app-render/index.tsx
+++ b/packages/next/src/server/app-render/index.tsx
@@ -74,6 +74,9 @@ import { handleAction } from './action-handler'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/constants'
 import { DEFAULT_METADATA_TAGS } from '../../lib/metadata/default-metadata'
 
+const arrayEquals = (a: any[], b: any[]) =>
+  a.length === b.length && a.every((v, i) => v === b[i])
+
 export const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 
 export type GetDynamicParamFromSegment = (
@@ -923,7 +926,10 @@ export async function renderToHTMLOrFlight(
           // Last item in the tree
           parallelRoutesKeys.length === 0 ||
           // Explicit refresh
-          flightRouterState[3] === 'refetch'
+          flightRouterState[3] === 'refetch' ||
+          // The layout needs to be re-rendered because the parallel slots differ,
+          // so that the layout can render the correct components in the new slots.
+          !arrayEquals(parallelRoutesKeys, Object.keys(flightRouterState[1]))
 
         if (!parentRendered && renderComponentsOnThisLevel) {
           return [

--- a/packages/next/src/server/lib/app-dir-module.ts
+++ b/packages/next/src/server/lib/app-dir-module.ts
@@ -13,7 +13,8 @@ export async function getLayoutOrPageModule(loaderTree: LoaderTree) {
   const { layout, page, defaultPage } = loaderTree[2]
   const isLayout = typeof layout !== 'undefined'
   const isPage = typeof page !== 'undefined'
-  const isDefaultPage = typeof defaultPage !== 'undefined'
+  const isDefaultPage =
+    typeof defaultPage !== 'undefined' && loaderTree[0] === '__DEFAULT__'
 
   let value = undefined
   let modType: 'layout' | 'page' | undefined = undefined

--- a/packages/next/src/server/lib/app-dir-module.ts
+++ b/packages/next/src/server/lib/app-dir-module.ts
@@ -10,18 +10,22 @@ export type LoaderTree = [
 ]
 
 export async function getLayoutOrPageModule(loaderTree: LoaderTree) {
-  const { layout, page } = loaderTree[2]
+  const { layout, page, defaultPage } = loaderTree[2]
   const isLayout = typeof layout !== 'undefined'
   const isPage = typeof page !== 'undefined'
+  const isDefaultPage = typeof defaultPage !== 'undefined'
 
   let value = undefined
   let modType: 'layout' | 'page' | undefined = undefined
+
   if (isLayout) {
     value = await layout[0]()
     modType = 'layout'
-  }
-  if (isPage) {
+  } else if (isPage) {
     value = await page[0]()
+    modType = 'page'
+  } else if (isDefaultPage) {
+    value = await defaultPage[0]()
     modType = 'page'
   }
 

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-tab-bar/default.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-tab-bar/default.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Default</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -1,243 +1,249 @@
 import { createNextDescribe } from 'e2e-utils'
 
-// TODO-APP: remove when parallel routes and interception are implemented
-const skipped = true
+createNextDescribe(
+  'parallel-routes-and-interception',
+  {
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true, // TODO: remove this once we can build route interceptions
+  },
+  ({ next, isNextDeploy }) => {
+    describe('parallel routes', () => {
+      it('should support parallel route tab bars', async () => {
+        const browser = await next.browser('/parallel-tab-bar', {
+          waitHydration: true,
+          retryWaitHydration: true,
+        })
 
-if (skipped) {
-  it.skip('skips parallel routes and interception as it is not implemented yet', () => {})
-} else {
-  createNextDescribe(
-    'parallel-routes-and-interception',
-    {
-      files: __dirname,
-    },
-    ({ next, isNextDeploy }) => {
-      describe('parallel routes', () => {
-        if (!isNextDeploy) {
-          it('should match parallel routes', async () => {
-            const html = await next.render('/parallel/nested')
-            expect(html).toContain('parallel/layout')
-            expect(html).toContain('parallel/@foo/nested/layout')
-            expect(html).toContain('parallel/@foo/nested/@a/page')
-            expect(html).toContain('parallel/@foo/nested/@b/page')
-            expect(html).toContain('parallel/@bar/nested/layout')
-            expect(html).toContain('parallel/@bar/nested/@a/page')
-            expect(html).toContain('parallel/@bar/nested/@b/page')
-            expect(html).toContain('parallel/nested/page')
-          })
+        const hasHome = async () => {
+          const text = await browser.waitForElementByCss('#home').text()
+          expect(text).toBe('Tab bar page (@children)')
+        }
+        const hasViewsHome = async () => {
+          const text = await browser.waitForElementByCss('#views-home').text()
+          expect(text).toBe('Views home')
+        }
+        const hasViewDuration = async () => {
+          const text = await browser
+            .waitForElementByCss('#view-duration')
+            .text()
+          expect(text).toBe('View duration')
+        }
+        const hasImpressions = async () => {
+          const text = await browser.waitForElementByCss('#impressions').text()
+          expect(text).toBe('Impressions')
+        }
+        const hasAudienceHome = async () => {
+          const text = await browser
+            .waitForElementByCss('#audience-home')
+            .text()
+          expect(text).toBe('Audience home')
+        }
+        const hasDemographics = async () => {
+          const text = await browser.waitForElementByCss('#demographics').text()
+          expect(text).toBe('Demographics')
+        }
+        const hasSubscribers = async () => {
+          const text = await browser.waitForElementByCss('#subscribers').text()
+          expect(text).toBe('Subscribers')
+        }
+        const checkUrlPath = async (path: string) => {
+          expect(await browser.url()).toBe(
+            `${next.url}/parallel-tab-bar${path}`
+          )
         }
 
-        it('should match parallel routes in route groups', async () => {
-          const html = await next.render('/parallel/nested-2')
+        // Initial page
+        const step1 = async () => {
+          await hasHome()
+          await hasViewsHome()
+          await hasAudienceHome()
+          await checkUrlPath('')
+        }
+
+        await step1()
+
+        console.log('step1')
+        // Navigate to /views/duration
+        await browser.elementByCss('#view-duration-link').click()
+
+        const step2 = async () => {
+          await hasHome()
+          await hasViewDuration()
+          await hasAudienceHome()
+          await checkUrlPath('/view-duration')
+        }
+
+        await step2()
+        console.log('step2')
+
+        // Navigate to /views/impressions
+        await browser.elementByCss('#impressions-link').click()
+
+        const step3 = async () => {
+          await hasHome()
+          await hasImpressions()
+          await hasAudienceHome()
+          await checkUrlPath('/impressions')
+        }
+
+        await step3()
+        console.log('step3')
+
+        // Navigate to /audience/demographics
+        await browser.elementByCss('#demographics-link').click()
+
+        const step4 = async () => {
+          await hasHome()
+          await hasImpressions()
+          await hasDemographics()
+          await checkUrlPath('/demographics')
+        }
+
+        await step4()
+        console.log('step4')
+
+        // Navigate to /audience/subscribers
+        await browser.elementByCss('#subscribers-link').click()
+
+        const step5 = async () => {
+          await hasHome()
+          await hasImpressions()
+          await hasSubscribers()
+          await checkUrlPath('/subscribers')
+        }
+
+        await step5()
+        console.log('step5')
+
+        // Navigate to /
+        await browser.elementByCss('#home-link-audience').click()
+
+        // TODO: home link behavior
+        // await step1()
+
+        // TODO: fix back/forward navigation test
+        // Test that back navigation works as intended
+        // await browser.back()
+        // await step5()
+        // console.log('step5 back')
+        // await browser.back()
+        // await step4()
+        // console.log('step4 back')
+        // await browser.back()
+        // await step3()
+        // console.log('step3 back')
+
+        // await browser.back()
+        // await step2()
+        // console.log('step2 back')
+        // await browser.back()
+        // await step1()
+        // console.log('step1 back')
+        // console.log('step6')
+
+        // // Test that forward navigation works as intended
+        // await browser.forward()
+        // await step2()
+        // console.log('step2 forward')
+        // await browser.forward()
+        // await step3()
+        // console.log('step3 forward')
+        // await browser.forward()
+        // await step4()
+        // console.log('step4 forward')
+        // await browser.forward()
+        // await step5()
+      })
+
+      if (!isNextDeploy) {
+        it('should match parallel routes', async () => {
+          const html = await next.render('/parallel/nested')
           expect(html).toContain('parallel/layout')
-          expect(html).toContain('parallel/(new)/layout')
-          expect(html).toContain('parallel/(new)/@baz/nested/page')
+          expect(html).toContain('parallel/@foo/nested/layout')
+          expect(html).toContain('parallel/@foo/nested/@a/page')
+          expect(html).toContain('parallel/@foo/nested/@b/page')
+          expect(html).toContain('parallel/@bar/nested/layout')
+          expect(html).toContain('parallel/@bar/nested/@a/page')
+          expect(html).toContain('parallel/@bar/nested/@b/page')
+          expect(html).toContain('parallel/nested/page')
         })
+      }
 
-        it('should support parallel route tab bars', async () => {
-          const browser = await next.browser('/parallel-tab-bar')
+      it('should match parallel routes in route groups', async () => {
+        const html = await next.render('/parallel/nested-2')
+        expect(html).toContain('parallel/layout')
+        expect(html).toContain('parallel/(new)/layout')
+        expect(html).toContain('parallel/(new)/@baz/nested/page')
+      })
+    })
 
-          const hasHome = async () => {
-            const text = await browser.waitForElementByCss('#home').text()
-            expect(text).toBe('Tab bar page (@children)')
-          }
-          const hasViewsHome = async () => {
-            const text = await browser.waitForElementByCss('#views-home').text()
-            expect(text).toBe('Views home')
-          }
-          const hasViewDuration = async () => {
-            const text = await browser
-              .waitForElementByCss('#view-duration')
-              .text()
-            expect(text).toBe('View duration')
-          }
-          const hasImpressions = async () => {
-            const text = await browser
-              .waitForElementByCss('#impressions')
-              .text()
-            expect(text).toBe('Impressions')
-          }
-          const hasAudienceHome = async () => {
-            const text = await browser
-              .waitForElementByCss('#audience-home')
-              .text()
-            expect(text).toBe('Audience home')
-          }
-          const hasDemographics = async () => {
-            const text = await browser
-              .waitForElementByCss('#demographics')
-              .text()
-            expect(text).toBe('Demographics')
-          }
-          const hasSubscribers = async () => {
-            const text = await browser
-              .waitForElementByCss('#subscribers')
-              .text()
-            expect(text).toBe('Subscribers')
-          }
-          const checkUrlPath = async (path: string) => {
-            expect(await browser.url()).toBe(
-              `${next.url}/parallel-tab-bar${path}`
-            )
-          }
+    describe.skip('route intercepting', () => {
+      it('should render intercepted route', async () => {
+        const browser = await next.browser('/intercepting-routes/feed')
 
-          // Initial page
-          const step1 = async () => {
-            await hasHome()
-            await hasViewsHome()
-            await hasAudienceHome()
-            await checkUrlPath('')
-          }
+        // Check if navigation to modal route works.
+        expect(
+          await browser
+            .elementByCss('[href="/intercepting-routes/photos/1"]')
+            .click()
+            .waitForElementByCss('#photo-intercepted-1')
+            .text()
+        ).toBe('Photo INTERCEPTED 1')
 
-          await step1()
+        // Check if intercepted route was rendered while existing page content was removed.
+        // Content would only be preserved when combined with parallel routes.
+        expect(await browser.elementByCss('#feed-page').text()).not.toBe('Feed')
 
-          // Navigate to /views/duration
-          await browser.elementByCss('#view-duration-link').click()
+        // Check if url matches even though it was intercepted.
+        expect(await browser.url()).toBe(
+          next.url + '/intercepting-routes/photos/1'
+        )
 
-          const step2 = async () => {
-            await hasHome()
-            await hasViewDuration()
-            await hasAudienceHome()
-            await checkUrlPath('/view-duration')
-          }
+        // Trigger a refresh, this should load the normal page, not the modal.
+        expect(
+          await browser.refresh().waitForElementByCss('#photo-page-1').text()
+        ).toBe('Photo PAGE 1')
 
-          await step2()
-
-          // Navigate to /views/impressions
-          await browser.elementByCss('#impressions-link').click()
-
-          const step3 = async () => {
-            await hasHome()
-            await hasImpressions()
-            await hasAudienceHome()
-            await checkUrlPath('/impressions')
-          }
-
-          await step3()
-
-          // Navigate to /audience/demographics
-          await browser.elementByCss('#demographics-link').click()
-
-          const step4 = async () => {
-            await hasHome()
-            await hasImpressions()
-            await hasDemographics()
-            await checkUrlPath('/demographics')
-          }
-
-          await step4()
-
-          // Navigate to /audience/subscribers
-          await browser.elementByCss('#subscribers-link').click()
-
-          const step5 = async () => {
-            await hasHome()
-            await hasImpressions()
-            await hasSubscribers()
-            await checkUrlPath('/subscribers')
-          }
-
-          await step5()
-
-          // Navigate to /
-          await browser.elementByCss('#home-link-audience').click()
-
-          // TODO: home link behavior
-          await step1()
-
-          // Test that back navigation works as intended
-          await browser.back()
-          await step5()
-          await browser.back()
-          await step4()
-          await browser.back()
-          await step3()
-          await browser.back()
-          await step2()
-          await browser.back()
-          await step1()
-
-          // Test that forward navigation works as intended
-          await browser.forward()
-          await step2()
-          await browser.forward()
-          await step3()
-          await browser.forward()
-          await step4()
-          await browser.forward()
-          await step5()
-        })
+        // Check if the url matches still.
+        expect(await browser.url()).toBe(
+          next.url + '/intercepting-routes/photos/1'
+        )
       })
 
-      describe('route intercepting', () => {
-        it('should render intercepted route', async () => {
-          const browser = await next.browser('/intercepting-routes/feed')
+      it('should render modal when paired with parallel routes', async () => {
+        const browser = await next.browser(
+          '/intercepting-parallel-modal/vercel'
+        )
+        // Check if navigation to modal route works.
+        expect(
+          await browser
+            .elementByCss('[href="/intercepting-parallel-modal/photos/1"]')
+            .click()
+            .waitForElementByCss('#photo-modal-1')
+            .text()
+        ).toBe('Photo MODAL 1')
 
-          // Check if navigation to modal route works.
-          expect(
-            await browser
-              .elementByCss('[href="/intercepting-routes/photos/1"]')
-              .click()
-              .waitForElementByCss('#photo-intercepted-1')
-              .text()
-          ).toBe('Photo INTERCEPTED 1')
+        // Check if modal was rendered while existing page content is preserved.
+        expect(await browser.elementByCss('#user-page').text()).toBe(
+          'Feed for vercel'
+        )
 
-          // Check if intercepted route was rendered while existing page content was removed.
-          // Content would only be preserved when combined with parallel routes.
-          expect(await browser.elementByCss('#feed-page').text()).not.toBe(
-            'Feed'
-          )
+        // Check if url matches even though it was intercepted.
+        expect(await browser.url()).toBe(
+          next.url + '/intercepting-parallel-modal/photos/1'
+        )
 
-          // Check if url matches even though it was intercepted.
-          expect(await browser.url()).toBe(
-            next.url + '/intercepting-routes/photos/1'
-          )
+        // Trigger a refresh, this should load the normal page, not the modal.
+        expect(
+          await browser.refresh().waitForElementByCss('#photo-page-1').text()
+        ).toBe('Photo PAGE 1')
 
-          // Trigger a refresh, this should load the normal page, not the modal.
-          expect(
-            await browser.refresh().waitForElementByCss('#photo-page-1').text()
-          ).toBe('Photo PAGE 1')
-
-          // Check if the url matches still.
-          expect(await browser.url()).toBe(
-            next.url + '/intercepting-routes/photos/1'
-          )
-        })
-
-        it('should render modal when paired with parallel routes', async () => {
-          const browser = await next.browser(
-            '/intercepting-parallel-modal/vercel'
-          )
-          // Check if navigation to modal route works.
-          expect(
-            await browser
-              .elementByCss('[href="/intercepting-parallel-modal/photos/1"]')
-              .click()
-              .waitForElementByCss('#photo-modal-1')
-              .text()
-          ).toBe('Photo MODAL 1')
-
-          // Check if modal was rendered while existing page content is preserved.
-          expect(await browser.elementByCss('#user-page').text()).toBe(
-            'Feed for vercel'
-          )
-
-          // Check if url matches even though it was intercepted.
-          expect(await browser.url()).toBe(
-            next.url + '/intercepting-parallel-modal/photos/1'
-          )
-
-          // Trigger a refresh, this should load the normal page, not the modal.
-          expect(
-            await browser.refresh().waitForElementByCss('#photo-page-1').text()
-          ).toBe('Photo PAGE 1')
-
-          // Check if the url matches still.
-          expect(await browser.url()).toBe(
-            next.url + '/intercepting-parallel-modal/photos/1'
-          )
-        })
+        // Check if the url matches still.
+        expect(await browser.url()).toBe(
+          next.url + '/intercepting-parallel-modal/photos/1'
+        )
       })
-    }
-  )
-}
+    })
+  }
+)

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -254,5 +254,6 @@ createNextDescribe(
         })
       })
     }
+    it.skip('noop to avoid jest error', () => {})
   }
 )

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -5,245 +5,254 @@ createNextDescribe(
   {
     files: __dirname,
     skipDeployment: true,
-    skipStart: true, // TODO: remove this once we can build route interceptions
   },
-  ({ next, isNextDeploy }) => {
-    describe('parallel routes', () => {
-      it('should support parallel route tab bars', async () => {
-        const browser = await next.browser('/parallel-tab-bar', {
-          waitHydration: true,
-          retryWaitHydration: true,
+  ({ next, isNextDeploy, isNextDev }) => {
+    if (isNextDev) {
+      describe('parallel routes', () => {
+        it('should support parallel route tab bars', async () => {
+          const browser = await next.browser('/parallel-tab-bar', {
+            waitHydration: true,
+            retryWaitHydration: true,
+          })
+
+          const hasHome = async () => {
+            const text = await browser.waitForElementByCss('#home').text()
+            expect(text).toBe('Tab bar page (@children)')
+          }
+          const hasViewsHome = async () => {
+            const text = await browser.waitForElementByCss('#views-home').text()
+            expect(text).toBe('Views home')
+          }
+          const hasViewDuration = async () => {
+            const text = await browser
+              .waitForElementByCss('#view-duration')
+              .text()
+            expect(text).toBe('View duration')
+          }
+          const hasImpressions = async () => {
+            const text = await browser
+              .waitForElementByCss('#impressions')
+              .text()
+            expect(text).toBe('Impressions')
+          }
+          const hasAudienceHome = async () => {
+            const text = await browser
+              .waitForElementByCss('#audience-home')
+              .text()
+            expect(text).toBe('Audience home')
+          }
+          const hasDemographics = async () => {
+            const text = await browser
+              .waitForElementByCss('#demographics')
+              .text()
+            expect(text).toBe('Demographics')
+          }
+          const hasSubscribers = async () => {
+            const text = await browser
+              .waitForElementByCss('#subscribers')
+              .text()
+            expect(text).toBe('Subscribers')
+          }
+          const checkUrlPath = async (path: string) => {
+            expect(await browser.url()).toBe(
+              `${next.url}/parallel-tab-bar${path}`
+            )
+          }
+
+          // Initial page
+          const step1 = async () => {
+            await hasHome()
+            await hasViewsHome()
+            await hasAudienceHome()
+            await checkUrlPath('')
+          }
+
+          await step1()
+
+          console.log('step1')
+          // Navigate to /views/duration
+          await browser.elementByCss('#view-duration-link').click()
+
+          const step2 = async () => {
+            await hasHome()
+            await hasViewDuration()
+            await hasAudienceHome()
+            await checkUrlPath('/view-duration')
+          }
+
+          await step2()
+          console.log('step2')
+
+          // Navigate to /views/impressions
+          await browser.elementByCss('#impressions-link').click()
+
+          const step3 = async () => {
+            await hasHome()
+            await hasImpressions()
+            await hasAudienceHome()
+            await checkUrlPath('/impressions')
+          }
+
+          await step3()
+          console.log('step3')
+
+          // Navigate to /audience/demographics
+          await browser.elementByCss('#demographics-link').click()
+
+          const step4 = async () => {
+            await hasHome()
+            await hasImpressions()
+            await hasDemographics()
+            await checkUrlPath('/demographics')
+          }
+
+          await step4()
+          console.log('step4')
+
+          // Navigate to /audience/subscribers
+          await browser.elementByCss('#subscribers-link').click()
+
+          const step5 = async () => {
+            await hasHome()
+            await hasImpressions()
+            await hasSubscribers()
+            await checkUrlPath('/subscribers')
+          }
+
+          await step5()
+          console.log('step5')
+
+          // Navigate to /
+          await browser.elementByCss('#home-link-audience').click()
+
+          // TODO: home link behavior
+          // await step1()
+
+          // TODO: fix back/forward navigation test
+          // Test that back navigation works as intended
+          // await browser.back()
+          // await step5()
+          // console.log('step5 back')
+          // await browser.back()
+          // await step4()
+          // console.log('step4 back')
+          // await browser.back()
+          // await step3()
+          // console.log('step3 back')
+
+          // await browser.back()
+          // await step2()
+          // console.log('step2 back')
+          // await browser.back()
+          // await step1()
+          // console.log('step1 back')
+          // console.log('step6')
+
+          // // Test that forward navigation works as intended
+          // await browser.forward()
+          // await step2()
+          // console.log('step2 forward')
+          // await browser.forward()
+          // await step3()
+          // console.log('step3 forward')
+          // await browser.forward()
+          // await step4()
+          // console.log('step4 forward')
+          // await browser.forward()
+          // await step5()
         })
 
-        const hasHome = async () => {
-          const text = await browser.waitForElementByCss('#home').text()
-          expect(text).toBe('Tab bar page (@children)')
-        }
-        const hasViewsHome = async () => {
-          const text = await browser.waitForElementByCss('#views-home').text()
-          expect(text).toBe('Views home')
-        }
-        const hasViewDuration = async () => {
-          const text = await browser
-            .waitForElementByCss('#view-duration')
-            .text()
-          expect(text).toBe('View duration')
-        }
-        const hasImpressions = async () => {
-          const text = await browser.waitForElementByCss('#impressions').text()
-          expect(text).toBe('Impressions')
-        }
-        const hasAudienceHome = async () => {
-          const text = await browser
-            .waitForElementByCss('#audience-home')
-            .text()
-          expect(text).toBe('Audience home')
-        }
-        const hasDemographics = async () => {
-          const text = await browser.waitForElementByCss('#demographics').text()
-          expect(text).toBe('Demographics')
-        }
-        const hasSubscribers = async () => {
-          const text = await browser.waitForElementByCss('#subscribers').text()
-          expect(text).toBe('Subscribers')
-        }
-        const checkUrlPath = async (path: string) => {
-          expect(await browser.url()).toBe(
-            `${next.url}/parallel-tab-bar${path}`
-          )
+        if (!isNextDeploy) {
+          it('should match parallel routes', async () => {
+            const html = await next.render('/parallel/nested')
+            expect(html).toContain('parallel/layout')
+            expect(html).toContain('parallel/@foo/nested/layout')
+            expect(html).toContain('parallel/@foo/nested/@a/page')
+            expect(html).toContain('parallel/@foo/nested/@b/page')
+            expect(html).toContain('parallel/@bar/nested/layout')
+            expect(html).toContain('parallel/@bar/nested/@a/page')
+            expect(html).toContain('parallel/@bar/nested/@b/page')
+            expect(html).toContain('parallel/nested/page')
+          })
         }
 
-        // Initial page
-        const step1 = async () => {
-          await hasHome()
-          await hasViewsHome()
-          await hasAudienceHome()
-          await checkUrlPath('')
-        }
-
-        await step1()
-
-        console.log('step1')
-        // Navigate to /views/duration
-        await browser.elementByCss('#view-duration-link').click()
-
-        const step2 = async () => {
-          await hasHome()
-          await hasViewDuration()
-          await hasAudienceHome()
-          await checkUrlPath('/view-duration')
-        }
-
-        await step2()
-        console.log('step2')
-
-        // Navigate to /views/impressions
-        await browser.elementByCss('#impressions-link').click()
-
-        const step3 = async () => {
-          await hasHome()
-          await hasImpressions()
-          await hasAudienceHome()
-          await checkUrlPath('/impressions')
-        }
-
-        await step3()
-        console.log('step3')
-
-        // Navigate to /audience/demographics
-        await browser.elementByCss('#demographics-link').click()
-
-        const step4 = async () => {
-          await hasHome()
-          await hasImpressions()
-          await hasDemographics()
-          await checkUrlPath('/demographics')
-        }
-
-        await step4()
-        console.log('step4')
-
-        // Navigate to /audience/subscribers
-        await browser.elementByCss('#subscribers-link').click()
-
-        const step5 = async () => {
-          await hasHome()
-          await hasImpressions()
-          await hasSubscribers()
-          await checkUrlPath('/subscribers')
-        }
-
-        await step5()
-        console.log('step5')
-
-        // Navigate to /
-        await browser.elementByCss('#home-link-audience').click()
-
-        // TODO: home link behavior
-        // await step1()
-
-        // TODO: fix back/forward navigation test
-        // Test that back navigation works as intended
-        // await browser.back()
-        // await step5()
-        // console.log('step5 back')
-        // await browser.back()
-        // await step4()
-        // console.log('step4 back')
-        // await browser.back()
-        // await step3()
-        // console.log('step3 back')
-
-        // await browser.back()
-        // await step2()
-        // console.log('step2 back')
-        // await browser.back()
-        // await step1()
-        // console.log('step1 back')
-        // console.log('step6')
-
-        // // Test that forward navigation works as intended
-        // await browser.forward()
-        // await step2()
-        // console.log('step2 forward')
-        // await browser.forward()
-        // await step3()
-        // console.log('step3 forward')
-        // await browser.forward()
-        // await step4()
-        // console.log('step4 forward')
-        // await browser.forward()
-        // await step5()
-      })
-
-      if (!isNextDeploy) {
-        it('should match parallel routes', async () => {
-          const html = await next.render('/parallel/nested')
+        it('should match parallel routes in route groups', async () => {
+          const html = await next.render('/parallel/nested-2')
           expect(html).toContain('parallel/layout')
-          expect(html).toContain('parallel/@foo/nested/layout')
-          expect(html).toContain('parallel/@foo/nested/@a/page')
-          expect(html).toContain('parallel/@foo/nested/@b/page')
-          expect(html).toContain('parallel/@bar/nested/layout')
-          expect(html).toContain('parallel/@bar/nested/@a/page')
-          expect(html).toContain('parallel/@bar/nested/@b/page')
-          expect(html).toContain('parallel/nested/page')
+          expect(html).toContain('parallel/(new)/layout')
+          expect(html).toContain('parallel/(new)/@baz/nested/page')
         })
-      }
-
-      it('should match parallel routes in route groups', async () => {
-        const html = await next.render('/parallel/nested-2')
-        expect(html).toContain('parallel/layout')
-        expect(html).toContain('parallel/(new)/layout')
-        expect(html).toContain('parallel/(new)/@baz/nested/page')
-      })
-    })
-
-    describe.skip('route intercepting', () => {
-      it('should render intercepted route', async () => {
-        const browser = await next.browser('/intercepting-routes/feed')
-
-        // Check if navigation to modal route works.
-        expect(
-          await browser
-            .elementByCss('[href="/intercepting-routes/photos/1"]')
-            .click()
-            .waitForElementByCss('#photo-intercepted-1')
-            .text()
-        ).toBe('Photo INTERCEPTED 1')
-
-        // Check if intercepted route was rendered while existing page content was removed.
-        // Content would only be preserved when combined with parallel routes.
-        expect(await browser.elementByCss('#feed-page').text()).not.toBe('Feed')
-
-        // Check if url matches even though it was intercepted.
-        expect(await browser.url()).toBe(
-          next.url + '/intercepting-routes/photos/1'
-        )
-
-        // Trigger a refresh, this should load the normal page, not the modal.
-        expect(
-          await browser.refresh().waitForElementByCss('#photo-page-1').text()
-        ).toBe('Photo PAGE 1')
-
-        // Check if the url matches still.
-        expect(await browser.url()).toBe(
-          next.url + '/intercepting-routes/photos/1'
-        )
       })
 
-      it('should render modal when paired with parallel routes', async () => {
-        const browser = await next.browser(
-          '/intercepting-parallel-modal/vercel'
-        )
-        // Check if navigation to modal route works.
-        expect(
-          await browser
-            .elementByCss('[href="/intercepting-parallel-modal/photos/1"]')
-            .click()
-            .waitForElementByCss('#photo-modal-1')
-            .text()
-        ).toBe('Photo MODAL 1')
+      describe.skip('route intercepting', () => {
+        it('should render intercepted route', async () => {
+          const browser = await next.browser('/intercepting-routes/feed')
 
-        // Check if modal was rendered while existing page content is preserved.
-        expect(await browser.elementByCss('#user-page').text()).toBe(
-          'Feed for vercel'
-        )
+          // Check if navigation to modal route works.
+          expect(
+            await browser
+              .elementByCss('[href="/intercepting-routes/photos/1"]')
+              .click()
+              .waitForElementByCss('#photo-intercepted-1')
+              .text()
+          ).toBe('Photo INTERCEPTED 1')
 
-        // Check if url matches even though it was intercepted.
-        expect(await browser.url()).toBe(
-          next.url + '/intercepting-parallel-modal/photos/1'
-        )
+          // Check if intercepted route was rendered while existing page content was removed.
+          // Content would only be preserved when combined with parallel routes.
+          expect(await browser.elementByCss('#feed-page').text()).not.toBe(
+            'Feed'
+          )
 
-        // Trigger a refresh, this should load the normal page, not the modal.
-        expect(
-          await browser.refresh().waitForElementByCss('#photo-page-1').text()
-        ).toBe('Photo PAGE 1')
+          // Check if url matches even though it was intercepted.
+          expect(await browser.url()).toBe(
+            next.url + '/intercepting-routes/photos/1'
+          )
 
-        // Check if the url matches still.
-        expect(await browser.url()).toBe(
-          next.url + '/intercepting-parallel-modal/photos/1'
-        )
+          // Trigger a refresh, this should load the normal page, not the modal.
+          expect(
+            await browser.refresh().waitForElementByCss('#photo-page-1').text()
+          ).toBe('Photo PAGE 1')
+
+          // Check if the url matches still.
+          expect(await browser.url()).toBe(
+            next.url + '/intercepting-routes/photos/1'
+          )
+        })
+
+        it('should render modal when paired with parallel routes', async () => {
+          const browser = await next.browser(
+            '/intercepting-parallel-modal/vercel'
+          )
+          // Check if navigation to modal route works.
+          expect(
+            await browser
+              .elementByCss('[href="/intercepting-parallel-modal/photos/1"]')
+              .click()
+              .waitForElementByCss('#photo-modal-1')
+              .text()
+          ).toBe('Photo MODAL 1')
+
+          // Check if modal was rendered while existing page content is preserved.
+          expect(await browser.elementByCss('#user-page').text()).toBe(
+            'Feed for vercel'
+          )
+
+          // Check if url matches even though it was intercepted.
+          expect(await browser.url()).toBe(
+            next.url + '/intercepting-parallel-modal/photos/1'
+          )
+
+          // Trigger a refresh, this should load the normal page, not the modal.
+          expect(
+            await browser.refresh().waitForElementByCss('#photo-page-1').text()
+          ).toBe('Photo PAGE 1')
+
+          // Check if the url matches still.
+          expect(await browser.url()).toBe(
+            next.url + '/intercepting-parallel-modal/photos/1'
+          )
+        })
       })
-    })
+    }
   }
 )

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -7,253 +7,242 @@ createNextDescribe(
     skipDeployment: true,
   },
   ({ next, isNextDeploy, isNextDev }) => {
-    if (isNextDev) {
-      describe('parallel routes', () => {
-        it('should support parallel route tab bars', async () => {
-          const browser = await next.browser('/parallel-tab-bar', {
-            waitHydration: true,
-            retryWaitHydration: true,
-          })
-
-          const hasHome = async () => {
-            const text = await browser.waitForElementByCss('#home').text()
-            expect(text).toBe('Tab bar page (@children)')
-          }
-          const hasViewsHome = async () => {
-            const text = await browser.waitForElementByCss('#views-home').text()
-            expect(text).toBe('Views home')
-          }
-          const hasViewDuration = async () => {
-            const text = await browser
-              .waitForElementByCss('#view-duration')
-              .text()
-            expect(text).toBe('View duration')
-          }
-          const hasImpressions = async () => {
-            const text = await browser
-              .waitForElementByCss('#impressions')
-              .text()
-            expect(text).toBe('Impressions')
-          }
-          const hasAudienceHome = async () => {
-            const text = await browser
-              .waitForElementByCss('#audience-home')
-              .text()
-            expect(text).toBe('Audience home')
-          }
-          const hasDemographics = async () => {
-            const text = await browser
-              .waitForElementByCss('#demographics')
-              .text()
-            expect(text).toBe('Demographics')
-          }
-          const hasSubscribers = async () => {
-            const text = await browser
-              .waitForElementByCss('#subscribers')
-              .text()
-            expect(text).toBe('Subscribers')
-          }
-          const checkUrlPath = async (path: string) => {
-            expect(await browser.url()).toBe(
-              `${next.url}/parallel-tab-bar${path}`
-            )
-          }
-
-          // Initial page
-          const step1 = async () => {
-            await hasHome()
-            await hasViewsHome()
-            await hasAudienceHome()
-            await checkUrlPath('')
-          }
-
-          await step1()
-
-          console.log('step1')
-          // Navigate to /views/duration
-          await browser.elementByCss('#view-duration-link').click()
-
-          const step2 = async () => {
-            await hasHome()
-            await hasViewDuration()
-            await hasAudienceHome()
-            await checkUrlPath('/view-duration')
-          }
-
-          await step2()
-          console.log('step2')
-
-          // Navigate to /views/impressions
-          await browser.elementByCss('#impressions-link').click()
-
-          const step3 = async () => {
-            await hasHome()
-            await hasImpressions()
-            await hasAudienceHome()
-            await checkUrlPath('/impressions')
-          }
-
-          await step3()
-          console.log('step3')
-
-          // Navigate to /audience/demographics
-          await browser.elementByCss('#demographics-link').click()
-
-          const step4 = async () => {
-            await hasHome()
-            await hasImpressions()
-            await hasDemographics()
-            await checkUrlPath('/demographics')
-          }
-
-          await step4()
-          console.log('step4')
-
-          // Navigate to /audience/subscribers
-          await browser.elementByCss('#subscribers-link').click()
-
-          const step5 = async () => {
-            await hasHome()
-            await hasImpressions()
-            await hasSubscribers()
-            await checkUrlPath('/subscribers')
-          }
-
-          await step5()
-          console.log('step5')
-
-          // Navigate to /
-          await browser.elementByCss('#home-link-audience').click()
-
-          // TODO: home link behavior
-          // await step1()
-
-          // TODO: fix back/forward navigation test
-          // Test that back navigation works as intended
-          // await browser.back()
-          // await step5()
-          // console.log('step5 back')
-          // await browser.back()
-          // await step4()
-          // console.log('step4 back')
-          // await browser.back()
-          // await step3()
-          // console.log('step3 back')
-
-          // await browser.back()
-          // await step2()
-          // console.log('step2 back')
-          // await browser.back()
-          // await step1()
-          // console.log('step1 back')
-          // console.log('step6')
-
-          // // Test that forward navigation works as intended
-          // await browser.forward()
-          // await step2()
-          // console.log('step2 forward')
-          // await browser.forward()
-          // await step3()
-          // console.log('step3 forward')
-          // await browser.forward()
-          // await step4()
-          // console.log('step4 forward')
-          // await browser.forward()
-          // await step5()
+    describe('parallel routes', () => {
+      it('should support parallel route tab bars', async () => {
+        const browser = await next.browser('/parallel-tab-bar', {
+          waitHydration: true,
+          retryWaitHydration: true,
         })
 
-        if (!isNextDeploy) {
-          it('should match parallel routes', async () => {
-            const html = await next.render('/parallel/nested')
-            expect(html).toContain('parallel/layout')
-            expect(html).toContain('parallel/@foo/nested/layout')
-            expect(html).toContain('parallel/@foo/nested/@a/page')
-            expect(html).toContain('parallel/@foo/nested/@b/page')
-            expect(html).toContain('parallel/@bar/nested/layout')
-            expect(html).toContain('parallel/@bar/nested/@a/page')
-            expect(html).toContain('parallel/@bar/nested/@b/page')
-            expect(html).toContain('parallel/nested/page')
-          })
+        const hasHome = async () => {
+          const text = await browser.waitForElementByCss('#home').text()
+          expect(text).toBe('Tab bar page (@children)')
+        }
+        const hasViewsHome = async () => {
+          const text = await browser.waitForElementByCss('#views-home').text()
+          expect(text).toBe('Views home')
+        }
+        const hasViewDuration = async () => {
+          const text = await browser
+            .waitForElementByCss('#view-duration')
+            .text()
+          expect(text).toBe('View duration')
+        }
+        const hasImpressions = async () => {
+          const text = await browser.waitForElementByCss('#impressions').text()
+          expect(text).toBe('Impressions')
+        }
+        const hasAudienceHome = async () => {
+          const text = await browser
+            .waitForElementByCss('#audience-home')
+            .text()
+          expect(text).toBe('Audience home')
+        }
+        const hasDemographics = async () => {
+          const text = await browser.waitForElementByCss('#demographics').text()
+          expect(text).toBe('Demographics')
+        }
+        const hasSubscribers = async () => {
+          const text = await browser.waitForElementByCss('#subscribers').text()
+          expect(text).toBe('Subscribers')
+        }
+        const checkUrlPath = async (path: string) => {
+          expect(await browser.url()).toBe(
+            `${next.url}/parallel-tab-bar${path}`
+          )
         }
 
-        it('should match parallel routes in route groups', async () => {
-          const html = await next.render('/parallel/nested-2')
+        // Initial page
+        const step1 = async () => {
+          await hasHome()
+          await hasViewsHome()
+          await hasAudienceHome()
+          await checkUrlPath('')
+        }
+
+        await step1()
+
+        console.log('step1')
+        // Navigate to /views/duration
+        await browser.elementByCss('#view-duration-link').click()
+
+        const step2 = async () => {
+          await hasHome()
+          await hasViewDuration()
+          await hasAudienceHome()
+          await checkUrlPath('/view-duration')
+        }
+
+        await step2()
+        console.log('step2')
+
+        // Navigate to /views/impressions
+        await browser.elementByCss('#impressions-link').click()
+
+        const step3 = async () => {
+          await hasHome()
+          await hasImpressions()
+          await hasAudienceHome()
+          await checkUrlPath('/impressions')
+        }
+
+        await step3()
+        console.log('step3')
+
+        // Navigate to /audience/demographics
+        await browser.elementByCss('#demographics-link').click()
+
+        const step4 = async () => {
+          await hasHome()
+          await hasImpressions()
+          await hasDemographics()
+          await checkUrlPath('/demographics')
+        }
+
+        await step4()
+        console.log('step4')
+
+        // Navigate to /audience/subscribers
+        await browser.elementByCss('#subscribers-link').click()
+
+        const step5 = async () => {
+          await hasHome()
+          await hasImpressions()
+          await hasSubscribers()
+          await checkUrlPath('/subscribers')
+        }
+
+        await step5()
+        console.log('step5')
+
+        // Navigate to /
+        await browser.elementByCss('#home-link-audience').click()
+
+        // TODO: home link behavior
+        // await step1()
+
+        // TODO: fix back/forward navigation test
+        // Test that back navigation works as intended
+        // await browser.back()
+        // await step5()
+        // console.log('step5 back')
+        // await browser.back()
+        // await step4()
+        // console.log('step4 back')
+        // await browser.back()
+        // await step3()
+        // console.log('step3 back')
+
+        // await browser.back()
+        // await step2()
+        // console.log('step2 back')
+        // await browser.back()
+        // await step1()
+        // console.log('step1 back')
+        // console.log('step6')
+
+        // // Test that forward navigation works as intended
+        // await browser.forward()
+        // await step2()
+        // console.log('step2 forward')
+        // await browser.forward()
+        // await step3()
+        // console.log('step3 forward')
+        // await browser.forward()
+        // await step4()
+        // console.log('step4 forward')
+        // await browser.forward()
+        // await step5()
+      })
+
+      if (!isNextDeploy) {
+        it('should match parallel routes', async () => {
+          const html = await next.render('/parallel/nested')
           expect(html).toContain('parallel/layout')
-          expect(html).toContain('parallel/(new)/layout')
-          expect(html).toContain('parallel/(new)/@baz/nested/page')
+          expect(html).toContain('parallel/@foo/nested/layout')
+          expect(html).toContain('parallel/@foo/nested/@a/page')
+          expect(html).toContain('parallel/@foo/nested/@b/page')
+          expect(html).toContain('parallel/@bar/nested/layout')
+          expect(html).toContain('parallel/@bar/nested/@a/page')
+          expect(html).toContain('parallel/@bar/nested/@b/page')
+          expect(html).toContain('parallel/nested/page')
         })
+      }
+
+      it('should match parallel routes in route groups', async () => {
+        const html = await next.render('/parallel/nested-2')
+        expect(html).toContain('parallel/layout')
+        expect(html).toContain('parallel/(new)/layout')
+        expect(html).toContain('parallel/(new)/@baz/nested/page')
+      })
+    })
+
+    describe.skip('route intercepting', () => {
+      it('should render intercepted route', async () => {
+        const browser = await next.browser('/intercepting-routes/feed')
+
+        // Check if navigation to modal route works.
+        expect(
+          await browser
+            .elementByCss('[href="/intercepting-routes/photos/1"]')
+            .click()
+            .waitForElementByCss('#photo-intercepted-1')
+            .text()
+        ).toBe('Photo INTERCEPTED 1')
+
+        // Check if intercepted route was rendered while existing page content was removed.
+        // Content would only be preserved when combined with parallel routes.
+        expect(await browser.elementByCss('#feed-page').text()).not.toBe('Feed')
+
+        // Check if url matches even though it was intercepted.
+        expect(await browser.url()).toBe(
+          next.url + '/intercepting-routes/photos/1'
+        )
+
+        // Trigger a refresh, this should load the normal page, not the modal.
+        expect(
+          await browser.refresh().waitForElementByCss('#photo-page-1').text()
+        ).toBe('Photo PAGE 1')
+
+        // Check if the url matches still.
+        expect(await browser.url()).toBe(
+          next.url + '/intercepting-routes/photos/1'
+        )
       })
 
-      describe.skip('route intercepting', () => {
-        it('should render intercepted route', async () => {
-          const browser = await next.browser('/intercepting-routes/feed')
+      it('should render modal when paired with parallel routes', async () => {
+        const browser = await next.browser(
+          '/intercepting-parallel-modal/vercel'
+        )
+        // Check if navigation to modal route works.
+        expect(
+          await browser
+            .elementByCss('[href="/intercepting-parallel-modal/photos/1"]')
+            .click()
+            .waitForElementByCss('#photo-modal-1')
+            .text()
+        ).toBe('Photo MODAL 1')
 
-          // Check if navigation to modal route works.
-          expect(
-            await browser
-              .elementByCss('[href="/intercepting-routes/photos/1"]')
-              .click()
-              .waitForElementByCss('#photo-intercepted-1')
-              .text()
-          ).toBe('Photo INTERCEPTED 1')
+        // Check if modal was rendered while existing page content is preserved.
+        expect(await browser.elementByCss('#user-page').text()).toBe(
+          'Feed for vercel'
+        )
 
-          // Check if intercepted route was rendered while existing page content was removed.
-          // Content would only be preserved when combined with parallel routes.
-          expect(await browser.elementByCss('#feed-page').text()).not.toBe(
-            'Feed'
-          )
+        // Check if url matches even though it was intercepted.
+        expect(await browser.url()).toBe(
+          next.url + '/intercepting-parallel-modal/photos/1'
+        )
 
-          // Check if url matches even though it was intercepted.
-          expect(await browser.url()).toBe(
-            next.url + '/intercepting-routes/photos/1'
-          )
+        // Trigger a refresh, this should load the normal page, not the modal.
+        expect(
+          await browser.refresh().waitForElementByCss('#photo-page-1').text()
+        ).toBe('Photo PAGE 1')
 
-          // Trigger a refresh, this should load the normal page, not the modal.
-          expect(
-            await browser.refresh().waitForElementByCss('#photo-page-1').text()
-          ).toBe('Photo PAGE 1')
-
-          // Check if the url matches still.
-          expect(await browser.url()).toBe(
-            next.url + '/intercepting-routes/photos/1'
-          )
-        })
-
-        it('should render modal when paired with parallel routes', async () => {
-          const browser = await next.browser(
-            '/intercepting-parallel-modal/vercel'
-          )
-          // Check if navigation to modal route works.
-          expect(
-            await browser
-              .elementByCss('[href="/intercepting-parallel-modal/photos/1"]')
-              .click()
-              .waitForElementByCss('#photo-modal-1')
-              .text()
-          ).toBe('Photo MODAL 1')
-
-          // Check if modal was rendered while existing page content is preserved.
-          expect(await browser.elementByCss('#user-page').text()).toBe(
-            'Feed for vercel'
-          )
-
-          // Check if url matches even though it was intercepted.
-          expect(await browser.url()).toBe(
-            next.url + '/intercepting-parallel-modal/photos/1'
-          )
-
-          // Trigger a refresh, this should load the normal page, not the modal.
-          expect(
-            await browser.refresh().waitForElementByCss('#photo-page-1').text()
-          ).toBe('Photo PAGE 1')
-
-          // Check if the url matches still.
-          expect(await browser.url()).toBe(
-            next.url + '/intercepting-parallel-modal/photos/1'
-          )
-        })
+        // Check if the url matches still.
+        expect(await browser.url()).toBe(
+          next.url + '/intercepting-parallel-modal/photos/1'
+        )
       })
-    }
-    it.skip('noop to avoid jest error', () => {})
+    })
   }
 )


### PR DESCRIPTION

### What?

This PR is another part of making parallel routes viable!

- enables some of the tests, partially only in dev (build fails because the intersection routes are not implemented)
- introduces a  new type of special file: a `default` file that can be added to any segment, next to `page` etc, that will act as the default/placeholder when a layout does not match
- this also fixes bugs when navigating within parallel routes

### Why?

### How?

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

fix NEXT-748 ([link](https://linear.app/vercel/issue/NEXT-748))