### PR TITLE
test: wait for the redbox

### DIFF
--- a/test/development/acceptance-app/unsupported-app-features.test.ts
+++ b/test/development/acceptance-app/unsupported-app-features.test.ts
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 import { sandbox } from './helpers'
 import { createNextDescribe, FileRef } from 'e2e-utils'
+import { check } from 'next-test-utils'
 import path from 'path'
 
 createNextDescribe(
@@ -35,7 +36,10 @@ createNextDescribe(
       `
       )
 
-      expect(await session.hasRedbox(true)).toBe(true)
+      await check(
+        async () => ((await session.hasRedbox(true)) ? 'redbox' : 'nothing'),
+        /redbox/
+      )
       expect(await session.getRedboxDescription()).toInclude(
         'AMP is not supported in the app directory. If you need to use AMP it will continue to be supported in the pages directory.'
       )

--- a/test/development/acceptance-app/unsupported-app-features.test.ts
+++ b/test/development/acceptance-app/unsupported-app-features.test.ts
@@ -17,6 +17,11 @@ createNextDescribe(
     it('should show error exporting AMP config in app dir', async () => {
       const { session, cleanup } = await sandbox(next)
 
+      // Make sure the page is rendering correctly first before patching to a bad file
+      expect(
+        await session.evaluate(() => document.querySelector('body').textContent)
+      ).toContain('new sandbox')
+
       // Add AMP export
       await session.patch(
         'app/page.js',


### PR DESCRIPTION
use `check()` to wait for the redbox

x-ref: https://github.com/vercel/next.js/actions/runs/4502846921/jobs/7925929558?pr=47446#step:6:263