### PR TITLE
docs: Add "special" to the Alex allowlist

### DIFF
--- a/.alexrc
+++ b/.alexrc
@@ -18,6 +18,7 @@
     "host-hostess",
     "invalid",
     "remains",
+    "special",
     "white"
   ]
 }


### PR DESCRIPTION
It's a common word we use in our docs, e.g.:

https://github.com/vercel/next.js/blob/e35710f71f8e0f2844add1a97513a65a54a6f2a3/docs/advanced-features/open-telemetry.md#L105