### PR TITLE
Skip favicon.js for metadata

### DIFF
--- a/packages/next/src/build/webpack/loaders/metadata/discover.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/discover.ts
@@ -86,7 +86,10 @@ export async function createStaticMetadataFromRoute(
     const resolvedMetadataFiles = await enumMetadataFiles(
       resolvedDir,
       STATIC_METADATA_IMAGES[type].filename,
-      pageExtensions.concat(STATIC_METADATA_IMAGES[type].extensions),
+      [
+        ...STATIC_METADATA_IMAGES[type].extensions,
+        ...(type === 'favicon' ? [] : pageExtensions),
+      ],
       opts
     )
     resolvedMetadataFiles

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/favicon.tsx
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/favicon.tsx
@@ -1,0 +1,23 @@
+// This file should be ignored
+import { ImageResponse } from 'next/server'
+
+export default function favicon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 88,
+          background: '#fff',
+          color: '#000',
+        }}
+      >
+        Favicon
+      </div>
+    )
+  )
+}

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -155,6 +155,8 @@ createNextDescribe(
         'content'
       )
 
+      expect($('link[rel="favicon"]')).toHaveLength(0)
+
       // non absolute urls
       expect($icon.attr('href')).toContain('/icon')
       expect($icon.attr('href')).toMatch(hashRegex)


### PR DESCRIPTION
For backward compatibility, we only handle `favicon.ico` file to generate `/favicon.ico` route and link tag. If you want to use other extension such as `png`, use `icon(\d)?.[ext]`