### PR TITLE
Fix: fixed incorrect classification of dependencies types (dev vs non-dev) when using create-next-app

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -198,12 +198,14 @@ export const installTemplate = async ({
         : ''
     }`,
   ]
+  
+  const devDependencies = []
 
   /**
    * TypeScript projects will have type definitions and other devDependencies.
    */
   if (mode === 'ts') {
-    dependencies.push(
+    devDependencies.push(
       'typescript',
       '@types/react',
       '@types/node',
@@ -215,14 +217,14 @@ export const installTemplate = async ({
    * Add Tailwind CSS dependencies.
    */
   if (tailwind) {
-    dependencies.push('tailwindcss', 'postcss', 'autoprefixer')
+    devDependencies.push('tailwindcss', 'postcss', 'autoprefixer')
   }
 
   /**
    * Default eslint dependencies.
    */
   if (eslint) {
-    dependencies.push('eslint', 'eslint-config-next')
+    devDependencies.push('eslint', 'eslint-config-next')
   }
   /**
    * Install package.json dependencies if they exist.
@@ -236,6 +238,20 @@ export const installTemplate = async ({
     console.log()
 
     await install(root, dependencies, installFlags)
+  }
+  
+  /**
+   * Install package.json devDependencies if they exist.
+   */
+  if (devDependencies.length) {
+    console.log()
+    console.log('Installing devDependencies:')
+    for (const dependency of devDependencies) {
+      console.log(`- ${chalk.cyan(dependency)}`)
+    }
+    console.log()
+
+    await install(root, devDependencies, { ...installFlags, devDependencies: true })
   }
 }
 


### PR DESCRIPTION
## What?
this PR fixes the problem that dependencies like (typescript, tailwindcss, postcss, autoprefixer, eslint, ...) are installed as normal `dependencies`, not `devDependencies`.

## Why?
this is the `package.json` generated by running `npx create-next-app@latest` with `typescript`, `eslint`, and `tailwindcss` included.

![Screenshot (400)](https://user-images.githubusercontent.com/58993233/230604474-84a4de91-7b3c-44b6-9545-7f3942f6d842.png)

which **contradicts** with the **recommended**  approaches from official sites as shown below.

* **Tailwindcss**

![Screenshot (402)](https://user-images.githubusercontent.com/58993233/230605836-d50aa9c9-b7c7-401a-9b81-3e71f63eeb78.png)

* **Typescript**

![Screenshot (403)](https://user-images.githubusercontent.com/58993233/230606098-1bd2edaf-d46b-4066-a92d-b1a293007896.png)

* **ESLint**

![Screenshot (404)](https://user-images.githubusercontent.com/58993233/230606838-cabc093e-e785-4c90-9543-cfc41234bd31.png)

## How?
just separated the `devDependencies` from `dependencies` and added them into an array for installation with the `devDependencies` option marked as `true`.
