### PR TITLE
Error during dev if returning `Response` in pages API routes in Node.js runtime

### DIFF
--- a/packages/next/src/server/api-utils/node.ts
+++ b/packages/next/src/server/api-utils/node.ts
@@ -530,7 +530,7 @@ export async function apiResolver(
     }
 
     // Call API route method
-    await getTracer().trace(
+    const apiRouteResult = await getTracer().trace(
       NodeSpan.runHandler,
       {
         spanName: `executing api route (pages) ${page}`,
@@ -538,15 +538,23 @@ export async function apiResolver(
       () => resolver(req, res)
     )
 
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      !externalResolver &&
-      !isResSent(res) &&
-      !wasPiped
-    ) {
-      console.warn(
-        `API resolved without sending a response for ${req.url}, this may result in stalled requests.`
-      )
+    if (process.env.NODE_ENV !== 'production') {
+      if (typeof apiRouteResult !== 'undefined') {
+        if (apiRouteResult instanceof Response) {
+          throw new Error(
+            'API handler returned a Response object in the Node.js runtime, this is not supported. Please use `runtime: "edge"` instead: https://nextjs.org/docs/api-routes/edge-api-routes'
+          )
+        }
+        console.warn(
+          `API handler should not return a value, received ${typeof apiRouteResult}.`
+        )
+      }
+
+      if (!externalResolver && !isResSent(res) && !wasPiped) {
+        console.warn(
+          `API resolved without sending a response for ${req.url}, this may result in stalled requests.`
+        )
+      }
     }
   } catch (err) {
     if (err instanceof ApiError) {

--- a/packages/next/src/server/api-utils/node.ts
+++ b/packages/next/src/server/api-utils/node.ts
@@ -542,7 +542,7 @@ export async function apiResolver(
       if (typeof apiRouteResult !== 'undefined') {
         if (apiRouteResult instanceof Response) {
           throw new Error(
-            'API handler returned a Response object in the Node.js runtime, this is not supported. Please use `runtime: "edge"` instead: https://nextjs.org/docs/api-routes/edge-api-routes'
+            'API route returned a Response object in the Node.js runtime, this is not supported. Please use `runtime: "edge"` instead: https://nextjs.org/docs/api-routes/edge-api-routes'
           )
         }
         console.warn(

--- a/test/e2e/og-api/app/pages/api/og-wrong-runtime.js
+++ b/test/e2e/og-api/app/pages/api/og-wrong-runtime.js
@@ -1,0 +1,22 @@
+// /pages/api/og.jsx
+import { ImageResponse } from '@vercel/og'
+
+export default function () {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 128,
+          background: 'lavender',
+        }}
+      >
+        Hello!
+      </div>
+    )
+  )
+}

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -53,5 +53,13 @@ describe('og-api', () => {
         )
       ).toBe(true)
     })
+  } else {
+    it('should throw error when returning a response object in pages/api in node runtime', async () => {
+      const res = await fetchViaHTTP(next.url, '/api/og-wrong-runtime')
+      expect(res.status).toBe(500)
+      expect(await res.text()).toContain(
+        `API handler returned a Response object in the Node.js runtime, this is not supported.`
+      )
+    })
   }
 })

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -58,7 +58,7 @@ describe('og-api', () => {
       const res = await fetchViaHTTP(next.url, '/api/og-wrong-runtime')
       expect(res.status).toBe(500)
       expect(await res.text()).toContain(
-        `API handler returned a Response object in the Node.js runtime, this is not supported.`
+        `API route returned a Response object in the Node.js runtime, this is not supported.`
       )
     })
   }


### PR DESCRIPTION
This avoids the case that one can accidentally return a `Response` object in the Node.js runtime in `pages/api/`, that causes the request to hang forever.