### PR TITLE
Fix trigger_release workflow type

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -1,5 +1,5 @@
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       releaseType:
         description: stable or canary (case sensitive)?


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/47461 swapping the workflow type