### PR TITLE
Increase CI test timeout

### DIFF
--- a/test/jest-setup-after-env.ts
+++ b/test/jest-setup-after-env.ts
@@ -3,4 +3,4 @@ expect.extend(matchers)
 
 // A default max-timeout of 90 seconds is allowed
 // per test we should aim to bring this down though
-jest.setTimeout((process.platform === 'win32' ? 180 : 90) * 1000)
+jest.setTimeout((process.platform === 'win32' ? 180 : 120) * 1000)


### PR DESCRIPTION
Seems builds in CI have been timing out with the 90s limit and with the shared concurrency of the limited CPUs additional time may be needed to avoid retrying un-necessarily.  

x-ref: https://github.com/vercel/next.js/actions/runs/4620023451/jobs/8170530943
x-ref: https://github.com/vercel/next.js/actions/runs/4619675493/jobs/8168849370