### PR TITLE
fix: handle `output: export` with `use client`

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2469,7 +2469,6 @@ export default async function build(
                   await staticWorkers.end()
                 }
               : undefined,
-            appPaths,
           }
 
           await exportApp(dir, exportOptions, nextBuildSpan)

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -259,6 +259,7 @@ export default async function build(
   appDirOnly = false,
   turboNextBuild = false
 ): Promise<void> {
+  let hasAppDir = false
   try {
     const nextBuildSpan = trace('next-build', undefined, {
       version: process.env.__NEXT_VERSION as string,
@@ -357,6 +358,7 @@ export default async function build(
       const { pagesDir, appDir } = findPagesDir(dir, isAppDirEnabled)
       NextBuildContext.pagesDir = pagesDir
       NextBuildContext.appDir = appDir
+      hasAppDir = Boolean(appDir)
 
       const isSrcDir = path
         .relative(dir, pagesDir || appDir || '')
@@ -2451,6 +2453,7 @@ export default async function build(
           const exportOptions: ExportOptions = {
             isInvokedFromCli: false,
             nextConfig: exportConfig,
+            hasAppDir,
             silent: false,
             buildExport: true,
             debugOutput,
@@ -3123,6 +3126,7 @@ export default async function build(
         const options: ExportOptions = {
           isInvokedFromCli: false,
           nextConfig: config,
+          hasAppDir,
           silent: true,
           threads: config.experimental.cpus,
           outdir: path.join(dir, configOutDir),

--- a/packages/next/src/cli/next-export.ts
+++ b/packages/next/src/cli/next-export.ts
@@ -63,6 +63,7 @@ const nextExport: CliCommand = (argv) => {
     threads: args['--threads'],
     outdir: args['--outdir'] ? resolve(args['--outdir']) : join(dir, 'out'),
     isInvokedFromCli: true,
+    hasAppDir: false, // "next export" command does not work for "app" directory
   }
 
   exportApp(dir, options, nextExportCliSpan)

--- a/packages/next/src/cli/next-export.ts
+++ b/packages/next/src/cli/next-export.ts
@@ -2,7 +2,8 @@
 import { resolve, join } from 'path'
 import { existsSync } from 'fs'
 import arg from 'next/dist/compiled/arg/index.js'
-import exportApp from '../export'
+import exportApp, { ExportError } from '../export'
+import * as Log from '../build/output/log'
 import { printAndExit } from '../server/lib/utils'
 import { CliCommand } from '../lib/commands'
 import { trace } from '../trace'
@@ -63,7 +64,7 @@ const nextExport: CliCommand = (argv) => {
     threads: args['--threads'],
     outdir: args['--outdir'] ? resolve(args['--outdir']) : join(dir, 'out'),
     isInvokedFromCli: true,
-    hasAppDir: false, // "next export" command does not work for "app" directory
+    hasAppDir: false,
   }
 
   exportApp(dir, options, nextExportCliSpan)
@@ -71,9 +72,14 @@ const nextExport: CliCommand = (argv) => {
       nextExportCliSpan.stop()
       printAndExit(`Export successful. Files written to ${options.outdir}`, 0)
     })
-    .catch((err) => {
+    .catch((err: unknown) => {
       nextExportCliSpan.stop()
-      printAndExit(err)
+      if (err instanceof ExportError) {
+        Log.error(err.message)
+      } else {
+        console.error(err)
+      }
+      process.exit(1)
     })
 }
 

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -155,7 +155,6 @@ export interface ExportOptions {
   statusMessage?: string
   exportPageWorker?: typeof import('./worker').default
   endWorker?: () => Promise<void>
-  //appPaths?: string[]
   nextConfig?: NextConfigComplete
 }
 

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -80,7 +80,6 @@ interface ExportPageInput {
   parentSpanId: any
   httpAgentOptions: NextConfigComplete['httpAgentOptions']
   serverComponents?: boolean
-  appPaths: string[]
   enableUndici: NextConfigComplete['experimental']['enableUndici']
   debugOutput?: boolean
   isrMemoryCacheSize?: NextConfigComplete['experimental']['isrMemoryCacheSize']

--- a/test/integration/app-dir-export/app/client/[slug]/page.js
+++ b/test/integration/app-dir-export/app/client/[slug]/page.js
@@ -1,0 +1,15 @@
+'use client'
+export const dynamic = 'force-static'
+
+export function generateStaticParams() {
+  return [{ slug: 'use client should not fail build' }]
+}
+
+export default function Page({ params }) {
+  return (
+    <main>
+      <h1>Use Client Example</h1>
+      <p>{params.slug}</p>
+    </main>
+  )
+}

--- a/test/integration/app-dir-export/test/index.test.ts
+++ b/test/integration/app-dir-export/test/index.test.ts
@@ -294,20 +294,26 @@ describe('app dir with output export', () => {
       expect(await getFiles()).toEqual([])
       let stdout = ''
       let stderr = ''
-      await nextExport(
-        appDir,
-        { outdir: exportDir },
-        {
-          onStdout(msg) {
-            stdout += msg
-          },
-          onStderr(msg) {
-            stderr += msg
-          },
-        }
-      )
+      let error = undefined
+      try {
+        await nextExport(
+          appDir,
+          { outdir: exportDir },
+          {
+            onStdout(msg) {
+              stdout += msg
+            },
+            onStderr(msg) {
+              stderr += msg
+            },
+          }
+        )
+      } catch (e) {
+        error = e
+      }
+      expect(error).toBeDefined()
       expect(stderr).toContain(
-        'error  - "next export" does not work with App Router. Please use "output: export" in next.config.js'
+        'error - "next export" does not work with App Router. Please use "output: export" in next.config.js'
       )
       expect(stdout).not.toContain('Export successful. Files written to')
       expect(await getFiles()).toEqual([])

--- a/test/integration/app-dir-export/test/index.test.ts
+++ b/test/integration/app-dir-export/test/index.test.ts
@@ -285,7 +285,7 @@ describe('app dir with output export', () => {
     expect(stdout).toContain('Export successful. Files written to')
     expect(await getFiles()).toEqual(expectedFiles)
   })
-  it('should warn with deprecation message when no config.output detected for next export', async () => {
+  it('should error when no config.output detected for next export', async () => {
     await fs.remove(distDir)
     await fs.remove(exportDir)
     nextConfig.replace(`output: 'export',`, '')
@@ -307,10 +307,10 @@ describe('app dir with output export', () => {
         }
       )
       expect(stderr).toContain(
-        'warn  - "next export" is deprecated in favor of "output: export" in next.config.js'
+        'error  - "next export" does not work with App Router. Please use "output: export" in next.config.js'
       )
-      expect(stdout).toContain('Export successful. Files written to')
-      expect(await getFiles()).toEqual(expectedFiles)
+      expect(stdout).not.toContain('Export successful. Files written to')
+      expect(await getFiles()).toEqual([])
     } finally {
       nextConfig.restore()
       await fs.remove(distDir)


### PR DESCRIPTION
This PR removes usage of `appPaths` in favor of `hasAppDir` to avoid the issue where export does not read app manifest.

Fixes the error:

```
TypeError: Cannot read properties of undefined (reading 'cssModules')
```

fix NEXT-885 ([link](https://linear.app/vercel/issue/NEXT-885))