### PR TITLE
feat(turbopack): support initial compiler.emotion / compiler.styledComponents flag

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "serde",
 ]
@@ -3302,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "serde",
@@ -6687,7 +6687,7 @@ dependencies = [
 [[package]]
 name = "turbo-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -6724,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "mimalloc",
 ]
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6762,7 +6762,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6774,7 +6774,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6789,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6803,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6820,7 +6820,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6849,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "base16",
  "hex",
@@ -6861,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -6875,7 +6875,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6885,7 +6885,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6907,7 +6907,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6945,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6988,7 +6988,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7023,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7042,7 +7042,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7075,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7111,7 +7111,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "serde",
@@ -7126,7 +7126,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "serde",
@@ -7141,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "serde",
@@ -7206,7 +7206,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7217,7 +7217,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230411.2#8a6c4b81f4952627cfac60b1a77240c1ea02ec4b"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230412.2#d1df1a810f0fec704ebcf2201691261d1249703d"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/packages/next-swc/Cargo.toml
+++ b/packages/next-swc/Cargo.toml
@@ -47,11 +47,11 @@ swc_emotion = { version = "0.29.10" }
 testing = { version = "0.31.31" }
 
 # Turbo crates
-turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230411.2" }
+turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230412.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230411.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230412.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230411.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230412.2" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -175,7 +175,7 @@ pub async fn get_client_module_options_context(
             .clone_if()
     };
 
