### PR TITLE
Change package path from `gitpkg.now.sh` to `gitpkg.vercel.app`

### DIFF
--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,7 +10,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev-runtime": "https://gitpkg.now.sh/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3",
+    "@vercel/turbopack-dev-runtime": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1004,7 +1004,7 @@ importers:
       '@types/react': ^18.0.26
       '@types/react-dom': ^18.0.9
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev-runtime': https://gitpkg.now.sh/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3
+      '@vercel/turbopack-dev-runtime': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1016,7 +1016,7 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev-runtime': '@gitpkg.now.sh/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3_react-refresh@0.12.0'
+      '@vercel/turbopack-dev-runtime': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3_react-refresh@0.12.0'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25545,9 +25545,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.now.sh/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.now.sh/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3}
-    id: '@gitpkg.now.sh/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230321.3'
     name: '@vercel/turbopack-dev-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
Avoids a couple of hops when installing packages as `.now.sh` returns a redirection.