### PR TITLE
Add option to preserve origin on rewrite

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -370,6 +370,9 @@ const configSchema = {
           minimum: 0,
           type: 'number',
         },
+        proxyPreserveOrigin: {
+          type: 'boolean',
+        },
         runtime: {
           // automatic typing doesn't like enum
           enum: Object.values(SERVER_RUNTIME) as any,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -137,6 +137,7 @@ export interface ExperimentalConfig {
   cpus?: number
   sharedPool?: boolean
   proxyTimeout?: number
+  proxyPreserveOrigin?: boolean
   isrFlushToDisk?: boolean
   workerThreads?: boolean
   pageEnv?: boolean

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -816,7 +816,7 @@ export default class NextNodeServer extends BaseServer {
       require('next/dist/compiled/http-proxy') as typeof import('next/dist/compiled/http-proxy')
     const proxy = new HttpProxy({
       target,
-      changeOrigin: true,
+      changeOrigin: !this.nextConfig.experimental.proxyPreserveOrigin,
       ignorePath: true,
       xfwd: true,
       ws: true,


### PR DESCRIPTION
## For Contributors

### Adding a feature

- ⌛️ Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- ✅ Related issues/discussions are linked using `fixes #number`
- ❌ e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- ❌ Documentation added
- ❌ Telemetry added. In case of a feature if it's used or not.
- ✅ Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### What?

This PR gives ability to change the changeOrigin parameter or the proxy instance used for Next rewrites.

### Why?

I need to redirect to my legacy server bypassing the DNS and using original Host header. I could not do it because changeOrigin is hardcoded in the proxy configuration

### How?

I added an experimental configuration.

Closes NEXT-
Fixes #47895

-->
