### PR TITLE
Fix types export for next/server with modularize imports

### DIFF
--- a/packages/next/src/server/web/exports/image-response.ts
+++ b/packages/next/src/server/web/exports/image-response.ts
@@ -1,2 +1,5 @@
 // This file is for modularized imports for next/server to get fully-treeshaking.
-export { ImageResponse as default } from '../spec-extension/image-response'
+export {
+  ImageResponse,
+  ImageResponse as default,
+} from '../spec-extension/image-response'

--- a/packages/next/src/server/web/exports/next-request.ts
+++ b/packages/next/src/server/web/exports/next-request.ts
@@ -1,2 +1,3 @@
 // This file is for modularized imports for next/server to get fully-treeshaking.
-export { NextRequest as default } from '../spec-extension/request'
+// Export the default export and named export for the same module for typing resolving.
+export { NextRequest, NextRequest as default } from '../spec-extension/request'

--- a/packages/next/src/server/web/exports/next-response.ts
+++ b/packages/next/src/server/web/exports/next-response.ts
@@ -1,2 +1,6 @@
 // This file is for modularized imports for next/server to get fully-treeshaking.
-export { NextResponse as default } from '../spec-extension/response'
+// Export the default export and named export for the same module for typing resolving.
+export {
+  NextResponse,
+  NextResponse as default,
+} from '../spec-extension/response'

--- a/packages/next/src/server/web/exports/url-pattern.ts
+++ b/packages/next/src/server/web/exports/url-pattern.ts
@@ -1,5 +1,8 @@
+// This file is for modularized imports for next/server to get fully-treeshaking.
+// Export the default export and named export for the same module for typing resolving.
 const GlobalURLPattern =
   // @ts-expect-error: URLPattern is not available in Node.js
   typeof URLPattern === 'undefined' ? undefined : URLPattern
 
 export default GlobalURLPattern
+export { GlobalURLPattern as URLPattern }

--- a/packages/next/src/server/web/exports/user-agent-from-string.ts
+++ b/packages/next/src/server/web/exports/user-agent-from-string.ts
@@ -1,2 +1,6 @@
 // This file is for modularized imports for next/server to get fully-treeshaking.
-export { userAgentFromString as default } from '../spec-extension/user-agent'
+// Export the default export and named export for the same module for typing resolving.
+export {
+  userAgentFromString,
+  userAgentFromString as default,
+} from '../spec-extension/user-agent'

--- a/packages/next/src/server/web/exports/user-agent.ts
+++ b/packages/next/src/server/web/exports/user-agent.ts
@@ -1,2 +1,3 @@
 // This file is for modularized imports for next/server to get fully-treeshaking.
-export { userAgent as default } from '../spec-extension/user-agent'
+// Export the default export and named export for the same module for typing resolving.
+export { userAgent, userAgent as default } from '../spec-extension/user-agent'


### PR DESCRIPTION
Found this error while running e2e test `test/e2e/middleware-general/test/index.test.ts`
```
./middleware.js
Attempted import error: 'NextResponse' is not exported from 'next/dist/server/web/exports/next-response' (imported as 'NextResponse').
```

We also need to export the default export as named exports as well to support typing