### PR TITLE
Speed up native dev build

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1098,7 +1098,7 @@ jobs:
 
   build-native-test:
     name: Build native binary for tests and metrics
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-core-oss
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: 'vercel'


### PR DESCRIPTION
### What?

More power for the CI to build the native binary for testing

### Why?

Waiting 1 hour for the tests is just too slow

### How?

More Cores
