### PR TITLE
avoid duplicated error output

### DIFF
--- a/packages/next-swc/crates/next-core/src/router_source.rs
+++ b/packages/next-swc/crates/next-core/src/router_source.rs
@@ -135,7 +135,7 @@ impl ContentSource for NextRouterContentSource {
         Ok(match &*res {
             RouterResult::Error(e) => {
                 return Err(anyhow!(e.clone()).context(format!(
-                    "error during Next.js routing for /{path}{}: {e}",
+                    "error during Next.js routing for /{path}{}",
                     formated_query(raw_query)
                 )))
             }


### PR DESCRIPTION
### What?

avoid including the error twice in the output

### Why?

`.context()` already keeps the previous error, no need to include in the error message again
