### PR TITLE
Convert tailwind.config to typescript

### DIFF
--- a/packages/create-next-app/templates/app-tw/ts/tailwind.config.ts
+++ b/packages/create-next-app/templates/app-tw/ts/tailwind.config.ts
@@ -1,5 +1,6 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
+import type { Config } from 'tailwindcss'
+
+export default {
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -15,4 +16,4 @@ module.exports = {
     },
   },
   plugins: [],
-}
+} satisfies Config

--- a/packages/create-next-app/templates/default-tw/ts/tailwind.config.ts
+++ b/packages/create-next-app/templates/default-tw/ts/tailwind.config.ts
@@ -1,5 +1,6 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
+import type { Config } from 'tailwindcss'
+
+export default {
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -15,4 +16,4 @@ module.exports = {
     },
   },
   plugins: [],
-}
+} satisfies Config

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -51,7 +51,8 @@ export const installTemplate = async ({
   const templatePath = path.join(__dirname, template, mode)
   const copySource = ['**']
   if (!eslint) copySource.push('!eslintrc.json')
-  if (!tailwind) copySource.push('!tailwind.config.js', '!postcss.config.js')
+  if (!tailwind)
+    copySource.push('!tailwind.config.{js,ts}', '!postcss.config.js')
 
   await cpy(copySource, root, {
     parents: true,
@@ -145,7 +146,9 @@ export const installTemplate = async ({
     )
 
     if (tailwind) {
-      const tailwindConfigFile = path.join(root, 'tailwind.config.js')
+      const configFileName =
+        mode === 'ts' ? 'tailwind.config.ts' : 'tailwind.config.js'
+      const tailwindConfigFile = path.join(root, configFileName)
       await fs.promises.writeFile(
         tailwindConfigFile,
         (


### PR DESCRIPTION
### What?

This PR converts the `tailwind.config` of create-next-app to typescript.

**More Info:** https://tailwindcss.com/blog/tailwindcss-v3-3#esm-and-typescript-support

### Depends on

#47645 <- Please merge this one first & rebase
