### PR TITLE
Fix module resolving error in tracer

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -952,10 +952,10 @@ export default async function getBaseWebpackConfig(
 
   const reactDir = path.dirname(require.resolve('react/package.json'))
   const reactDomDir = path.dirname(require.resolve('react-dom/package.json'))
-  let hasOptionalOTELAPIPackage = false
+  let hasExternalOtelApiPackage = false
   try {
-    require('@opentelemetry/api')
-    hasOptionalOTELAPIPackage = true
+    require.resolve('@opentelemetry/api')
+    hasExternalOtelApiPackage = true
   } catch {}
 
   const resolveConfig: webpack.Configuration['resolve'] = {
@@ -999,11 +999,13 @@ export default async function getBaseWebpackConfig(
               'next/dist/client/components/navigation',
             [require.resolve('next/dist/client/components/headers')]:
               'next/dist/client/components/headers',
-            '@opentelemetry/api': hasOptionalOTELAPIPackage
-              ? '@opentelemetry/api'
-              : 'next/dist/compiled/@opentelemetry/api',
           }
         : undefined),
+
+      // For RSC server bundle
+      ...(!hasExternalOtelApiPackage && {
+        '@opentelemetry/api': 'next/dist/compiled/@opentelemetry/api',
+      }),
 
       ...(config.images.loaderFile
         ? {

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -6,9 +6,9 @@ import type {
   SpanOptions,
   Tracer,
   AttributeValue,
-} from '@opentelemetry/api'
+} from 'next/dist/compiled/@opentelemetry/api'
 
-let api: typeof import('@opentelemetry/api')
+let api: typeof import('next/dist/compiled/@opentelemetry/api')
 
 // we want to allow users to use their own version of @opentelemetry/api if they
 // want to, so we try to require it first, and if it fails we fall back to the


### PR DESCRIPTION
Fix the module resolving error found during development, because now few app route code is bundled into RSC server layer, it can't resolve opentelementry properly and will throw the error blow due to the check of `require('@opentelemetry/api')` to see if it's installed.

```
Module not found: Can't resolve '@opentelemetry/api'
```

Thus I alias it to default `next/dist/compiled/@opentelemetry/api` when it doesn't have external module