### PR TITLE
Temporarily disable app dir export integration test

### DIFF
--- a/test/integration/app-dir-export/test/config.test.ts
+++ b/test/integration/app-dir-export/test/config.test.ts
@@ -10,7 +10,7 @@ import {
   nextConfig,
 } from './utils'
 
-describe('app dir with output export (next dev / next build)', () => {
+describe.skip('app dir with output export (next dev / next build)', () => {
   it('should throw when exportPathMap configured', async () => {
     nextConfig.replace(
       'trailingSlash: true,',

--- a/test/integration/app-dir-export/test/dynamicapiroute-dev.test.ts
+++ b/test/integration/app-dir-export/test/dynamicapiroute-dev.test.ts
@@ -1,17 +1,19 @@
 import { runTests } from './utils'
 
-it.each([
-  { dynamicApiRoute: 'undefined' },
-  { dynamicApiRoute: "'error'" },
-  { dynamicApiRoute: "'force-static'" },
-  {
-    dynamicApiRoute: "'force-dynamic'",
-    expectedErrMsg:
-      'export const dynamic = "force-dynamic" on page "/api/json" cannot be used with "output: export".',
-  },
-])(
-  'should work in dev with dynamicApiRoute $dynamicApiRoute',
-  async ({ dynamicApiRoute, expectedErrMsg }) => {
-    await runTests({ isDev: true, dynamicApiRoute, expectedErrMsg })
-  }
-)
+describe.skip('dynamic api route dev', () => {
+  it.each([
+    { dynamicApiRoute: 'undefined' },
+    { dynamicApiRoute: "'error'" },
+    { dynamicApiRoute: "'force-static'" },
+    {
+      dynamicApiRoute: "'force-dynamic'",
+      expectedErrMsg:
+        'export const dynamic = "force-dynamic" on page "/api/json" cannot be used with "output: export".',
+    },
+  ])(
+    'should work in dev with dynamicApiRoute $dynamicApiRoute',
+    async ({ dynamicApiRoute, expectedErrMsg }) => {
+      await runTests({ isDev: true, dynamicApiRoute, expectedErrMsg })
+    }
+  )
+})

--- a/test/integration/app-dir-export/test/dynamicapiroute-prod.test.ts
+++ b/test/integration/app-dir-export/test/dynamicapiroute-prod.test.ts
@@ -1,17 +1,19 @@
 import { runTests } from './utils'
 
-it.each([
-  { dynamicApiRoute: 'undefined' },
-  { dynamicApiRoute: "'error'" },
-  { dynamicApiRoute: "'force-static'" },
-  {
-    dynamicApiRoute: "'force-dynamic'",
-    expectedErrMsg:
-      'export const dynamic = "force-dynamic" on page "/api/json" cannot be used with "output: export".',
-  },
-])(
-  'should work in prod with dynamicApiRoute $dynamicApiRoute',
-  async ({ dynamicApiRoute, expectedErrMsg }) => {
-    await runTests({ isDev: false, dynamicApiRoute, expectedErrMsg })
-  }
-)
+describe.skip('dynamic api route prod', () => {
+  it.each([
+    { dynamicApiRoute: 'undefined' },
+    { dynamicApiRoute: "'error'" },
+    { dynamicApiRoute: "'force-static'" },
+    {
+      dynamicApiRoute: "'force-dynamic'",
+      expectedErrMsg:
+        'export const dynamic = "force-dynamic" on page "/api/json" cannot be used with "output: export".',
+    },
+  ])(
+    'should work in prod with dynamicApiRoute $dynamicApiRoute',
+    async ({ dynamicApiRoute, expectedErrMsg }) => {
+      await runTests({ isDev: false, dynamicApiRoute, expectedErrMsg })
+    }
+  )
+})

--- a/test/integration/app-dir-export/test/dynamicpage-dev.test.ts
+++ b/test/integration/app-dir-export/test/dynamicpage-dev.test.ts
@@ -1,17 +1,19 @@
 import { runTests } from './utils'
 
-it.each([
-  { dynamicPage: 'undefined' },
-  { dynamicPage: "'error'" },
-  { dynamicPage: "'force-static'" },
-  {
-    dynamicPage: "'force-dynamic'",
-    expectedErrMsg:
-      'Page with `dynamic = "force-dynamic"` couldn\'t be rendered statically because it used `output: export`.',
-  },
-])(
-  'should work in dev with dynamicPage $dynamicPage',
-  async ({ dynamicPage, expectedErrMsg }) => {
-    await runTests({ isDev: true, dynamicPage, expectedErrMsg })
-  }
-)
+describe.skip('dynamic page dev', () => {
+  it.each([
+    { dynamicPage: 'undefined' },
+    { dynamicPage: "'error'" },
+    { dynamicPage: "'force-static'" },
+    {
+      dynamicPage: "'force-dynamic'",
+      expectedErrMsg:
+        'Page with `dynamic = "force-dynamic"` couldn\'t be rendered statically because it used `output: export`.',
+    },
+  ])(
+    'should work in dev with dynamicPage $dynamicPage',
+    async ({ dynamicPage, expectedErrMsg }) => {
+      await runTests({ isDev: true, dynamicPage, expectedErrMsg })
+    }
+  )
+})

--- a/test/integration/app-dir-export/test/dynamicpage-prod.test.ts
+++ b/test/integration/app-dir-export/test/dynamicpage-prod.test.ts
@@ -1,17 +1,19 @@
 import { runTests } from './utils'
 
-it.each([
-  { dynamicPage: 'undefined' },
-  { dynadynamicPagemic: "'error'" },
-  { dynamicPage: "'force-static'" },
-  {
-    dynamicPage: "'force-dynamic'",
-    expectedErrMsg:
-      'Page with `dynamic = "force-dynamic"` couldn\'t be rendered statically because it used `output: export`.',
-  },
-])(
-  'should work in prod with dynamicPage $dynamicPage',
-  async ({ dynamicPage, expectedErrMsg }) => {
-    await runTests({ isDev: false, dynamicPage, expectedErrMsg })
-  }
-)
+describe.skip('dynamic page dev', () => {
+  it.each([
+    { dynamicPage: 'undefined' },
+    { dynadynamicPagemic: "'error'" },
+    { dynamicPage: "'force-static'" },
+    {
+      dynamicPage: "'force-dynamic'",
+      expectedErrMsg:
+        'Page with `dynamic = "force-dynamic"` couldn\'t be rendered statically because it used `output: export`.',
+    },
+  ])(
+    'should work in prod with dynamicPage $dynamicPage',
+    async ({ dynamicPage, expectedErrMsg }) => {
+      await runTests({ isDev: false, dynamicPage, expectedErrMsg })
+    }
+  )
+})

--- a/test/integration/app-dir-export/test/start.test.ts
+++ b/test/integration/app-dir-export/test/start.test.ts
@@ -17,7 +17,7 @@ const exportDir = join(appDir, 'out')
 const nextConfig = new File(join(appDir, 'next.config.js'))
 let app
 
-describe('app dir with output export (next start)', () => {
+describe.skip('app dir with output export (next start)', () => {
   afterEach(async () => {
     await killApp(app)
     nextConfig.restore()

--- a/test/integration/app-dir-export/test/trailing-slash-dev.test.ts
+++ b/test/integration/app-dir-export/test/trailing-slash-dev.test.ts
@@ -1,8 +1,10 @@
 import { runTests } from './utils'
 
-it.each([{ trailingSlash: false }, { trailingSlash: true }])(
-  "should work in dev with trailingSlash '$trailingSlash'",
-  async ({ trailingSlash }) => {
-    await runTests({ isDev: true, trailingSlash })
-  }
-)
+describe.skip('trailing slash dev', () => {
+  it.each([{ trailingSlash: false }, { trailingSlash: true }])(
+    "should work in dev with trailingSlash '$trailingSlash'",
+    async ({ trailingSlash }) => {
+      await runTests({ isDev: true, trailingSlash })
+    }
+  )
+})

--- a/test/integration/app-dir-export/test/trailing-slash-start.test.ts
+++ b/test/integration/app-dir-export/test/trailing-slash-start.test.ts
@@ -1,8 +1,10 @@
 import { runTests } from './utils'
 
-it.each([{ trailingSlash: false }, { trailingSlash: true }])(
-  "should work in prod with trailingSlash '$trailingSlash'",
-  async ({ trailingSlash }) => {
-    await runTests({ isDev: false, trailingSlash })
-  }
-)
+describe.skip('trailing slash dev', () => {
+  it.each([{ trailingSlash: false }, { trailingSlash: true }])(
+    "should work in prod with trailingSlash '$trailingSlash'",
+    async ({ trailingSlash }) => {
+      await runTests({ isDev: false, trailingSlash })
+    }
+  )
+})


### PR DESCRIPTION
As the integration tests are keeping failed on canary, turns out that the require hook didn't set up properly so when running the app-dir-export integration test it breaks others. Will re-enable it once migrated to e2e tests

x-ref: https://github.com/vercel/next.js/actions/runs/4668919790/jobs/8266728783?pr=48252#step:6:149
x-ref: https://github.com/vercel/next.js/actions/runs/4668707070/jobs/8266215431?pr=48252#step:6:325
x-ref: https://github.com/vercel/next.js/actions/runs/4675947717/jobs/8281764592?pr=48276