### PR TITLE
Revert "feat: change `next build` to emit output with `output: export`"

### DIFF
--- a/docs/advanced-features/static-html-export.md
+++ b/docs/advanced-features/static-html-export.md
@@ -17,9 +17,9 @@ The core of Next.js has been designed to enable starting as a static site (or Si
 
 Since Next.js supports this static export, it can be deployed and hosted on any web server that can serve HTML/CSS/JS static assets.
 
-## Usage
+## `next export`
 
-Update your [`next.config.js`](/docs/api-reference/next.config.js/introduction.md) file to include `output: 'export'` like the following:
+Update your `next.config.js` file to include `output: "export"` like the following:
 
 ```js
 /**
@@ -32,45 +32,21 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
-Then run `next build` to generate an `out` directory containing the HTML/CSS/JS static assets.
+Update your scripts in `package.json` file to include `next export` like the following:
 
-You can utilize [`getStaticProps`](/docs/basic-features/data-fetching/get-static-props.md) and [`getStaticPaths`](/docs/basic-features/data-fetching/get-static-paths.md) to generate an HTML file for each page in your `pages` directory (or more for [dynamic routes](/docs/routing/dynamic-routes.md)).
-
-If you want to change the output directory, you can configure `distDir` like the following:
-
-```js
-/**
- * @type {import('next').NextConfig}
- */
-const nextConfig = {
-  output: 'export',
-  distDir: 'dist',
+```json
+"scripts": {
+  "build": "next build && next export"
 }
-
-module.exports = nextConfig
 ```
 
-In this example, `next build` will generate a `dist` directory containing the HTML/CSS/JS static assets.
+Running `npm run build` will generate an `out` directory.
 
-Learn more about [Setting a custom build directory](/docs/api-reference/next.config.js/setting-a-custom-build-directory.md).
+`next export` builds an HTML version of your app. During `next build`, [`getStaticProps`](/docs/basic-features/data-fetching/get-static-props.md) and [`getStaticPaths`](/docs/basic-features/data-fetching/get-static-paths.md) will generate an HTML file for each page in your `pages` directory (or more for [dynamic routes](/docs/routing/dynamic-routes.md)). Then, `next export` will copy the already exported files into the correct directory. `getInitialProps` will generate the HTML files during `next export` instead of `next build`.
 
-If you want to change the output directory structure to always include a trailing slash, you can configure `trailingSlash` like the following:
+For more advanced scenarios, you can define a parameter called [`exportPathMap`](/docs/api-reference/next.config.js/exportPathMap.md) in your [`next.config.js`](/docs/api-reference/next.config.js/introduction.md) file to configure exactly which pages will be generated.
 
-```js
-/**
- * @type {import('next').NextConfig}
- */
-const nextConfig = {
-  output: 'export',
-  trailingSlash: true,
-}
-
-module.exports = nextConfig
-```
-
-This will change links so that `href="/about"` will instead be `herf="/about/"`. It will also change the output so that `out/about.html` will instead emit `out/about/index.html`.
-
-Learn more about [Trailing Slash](/docs/api-reference/next.config.js/trailing-slash.md).
+> **Warning**: Using `exportPathMap` is deprecated and is overridden by `getStaticPaths` inside `pages`. We recommend not to use them together.
 
 ## Supported Features
 
@@ -112,23 +88,3 @@ It's possible to use the [`getInitialProps`](/docs/api-reference/data-fetching/g
 - `getInitialProps` should fetch from an API and cannot use Node.js-specific libraries or the file system like `getStaticProps` can.
 
 We recommend migrating towards `getStaticProps` over `getInitialProps` whenever possible.
-
-## next export
-
-> **Warning**: "next export" is deprecated since Next.js 13.3 in favor of "output: 'export'" configuration.
-
-In versions of Next.js prior to 13.3, there was no configuration option in next.config.js and instead there was a separate command for `next export`.
-
-This could be used by updating your `package.json` file to include `next export` like the following:
-
-```json
-"scripts": {
-  "build": "next build && next export"
-}
-```
-
-Running `npm run build` will generate an `out` directory.
-
-`next export` builds an HTML version of your app. During `next build`, [`getStaticProps`](/docs/basic-features/data-fetching/get-static-props.md) and [`getStaticPaths`](/docs/basic-features/data-fetching/get-static-paths.md) will generate an HTML file for each page in your `pages` directory (or more for [dynamic routes](/docs/routing/dynamic-routes.md)). Then, `next export` will copy the already exported files into the correct directory. `getInitialProps` will generate the HTML files during `next export` instead of `next build`.
-
-> **Warning**: Using [`exportPathMap`](/docs/api-reference/next.config.js/exportPathMap.md) is deprecated and is overridden by `getStaticPaths` inside `pages`. We recommend not to use them together.

--- a/packages/next/src/cli/next-export.ts
+++ b/packages/next/src/cli/next-export.ts
@@ -62,7 +62,6 @@ const nextExport: CliCommand = (argv) => {
     silent: args['--silent'] || false,
     threads: args['--threads'],
     outdir: args['--outdir'] ? resolve(args['--outdir']) : join(dir, 'out'),
-    isInvokedFromCli: true,
   }
 
   exportApp(dir, options, nextExportCliSpan)

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -145,7 +145,6 @@ const createProgress = (total: number, label: string) => {
 
 export interface ExportOptions {
   outdir: string
-  isInvokedFromCli: boolean
   silent?: boolean
   threads?: number
   debugOutput?: boolean
@@ -155,13 +154,13 @@ export interface ExportOptions {
   exportPageWorker?: typeof import('./worker').default
   endWorker?: () => Promise<void>
   appPaths?: string[]
-  nextConfig?: NextConfigComplete
 }
 
 export default async function exportApp(
   dir: string,
   options: ExportOptions,
-  span: Span
+  span: Span,
+  configuration?: NextConfigComplete
 ): Promise<void> {
   const nextExportSpan = span.traceChild('next-export')
   const hasAppDir = !!options.appPaths
@@ -175,24 +174,10 @@ export default async function exportApp(
       .traceFn(() => loadEnvConfig(dir, false, Log))
 
     const nextConfig =
-      options.nextConfig ||
+      configuration ||
       (await nextExportSpan
         .traceChild('load-next-config')
         .traceAsyncFn(() => loadConfig(PHASE_EXPORT, dir)))
-
-    if (options.isInvokedFromCli) {
-      if (nextConfig.output === 'export') {
-        Log.warn(
-          '"next export" is no longer needed when "output: export" is configured in next.config.js'
-        )
-        return
-      } else {
-        Log.warn(
-          '"next export" is deprecated in favor of "output: export" in next.config.js https://nextjs.org/docs/advanced-features/static-html-export'
-        )
-      }
-    }
-
     const threads = options.threads || nextConfig.experimental.cpus
     const distDir = join(dir, nextConfig.distDir)
 
@@ -642,7 +627,7 @@ export default async function exportApp(
         )
     }
 
-    const timeout = nextConfig?.staticPageGenerationTimeout || 0
+    const timeout = configuration?.staticPageGenerationTimeout || 0
     let infoPrinted = false
     let exportPage: typeof import('./worker').default
     let endWorker: () => Promise<void>
@@ -729,22 +714,23 @@ export default async function exportApp(
             errorPaths.push(page !== path ? `${page}: ${path}` : path)
           }
 
-          if (options.buildExport) {
+          if (options.buildExport && configuration) {
             if (typeof result.fromBuildExportRevalidate !== 'undefined') {
-              nextConfig.initialPageRevalidationMap[path] =
+              configuration.initialPageRevalidationMap[path] =
                 result.fromBuildExportRevalidate
             }
 
             if (typeof result.fromBuildExportMeta !== 'undefined') {
-              nextConfig.initialPageMetaMap[path] = result.fromBuildExportMeta
+              configuration.initialPageMetaMap[path] =
+                result.fromBuildExportMeta
             }
 
             if (result.ssgNotFound === true) {
-              nextConfig.ssgNotFoundPaths.push(path)
+              configuration.ssgNotFoundPaths.push(path)
             }
 
-            const durations = (nextConfig.pageDurationMap[pathMap.page] =
-              nextConfig.pageDurationMap[pathMap.page] || {})
+            const durations = (configuration.pageDurationMap[pathMap.page] =
+              configuration.pageDurationMap[pathMap.page] || {})
             durations[path] = result.duration
           }
 

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -216,16 +216,13 @@ export function runNextCommand(argv, options = {}) {
     let mergedStdio = ''
 
     let stderrOutput = ''
-    if (options.stderr || options.onStderr) {
+    if (options.stderr) {
       instance.stderr.on('data', function (chunk) {
         mergedStdio += chunk
         stderrOutput += chunk
 
         if (options.stderr === 'log') {
           console.log(chunk.toString())
-        }
-        if (typeof options.onStderr === 'function') {
-          options.onStderr(chunk.toString())
         }
       })
     } else {
@@ -235,16 +232,13 @@ export function runNextCommand(argv, options = {}) {
     }
 
     let stdoutOutput = ''
-    if (options.stdout || options.onStdout) {
+    if (options.stdout) {
       instance.stdout.on('data', function (chunk) {
         mergedStdio += chunk
         stdoutOutput += chunk
 
         if (options.stdout === 'log') {
           console.log(chunk.toString())
-        }
-        if (typeof options.onStdout === 'function') {
-          options.onStdout(chunk.toString())
         }
       })
     } else {


### PR DESCRIPTION
Reverts vercel/next.js#47376

This might have caused a regression so seeing if CI passes now
fix NEXT-868 ([link](https://linear.app/vercel/issue/NEXT-868))