### PR TITLE
chore(ci): always run lint

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -139,7 +139,6 @@ jobs:
       - run: ./scripts/check-manifests.js
 
       - run: pnpm lint
-        if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: pnpm lint-no-typescript
         if: ${{needs.build.outputs.docsChange != 'nope'}}


### PR DESCRIPTION
In PR #47955, the docs were updated to include a word that is not allowed. However, lint was skipped and the PR merged.

Subsequent PRs that ran lint were failing.

So we had to add the word to the allow list in PR #48021.

To fix this type of problem, we should always run lint unconditionally.