### PR TITLE
Fix skipMiddlewareUrlNormalize with i18n

### DIFF
--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -99,7 +99,9 @@ export async function adapter(
 
   const request = new NextRequestHint({
     page: params.page,
-    input: String(requestUrl),
+    input: process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE
+      ? params.request.url
+      : String(requestUrl),
     init: {
       body: params.request.body,
       geo: params.request.geo,

--- a/test/e2e/skip-trailing-slash-redirect/app/middleware.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/middleware.js
@@ -1,13 +1,35 @@
 import { NextResponse } from 'next/server'
 
 export default function handler(req) {
+  const parsedOrigUrl = new URL(req.url)
+  const origPathname = parsedOrigUrl.pathname
+  const lowerPathname = origPathname.toLowerCase()
+
+  // ensure locale casing can be redirected
+  if (
+    (lowerPathname.startsWith('/en') || lowerPathname.startsWith('/ja-jp')) &&
+    origPathname !== lowerPathname &&
+    !lowerPathname.includes('_next')
+  ) {
+    parsedOrigUrl.pathname = lowerPathname
+    return NextResponse.redirect(parsedOrigUrl)
+  }
+
   console.log(req.nextUrl)
   let { pathname } = req.nextUrl
 
   if (pathname.includes('docs') || pathname.includes('chained-rewrite')) {
+    if (pathname.startsWith('/en')) {
+      pathname = pathname.replace(/^\/en/, '') || '/'
+    }
+
     if (pathname === '/docs') {
       pathname = '/'
     }
+
+    console.log(
+      `rewriting to https://middleware-external-rewrite-target-epsp8idgo-uncurated-tests.vercel.app${pathname}`
+    )
 
     return NextResponse.rewrite(
       `https://middleware-external-rewrite-target-epsp8idgo-uncurated-tests.vercel.app${pathname}`

--- a/test/e2e/skip-trailing-slash-redirect/app/next.config.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/next.config.js
@@ -5,6 +5,10 @@ const nextConfig = {
   experimental: {
     externalMiddlewareRewritesResolve: true,
   },
+  i18n: {
+    locales: ['en', 'ja-jp'],
+    defaultLocale: 'en',
+  },
   async redirects() {
     return [
       {

--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -16,6 +16,17 @@ describe('skip-trailing-slash-redirect', () => {
   })
   afterAll(() => next.destroy())
 
+  it.each(['EN', 'JA-JP'])(
+    'should be able to redirect locale casing $1',
+    async (locale) => {
+      const res = await next.fetch(`/${locale}`, { redirect: 'manual' })
+      expect(res.status).toBe(307)
+      expect(new URL(res.headers.get('location'), 'http://n').pathname).toBe(
+        `/${locale.toLowerCase()}`
+      )
+    }
+  )
+
   it.each([
     { pathname: '/chained-rewrite-ssg' },
     { pathname: '/chained-rewrite-static' },


### PR DESCRIPTION
This ensures we don't normalize locales in the URL with the skipMiddlewareUrlNormalize flag enabled so that casing redirects can be applied correctly for locales. 