### PR TITLE
Turbopack: Use `SharedError` for body streaming

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "serde",
 ]
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "serde",
@@ -6684,7 +6684,7 @@ dependencies = [
 [[package]]
 name = "turbo-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -6721,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "mimalloc",
 ]
@@ -6729,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6759,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6771,7 +6771,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6786,7 +6786,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6800,7 +6800,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6817,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6846,7 +6846,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "base16",
  "hex",
@@ -6858,7 +6858,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -6872,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6882,7 +6882,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6904,7 +6904,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6916,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6942,7 +6942,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6958,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6985,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6998,7 +6998,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7020,7 +7020,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7039,7 +7039,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7055,7 +7055,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7073,7 +7072,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7109,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "serde",
@@ -7124,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "serde",
@@ -7139,7 +7138,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7154,7 +7153,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7189,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "serde",
@@ -7205,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7216,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230329.3#ffb7e70a7e8b1503bdb50e955009f451b49226b2"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230331.3#1414a695ace2fb52a204fdee374be4dd0a98c8f5"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/packages/next-swc/Cargo.toml
+++ b/packages/next-swc/Cargo.toml
@@ -47,11 +47,11 @@ swc_emotion = { version = "0.29.10" }
 testing = { version = "0.31.31" }
 
 # Turbo crates
-turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230329.3" }
+turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230331.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230329.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230331.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230329.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230331.3" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/src/router.rs
+++ b/packages/next-swc/crates/next-core/src/router.rs
@@ -120,7 +120,7 @@ enum RouterIncomingMessage {
     Error { error: StructuredError },
 }
 
-#[turbo_tasks::value(eq = "manual", cell = "new", serialization = "none")]
+#[turbo_tasks::value]
 #[derive(Debug, Clone, Default)]
 pub struct MiddlewareResponse {
     pub status_code: u16,
@@ -129,8 +129,8 @@ pub struct MiddlewareResponse {
     pub body: Stream<Result<Bytes, SharedError>>,
 }
 
-#[turbo_tasks::value(eq = "manual", cell = "new", serialization = "none")]
 #[derive(Debug)]
+#[turbo_tasks::value]
 pub enum RouterResult {
     Rewrite(RewriteResponse),
     Middleware(MiddlewareResponse),

--- a/packages/next-swc/crates/next-core/src/router_source.rs
+++ b/packages/next-swc/crates/next-core/src/router_source.rs
@@ -7,9 +7,9 @@ use turbo_binding::turbopack::{
         introspect::{Introspectable, IntrospectableChildrenVc, IntrospectableVc},
     },
     dev_server::source::{
-        Body, BodyError, ContentSource, ContentSourceContent, ContentSourceData,
-        ContentSourceDataVary, ContentSourceResultVc, ContentSourceVc, HeaderListVc, NeededData,
-        ProxyResult, RewriteBuilder,
+        Body, ContentSource, ContentSourceContent, ContentSourceData, ContentSourceDataVary,
+        ContentSourceResultVc, ContentSourceVc, HeaderListVc, NeededData, ProxyResult,
+        RewriteBuilder,
     },
     node::execution_context::ExecutionContextVc,
 };
@@ -156,11 +156,7 @@ impl ContentSource for NextRouterContentSource {
                     ProxyResult {
                         status: data.status_code,
                         headers: data.headers.clone(),
-                        body: Body::from_stream(data.body.read().map(|chunk| {
-                            chunk.map_err(|e| {
-                                BodyError::new(format!("error streaming proxied contents: {}", e))
-                            })
-                        })),
+                        body: Body::from_stream(data.body.read()),
                     }
                     .cell(),
                 )


### PR DESCRIPTION
Pending https://github.com/vercel/turbo/pull/4392 landing in Turbopack (and https://github.com/vercel/next.js/pull/47476 landing here), this removes `BodyError` and switches to `SharedError`. That should allow us to preserve the source chain of errors for when we finally display it to the dev, aiding debugging.