### PR TITLE
(Feature) `prettier-plugin-tailwind` add it as a `devDependency` whn using `create-next-app` with tailwind.

### DIFF
--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -35,6 +35,7 @@ export async function createApp({
   examplePath,
   typescript,
   tailwind,
+  tailwind_prettier,
   eslint,
   experimentalApp,
   srcDir,
@@ -46,6 +47,7 @@ export async function createApp({
   examplePath?: string
   typescript: boolean
   tailwind: boolean
+  tailwind_prettier: boolean
   eslint: boolean
   experimentalApp: boolean
   srcDir: boolean

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -56,7 +56,7 @@ const program = new Commander.Command(packageJson.name)
     '--tailwind',
     `
 
-  Initialize with Tailwind CSS config. (default)
+  Initialize with Tailwind CSS and prettier plugin for Tailwind config. (default)
 `
   )
   .option(
@@ -307,7 +307,7 @@ async function run(): Promise<void> {
           onState: onPromptState,
           type: 'toggle',
           name: 'tailwind',
-          message: `Would you like to use ${tw} with this project?`,
+          message: `Would you like to use ${tw} and prettier plugin for tailwind with this project?`,
           initial: getPrefOrDefault('tailwind'),
           active: 'Yes',
           inactive: 'No',

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -304,10 +304,13 @@ async function run(): Promise<void> {
 
     if (
       !process.argv.includes('--tailwind') &&
-      !process.argv.includes('--no-tailwind')
+      !process.argv.includes('--no-tailwind') &&
+      !process.argv.includes('--tailwind-prettier') && 
+      !process.argv.includes('--no-tailwind-prettier') 
     ) {
       if (ciInfo.isCI) {
         program.tailwind = false
+        program.tailwind_prettier = false
       } else {
         const tw = chalk.hex('#007acc')('Tailwind CSS')
         const { tailwind } = await prompts({
@@ -321,29 +324,21 @@ async function run(): Promise<void> {
         })
         program.tailwind = Boolean(tailwind)
         preferences.tailwind = Boolean(tailwind)
+        if (tailwind) {
+          const pt = chalk.hex('#007acc')('Prettier Plugin for Tailwind CSS')
+          const { tailwind_prettier } = await prompts({
+            onState: onPromptState,
+            type: 'toggle',
+            name: 'Prettier-Plugin',
+            message: `Would you like to use ${pt} with this project?`,
+            initial: getPrefOrDefault('Prettier-Plugin'),
+            active: 'Yes',
+            inactive: 'No',
+          })
+          program.tailwind_prettier = Boolean(tailwind_prettier)
+          preferences.tailwind_prettier = Boolean(tailwind_prettier)
+        }
       }
-    }
-
-    if (
-      (process.argv.includes("--tailwind") &&
-      !process.argv.includes("--tailwind-prettier")) ||
-      program.tailwind
-    ) {if (ciInfo.isCI) {
-      program.tailwind_prettier = false;
-    } else {
-      const tw = chalk.hex("#007acc")("Prettier Plugin for Tailwind CSS");
-      const { tailwind_prettier } = await prompts({
-        onState: onPromptState,
-        type: "toggle",
-        name: "tailwind",
-        message: `Would you like to use ${tw} with this project?`,
-        initial: getPrefOrDefault("tailwind"),
-        active: "Yes",
-        inactive: "No",
-      });
-      program.tailwind_prettier = Boolean(tailwind_prettier);
-      preferences.tailwind_prettier = Boolean(tailwind_prettier);
-    }
     }
 
     if (

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -56,6 +56,13 @@ const program = new Commander.Command(packageJson.name)
     '--tailwind',
     `
 
+  Initialize with Tailwind CSS config. (default)
+`
+  )
+  .option(
+    '--tailwind-prettier',
+    `
+
   Initialize with Tailwind CSS and prettier plugin for Tailwind config. (default)
 `
   )
@@ -307,7 +314,7 @@ async function run(): Promise<void> {
           onState: onPromptState,
           type: 'toggle',
           name: 'tailwind',
-          message: `Would you like to use ${tw} and prettier plugin for tailwind with this project?`,
+          message: `Would you like to use ${tw} with this project?`,
           initial: getPrefOrDefault('tailwind'),
           active: 'Yes',
           inactive: 'No',
@@ -315,6 +322,28 @@ async function run(): Promise<void> {
         program.tailwind = Boolean(tailwind)
         preferences.tailwind = Boolean(tailwind)
       }
+    }
+
+    if (
+      (process.argv.includes("--tailwind") &&
+      !process.argv.includes("--tailwind-prettier")) ||
+      program.tailwind
+    ) {if (ciInfo.isCI) {
+      program.tailwind_prettier = false;
+    } else {
+      const tw = chalk.hex("#007acc")("Prettier Plugin for Tailwind CSS");
+      const { tailwind_prettier } = await prompts({
+        onState: onPromptState,
+        type: "toggle",
+        name: "tailwind",
+        message: `Would you like to use ${tw} with this project?`,
+        initial: getPrefOrDefault("tailwind"),
+        active: "Yes",
+        inactive: "No",
+      });
+      program.tailwind_prettier = Boolean(tailwind_prettier);
+      preferences.tailwind_prettier = Boolean(tailwind_prettier);
+    }
     }
 
     if (
@@ -395,6 +424,7 @@ async function run(): Promise<void> {
       examplePath: program.examplePath,
       typescript: program.typescript,
       tailwind: program.tailwind,
+      tailwind_prettier: program.tailwind_prettier,
       eslint: program.eslint,
       experimentalApp: program.experimentalApp,
       srcDir: program.srcDir,
@@ -424,6 +454,7 @@ async function run(): Promise<void> {
       typescript: program.typescript,
       eslint: program.eslint,
       tailwind: program.tailwind,
+      tailwind_prettier: program.tailwind_prettier,
       experimentalApp: program.experimentalApp,
       srcDir: program.srcDir,
       importAlias: program.importAlias,

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -37,6 +37,7 @@ export const installTemplate = async ({
   template,
   mode,
   tailwind,
+  tailwind_prettier,
   eslint,
   srcDir,
   importAlias,
@@ -184,7 +185,7 @@ export const installTemplate = async ({
    * These flags will be passed to `install()`, which calls the package manager
    * install process.
    */
-  const installFlags = { packageManager, isOnline, devDependencies }
+  const installFlags = { packageManager, isOnline }
 
   /**
    * Default dependencies.
@@ -200,14 +201,10 @@ export const installTemplate = async ({
   ]
 
   /**
-   * devDependencies.
-   */
-  const devDependencies = []
-  /**
    * TypeScript projects will have type definitions and other devDependencies.
    */
   if (mode === 'ts') {
-    devDependencies.push(
+    dependencies.push(
       'typescript',
       '@types/react',
       '@types/node',
@@ -220,7 +217,13 @@ export const installTemplate = async ({
    */
   if (tailwind) {
     dependencies.push('tailwindcss', 'postcss', 'autoprefixer')
-    devDependencies.push('prettier', 'prettier-plugin-tailwindcss')
+  }
+
+  /**
+   * Add Prettier Plugin for Tailwind CSS dependencies.
+   */
+  if (tailwind && tailwind_prettier) {
+    dependencies.push('prettier', 'prettier-plugin-tailwindcss')
   }
 
   /**

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -184,7 +184,7 @@ export const installTemplate = async ({
    * These flags will be passed to `install()`, which calls the package manager
    * install process.
    */
-  const installFlags = { packageManager, isOnline }
+  const installFlags = { packageManager, isOnline, devDependencies }
 
   /**
    * Default dependencies.
@@ -200,22 +200,27 @@ export const installTemplate = async ({
   ]
 
   /**
+   * devDependencies.
+   */
+  const devDependencies = []
+  /**
    * TypeScript projects will have type definitions and other devDependencies.
    */
   if (mode === 'ts') {
-    dependencies.push(
+    devDependencies.push(
       'typescript',
       '@types/react',
       '@types/node',
       '@types/react-dom'
-    )
-  }
+      )
+    }
 
   /**
    * Add Tailwind CSS dependencies.
    */
   if (tailwind) {
     dependencies.push('tailwindcss', 'postcss', 'autoprefixer')
+    devDependencies.push('prettier', 'prettier-plugin-tailwindcss')
   }
 
   /**

--- a/packages/create-next-app/templates/types.ts
+++ b/packages/create-next-app/templates/types.ts
@@ -19,6 +19,7 @@ export interface InstallTemplateArgs {
   mode: TemplateMode
   eslint: boolean
   tailwind: boolean
+  tailwind_prettier: boolean
   srcDir: boolean
   importAlias: string
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
`prettier-plugin-tailwind` is added as one of the `devDependency` when using taiwindcss fixes #47366 

**Question** 
```typescript
/**
   * TypeScript projects will have type definitions and other devDependencies.
   */
  if (mode === 'ts') {
    dependencies.push(
     'typescript',
      '@types/react',
      '@types/node',
      '@types/react-dom'
    )
  }
```  
Here in this code the sentence _TypeScript projects will have type definitions and other devDependencies_ but the dependencies are not pushed as `devDependency` and there is no array for `devDependency`, Is it intentional?