### PR TITLE
Update failing i18n e2e deploy test

### DIFF
--- a/test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.js
+++ b/test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.js
@@ -8,13 +8,18 @@ const { i18n } = require('./next.config')
 
 const urls = [
   // Include the app page without a locale.
-  {
-    pathname: '/blog/first-post',
-    expected: {
-      pathname: '/blog/first-post',
-      page: '/app/blog/[slug]/page.js',
-    },
-  },
+  ...(global.isNextDeploy
+    ? []
+    : [
+        // TODO: enable for deploy mode when behavior is corrected
+        {
+          pathname: '/blog/first-post',
+          expected: {
+            pathname: '/blog/first-post',
+            page: '/app/blog/[slug]/page.js',
+          },
+        },
+      ]),
 
   // Include the app pages with locales (should not resolve).
   ...i18n.locales.map((locale) => ({


### PR DESCRIPTION
Temporarily skips a failing test case on e2e deploy mode for i18n-hybrid test suite.

x-ref: https://github.com/vercel/next.js/actions/runs/4520873270/jobs/7962318031