### PR TITLE
Add missing `module.hot.accept` call to server CSS modules

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-css-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-css-loader.ts
@@ -22,10 +22,6 @@ const NextServerCSSLoader = function (this: any, content: string) {
 
   // Only add the checksum during development.
   if (process.env.NODE_ENV !== 'production') {
-    // Server CSS modules are always available for HMR, so we attach
-    // `module.hot.accept()` to the generated module.
-    const hmrCode = 'if (module.hot) { module.hot.accept() }'
-
     const isCSSModule = this.resourcePath.match(/\.module\.(css|sass|scss)$/)
     const checksum = crypto
       .createHash('sha256')
@@ -41,9 +37,12 @@ const NextServerCSSLoader = function (this: any, content: string) {
       return `\
 ${content}
 module.exports.__checksum = ${JSON.stringify(checksum)}
-${hmrCode}
 `
     }
+
+    // Server CSS imports are always available for HMR, so we attach
+    // `module.hot.accept()` to the generated module.
+    const hmrCode = 'if (module.hot) { module.hot.accept() }'
 
     return `\
 export default ${JSON.stringify(checksum)}

--- a/packages/next/src/build/webpack/loaders/next-flight-css-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-css-loader.ts
@@ -22,6 +22,10 @@ const NextServerCSSLoader = function (this: any, content: string) {
 
   // Only add the checksum during development.
   if (process.env.NODE_ENV !== 'production') {
+    // Server CSS modules are always available for HMR, so we attach
+    // `module.hot.accept()` to the generated module.
+    const hmrCode = 'if (module.hot) { module.hot.accept() }'
+
     const isCSSModule = this.resourcePath.match(/\.module\.(css|sass|scss)$/)
     const checksum = crypto
       .createHash('sha256')
@@ -34,12 +38,17 @@ const NextServerCSSLoader = function (this: any, content: string) {
       .substring(0, 12)
 
     if (isCSSModule) {
-      return (
-        content + '\nmodule.exports.__checksum = ' + JSON.stringify(checksum)
-      )
+      return `\
+${content}
+module.exports.__checksum = ${JSON.stringify(checksum)}
+${hmrCode}
+`
     }
 
-    return `export default ${JSON.stringify(checksum)}`
+    return `\
+export default ${JSON.stringify(checksum)}
+${hmrCode}
+`
   }
 
   return content

--- a/test/e2e/app-dir/app-css/app/hmr/global.css
+++ b/test/e2e/app-dir/app-css/app/hmr/global.css
@@ -1,0 +1,3 @@
+body {
+  background: gray;
+}

--- a/test/e2e/app-dir/app-css/app/hmr/page.js
+++ b/test/e2e/app-dir/app-css/app/hmr/page.js
@@ -1,0 +1,5 @@
+import './global.css'
+
+export default function Page() {
+  return <div>hello!</div>
+}

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -496,6 +496,26 @@ createNextDescribe(
             await next.patchFile(filePath, origContent)
           }
         })
+
+        it('should not break HMR when CSS is imported in a server component', async () => {
+          const filePath = 'app/hmr/page.js'
+          const origContent = await next.readFile(filePath)
+
+          const browser = await next.browser('/hmr')
+          await browser.eval(`window.__v = 1`)
+          try {
+            await next.patchFile(
+              filePath,
+              origContent.replace('hello!', 'hmr!')
+            )
+            await check(() => browser.elementByCss('body').text(), 'hmr!')
+
+            // Make sure it doesn't reload the page
+            expect(await browser.eval(`window.__v`)).toBe(1)
+          } finally {
+            await next.patchFile(filePath, origContent)
+          }
+        })
       }
     })
 


### PR DESCRIPTION
Since we compile global server CSS imports into a special module with a checksum of the original content, it should always accept HMR updates. This fixes `Fast Refresh had to perform a full reload` errors.