### PR TITLE
Fix prefetch only being applied once

### DIFF
--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -7,7 +7,8 @@ import { ReadonlyReducerState } from './router-reducer-types'
 export function applyFlightData(
   state: ReadonlyReducerState,
   cache: CacheNode,
-  flightDataPath: FlightDataPath
+  flightDataPath: FlightDataPath,
+  wasPrefetched?: boolean
 ): boolean {
   // The one before last item is the router state tree patch
   const [treePatch, subTreeData, head] = flightDataPath.slice(-3)
@@ -20,7 +21,13 @@ export function applyFlightData(
   if (flightDataPath.length === 3) {
     cache.status = CacheStates.READY
     cache.subTreeData = subTreeData
-    fillLazyItemsTillLeafWithHead(cache, state.cache, treePatch, head)
+    fillLazyItemsTillLeafWithHead(
+      cache,
+      state.cache,
+      treePatch,
+      head,
+      wasPrefetched
+    )
   } else {
     // Copy subTreeData for the root node of the cache.
     cache.status = CacheStates.READY

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -107,7 +107,7 @@ export function navigateReducer(
         return handleExternalUrl(state, mutable, href, pendingPush)
       }
 
-      const applied = applyFlightData(state, cache, flightDataPath)
+      const applied = applyFlightData(state, cache, flightDataPath, true)
 
       const hardNavigate = shouldHardNavigate(
         // TODO-APP: remove ''

--- a/test/e2e/app-dir/app-prefetch/app/static-page/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/static-page/page.js
@@ -1,7 +1,14 @@
+import Link from 'next/link'
+
 export default async function Page() {
   return (
     <>
       <p id="static-page">Static Page</p>
+      <p>
+        <Link href="/" id="to-home">
+          To home
+        </Link>
+      </p>
     </>
   )
 }


### PR DESCRIPTION
### What / why?

Currently there is a bug because the `subTreeData` can only be applied once, however, we reuse the same response when a url was prefetched. During the first render of the response we apply the cacheNodes and then these should be reused for subsequent navigations. There's currently a bug because `fillLazyItemsTillLeafWithHead` creates `LAZY_INITIALIZED` cache nodes that don't copy the previous cache node `parallelRoutes` and `subTreeData` value, causing the cache nodes below where the `subTreeData` is applied to be deleted from the cache, even when they're not affected by the navigation.

### How?

This PR adds copying of the cache node when it exists already, I've added a marker for `wasPrefetched` to trigger that behavior but in talking to @feedthejim about this it seems we can swap to this behavior always when applying the server response, that needs to be discussed further though, this is temporary implementation with the fix for routes that were prefetched.

Fixes NEXT-402

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
