### PR TITLE
chore: tweak CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,12 +2,14 @@
 # https://help.github.com/en/articles/about-code-owners
 
 *                                             @timneutkens @ijjk @shuding @huozhi @feedthejim
-/.github/                                     @vercel/next-js
+/.git*                                        @vercel/next-js
 /docs/                                        @vercel/next-js @leerob
 /errors/                                      @vercel/next-js @leerob
 /examples/                                    @vercel/next-js @leerob @steven-tey
 /scripts/                                     @vercel/next-js
-/.*                                           @vercel/next-js @leerob
+/.alex*                                       @vercel/next-js @leerob
+/.eslint*                                     @vercel/next-js @leerob
+/.prettier*                                   @vercel/next-js @leerob
 /*.md                                         @vercel/next-js @leerob
 /packages/create-next-app/                    @vercel/next-js
 


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/47451#discussion_r1146696503 assumption here was wrong. `/.*` matches directories too.

Just look at this PR, Lee should not be asked for a review:
![image](https://user-images.githubusercontent.com/18369201/227534156-8923acc1-9e2a-4602-8882-30fd92a13145.png)