### PR TITLE
fix: improve error message pages for `output: export`

### DIFF
--- a/errors/export-no-custom-routes.md
+++ b/errors/export-no-custom-routes.md
@@ -1,4 +1,4 @@
-# `Export Custom Routes
+# Export Custom Routes
 
 #### Why This Error Occurred
 
@@ -8,7 +8,8 @@ These configs do not apply when exporting your Next.js application manually.
 
 #### Possible Ways to Fix It
 
-Disable the `rewrites`, `redirects`, and `headers` from your `next.config.js` when using `output: 'export'` (or `next export`) to deploy your application or deploy your application using [a method](https://nextjs.org/docs/deployment#managed-nextjs-with-vercel) that supports these configs.
+- Remove `rewrites`, `redirects`, and `headers` from your `next.config.js` to disable these features or
+- Remove `output: 'export'` (or `next export`) in favor of [`next start`](https://nextjs.org/docs/api-reference/cli#production) to run a production server
 
 ### Useful Links
 

--- a/errors/export-no-i18n.md
+++ b/errors/export-no-i18n.md
@@ -1,0 +1,16 @@
+# Export Internationalization (i18n)
+
+#### Why This Error Occurred
+
+In your `next.config.js` you defined `i18n`, along with `output: 'export'` (or you ran `next export`).
+
+#### Possible Ways to Fix It
+
+- Remove `i18n` from your `next.config.js` to disable Internationalization or
+- Remove `output: 'export'` (or `next export`) in favor of [`next start`](https://nextjs.org/docs/api-reference/cli#production) to run a production server
+
+### Useful Links
+
+- [Deployment Documentation](https://nextjs.org/docs/deployment)
+- [`output: 'export'` Documentation](https://nextjs.org/docs/advanced-features/static-html-export)
+- [Internationalized Routing](https://nextjs.org/docs/advanced-features/i18n-routing)

--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -155,6 +155,10 @@
           "path": "/errors/export-no-custom-routes.md"
         },
         {
+          "title": "export-no-i18n",
+          "path": "/errors/export-no-i18n.md"
+        },
+        {
           "title": "export-path-mismatch",
           "path": "/errors/export-path-mismatch.md"
         },

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -403,7 +403,7 @@ export default async function exportApp(
 
     if (i18n && !options.buildExport) {
       throw new ExportError(
-        `i18n support is not compatible with next export. See here for more info on deploying: https://nextjs.org/docs/deployment`
+        `i18n support is not compatible with next export. See here for more info on deploying: https://nextjs.org/docs/messages/export-no-custom-routes`
       )
     }
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -263,22 +263,22 @@ function assignDefaults(
   if (result.output === 'export') {
     if (result.i18n) {
       throw new Error(
-        'Specified "i18n" cannot be used with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export'
+        'Specified "i18n" cannot be used with "output: export". See more info here: https://nextjs.org/docs/messages/export-no-i18n'
       )
     }
     if (result.rewrites) {
       throw new Error(
-        'Specified "rewrites" cannot be used with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export'
+        'Specified "rewrites" cannot be used with "output: export". See more info here: https://nextjs.org/docs/messages/export-no-custom-routes'
       )
     }
     if (result.redirects) {
       throw new Error(
-        'Specified "redirects" cannot be used with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export'
+        'Specified "redirects" cannot be used with "output: export". See more info here: https://nextjs.org/docs/messages/export-no-custom-routes'
       )
     }
     if (result.headers) {
       throw new Error(
-        'Specified "headers" cannot be used with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export'
+        'Specified "headers" cannot be used with "output: export". See more info here: https://nextjs.org/docs/messages/export-no-custom-routes'
       )
     }
   }


### PR DESCRIPTION

fix NEXT-928 ([link](https://linear.app/vercel/issue/NEXT-928))