### PR TITLE
Tweak Vercel CLI installing for E2E tests

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1047,6 +1047,8 @@ jobs:
           name: next-swc-test-binary
           path: packages/next-swc/native
 
+      - run: npm i -g vercel@latest
+
       - run: RESET_VC_PROJECT=true node scripts/reset-vercel-project.mjs
         name: Reset test project
 


### PR DESCRIPTION
Avoids accidentally running the CLI install twice at the same time due to concurrency by pre-installing it before starting tests. 

x-ref: https://github.com/vercel/next.js/actions/runs/4581102424/jobs/8090565967
x-ref: https://github.com/vercel/next.js/blob/canary/test/lib/next-modes/next-deploy.ts#L27