### PR TITLE
Fix fetchCache config and On-Demand Revalidate handling

### DIFF
--- a/packages/next/src/client/components/static-generation-async-storage.ts
+++ b/packages/next/src/client/components/static-generation-async-storage.ts
@@ -7,6 +7,7 @@ export interface StaticGenerationStore {
   readonly pathname: string
   readonly incrementalCache?: IncrementalCache
   readonly isRevalidate?: boolean
+  readonly isOnDemandRevalidate?: boolean
   readonly isPrerendering?: boolean
 
   forceDynamic?: boolean

--- a/packages/next/src/server/api-utils/index.ts
+++ b/packages/next/src/server/api-utils/index.ts
@@ -79,11 +79,11 @@ export function checkIsOnDemandRevalidate(
   req: IncomingMessage | BaseNextRequest,
   previewProps: __ApiPreviewProps
 ): {
-  isManualRevalidate: boolean
+  isOnDemandRevalidate: boolean
   revalidateOnlyGenerated: boolean
 } {
   return {
-    isManualRevalidate:
+    isOnDemandRevalidate:
       req.headers[PRERENDER_REVALIDATE_HEADER] === previewProps.previewModeId,
     revalidateOnlyGenerated:
       !!req.headers[PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER],

--- a/packages/next/src/server/api-utils/index.ts
+++ b/packages/next/src/server/api-utils/index.ts
@@ -75,7 +75,7 @@ export const PRERENDER_REVALIDATE_HEADER = 'x-prerender-revalidate'
 export const PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER =
   'x-prerender-revalidate-if-generated'
 
-export function checkIsManualRevalidate(
+export function checkIsOnDemandRevalidate(
   req: IncomingMessage | BaseNextRequest,
   previewProps: __ApiPreviewProps
 ): {

--- a/packages/next/src/server/api-utils/node.ts
+++ b/packages/next/src/server/api-utils/node.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'http'
 import type { NextApiRequest, NextApiResponse } from '../../shared/lib/utils'
 import type { PageConfig, ResponseLimit, SizeLimit } from 'next/types'
 import {
-  checkIsManualRevalidate,
+  checkIsOnDemandRevalidate,
   PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER,
   __ApiPreviewProps,
 } from '.'
@@ -44,7 +44,7 @@ export function tryGetPreviewData(
 ): PreviewData {
   // if an On-Demand revalidation is being done preview mode
   // is disabled
-  if (options && checkIsManualRevalidate(req, options).isManualRevalidate) {
+  if (options && checkIsOnDemandRevalidate(req, options).isManualRevalidate) {
     return false
   }
 

--- a/packages/next/src/server/api-utils/node.ts
+++ b/packages/next/src/server/api-utils/node.ts
@@ -44,7 +44,7 @@ export function tryGetPreviewData(
 ): PreviewData {
   // if an On-Demand revalidation is being done preview mode
   // is disabled
-  if (options && checkIsOnDemandRevalidate(req, options).isManualRevalidate) {
+  if (options && checkIsOnDemandRevalidate(req, options).isOnDemandRevalidate) {
     return false
   }
 

--- a/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
@@ -9,6 +9,7 @@ export type StaticGenerationContext = {
     incrementalCache?: IncrementalCache
     supportsDynamicHTML: boolean
     isRevalidate?: boolean
+    isOnDemandRevalidate?: boolean
     isBot?: boolean
     nextExport?: boolean
     fetchCache?: StaticGenerationStore['fetchCache']
@@ -57,6 +58,7 @@ export const StaticGenerationAsyncStorageWrapper: AsyncStorageWrapper<
       isRevalidate: renderOpts.isRevalidate,
       isPrerendering: renderOpts.nextExport,
       fetchCache: renderOpts.fetchCache,
+      isOnDemandRevalidate: renderOpts.isOnDemandRevalidate,
     }
 
     // TODO: remove this when we resolve accessing the store outside the execution context

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -45,7 +45,7 @@ import { isDynamicRoute } from '../shared/lib/router/utils'
 import {
   setLazyProp,
   getCookieParser,
-  checkIsManualRevalidate,
+  checkIsOnDemandRevalidate,
 } from './api-utils'
 import { setConfig } from '../shared/lib/runtime-config'
 import Router from './router'
@@ -1416,12 +1416,12 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       }
     }
 
-    let isManualRevalidate = false
+    let isOnDemandRevalidate = false
     let revalidateOnlyGenerated = false
 
     if (isSSG) {
-      ;({ isManualRevalidate, revalidateOnlyGenerated } =
-        checkIsManualRevalidate(req, this.renderOpts.previewProps))
+      ;({ isManualRevalidate: isOnDemandRevalidate, revalidateOnlyGenerated } =
+        checkIsOnDemandRevalidate(req, this.renderOpts.previewProps))
     }
 
     if (isSSG && this.minimalMode && req.headers['x-matched-path']) {
@@ -1646,6 +1646,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
             : resolvedUrl,
 
         supportsDynamicHTML,
+        isOnDemandRevalidate,
       }
 
       const renderResult = await this.renderHTML(
@@ -1735,7 +1736,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         // skip manual revalidate if cache is not present and
         // revalidate-if-generated is set
         if (
-          isManualRevalidate &&
+          isOnDemandRevalidate &&
           revalidateOnlyGenerated &&
           !hadCache &&
           !this.minimalMode
@@ -1746,7 +1747,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
         // only allow manual revalidate for fallback: true/blocking
         // or for prerendered fallback: false paths
-        if (isManualRevalidate && (fallbackMode !== false || hadCache)) {
+        if (isOnDemandRevalidate && (fallbackMode !== false || hadCache)) {
           fallbackMode = 'blocking'
         }
 
@@ -1838,13 +1839,13 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       },
       {
         incrementalCache,
-        isManualRevalidate,
+        isManualRevalidate: isOnDemandRevalidate,
         isPrefetch: req.headers.purpose === 'prefetch',
       }
     )
 
     if (!cacheEntry) {
-      if (ssgCacheKey && !(isManualRevalidate && revalidateOnlyGenerated)) {
+      if (ssgCacheKey && !(isOnDemandRevalidate && revalidateOnlyGenerated)) {
         // A cache entry might not be generated if a response is written
         // in `getInitialProps` or `getServerSideProps`, but those shouldn't
         // have a cache key. If we do have a cache key but we don't end up
@@ -1860,7 +1861,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       // we set for the image-optimizer
       res.setHeader(
         'x-nextjs-cache',
-        isManualRevalidate
+        isOnDemandRevalidate
           ? 'REVALIDATED'
           : cacheEntry.isMiss
           ? 'MISS'

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1420,7 +1420,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     let revalidateOnlyGenerated = false
 
     if (isSSG) {
-      ;({ isManualRevalidate: isOnDemandRevalidate, revalidateOnlyGenerated } =
+      ;({ isOnDemandRevalidate, revalidateOnlyGenerated } =
         checkIsOnDemandRevalidate(req, this.renderOpts.previewProps))
     }
 
@@ -1471,7 +1471,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
     let ssgCacheKey =
       isPreviewMode || !isSSG || opts.supportsDynamicHTML
-        ? null // Preview mode, manual revalidate, flight request can bypass the cache
+        ? null // Preview mode, on-demand revalidate, flight request can bypass the cache
         : `${locale ? `/${locale}` : ''}${
             (pathname === '/' || resolvedUrlPathname === '/') && locale
               ? ''
@@ -1733,7 +1733,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           fallbackMode = 'blocking'
         }
 
-        // skip manual revalidate if cache is not present and
+        // skip on-demand revalidate if cache is not present and
         // revalidate-if-generated is set
         if (
           isOnDemandRevalidate &&
@@ -1745,7 +1745,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           return null
         }
 
-        // only allow manual revalidate for fallback: true/blocking
+        // only allow on-demand revalidate for fallback: true/blocking
         // or for prerendered fallback: false paths
         if (isOnDemandRevalidate && (fallbackMode !== false || hadCache)) {
           fallbackMode = 'blocking'
@@ -1839,7 +1839,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       },
       {
         incrementalCache,
-        isManualRevalidate: isOnDemandRevalidate,
+        isOnDemandRevalidate: isOnDemandRevalidate,
         isPrefetch: req.headers.purpose === 'prefetch',
       }
     )

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -80,9 +80,18 @@ export function patchFetch({
             ? (input as any).next?.revalidate
             : undefined
 
+        const isOnlyCache = staticGenerationStore.fetchCache === 'only-cache'
+        const isForceCache = staticGenerationStore.fetchCache === 'force-cache'
+        const isDefaultNoStore =
+          staticGenerationStore.fetchCache === 'default-no-store'
+        const isOnlyNoStore =
+          staticGenerationStore.fetchCache === 'only-no-store'
+        const isForceNoStore =
+          staticGenerationStore.fetchCache === 'force-no-store'
+
         const _cache = getRequestMeta('cache')
 
-        if (_cache === 'force-cache') {
+        if (_cache === 'force-cache' || isForceCache) {
           curRevalidate = false
         }
         if (['no-cache', 'no-store'].includes(_cache || '')) {
@@ -102,15 +111,6 @@ export function patchFetch({
             ? _headers
             : new Headers(_headers || {})
 
-        // const isOnlyCache = staticGenerationStore.fetchCache === 'only-cache'
-        // const isForceCache = staticGenerationStore.fetchCache === 'force-cache'
-        // const isDefaultNoStore =
-        //   staticGenerationStore.fetchCache === 'default-no-store'
-        // const isOnlyNoStore =
-        //   staticGenerationStore.fetchCache === 'only-no-store'
-        // const isForceNoStore =
-        //   staticGenerationStore.fetchCache === 'force-no-store'
-
         const hasUnCacheableHeader =
           initHeaders.get('authorization') || initHeaders.get('cookie')
 
@@ -125,8 +125,28 @@ export function patchFetch({
           (hasUnCacheableHeader || isUnCacheableMethod) &&
           staticGenerationStore.revalidate === 0
 
+        if (isForceNoStore) {
+          revalidate = 0
+        }
+
         if (typeof revalidate === 'undefined') {
-          if (autoNoCache) {
+          if (isOnlyCache && _cache === 'no-store') {
+            throw new Error(
+              `cache: 'no-store' used on fetch for ${input.toString()} with 'export const fetchCache = 'only-cache'`
+            )
+          }
+
+          if (isOnlyNoStore) {
+            revalidate = 0
+
+            if (_cache === 'force-cache') {
+              throw new Error(
+                `cache: 'force-cache' used on fetch for ${input.toString()} with 'export const fetchCache = 'only-no-store'`
+              )
+            }
+          } else if (autoNoCache) {
+            revalidate = 0
+          } else if (isDefaultNoStore) {
             revalidate = 0
           } else {
             revalidate =
@@ -251,11 +271,13 @@ export function patchFetch({
         }
 
         if (cacheKey && staticGenerationStore?.incrementalCache) {
-          const entry = await staticGenerationStore.incrementalCache.get(
-            cacheKey,
-            true,
-            revalidate
-          )
+          const entry = staticGenerationStore.isOnDemandRevalidate
+            ? null
+            : await staticGenerationStore.incrementalCache.get(
+                cacheKey,
+                true,
+                revalidate
+              )
 
           if (entry?.value && entry.value.kind === 'FETCH') {
             // when stale and is revalidating we wait for fresh data

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -80,7 +80,7 @@ import { urlQueryToSearchParams } from '../shared/lib/router/utils/querystring'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { getNextPathnameInfo } from '../shared/lib/router/utils/get-next-pathname-info'
 import { getCloneableBody } from './body-streams'
-import { checkIsManualRevalidate } from './api-utils'
+import { checkIsOnDemandRevalidate } from './api-utils'
 import ResponseCache from './response-cache'
 import { IncrementalCache } from './lib/incremental-cache'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
@@ -1788,7 +1788,7 @@ export default class NextNodeServer extends BaseServer {
   }) {
     // Middleware is skipped for on-demand revalidate requests
     if (
-      checkIsManualRevalidate(params.request, this.renderOpts.previewProps)
+      checkIsOnDemandRevalidate(params.request, this.renderOpts.previewProps)
         .isManualRevalidate
     ) {
       return { finished: false }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1789,7 +1789,7 @@ export default class NextNodeServer extends BaseServer {
     // Middleware is skipped for on-demand revalidate requests
     if (
       checkIsOnDemandRevalidate(params.request, this.renderOpts.previewProps)
-        .isManualRevalidate
+        .isOnDemandRevalidate
     ) {
       return { finished: false }
     }

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -264,6 +264,7 @@ export type RenderOptsPartial = {
   crossOrigin?: string
   images: ImageConfigComplete
   largePageDataBytes?: number
+  isOnDemandRevalidate?: boolean
 }
 
 export type RenderOpts = LoadComponentsReturnType & RenderOptsPartial

--- a/packages/next/src/server/response-cache/index.ts
+++ b/packages/next/src/server/response-cache/index.ts
@@ -27,15 +27,15 @@ export default class ResponseCache {
     key: string | null,
     responseGenerator: ResponseGenerator,
     context: {
-      isManualRevalidate?: boolean
+      isOnDemandRevalidate?: boolean
       isPrefetch?: boolean
       incrementalCache: IncrementalCache
     }
   ): Promise<ResponseCacheEntry | null> {
     const { incrementalCache } = context
-    // ensure manual revalidate doesn't block normal requests
+    // ensure on-demand revalidate doesn't block normal requests
     const pendingResponseKey = key
-      ? `${key}-${context.isManualRevalidate ? '1' : '0'}`
+      ? `${key}-${context.isOnDemandRevalidate ? '1' : '0'}`
       : null
 
     const pendingResponse = pendingResponseKey
@@ -95,7 +95,7 @@ export default class ResponseCache {
         cachedResponse =
           key && !this.minimalMode ? await incrementalCache.get(key) : null
 
-        if (cachedResponse && !context.isManualRevalidate) {
+        if (cachedResponse && !context.isOnDemandRevalidate) {
           if (cachedResponse.value?.kind === 'FETCH') {
             throw new Error(
               `invariant: unexpected cachedResponse of kind fetch in response cache`
@@ -130,8 +130,8 @@ export default class ResponseCache {
                 isMiss: !cachedResponse,
               }
 
-        // for manual revalidate wait to resolve until cache is set
-        if (!context.isManualRevalidate) {
+        // for on-demand revalidate wait to resolve until cache is set
+        if (!context.isOnDemandRevalidate) {
           resolve(resolveValue)
         }
 
@@ -159,7 +159,7 @@ export default class ResponseCache {
           this.previousCacheItem = undefined
         }
 
-        if (context.isManualRevalidate) {
+        if (context.isOnDemandRevalidate) {
           resolve(resolveValue)
         }
       } catch (err) {

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -6,7 +6,7 @@ export interface ResponseCacheBase {
     key: string | null,
     responseGenerator: ResponseGenerator,
     context: {
-      isManualRevalidate?: boolean
+      isOnDemandRevalidate?: boolean
       isPrefetch?: boolean
       incrementalCache: IncrementalCache
     }

--- a/packages/next/src/server/response-cache/web.ts
+++ b/packages/next/src/server/response-cache/web.ts
@@ -22,14 +22,14 @@ export default class WebResponseCache {
     key: string | null,
     responseGenerator: ResponseGenerator,
     context: {
-      isManualRevalidate?: boolean
+      isOnDemandRevalidate?: boolean
       isPrefetch?: boolean
       incrementalCache: any
     }
   ): Promise<ResponseCacheEntry | null> {
-    // ensure manual revalidate doesn't block normal requests
+    // ensure on-demand revalidate doesn't block normal requests
     const pendingResponseKey = key
-      ? `${key}-${context.isManualRevalidate ? '1' : '0'}`
+      ? `${key}-${context.isOnDemandRevalidate ? '1' : '0'}`
       : null
 
     const pendingResponse = pendingResponseKey
@@ -93,8 +93,8 @@ export default class WebResponseCache {
                 isMiss: true,
               }
 
-        // for manual revalidate wait to resolve until cache is set
-        if (!context.isManualRevalidate) {
+        // for on-demand revalidate wait to resolve until cache is set
+        if (!context.isOnDemandRevalidate) {
           resolve(resolveValue)
         }
 
@@ -108,7 +108,7 @@ export default class WebResponseCache {
           this.previousCacheItem = undefined
         }
 
-        if (context.isManualRevalidate) {
+        if (context.isOnDemandRevalidate) {
           resolve(resolveValue)
         }
       } catch (err) {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -76,32 +76,35 @@ createNextDescribe(
       }
     })
 
-    it('should revalidate all fetches during on-demand revalidate', async () => {
-      const initRes = await next.fetch('/variable-revalidate/revalidate-360')
-      const html = await initRes.text()
-      const $ = cheerio.load(html)
-      const initLayoutData = $('#layout-data').text()
-      const initPageData = $('#page-data').text()
+    // On-Demand Revalidate has not effect in dev
+    if (!(global as any).isNextDev) {
+      it('should revalidate all fetches during on-demand revalidate', async () => {
+        const initRes = await next.fetch('/variable-revalidate/revalidate-360')
+        const html = await initRes.text()
+        const $ = cheerio.load(html)
+        const initLayoutData = $('#layout-data').text()
+        const initPageData = $('#page-data').text()
 
-      expect(initLayoutData).toBeTruthy()
-      expect(initPageData).toBeTruthy()
+        expect(initLayoutData).toBeTruthy()
+        expect(initPageData).toBeTruthy()
 
-      const revalidateRes = await next.fetch(
-        '/api/revalidate?path=/variable-revalidate/revalidate-360'
-      )
-      expect((await revalidateRes.json()).revalidated).toBe(true)
+        const revalidateRes = await next.fetch(
+          '/api/revalidate?path=/variable-revalidate/revalidate-360'
+        )
+        expect((await revalidateRes.json()).revalidated).toBe(true)
 
-      const newRes = await next.fetch('/variable-revalidate/revalidate-360')
-      const newHtml = await newRes.text()
-      const new$ = cheerio.load(newHtml)
-      const newLayoutData = new$('#layout-data').text()
-      const newPageData = new$('#page-data').text()
+        const newRes = await next.fetch('/variable-revalidate/revalidate-360')
+        const newHtml = await newRes.text()
+        const new$ = cheerio.load(newHtml)
+        const newLayoutData = new$('#layout-data').text()
+        const newPageData = new$('#page-data').text()
 
-      expect(newLayoutData).toBeTruthy()
-      expect(newPageData).toBeTruthy()
-      expect(newLayoutData).not.toBe(initLayoutData)
-      expect(newPageData).not.toBe(initPageData)
-    })
+        expect(newLayoutData).toBeTruthy()
+        expect(newPageData).toBeTruthy()
+        expect(newLayoutData).not.toBe(initLayoutData)
+        expect(newPageData).not.toBe(initPageData)
+      })
+    }
 
     it('should correctly handle fetchCache = "force-no-store"', async () => {
       const initRes = await next.fetch('/force-no-store')
@@ -1281,7 +1284,7 @@ createNextDescribe(
       }, 'success')
     })
 
-    if (!(process.env.CUSTOM_CACHE_HANDLER || (global as any).isNextDev)) {
+    if (!process.env.CUSTOM_CACHE_HANDLER) {
       it('should honor dynamic = "force-static" correctly', async () => {
         const res = await next.fetch('/force-static/first')
         expect(res.status).toBe(200)

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -1281,49 +1281,51 @@ createNextDescribe(
       }, 'success')
     })
 
-    it('should honor dynamic = "force-static" correctly', async () => {
-      const res = await next.fetch('/force-static/first')
-      expect(res.status).toBe(200)
+    if (!process.env.CUSTOM_CACHE_HANDLER) {
+      it('should honor dynamic = "force-static" correctly', async () => {
+        const res = await next.fetch('/force-static/first')
+        expect(res.status).toBe(200)
 
-      const html = await res.text()
-      const $ = cheerio.load(html)
+        const html = await res.text()
+        const $ = cheerio.load(html)
 
-      expect(JSON.parse($('#params').text())).toEqual({ slug: 'first' })
-      expect(JSON.parse($('#headers').text())).toEqual([])
-      expect(JSON.parse($('#cookies').text())).toEqual([])
+        expect(JSON.parse($('#params').text())).toEqual({ slug: 'first' })
+        expect(JSON.parse($('#headers').text())).toEqual([])
+        expect(JSON.parse($('#cookies').text())).toEqual([])
 
-      const firstTime = $('#now').text()
+        const firstTime = $('#now').text()
 
-      if (!(global as any).isNextDev) {
-        const res2 = await next.fetch('/force-static/first')
-        expect(res2.status).toBe(200)
+        if (!(global as any).isNextDev) {
+          const res2 = await next.fetch('/force-static/first')
+          expect(res2.status).toBe(200)
 
-        const $2 = cheerio.load(await res2.text())
-        expect(firstTime).toBe($2('#now').text())
-      }
-    })
+          const $2 = cheerio.load(await res2.text())
+          expect(firstTime).toBe($2('#now').text())
+        }
+      })
 
-    it('should honor dynamic = "force-static" correctly (lazy)', async () => {
-      const res = await next.fetch('/force-static/random')
-      expect(res.status).toBe(200)
+      it('should honor dynamic = "force-static" correctly (lazy)', async () => {
+        const res = await next.fetch('/force-static/random')
+        expect(res.status).toBe(200)
 
-      const html = await res.text()
-      const $ = cheerio.load(html)
+        const html = await res.text()
+        const $ = cheerio.load(html)
 
-      expect(JSON.parse($('#params').text())).toEqual({ slug: 'random' })
-      expect(JSON.parse($('#headers').text())).toEqual([])
-      expect(JSON.parse($('#cookies').text())).toEqual([])
+        expect(JSON.parse($('#params').text())).toEqual({ slug: 'random' })
+        expect(JSON.parse($('#headers').text())).toEqual([])
+        expect(JSON.parse($('#cookies').text())).toEqual([])
 
-      const firstTime = $('#now').text()
+        const firstTime = $('#now').text()
 
-      if (!(global as any).isNextDev) {
-        const res2 = await next.fetch('/force-static/random')
-        expect(res2.status).toBe(200)
+        if (!(global as any).isNextDev) {
+          const res2 = await next.fetch('/force-static/random')
+          expect(res2.status).toBe(200)
 
-        const $2 = cheerio.load(await res2.text())
-        expect(firstTime).toBe($2('#now').text())
-      }
-    })
+          const $2 = cheerio.load(await res2.text())
+          expect(firstTime).toBe($2('#now').text())
+        }
+      })
+    }
 
     // since we aren't leveraging fs cache with custom handler
     // then these will 404 as they are cache misses

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -1281,7 +1281,7 @@ createNextDescribe(
       }, 'success')
     })
 
-    if (!process.env.CUSTOM_CACHE_HANDLER) {
+    if (!(process.env.CUSTOM_CACHE_HANDLER || (global as any).isNextDev)) {
       it('should honor dynamic = "force-static" correctly', async () => {
         const res = await next.fetch('/force-static/first')
         expect(res.status).toBe(200)

--- a/test/e2e/app-dir/app-static/app/force-no-store/page.js
+++ b/test/e2e/app-dir/app-static/app/force-no-store/page.js
@@ -1,0 +1,21 @@
+import { cache, use } from 'react'
+
+export const fetchCache = 'force-no-store'
+
+export default function Page() {
+  const getData = cache(() =>
+    fetch('https://next-data-api-endpoint.vercel.app/api/random?page', {}).then(
+      (res) => res.text()
+    )
+  )
+  const dataPromise = getData()
+  const data = use(dataPromise)
+
+  return (
+    <>
+      <p id="page">/force-no-store</p>
+      <p id="page-data">{data}</p>
+      <p id="now">{Date.now()}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/revalidate-360/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/revalidate-360/page.js
@@ -1,0 +1,19 @@
+import { cache, use } from 'react'
+
+export default function Page() {
+  const getData = cache(() =>
+    fetch('https://next-data-api-endpoint.vercel.app/api/random?page', {
+      next: { revalidate: 360 },
+    }).then((res) => res.text())
+  )
+  const dataPromise = getData()
+  const data = use(dataPromise)
+
+  return (
+    <>
+      <p id="page">/variable-revalidate/revalidate-360</p>
+      <p id="page-data">revalidate 360: {data}</p>
+      <p id="now">{Date.now()}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/pages/api/revalidate.js
+++ b/test/e2e/app-dir/app-static/pages/api/revalidate.js
@@ -1,0 +1,9 @@
+export default async function handler(req, res) {
+  try {
+    await res.revalidate(req.query.path)
+    return res.json({ revalidated: true, now: Date.now() })
+  } catch (err) {
+    console.error('Failed to revalidate', req.query, err)
+    return res.json({ revalidated: false })
+  }
+}

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -1818,7 +1818,7 @@ describe('Prerender', () => {
         })
       }
 
-      it('should not throw error for manual revalidate for SSR path', async () => {
+      it('should not throw error for on-demand revalidate for SSR path', async () => {
         const res = await fetchViaHTTP(next.url, '/api/manual-revalidate', {
           pathname: '/ssr',
         })
@@ -1828,7 +1828,7 @@ describe('Prerender', () => {
         expect(stripAnsi(next.cliOutput)).not.toContain('hasHeader')
       })
 
-      it('should revalidate manual revalidate with preview cookie', async () => {
+      it('should revalidate on-demand revalidate with preview cookie', async () => {
         const initialRes = await fetchViaHTTP(next.url, '/preview')
         expect(initialRes.status).toBe(200)
 
@@ -2133,7 +2133,7 @@ describe('Prerender', () => {
     }
 
     if (!isDev) {
-      it('should handle manual revalidate for fallback: blocking', async () => {
+      it('should handle on-demand revalidate for fallback: blocking', async () => {
         const beforeRevalidate = Date.now()
         const res = await fetchViaHTTP(
           next.url,
@@ -2247,7 +2247,7 @@ describe('Prerender', () => {
         )
       })
 
-      it('should not manual revalidate for fallback: blocking with onlyGenerated if not generated', async () => {
+      it('should not on-demand revalidate for fallback: blocking with onlyGenerated if not generated', async () => {
         const res = await fetchViaHTTP(
           next.url,
           '/api/manual-revalidate',
@@ -2274,7 +2274,7 @@ describe('Prerender', () => {
         expect(next.cliOutput).toContain(`getStaticProps test-if-generated-1`)
       })
 
-      it('should manual revalidate for fallback: blocking with onlyGenerated if generated', async () => {
+      it('should on-demand revalidate for fallback: blocking with onlyGenerated if generated', async () => {
         const beforeRevalidate = Date.now()
         const res = await fetchViaHTTP(
           next.url,
@@ -2324,7 +2324,7 @@ describe('Prerender', () => {
         expect(res4.headers.get('x-nextjs-cache')).toMatch(/(HIT|STALE)/)
       })
 
-      it('should manual revalidate for revalidate: false', async () => {
+      it('should on-demand revalidate for revalidate: false', async () => {
         const html = await renderViaHTTP(
           next.url,
           '/blocking-fallback-once/test-manual-1'
@@ -2363,7 +2363,7 @@ describe('Prerender', () => {
         expect($4('#time').text()).not.toBe(initialTime)
       })
 
-      it('should manual revalidate that returns notFound: true', async () => {
+      it('should on-demand revalidate that returns notFound: true', async () => {
         const res = await fetchViaHTTP(
           next.url,
           '/blocking-fallback-once/404-on-manual-revalidate'
@@ -2404,7 +2404,7 @@ describe('Prerender', () => {
         expect(res3.headers.get('x-nextjs-cache')).toBe('HIT')
       })
 
-      it('should handle manual revalidate for fallback: false', async () => {
+      it('should handle on-demand revalidate for fallback: false', async () => {
         const res = await fetchViaHTTP(
           next.url,
           '/catchall-explicit/test-manual-1'

--- a/test/production/standalone-mode/required-server-files/precompiled-server.test.ts
+++ b/test/production/standalone-mode/required-server-files/precompiled-server.test.ts
@@ -403,7 +403,7 @@ describe('should set-up next', () => {
     expect(props2.gspCalls).not.toBe(props.gspCalls)
   })
 
-  it('should not 404 for onlyGenerated manual revalidate in minimal mode', async () => {
+  it('should not 404 for onlyGenerated on-demand revalidate in minimal mode', async () => {
     const previewProps = JSON.parse(
       await next.readFile('standalone/.next/prerender-manifest.json')
     ).preview

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -402,7 +402,7 @@ describe('should set-up next', () => {
     expect(props2.gspCalls).not.toBe(props.gspCalls)
   })
 
-  it('should not 404 for onlyGenerated manual revalidate in minimal mode', async () => {
+  it('should not 404 for onlyGenerated on-demand revalidate in minimal mode', async () => {
     const previewProps = JSON.parse(
       await next.readFile('standalone/.next/prerender-manifest.json')
     ).preview


### PR DESCRIPTION
This ensures we properly honor the `export const fetchCache` config and also ensures we properly bypass fetch-cache when an On-Demand Revalidation is occurring. 

The `export const dynamic` handling is not changed here as that was behaving correctly and should not influence fetch cache handling only whether a page is prerendered fully or treated as SSR. 

Fixes: https://github.com/vercel/next.js/issues/47273
x-ref: [slack thread](https://vercel.slack.com/archives/C042LHPJ1NX/p1679078572123979)