### PR TITLE
fix: typo in max cache size error message

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -354,7 +354,7 @@ export class IncrementalCache {
     // fetchCache has upper limit of 2MB per-entry currently
     if (fetchCache && JSON.stringify(data).length > 2 * 1024 * 1024) {
       if (this.dev) {
-        throw new Error(`fetch for over 1MB of data can not be cached`)
+        throw new Error(`fetch for over 2MB of data can not be cached`)
       }
       return
     }


### PR DESCRIPTION
Update error message for cache size limit to match the increased limit of 2MB (https://github.com/vercel/next.js/pull/47465)
