### PR TITLE
parallel routes: remove the per-route default 404 handler

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -645,8 +645,6 @@ export async function renderToHTMLOrFlight(
             getComponent: notFound[0],
             injectedCSS: injectedCSSWithCurrentLayout,
           })
-        : rootLayoutAtThisLevel
-        ? [DefaultNotFound]
         : []
 
       let dynamic = layoutOrPageMod?.dynamic

--- a/test/e2e/app-dir/parallel-routes-not-found/app/@slot/nested/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-not-found/app/@slot/nested/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return '@slot/nested'
+}

--- a/test/e2e/app-dir/parallel-routes-not-found/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-not-found/app/layout.tsx
@@ -1,0 +1,16 @@
+export default function Layout({
+  children,
+  slot,
+}: {
+  children: React.ReactNode
+  slot: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        {children}
+        {slot}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-not-found/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-not-found/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div id="children-slot">@children rendered</div>
+}

--- a/test/e2e/app-dir/parallel-routes-not-found/next.config.js
+++ b/test/e2e/app-dir/parallel-routes-not-found/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: { appDir: true },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -1,0 +1,25 @@
+import { createNextDescribe } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+createNextDescribe(
+  'parallel-routes-and-interception',
+  {
+    files: __dirname,
+    // TODO: remove after deployment handling is updated
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should not render the @children slot when the @slot is not found', async () => {
+      const browser = await next.browser('/')
+      // we make sure the page is available through navigating
+      expect(await browser.elementByCss('body').text()).toMatch(
+        /This page could not be found/
+      )
+
+      // we also check that the #children-slot id is not present
+      expect(await browser.hasElementByCssSelector('#children-slot')).toBe(
+        false
+      )
+    })
+  }
+)

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -1,5 +1,4 @@
 import { createNextDescribe } from 'e2e-utils'
-import { check } from 'next-test-utils'
 
 createNextDescribe(
   'parallel-routes-and-interception',

--- a/test/e2e/app-dir/parallel-routes-not-found/tsconfig.json
+++ b/test/e2e/app-dir/parallel-routes-not-found/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR fixes an issue where throwing a notFound error in a parallel route at the top level at the root level would trigger a notfound boundary at the parallel route level, which meant in practice that you could still see the other slots being rendered below.

This behaviour is undesirable and was caused by the fact that we were inserting a default one at each top-level parallel route. This is not longer needed as we have a global one in `app-router.tsx`


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
fixes NEXT-968