### PR TITLE
Remove change leftover from experimental precompiled server

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -730,10 +730,7 @@ export default async function loadConfig(
     : Log
 
   await loadEnvConfig(dir, phase === PHASE_DEVELOPMENT_SERVER, curLog)
-
-  if (!customConfig) {
-    loadWebpackHook()
-  }
+  loadWebpackHook()
 
   let configFileName = 'next.config.js'
 


### PR DESCRIPTION
This is no longer needed as the experimental precompiled server was removed. 

Closes: https://github.com/vercel/next.js/issues/46588