### PR TITLE
Support alt.txt for static metadata og image

### DIFF
--- a/packages/next/src/build/webpack/loaders/metadata/types.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/types.ts
@@ -24,6 +24,7 @@ export type CollectedMetadata = {
 export type MetadataImageModule = {
   url: string
   type?: string
+  alt?: string
 } & (
   | { sizes?: string }
   | {

--- a/test/e2e/app-dir/metadata/app/opengraph/static/opengraph-image.alt.txt
+++ b/test/e2e/app-dir/metadata/app/opengraph/static/opengraph-image.alt.txt
@@ -1,0 +1,1 @@
+A alt txt for og

--- a/test/e2e/app-dir/metadata/app/opengraph/static/twitter-image.alt.txt
+++ b/test/e2e/app-dir/metadata/app/opengraph/static/twitter-image.alt.txt
@@ -1,0 +1,1 @@
+A alt txt for twitter

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -478,21 +478,23 @@ createNextDescribe(
 
       it('should pick up opengraph-image and twitter-image as static metadata files', async () => {
         const $ = await next.render$('/opengraph/static')
-        expect($('[property="og:image"]').attr('content')).toBe(
-          'https://example.com/opengraph/static/opengraph-image.png?b76e8f0282c93c8e'
-        )
-        expect($('[property="og:image:type"]').attr('content')).toBe(
-          'image/png'
-        )
-        expect($('[property="og:image:width"]').attr('content')).toBe('114')
-        expect($('[property="og:image:height"]').attr('content')).toBe('114')
 
-        expect($('[name="twitter:image"]').attr('content')).toBe(
-          'https://example.com/opengraph/static/twitter-image.png?b76e8f0282c93c8e'
-        )
-        expect($('[name="twitter:card"]').attr('content')).toBe(
-          'summary_large_image'
-        )
+        const match = createMultiHtmlMatcher($)
+        await match('meta', 'property', 'content', {
+          'og:image:width': '114',
+          'og:image:height': '114',
+          'og:image:type': 'image/png',
+          'og:image:alt': 'A alt txt for og',
+          'og:image':
+            'https://example.com/opengraph/static/opengraph-image.png?b76e8f0282c93c8e',
+        })
+
+        await match('meta', 'name', 'content', {
+          'twitter:image':
+            'https://example.com/opengraph/static/twitter-image.png?b76e8f0282c93c8e',
+          'twitter:image:alt': 'A alt txt for twitter',
+          'twitter:card': 'summary_large_image',
+        })
 
         // favicon shouldn't be overridden
         const $icon = $('link[rel="icon"]')


### PR DESCRIPTION
### What

Support `opengraph-image.alt.txt` and `twitter-image.alt.txt` for static og/tw metadata image when they need to specify alt txt.

Closes NEXT-990

### Why

for og/tw images, you could have multiple images, so it's tricky to set alt in metadata exports with alt text. For static case we want it can work with static files, `.alt.txt` files will be the type to provide alt text content