### PR TITLE
Fix failing rust-check

### DIFF
--- a/packages/next-swc/crates/next-core/src/router_source.rs
+++ b/packages/next-swc/crates/next-core/src/router_source.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Context, Result};
-use futures::stream::StreamExt;
 use indexmap::IndexSet;
 use turbo_binding::turbopack::{
     core::{


### PR DESCRIPTION
This corrects a failing rust-check that slipped through in https://github.com/vercel/next.js/pull/47677 due to the check not being marked as required which it now is. 

x-ref: https://github.com/vercel/next.js/actions/runs/4587341207/jobs/8100906394