-    let emotion_compiler_options = get_emotion_compiler_config(next_config);
+    let enable_emotion = *get_emotion_compiler_config(next_config).await?;
 
     let module_options_context = ModuleOptionsContext {
         custom_ecmascript_transforms: vec![EcmascriptInputTransform::ServerDirective(
@@ -191,7 +191,7 @@ pub async fn get_client_module_options_context(
         // we try resolve it once at the root and pass down a context to all
         // the modules.
         enable_jsx: Some(jsx_runtime_options),
-        enable_emotion: Some(emotion_compiler_options),
+        enable_emotion,
         enable_react_refresh,
         enable_styled_components: true,
         enable_styled_jsx: true,

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -48,7 +48,7 @@ use crate::{
     },
     react_refresh::assert_can_resolve_react_refresh,
     transform_options::{
-        get_decorators_transform_options, get_jsx_transform_options,
+        get_decorators_transform_options, get_emotion_compiler_config, get_jsx_transform_options,
         get_typescript_transform_options,
     },
     util::foreign_code_context_condition,
@@ -175,6 +175,8 @@ pub async fn get_client_module_options_context(
             .clone_if()
     };
 
+    let emotion_compiler_options = get_emotion_compiler_config(next_config);
+
     let module_options_context = ModuleOptionsContext {
         custom_ecmascript_transforms: vec![EcmascriptInputTransform::ServerDirective(
             StringVc::cell("TODO".to_string()),
@@ -189,7 +191,7 @@ pub async fn get_client_module_options_context(
         // we try resolve it once at the root and pass down a context to all
         // the modules.
         enable_jsx: Some(jsx_runtime_options),
-        enable_emotion: true,
+        enable_emotion: Some(emotion_compiler_options),
         enable_react_refresh,
         enable_styled_components: true,
         enable_styled_jsx: true,

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -49,7 +49,7 @@ use crate::{
     react_refresh::assert_can_resolve_react_refresh,
     transform_options::{
         get_decorators_transform_options, get_emotion_compiler_config, get_jsx_transform_options,
-        get_typescript_transform_options,
+        get_styled_components_compiler_config, get_typescript_transform_options,
     },
     util::foreign_code_context_condition,
 };
@@ -186,6 +186,8 @@ pub async fn get_client_module_options_context(
         ..Default::default()
     };
 
+    let enable_styled_components = *get_styled_components_compiler_config(next_config).await?;
+
     let module_options_context = ModuleOptionsContext {
         // We don't need to resolve React Refresh for each module. Instead,
         // we try resolve it once at the root and pass down a context to all
@@ -193,7 +195,7 @@ pub async fn get_client_module_options_context(
         enable_jsx: Some(jsx_runtime_options),
         enable_emotion,
         enable_react_refresh,
-        enable_styled_components: true,
+        enable_styled_components,
         enable_styled_jsx: true,
         enable_postcss_transform: Some(PostCssTransformOptions {
             postcss_package: Some(get_postcss_package_mapping(project_path)),

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -55,9 +55,11 @@ pub struct NextConfig {
     pub rewrites: Rewrites,
     pub transpile_packages: Option<Vec<String>>,
 
+    // Partially supported
+    pub compiler: Option<CompilerConfig>,
+
     // unsupported
     cross_origin: Option<String>,
-    compiler: Option<CompilerConfig>,
     amp: AmpConfig,
     analytics_id: String,
     asset_prefix: String,
@@ -353,6 +355,7 @@ pub struct ExperimentalConfig {
     pub app_dir: Option<bool>,
     pub server_components_external_packages: Option<Vec<String>>,
     pub turbo: Option<ExperimentalTurboConfig>,
+    pub compiler: Option<CompilerConfig>,
 
     // unsupported
     adjust_font_fallbacks: Option<bool>,
@@ -420,6 +423,7 @@ enum MiddlewarePrefetchType {
 pub struct CompilerConfig {
     pub react_remove_properties: Option<bool>,
     pub relay: Option<RelayConfig>,
+    pub emotion: Option<serde_json::Value>,
     pub remove_console: Option<RemoveConsoleConfig>,
 }
 

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -29,7 +29,8 @@ use turbo_binding::{
             transforms::webpack::{WebpackLoaderConfigItems, WebpackLoaderConfigItemsVc},
         },
         turbopack::{
-            evaluate_context::node_evaluate_asset_context, module_options::EmotionTransformConfig,
+            evaluate_context::node_evaluate_asset_context,
+            module_options::{EmotionTransformConfig, StyledComponentsTransformConfig},
         },
     },
 };
@@ -427,12 +428,20 @@ pub enum EmotionTransformOptionsOrBoolean {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]
+#[serde(untagged)]
+pub enum StyledComponentsTransformOptionsOrBoolean {
+    Boolean(bool),
+    Options(StyledComponentsTransformConfig),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]
 #[serde(rename_all = "camelCase")]
 pub struct CompilerConfig {
     pub react_remove_properties: Option<bool>,
     pub relay: Option<RelayConfig>,
     pub emotion: Option<EmotionTransformOptionsOrBoolean>,
     pub remove_console: Option<RemoveConsoleConfig>,
+    pub styled_components: Option<StyledComponentsTransformOptionsOrBoolean>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -28,7 +28,9 @@ use turbo_binding::{
             execution_context::{ExecutionContext, ExecutionContextVc},
             transforms::webpack::{WebpackLoaderConfigItems, WebpackLoaderConfigItemsVc},
         },
-        turbopack::evaluate_context::node_evaluate_asset_context,
+        turbopack::{
+            evaluate_context::node_evaluate_asset_context, module_options::EmotionTransformConfig,
+        },
     },
 };
 use turbo_tasks::{
@@ -355,7 +357,6 @@ pub struct ExperimentalConfig {
     pub app_dir: Option<bool>,
     pub server_components_external_packages: Option<Vec<String>>,
     pub turbo: Option<ExperimentalTurboConfig>,
-    pub compiler: Option<CompilerConfig>,
 
     // unsupported
     adjust_font_fallbacks: Option<bool>,
@@ -419,11 +420,18 @@ enum MiddlewarePrefetchType {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]
+#[serde(untagged)]
+pub enum EmotionTransformOptionsOrBoolean {
+    Boolean(bool),
+    Options(EmotionTransformConfig),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]
 #[serde(rename_all = "camelCase")]
 pub struct CompilerConfig {
     pub react_remove_properties: Option<bool>,
     pub relay: Option<RelayConfig>,
-    pub emotion: Option<serde_json::Value>,
+    pub emotion: Option<EmotionTransformOptionsOrBoolean>,
     pub remove_console: Option<RemoveConsoleConfig>,
 }
 

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -235,7 +235,7 @@ pub async fn get_server_module_options_context(
     let tsconfig = get_typescript_transform_options(project_path);
     let decorators_options = get_decorators_transform_options(project_path);
     let jsx_runtime_options = get_jsx_transform_options(project_path);
-    let emotion_compiler_options = get_emotion_compiler_config(next_config);
+    let enable_emotion = *get_emotion_compiler_config(next_config).await?;
 
     let module_options_context = match ty.into_value() {
         ServerContextType::Pages { .. } | ServerContextType::PagesData { .. } => {
@@ -246,7 +246,7 @@ pub async fn get_server_module_options_context(
             ModuleOptionsContext {
                 enable_jsx: Some(jsx_runtime_options),
                 enable_styled_jsx: true,
-                enable_emotion: Some(emotion_compiler_options),
+                enable_emotion,
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
@@ -272,7 +272,7 @@ pub async fn get_server_module_options_context(
             ModuleOptionsContext {
                 enable_jsx: Some(jsx_runtime_options),
                 enable_styled_jsx: true,
-                enable_emotion: Some(emotion_compiler_options),
+                enable_emotion,
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
@@ -303,7 +303,7 @@ pub async fn get_server_module_options_context(
             };
             ModuleOptionsContext {
                 enable_jsx: Some(jsx_runtime_options),
-                enable_emotion: Some(emotion_compiler_options),
+                enable_emotion,
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
@@ -341,7 +341,7 @@ pub async fn get_server_module_options_context(
             };
             ModuleOptionsContext {
                 enable_jsx: Some(jsx_runtime_options),
-                enable_emotion: Some(emotion_compiler_options),
+                enable_emotion,
                 enable_styled_jsx: true,
                 enable_postcss_transform,
                 enable_webpack_loaders,

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -33,7 +33,7 @@ use crate::{
     next_import_map::get_next_server_import_map,
     transform_options::{
         get_decorators_transform_options, get_emotion_compiler_config, get_jsx_transform_options,
-        get_typescript_transform_options,
+        get_styled_components_compiler_config, get_typescript_transform_options,
     },
     util::foreign_code_context_condition,
 };
@@ -236,6 +236,7 @@ pub async fn get_server_module_options_context(
     let decorators_options = get_decorators_transform_options(project_path);
     let jsx_runtime_options = get_jsx_transform_options(project_path);
     let enable_emotion = *get_emotion_compiler_config(next_config).await?;
+    let enable_styled_components = *get_styled_components_compiler_config(next_config).await?;
 
     let module_options_context = match ty.into_value() {
         ServerContextType::Pages { .. } | ServerContextType::PagesData { .. } => {
@@ -247,6 +248,7 @@ pub async fn get_server_module_options_context(
                 enable_jsx: Some(jsx_runtime_options),
                 enable_styled_jsx: true,
                 enable_emotion,
+                enable_styled_components,
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
@@ -273,6 +275,7 @@ pub async fn get_server_module_options_context(
                 enable_jsx: Some(jsx_runtime_options),
                 enable_styled_jsx: true,
                 enable_emotion,
+                enable_styled_components,
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
@@ -304,6 +307,7 @@ pub async fn get_server_module_options_context(
             ModuleOptionsContext {
                 enable_jsx: Some(jsx_runtime_options),
                 enable_emotion,
+                enable_styled_components,
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
@@ -343,6 +347,7 @@ pub async fn get_server_module_options_context(
                 enable_jsx: Some(jsx_runtime_options),
                 enable_emotion,
                 enable_styled_jsx: true,
+                enable_styled_components,
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -32,7 +32,7 @@ use crate::{
     next_config::NextConfigVc,
     next_import_map::get_next_server_import_map,
     transform_options::{
-        get_decorators_transform_options, get_jsx_transform_options,
+        get_decorators_transform_options, get_emotion_compiler_config, get_jsx_transform_options,
         get_typescript_transform_options,
     },
     util::foreign_code_context_condition,
@@ -235,6 +235,7 @@ pub async fn get_server_module_options_context(
     let tsconfig = get_typescript_transform_options(project_path);
     let decorators_options = get_decorators_transform_options(project_path);
     let jsx_runtime_options = get_jsx_transform_options(project_path);
+    let emotion_compiler_options = get_emotion_compiler_config(next_config);
 
     let module_options_context = match ty.into_value() {
         ServerContextType::Pages { .. } | ServerContextType::PagesData { .. } => {
@@ -245,6 +246,7 @@ pub async fn get_server_module_options_context(
             ModuleOptionsContext {
                 enable_jsx: Some(jsx_runtime_options),
                 enable_styled_jsx: true,
+                enable_emotion: Some(emotion_compiler_options),
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
@@ -270,6 +272,7 @@ pub async fn get_server_module_options_context(
             ModuleOptionsContext {
                 enable_jsx: Some(jsx_runtime_options),
                 enable_styled_jsx: true,
+                enable_emotion: Some(emotion_compiler_options),
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
@@ -300,6 +303,7 @@ pub async fn get_server_module_options_context(
             };
             ModuleOptionsContext {
                 enable_jsx: Some(jsx_runtime_options),
+                enable_emotion: Some(emotion_compiler_options),
                 enable_postcss_transform,
                 enable_webpack_loaders,
                 enable_typescript_transform: Some(tsconfig),
@@ -337,6 +341,7 @@ pub async fn get_server_module_options_context(
             };
             ModuleOptionsContext {
                 enable_jsx: Some(jsx_runtime_options),
+                enable_emotion: Some(emotion_compiler_options),
                 enable_styled_jsx: true,
                 enable_postcss_transform,
                 enable_webpack_loaders,

--- a/packages/next-swc/crates/next-core/src/transform_options.rs
+++ b/packages/next-swc/crates/next-core/src/transform_options.rs
@@ -14,6 +14,8 @@ use turbo_binding::turbopack::{
 };
 use turbo_tasks_fs::{FileJsonContentVc, FileSystemPathVc};
 
+use crate::next_config::NextConfigVc;
+
 async fn get_typescript_options(
     project_path: FileSystemPathVc,
 ) -> Option<Vec<(FileJsonContentVc, AssetVc)>> {

--- a/packages/next-swc/crates/next-core/src/transform_options.rs
+++ b/packages/next-swc/crates/next-core/src/transform_options.rs
@@ -163,7 +163,8 @@ pub async fn get_jsx_transform_options(
 pub async fn get_emotion_compiler_config(
     next_config: NextConfigVc,
 ) -> Result<OptionEmotionTransformConfigVc> {
-    let emotion_compiler_config = (*next_config.await?)
+    let emotion_compiler_config = next_config
+        .await?
         .compiler
         .as_ref()
         .map(|value| {
@@ -196,7 +197,8 @@ pub async fn get_emotion_compiler_config(
 pub async fn get_styled_components_compiler_config(
     next_config: NextConfigVc,
 ) -> Result<OptionStyledComponentsTransformConfigVc> {
-    let styled_components_compiler_config = (*next_config.await?)
+    let styled_components_compiler_config = next_config
+        .await?
         .compiler
         .as_ref()
         .map(|value| {

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -7,6 +7,7 @@ const supportedTurbopackNextConfigOptions = [
   'configFileName',
   'env',
   'experimental.appDir',
+  'compiler.emotion',
   'experimental.serverComponentsExternalPackages',
   'experimental.turbo',
   'images',

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -8,6 +8,7 @@ const supportedTurbopackNextConfigOptions = [
   'env',
   'experimental.appDir',
   'compiler.emotion',
+  'compiler.styledComponents',
   'experimental.serverComponentsExternalPackages',
   'experimental.turbo',
   'images',

--- a/test/development/basic/emotion-swc.test.ts
+++ b/test/development/basic/emotion-swc.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
-import { shouldRunTurboDevTest } from 'test/lib/next-test-utils'
+import { shouldRunTurboDevTest } from '../../lib/next-test-utils'
 
 describe('emotion SWC option', () => {
   let next: NextInstance

--- a/test/development/basic/emotion-swc.test.ts
+++ b/test/development/basic/emotion-swc.test.ts
@@ -2,11 +2,13 @@ import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
+import { shouldRunTurboDevTest } from 'test/lib/next-test-utils'
 
 describe('emotion SWC option', () => {
   let next: NextInstance
 
   beforeAll(async () => {
+    const useTurbo = !!process.env.TEST_WASM ? false : shouldRunTurboDevTest()
     next = await createNext({
       files: {
         'jsconfig.json': new FileRef(
@@ -14,11 +16,15 @@ describe('emotion SWC option', () => {
         ),
         pages: new FileRef(join(__dirname, 'emotion-swc/pages')),
         shared: new FileRef(join(__dirname, 'emotion-swc/shared')),
+        // Stopgap until turobpack supports full next.config.js for `reactStrictMode`
         'next.config.js': new FileRef(
-          join(__dirname, 'emotion-swc/next.config.js')
+          useTurbo
+            ? join(__dirname, 'emotion-swc/next.turbopack.config.js')
+            : join(__dirname, 'emotion-swc/next.config.js')
         ),
       },
       dependencies: {
+        '@emotion/cache': '^10.0.29',
         '@emotion/core': '^10.0.35',
         '@emotion/styled': '^10.0.27',
       },

--- a/test/development/basic/emotion-swc/next.turbopack.config.js
+++ b/test/development/basic/emotion-swc/next.turbopack.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+
+const nextConfig = {
+  compiler: {
+    emotion: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Related with WEB-669 and initial support for [WEB-670](https://linear.app/vercel/issue/WEB-670), allows to consume compiler.emotion with latest turbopack. 

I was trying to make additional changes to make test fully pass, but there are some other failures around so this change cannot able to pass existing tests yet.

Turbopack changes: https://github.com/vercel/turbo/pull/4482