### PR TITLE
Implement MutableRequestCookies in server entries

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -569,6 +569,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
     export { staticGenerationAsyncStorage } from 'next/dist/client/components/static-generation-async-storage'
 
     export { requestAsyncStorage } from 'next/dist/client/components/request-async-storage'
+    export { actionAsyncStorage } from 'next/dist/client/components/action-async-storage'
 
     export { staticGenerationBailout } from 'next/dist/client/components/static-generation-bailout'
     export { default as StaticGenerationSearchParamsBailoutProvider } from 'next/dist/client/components/static-generation-searchparams-bailout-provider'

--- a/packages/next/src/client/components/action-async-storage.ts
+++ b/packages/next/src/client/components/action-async-storage.ts
@@ -1,0 +1,11 @@
+import type { AsyncLocalStorage } from 'async_hooks'
+
+import { createAsyncLocalStorage } from './async-local-storage'
+
+export interface ActionStore {
+  readonly isAction: boolean
+}
+
+export type ActionAsyncStorage = AsyncLocalStorage<ActionStore>
+
+export const actionAsyncStorage: ActionAsyncStorage = createAsyncLocalStorage()

--- a/packages/next/src/client/components/async-local-storage.ts
+++ b/packages/next/src/client/components/async-local-storage.ts
@@ -1,4 +1,4 @@
-import { AsyncLocalStorage } from 'async_hooks'
+import type { AsyncLocalStorage } from 'async_hooks'
 
 class FakeAsyncLocalStorage<Store extends {}>
   implements AsyncLocalStorage<Store>

--- a/packages/next/src/client/components/headers.ts
+++ b/packages/next/src/client/components/headers.ts
@@ -1,4 +1,5 @@
 import { RequestCookies } from '../../server/web/spec-extension/cookies'
+import { actionAsyncStorage } from './action-async-storage'
 import { requestAsyncStorage } from './request-async-storage'
 import { staticGenerationBailout } from './static-generation-bailout'
 
@@ -38,6 +39,11 @@ export function cookies() {
     throw new Error(
       `Invariant: Method expects to have requestAsyncStorage, none available`
     )
+  }
+
+  const asyncActionStore = actionAsyncStorage.getStore()
+  if (asyncActionStore && asyncActionStore.isAction) {
+    return requestStore.mutableCookies
   }
 
   return requestStore.cookies

--- a/packages/next/src/client/components/request-async-storage.ts
+++ b/packages/next/src/client/components/request-async-storage.ts
@@ -1,12 +1,15 @@
 import type { AsyncLocalStorage } from 'async_hooks'
-import { PreviewData } from '../../../types'
+import type { PreviewData } from '../../../types'
+import type { MutableRequestCookies } from '../../server/app-render/mutable-request-cookies'
 import type { ReadonlyHeaders } from '../../server/app-render/readonly-headers'
 import type { ReadonlyRequestCookies } from '../../server/app-render/readonly-request-cookies'
+
 import { createAsyncLocalStorage } from './async-local-storage'
 
 export interface RequestStore {
   readonly headers: ReadonlyHeaders
   readonly cookies: ReadonlyRequestCookies
+  readonly mutableCookies: MutableRequestCookies
   readonly previewData: PreviewData
 }
 

--- a/packages/next/src/server/app-render/mutable-request-cookies.ts
+++ b/packages/next/src/server/app-render/mutable-request-cookies.ts
@@ -1,0 +1,87 @@
+import { RequestCookies } from '../web/spec-extension/cookies'
+
+const INTERNAL_COOKIES_INSTANCE = Symbol('internal for cookies mutable')
+
+export class MutableRequestCookies {
+  [INTERNAL_COOKIES_INSTANCE]: RequestCookies
+
+  get: RequestCookies['get']
+  getAll: RequestCookies['getAll']
+  has: RequestCookies['has']
+  set: RequestCookies['set']
+  delete: RequestCookies['delete']
+  clear: RequestCookies['clear']
+
+  constructor(request: {
+    headers: {
+      get(key: 'cookie'): string | null | undefined
+      set(name: 'cookie', value: string): void
+    }
+    onSetCookie(values: string[]): void
+  }) {
+    // Since `new Headers` uses `this.append()` to fill the headers object ReadonlyHeaders can't extend from Headers directly as it would throw.
+    // Request overridden to not have to provide a fully request object.
+    const cookiesInstance = new RequestCookies(request.headers as Headers)
+    this[INTERNAL_COOKIES_INSTANCE] = cookiesInstance
+
+    const modifiedCookies = new Set<string>()
+    const updateResponseCookies = () => {
+      const cookies = cookiesInstance.getAll()
+      const values = cookies
+        .filter((cookie) => modifiedCookies.has(cookie.name))
+        .map((cookie) => `${cookie.name}=${cookie.value}`)
+      request.onSetCookie(values)
+    }
+
+    this.get = cookiesInstance.get.bind(cookiesInstance)
+    this.getAll = cookiesInstance.getAll.bind(cookiesInstance)
+    this.has = cookiesInstance.has.bind(cookiesInstance)
+    this.set = (
+      ...args:
+        | [key: string, value: string]
+        | [options: NonNullable<ReturnType<typeof cookiesInstance.get>>]
+    ) => {
+      const [key, value] = args
+      if (typeof key === 'string') {
+        modifiedCookies.add(key)
+        try {
+          return cookiesInstance.set(key, value!)
+        } finally {
+          updateResponseCookies()
+        }
+      }
+      modifiedCookies.add(key.name)
+      try {
+        return cookiesInstance.set(key)
+      } finally {
+        updateResponseCookies()
+      }
+    }
+    this.delete = (names: string | string[]) => {
+      if (Array.isArray(names)) {
+        names.forEach((name) => modifiedCookies.add(name))
+      } else {
+        modifiedCookies.add(names)
+      }
+      try {
+        return cookiesInstance.delete(names)
+      } finally {
+        updateResponseCookies()
+      }
+    }
+    this.clear = () => {
+      for (const cookie of cookiesInstance.getAll()) {
+        modifiedCookies.add(cookie.name)
+      }
+      try {
+        return cookiesInstance.clear()
+      } finally {
+        updateResponseCookies()
+      }
+    }
+  }
+
+  [Symbol.iterator]() {
+    return (this[INTERNAL_COOKIES_INSTANCE] as any)[Symbol.iterator]()
+  }
+}

