### PR TITLE
Update fetch cache memory handling

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -62,3 +62,5 @@ jobs:
       - run: pnpm run build
 
       - run: node ./scripts/start-release.js --release-type ${{ github.event.inputs.releaseType }} --semver-type ${{ github.event.inputs.semverType }}
+        env:
+          START_RELEASE_TOKEN: ${{ secrets.START_RELEASE_TOKEN }}

--- a/packages/next/src/client/components/static-generation-async-storage.ts
+++ b/packages/next/src/client/components/static-generation-async-storage.ts
@@ -9,6 +9,12 @@ export interface StaticGenerationStore {
   readonly isPrerendering?: boolean
 
   forceDynamic?: boolean
+  fetchCache?:
+    | 'only-cache'
+    | 'force-cache'
+    | 'force-no-store'
+    | 'default-no-store'
+    | 'only-no-store'
   revalidate?: false | number
   forceStatic?: boolean
   dynamicShouldError?: boolean

--- a/packages/next/src/server/app-render/index.tsx
+++ b/packages/next/src/server/app-render/index.tsx
@@ -530,6 +530,10 @@ export async function renderToHTMLOrFlight(
         }
       }
 
+      if (typeof layoutOrPageMod?.fetchCache === 'string') {
+        staticGenerationStore.fetchCache = layoutOrPageMod?.fetchCache
+      }
+
       if (typeof layoutOrPageMod?.revalidate === 'number') {
         defaultRevalidate = layoutOrPageMod.revalidate as number
 

--- a/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
@@ -11,6 +11,7 @@ export type RequestContext = {
     isRevalidate?: boolean
     isBot?: boolean
     nextExport?: boolean
+    fetchCache?: StaticGenerationStore['fetchCache']
   }
 }
 
@@ -55,6 +56,7 @@ export class StaticGenerationAsyncStorageWrapper
       incrementalCache: renderOpts.incrementalCache,
       isRevalidate: renderOpts.isRevalidate,
       isPrerendering: renderOpts.nextExport,
+      fetchCache: renderOpts.fetchCache,
     }
     ;(renderOpts as any).store = store
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1485,6 +1485,15 @@ export default abstract class Server<ServerOptions extends Options = Options> {
               if (!headers['content-type'] && blob.type) {
                 headers['content-type'] = blob.type
               }
+              let revalidate: number | false | undefined = (
+                (context as any).store as any as
+                  | { revalidate?: number }
+                  | undefined
+              )?.revalidate
+
+              if (typeof revalidate == 'undefined') {
+                revalidate = false
+              }
 
               // Create the cache entry for the response.
               const cacheEntry: ResponseCacheEntry = {
@@ -1494,12 +1503,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
                   body: Buffer.from(await blob.arrayBuffer()),
                   headers,
                 },
-                revalidate:
-                  (
-                    (context as any).store as any as
-                      | { revalidate?: number }
-                      | undefined
-                  )?.revalidate || false,
+                revalidate,
               }
 
               return cacheEntry

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1495,8 +1495,11 @@ export default abstract class Server<ServerOptions extends Options = Options> {
                   headers,
                 },
                 revalidate:
-                  ((context as any).store as any as { revalidate?: number })
-                    .revalidate || false,
+                  (
+                    (context as any).store as any as
+                      | { revalidate?: number }
+                      | undefined
+                  )?.revalidate || false,
               }
 
               return cacheEntry

--- a/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
+++ b/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
@@ -539,8 +539,9 @@ export class AppRouteRouteHandler implements RouteHandler<AppRouteRouteMatch> {
               default:
                 break
             }
+            ;(context as any).store = staticGenerationStore
 
