### PR TITLE
chore: reduce noisy logs when updating timing gist

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -516,9 +516,9 @@ async function main() {
         if (!timingsRes.ok) {
           throw new Error(`request status: ${timingsRes.status}`)
         }
+        const result = await timingsRes.json()
         console.log(
-          'Sent updated timings successfully',
-          await timingsRes.json()
+          `Sent updated timings successfully. API URL: "${result?.url}" HTML URL: "${result?.html_url}"`
         )
       } catch (err) {
         console.log('Failed to update timings data', err)


### PR DESCRIPTION
Example noisy logs today: https://github.com/vercel/next.js/actions/runs/4501965165/jobs/7923231538#step:6:130