### PR TITLE
Update dev IPC request

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -102,6 +102,7 @@ import { IncrementalCache } from '../lib/incremental-cache'
 import LRUCache from 'next/dist/compiled/lru-cache'
 import { NextUrlWithParsedQuery } from '../request-meta'
 import { deserializeErr, errorToJSON } from '../render'
+import { invokeRequest } from '../lib/server-ipc'
 
 // Load ReactDevOverlay only when needed
 let ReactDevOverlayImpl: FunctionComponent
@@ -1257,12 +1258,23 @@ export default class DevServer extends Server {
   private async invokeIpcMethod(method: string, args: any[]): Promise<any> {
     const ipcPort = process.env.__NEXT_PRIVATE_ROUTER_IPC_PORT
     if (ipcPort) {
-      const res = await this.originalFetch(
+      const res = await invokeRequest(
         `http://${this.hostname}:${ipcPort}?method=${
           method as string
-        }&args=${encodeURIComponent(JSON.stringify(args))}`
+        }&args=${encodeURIComponent(JSON.stringify(args))}`,
+        {
+          method: 'GET',
+          headers: {},
+        }
       )
-      const body = await res.text()
+      const chunks = []
+
+      for await (const chunk of res) {
+        if (chunk) {
+          chunks.push(chunk)
+        }
+      }
+      const body = Buffer.concat(chunks).toString()
 
       if (body.startsWith('{') && body.endsWith('}')) {
         const parsedBody = JSON.parse(body)

--- a/packages/next/src/server/lib/server-ipc.ts
+++ b/packages/next/src/server/lib/server-ipc.ts
@@ -140,6 +140,13 @@ export const invokeRequest = async (
   },
   readableBody?: import('stream').Readable
 ) => {
+  const parsedUrl = new URL(targetUrl)
+
+  // force localhost to IPv4 as some DNS may
+  // resolve to IPv6 instead
+  if (parsedUrl.hostname === 'localhost') {
+    parsedUrl.hostname = '127.0.0.1'
+  }
   const invokeHeaders = filterReqHeaders({
     ...requestInit.headers,
   }) as IncomingMessage['headers']


### PR DESCRIPTION
This ensures we don't fail to send dev IPC requests when `localhost` resolves to an IPv6 address but the IPC server is listening on IPv4. 

<details>

<summary>example error</summary>

```sh
TypeError: fetch failed
    at Object.fetch (node:internal/deps/undici/undici:11118:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async DevServer.invokeIpcMethod (/Users/test/projects/blog/node_modules/.pnpm/next@13.2.5-canary.28_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/dev/next-dev-server.js:881:25)
    at async DevServer.ensurePage (/Users/test/projects/blog/node_modules/.pnpm/next@13.2.5-canary.28_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/dev/next-dev-server.js:1199:13)
    at async Object.fn (/Users/test/projects/blog/node_modules/.pnpm/next@13.2.5-canary.28_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/next-server.js:1496:29)
    at async Router.execute (/Users/test/projects/blog/node_modules/.pnpm/next@13.2.5-canary.28_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/router.js:293:32)
    at async DevServer.runImpl (/Users/test/projects/blog/node_modules/.pnpm/next@13.2.5-canary.28_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/base-server.js:494:29)
    at async DevServer.run (/Users/test/projects/blog/node_modules/.pnpm/next@13.2.5-canary.28_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/dev/next-dev-server.js:860:20)
    at async DevServer.handleRequestImpl (/Users/test/projects/blog/node_modules/.pnpm/next@13.2.5-canary.28_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/base-server.js:437:20) {
  cause: Error: connect ECONNREFUSED ::1:49507
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1300:16) {
    errno: -61,
    code: 'ECONNREFUSED',
    syscall: 'connect',
    address: '::1',
    port: 49507
  }
}
```

</details>