### PR TITLE
turbopack: pass ENV vars to route handlers

### DIFF
--- a/packages/next-swc/crates/next-core/js/src/entry/app/route.ts
+++ b/packages/next-swc/crates/next-core/js/src/entry/app/route.ts
@@ -1,39 +1,39 @@
 // IPC need to be the first import to allow it to catch errors happening during
 // the other imports
-import startHandler from "@vercel/turbopack-next/internal/api-server-handler";
-import { runEdgeFunction } from "@vercel/turbopack-next/internal/edge";
+import startHandler from '@vercel/turbopack-next/internal/api-server-handler'
+import { runEdgeFunction } from '@vercel/turbopack-next/internal/edge'
 
-import { join } from "path";
+import { join } from 'path'
 
-import "next/dist/server/node-polyfill-fetch.js";
+import 'next/dist/server/node-polyfill-fetch.js'
 
-import chunkGroup from "ROUTE_CHUNK_GROUP";
+import chunkGroup from 'ROUTE_CHUNK_GROUP'
 
 import {
   NodeNextRequest,
   NodeNextResponse,
-} from "next/dist/server/base-http/node";
+} from 'next/dist/server/base-http/node'
 
 startHandler(async ({ request, response, query, params, path }) => {
   const edgeInfo = {
-    name: "edge",
+    name: 'edge',
     paths: chunkGroup.map((chunk) =>
-      join(process.cwd(), ".next/server/app", chunk)
+      join(process.cwd(), '.next/server/app', chunk)
     ),
     wasm: [],
-    env: [],
+    env: Object.keys(process.env),
     assets: [],
-  };
+  }
   await runEdgeFunction({
     edgeInfo,
-    outputDir: "app",
+    outputDir: 'app',
     req: new NodeNextRequest(request),
     res: new NodeNextResponse(response),
     query,
     params,
     path,
     onWarning(warning) {
-      console.warn(warning);
+      console.warn(warning)
     },
-  });
-});
+  })
+})

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/.env
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/.env
@@ -1,0 +1,1 @@
+FOOBAR="foobar"

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/app/[slug]/route.ts
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/app/[slug]/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export const helloHandler = async (_req: NextRequest): Promise<Response> => {
+  return NextResponse.json(process.env)
+}
+
+export const GET = helloHandler

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/app/layout.tsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }: { children: any }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/app/page.tsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/app/page.tsx
@@ -1,0 +1,9 @@
+import Test from './test'
+
+export default function Page() {
+  return (
+    <div>
+      <Test />
+    </div>
+  )
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/app/test.tsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/app/test.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Test() {
+  useEffect(() => {
+    import('@turbo/pack-test-harness').then(() => {
+      it('includes ENV vars in route edge runner', async () => {
+        const res = await fetch('/route')
+        const json = await res.json()
+        expect(json).toMatchObject({
+          FOOBAR: 'foobar',
+        })
+      }, 20000)
+    })
+    return () => {}
+  }, [])
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/next.config.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/route-WEB-869/input/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+  },
+}


### PR DESCRIPTION
Same as https://github.com/vercel/next.js/pull/47767, we need to pass the full list of `process.env` keys to the edge invocation so that the ENV vars are available to the route handlers.

Fixes https://github.com/vercel/turbo/issues/4489
Fixes https://github.com/vercel/next.js/issues/48036
Fixes WEB-869
Fixes NEXT-961
fix #48036