### PR TITLE
Fix missing favicon when other icon exist

### DIFF
--- a/packages/next/src/build/webpack/loaders/metadata/discover.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/discover.ts
@@ -57,13 +57,13 @@ export async function createStaticMetadataFromRoute(
   {
     segment,
     resolvePath,
-    isRootLayer,
+    isRootLayoutOrRootPage,
     loaderContext,
     pageExtensions,
   }: {
     segment: string
     resolvePath: (pathname: string) => Promise<string>
-    isRootLayer: boolean
+    isRootLayoutOrRootPage: boolean
     loaderContext: webpack.LoaderContext<any>
     pageExtensions: string[]
   }
@@ -122,7 +122,7 @@ export async function createStaticMetadataFromRoute(
     collectIconModuleIfExists('apple'),
     collectIconModuleIfExists('openGraph'),
     collectIconModuleIfExists('twitter'),
-    isRootLayer && collectIconModuleIfExists('favicon'),
+    isRootLayoutOrRootPage && collectIconModuleIfExists('favicon'),
   ])
 
   return hasStaticMetadataFiles ? staticImagesMetadata : null

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -237,6 +237,7 @@ async function createTreeCodeFromPath(
     // Existing tree are the children of the current segment
     const props: Record<string, string> = {}
     const isRootLayer = segments.length === 0
+    const isRootLayoutOrRootPage = segments.length <= 1
 
     // We need to resolve all parallel routes in this level.
     const parallelSegments: [key: string, segment: string | string[]][] = []
@@ -256,7 +257,7 @@ async function createTreeCodeFromPath(
         metadata = await createStaticMetadataFromRoute(resolvedRouteDir, {
           segment: segmentPath,
           resolvePath,
-          isRootLayer,
+          isRootLayoutOrRootPage,
           loaderContext,
           pageExtensions,
         })

--- a/test/e2e/app-dir/metadata/app/icon.svg
+++ b/test/e2e/app-dir/metadata/app/icon.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Created with Vectornator (http://vectornator.io/) -->
+<svg height="100%" stroke-miterlimit="10" style="fill-rule:nonzero;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;" version="1.1" viewBox="0 0 48 48" width="100%" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs/>
+<g id="Background">
+<path d="M9.6 0L38.4 0C43.7019 0 48 4.29807 48 9.6L48 38.4C48 43.7019 43.7019 48 38.4 48L9.6 48C4.29807 48 0 43.7019 0 38.4L0 9.6C0 4.29807 4.29807 0 9.6 0Z" fill="#ffffff" fill-rule="nonzero" opacity="1" stroke="none"/>
+</g>
+<g id="Icon">
+<path d="M19.2 24C16.549 24 14.4 26.149 14.4 28.8C14.4 31.451 16.549 33.6 19.2 33.6C21.851 33.6 24 31.451 24 28.8C24 26.149 21.851 24 19.2 24Z" fill="#000000" fill-rule="nonzero" opacity="1" stroke="none"/>
+<path d="M24 4.8C13.44 4.8 4.8 13.3978 4.8 24.096C4.8 34.7942 13.44 43.2 24 43.2C34.56 43.2 43.2 34.6022 43.2 24.096C43.2 13.5898 34.752 4.8 24 4.8ZM22.464 39.3792C14.784 38.615 8.64 32.1197 8.64 24.096C8.64 16.0723 14.592 9.76704 22.464 8.8128C24.576 9.95904 26.496 11.4874 28.032 13.3978C28.8 13.0157 29.76 12.6336 30.72 12.6336C33.408 12.6336 35.52 14.736 35.52 17.4106C35.52 19.703 33.792 21.8054 31.488 22.1875C31.488 22.7616 31.68 23.5258 31.68 24.0979C31.68 30.7814 27.84 36.5126 22.464 39.3792ZM35.52 33.648C34.368 33.648 33.6 32.8838 33.6 31.7376C33.6 30.5914 34.368 29.8272 35.52 29.8272C36.672 29.8272 37.44 30.5914 37.44 31.7376C37.44 32.8838 36.672 33.648 35.52 33.648Z" fill="#000000" fill-rule="nonzero" opacity="1" stroke="none"/>
+<path d="M15.36 14.4C13.7694 14.4 12.48 15.6894 12.48 17.28C12.48 18.8706 13.7694 20.16 15.36 20.16C16.9506 20.16 18.24 18.8706 18.24 17.28C18.24 15.6894 16.9506 14.4 15.36 14.4Z" fill="#000000" fill-rule="nonzero" opacity="1" stroke="none"/>
+</g>
+</svg>

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -545,15 +545,18 @@ createNextDescribe(
 
       it('should support root level of favicon.ico', async () => {
         let $ = await next.render$('/')
-        let $icon = $('link[rel="icon"]')
-        expect($icon.attr('href')).toBe('/favicon.ico')
-        expect($icon.attr('type')).toBe('image/x-icon')
-        expect($icon.attr('sizes')).toBe('any')
+        const favIcon = $('link[rel="icon"]')
+        expect(favIcon.attr('href')).toBe('/favicon.ico')
+        expect(favIcon.attr('type')).toBe('image/x-icon')
+        expect(favIcon.attr('sizes')).toBe('any')
+
+        const iconSvg = $('link[rel="icon"][type="image/svg+xml"]')
+        expect(iconSvg.attr('href')).toBe('/icon.svg?90699bff34adba1f')
 
         $ = await next.render$('/basic')
-        $icon = $('link[rel="icon"]')
-        expect($icon.attr('href')).toBe('/favicon.ico')
-        expect($icon.attr('sizes')).toBe('any')
+        const icon = $('link[rel="icon"]')
+        expect(icon.attr('href')).toBe('/favicon.ico')
+        expect(icon.attr('sizes')).toBe('any')
       })
     })
 


### PR DESCRIPTION
When collecting static icons we need both collect the one from layout and page, but for root level route `/` we missed the `favicon.ico` before so when other icon existed, the root page's collected icons will cover root layout collected ones, which resulted into favicon missing

Fixes #48147
Closes NEXT-976 