### PR TITLE
feat(turbopack): initial mdxrs config support

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "serde",
 ]
@@ -3302,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "serde",
@@ -6687,7 +6687,7 @@ dependencies = [
 [[package]]
 name = "turbo-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -6724,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "mimalloc",
 ]
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6762,7 +6762,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6774,7 +6774,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6789,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6803,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6820,7 +6820,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6849,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "base16",
  "hex",
@@ -6861,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -6875,7 +6875,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6885,7 +6885,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6907,7 +6907,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6945,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6988,7 +6988,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7023,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7042,7 +7042,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7075,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7111,7 +7111,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "serde",
@@ -7126,7 +7126,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "serde",
@@ -7141,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "serde",
@@ -7206,7 +7206,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7217,7 +7217,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.3#13ff78b906a5883e8a1667ad8a4636c4cf6550c3"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/packages/next-swc/Cargo.toml
+++ b/packages/next-swc/Cargo.toml
@@ -47,11 +47,11 @@ swc_emotion = { version = "0.29.10" }
 testing = { version = "0.31.31" }
 
 # Turbo crates
-turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230412.2" }
+turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230412.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230412.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230412.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230412.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230412.3" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -158,7 +158,8 @@ pub async fn get_client_module_options_context(
 
     let tsconfig = get_typescript_transform_options(project_path);
     let decorators_options = get_decorators_transform_options(project_path);
-    let jsx_runtime_options = get_jsx_transform_options(project_path);
+    let mdx_rs_options = *next_config.mdx_rs().await?;
+    let jsx_runtime_options = get_jsx_transform_options(project_path, mdx_rs_options);
     let enable_webpack_loaders = {
         let options = &*next_config.webpack_loaders_options().await?;
         let loaders_options = WebpackLoadersOptions {
@@ -203,6 +204,7 @@ pub async fn get_client_module_options_context(
         }),
         enable_webpack_loaders,
         enable_typescript_transform: Some(tsconfig),
+        enable_mdx_rs: mdx_rs_options,
         decorators: Some(decorators_options),
         rules: vec![(
             foreign_code_context_condition(next_config).await?,

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -358,6 +358,7 @@ pub struct ExperimentalConfig {
     pub app_dir: Option<bool>,
     pub server_components_external_packages: Option<Vec<String>>,
     pub turbo: Option<ExperimentalTurboConfig>,
+    mdx_rs: Option<bool>,
 
     // unsupported
     adjust_font_fallbacks: Option<bool>,
@@ -383,7 +384,6 @@ pub struct ExperimentalConfig {
     large_page_data_bytes: Option<f64>,
     legacy_browsers: Option<bool>,
     manual_client_base_path: Option<bool>,
-    mdx_rs: Option<serde_json::Value>,
     middleware_prefetch: Option<MiddlewarePrefetchType>,
     modularize_imports: Option<serde_json::Value>,
     new_next_link_behavior: Option<bool>,
@@ -555,6 +555,13 @@ impl NextConfigVc {
         };
         let alias_map: ResolveAliasMap = resolve_alias.try_into()?;
         Ok(alias_map.cell())
+    }
+
+    #[turbo_tasks::function]
+    pub async fn mdx_rs(self) -> Result<BoolVc> {
+        Ok(BoolVc::cell(
+            self.await?.experimental.mdx_rs.unwrap_or(false),
+        ))
     }
 }
 

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -234,7 +234,8 @@ pub async fn get_server_module_options_context(
 
     let tsconfig = get_typescript_transform_options(project_path);
     let decorators_options = get_decorators_transform_options(project_path);
-    let jsx_runtime_options = get_jsx_transform_options(project_path);
+    let mdx_rs_options = *next_config.mdx_rs().await?;
+    let jsx_runtime_options = get_jsx_transform_options(project_path, mdx_rs_options);
     let enable_emotion = *get_emotion_compiler_config(next_config).await?;
     let enable_styled_components = *get_styled_components_compiler_config(next_config).await?;
 
@@ -252,6 +253,7 @@ pub async fn get_server_module_options_context(
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
+                enable_mdx_rs: mdx_rs_options,
                 decorators: Some(decorators_options),
                 rules: vec![(
                     foreign_code_context_condition,
@@ -279,6 +281,7 @@ pub async fn get_server_module_options_context(
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
+                enable_mdx_rs: mdx_rs_options,
                 decorators: Some(decorators_options),
                 rules: vec![(
                     foreign_code_context_condition,
@@ -311,6 +314,7 @@ pub async fn get_server_module_options_context(
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
+                enable_mdx_rs: mdx_rs_options,
                 decorators: Some(decorators_options),
                 rules: vec![(
                     foreign_code_context_condition,
@@ -329,6 +333,7 @@ pub async fn get_server_module_options_context(
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
+                enable_mdx_rs: mdx_rs_options,
                 decorators: Some(decorators_options),
                 rules: vec![(
                     foreign_code_context_condition,
@@ -351,6 +356,7 @@ pub async fn get_server_module_options_context(
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
+                enable_mdx_rs: mdx_rs_options,
                 decorators: Some(decorators_options),
                 rules: vec![(
                     foreign_code_context_condition,

--- a/packages/next-swc/crates/next-core/src/transform_options.rs
+++ b/packages/next-swc/crates/next-core/src/transform_options.rs
@@ -123,6 +123,7 @@ pub async fn get_decorators_transform_options(
 #[turbo_tasks::function]
 pub async fn get_jsx_transform_options(
     project_path: FileSystemPathVc,
+    is_mdx_rs_enabled: bool,
 ) -> Result<JsxTransformOptionsVc> {
     let tsconfig = get_typescript_options(project_path).await;
 
@@ -152,6 +153,13 @@ pub async fn get_jsx_transform_options(
         })
         .await?
         .unwrap_or_default()
+    } else if is_mdx_rs_enabled {
+        // Mdx can implicitly includes jsx components, trying to enable jsx with default
+        // if jsx is not explicitly enabled
+        JsxTransformOptions {
+            import_source: None,
+            runtime: None,
+        }
     } else {
         Default::default()
     };

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -11,6 +11,7 @@ const supportedTurbopackNextConfigOptions = [
   'compiler.styledComponents',
   'experimental.serverComponentsExternalPackages',
   'experimental.turbo',
+  'experimental.mdxRs',
   'images',
   'pageExtensions',
   'onDemandEntries',


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?
Part of WEB-488.

This PR implements path to the `experimental.mdxRs` config in next.config.js pass into turbopack. Also adds a test cases supposed to pass with turbopack when mdxRs is enabled. PR requires to land https://github.com/vercel/turbo/pull/4442 first, so it is expected to fail for now.

One thing this PR (and its counterpart in turbopack) did not resolve yet is classic runtime's runtime import (import react ..)

https://github.com/vercel/next.js/compare/mdx-rs-turbopack?expand=1#diff-9c0234d0299e461e59c7cdcb853d11624fc287243a8941a61a15e4ad926be8c0R1

which is not being explicitly applied in existing test cases (https://github.com/vercel/next.js/blob/canary/test/integration/plugin-mdx-rs/components/button.js#L1). Bit unclear where / how does injection currently occurs, would need a followup changes if we'd like to properly support.




