### PR TITLE
Fix documentation link for transpilePackages in NextConfig

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -580,7 +580,7 @@ export interface NextConfig extends Record<string, any> {
   /**
    * Automatically transpile and bundle dependencies from local packages (like monorepos) or from external dependencies (`node_modules`). This replaces the
    * `next-transpile-modules` package.
-   * @see [transpilePackages](https://beta.nextjs.org/docs/api-reference/next.config.js#transpilepackages)
+   * @see [transpilePackages](https://nextjs.org/docs/advanced-features/compiler#module-transpilation)
    */
   transpilePackages?: string[]
 


### PR DESCRIPTION
The documentation link in NextConfig's JSDoc for 'transpilePackages' was returning a 404 error.
