### PR TITLE
interception: fix infinite refetch when rendering a slotted interception

### DIFF
--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -32,6 +32,7 @@ export function applyFlightData(
     // Copy subTreeData for the root node of the cache.
     cache.status = CacheStates.READY
     cache.subTreeData = state.cache.subTreeData
+    cache.parallelRoutes = new Map(state.cache.parallelRoutes)
     // Create a copy of the existing cache with the subTreeData applied.
     fillCacheWithNewSubTreeData(cache, state.cache, flightDataPath)
   }

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -84,9 +84,6 @@ export function computeChangedPath(
         parallelRoutesB[parallelRouterKey]
       )
       if (changedPath !== null) {
-        if (changedPath === '') {
-          return segmentToPathname(segmentB)
-        }
         return `${segmentToPathname(segmentB)}/${changedPath}`
       }
     }

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -21,9 +21,6 @@ export function fillLazyItemsTillLeafWithHead(
     const cacheKey = createRouterCacheKey(segmentForParallelRoute)
 
     if (existingCache) {
-      if (cacheKey === '__DEFAULT__') {
-        continue
-      }
       const existingParallelRoutesCacheNode =
         existingCache.parallelRoutes.get(key)
       if (existingParallelRoutesCacheNode) {

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/@slot/(..)nested/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/@slot/(..)nested/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Page() {
+  return <p id="interception-slot">interception from @slot/nested</p>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/@slot/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/@slot/default.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Default() {
+  return <p id="default-slot">default from @slot</p>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/layout.tsx
@@ -1,7 +1,18 @@
-export default function Root({ children }: { children: React.ReactNode }) {
+import React from 'react'
+
+export default function Root({
+  children,
+  slot,
+}: {
+  children: React.ReactNode
+  slot: React.ReactNode
+}) {
   return (
     <html>
-      <body>{children}</body>
+      <body>
+        {children}
+        {slot}
+      </body>
     </html>
   )
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/nested/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/nested/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Page() {
+  return <p id="nested">hello world from /nested</p>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/page.tsx
@@ -1,3 +1,11 @@
+import Link from 'next/link'
+import React from 'react'
+
 export default function Page() {
-  return <p>hello world</p>
+  return (
+    <>
+      <p>hello world</p>
+      <Link href="/nested">to nested</Link>
+    </>
+  )
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -246,6 +246,30 @@ createNextDescribe(
         )
       })
 
+      it('should render an intercepted route from a slot', async () => {
+        const browser = await next.browser('/')
+
+        await check(
+          () => browser.waitForElementByCss('#default-slot').text(),
+          'default from @slot'
+        )
+
+        await check(
+          () =>
+            browser
+              .elementByCss('[href="/nested"]')
+              .click()
+              .waitForElementByCss('#interception-slot')
+              .text(),
+          'interception from @slot/nested'
+        )
+
+        await check(
+          () => browser.refresh().waitForElementByCss('#nested').text(),
+          'hello world from /nested'
+        )
+      })
+
       it('should render intercepted route from a nested route', async () => {
         const browser = await next.browser('/intercepting-routes/feed/nested')
 


### PR DESCRIPTION

### What?

This PR fixes the infinite reloading happening when navigating to an intercepted route in a slot/parallel route.


### How?
- the infinite fetch was triggered by the branch of the router state that was not affected by the navigation never having its cache node populated because of something I added in earlier versions of the parallel route implementation that skipped applying the logic when __DEFAULT__  was a cache key. Needless to say this was wrong
- also fixes another bug where the next referrer (used for interception routes) was not computed properly on the root path with the kind of navigation aforementioned.

fixes NEXT-965

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

fix NEXT-967