--- a/packages/next/src/server/app-render/readonly-request-cookies.ts
+++ b/packages/next/src/server/app-render/readonly-request-cookies.ts
@@ -32,12 +32,29 @@ export class ReadonlyRequestCookies {
     return (this[INTERNAL_COOKIES_INSTANCE] as any)[Symbol.iterator]()
   }
 
+  /**
+   * This method is only allowed in Server Actions. Cookies are readonly in
+   * components.
+   * @link https://nextjs.org/api-reference/cookies
+   */
   clear() {
     throw new ReadonlyRequestCookiesError()
   }
+
+  /**
+   * This method is only allowed in Server Actions. Cookies are readonly in
+   * components.
+   * @link https://nextjs.org/api-reference/cookies
+   */
   delete() {
     throw new ReadonlyRequestCookiesError()
   }
+
+  /**
+   * This method is only allowed in Server Actions. Cookies are readonly in
+   * components.
+   * @link https://nextjs.org/api-reference/cookies
+   */
   set() {
     throw new ReadonlyRequestCookiesError()
   }

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -42,6 +42,16 @@ createNextDescribe(
         const res = (await browser.elementByCss('h1').text()) || ''
         return res.includes('Mozilla') ? 'UA' : ''
       }, 'UA')
+
+      // Set cookies
+      await browser.elementByCss('#setCookie').click()
+      await check(async () => {
+        const res = (await browser.elementByCss('h1').text()) || ''
+        const id = res.split(':')
+        return id[0] === id[1] && id[0] === id[2] && id[0]
+          ? 'same'
+          : 'different'
+      }, 'same')
     })
 
     it('should support formData and redirect', async () => {

--- a/test/e2e/app-dir/actions/app/header/actions.js
+++ b/test/e2e/app-dir/actions/app/header/actions.js
@@ -9,3 +9,8 @@ export async function getCookie(name) {
 export async function getHeader(name) {
   return headers().get(name)
 }
+
+export async function setCookie(name, value) {
+  cookies().set(name, value)
+  return cookies().get(name)
+}

--- a/test/e2e/app-dir/actions/app/header/page.js
+++ b/test/e2e/app-dir/actions/app/header/page.js
@@ -1,6 +1,6 @@
 import UI from './ui'
 
-import { getCookie, getHeader } from './actions'
+import { getCookie, getHeader, setCookie } from './actions'
 import { validator } from './validator'
 
 export default function Page() {
@@ -9,6 +9,7 @@ export default function Page() {
     <UI
       getCookie={getCookie}
       getHeader={getHeader}
+      setCookie={setCookie}
       getAuthedUppercase={validator(async (str) => {
         'use server'
         return prefix + ' ' + str.toUpperCase()

--- a/test/e2e/app-dir/actions/app/header/ui.js
+++ b/test/e2e/app-dir/actions/app/header/ui.js
@@ -2,7 +2,12 @@
 
 import { useState } from 'react'
 
-export default function UI({ getCookie, getHeader, getAuthedUppercase }) {
+export default function UI({
+  getCookie,
+  getHeader,
+  setCookie,
+  getAuthedUppercase,
+}) {
   const [result, setResult] = useState('')
 
   return (
@@ -19,6 +24,23 @@ export default function UI({ getCookie, getHeader, getAuthedUppercase }) {
         }}
       >
         getCookie
+      </button>
+      <button
+        id="setCookie"
+        onClick={async () => {
+          // set cookie on server side
+          const random = Math.random()
+          const res = await setCookie('random-server', random)
+          setResult(
+            random +
+              ':' +
+              res.value +
+              ':' +
+              document.cookie.match(/random-server=([^;]+)/)?.[1]
+          )
+        }}
+      >
+        setCookie
       </button>
       <button
         id="header"


### PR DESCRIPTION
This PR implements the `MutableRequestCookies` instance for `cookies()` based on the current async context, so we can allow setting cookies in certain places such as Server Functions and Route handlers. Note that to support Route Handlers, we need to also implement the logic of merging `Response`'s `Set-Cookie` header and the `cookies()` mutations, hence it's not included in this PR.

fix NEXT-942