### PR TITLE
Support accessing request in metadata text routes

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -76,8 +76,8 @@ import { resolveRouteData } from 'next/dist/build/webpack/loaders/metadata/resol
 const contentType = ${JSON.stringify(getContentType(resourcePath))}
 const fileType = ${JSON.stringify(getFilenameAndExtension(resourcePath).name)}
 
-export async function GET() {
-  const data = await handler()
+export async function GET(req) {
+  const data = await handler(req)
   const content = resolveRouteData(data, fileType)
 
   return new NextResponse(content, {

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/robots.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/robots.ts
@@ -1,11 +1,12 @@
 import type { MetadataRoute } from 'next'
+import type { NextRequest } from 'next/server'
 
-export default function robots(): MetadataRoute.Robots {
+export default function robots(req: NextRequest): MetadataRoute.Robots {
   return {
     rules: [
       {
         userAgent: 'Googlebot',
-        allow: ['/'],
+        allow: ['/', req.nextUrl.pathname],
       },
       {
         userAgent: ['Applebot', 'Bingbot'],

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -27,6 +27,7 @@ createNextDescribe(
         expect(text).toMatchInlineSnapshot(`
           "User-Agent: Googlebot
           Allow: /
+          Allow: /robots.txt
 
           User-Agent: Applebot
           User-Agent: Bingbot


### PR DESCRIPTION
Requests should be accessible in the robots.js / sitemap.js / manifest.js