### PR TITLE
Add "initial-scale=1" to default viewport meta tag

### DIFF
--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -14,7 +14,7 @@ type WithInAmpMode = {
 export function defaultHead(inAmpMode = false): JSX.Element[] {
   const head = [<meta charSet="utf-8" />]
   if (!inAmpMode) {
-    head.push(<meta name="viewport" content="width=device-width" />)
+    head.push(<meta name="viewport" content="width=device-width, initial-scale=1" />)
   }
   return head
 }


### PR DESCRIPTION
Not setting the initial scale to `1` results in abnormal behavior on select mobile devices. Refer to [this post](https://www.sitepoint.com/community/t/mobile-viewport-orientations-initial-scale-1-0/38495/11).

[Spec](https://www.w3.org/TR/css-device-adapt-1/#min-scale-max-scale)