### PR TITLE
turbopack: add vary header to app routes

### DIFF
--- a/packages/next-swc/crates/next-core/js/src/entry/app-renderer.tsx
+++ b/packages/next-swc/crates/next-core/js/src/entry/app-renderer.tsx
@@ -290,6 +290,7 @@ async function runOperation(renderData: RenderData) {
   return {
     headers: [
       ["Content-Type", result.contentType() ?? MIME_TEXT_HTML_UTF8],
+      ["Vary", "RSC"],
     ] as [string, string][],
     body,
   };

--- a/packages/next-swc/crates/next-core/js/src/entry/app-renderer.tsx
+++ b/packages/next-swc/crates/next-core/js/src/entry/app-renderer.tsx
@@ -27,10 +27,11 @@ import "next/dist/server/node-polyfill-fetch";
 import "next/dist/server/node-polyfill-web-streams";
 import "@vercel/turbopack-next/polyfill/async-local-storage";
 import { renderToHTMLOrFlight } from "next/dist/server/app-render/app-render";
-import { PassThrough } from "stream";
+import { RSC_VARY_HEADER } from "next/dist/client/components/app-router-headers"
 import { ServerResponseShim } from "@vercel/turbopack-next/internal/http";
 import { headersFromEntries } from "@vercel/turbopack-next/internal/headers";
 import { parse, ParsedUrlQuery } from "node:querystring";
+import { PassThrough } from "node:stream";
 
 ("TURBOPACK { transition: next-layout-entry; chunking-type: isolatedParallel }");
 // @ts-ignore
@@ -290,7 +291,7 @@ async function runOperation(renderData: RenderData) {
   return {
     headers: [
       ["Content-Type", result.contentType() ?? MIME_TEXT_HTML_UTF8],
-      ["Vary", "RSC"],
+      ["Vary", RSC_VARY_HEADER],
     ] as [string, string][],
     body,
   };

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/next.config.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+}
+
+module.exports = nextConfig

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/src/app/app/page.jsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/src/app/app/page.jsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return 'app'
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/src/app/layout.jsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/src/app/layout.jsx
@@ -1,0 +1,8 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <head />
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/src/app/page.jsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/src/app/page.jsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import { RSC_VARY_HEADER } from 'next/dist/client/components/app-router-headers'
 
 export default function Home() {
   useEffect(() => {
@@ -13,8 +14,7 @@ function runTests() {
   it('should include RSC vary for app route', async () => {
     const res = await fetch('/app')
 
-    const vary = res.headers.get('vary') || ''
-    expect(vary.split(/\s*,\s*/g)).toContain('RSC')
+    expect(res.headers.get('vary')).toBe(RSC_VARY_HEADER)
 
     const text = await res.text()
     expect(text).toContain('<html')
@@ -28,8 +28,7 @@ function runTests() {
       },
     })
 
-    const vary = res.headers.get('vary') || ''
-    expect(vary.split(/\s*,\s*/g)).toContain('RSC')
+    expect(res.headers.get('vary')).toBe(RSC_VARY_HEADER)
 
     const text = await res.text()
     expect(text).not.toContain('<html')

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/src/app/page.jsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/src/app/page.jsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Home() {
+  useEffect(() => {
+    import('@turbo/pack-test-harness').then(runTests)
+  }, [])
+  return 'index'
+}
+
+function runTests() {
+  it('should include RSC vary for app route', async () => {
+    const res = await fetch('/app')
+
+    const vary = res.headers.get('vary') || ''
+    expect(vary.split(/\s*,\s*/g)).toContain('RSC')
+
+    const text = await res.text()
+    expect(text).toContain('<html')
+    expect(text).toContain('app')
+  })
+
+  it('should include RSC vary for flight route', async () => {
+    const res = await fetch('/app', {
+      headers: {
+        RSC: 1,
+      },
+    })
+
+    const vary = res.headers.get('vary') || ''
+    expect(vary.split(/\s*,\s*/g)).toContain('RSC')
+
+    const text = await res.text()
+    expect(text).not.toContain('<html')
+    expect(text).toContain('app')
+  })
+
+  it('should not include RSC vary for page route', async () => {
+    const res = await fetch('/page')
+
+    const vary = res.headers.get('vary') || ''
+    expect(vary.split(/\s*,\s*/g)).not.toContain('RSC')
+
+    const text = await res.text()
+    expect(text).toContain('<html')
+    expect(text).toContain('page')
+  })
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/src/pages/page.jsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/rsc-NEXT-657/input/src/pages/page.jsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return 'page'
+}


### PR DESCRIPTION
Next.js adds a `Vary: RSC, Next-Router-State-Tree, Next-Router-Prefetch` to app routes for both rendering and flight requests. Without this, the browser can mistakenly serve the flight request to the app render, and vice versa.

This only adds `Vary: RSC` for the moment, I'm not sure what the others are used for. We also don't add a `Cache-Control: max-age=0` header, but I'm not sure if that's necessary either.

Fixes NEXT-657
fix #45595