### PR TITLE
dependency updates for swc_core update

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "ast_node"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf94863c5fdfee166d0907c44e5fee970123b2b7307046d35d1e671aa93afbba"
+checksum = "43e351bf9f01438f9479f39ed9d2c26dab615f9887d8ba50d50addd0c6536d51"
 dependencies = [
  "darling 0.13.4",
  "pmutil",
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.44.23"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df018ae4a80a06cef289384bf89614451c4f30c6238976ce5c00c1f4379b8eca"
+checksum = "7e2a4795ec5e2913473b02e947169b648b0e4959c92f135f6ad2cddf16fbf3b4"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -1541,18 +1541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum_kind"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b940da354ae81ef0926c5eaa428207b8f4f091d3956c891dfbd124162bed99"
-dependencies = [
- "pmutil",
- "proc-macro2",
- "swc_macros_common",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "enumset"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "from_variant"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0981e470d2ab9f643df3921d54f1952ea100c39fdb6a3fdc820e20d2291df6c"
+checksum = "1d449976075322384507443937df2f1d5577afbf4282f12a5a66ef29fa3e6307"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -2781,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe25a3b6ba9aad427fa5ef59c99506bb6954748dd82211223dfd8a40dd75ae80"
+checksum = "1b1163df70b5a9fc688718f8197a3ab9d28110fa793a90eb3ec6d6832e5d1be3"
 dependencies = [
  "markdown",
  "serde",
@@ -2960,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.26.11"
+version = "0.26.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0afe8dd51536ab2038f14324245d53effcc3934ba646479f28834744209a7c"
+checksum = "b1ae0508f46787af99ec8dd11e7f1e20f8fe5038c06566e31fafc706f1ce9007"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -3822,9 +3810,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "preset_env_base"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4a43af74678e784b17db952b7fd726937b0a058c7c972624ddfd366e7603e4"
+checksum = "c963ac17c08dfc36f01b7d2c4426e759ac1cbd181c2a9ed807f3dea5200b90e1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4936,9 +4924,9 @@ dependencies = [
 
 [[package]]
 name = "string_enum"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41491e23e7db79343236a6ced96325ff132eb09e29ac4c5b8132b9c55aaaae89"
+checksum = "0090512bdfee4b56d82480d66c0fd8a6f53f0fe0f97e075e949b252acdd482e0"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -4955,9 +4943,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.53.11"
+version = "0.53.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e4d3762e21cd415d838b60b9007e2de112203f096f1c68aef32eb3465ef5d8"
+checksum = "551b5dbb683a5a8356e2ccbb65824f4a29dad914b46c5324f99f08ef75d49b15"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -4969,9 +4957,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.30.11"
+version = "0.30.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95db8d0df1301fa85243cbd0fbe3328a12d1e0d48eac0638d3dc295d4d7811c"
+checksum = "2aa17b289006dc3bbd368effabe90a91313f98cd6b0a0e193a45449ed7b037f7"
 dependencies = [
  "easy-error",
  "swc_core",
@@ -5014,9 +5002,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.255.23"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d93b381ac343f8548ef10a400aaf91604e94258e5c11753cece061275ed4c1"
+checksum = "b1dd97fd0887ef018ad0f8ff6be9da278530383e82311a525bfb6899ebac7902"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5081,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.208.19"
+version = "0.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d90393e5ac143a687f422f288bc706e3139a862d4c790cf301086aabd0cdf9"
+checksum = "55a048c17e6d19dd2357a03e6192e87685fd7cc00f9777dbcc56ef00a5b5779d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5128,9 +5116,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.37"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5005cd73617e18592faa31298225b26f1c407b84a681d67efb735c3d3458e101"
+checksum = "2625cf59127d2ccef0e3cbff5b2c0e370415ef274c03a49d733d0a6a03be53db"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5161,9 +5149,9 @@ dependencies = [
 
 [[package]]
 name = "swc_config"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4de36224eb9498fccd4e68971f0b83326ccf8592c2d424f257f3a1c76b2b211"
+checksum = "89c8fc2c12bb1634c7c32fc3c9b6b963ad8f034cc62c4ecddcf215dc4f6f959d"
 dependencies = [
  "indexmap",
  "serde",
@@ -5173,9 +5161,9 @@ dependencies = [
 
 [[package]]
 name = "swc_config_macro"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb64bc03d90fd5c90d6ab917bb2b1d7fbd31957df39e31ea24a3f554b4372251"
+checksum = "7dadb9998d4f5fc36ef558ed5a092579441579ee8c6fcce84a5228cca9df4004"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -5186,9 +5174,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.69.23"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d13d1df11c7a0c2876ccf36bda91da3686310fb0ab853a22aac5496e02e5e9f"
+checksum = "be852c9f58dd2257b09f7b10bc5755d55ace1373f719f0a7074cd9bb61767bc5"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5232,12 +5220,11 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.134.11"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00eeb01472c11945107c881525e6ce89c2596cf7965e51f847a8029916ce7e9"
+checksum = "8de81ea88e8cf5dc957dc5a256a1f56512ba7405881ac6ea0f1369f9c78d0186"
 dependencies = [
  "is-macro",
- "serde",
  "string_enum",
  "swc_atoms",
  "swc_common",
@@ -5245,9 +5232,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.144.14"
+version = "0.146.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa6ae6065fa3a75c3bd9d4e8747d692a57ab5ac3259c5b3e5811965cce92d4"
+checksum = "c015c204139d3af0b8dbd9720a4551e547ce4f09f28084b2c6f1adbabe9b45bb"
 dependencies = [
  "auto_impl",
  "bitflags 1.3.2",
@@ -5262,9 +5249,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen_macros"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe27425548d11afee43ddbe1d0cd882cb5e042f61b1503651dae2219c92333f5"
+checksum = "01c132d9ba562343f7c49d776c4a09b362a4a4104b7cb0a0f7b785986a492e1b"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -5275,9 +5262,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.20.14"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608c5e294e2fcbea240831e02863c68e765d2508c42cc3bda492a18198e3081f"
+checksum = "a0e566598d8647398571dcfa84ac36249574af20d5abab0c9364dee2eaf9c9e4"
 dependencies = [
  "bitflags 1.3.2",
  "once_cell",
@@ -5292,9 +5279,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.21.16"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3b768156027bb4f57cefa4eec66d2f2b122eb81937c62f2f820123b7617727"
+checksum = "a6b9f05ec8fce58a8abf501314c909c5026732b9f1574425abe570e463fab592"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -5308,9 +5295,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.143.12"
+version = "0.145.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4dc464bb7b97db5cb057164af91d1a374bffa48170d67604c7f3158639ed27"
+checksum = "593c8f17cbf0e18e023de2b931e2e5c0a83bf2cbff30150c5ac13d372c1bc7b7"
 dependencies = [
  "bitflags 1.3.2",
  "lexical",
@@ -5322,9 +5309,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.146.14"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb14aeb39b8b43c2c84b4ec8ed3d7af419204385621dcd837a9d0cf8da9cbb"
+checksum = "310a5e40a0ea83b6e7561800e80eebe893fbc5327de3cd8dd67087fba5057a99"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -5339,9 +5326,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.131.12"
+version = "0.133.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a18df9c717eec8ff9760a27c7337c507a10b23ec301dbc23249dadf7ba78524"
+checksum = "f7fd2e93666dad689b68984e3bd988cefc5c01a09a016898510cf2b4a7d12efc"
 dependencies = [
  "once_cell",
  "serde",
@@ -5354,9 +5341,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.133.11"
+version = "0.135.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2080e5a67f015365661e5bd26cd7d8cf766395eaa9c4dc95ef58054af624e3"
+checksum = "28f5ffb73f585a7e3402a18004d7a803793cbe6a475bbbe525e6ab7c0ce98a5f"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5367,9 +5354,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.100.3"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b135a8de6b20bcc99711a95e6c7c2ffd75e2ce7ef530e67eec4093bd3d063e0"
+checksum = "665dc78d58a6d2fe7fdccac27aab0084263af6f2281c4b3b8ad5b1499d334939"
 dependencies = [
  "bitflags 1.3.2",
  "is-macro",
@@ -5385,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.135.8"
+version = "0.137.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eea38f0aa2bdafb48927cb30a714ad6cc27c17cd40a867ab1f2c0782e6080e6"
+checksum = "4ae98ea91459a603ce9c47a53f45051db9b0b27c0d418b9b72b62e21a9c342c3"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -5404,9 +5391,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0159c99f81f52e48fe692ef7af1b0990b45d3006b14c6629be0b1ffee1b23aea"
+checksum = "bf4ee0caee1018808d94ecd09490cb7affd3d504b19aa11c49238f5fc4b54901"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -5417,9 +5404,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.99.8"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc9c335e425617120ec2f2af01c59541571afd7d834b9d7c312faf9d8acc7c4"
+checksum = "d53b5d0f712ea7b45cfbf4029dbac091db8c51ef2baeb0680afe61f7b5ecf124"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -5431,9 +5418,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.77.13"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fd2faab68aad3197670627ec7d9a9250cfe28641afa8a8c7aa8d21d6014df"
+checksum = "785fc53ccca5917b07cc563cc87de0999437851d9b885861f34f8852e70529ab"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -5452,9 +5439,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.41.39"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681c1fbb762c82700a5bd23dc39bad892a287ea9fb2121cf56e77f1ddc89afeb"
+checksum = "668223e740d85e242388bcc586cc9d2eb7f398933fd86592ff56c3099ee705bc"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5474,9 +5461,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.175.19"
+version = "0.178.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c2cd0cb9f66b75be8ba3ae6122a7989afe0f45af5ea72a1ab6755240e6183c"
+checksum = "55a29e3345df07e809966d2b7df0084e6aae1c80bf99901075d801aa6032ccd9"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -5510,12 +5497,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.130.7"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79a4d3b941551a586d2dc06bd05ef654e500ce1e1da2425a3a97b98cecd282b"
+checksum = "e1e18a7dc53b4c26bf35197610356aeda8025971667228c52d27aca124077ab0"
 dependencies = [
  "either",
- "enum_kind",
  "lexical",
  "num-bigint",
  "serde",
@@ -5531,9 +5517,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.189.17"
+version = "0.192.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f5d2be1bdf27dec511d2108c0bc25f0f955a248b2d307b352a45eac7fcf117"
+checksum = "cedf7ab6136f6cbcb551890293c0ce001ccc44f4efcfc30db61c5dc1741ba17e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5556,9 +5542,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.41.7"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf398b83e9b77ee80fca2bb079cd3495f3d2e1b52ccb7645f1b33b395d6410e"
+checksum = "ba1bc191897cc18410399e4d1bb9a98b8960835f8ccc3f9a7b245e3ac4398710"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -5586,9 +5572,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.212.17"
+version = "0.215.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7490393ee05987fe77719bd965ce853f760e20dac1dab53129b8d636dc46c1"
+checksum = "55931ed9f3d5e8b8134076685e04ae66e916fd94413b27476811d24eaecf5584"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5606,9 +5592,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.122.13"
+version = "0.124.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96253f9d410d18a9aae6c7f59ddc697dd78dcd130f5d1a8750cc5b8f5d71472e"
+checksum = "7c75dcdb2354e19002b2af8d6bc9f069aa32114d39c2c83735617acc8261a8db"
 dependencies = [
  "better_scoped_tls",
  "bitflags 1.3.2",
@@ -5630,9 +5616,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.111.13"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc315b53be4d9004134001b46258b32fee64ebc5dd964f72c2b1258324246a7"
+checksum = "46a492f5d419319cdc30efcff9d468bd0d25f572237322ba6edc6353c9d783e3"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5644,9 +5630,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.148.15"
+version = "0.150.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a1a4a3c413bfd03e38e8ee9fb9bb761f478ebe4f8b1f51e154375fcc1ca17a"
+checksum = "d5ac609994fba93cc3bb6bda16233d179eea075dbf753a372af36eb05b8fd754"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -5671,9 +5657,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf907935ec5492256b523ae7935a824d9fdc0368dcadc41375bad0dca91cd8b"
+checksum = "984d5ac69b681fc5438f9abf82b0fda34fe04e119bc75f8213b7e01128c7c9a2"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -5684,9 +5670,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.165.15"
+version = "0.167.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f53c50506abc0db9a768b190d28dbc6968844d6f6f7fe98967f01bf4c0890ba"
+checksum = "ee56186f6d2b68aa39786557481523bd26ed5852f7517b8590249a35a4b5de90"
 dependencies = [
  "Inflector",
  "ahash",
@@ -5712,9 +5698,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.181.17"
+version = "0.184.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08181f21f6bafb718ef3bed83817545f53af69852550177de19cc20d618a95b7"
+checksum = "0ed2f4b8c5ac9d935682ba4ee395ed6d650972ab250f394d3abd932989675979"
 dependencies = [
  "ahash",
  "dashmap",
@@ -5738,9 +5724,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.156.15"
+version = "0.158.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c09b747e7829d22f6fe393fb002487133483967d4bd051d9b69a1d5d65a8a"
+checksum = "4fc5bca04f0475701cc9bba4721781696b4048a0382702e677a178bcbc05a969"
 dependencies = [
  "either",
  "serde",
@@ -5757,9 +5743,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.167.17"
+version = "0.170.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a423b55598ab93ecd4e2a232b9f9a33a0e742b9ba2229a00972ead82bf0a6693"
+checksum = "d26dc6b7a7139b818323c83814516c45a92f54a1747ca4e706b92296848c474c"
 dependencies = [
  "ahash",
  "base64 0.13.1",
@@ -5784,9 +5770,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.125.13"
+version = "0.127.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07bfbd7b8739ad54b564b2c19476978cd4d48ada980307a20469021c3343938"
+checksum = "8b6357a709748a96e29b29a2a75c743b8586a949694a991f2511ee81ed12ca3a"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -5810,9 +5796,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.171.17"
+version = "0.174.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ba6c548f2b4ad7e1b71c85c4771242a800886547933129f41a7877a5c47332"
+checksum = "6da5625decc95363354162e3f64ee3ccc5086895692187d411e4cd29586cb9a7"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5826,9 +5812,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.9.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab0dcc471e8a980062c21257070ed522f48e77f83e61f2522f8a26f96f6ce89"
+checksum = "36820670d645894ea09fc721f4f1a2dbda77f9b813a47d3aa76c3520a319a316"
 dependencies = [
  "ahash",
  "indexmap",
@@ -5844,9 +5830,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.113.8"
+version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d422284424a29a95ce5d896ab4f8da35316cd0291e15759c0aae30abd2947be"
+checksum = "807dc291b5fc3911b4da04d4002260ed369e43dbd9e70a69353329de888643c2"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -5863,9 +5849,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.86.4"
+version = "0.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb3aaa504f9a520cb73e8d361d30aaceeb8643cc2f048e0dc1808d213ef76a9"
+checksum = "bfde1d1b73164ca87511c90cd539d49ba29d21a03b124b378dc013800c76d262"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -5877,9 +5863,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.29.11"
+version = "0.29.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b32d130dc10d63b2f6ccf8d59c693748f0b41ed80ae79df56476f69ac687c9b"
+checksum = "2a74861e8a9ece7ce42acd72b98cec85fdfe97da3fa1d1df84cdacd627df92a3"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -5907,9 +5893,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.38"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5652942f29f76b08bc2a23228e87c8dff1f037de17d18166753e90f4baacf61"
+checksum = "315b6f36c7dc66b87aff594bf84448b6348df0e320fc4ec669850259529b9e72"
 dependencies = [
  "anyhow",
  "miette",
@@ -5920,21 +5906,21 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.17.38"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a720ad8028d6c6e992039c862ed7318d143dee3994929793f59067fd69600b"
+checksum = "f106eaf601212e4ff2b24c483d881327aafc66ddfb1b0072ecea02ae00fef940"
 dependencies = [
- "ahash",
  "indexmap",
  "petgraph",
+ "rustc-hash",
  "swc_common",
 ]
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.18.41"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25ac475500b0776f1bb82da02eff867819b3c653130023ea957cbd1e91befa8"
+checksum = "7426083783a95eb7515c1597edf29e00ac498c19f0e7740ea7464918ee508b9e"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -5945,9 +5931,9 @@ dependencies = [
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4be988307882648d9bc7c71a6a73322b7520ef0211e920489a98f8391d8caa2"
+checksum = "3e582c3e3c2269238524923781df5be49e011dbe29cf7683a2215d600a562ea6"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -5957,9 +5943,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.16.37"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762f79bc1f940df95655603298b3ea382765185e091360d7f895475a5437a92"
+checksum = "e10bb21a0ee5171c4488cc3317d9a154d70ed3e64517e2bbafd9700df81c5ab6"
 dependencies = [
  "ahash",
  "dashmap",
@@ -5983,9 +5969,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.29.3"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb64bf10458ef02e97ca7e43b75a3519373f97bf77728c50148799d87a14658c"
+checksum = "77e6d478428f4158c67a5681397cd5a282fc1a3024b53851c35ea339834952b4"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -5997,9 +5983,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.91.7"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c790a1870b2f5460f72622ff7a2f72c16597608683e3bfa7feb762bc6392df0"
+checksum = "886025b5929ac675223d7ed5c74e752a2daba5b896414b09af66c50353e4d4dc"
 dependencies = [
  "anyhow",
  "enumset",
@@ -6020,9 +6006,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1023f06fac2cfb3531b96edfa9e17cb66b1bbd7e91b13c981e72e3486ab310d"
+checksum = "fb2b112eeae124b5824f73c0bcda9dce7e6c8f0541c4edfffa3a11edfee0dafb"
 dependencies = [
  "once_cell",
  "regex",
@@ -6035,9 +6021,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.17.42"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11afada7873b24725061271e1b3e49f2f8f625535fee2b4c55603b6f1a5fa0b"
+checksum = "ac7ad5b8e561bacf46cc8ec33813b4d40ccf7f643330bf654485219261aa9656"
 dependencies = [
  "tracing",
 ]
@@ -6055,9 +6041,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470a1963cf182fdcbbac46e3a7fd2caf7329da0e568d3668202da9501c880e16"
+checksum = "d1d5999f23421c8e21a0f2bc53a0b9e8244f3b421de89471561af2fbe40b9cca"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -6065,9 +6051,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6098b717cfd4c85f5cddec734af191dbce461c39975ed567c32ac6d0c6d61a6d"
+checksum = "ebeed7eb0f545f48ad30f5aab314e5208b735bcea1d1464f26e20f06db904989"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -6145,9 +6131,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.40"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda8d4f62089d08b0575a92273f2c824ca6e3958cd23ad2a0eb3f25438a0e9c9"
+checksum = "76d2cb78655486b043326aec620ca556fca7d17f452a363be4b6bfca0d351430"
 dependencies = [
  "ansi_term",
  "difference",

--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "ast_node"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e351bf9f01438f9479f39ed9d2c26dab615f9887d8ba50d50addd0c6536d51"
+checksum = "7976b3a3e10d7f95891b780534b92f00d914962ab31884b0bde25762b03a0b73"
 dependencies = [
  "darling 0.13.4",
  "pmutil",
@@ -283,7 +283,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -349,7 +349,7 @@ checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "serde",
 ]
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.47.0"
+version = "0.47.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2a4795ec5e2913473b02e947169b648b0e4959c92f135f6ad2cddf16fbf3b4"
+checksum = "a2032e4bb80e576ed5ae7c64877d4d28eb4782c331716be6deff15cc82f9f7ce"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -1029,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -1300,7 +1300,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -1317,7 +1317,7 @@ checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -2285,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -2948,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.26.14"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ae0508f46787af99ec8dd11e7f1e20f8fe5038c06566e31fafc706f1ce9007"
+checksum = "9893cc1697a0eb9ba24eb882f101a3ff740fc75915d065cfb615e74b136e5453"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -3260,12 +3260,14 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
+ "clap 4.1.11",
  "serde",
  "serde_json",
  "tokio",
+ "turbo-malloc",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -3880,9 +3882,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -4069,9 +4071,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4113,9 +4115,9 @@ checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
 
 [[package]]
 name = "rend"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
  "bytecheck",
 ]
@@ -4179,9 +4181,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.37"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f08c8062c1fe1253064043b8fc07bfea1b9702b71b4a86c11ea3588183b12e1"
+checksum = "c30f1d45d9aa61cbc8cd1eb87705470892289bb2d01943e7803b873a57404dc3"
 dependencies = [
  "bytecheck",
  "hashbrown 0.12.3",
@@ -4193,9 +4195,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.37"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e289706df51226e84814bf6ba1a9e1013112ae29bc7a9878f73fce360520c403"
+checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4542,7 +4544,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -4943,9 +4945,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.53.14"
+version = "0.54.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551b5dbb683a5a8356e2ccbb65824f4a29dad914b46c5324f99f08ef75d49b15"
+checksum = "7f7f3e09cbfe8ff9b934d85994d88e642d8a6cb4cf9f9b198b123deabb18ae9c"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -4957,9 +4959,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.30.14"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa17b289006dc3bbd368effabe90a91313f98cd6b0a0e193a45449ed7b037f7"
+checksum = "6efe66b4607c61646708ecbc367858806fa5ce3315b9cea190f7f878c9bcb065"
 dependencies = [
  "easy-error",
  "swc_core",
@@ -5002,9 +5004,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.258.0"
+version = "0.258.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dd97fd0887ef018ad0f8ff6be9da278530383e82311a525bfb6899ebac7902"
+checksum = "0e9fcaeebf41e1b871274a853fd40c6489e649d8ecafbda4d19c02d74a466082"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5054,9 +5056,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.39"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ebef84c2948cd0d1ba25acbf1b4bd9d80ab6f057efdbe35d8449b8d54699401"
+checksum = "389686ca731d3aa643431c8af606ff3eaf921e76027b2d9aeafb8cc4b43c0fe7"
 dependencies = [
  "once_cell",
  "rkyv",
@@ -5069,9 +5071,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.211.0"
+version = "0.211.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a048c17e6d19dd2357a03e6192e87685fd7cc00f9777dbcc56ef00a5b5779d"
+checksum = "da013dfe034a2e58d15a8f094db6bef18c6f0244956302dcd11dc5e0ea36df3b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5116,9 +5118,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.30.0"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2625cf59127d2ccef0e3cbff5b2c0e370415ef274c03a49d733d0a6a03be53db"
+checksum = "58d48ba41409dfd2ce48a2e4c311020170730559850cfec79ba2694bd95bed71"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5174,9 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.72.0"
+version = "0.72.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be852c9f58dd2257b09f7b10bc5755d55ace1373f719f0a7074cd9bb61767bc5"
+checksum = "3f2a9bfe636f3e0ee22e76298ce5b3541a9d7feea4f9f14ca6a981ef11077a64"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5220,9 +5222,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.136.0"
+version = "0.136.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de81ea88e8cf5dc957dc5a256a1f56512ba7405881ac6ea0f1369f9c78d0186"
+checksum = "b250ab0726effa4f773522ee46494f7f167adc0fd7b429ba269d8a2e3006fd2a"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -5232,9 +5234,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.146.0"
+version = "0.146.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c015c204139d3af0b8dbd9720a4551e547ce4f09f28084b2c6f1adbabe9b45bb"
+checksum = "44b9010d56dbba4aa3b228e5066fb33e3f4d841456d654524c60b1fb59413714"
 dependencies = [
  "auto_impl",
  "bitflags 1.3.2",
@@ -5262,9 +5264,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.22.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e566598d8647398571dcfa84ac36249574af20d5abab0c9364dee2eaf9c9e4"
+checksum = "5c06d2030d40741bc44732621d918a8a623e5e5d76e376c81652eb1bf7cf4a96"
 dependencies = [
  "bitflags 1.3.2",
  "once_cell",
@@ -5279,9 +5281,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.23.0"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6b9f05ec8fce58a8abf501314c909c5026732b9f1574425abe570e463fab592"
+checksum = "1b7c74f8ca9907e3bc43fd2f6ba26341d2d3e6b232f6965b973dd1c71638b85b"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -5295,9 +5297,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.145.0"
+version = "0.145.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "593c8f17cbf0e18e023de2b931e2e5c0a83bf2cbff30150c5ac13d372c1bc7b7"
+checksum = "8acd046b4e50f301be4a2bc6de7596082a9a5c2148af91d49ccecbc83d10dda7"
 dependencies = [
  "bitflags 1.3.2",
  "lexical",
@@ -5309,9 +5311,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.148.0"
+version = "0.148.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310a5e40a0ea83b6e7561800e80eebe893fbc5327de3cd8dd67087fba5057a99"
+checksum = "8059c359ce3b2cf1723d7433f4e300881bb93cbc80cfe80be77abd3febc1dbaf"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -5326,9 +5328,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.133.0"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fd2e93666dad689b68984e3bd988cefc5c01a09a016898510cf2b4a7d12efc"
+checksum = "614ae2d63612e30fe16d7dba47102ad6f62dc8607e08c9340d72990470e25360"
 dependencies = [
  "once_cell",
  "serde",
@@ -5341,9 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.135.0"
+version = "0.135.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f5ffb73f585a7e3402a18004d7a803793cbe6a475bbbe525e6ab7c0ce98a5f"
+checksum = "712c7554457f0a0464b38b4873f5400df37bc6344accb228f8e2e4b0156d7ca2"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5354,9 +5356,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.102.0"
+version = "0.102.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "665dc78d58a6d2fe7fdccac27aab0084263af6f2281c4b3b8ad5b1499d334939"
+checksum = "7ad2794757df64b37ae259ce7f6e80a7953c53af6f7cc34ba33e20d4c4debc86"
 dependencies = [
  "bitflags 1.3.2",
  "is-macro",
@@ -5372,9 +5374,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.137.0"
+version = "0.137.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae98ea91459a603ce9c47a53f45051db9b0b27c0d418b9b72b62e21a9c342c3"
+checksum = "1a051f3c3ce1470028c84559e0140b6b836e668f46724be2bbf286e7abee4ba9"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -5404,9 +5406,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.101.0"
+version = "0.101.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53b5d0f712ea7b45cfbf4029dbac091db8c51ef2baeb0680afe61f7b5ecf124"
+checksum = "82da6edd5dc238e17c312e73a6627d14853b56f24fbe4860920526ef2ea20287"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -5418,9 +5420,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.79.0"
+version = "0.79.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785fc53ccca5917b07cc563cc87de0999437851d9b885861f34f8852e70529ab"
+checksum = "0c362fdab1e968974c8b38f4db1e3f91a735e31db7b28d7d511b31b3f5423a59"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -5439,9 +5441,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.42.0"
+version = "0.42.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668223e740d85e242388bcc586cc9d2eb7f398933fd86592ff56c3099ee705bc"
+checksum = "f32073389d529df9c78cc7eb2b4ea8c6d8d8a7794976f2e65299f3f5918de7d3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5461,9 +5463,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.178.0"
+version = "0.178.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a29e3345df07e809966d2b7df0084e6aae1c80bf99901075d801aa6032ccd9"
+checksum = "73af86423c036e1fbdb9d3eb97af3f7ae196cc7f7ba40d7c954990e346babb95"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -5497,9 +5499,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.132.0"
+version = "0.132.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e18a7dc53b4c26bf35197610356aeda8025971667228c52d27aca124077ab0"
+checksum = "1e94ae390ed98d06de525903f382774b7a0c4f2fc6530c95a47ae897337769c0"
 dependencies = [
  "either",
  "lexical",
@@ -5517,9 +5519,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.192.0"
+version = "0.192.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cedf7ab6136f6cbcb551890293c0ce001ccc44f4efcfc30db61c5dc1741ba17e"
+checksum = "3665794fae4c375d8b0593424b0cf966c55c82063392b5138b5ea77fd7a0af86"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5542,9 +5544,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.43.0"
+version = "0.43.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1bc191897cc18410399e4d1bb9a98b8960835f8ccc3f9a7b245e3ac4398710"
+checksum = "63a29adc285b929049b67fd8d25f131ea8fe2ba4a177a32f209f669e371e4cc0"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -5572,9 +5574,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.215.0"
+version = "0.215.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55931ed9f3d5e8b8134076685e04ae66e916fd94413b27476811d24eaecf5584"
+checksum = "e563f5627a4ae0bebd997683b2f99239998ca697951f453344cbe559eeb3514b"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5592,9 +5594,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.124.0"
+version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c75dcdb2354e19002b2af8d6bc9f069aa32114d39c2c83735617acc8261a8db"
+checksum = "7d2e2deddbdb68275220b7f951384349913de57e50d656402d6eb29a16c0026d"
 dependencies = [
  "better_scoped_tls",
  "bitflags 1.3.2",
@@ -5616,9 +5618,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.113.0"
+version = "0.113.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a492f5d419319cdc30efcff9d468bd0d25f572237322ba6edc6353c9d783e3"
+checksum = "d369bfc2a586d4dd949ba8fd680dad5960ae9aa79a8653e191c3bba5b5ffa95a"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5630,9 +5632,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.150.0"
+version = "0.150.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ac609994fba93cc3bb6bda16233d179eea075dbf753a372af36eb05b8fd754"
+checksum = "9b1a621b3b526c6871e50aef790a9388924c94791d3554df62697426de583476"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -5670,9 +5672,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.167.0"
+version = "0.167.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee56186f6d2b68aa39786557481523bd26ed5852f7517b8590249a35a4b5de90"
+checksum = "6367d46c33ca7ef76b97a52da335ea38a6a7e588265a0b7f42f2348932aa8b28"
 dependencies = [
  "Inflector",
  "ahash",
@@ -5698,9 +5700,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.184.0"
+version = "0.184.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed2f4b8c5ac9d935682ba4ee395ed6d650972ab250f394d3abd932989675979"
+checksum = "59f1844619b4069353f91334d7926270e38b378f18e3bf7d137b3f6e408a0342"
 dependencies = [
  "ahash",
  "dashmap",
@@ -5724,9 +5726,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.158.0"
+version = "0.158.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc5bca04f0475701cc9bba4721781696b4048a0382702e677a178bcbc05a969"
+checksum = "ea607e7f4e9fa487441df5417a984caa360ce327aec276805c1ec72aaf78b429"
 dependencies = [
  "either",
  "serde",
@@ -5743,9 +5745,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.170.0"
+version = "0.170.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26dc6b7a7139b818323c83814516c45a92f54a1747ca4e706b92296848c474c"
+checksum = "316e5c6e62eb765976f8dbe7580f9fdb5606c165a1c6b3bfb95471e4974facd7"
 dependencies = [
  "ahash",
  "base64 0.13.1",
@@ -5770,9 +5772,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.127.0"
+version = "0.127.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6357a709748a96e29b29a2a75c743b8586a949694a991f2511ee81ed12ca3a"
+checksum = "fa4b2b9a2320cff5175c75955ea99a71f8d09343a6614c3d19e21d2f2eedadc9"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -5796,9 +5798,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.174.0"
+version = "0.174.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da5625decc95363354162e3f64ee3ccc5086895692187d411e4cd29586cb9a7"
+checksum = "cd96dafa71ffa5d576315ce6913ebf6dcc5bdbb57ca1cef03f393bf8696a09a8"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5812,9 +5814,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.11.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36820670d645894ea09fc721f4f1a2dbda77f9b813a47d3aa76c3520a319a316"
+checksum = "34bfc614587467cad2e16b91d96b0173a603d3b1d8d4346f52a7b054db4eaef3"
 dependencies = [
  "ahash",
  "indexmap",
@@ -5830,9 +5832,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.115.0"
+version = "0.115.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807dc291b5fc3911b4da04d4002260ed369e43dbd9e70a69353329de888643c2"
+checksum = "1333060fc019148e6ede1d2483bfdbfe4bec6768c6265be5cf1eaf4976159c63"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -5849,9 +5851,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.88.0"
+version = "0.88.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfde1d1b73164ca87511c90cd539d49ba29d21a03b124b378dc013800c76d262"
+checksum = "379fb7e283b4b8752e7447af22c575c9e7e0cbe518fbae3fbde6abf0119828df"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -5863,9 +5865,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.29.14"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a74861e8a9ece7ce42acd72b98cec85fdfe97da3fa1d1df84cdacd627df92a3"
+checksum = "7c94d1b226c40d8e05e50bcbc53a1d79375c757ceee6436337c1f17f82bd19f0"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -5893,9 +5895,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "315b6f36c7dc66b87aff594bf84448b6348df0e320fc4ec669850259529b9e72"
+checksum = "fe5e776cb3378f6159f5140e0376d84711894660080c66547684d8d6f4d0b4aa"
 dependencies = [
  "anyhow",
  "miette",
@@ -5906,9 +5908,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.18.0"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f106eaf601212e4ff2b24c483d881327aafc66ddfb1b0072ecea02ae00fef940"
+checksum = "b399fc693481eb2ab21906e67bbabe1ff0b7b59506a5f9010e8786ef3a527215"
 dependencies = [
  "indexmap",
  "petgraph",
@@ -5918,9 +5920,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.19.0"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7426083783a95eb7515c1597edf29e00ac498c19f0e7740ea7464918ee508b9e"
+checksum = "e86ac138d3c097c06d515cae3c6ee99c4b98b7a2c4f04b2d34a8b356bf2ddf8e"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -5943,9 +5945,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.17.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10bb21a0ee5171c4488cc3317d9a154d70ed3e64517e2bbafd9700df81c5ab6"
+checksum = "92e40eff35780a92fde9fe115e6226fadc84c7c0511163196e659d3a8f31f306"
 dependencies = [
  "ahash",
  "dashmap",
@@ -5969,9 +5971,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.31.0"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e6d478428f4158c67a5681397cd5a282fc1a3024b53851c35ea339834952b4"
+checksum = "3797492326b42c1e52e9c2b1cd5ba586313e7572652256e89e2abf673d1affb7"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -5983,9 +5985,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.93.0"
+version = "0.93.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886025b5929ac675223d7ed5c74e752a2daba5b896414b09af66c50353e4d4dc"
+checksum = "9547e0a7c16774b5d0b30561a6a279595adccf5e43e09f666800c467a83fee2c"
 dependencies = [
  "anyhow",
  "enumset",
@@ -6021,9 +6023,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.18.0"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7ad5b8e561bacf46cc8ec33813b4d40ccf7f643330bf654485219261aa9656"
+checksum = "61f3c1086df56c583f02c11760a0b9c4557ea186aadd87aeeb90eca022dbb68d"
 dependencies = [
  "tracing",
 ]
@@ -6076,9 +6078,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6131,9 +6133,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.32.0"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d2cb78655486b043326aec620ca556fca7d17f452a363be4b6bfca0d351430"
+checksum = "26ac424dfe81bc1671c06ddf836859dd486143013cbd0140ee3865ddd841ef0f"
 dependencies = [
  "ansi_term",
  "difference",
@@ -6199,7 +6201,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -6627,7 +6629,7 @@ dependencies = [
 [[package]]
 name = "turbo-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -6664,7 +6666,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "mimalloc",
 ]
@@ -6672,7 +6674,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6702,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6714,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6729,7 +6731,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6743,7 +6745,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6760,7 +6762,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6789,7 +6791,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "base16",
  "hex",
@@ -6801,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -6815,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6825,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6847,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6859,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6885,7 +6887,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6901,7 +6903,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6928,7 +6930,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6941,7 +6943,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6963,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6982,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7016,7 +7018,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7052,7 +7054,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "serde",
@@ -7067,7 +7069,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "serde",
@@ -7082,7 +7084,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7097,7 +7099,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7132,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "serde",
@@ -7148,7 +7150,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7159,7 +7161,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.2#ad2bf568a12b25c06a88e0e0a508f053634084ee"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -7177,7 +7179,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand",
  "static_assertions",
 ]

--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "serde",
 ]
@@ -3260,14 +3260,12 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
- "clap 4.1.11",
  "serde",
  "serde_json",
  "tokio",
- "turbo-malloc",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -6629,7 +6627,7 @@ dependencies = [
 [[package]]
 name = "turbo-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -6666,7 +6664,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "mimalloc",
 ]
@@ -6674,7 +6672,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6704,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6716,7 +6714,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6731,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6745,7 +6743,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6762,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6791,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "base16",
  "hex",
@@ -6803,7 +6801,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -6817,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6827,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6849,7 +6847,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6861,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6887,7 +6885,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6903,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6930,7 +6928,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6943,7 +6941,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6965,7 +6963,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6984,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7018,7 +7016,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7054,7 +7052,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "serde",
@@ -7069,7 +7067,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "serde",
@@ -7084,7 +7082,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7099,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7134,7 +7132,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "serde",
@@ -7150,7 +7148,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7161,7 +7159,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#39ceedbd717699d48f9c8b456a8c179143be55a1"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-update#b61e45e9710b98fb8d203753f953d94e18cbb88f"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -7179,7 +7177,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand",
  "static_assertions",
 ]

--- a/packages/next-swc/Cargo.toml
+++ b/packages/next-swc/Cargo.toml
@@ -36,20 +36,20 @@ next-transform-strip-page-exports = { path = "crates/next-transform-strip-page-e
 # SWC crates
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.12.2" }
-mdxjs = { version = "0.1.8" }
-modularize_imports = { version = "0.26.10" }
-styled_components = { version = "0.53.10" }
-styled_jsx = { version = "0.30.10" }
-swc_core = { version = "0.69.6" }
-swc_emotion = { version = "0.29.10" }
-testing = { version = "0.31.31" }
+mdxjs = { version = "0.1.9" }
+modularize_imports = { version = "0.26.14" }
+styled_components = { version = "0.53.14" }
+styled_jsx = { version = "0.30.14" }
+swc_core = { version = "0.72.0" }
+swc_emotion = { version = "0.29.14" }
+testing = { version = "0.32.0" }
 
 # Turbo crates
-turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230329.2" }
+turbo-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-update" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230329.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-update" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230329.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-update" }
 
 # General Deps
 

--- a/packages/next-swc/Cargo.toml
+++ b/packages/next-swc/Cargo.toml
@@ -37,12 +37,12 @@ next-transform-strip-page-exports = { path = "crates/next-transform-strip-page-e
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.12.2" }
 mdxjs = { version = "0.1.9" }
-modularize_imports = { version = "0.26.14" }
-styled_components = { version = "0.53.14" }
-styled_jsx = { version = "0.30.14" }
-swc_core = { version = "0.72.0" }
-swc_emotion = { version = "0.29.14" }
-testing = { version = "0.32.0" }
+modularize_imports = { version = "0.27.1" }
+styled_components = { version = "0.54.1" }
+styled_jsx = { version = "0.31.1" }
+swc_core = { version = "0.72.4" }
+swc_emotion = { version = "0.30.1" }
+testing = { version = "0.32.3" }
 
 # Turbo crates
 turbo-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-update" }

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -31,7 +31,7 @@ turbo-binding = { workspace = true, features = [
   "__swc_transform_modularize_imports",
   "__swc_transform_relay",
 ] }
-swc_relay = "0.1.0"
+swc_relay = "0.1.2"
 
 [dev-dependencies]
 turbo-binding = { workspace = true, features = [

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -103,6 +103,7 @@ fn next_ssg_fixture(input: PathBuf) {
         syntax(),
         &|tr| {
             let top_level_mark = Mark::fresh(Mark::root());
+            let unresolved_mark = Mark::fresh(Mark::root());
             let jsx = jsx::<SingleThreadedComments>(
                 tr.cm.clone(),
                 None,
@@ -118,6 +119,7 @@ fn next_ssg_fixture(input: PathBuf) {
                     ..Default::default()
                 },
                 top_level_mark,
+                unresolved_mark,
             );
             chain!(next_ssg(Default::default()), jsx)
         },

--- a/packages/next-swc/crates/next-transform-strip-page-exports/tests/fixture.rs
+++ b/packages/next-swc/crates/next-transform-strip-page-exports/tests/fixture.rs
@@ -25,6 +25,7 @@ fn run_test(input: &Path, output: &Path, mode: ExportFilter) {
         syntax(),
         &|tr| {
             let top_level_mark = Mark::fresh(Mark::root());
+            let unresolved_mark = Mark::fresh(Mark::root());
             let jsx = jsx::<SingleThreadedComments>(
                 tr.cm.clone(),
                 None,
@@ -39,6 +40,7 @@ fn run_test(input: &Path, output: &Path, mode: ExportFilter) {
                     ..Default::default()
                 },
                 top_level_mark,
+                unresolved_mark,
             );
             chain!(
                 next_transform_strip_page_exports(mode, Default::default()),


### PR DESCRIPTION
### What?

see https://github.com/vercel/turbo/pull/4358

### Why?

Avoiding conflicts between dependencies and having only a single swc_core version in lockfile
