### PR TITLE
Update app router filter handling

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -892,7 +892,8 @@ export default async function build(
           appPageKeys,
           config.experimental.clientRouterFilterRedirects
             ? nonInternalRedirects
-            : []
+            : [],
+          config.experimental.clientRouterFilterAllowedRate
         )
 
         NextBuildContext.clientRouterFilters = clientRouterFilters

--- a/packages/next/src/lib/create-client-router-filter.ts
+++ b/packages/next/src/lib/create-client-router-filter.ts
@@ -9,7 +9,8 @@ const POTENTIAL_ERROR_RATE = 0.01
 
 export function createClientRouterFilter(
   paths: string[],
-  redirects: Redirect[]
+  redirects: Redirect[],
+  allowedErrorRate: number = POTENTIAL_ERROR_RATE
 ): {
   staticFilter: ReturnType<BloomFilter['export']>
   dynamicFilter: ReturnType<BloomFilter['export']>
@@ -56,12 +57,9 @@ export function createClientRouterFilter(
     }
   }
 
-  const staticFilter = BloomFilter.from([...staticPaths], POTENTIAL_ERROR_RATE)
+  const staticFilter = BloomFilter.from([...staticPaths], allowedErrorRate)
 
-  const dynamicFilter = BloomFilter.from(
-    [...dynamicPaths],
-    POTENTIAL_ERROR_RATE
-  )
+  const dynamicFilter = BloomFilter.from([...dynamicPaths], allowedErrorRate)
   const data = {
     staticFilter: staticFilter.export(),
     dynamicFilter: dynamicFilter.export(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -256,6 +256,9 @@ const configSchema = {
         clientRouterFilterRedirects: {
           type: 'boolean',
         },
+        clientRouterFilterAllowedRate: {
+          type: 'number',
+        },
         cpus: {
           type: 'number',
         },

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -116,6 +116,10 @@ export interface NextJsWebpackConfig {
 export interface ExperimentalConfig {
   clientRouterFilter?: boolean
   clientRouterFilterRedirects?: boolean
+  // decimal for percent for possible false positives
+  // e.g. 0.01 for 10% potential false matches lower
+  // percent increases size of the filter
+  clientRouterFilterAllowedRate?: number
   externalMiddlewareRewritesResolve?: boolean
   extensionAlias?: Record<string, any>
   allowedRevalidateHeaderKeys?: string[]

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -630,7 +630,8 @@ export default class DevServer extends Server {
               ? ((this.nextConfig as any)._originalRedirects || []).filter(
                   (r: any) => !r.internal
                 )
-              : []
+              : [],
+            this.nextConfig.experimental.clientRouterFilterAllowedRate
           )
 
           if (

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -16,6 +16,24 @@ createNextDescribe(
     },
   },
   ({ next, isNextDev: isDev, isNextStart, isNextDeploy }) => {
+    if (!isDev) {
+      it('should successfully detect app route during prefetch', async () => {
+        const browser = await next.browser('/')
+
+        await check(async () => {
+          const found = await browser.eval(
+            '!!window.next.router.components["/dashboard"]'
+          )
+          return found
+            ? 'success'
+            : await browser.eval('Object.keys(window.next.router.components)')
+        }, 'success')
+
+        await browser.elementByCss('a').click()
+        await browser.waitForElementByCss('#from-dashboard')
+      })
+    }
+
     it('should encode chunk path correctly', async () => {
       await next.fetch('/dynamic-client/first/second')
       const browser = await next.browser('/')


### PR DESCRIPTION
This ensures we check if a path is `appRouter` during prefetching so that we can trigger hard navigations quicker when routing from pages -> app. An additional config is also exposed to allow configuring the potential false positive rate for the client filter.

x-ref: [slack thread](https://vercel.slack.com/archives/C017QMYC5FB/p1680225393243459)