### PR TITLE
Add content hash for dynamic og image routes

### DIFF
--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -1,6 +1,14 @@
 import { createNextDescribe } from 'e2e-utils'
 import imageSize from 'image-size'
 
+const CACHE_HEADERS = {
+  NONE: 'no-cache, no-store',
+  LONG: 'public, immutable, no-transform, max-age=31536000',
+  REVALIDATE: 'public, max-age=0, must-revalidate',
+}
+
+const hashRegex = /\?\w+$/
+
 createNextDescribe(
   'app dir - metadata dynamic routes',
   {
@@ -10,16 +18,14 @@ createNextDescribe(
       '@vercel/og': '0.4.1',
     },
   },
-  ({ next }) => {
+  ({ next, isNextDev }) => {
     describe('text routes', () => {
       it('should handle robots.[ext] dynamic routes', async () => {
         const res = await next.fetch('/robots.txt')
         const text = await res.text()
 
         expect(res.headers.get('content-type')).toBe('text/plain')
-        expect(res.headers.get('cache-control')).toBe(
-          'public, max-age=0, must-revalidate'
-        )
+        expect(res.headers.get('cache-control')).toBe(CACHE_HEADERS.REVALIDATE)
 
         expect(text).toMatchInlineSnapshot(`
           "User-Agent: Googlebot
@@ -41,9 +47,7 @@ createNextDescribe(
         const text = await res.text()
 
         expect(res.headers.get('content-type')).toBe('application/xml')
-        expect(res.headers.get('cache-control')).toBe(
-          'public, max-age=0, must-revalidate'
-        )
+        expect(res.headers.get('cache-control')).toBe(CACHE_HEADERS.REVALIDATE)
 
         expect(text).toMatchInlineSnapshot(`
           "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -70,9 +74,7 @@ createNextDescribe(
         expect(res.headers.get('content-type')).toBe(
           'application/manifest+json'
         )
-        expect(res.headers.get('cache-control')).toBe(
-          'public, max-age=0, must-revalidate'
-        )
+        expect(res.headers.get('cache-control')).toBe(CACHE_HEADERS.REVALIDATE)
 
         expect(json).toMatchObject({
           name: 'Next.js App',
@@ -97,7 +99,7 @@ createNextDescribe(
 
         expect(res.headers.get('content-type')).toBe('image/png')
         expect(res.headers.get('cache-control')).toBe(
-          'public, max-age=0, must-revalidate'
+          isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.LONG
         )
       })
 
@@ -106,7 +108,7 @@ createNextDescribe(
 
         expect(res.headers.get('content-type')).toBe('image/png')
         expect(res.headers.get('cache-control')).toBe(
-          'public, max-age=0, must-revalidate'
+          isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.LONG
         )
       })
 
@@ -131,7 +133,7 @@ createNextDescribe(
 
         expect(res.headers.get('content-type')).toBe('image/png')
         expect(res.headers.get('cache-control')).toBe(
-          'public, max-age=0, must-revalidate'
+          isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.LONG
         )
       })
 
@@ -140,7 +142,7 @@ createNextDescribe(
 
         expect(res.headers.get('content-type')).toBe('image/png')
         expect(res.headers.get('cache-control')).toBe(
-          'public, max-age=0, must-revalidate'
+          isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.LONG
         )
       })
     })
@@ -157,10 +159,12 @@ createNextDescribe(
       )
 
       // non absolute urls
-      expect($icon.attr('href')).toBe('/icon')
+      expect($icon.attr('href')).toContain('/icon')
+      expect($icon.attr('href')).toMatch(hashRegex)
       expect($icon.attr('sizes')).toBe('512x512')
       expect($icon.attr('type')).toBe('image/png')
-      expect($appleIcon.attr('href')).toBe('/apple-icon')
+      expect($appleIcon.attr('href')).toContain('/apple-icon')
+      expect($appleIcon.attr('href')).toMatch(hashRegex)
       expect($appleIcon.attr('sizes')).toBe(undefined)
       expect($appleIcon.attr('type')).toBe('image/png')
 
@@ -169,12 +173,14 @@ createNextDescribe(
       expect(twitterDescription).toBe('Twitter - This is a Next.js App')
 
       // absolute urls
-      expect(ogImageUrl).toBe(
-        'https://deploy-preview-abc.vercel.app/opengraph-image'
+      expect(ogImageUrl).toContain(
+        `https://deploy-preview-abc.vercel.app/opengraph-image`
       )
-      expect(twitterImageUrl).toBe(
-        'https://deploy-preview-abc.vercel.app/twitter-image'
+      expect(ogImageUrl).toMatch(hashRegex)
+      expect(twitterImageUrl).toContain(
+        `https://deploy-preview-abc.vercel.app/twitter-image`
       )
+      expect(twitterImageUrl).toMatch(hashRegex)
 
       // alt text
       expect($('meta[property="og:image:alt"]').attr('content')).toBe(

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -658,12 +658,16 @@ createNextDescribe(
         expect(resAppleIcon.status).toBe(200)
         expect(resAppleIcon.headers.get('content-type')).toBe('image/png')
         expect(resAppleIcon.headers.get('cache-control')).toBe(
-          'public, max-age=0, must-revalidate'
+          isNextDev
+            ? 'no-cache, no-store'
+            : 'public, immutable, no-transform, max-age=31536000'
         )
         expect(resIcon.status).toBe(200)
         expect(resIcon.headers.get('content-type')).toBe('image/png')
         expect(resIcon.headers.get('cache-control')).toBe(
-          'public, max-age=0, must-revalidate'
+          isNextDev
+            ? 'no-cache, no-store'
+            : 'public, immutable, no-transform, max-age=31536000'
         )
       })
 


### PR DESCRIPTION
* Add `contenthash` as query (`?<hash>`) for dynamic image and icon routes as well.
* Merge the metadata image info extration into 1 single loader, dynamic and static image route will all pass through `next-metadata-image-loader` to extract the image info such as size, content type, etc.
* Applying same cache header from `@vercel/og`, for development we use "no cache" header, for production, we use "long cache" header

Closes NEXT-882