### PR TITLE
Update normalize revalidate params for named matches

### DIFF
--- a/packages/next/src/server/server-utils.ts
+++ b/packages/next/src/server/server-utils.ts
@@ -262,6 +262,21 @@ export function getUtils({
               const matchesHasLocale =
                 i18n && detectedLocale && obj['1'] === detectedLocale
 
+              for (const key of Object.keys(obj)) {
+                const value = obj[key]
+
+                if (
+                  key !== NEXT_QUERY_PARAM_PREFIX &&
+                  key.startsWith(NEXT_QUERY_PARAM_PREFIX)
+                ) {
+                  const normalizedKey = key.substring(
+                    NEXT_QUERY_PARAM_PREFIX.length
+                  )
+                  obj[normalizedKey] = value
+                  delete obj[key]
+                }
+              }
+
               // favor named matches if available
               const routeKeyNames = Object.keys(routeKeys || {})
               const filterLocaleItem = (val: string | string[] | undefined) => {

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -349,7 +349,7 @@ describe('should set-up next', () => {
     const html3 = await renderViaHTTP(appPort, '/some-other-path', undefined, {
       headers: {
         'x-matched-path': '/dynamic/[slug]?slug=%5Bslug%5D.json',
-        'x-now-route-matches': '1=second&slug=second',
+        'x-now-route-matches': '1=second&nextParamslug=second',
       },
     })
     const $3 = cheerio.load(html3)
@@ -451,7 +451,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': '/catch-all/[[...rest]]',
-          'x-now-route-matches': '1=hello&catchAll=hello',
+          'x-now-route-matches': '1=hello&nextParamcatchAll=hello',
         },
       }
     )
@@ -470,7 +470,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': '/catch-all/[[...rest]]',
-          'x-now-route-matches': '1=hello/world&catchAll=hello/world',
+          'x-now-route-matches': '1=hello/world&nextParamcatchAll=hello/world',
         },
       }
     )
@@ -507,7 +507,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': `/_next/data/${next.buildId}/en/catch-all/[[...rest]].json`,
-          'x-now-route-matches': '1=hello&rest=hello',
+          'x-now-route-matches': '1=hello&nextParamrest=hello',
         },
       }
     )
@@ -524,7 +524,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': `/_next/data/${next.buildId}/en/catch-all/[[...rest]].json`,
-          'x-now-route-matches': '1=hello/world&rest=hello/world',
+          'x-now-route-matches': '1=hello/world&nextParamrest=hello/world',
         },
       }
     )
@@ -682,7 +682,8 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': '/en/[slug]/social/[[...rest]]',
-          'x-now-route-matches': 'nextLocale=en&1=en&2=user-123&slug=user-123',
+          'x-now-route-matches':
+            'nextLocale=en&1=en&2=user-123&nextParamslug=user-123',
         },
       }
     )
@@ -705,7 +706,7 @@ describe('should set-up next', () => {
         headers: {
           'x-matched-path': '/optional-ssg/[[...rest]]',
           'x-now-route-matches':
-            '1=en%2Fes%2Fhello%252Fworld&rest=en%2Fes%2Fhello%252Fworld',
+            '1=en%2Fes%2Fhello%252Fworld&nextParamrest=en%2Fes%2Fhello%252Fworld',
         },
       }
     )
@@ -765,7 +766,8 @@ describe('should set-up next', () => {
     const res = await fetchViaHTTP(appPort, '/en/fallback/[slug]', undefined, {
       headers: {
         'x-matched-path': '/en/fallback/[slug]',
-        'x-now-route-matches': '2=another&slug=another&1=en&nextLocale=en',
+        'x-now-route-matches':
+          '2=another&nextParamslug=another&1=en&nextLocale=en',
       },
       redirect: 'manual',
     })
@@ -783,7 +785,8 @@ describe('should set-up next', () => {
     const res = await fetchViaHTTP(appPort, '/fr/fallback/[slug]', undefined, {
       headers: {
         'x-matched-path': '/fr/fallback/[slug]',
-        'x-now-route-matches': '2=another&slug=another&1=fr&nextLocale=fr',
+        'x-now-route-matches':
+          '2=another&nextParamslug=another&1=fr&nextLocale=fr',
       },
       redirect: 'manual',
     })

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -606,7 +606,7 @@ describe('should set-up next', () => {
     const html3 = await renderViaHTTP(appPort, '/some-other-path', undefined, {
       headers: {
         'x-matched-path': '/dynamic/[slug]',
-        'x-now-route-matches': '1=second&slug=second',
+        'x-now-route-matches': '1=second&nextParamslug=second',
       },
     })
     const $3 = cheerio.load(html3)
@@ -761,7 +761,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': '/catch-all/[[...rest]]',
-          'x-now-route-matches': '1=hello&catchAll=hello',
+          'x-now-route-matches': '1=hello&nextParamcatchAll=hello',
         },
       }
     )
@@ -780,7 +780,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': '/catch-all/[[...rest]]',
-          'x-now-route-matches': '1=hello/world&catchAll=hello/world',
+          'x-now-route-matches': '1=hello/world&nextParamcatchAll=hello/world',
         },
       }
     )
@@ -818,7 +818,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': `/_next/data/${next.buildId}/catch-all/[[...rest]].json`,
-          'x-now-route-matches': '1=hello&rest=hello',
+          'x-now-route-matches': '1=hello&nextParamrest=hello',
         },
       }
     )
@@ -835,7 +835,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': `/_next/data/${next.buildId}/catch-all/[[...rest]].json`,
-          'x-now-route-matches': '1=hello/world&rest=hello/world',
+          'x-now-route-matches': '1=hello/world&nextParamrest=hello/world',
         },
       }
     )
@@ -1111,7 +1111,7 @@ describe('should set-up next', () => {
         headers: {
           'x-matched-path': '/optional-ssg/[[...rest]]',
           'x-now-route-matches':
-            '1=en%2Fes%2Fhello%252Fworld&rest=en%2Fes%2Fhello%252Fworld',
+            '1=en%2Fes%2Fhello%252Fworld&nextParamrest=en%2Fes%2Fhello%252Fworld',
         },
       }
     )


### PR DESCRIPTION
This ensures the prefix for route params is stripped when pulled from the revalidate headers. Also updates tests accordingly. 

x-ref: https://github.com/vercel/next.js/pull/47930