### PR TITLE
Fix typo for secure url types for open graph meta

### DIFF
--- a/packages/next/src/lib/metadata/types/opengraph-types.ts
+++ b/packages/next/src/lib/metadata/types/opengraph-types.ts
@@ -125,7 +125,7 @@ type OpenGraphVideoOther = OpenGraphMetadata & {
 type OGImage = string | OGImageDescriptor | URL
 type OGImageDescriptor = {
   url: string | URL
-  secureUrl?: string | URL
+  secure_url?: string | URL
   alt?: string
   type?: string
   width?: string | number
@@ -140,7 +140,7 @@ type OGAudioDescriptor = {
 type OGVideo = string | OGVideoDescriptor | URL
 type OGVideoDescriptor = {
   url: string | URL
-  secureUrl?: string | URL
+  secure_url?: string | URL
   type?: string
   width?: string | number
   height?: string | number


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
Related with #47411

### What?
According to Open Graph protocol, secure urls written in snake case (eg. `og:image:secure_url`). This pr fixes that typo in the type definition.
### Why?
Most sites doesn't render open graph images served from https unless they are provided with secure_url tag.