### PR TITLE
Fix next-flight-loader resourcePath in Windows

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -64,7 +64,7 @@ export default async function transformSource(
 
       let esmSource = `\
 import { createProxy } from "${moduleProxy}"
-const proxy = createProxy("${this.resourcePath}")
+const proxy = createProxy(String.raw\`${this.resourcePath}\`)
 
 // Accessing the __esModule property and exporting $$typeof are required here.
 // The __esModule getter forces the proxy target to create the default export


### PR DESCRIPTION
### What?
It's path backslash and string escape bug at [next-flight-loader](https://linear.app/vercel/issue/NEXT-flight-loader), in Windows

### Why?

### How?

Closes NEXT-940
Fixes #47704

