### PR TITLE
Add `computeWorkerKey` to the static optimization worker

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1272,6 +1272,20 @@ export default async function build(
         },
         numWorkers: config.experimental.cpus,
         enableWorkerThreads: config.experimental.workerThreads,
+        computeWorkerKey(method, ...args) {
+          if (method === 'exportPage') {
+            const typedArgs = args as Parameters<
+              typeof import('./worker').exportPage
+            >
+            return typedArgs[0].pathMap.page
+          } else if (method === 'isPageStatic') {
+            const typedArgs = args as Parameters<
+              typeof import('./worker').isPageStatic
+            >
+            return typedArgs[0].originalAppPath || typedArgs[0].page
+          }
+          return method
+        },
         exposedMethods: sharedPool
           ? [
               'hasCustomGetInitialProps',


### PR DESCRIPTION
Since both `exportPage` and `isPageStatic` methods in the static optimization worker involve loading the actual page component, it's better to assign the same page to the same worker for these 2 tasks to avoid unnecessary memory allocation.
