### PR TITLE
Return null for useParams in pages

### DIFF
--- a/packages/next/navigation-types/compat/navigation.d.ts
+++ b/packages/next/navigation-types/compat/navigation.d.ts
@@ -18,4 +18,12 @@ declare module 'next/navigation' {
    * router is not ready.
    */
   export function usePathname(): string | null
+
+  /**
+   * Get the current parameters. For example useParams() on /dashboard/[team]
+   * where pathname is /dashboard/nextjs would return { team: 'nextjs' }
+   *
+   * If used from `pages/`, the hook will return `null`.
+   */
+  export function useSearchParams(): ReadonlyURLSearchParams | null
 }

--- a/packages/next/navigation-types/compat/navigation.d.ts
+++ b/packages/next/navigation-types/compat/navigation.d.ts
@@ -25,5 +25,5 @@ declare module 'next/navigation' {
    *
    * If used from `pages/`, the hook will return `null`.
    */
-  export function useSearchParams(): ReadonlyURLSearchParams | null
+  export function useParams(): Record<string, string | string[]> | null
 }

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -153,7 +153,8 @@ function getSelectedParams(
 }
 
 /**
- * Get the current parameters. For example useParams() on /dashboard/[team] where pathname is /dashboard/nextjs would return { team: 'nextjs' }
+ * Get the current parameters. For example useParams() on /dashboard/[team]
+ * where pathname is /dashboard/nextjs would return { team: 'nextjs' }
  */
 export function useParams(): Params {
   clientHookInServerComponentError('useParams')

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -109,12 +109,6 @@ export function usePathname(): string {
   return useContext(PathnameContext) as string
 }
 
-// TODO-APP: getting all params when client-side navigating is non-trivial as it does not have route matchers so this might have to be a server context instead.
-// export function useParams() {
-//   clientHookInServerComponentError('useParams')
-//   return useContext(ParamsContext)
-// }
-
 export {
   ServerInsertedHTMLContext,
   useServerInsertedHTML,
@@ -158,9 +152,16 @@ function getSelectedParams(
   return getSelectedParams(node, params)
 }
 
-export function useParams() {
+/**
+ * Get the current parameters. For example useParams() on /dashboard/[team] where pathname is /dashboard/nextjs would return { team: 'nextjs' }
+ */
+export function useParams(): Params {
   clientHookInServerComponentError('useParams')
   const { tree } = useContext(GlobalLayoutRouterContext)
+  if (!tree) {
+    // This only happens in `pages`. Type is overwritten in navigation.d.ts
+    return null!
+  }
   return getSelectedParams(tree)
 }
 


### PR DESCRIPTION
### What?

Ensures `useParams` can be called in `pages`. In that case it returns `null` similar to other navigation hooks that can't be backported.

### Why?

When migrating you can have components that are rendered in both `app` and `pages`.

### How?

Uses the same approach as `useSearchParams` and `usePathname`. Type is added to `navigation.d.ts` that overrides `next/navigation` only when `pages` exist, that way applications built entirely on `app` don't get the `null` type.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
