### PR TITLE
docs: clarify returning response in Middleware

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -225,7 +225,7 @@ export function middleware(request: NextRequest) {
 
 ## Producing a Response
 
-You can respond from Middleware directly by returning a `Response` or `NextResponse` instance. (Since [Next.js v13.1.0](https://nextjs.org/blog/next-13-1#nextjs-advanced-middleware), this is available without passing any flags to `next.config.js`.)
+You can respond from Middleware directly by returning a `Response` or `NextResponse` instance. (This is available since [Next.js v13.1.0](https://nextjs.org/blog/next-13-1#nextjs-advanced-middleware))
 
 ```ts
 // middleware.ts

--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -225,13 +225,11 @@ export function middleware(request: NextRequest) {
 
 ## Producing a Response
 
-You can respond to middleware directly by returning a `NextResponse` (responding from middleware is available since Next.js v13.1.0).
-
-Once enabled, you can provide a response from middleware using the `Response` or `NextResponse` API:
+You can respond from Middleware directly by returning a `Response` or `NextResponse` instance. (Since [Next.js v13.1.0](https://nextjs.org/blog/next-13-1#nextjs-advanced-middleware), this is available without passing any flags to `next.config.js`.)
 
 ```ts
 // middleware.ts
-import { NextRequest, NextResponse } from 'next/server'
+import { type NextRequest, NextResponse } from 'next/server'
 import { isAuthenticated } from '@lib/auth'
 
 // Limit the middleware to paths starting with `/api/`

--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -229,7 +229,7 @@ You can respond from Middleware directly by returning a `Response` or `NextRespo
 
 ```ts
 // middleware.ts
-import { type NextRequest, NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { isAuthenticated } from '@lib/auth'
 
 // Limit the middleware to paths starting with `/api/`


### PR DESCRIPTION
I noticed that the wording was still suggesting that you needed to "enable" this, but since [`13.1`](https://nextjs.org/blog/next-13-1#nextjs-advanced-middleware), `experimental.allowMiddlewareResponseBody` is not needed anymore.

Ref: #44224