### PR TITLE
Fix dev case when proxying to self

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1434,6 +1434,7 @@ export default class NextNodeServer extends BaseServer {
             const invokeHeaders: typeof req.headers = {
               'cache-control': '',
               ...req.headers,
+              'x-middleware-invoke': '',
               'x-invoke-path': invokePathname,
               'x-invoke-query': encodeURIComponent(invokeQuery),
             }
@@ -2254,6 +2255,8 @@ export default class NextNodeServer extends BaseServer {
 
                 const invokeHeaders: typeof req.headers = {
                   ...req.headers,
+                  'x-invoke-path': '',
+                  'x-invoke-query': '',
                   'x-middleware-invoke': '1',
                 }
                 const invokeRes = await invokeRequest(

--- a/packages/next/src/server/router.ts
+++ b/packages/next/src/server/router.ts
@@ -356,19 +356,17 @@ export default class Router {
     // we only honor this header if we are inside of a render worker to
     // prevent external users coercing the routing path
     const matchedPath = req.headers['x-invoke-path'] as string
-    const curRoutes = matchedPath
-      ? this.compiledRoutes.filter((r) => {
-          return (
-            r.name === 'Catchall render' || r.name === '_next/data catchall'
-          )
-        })
-      : this.compiledRoutes
+    let curRoutes = this.compiledRoutes
 
     if (
       process.env.NEXT_RUNTIME !== 'edge' &&
       process.env.__NEXT_PRIVATE_RENDER_WORKER &&
       matchedPath
     ) {
+      curRoutes = this.compiledRoutes.filter((r) => {
+        return r.name === 'Catchall render' || r.name === '_next/data catchall'
+      })
+
       const parsedMatchedPath = new URL(matchedPath || '/', 'http://n')
 
       const pathnameInfo = getNextPathnameInfo(parsedMatchedPath.pathname, {

--- a/test/integration/api-support/pages/api/proxy-self.js
+++ b/test/integration/api-support/pages/api/proxy-self.js
@@ -1,0 +1,19 @@
+import httpProxy from 'http-proxy'
+
+export default async function handler(req, res) {
+  const port = req.headers.host.split(':').pop()
+  const proxy = httpProxy.createProxy({
+    target: `http://127.0.0.1:${port}/${
+      req.query.buildId
+        ? `_next/static/${req.query.buildId}/_ssgManifest.js`
+        : `user`
+    }`,
+    ignorePath: true,
+  })
+
+  await new Promise((resolve, reject) => {
+    proxy.on('error', reject)
+    proxy.on('close', resolve)
+    proxy.web(req, res)
+  })
+}

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -25,6 +25,23 @@ let mode
 let app
 
 function runTests(dev = false) {
+  it('should handle proxying to self correctly', async () => {
+    const res1 = await fetchViaHTTP(appPort, '/api/proxy-self')
+    expect(res1.status).toBe(200)
+    expect(await res1.text()).toContain('User')
+
+    const buildId = dev
+      ? 'development'
+      : await fs.readFile(join(appDir, '.next', 'BUILD_ID'), 'utf8')
+
+    const res2 = await fetchViaHTTP(
+      appPort,
+      `/api/proxy-self?buildId=${buildId}`
+    )
+    expect(res2.status).toBe(200)
+    expect(await res2.text()).toContain('__SSG_MANIFEST')
+  })
+
   it('should respond from /api/auth/[...nextauth] correctly', async () => {
     const res = await fetchViaHTTP(appPort, '/api/auth/signin', undefined, {
       redirect: 'manual',


### PR DESCRIPTION
This ensures we don't pass along original headers when an API route is proxying back to the dev server. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1681231721085539)