### PR TITLE
fix code generation for loader tree

### DIFF
--- a/packages/next-swc/crates/next-core/src/app_source.rs
+++ b/packages/next-swc/crates/next-core/src/app_source.rs
@@ -597,9 +597,9 @@ impl AppRendererVc {
                 state.counter += 1;
                 let identifier = magic_identifier::mangle(&format!("{name} #{i}"));
                 let chunks_identifier = magic_identifier::mangle(&format!("chunks of {name} #{i}"));
-                write!(
+                writeln!(
                     state.loader_tree_code,
-                    "{name}: [() => {identifier}, JSON.stringify({chunks_identifier}) + '.js']",
+                    "  {name}: [() => {identifier}, JSON.stringify({chunks_identifier}) + '.js'],",
                     name = StringifyJs(name)
                 )?;
                 state.imports.push(format!(
@@ -638,7 +638,7 @@ import {}, {{ chunks as {} }} from "COMPONENT_{}";
                 components,
             } = &*loader_tree.await?;
 
-            write!(
+            writeln!(
                 state.loader_tree_code,
                 "[{segment}, {{",
                 segment = StringifyJs(segment)
@@ -649,7 +649,7 @@ import {}, {{ chunks as {} }} from "COMPONENT_{}";
                 walk_tree(state, parallel_route).await?;
                 writeln!(state.loader_tree_code, ",")?;
             }
-            write!(state.loader_tree_code, "}}, {{")?;
+            writeln!(state.loader_tree_code, "}}, {{")?;
             // add components
             let Components {
                 page,
@@ -884,6 +884,11 @@ impl Issue for UnsupportedImplicitMetadataIssue {
     #[turbo_tasks::function]
     fn severity(&self) -> IssueSeverityVc {
         IssueSeverity::Warning.into()
+    }
+
+    #[turbo_tasks::function]
+    fn category(&self) -> StringVc {
+        StringVc::cell("unsupported".to_string())
     }
 
     #[turbo_tasks::function]

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/basic/input/app/loading.tsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/basic/input/app/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <>Loading</>
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/implicit-metadata/issues/Implicit metadata from filesystem is currently not supported in Turbopack-968612.txt
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/implicit-metadata/issues/Implicit metadata from filesystem is currently not supported in Turbopack-968612.txt
@@ -1,7 +1,7 @@
 PlainIssue {
     severity: Warning,
     context: "[project]/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/implicit-metadata/input/app",
-    category: "",
+    category: "unsupported",
     title: "Implicit metadata from filesystem is currently not supported in Turbopack",
     description: "The following files were found in the app directory, but are not supported by Turbopack. They are ignored:\n\n- [project]/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/implicit-metadata/input/app/apple-icon.png\n- [project]/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/implicit-metadata/input/app/icon1234.png\n- [project]/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/implicit-metadata/input/app/icon234.png",
     detail: "",


### PR DESCRIPTION
### What?

Fix missing `,` in loader tree code.

also adds `unsupported` as category of implicit metadata issue

### Why?

The loader tree to JS generated invalid code when there there where two non-page files in a directory.

fixes WEB-861