### PR TITLE
Ensure GH actions tests run for trunk branches

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [canary]
+    branches: ['*']
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ['**']
+    branches: ['canary', 'trunk-merge/*']
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ['*']
+    branches: ['**']
   pull_request:
     types: [opened, synchronize]
 


### PR DESCRIPTION
We need to run for all branches for trunk to test correctly 