### PR TITLE
Update query param prefix to reduce length

### DIFF
--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -1,6 +1,6 @@
 import type { ServerRuntime } from '../../types'
 
-export const NEXT_QUERY_PARAM_PREFIX = 'nextParam'
+export const NEXT_QUERY_PARAM_PREFIX = 'nxtP'
 
 // in seconds
 export const CACHE_ONE_YEAR = 31536000

--- a/packages/next/src/shared/lib/router/utils/route-regex.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.ts
@@ -1,7 +1,7 @@
 import { escapeStringRegexp } from '../../escape-regexp'
 import { removeTrailingSlash } from './remove-trailing-slash'
 
-const NEXT_QUERY_PARAM_PREFIX = 'nextParam'
+const NEXT_QUERY_PARAM_PREFIX = 'nxtP'
 
 export interface Group {
   pos: number
@@ -102,6 +102,10 @@ function getNamedParametrizedRoute(route: string, prefixRouteKeys: boolean) {
           // replace any non-word characters since they can break
           // the named regex
           let cleanedKey = key.replace(/\W/g, '')
+
+          if (prefixRouteKeys) {
+            cleanedKey = `${NEXT_QUERY_PARAM_PREFIX}${cleanedKey}`
+          }
           let invalidKey = false
 
           // check if the key is still invalid and fallback to using a known
@@ -118,7 +122,6 @@ function getNamedParametrizedRoute(route: string, prefixRouteKeys: boolean) {
           }
 
           if (prefixRouteKeys) {
-            cleanedKey = `${NEXT_QUERY_PARAM_PREFIX}${cleanedKey}`
             routeKeys[cleanedKey] = `${NEXT_QUERY_PARAM_PREFIX}${key}`
           } else {
             routeKeys[cleanedKey] = `${key}`

--- a/test/e2e/edge-render-getserversideprops/index.test.ts
+++ b/test/e2e/edge-render-getserversideprops/index.test.ts
@@ -140,10 +140,10 @@ describe('edge-render-getserversideprops', () => {
           ),
           namedDataRouteRegex: `^/_next/data/${escapeStringRegexp(
             next.buildId
-          )}/(?<nextParamid>[^/]+?)\\.json$`,
+          )}/(?<nxtPid>[^/]+?)\\.json$`,
           page: '/[id]',
           routeKeys: {
-            nextParamid: 'nextParamid',
+            nxtPid: 'nxtPid',
           },
         },
       ])

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -43,19 +43,19 @@ const expectedManifestRoutes = () => [
   {
     namedDataRouteRegex: `^/_next/data/${escapeRegex(
       buildId
-    )}/blog/(?<nextParampost>[^/]+?)\\.json$`,
+    )}/blog/(?<nxtPpost>[^/]+?)\\.json$`,
     dataRouteRegex: normalizeRegEx(
       `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/blog\\/([^\\/]+?)\\.json$`
     ),
     page: '/blog/[post]',
     routeKeys: {
-      nextParampost: 'nextParampost',
+      nxtPpost: 'nxtPpost',
     },
   },
   {
     namedDataRouteRegex: `^/_next/data/${escapeRegex(
       buildId
-    )}/blog/(?<nextParampost>[^/]+?)/(?<nextParamcomment>[^/]+?)\\.json$`,
+    )}/blog/(?<nxtPpost>[^/]+?)/(?<nxtPcomment>[^/]+?)\\.json$`,
     dataRouteRegex: normalizeRegEx(
       `^\\/_next\\/data\\/${escapeRegex(
         buildId
@@ -63,20 +63,20 @@ const expectedManifestRoutes = () => [
     ),
     page: '/blog/[post]/[comment]',
     routeKeys: {
-      nextParampost: 'nextParampost',
-      nextParamcomment: 'nextParamcomment',
+      nxtPpost: 'nxtPpost',
+      nxtPcomment: 'nxtPcomment',
     },
   },
   {
     namedDataRouteRegex: `^/_next/data/${escapeRegex(
       buildId
-    )}/catchall/(?<nextParampath>.+?)\\.json$`,
+    )}/catchall/(?<nxtPpath>.+?)\\.json$`,
     dataRouteRegex: normalizeRegEx(
       `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/catchall\\/(.+?)\\.json$`
     ),
     page: '/catchall/[...path]',
     routeKeys: {
-      nextParampath: 'nextParampath',
+      nxtPpath: 'nxtPpath',
     },
   },
   {
@@ -127,10 +127,10 @@ const expectedManifestRoutes = () => [
     )}\\/not\\-found\\/([^\\/]+?)\\.json$`,
     namedDataRouteRegex: `^/_next/data/${escapeRegex(
       buildId
-    )}/not\\-found/(?<nextParamslug>[^/]+?)\\.json$`,
+    )}/not\\-found/(?<nxtPslug>[^/]+?)\\.json$`,
     page: '/not-found/[slug]',
     routeKeys: {
-      nextParamslug: 'nextParamslug',
+      nxtPslug: 'nxtPslug',
     },
   },
   {
@@ -182,7 +182,7 @@ const expectedManifestRoutes = () => [
   {
     namedDataRouteRegex: `^/_next/data/${escapeRegex(
       buildId
-    )}/user/(?<nextParamuser>[^/]+?)/profile\\.json$`,
+    )}/user/(?<nxtPuser>[^/]+?)/profile\\.json$`,
     dataRouteRegex: normalizeRegEx(
       `^\\/_next\\/data\\/${escapeRegex(
         buildId
@@ -190,7 +190,7 @@ const expectedManifestRoutes = () => [
     ),
     page: '/user/[user]/profile',
     routeKeys: {
-      nextParamuser: 'nextParamuser',
+      nxtPuser: 'nxtPuser',
     },
   },
 ]

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -1316,10 +1316,10 @@ describe('Prerender', () => {
               ),
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/api\\-docs/(?<nextParamslug>.+?)\\.json$`,
+              )}/api\\-docs/(?<nxtPslug>.+?)\\.json$`,
               page: '/api-docs/[...slug]',
               routeKeys: {
-                nextParamslug: 'nextParamslug',
+                nxtPslug: 'nxtPslug',
               },
             },
             {
@@ -1346,9 +1346,9 @@ describe('Prerender', () => {
               ),
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/blocking\\-fallback/(?<nextParamslug>[^/]+?)\\.json$`,
+              )}/blocking\\-fallback/(?<nxtPslug>[^/]+?)\\.json$`,
               page: '/blocking-fallback/[slug]',
-              routeKeys: { nextParamslug: 'nextParamslug' },
+              routeKeys: { nxtPslug: 'nxtPslug' },
             },
             {
               dataRouteRegex: normalizeRegEx(
@@ -1358,9 +1358,9 @@ describe('Prerender', () => {
               ),
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/blocking\\-fallback\\-once/(?<nextParamslug>[^/]+?)\\.json$`,
+              )}/blocking\\-fallback\\-once/(?<nxtPslug>[^/]+?)\\.json$`,
               page: '/blocking-fallback-once/[slug]',
-              routeKeys: { nextParamslug: 'nextParamslug' },
+              routeKeys: { nxtPslug: 'nxtPslug' },
             },
             {
               dataRouteRegex: normalizeRegEx(
@@ -1370,9 +1370,9 @@ describe('Prerender', () => {
               ),
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/blocking\\-fallback\\-some/(?<nextParamslug>[^/]+?)\\.json$`,
+              )}/blocking\\-fallback\\-some/(?<nxtPslug>[^/]+?)\\.json$`,
               page: '/blocking-fallback-some/[slug]',
-              routeKeys: { nextParamslug: 'nextParamslug' },
+              routeKeys: { nxtPslug: 'nxtPslug' },
             },
             {
               dataRouteRegex: normalizeRegEx(
@@ -1383,7 +1383,7 @@ describe('Prerender', () => {
             {
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/blog/(?<nextParampost>[^/]+?)\\.json$`,
+              )}/blog/(?<nxtPpost>[^/]+?)\\.json$`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
@@ -1391,13 +1391,13 @@ describe('Prerender', () => {
               ),
               page: '/blog/[post]',
               routeKeys: {
-                nextParampost: 'nextParampost',
+                nxtPpost: 'nxtPpost',
               },
             },
             {
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/blog/(?<nextParampost>[^/]+?)/(?<nextParamcomment>[^/]+?)\\.json$`,
+              )}/blog/(?<nxtPpost>[^/]+?)/(?<nxtPcomment>[^/]+?)\\.json$`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
@@ -1405,14 +1405,14 @@ describe('Prerender', () => {
               ),
               page: '/blog/[post]/[comment]',
               routeKeys: {
-                nextParampost: 'nextParampost',
-                nextParamcomment: 'nextParamcomment',
+                nxtPpost: 'nxtPpost',
+                nxtPcomment: 'nxtPcomment',
               },
             },
             {
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/catchall/(?<nextParamslug>.+?)\\.json$`,
+              )}/catchall/(?<nxtPslug>.+?)\\.json$`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
@@ -1420,13 +1420,13 @@ describe('Prerender', () => {
               ),
               page: '/catchall/[...slug]',
               routeKeys: {
-                nextParamslug: 'nextParamslug',
+                nxtPslug: 'nxtPslug',
               },
             },
             {
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/catchall\\-explicit/(?<nextParamslug>.+?)\\.json$`,
+              )}/catchall\\-explicit/(?<nxtPslug>.+?)\\.json$`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
@@ -1434,13 +1434,13 @@ describe('Prerender', () => {
               ),
               page: '/catchall-explicit/[...slug]',
               routeKeys: {
-                nextParamslug: 'nextParamslug',
+                nxtPslug: 'nxtPslug',
               },
             },
             {
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/catchall\\-optional(?:/(?<nextParamslug>.+?))?\\.json$`,
+              )}/catchall\\-optional(?:/(?<nxtPslug>.+?))?\\.json$`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
@@ -1448,7 +1448,7 @@ describe('Prerender', () => {
               ),
               page: '/catchall-optional/[[...slug]]',
               routeKeys: {
-                nextParamslug: 'nextParamslug',
+                nxtPslug: 'nxtPslug',
               },
             },
             {
@@ -1467,10 +1467,10 @@ describe('Prerender', () => {
               ),
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/dynamic/(?<nextParamslug>[^/]+?)\\.json$`,
+              )}/dynamic/(?<nxtPslug>[^/]+?)\\.json$`,
               page: '/dynamic/[slug]',
               routeKeys: {
-                nextParamslug: 'nextParamslug',
+                nxtPslug: 'nxtPslug',
               },
             },
             {
@@ -1481,10 +1481,10 @@ describe('Prerender', () => {
               ),
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/fallback\\-only/(?<nextParamslug>[^/]+?)\\.json$`,
+              )}/fallback\\-only/(?<nxtPslug>[^/]+?)\\.json$`,
               page: '/fallback-only/[slug]',
               routeKeys: {
-                nextParamslug: 'nextParamslug',
+                nxtPslug: 'nxtPslug',
               },
             },
             // TODO: investigate index/index
@@ -1499,7 +1499,7 @@ describe('Prerender', () => {
             {
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/lang/(?<nextParamlang>[^/]+?)/about\\.json$`,
+              )}/lang/(?<nxtPlang>[^/]+?)/about\\.json$`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
@@ -1507,7 +1507,7 @@ describe('Prerender', () => {
               ),
               page: '/lang/[lang]/about',
               routeKeys: {
-                nextParamlang: 'nextParamlang',
+                nxtPlang: 'nxtPlang',
               },
             },
             {
@@ -1525,7 +1525,7 @@ describe('Prerender', () => {
             {
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/non\\-json/(?<nextParamp>[^/]+?)\\.json$`,
+              )}/non\\-json/(?<nxtPp>[^/]+?)\\.json$`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
@@ -1533,13 +1533,13 @@ describe('Prerender', () => {
               ),
               page: '/non-json/[p]',
               routeKeys: {
-                nextParamp: 'nextParamp',
+                nxtPp: 'nxtPp',
               },
             },
             {
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/non\\-json\\-blocking/(?<nextParamp>[^/]+?)\\.json$`,
+              )}/non\\-json\\-blocking/(?<nxtPp>[^/]+?)\\.json$`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
@@ -1547,7 +1547,7 @@ describe('Prerender', () => {
               ),
               page: '/non-json-blocking/[p]',
               routeKeys: {
-                nextParamp: 'nextParamp',
+                nxtPp: 'nxtPp',
               },
             },
             {
@@ -1575,7 +1575,7 @@ describe('Prerender', () => {
             {
               namedDataRouteRegex: `^/_next/data/${escapeRegex(
                 next.buildId
-              )}/user/(?<nextParamuser>[^/]+?)/profile\\.json$`,
+              )}/user/(?<nxtPuser>[^/]+?)/profile\\.json$`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
@@ -1583,7 +1583,7 @@ describe('Prerender', () => {
               ),
               page: '/user/[user]/profile',
               routeKeys: {
-                nextParamuser: 'nextParamuser',
+                nxtPuser: 'nxtPuser',
               },
             },
           ])

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -1544,10 +1544,10 @@ const runTests = (isDev = false, isTurbo = false) => {
             ),
             namedDataRouteRegex: `^/_next/data/${escapeRegex(
               buildId
-            )}/blog\\-catchall/(?<nextParamslug>.+?)\\.json$`,
+            )}/blog\\-catchall/(?<nxtPslug>.+?)\\.json$`,
             page: '/blog-catchall/[...slug]',
             routeKeys: {
-              nextParamslug: 'nextParamslug',
+              nxtPslug: 'nxtPslug',
             },
           },
           {
@@ -1556,10 +1556,10 @@ const runTests = (isDev = false, isTurbo = false) => {
             )}\\/overridden\\/([^\\/]+?)\\.json$`,
             namedDataRouteRegex: `^/_next/data/${escapeRegex(
               buildId
-            )}/overridden/(?<nextParamslug>[^/]+?)\\.json$`,
+            )}/overridden/(?<nxtPslug>[^/]+?)\\.json$`,
             page: '/overridden/[slug]',
             routeKeys: {
-              nextParamslug: 'nextParamslug',
+              nxtPslug: 'nxtPslug',
             },
           },
         ],
@@ -2464,67 +2464,67 @@ const runTests = (isDev = false, isTurbo = false) => {
         },
         dynamicRoutes: [
           {
-            namedRegex: '^/_sport/(?<nextParamslug>[^/]+?)(?:/)?$',
+            namedRegex: '^/_sport/(?<nxtPslug>[^/]+?)(?:/)?$',
             page: '/_sport/[slug]',
             regex: normalizeRegEx('^\\/_sport\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamslug: 'nextParamslug',
+              nxtPslug: 'nxtPslug',
             },
           },
           {
-            namedRegex: '^/_sport/(?<nextParamslug>[^/]+?)/test(?:/)?$',
+            namedRegex: '^/_sport/(?<nxtPslug>[^/]+?)/test(?:/)?$',
             page: '/_sport/[slug]/test',
             regex: normalizeRegEx('^\\/_sport\\/([^\\/]+?)\\/test(?:\\/)?$'),
             routeKeys: {
-              nextParamslug: 'nextParamslug',
+              nxtPslug: 'nxtPslug',
             },
           },
           {
-            namedRegex: '^/another/(?<nextParamid>[^/]+?)(?:/)?$',
+            namedRegex: '^/another/(?<nxtPid>[^/]+?)(?:/)?$',
             page: '/another/[id]',
             regex: normalizeRegEx('^\\/another\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamid: 'nextParamid',
+              nxtPid: 'nxtPid',
             },
           },
           {
-            namedRegex: '^/api/dynamic/(?<nextParamslug>[^/]+?)(?:/)?$',
+            namedRegex: '^/api/dynamic/(?<nxtPslug>[^/]+?)(?:/)?$',
             page: '/api/dynamic/[slug]',
             regex: normalizeRegEx('^\\/api\\/dynamic\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamslug: 'nextParamslug',
+              nxtPslug: 'nxtPslug',
             },
           },
           {
-            namedRegex: '^/auto\\-export/(?<nextParamslug>[^/]+?)(?:/)?$',
+            namedRegex: '^/auto\\-export/(?<nxtPslug>[^/]+?)(?:/)?$',
             page: '/auto-export/[slug]',
             regex: normalizeRegEx('^\\/auto\\-export\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamslug: 'nextParamslug',
+              nxtPslug: 'nxtPslug',
             },
           },
           {
-            namedRegex: '^/blog/(?<nextParampost>[^/]+?)(?:/)?$',
+            namedRegex: '^/blog/(?<nxtPpost>[^/]+?)(?:/)?$',
             page: '/blog/[post]',
             regex: normalizeRegEx('^\\/blog\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParampost: 'nextParampost',
+              nxtPpost: 'nxtPpost',
             },
           },
           {
-            namedRegex: '^/blog\\-catchall/(?<nextParamslug>.+?)(?:/)?$',
+            namedRegex: '^/blog\\-catchall/(?<nxtPslug>.+?)(?:/)?$',
             page: '/blog-catchall/[...slug]',
             regex: normalizeRegEx('^\\/blog\\-catchall\\/(.+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamslug: 'nextParamslug',
+              nxtPslug: 'nxtPslug',
             },
           },
           {
-            namedRegex: '^/overridden/(?<nextParamslug>[^/]+?)(?:/)?$',
+            namedRegex: '^/overridden/(?<nxtPslug>[^/]+?)(?:/)?$',
             page: '/overridden/[slug]',
             regex: '^\\/overridden\\/([^\\/]+?)(?:\\/)?$',
             routeKeys: {
-              nextParamslug: 'nextParamslug',
+              nxtPslug: 'nxtPslug',
             },
           },
         ],

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -1257,10 +1257,10 @@ function runTests({ dev }) {
             )}\\/b\\/([^\\/]+?)\\.json$`,
             namedDataRouteRegex: `^/_next/data/${escapeRegex(
               buildId
-            )}/b/(?<nextParama>[^/]+?)\\.json$`,
+            )}/b/(?<nxtP123>[^/]+?)\\.json$`,
             page: '/b/[123]',
             routeKeys: {
-              nextParama: 'nextParam123',
+              nxtP123: 'nxtP123',
             },
           },
           {
@@ -1269,17 +1269,16 @@ function runTests({ dev }) {
             )}\\/c\\/([^\\/]+?)\\.json$`,
             namedDataRouteRegex: `^/_next/data/${escapeRegex(
               buildId
-            )}/c/(?<nextParama>[^/]+?)\\.json$`,
+            )}/c/(?<a>[^/]+?)\\.json$`,
             page: '/c/[alongparamnameshouldbeallowedeventhoughweird]',
             routeKeys: {
-              nextParama:
-                'nextParamalongparamnameshouldbeallowedeventhoughweird',
+              a: 'nxtPalongparamnameshouldbeallowedeventhoughweird',
             },
           },
           {
             namedDataRouteRegex: `^/_next/data/${escapeRegex(
               buildId
-            )}/p1/p2/all\\-ssg/(?<nextParamrest>.+?)\\.json$`,
+            )}/p1/p2/all\\-ssg/(?<nxtPrest>.+?)\\.json$`,
             dataRouteRegex: normalizeRegEx(
               `^\\/_next\\/data\\/${escapeRegex(
                 buildId
@@ -1287,13 +1286,13 @@ function runTests({ dev }) {
             ),
             page: '/p1/p2/all-ssg/[...rest]',
             routeKeys: {
-              nextParamrest: 'nextParamrest',
+              nxtPrest: 'nxtPrest',
             },
           },
           {
             namedDataRouteRegex: `^/_next/data/${escapeRegex(
               buildId
-            )}/p1/p2/nested\\-all\\-ssg/(?<nextParamrest>.+?)\\.json$`,
+            )}/p1/p2/nested\\-all\\-ssg/(?<nxtPrest>.+?)\\.json$`,
             dataRouteRegex: normalizeRegEx(
               `^\\/_next\\/data\\/${escapeRegex(
                 buildId
@@ -1301,13 +1300,13 @@ function runTests({ dev }) {
             ),
             page: '/p1/p2/nested-all-ssg/[...rest]',
             routeKeys: {
-              nextParamrest: 'nextParamrest',
+              nxtPrest: 'nxtPrest',
             },
           },
           {
             namedDataRouteRegex: `^/_next/data/${escapeRegex(
               buildId
-            )}/p1/p2/predefined\\-ssg/(?<nextParamrest>.+?)\\.json$`,
+            )}/p1/p2/predefined\\-ssg/(?<nxtPrest>.+?)\\.json$`,
             dataRouteRegex: normalizeRegEx(
               `^\\/_next\\/data\\/${escapeRegex(
                 buildId
@@ -1315,148 +1314,147 @@ function runTests({ dev }) {
             ),
             page: '/p1/p2/predefined-ssg/[...rest]',
             routeKeys: {
-              nextParamrest: 'nextParamrest',
+              nxtPrest: 'nxtPrest',
             },
           },
         ],
         dynamicRoutes: [
           {
-            namedRegex: '^/b/(?<nextParama>[^/]+?)(?:/)?$',
+            namedRegex: '^/b/(?<nxtP123>[^/]+?)(?:/)?$',
             page: '/b/[123]',
             regex: normalizeRegEx('^\\/b\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParama: 'nextParam123',
+              nxtP123: 'nxtP123',
             },
           },
           {
-            namedRegex: `^/blog/(?<nextParamname>[^/]+?)/comment/(?<nextParamid>[^/]+?)(?:/)?$`,
+            namedRegex: `^/blog/(?<nxtPname>[^/]+?)/comment/(?<nxtPid>[^/]+?)(?:/)?$`,
             page: '/blog/[name]/comment/[id]',
             regex: normalizeRegEx(
               '^\\/blog\\/([^\\/]+?)\\/comment\\/([^\\/]+?)(?:\\/)?$'
             ),
             routeKeys: {
-              nextParamname: 'nextParamname',
-              nextParamid: 'nextParamid',
+              nxtPname: 'nxtPname',
+              nxtPid: 'nxtPid',
             },
           },
           {
-            namedRegex: '^/c/(?<nextParama>[^/]+?)(?:/)?$',
+            namedRegex: '^/c/(?<a>[^/]+?)(?:/)?$',
             page: '/c/[alongparamnameshouldbeallowedeventhoughweird]',
             regex: normalizeRegEx('^\\/c\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParama:
-                'nextParamalongparamnameshouldbeallowedeventhoughweird',
+              a: 'nxtPalongparamnameshouldbeallowedeventhoughweird',
             },
           },
           {
-            namedRegex: '^/catchall\\-dash/(?<nextParamhelloworld>.+?)(?:/)?$',
+            namedRegex: '^/catchall\\-dash/(?<nxtPhelloworld>.+?)(?:/)?$',
             page: '/catchall-dash/[...hello-world]',
             regex: normalizeRegEx('^\\/catchall\\-dash\\/(.+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamhelloworld: 'nextParamhello-world',
+              nxtPhelloworld: 'nxtPhello-world',
             },
           },
           {
-            namedRegex: '^/d/(?<nextParamid>[^/]+?)(?:/)?$',
+            namedRegex: '^/d/(?<nxtPid>[^/]+?)(?:/)?$',
             page: '/d/[id]',
             regex: normalizeRegEx('^\\/d\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamid: 'nextParamid',
+              nxtPid: 'nxtPid',
             },
           },
           {
-            namedRegex: '^/dash/(?<nextParamhelloworld>[^/]+?)(?:/)?$',
+            namedRegex: '^/dash/(?<nxtPhelloworld>[^/]+?)(?:/)?$',
             page: '/dash/[hello-world]',
             regex: normalizeRegEx('^\\/dash\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamhelloworld: 'nextParamhello-world',
+              nxtPhelloworld: 'nxtPhello-world',
             },
           },
           {
-            namedRegex: '^/index/(?<nextParamslug>.+?)(?:/)?$',
+            namedRegex: '^/index/(?<nxtPslug>.+?)(?:/)?$',
             page: '/index/[...slug]',
             regex: normalizeRegEx('^/index/(.+?)(?:/)?$'),
             routeKeys: {
-              nextParamslug: 'nextParamslug',
+              nxtPslug: 'nxtPslug',
             },
           },
           {
-            namedRegex: `^/on\\-mount/(?<nextParampost>[^/]+?)(?:/)?$`,
+            namedRegex: `^/on\\-mount/(?<nxtPpost>[^/]+?)(?:/)?$`,
             page: '/on-mount/[post]',
             regex: normalizeRegEx('^\\/on\\-mount\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParampost: 'nextParampost',
+              nxtPpost: 'nxtPpost',
             },
           },
           {
-            namedRegex: `^/p1/p2/all\\-ssg/(?<nextParamrest>.+?)(?:/)?$`,
+            namedRegex: `^/p1/p2/all\\-ssg/(?<nxtPrest>.+?)(?:/)?$`,
             page: '/p1/p2/all-ssg/[...rest]',
             regex: normalizeRegEx('^\\/p1\\/p2\\/all\\-ssg\\/(.+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamrest: 'nextParamrest',
+              nxtPrest: 'nxtPrest',
             },
           },
           {
-            namedRegex: `^/p1/p2/all\\-ssr/(?<nextParamrest>.+?)(?:/)?$`,
+            namedRegex: `^/p1/p2/all\\-ssr/(?<nxtPrest>.+?)(?:/)?$`,
             page: '/p1/p2/all-ssr/[...rest]',
             regex: normalizeRegEx('^\\/p1\\/p2\\/all\\-ssr\\/(.+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamrest: 'nextParamrest',
+              nxtPrest: 'nxtPrest',
             },
           },
           {
-            namedRegex: `^/p1/p2/nested\\-all\\-ssg/(?<nextParamrest>.+?)(?:/)?$`,
+            namedRegex: `^/p1/p2/nested\\-all\\-ssg/(?<nxtPrest>.+?)(?:/)?$`,
             page: '/p1/p2/nested-all-ssg/[...rest]',
             regex: normalizeRegEx(
               '^\\/p1\\/p2\\/nested\\-all\\-ssg\\/(.+?)(?:\\/)?$'
             ),
             routeKeys: {
-              nextParamrest: 'nextParamrest',
+              nxtPrest: 'nxtPrest',
             },
           },
           {
-            namedRegex: `^/p1/p2/predefined\\-ssg/(?<nextParamrest>.+?)(?:/)?$`,
+            namedRegex: `^/p1/p2/predefined\\-ssg/(?<nxtPrest>.+?)(?:/)?$`,
             page: '/p1/p2/predefined-ssg/[...rest]',
             regex: normalizeRegEx(
               '^\\/p1\\/p2\\/predefined\\-ssg\\/(.+?)(?:\\/)?$'
             ),
             routeKeys: {
-              nextParamrest: 'nextParamrest',
+              nxtPrest: 'nxtPrest',
             },
           },
           {
-            namedRegex: `^/(?<nextParamname>[^/]+?)(?:/)?$`,
+            namedRegex: `^/(?<nxtPname>[^/]+?)(?:/)?$`,
             page: '/[name]',
             regex: normalizeRegEx('^\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamname: 'nextParamname',
+              nxtPname: 'nxtPname',
             },
           },
           {
-            namedRegex: `^/(?<nextParamname>[^/]+?)/comments(?:/)?$`,
+            namedRegex: `^/(?<nxtPname>[^/]+?)/comments(?:/)?$`,
             page: '/[name]/comments',
             regex: normalizeRegEx('^\\/([^\\/]+?)\\/comments(?:\\/)?$'),
             routeKeys: {
-              nextParamname: 'nextParamname',
+              nxtPname: 'nxtPname',
             },
           },
           {
-            namedRegex: `^/(?<nextParamname>[^/]+?)/on\\-mount\\-redir(?:/)?$`,
+            namedRegex: `^/(?<nxtPname>[^/]+?)/on\\-mount\\-redir(?:/)?$`,
             page: '/[name]/on-mount-redir',
             regex: normalizeRegEx(
               '^\\/([^\\/]+?)\\/on\\-mount\\-redir(?:\\/)?$'
             ),
             routeKeys: {
-              nextParamname: 'nextParamname',
+              nxtPname: 'nxtPname',
             },
           },
           {
-            namedRegex: `^/(?<nextParamname>[^/]+?)/(?<nextParamcomment>[^/]+?)(?:/)?$`,
+            namedRegex: `^/(?<nxtPname>[^/]+?)/(?<nxtPcomment>[^/]+?)(?:/)?$`,
             page: '/[name]/[comment]',
             regex: normalizeRegEx('^\\/([^\\/]+?)\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
-              nextParamname: 'nextParamname',
-              nextParamcomment: 'nextParamcomment',
+              nxtPname: 'nxtPname',
+              nxtPcomment: 'nxtPcomment',
             },
           },
         ],

--- a/test/integration/required-server-files-ssr-404/test/index.test.js
+++ b/test/integration/required-server-files-ssr-404/test/index.test.js
@@ -193,7 +193,7 @@ describe('Required Server Files', () => {
   it('should render dynamic SSR page correctly with x-matched-path', async () => {
     const html = await renderViaHTTP(
       appPort,
-      '/some-other-path?nextParamslug=first',
+      '/some-other-path?nxtPslug=first',
       undefined,
       {
         headers: {
@@ -259,7 +259,7 @@ describe('Required Server Files', () => {
   it('should return data correctly with x-matched-path', async () => {
     const res = await fetchViaHTTP(
       appPort,
-      `/_next/data/${buildId}/dynamic/first.json?nextParamslug=first`,
+      `/_next/data/${buildId}/dynamic/first.json?nxtPslug=first`,
       undefined,
       {
         headers: {

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -313,7 +313,7 @@ describe('should set-up next', () => {
   it('should render dynamic SSR page correctly with x-matched-path', async () => {
     const html = await renderViaHTTP(
       appPort,
-      '/some-other-path?nextParamslug=first',
+      '/some-other-path?nxtPslug=first',
       undefined,
       {
         headers: {
@@ -330,7 +330,7 @@ describe('should set-up next', () => {
 
     const html2 = await renderViaHTTP(
       appPort,
-      '/some-other-path?nextParamslug=second',
+      '/some-other-path?nxtPslug=second',
       undefined,
       {
         headers: {
@@ -349,7 +349,7 @@ describe('should set-up next', () => {
     const html3 = await renderViaHTTP(appPort, '/some-other-path', undefined, {
       headers: {
         'x-matched-path': '/dynamic/[slug]?slug=%5Bslug%5D.json',
-        'x-now-route-matches': '1=second&nextParamslug=second',
+        'x-now-route-matches': '1=second&nxtPslug=second',
       },
     })
     const $3 = cheerio.load(html3)
@@ -393,7 +393,7 @@ describe('should set-up next', () => {
   it('should return data correctly with x-matched-path', async () => {
     const res = await fetchViaHTTP(
       appPort,
-      `/_next/data/${next.buildId}/en/dynamic/first.json?nextParamslug=first`,
+      `/_next/data/${next.buildId}/en/dynamic/first.json?nxtPslug=first`,
       undefined,
       {
         headers: {
@@ -451,7 +451,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': '/catch-all/[[...rest]]',
-          'x-now-route-matches': '1=hello&nextParamcatchAll=hello',
+          'x-now-route-matches': '1=hello&nxtPcatchAll=hello',
         },
       }
     )
@@ -470,7 +470,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': '/catch-all/[[...rest]]',
-          'x-now-route-matches': '1=hello/world&nextParamcatchAll=hello/world',
+          'x-now-route-matches': '1=hello/world&nxtPcatchAll=hello/world',
         },
       }
     )
@@ -507,7 +507,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': `/_next/data/${next.buildId}/en/catch-all/[[...rest]].json`,
-          'x-now-route-matches': '1=hello&nextParamrest=hello',
+          'x-now-route-matches': '1=hello&nxtPrest=hello',
         },
       }
     )
@@ -524,7 +524,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': `/_next/data/${next.buildId}/en/catch-all/[[...rest]].json`,
-          'x-now-route-matches': '1=hello/world&nextParamrest=hello/world',
+          'x-now-route-matches': '1=hello/world&nxtPrest=hello/world',
         },
       }
     )
@@ -640,7 +640,7 @@ describe('should set-up next', () => {
     const res = await fetchViaHTTP(
       appPort,
       '/optional-ssp',
-      { nextParamrest: '', another: 'value' },
+      { nxtPrest: '', another: 'value' },
       {
         headers: {
           'x-matched-path': '/optional-ssp/[[...rest]]',
@@ -683,7 +683,7 @@ describe('should set-up next', () => {
         headers: {
           'x-matched-path': '/en/[slug]/social/[[...rest]]',
           'x-now-route-matches':
-            'nextLocale=en&1=en&2=user-123&nextParamslug=user-123',
+            'nextLocale=en&1=en&2=user-123&nxtPslug=user-123',
         },
       }
     )
@@ -706,7 +706,7 @@ describe('should set-up next', () => {
         headers: {
           'x-matched-path': '/optional-ssg/[[...rest]]',
           'x-now-route-matches':
-            '1=en%2Fes%2Fhello%252Fworld&nextParamrest=en%2Fes%2Fhello%252Fworld',
+            '1=en%2Fes%2Fhello%252Fworld&nxtPrest=en%2Fes%2Fhello%252Fworld',
         },
       }
     )
@@ -723,7 +723,7 @@ describe('should set-up next', () => {
     const res = await fetchViaHTTP(
       appPort,
       '/api/optional',
-      { nextParamrest: '', another: 'value' },
+      { nxtPrest: '', another: 'value' },
       {
         headers: {
           'x-matched-path': '/api/optional/[[...rest]]',
@@ -766,8 +766,7 @@ describe('should set-up next', () => {
     const res = await fetchViaHTTP(appPort, '/en/fallback/[slug]', undefined, {
       headers: {
         'x-matched-path': '/en/fallback/[slug]',
-        'x-now-route-matches':
-          '2=another&nextParamslug=another&1=en&nextLocale=en',
+        'x-now-route-matches': '2=another&nxtPslug=another&1=en&nextLocale=en',
       },
       redirect: 'manual',
     })
@@ -785,8 +784,7 @@ describe('should set-up next', () => {
     const res = await fetchViaHTTP(appPort, '/fr/fallback/[slug]', undefined, {
       headers: {
         'x-matched-path': '/fr/fallback/[slug]',
-        'x-now-route-matches':
-          '2=another&nextParamslug=another&1=fr&nextLocale=fr',
+        'x-now-route-matches': '2=another&nxtPslug=another&1=fr&nextLocale=fr',
       },
       redirect: 'manual',
     })

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -570,7 +570,7 @@ describe('should set-up next', () => {
   it('should render dynamic SSR page correctly with x-matched-path', async () => {
     const html = await renderViaHTTP(
       appPort,
-      '/some-other-path?nextParamslug=first',
+      '/some-other-path?nxtPslug=first',
       undefined,
       {
         headers: {
@@ -587,7 +587,7 @@ describe('should set-up next', () => {
 
     const html2 = await renderViaHTTP(
       appPort,
-      '/some-other-path?nextParamslug=second',
+      '/some-other-path?nxtPslug=second',
       undefined,
       {
         headers: {
@@ -606,7 +606,7 @@ describe('should set-up next', () => {
     const html3 = await renderViaHTTP(appPort, '/some-other-path', undefined, {
       headers: {
         'x-matched-path': '/dynamic/[slug]',
-        'x-now-route-matches': '1=second&nextParamslug=second',
+        'x-now-route-matches': '1=second&nxtPslug=second',
       },
     })
     const $3 = cheerio.load(html3)
@@ -703,7 +703,7 @@ describe('should set-up next', () => {
   it('should return data correctly with x-matched-path', async () => {
     const res = await fetchViaHTTP(
       appPort,
-      `/_next/data/${next.buildId}/dynamic/first.json?nextParamslug=first`,
+      `/_next/data/${next.buildId}/dynamic/first.json?nxtPslug=first`,
       undefined,
       {
         headers: {
@@ -761,7 +761,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': '/catch-all/[[...rest]]',
-          'x-now-route-matches': '1=hello&nextParamcatchAll=hello',
+          'x-now-route-matches': '1=hello&nxtPcatchAll=hello',
         },
       }
     )
@@ -780,7 +780,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': '/catch-all/[[...rest]]',
-          'x-now-route-matches': '1=hello/world&nextParamcatchAll=hello/world',
+          'x-now-route-matches': '1=hello/world&nxtPcatchAll=hello/world',
         },
       }
     )
@@ -818,7 +818,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': `/_next/data/${next.buildId}/catch-all/[[...rest]].json`,
-          'x-now-route-matches': '1=hello&nextParamrest=hello',
+          'x-now-route-matches': '1=hello&nxtPrest=hello',
         },
       }
     )
@@ -835,7 +835,7 @@ describe('should set-up next', () => {
       {
         headers: {
           'x-matched-path': `/_next/data/${next.buildId}/catch-all/[[...rest]].json`,
-          'x-now-route-matches': '1=hello/world&nextParamrest=hello/world',
+          'x-now-route-matches': '1=hello/world&nxtPrest=hello/world',
         },
       }
     )
@@ -1111,7 +1111,7 @@ describe('should set-up next', () => {
         headers: {
           'x-matched-path': '/optional-ssg/[[...rest]]',
           'x-now-route-matches':
-            '1=en%2Fes%2Fhello%252Fworld&nextParamrest=en%2Fes%2Fhello%252Fworld',
+            '1=en%2Fes%2Fhello%252Fworld&nxtPrest=en%2Fes%2Fhello%252Fworld',
         },
       }
     )
@@ -1145,7 +1145,7 @@ describe('should set-up next', () => {
     const res = await fetchViaHTTP(
       appPort,
       '/api/optional/index',
-      { nextParamrest: 'index', another: 'value' },
+      { nxtPrest: 'index', another: 'value' },
       {
         headers: {
           'x-matched-path': '/api/optional/[[...rest]]',


### PR DESCRIPTION
With the addition of the query prefix we can hit the max length for PCRE named matches so this reduces the prefix length and ensures we go through the param name validation still

x-ref: https://twitter.com/simonecervini/status/1644123851003928579