### PR TITLE
Change metadata routes suffix to number and chars

### DIFF
--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -8,13 +8,13 @@ import { djb2Hash } from '../../shared/lib/hash'
  *
  * e.g.
  * /app/open-graph.tsx -> /open-graph/route
- * /app/(post)/open-graph.tsx -> /open-graph/route-123456
+ * /app/(post)/open-graph.tsx -> /open-graph/route-[0-9a-z]{6}
  */
 export function getMetadataRouteSuffix(page: string) {
   let suffix = ''
 
   if ((page.includes('(') && page.includes(')')) || page.includes('@')) {
-    suffix = djb2Hash(page).toString().slice(0, 6)
+    suffix = djb2Hash(page).toString(36).slice(0, 6)
   }
   return suffix
 }

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -166,7 +166,7 @@ createNextDescribe(
       const res = await next.fetch(ogImageUrlInstance.pathname)
 
       // generate unique path with suffix for image routes under group routes
-      expect(ogImageUrl).toMatch(/opengraph-image-\d{6}\?/)
+      expect(ogImageUrl).toMatch(/opengraph-image-\w{6}\?/)
       expect(ogImageUrl).toMatch(hashRegex)
       expect(res.status).toBe(200)
     })


### PR DESCRIPTION
Follow up of #47985 

Change `-\d{6}` to `-[a-z0-9]{6}` which reduces the chance of hash collision