### PR TITLE
Add additional context for fetch cache requests

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -5,6 +5,13 @@ import type { CacheHandler, CacheHandlerContext, CacheHandlerValue } from './'
 
 let memoryCache: LRUCache<string, CacheHandlerValue> | undefined
 
+interface NextFetchCacheParams {
+  internal?: boolean
+  fetchType?: string
+  fetchIdx?: number
+  originUrl?: string
+}
+
 export default class FetchCache implements CacheHandler {
   private headers: Record<string, string>
   private cacheEndpoint?: string
@@ -86,17 +93,18 @@ export default class FetchCache implements CacheHandler {
     if (!data && this.cacheEndpoint) {
       try {
         const start = Date.now()
+        const fetchParams: NextFetchCacheParams = {
+          internal: true,
+          fetchType: 'fetch-get',
+          originUrl,
+          fetchIdx,
+        }
         const res = await fetch(
           `${this.cacheEndpoint}/v1/suspense-cache/${key}`,
           {
             method: 'GET',
             headers: this.headers,
-            next: {
-              internal: true,
-              fetchType: 'fetch-get',
-              originUrl,
-              fetchIdx,
-            },
+            next: fetchParams as NextFetchRequestConfig,
           }
         )
 
@@ -185,18 +193,19 @@ export default class FetchCache implements CacheHandler {
             data.data.headers['cache-control']
         }
         const body = JSON.stringify(data)
+        const fetchParams: NextFetchCacheParams = {
+          internal: true,
+          fetchType: 'fetch-set',
+          originUrl,
+          fetchIdx,
+        }
         const res = await fetch(
           `${this.cacheEndpoint}/v1/suspense-cache/${key}`,
           {
             method: 'POST',
             headers: this.headers,
             body: body,
-            next: {
-              internal: true,
-              fetchType: 'fetch-set',
-              originUrl,
-              fetchIdx,
-            },
+            next: fetchParams as NextFetchRequestConfig,
           }
         )
 

--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -66,7 +66,12 @@ export default class FetchCache implements CacheHandler {
     }
   }
 
-  public async get(key: string, fetchCache?: boolean) {
+  public async get(
+    key: string,
+    fetchCache?: boolean,
+    originUrl?: string,
+    fetchIdx?: number
+  ) {
     if (!fetchCache) return null
 
     let data = memoryCache?.get(key)
@@ -86,8 +91,12 @@ export default class FetchCache implements CacheHandler {
           {
             method: 'GET',
             headers: this.headers,
-            // @ts-expect-error
-            next: { internal: true },
+            next: {
+              internal: true,
+              fetchType: 'fetch-get',
+              originUrl,
+              fetchIdx,
+            },
           }
         )
 
@@ -150,7 +159,9 @@ export default class FetchCache implements CacheHandler {
   public async set(
     key: string,
     data: CacheHandlerValue['value'],
-    fetchCache?: boolean
+    fetchCache?: boolean,
+    originUrl?: string,
+    fetchIdx?: number
   ) {
     if (!fetchCache) return
 
@@ -180,8 +191,12 @@ export default class FetchCache implements CacheHandler {
             method: 'POST',
             headers: this.headers,
             body: body,
-            // @ts-expect-error
-            next: { internal: true },
+            next: {
+              internal: true,
+              fetchType: 'fetch-set',
+              originUrl,
+              fetchIdx,
+            },
           }
         )
 

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -39,7 +39,9 @@ export class CacheHandler {
 
   public async get(
     _key: string,
-    _fetchCache?: boolean
+    _fetchCache?: boolean,
+    _originUrl?: string,
+    _fetchIdx?: number
   ): Promise<CacheHandlerValue | null> {
     return {} as any
   }
@@ -47,7 +49,9 @@ export class CacheHandler {
   public async set(
     _key: string,
     _data: IncrementalCacheValue | null,
-    _fetchCache?: boolean
+    _fetchCache?: boolean,
+    _originUrl?: string,
+    _fetchIdx?: number
   ): Promise<void> {}
 }
 
@@ -266,7 +270,9 @@ export class IncrementalCache {
   async get(
     pathname: string,
     fetchCache?: boolean,
-    revalidate?: number
+    revalidate?: number,
+    originUrl?: string,
+    fetchIdx?: number
   ): Promise<IncrementalCacheEntry | null> {
     // we don't leverage the prerender cache in dev mode
     // so that getStaticProps is always called for easier debugging
@@ -279,7 +285,12 @@ export class IncrementalCache {
 
     pathname = this._getPathname(pathname, fetchCache)
     let entry: IncrementalCacheEntry | null = null
-    const cacheData = await this.cacheHandler?.get(pathname, fetchCache)
+    const cacheData = await this.cacheHandler?.get(
+      pathname,
+      fetchCache,
+      originUrl,
+      fetchIdx
+    )
 
     if (cacheData?.value?.kind === 'FETCH') {
       revalidate = revalidate || cacheData.value.revalidate
@@ -337,7 +348,14 @@ export class IncrementalCache {
         curRevalidate,
         revalidateAfter,
       }
-      this.set(pathname, entry.value, curRevalidate, fetchCache)
+      this.set(
+        pathname,
+        entry.value,
+        curRevalidate,
+        fetchCache,
+        originUrl,
+        fetchIdx
+      )
     }
     return entry
   }
@@ -347,7 +365,9 @@ export class IncrementalCache {
     pathname: string,
     data: IncrementalCacheValue | null,
     revalidateSeconds?: number | false,
-    fetchCache?: boolean
+    fetchCache?: boolean,
+    originUrl?: string,
+    fetchIdx?: number
   ) {
     if (this.dev && !fetchCache) return
     // fetchCache has upper limit of 2MB per-entry currently
@@ -374,7 +394,13 @@ export class IncrementalCache {
           initialRevalidateSeconds: revalidateSeconds,
         }
       }
-      await this.cacheHandler?.set(pathname, data, fetchCache)
+      await this.cacheHandler?.set(
+        pathname,
+        data,
+        fetchCache,
+        originUrl,
+        fetchIdx
+      )
     } catch (error) {
       console.warn('Failed to update prerender cache for', pathname, error)
     }

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -26,7 +26,7 @@ export function patchFetch({
     input: RequestInfo | URL,
     init: RequestInit | undefined
   ) => {
-    let url
+    let url: URL | undefined
     try {
       url = new URL(input instanceof Request ? input.url : input)
       url.username = ''
@@ -37,8 +37,6 @@ export function patchFetch({
     }
 
     const method = init?.method?.toUpperCase() || 'GET'
-    const originUrl = url?.toString() ?? ''
-    const fetchIdx = nextFetchIdx++
 
     return await getTracer().trace(
       AppRenderSpan.fetch,
@@ -224,6 +222,9 @@ export function patchFetch({
             init[field] = initialInit[field]
           }
         }
+
+        const originUrl = url?.toString() ?? ''
+        const fetchIdx = nextFetchIdx++
 
         const doOriginalFetch = async () => {
           // add metadata to init without editing the original

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -40,6 +40,10 @@ interface Window {
 
 interface NextFetchRequestConfig {
   revalidate?: number | false
+  internal?: boolean
+  fetchType?: string
+  fetchIdx?: number
+  originUrl?: string
 }
 
 interface RequestInit {

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -40,10 +40,6 @@ interface Window {
 
 interface NextFetchRequestConfig {
   revalidate?: number | false
-  internal?: boolean
-  fetchType?: string
-  fetchIdx?: number
-  originUrl?: string
 }
 
 interface RequestInit {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
