### PR TITLE
Update link to more current React Docs

### DIFF
--- a/docs/basic-features/pages.md
+++ b/docs/basic-features/pages.md
@@ -8,7 +8,7 @@ description: Next.js pages are React Components exported in a file in the pages 
 >
 > [Learn more about incrementally adopting `app/`](https://beta.nextjs.org/docs/upgrade-guide).
 
-In Next.js, a **page** is a [React Component](https://reactjs.org/docs/components-and-props.html) exported from a `.js`, `.jsx`, `.ts`, or `.tsx` file in the `pages` directory. Each page is associated with a route based on its file name.
+In Next.js, a **page** is a [React Component](https://react.dev/learn/your-first-component) exported from a `.js`, `.jsx`, `.ts`, or `.tsx` file in the `pages` directory. Each page is associated with a route based on its file name.
 
 **Example**: If you create `pages/about.js` that exports a React component like below, it will be accessible at `/about`.
 


### PR DESCRIPTION
The previous link lead to a page that is eventually going to be deprecated, as evidenced by a paragraph header at the link. The link has been updated to follow the suggested link to the current domain where updated React docs are hosted.
