### PR TITLE
Fix dev ipc request on node v16

### DIFF
--- a/packages/next/src/server/lib/server-ipc.ts
+++ b/packages/next/src/server/lib/server-ipc.ts
@@ -102,3 +102,25 @@ export const createWorker = (
 
   return worker
 }
+
+export const filterReqHeaders = (
+  headers: Record<string, undefined | string | string[]> | Headers
+) => {
+  const forbiddenHeaders = [
+    'content-length',
+    'keepalive',
+    'content-encoding',
+    'transfer-encoding',
+    // https://github.com/nodejs/undici/issues/1470
+    'connection',
+  ]
+
+  for (const key of forbiddenHeaders) {
+    if (headers instanceof Headers) {
+      headers.delete(key)
+    } else {
+      delete headers[key]
+    }
+  }
+  return headers
+}

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -102,6 +102,7 @@ import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { removePathPrefix } from '../shared/lib/router/utils/remove-path-prefix'
 import { addPathPrefix } from '../shared/lib/router/utils/add-path-prefix'
 import { pathHasPrefix } from '../shared/lib/router/utils/path-has-prefix'
+import { filterReqHeaders } from './lib/server-ipc'
 
 export * from './base-server'
 
@@ -1409,26 +1410,7 @@ export default class NextNodeServer extends BaseServer {
               'x-invoke-path': invokePathname,
               'x-invoke-query': encodeURIComponent(invokeQuery),
             }
-
-            const forbiddenHeaders = (global as any).__NEXT_USE_UNDICI
-              ? [
-                  'content-length',
-                  'keepalive',
-                  'content-encoding',
-                  'transfer-encoding',
-                  // https://github.com/nodejs/undici/issues/1470
-                  'connection',
-                ]
-              : [
-                  'content-length',
-                  'keepalive',
-                  'content-encoding',
-                  'transfer-encoding',
-                ]
-
-            for (const key of forbiddenHeaders) {
-              delete invokeHeaders[key]
-            }
+            filterReqHeaders(invokeHeaders)
 
             const invokeRes = await fetch(renderUrl, {
               method: req.method,
@@ -2258,14 +2240,7 @@ export default class NextNodeServer extends BaseServer {
                   ...req.headers,
                   'x-middleware-invoke': '1',
                 }
-                for (const key of [
-                  'content-length',
-                  'keepalive',
-                  'content-encoding',
-                  'transfer-encoding',
-                ]) {
-                  delete invokeHeaders[key]
-                }
+                filterReqHeaders(invokeHeaders)
 
                 const invokeRes = await fetch(renderUrl, {
                   method: req.method,


### PR DESCRIPTION
This ensures we filter conflicting headers from the initial request when passing it to a render worker since undici in Node.js v16 fails on these. 

x-ref: https://github.com/vercel/next.js/actions/runs/4588955268/jobs/8105263272