### PR TITLE
Fix the typo on README.md

### DIFF
--- a/examples/with-dynamic-import/README.md
+++ b/examples/with-dynamic-import/README.md
@@ -1,6 +1,6 @@
 # Example app with dynamic-imports
 
-This examples shows how to dynamically import modules via [`import()`](https://github.com/tc39/proposal-dynamic-import) API
+This example shows how to dynamically import modules via [`import()`](https://github.com/tc39/proposal-dynamic-import) API
 
 ## Deploy your own
 


### PR DESCRIPTION
This is a very tiny fix. I hope it helps.
`examples` → `example`