-            if (typeof staticGenerationStore.revalidate === 'undefined') {
+            if (typeof staticGenerationStore?.revalidate === 'undefined') {
               staticGenerationStore.revalidate =
                 module.handlers.revalidate ?? false
             }

--- a/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
+++ b/packages/next/src/server/future/route-handlers/app-route-route-handler.ts
@@ -74,7 +74,8 @@ export type AppRouteModule = {
    */
   handlers: Record<HTTP_METHOD, AppRouteHandlerFn> &
     Record<'dynamic', AppConfig['dynamic']> &
-    Record<'revalidate', AppConfig['revalidate']>
+    Record<'revalidate', AppConfig['revalidate']> &
+    Record<'fetchCache', AppConfig['fetchCache']>
 
   /**
    * The exported async storage object for this worker/module.
@@ -483,8 +484,11 @@ export class AppRouteRouteHandler implements RouteHandler<AppRouteRouteMatch> {
           staticGenerationAsyncStorage,
           {
             pathname: definition.pathname,
-            renderOpts: context ?? {
-              supportsDynamicHTML: false,
+            renderOpts: {
+              fetchCache: module.handlers.fetchCache,
+              ...(context ?? {
+                supportsDynamicHTML: false,
+              }),
             },
           },
           (staticGenerationStore) => {

--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -71,6 +71,12 @@ export default class FetchCache implements CacheHandler {
 
     let data = memoryCache?.get(key)
 
+    // memory cache data is only leveraged for up to 1 seconds
+    // so that revalidation events can be pulled from source
+    if (Date.now() - (data?.lastModified || 0) > 2000) {
+      data = undefined
+    }
+
     // get data from fetch cache
     if (!data && this.cacheEndpoint) {
       try {

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -351,8 +351,8 @@ export class IncrementalCache {
     fetchCache?: boolean
   ) {
     if (this.dev && !fetchCache) return
-    // fetchCache has upper limit of 1MB per-entry currently
-    if (fetchCache && JSON.stringify(data).length > 1024 * 1024) {
+    // fetchCache has upper limit of 2MB per-entry currently
+    if (fetchCache && JSON.stringify(data).length > 2 * 1024 * 1024) {
       if (this.dev) {
         throw new Error(`fetch for over 1MB of data can not be cached`)
       }

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -99,6 +99,15 @@ export function patchFetch({
             ? _headers
             : new Headers(_headers || {})
 
+        const isOnlyCache = staticGenerationStore.fetchCache === 'only-cache'
+        const isForceCache = staticGenerationStore.fetchCache === 'force-cache'
+        const isDefaultNoStore =
+          staticGenerationStore.fetchCache === 'default-no-store'
+        const isOnlyNoStore =
+          staticGenerationStore.fetchCache === 'only-no-store'
+        const isForceNoStore =
+          staticGenerationStore.fetchCache === 'force-no-store'
+
         const hasUnCacheableHeader =
           initHeaders.get('authorization') || initHeaders.get('cookie')
 

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -99,14 +99,14 @@ export function patchFetch({
             ? _headers
             : new Headers(_headers || {})
 
-        const isOnlyCache = staticGenerationStore.fetchCache === 'only-cache'
-        const isForceCache = staticGenerationStore.fetchCache === 'force-cache'
-        const isDefaultNoStore =
-          staticGenerationStore.fetchCache === 'default-no-store'
-        const isOnlyNoStore =
-          staticGenerationStore.fetchCache === 'only-no-store'
-        const isForceNoStore =
-          staticGenerationStore.fetchCache === 'force-no-store'
+        // const isOnlyCache = staticGenerationStore.fetchCache === 'only-cache'
+        // const isForceCache = staticGenerationStore.fetchCache === 'force-cache'
+        // const isDefaultNoStore =
+        //   staticGenerationStore.fetchCache === 'default-no-store'
+        // const isOnlyNoStore =
+        //   staticGenerationStore.fetchCache === 'only-no-store'
+        // const isForceNoStore =
+        //   staticGenerationStore.fetchCache === 'force-no-store'
 
         const hasUnCacheableHeader =
           initHeaders.get('authorization') || initHeaders.get('cookie')

--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -7,7 +7,7 @@ async function main() {
   const args = process.argv
   const releaseType = args[args.indexOf('--release-type') + 1]
   const semverType = args[args.indexOf('--semver-type') + 1]
-  const isCanary = releaseType === 'canary'
+  const isCanary = releaseType !== 'stable'
 
   if (releaseType !== 'stable' && releaseType !== 'canary') {
     console.log(`Invalid release type ${releaseType}, must be stable or canary`)

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -127,20 +127,32 @@ function runTests(mode) {
         const imagesizes = await link.getAttribute('imagesizes')
         entries.push({ fetchpriority, imagesrcset, imagesizes })
       }
-      expect(entries).toEqual([
-        {
-          fetchpriority: 'high',
-          imagesizes: '',
-          imagesrcset:
-            '/_next/image?url=%2Ftest.jpg&w=640&q=75 1x, /_next/image?url=%2Ftest.jpg&w=828&q=75 2x',
-        },
-        {
-          fetchpriority: 'high',
-          imagesizes: '100vw',
-          imagesrcset:
-            '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w',
-        },
-      ])
+
+      expect(
+        entries.find(
+          (item) =>
+            item.imagesrcset ===
+            '/_next/image?url=%2Ftest.jpg&w=640&q=75 1x, /_next/image?url=%2Ftest.jpg&w=828&q=75 2x'
+        )
+      ).toEqual({
+        fetchpriority: 'high',
+        imagesizes: '',
+        imagesrcset:
+          '/_next/image?url=%2Ftest.jpg&w=640&q=75 1x, /_next/image?url=%2Ftest.jpg&w=828&q=75 2x',
+      })
+
+      expect(
+        entries.find(
+          (item) =>
+            item.imagesrcset ===
+            '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
+        )
+      ).toEqual({
+        fetchpriority: 'high',
+        imagesizes: '100vw',
+        imagesrcset:
+          '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w',
+      })
 
       // When priority={true}, we should _not_ set loading="lazy"
       expect(

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -198,9 +198,11 @@ function runTests(mode) {
 
       // should preload with crossorigin
       expect(
-        await browser.elementsByCss(
-          'link[rel=preload][as=image][crossorigin=anonymous][imagesrcset*="test.jpg"]'
-        )
+        (
+          await browser.elementsByCss(
+            'link[rel=preload][as=image][crossorigin=anonymous][imagesrcset*="test.jpg"]'
+          )
+        ).length
       ).toBeGreaterThanOrEqual(1)
     } finally {
       if (browser) {

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -201,7 +201,7 @@ function runTests(mode) {
         await browser.elementsByCss(
           'link[rel=preload][as=image][crossorigin=anonymous][imagesrcset*="test.jpg"]'
         )
-      ).toHaveLength(1)
+      ).toBeGreaterThanOrEqual(1)
     } finally {
       if (browser) {
         await browser.close()

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -126,20 +126,31 @@ function runTests(mode) {
         const imagesizes = await link.getAttribute('imagesizes')
         entries.push({ fetchpriority, imagesrcset, imagesizes })
       }
-      expect(entries).toEqual([
-        {
-          fetchpriority: 'high',
-          imagesizes: '',
-          imagesrcset:
-            '/_next/image?url=%2Ftest.jpg&w=640&q=75 1x, /_next/image?url=%2Ftest.jpg&w=828&q=75 2x',
-        },
-        {
-          fetchpriority: 'high',
-          imagesizes: '100vw',
-          imagesrcset:
-            '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w',
-        },
-      ])
+      expect(
+        entries.find(
+          (item) =>
+            item.imagesrcset ===
+            '/_next/image?url=%2Ftest.jpg&w=640&q=75 1x, /_next/image?url=%2Ftest.jpg&w=828&q=75 2x'
+        )
+      ).toEqual({
+        fetchpriority: 'high',
+        imagesizes: '',
+        imagesrcset:
+          '/_next/image?url=%2Ftest.jpg&w=640&q=75 1x, /_next/image?url=%2Ftest.jpg&w=828&q=75 2x',
+      })
+
+      expect(
+        entries.find(
+          (item) =>
+            item.imagesrcset ===
+            '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
+        )
+      ).toEqual({
+        fetchpriority: 'high',
+        imagesizes: '100vw',
+        imagesrcset:
+          '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w',
+      })
 
       // When priority={true}, we should _not_ set loading="lazy"
       expect(


### PR DESCRIPTION
This ensures we only honor cache entries from the in memory cache for up to 2 seconds so that revalidates can correctly propagate and also increases max fetch cache entry size to 2 MB. The `fetchCache` export is also being detected in this PR but not yet honored which will be done in a follow-up.  