### PR TITLE
Add information about deploy to open telemetry docs

### DIFF
--- a/docs/advanced-features/open-telemetry.md
+++ b/docs/advanced-features/open-telemetry.md
@@ -54,6 +54,32 @@ All other spans from that particular trace will be nested under it.
 Next.js traces more spans than are emitted by default.
 To see more spans, you must set `NEXT_OTEL_VERBOSE=1`.
 
+## Deployment
+
+### Using OpenTelemetry Collector
+
+When you are deploying with OpenTelemetry Collector, you can use `@vercel/otel`.
+It will work both on Vercel and when self-hosted.
+
+#### Deploying on Vercel
+
+We made sure that OpenTelemetry works out-of the box on Vercel.
+
+Follow [Vercel documentation](https://vercel.com/docs/concepts/observability/otel-overview/quickstart) to connect your project to an observability provider.
+
+#### Self-hosting
+
+Deploying to other platforms is also straightforward. You will need to spin up your own OpenTelemetry Collector to receive and process the telemetry data from your Next.js app.
+
+To do this, follow the [OpenTelemetry Collector Getting Started guide](https://opentelemetry.io/docs/collector/getting-started/), which will walk you through setting up the collector and configuring it to receive data from your Next.js app.
+
+Once you have your collector up and running, you can deploy your Next.js app to your chosen platform following their respective deployment guides.
+
+### Custom Exporters
+
+You can use custom OpenTelemetry initialization in order to specify a custom OpenTelemetry exporter.
+We recommend using OpenTelemetry Collector for
+
 ## Custom Spans
 
 You can add your own span with [OpenTelemetry APIs](https://opentelemetry.io/docs/instrumentation/js/instrumentation).

--- a/docs/advanced-features/open-telemetry.md
+++ b/docs/advanced-features/open-telemetry.md
@@ -113,7 +113,7 @@ It will work both on Vercel and when self-hosted.
 
 #### Deploying on Vercel
 
-We made sure that OpenTelemetry works out-of the box on Vercel.
+We made sure that OpenTelemetry works out of the box on Vercel.
 
 Follow [Vercel documentation](https://vercel.com/docs/concepts/observability/otel-overview/quickstart) to connect your project to an observability provider.
 
@@ -127,8 +127,8 @@ Once you have your collector up and running, you can deploy your Next.js app to 
 
 ### Custom Exporters
 
-You can use custom OpenTelemetry initialization in order to specify a custom OpenTelemetry exporter.
-We recommend using OpenTelemetry Collector for
+We recommend using OpenTelemetry Collector.
+If that is not possible on your platform, you can use a custom OpenTelemetry exporter with [manual OpenTelemetry configuration](https://nextjs.org/docs/advanced-features/open-telemetry#manual-opentelemetry-configuration)
 
 ## Custom Spans
 


### PR DESCRIPTION
Added information on how to deploy with OTEL.

- mentioned that `@vercel/otel` works on Vercel and when self-hosted
- added links to Vercel docs
- added links into OTEL docs for self-hosted
- Added information about custom exporter

Questions:

- should we mention Datadog, NewRelic and others as an examples of custom exporters?
  - https://docs.datadoghq.com/opentelemetry/
  - https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-legacy-new-relic-exporters/