### PR TITLE
turbopack: ensure ENV values are available in middleware

### DIFF
--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware-env/input/.env
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware-env/input/.env
@@ -1,0 +1,1 @@
+CUSTOM_ENV=foobar

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware-env/input/middleware.ts
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware-env/input/middleware.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(_request: NextRequest) {
+  return NextResponse.json(process.env)
+}
+
+export const config = {
+  matcher: '/body',
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware-env/input/next.config.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware-env/input/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = {}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware-env/input/pages/index.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/router/middleware-env/input/pages/index.js
@@ -1,0 +1,18 @@
+import { useEffect } from 'react'
+
+export default function Foo() {
+  useEffect(() => {
+    // Only run on client
+    import('@turbo/pack-test-harness').then(runTests)
+  })
+
+  return 'index'
+}
+
+function runTests() {
+  it('should include custom env fields in middleware process', async () => {
+    const res = await fetch('/body')
+    const env = await res.json()
+    expect(env).toHaveProperty('CUSTOM_ENV', 'foobar')
+  })
+}

--- a/packages/next/src/server/lib/route-resolver.ts
+++ b/packages/next/src/server/lib/route-resolver.ts
@@ -159,7 +159,7 @@ export async function makeResolver(
           return {
             name: 'middleware',
             paths: middleware.files.map((file) => join(process.cwd(), file)),
-            env: [],
+            env: Object.keys(process.env),
             wasm: [],
             assets: [],
           }


### PR DESCRIPTION
Turbopack starts up the router process with all ENV values, but the edge function definition didn't list any `env` keys for the function invocation. So, middleware couldn't access any ENV values.

Turbopack doesn't currently have a way to determine what ENV keys are actually used by the source program, so I'm just passing everything defined. I'm not sure if that's an issue during dev (I could see it being one for the build process, but that doesn't matter for this case).

Fixes #47766
Fixes WEB-831
Fixes WEB-834