### PR TITLE
turbopack: parse and propagate `output: 'export'`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "serde",
 ]
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "serde",
@@ -6973,7 +6973,7 @@ dependencies = [
 [[package]]
 name = "turbo-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7013,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "mimalloc",
 ]
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7051,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7063,7 +7063,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7078,7 +7078,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7092,7 +7092,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7109,7 +7109,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7138,7 +7138,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "base16",
  "hex",
@@ -7150,7 +7150,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7164,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7196,7 +7196,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7237,7 +7237,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7267,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7284,7 +7284,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7324,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7346,7 +7346,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7367,7 +7367,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7401,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7437,7 +7437,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "serde",
@@ -7451,7 +7451,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7467,7 +7467,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7485,7 +7485,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "serde",
@@ -7500,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7515,7 +7515,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7549,7 +7549,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "serde",
@@ -7565,7 +7565,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.2#af5fbbb42e76e8a3e4ac75505cca9b0346a06cb6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230427.3#0e9881f822a6854a2b0daaf550b5eab91fd56771"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ swc_relay = { version = "0.2.5" }
 testing = { version = "0.33.4" }
 
 # Turbo crates
-turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230427.2" }
+turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230427.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230427.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230427.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230427.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230427.3" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.2",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230427.2",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.3",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230427.3",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/src/entry/app-renderer.tsx
+++ b/packages/next-swc/crates/next-core/js/src/entry/app-renderer.tsx
@@ -284,6 +284,7 @@ async function runOperation(renderData: RenderData) {
     assetPrefix: '',
     pageConfig: {},
     reactLoadableManifest: {},
+    nextConfigOutput: renderData.data?.nextConfigOutput,
   }
   const result = await renderToHTMLOrFlight(
     req,

--- a/packages/next-swc/crates/next-core/js/src/internal/page-server-handler.tsx
+++ b/packages/next-swc/crates/next-core/js/src/internal/page-server-handler.tsx
@@ -181,6 +181,7 @@ export default function startHandler({
       basePath: '',
       // TODO(WEB-583) this isn't correct, instead it should set `dev: true`
       nextExport: true,
+      nextConfigOutput: renderData.data?.nextConfigOutput,
       resolvedUrl: renderData.url,
       optimizeFonts: false,
       optimizeCss: false,

--- a/packages/next-swc/crates/next-core/js/types/turbopack.d.ts
+++ b/packages/next-swc/crates/next-core/js/types/turbopack.d.ts
@@ -1,4 +1,4 @@
-import { NextParsedUrlQuery } from 'next/dist/server/request-meta'
+import type { RenderOptsPartial } from 'next/dist/server/render'
 
 export type RenderData = {
   params: Record<string, string | string[]>
@@ -7,4 +7,7 @@ export type RenderData = {
   path: string
   rawQuery: string
   rawHeaders: Array<[string, string]>
+  data?: {
+    nextConfigOutput?: RenderOptsPartial['nextConfigOutput']
+  }
 }

--- a/packages/next-swc/crates/next-core/src/app_source.rs
+++ b/packages/next-swc/crates/next-core/src/app_source.rs
@@ -60,7 +60,7 @@ use turbo_binding::{
         },
     },
 };
-use turbo_tasks::{TryJoinIterExt, ValueToString};
+use turbo_tasks::{primitives::JsonValueVc, TryJoinIterExt, ValueToString};
 
 use crate::{
     app_render::next_layout_entry_transition::NextServerComponentTransition,
@@ -96,6 +96,7 @@ use crate::{
         get_server_compile_time_info, get_server_module_options_context,
         get_server_resolve_options_context, ServerContextType,
     },
+    util::render_data,
 };
 
 #[turbo_tasks::function]
@@ -421,6 +422,7 @@ pub async fn create_app_source(
         client_compile_time_info,
         next_config,
     );
+    let render_data = render_data(next_config);
 
     let sources = entrypoints
         .await?
@@ -438,6 +440,7 @@ pub async fn create_app_source(
                 server_runtime_entries,
                 fallback_page,
                 output_path,
+                render_data,
             ),
             Entrypoint::AppRoute { path } => create_app_route_source_for_route(
                 pathname,
@@ -449,6 +452,7 @@ pub async fn create_app_source(
                 server_root,
                 server_runtime_entries,
                 output_path,
+                render_data,
             ),
         })
         .chain(once(create_global_metadata_source(
@@ -517,6 +521,7 @@ async fn create_app_page_source_for_route(
     runtime_entries: AssetsVc,
     fallback_page: DevHtmlAssetVc,
     intermediate_output_path_root: FileSystemPathVc,
+    render_data: JsonValueVc,
 ) -> Result<ContentSourceVc> {
     let pathname_vc = StringVc::cell(pathname.to_string());
 
@@ -542,6 +547,7 @@ async fn create_app_page_source_for_route(
         .cell()
         .into(),
         fallback_page,
+        render_data,
     );
 
     Ok(source.issue_context(app_dir, &format!("Next.js App Page Route {pathname}")))
@@ -559,6 +565,7 @@ async fn create_app_route_source_for_route(
     server_root: FileSystemPathVc,
     runtime_entries: AssetsVc,
     intermediate_output_path_root: FileSystemPathVc,
+    render_data: JsonValueVc,
 ) -> Result<ContentSourceVc> {
     let pathname_vc = StringVc::cell(pathname.to_string());
 
@@ -582,6 +589,7 @@ async fn create_app_route_source_for_route(
         }
         .cell()
         .into(),
+        render_data,
     );
 
     Ok(source.issue_context(app_dir, &format!("Next.js App Route {pathname}")))

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -63,6 +63,8 @@ pub struct NextConfig {
     // Partially supported
     pub compiler: Option<CompilerConfig>,
 
+    pub output: Option<OutputType>,
+
     // unsupported
     cross_origin: Option<String>,
     amp: AmpConfig,
@@ -85,7 +87,6 @@ pub struct NextConfig {
     i18n: Option<I18NConfig>,
     on_demand_entries: OnDemandEntriesConfig,
     optimize_fonts: bool,
-    output: Option<OutputType>,
     output_file_tracing: bool,
     powered_by_header: bool,
     production_browser_source_maps: bool,
@@ -165,8 +166,9 @@ struct I18NConfig {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]
 #[serde(rename_all = "kebab-case")]
-enum OutputType {
+pub enum OutputType {
     Standalone,
+    Export,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1018,8 +1018,8 @@ importers:
       '@types/react': 18.0.37
       '@types/react-dom': 18.0.11
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.2
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230427.2
+      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.3
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230427.3
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1031,8 +1031,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.2_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230427.2'
+      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.3_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230427.3'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -6002,7 +6002,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.2.1
       source-map: 0.7.3
-      webpack: 5.74.0
+      webpack: 5.74.0_@swc+core@1.3.55
     transitivePeerDependencies:
       - supports-color
 
@@ -6672,7 +6672,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64/1.3.55:
@@ -6681,7 +6680,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.3.55:
@@ -6690,7 +6688,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.3.55:
@@ -6699,7 +6696,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl/1.3.55:
@@ -6708,7 +6704,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu/1.3.55:
@@ -6717,7 +6712,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl/1.3.55:
@@ -6726,7 +6720,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.3.55:
@@ -6735,7 +6728,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.3.55:
@@ -6744,7 +6736,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc/1.3.55:
@@ -6753,7 +6744,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core/1.3.55_@swc+helpers@0.5.1:
@@ -6778,7 +6768,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.55
       '@swc/core-win32-ia32-msvc': 1.3.55
       '@swc/core-win32-x64-msvc': 1.3.55
-    dev: true
 
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
@@ -23775,7 +23764,6 @@ packages:
       source-map: 0.6.1
       terser: 5.14.1
       webpack: 5.74.0_@swc+core@1.3.55
-    dev: true
 
   /terser-webpack-plugin/5.2.4_webpack@5.74.0:
     resolution: {integrity: sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==}
@@ -25181,7 +25169,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /websocket-driver/0.7.3:
     resolution: {integrity: sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==}
@@ -25587,9 +25574,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.2_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.2}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.2'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.3_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.3}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230427.3'
     name: '@vercel/turbopack-dev'
     version: 0.0.0
     dependencies:
@@ -25599,8 +25586,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230427.2':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230427.2}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230427.3':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230427.3}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
Depends on https://github.com/vercel/turbo/pull/4491

This adds support for the new `output: 'export'` configuration, and propagates the value through to our Node.js rendering code to render. Unfortunately, we don't support page-level configs at the moment, so we can't set a `export const config = { dynamic: 'force-dynamic' }` and test that the export value is being received (I've manually verified it, though).

Fixes WEB-842