### PR TITLE
Move modularize imports for next/server to next-swc

### DIFF
--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -153,6 +153,21 @@ where
         }
     };
 
+    let mut modularize_imports_config = match &opts.modularize_imports {
+        Some(config) => config.clone(),
+        None => turbo_binding::swc::custom_transform::modularize_imports::Config {
+            packages: std::collections::HashMap::new(),
+        },
+    };
+    modularize_imports_config.packages.insert(
+        "next/server".to_string(),
+        turbo_binding::swc::custom_transform::modularize_imports::PackageConfig {
+            transform: "next/dist/server/web/exports/{{ kebabCase member }}".to_string(),
+            prevent_full_import: true,
+            skip_default_conversion: true,
+        },
+    );
+
     chain!(
         disallow_re_export_all_in_page::disallow_re_export_all_in_page(opts.is_page_file),
         match &opts.server_components {
@@ -244,14 +259,9 @@ where
                 }
             })
             .unwrap_or_else(|| Either::Right(noop())),
-        match &opts.modularize_imports {
-            Some(config) => Either::Left(
-                turbo_binding::swc::custom_transform::modularize_imports::modularize_imports(
-                    config.clone()
-                )
-            ),
-            None => Either::Right(noop()),
-        },
+        turbo_binding::swc::custom_transform::modularize_imports::modularize_imports(
+            modularize_imports_config
+        ),
         match &opts.font_loaders {
             Some(config) => Either::Left(next_font_loaders(config.clone())),
             None => Either::Right(noop()),

--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -163,8 +163,8 @@ where
         "next/server".to_string(),
         turbo_binding::swc::custom_transform::modularize_imports::PackageConfig {
             transform: "next/dist/server/web/exports/{{ kebabCase member }}".to_string(),
-            prevent_full_import: true,
-            skip_default_conversion: true,
+            prevent_full_import: false,
+            skip_default_conversion: false,
         },
     );
 

--- a/packages/next-swc/crates/next-core/src/router_source.rs
+++ b/packages/next-swc/crates/next-core/src/router_source.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Context, Result};
-use futures::stream::StreamExt;
 use indexmap::IndexSet;
 use turbo_binding::turbopack::{
     core::{

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -50,14 +50,6 @@ function getBaseSWCOptions({
     .filter(Array.isArray)
     .map(([name, options]: any) => [require.resolve(name), options])
 
-  // Use modularized imports for next/server to ensure treeshaking.
-  // This prevents ImageResponse related assets from being bundled when not used.
-  // TODO: move it into next-swc
-  const modularizeImports = nextConfig?.modularizeImports || {}
-  modularizeImports['next/server'] = {
-    transform: 'next/dist/server/web/exports/{{ kebabCase member }}',
-  }
-
   return {
     jsc: {
       ...(resolvedBaseUrl && paths
@@ -123,7 +115,7 @@ function getBaseSWCOptions({
     reactRemoveProperties: jest
       ? false
       : nextConfig?.compiler?.reactRemoveProperties,
-    modularizeImports,
+    modularizeImports: nextConfig?.modularizeImports,
     relay: nextConfig?.compiler?.relay,
     // Always transform styled-jsx and error when `client-only` condition is triggered
     styledJsx: true,


### PR DESCRIPTION
Follow up for #47715 

Moving modularize imports handlign for next/server into `next-swc` side