### PR TITLE
Fix dev getStaticPaths/generateStaticParams calling

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -151,36 +151,30 @@ export default class DevServer extends Server {
   private getStaticPathsWorker(): { [key: string]: any } & {
     loadStaticPaths: typeof import('./static-paths-worker').loadStaticPaths
   } {
-    if (this.staticPathsWorker) {
-      return this.staticPathsWorker
-    }
-    this.staticPathsWorker = new Worker(
-      require.resolve('./static-paths-worker'),
-      {
-        maxRetries: 1,
-        // For dev server, it's not necessary to spin up too many workers as long as you are not doing a load test.
-        // This helps reusing the memory a lot.
-        numWorkers: Math.min(this.nextConfig.experimental.cpus || 2, 2),
-        enableWorkerThreads: this.nextConfig.experimental.workerThreads,
-        forkOptions: {
-          env: {
-            ...process.env,
-            // discard --inspect/--inspect-brk flags from process.env.NODE_OPTIONS. Otherwise multiple Node.js debuggers
-            // would be started if user launch Next.js in debugging mode. The number of debuggers is linked to
-            // the number of workers Next.js tries to launch. The only worker users are interested in debugging
-            // is the main Next.js one
-            NODE_OPTIONS: getNodeOptionsWithoutInspect(),
-          },
+    const worker = new Worker(require.resolve('./static-paths-worker'), {
+      maxRetries: 1,
+      // For dev server, it's not necessary to spin up too many workers as long as you are not doing a load test.
+      // This helps reusing the memory a lot.
+      numWorkers: 1,
+      enableWorkerThreads: this.nextConfig.experimental.workerThreads,
+      forkOptions: {
+        env: {
+          ...process.env,
+          // discard --inspect/--inspect-brk flags from process.env.NODE_OPTIONS. Otherwise multiple Node.js debuggers
+          // would be started if user launch Next.js in debugging mode. The number of debuggers is linked to
+          // the number of workers Next.js tries to launch. The only worker users are interested in debugging
+          // is the main Next.js one
+          NODE_OPTIONS: getNodeOptionsWithoutInspect(),
         },
-      }
-    ) as Worker & {
+      },
+    }) as Worker & {
       loadStaticPaths: typeof import('./static-paths-worker').loadStaticPaths
     }
 
-    this.staticPathsWorker.getStdout().pipe(process.stdout)
-    this.staticPathsWorker.getStderr().pipe(process.stderr)
+    worker.getStdout().pipe(process.stdout)
+    worker.getStderr().pipe(process.stderr)
 
-    return this.staticPathsWorker
+    return worker
   }
 
   constructor(options: Options) {
@@ -976,7 +970,6 @@ export default class DevServer extends Server {
 
   protected async close(): Promise<void> {
     await this.stopWatcher()
-    await this.getStaticPathsWorker().end()
     if (this.hotReloader) {
       await this.hotReloader.stop()
     }
@@ -1661,29 +1654,35 @@ export default class DevServer extends Server {
         experimental: { enableUndici },
       } = this.nextConfig
       const { locales, defaultLocale } = this.nextConfig.i18n || {}
+      const staticPathsWorker = this.getStaticPathsWorker()
 
-      const pathsResult = await this.getStaticPathsWorker().loadStaticPaths({
-        distDir: this.distDir,
-        pathname,
-        config: {
-          configFileName,
-          publicRuntimeConfig,
-          serverRuntimeConfig,
-        },
-        httpAgentOptions,
-        enableUndici,
-        locales,
-        defaultLocale,
-        originalAppPath,
-        isAppPath,
-        requestHeaders,
-        incrementalCacheHandlerPath:
-          this.nextConfig.experimental.incrementalCacheHandlerPath,
-        fetchCacheKeyPrefix: this.nextConfig.experimental.fetchCacheKeyPrefix,
-        isrFlushToDisk: this.nextConfig.experimental.isrFlushToDisk,
-        maxMemoryCacheSize: this.nextConfig.experimental.isrMemoryCacheSize,
-      })
-      return pathsResult
+      try {
+        const pathsResult = await staticPathsWorker.loadStaticPaths({
+          distDir: this.distDir,
+          pathname,
+          config: {
+            configFileName,
+            publicRuntimeConfig,
+            serverRuntimeConfig,
+          },
+          httpAgentOptions,
+          enableUndici,
+          locales,
+          defaultLocale,
+          originalAppPath,
+          isAppPath,
+          requestHeaders,
+          incrementalCacheHandlerPath:
+            this.nextConfig.experimental.incrementalCacheHandlerPath,
+          fetchCacheKeyPrefix: this.nextConfig.experimental.fetchCacheKeyPrefix,
+          isrFlushToDisk: this.nextConfig.experimental.isrFlushToDisk,
+          maxMemoryCacheSize: this.nextConfig.experimental.isrMemoryCacheSize,
+        })
+        return pathsResult
+      } finally {
+        // we don't re-use workers so destroy the used one
+        staticPathsWorker.end()
+      }
     }
     const result = this.staticPathsCache.get(pathname)
 

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -89,51 +89,43 @@ export async function loadStaticPaths({
     )
   }
 
-  try {
-    if (isAppPath) {
-      const userland: AppRouteUserlandModule | undefined =
-        components.ComponentMod.routeModule?.userland
-      const generateParams: GenerateParams = userland
-        ? [
-            {
-              config: {
-                revalidate: userland.revalidate,
-                dynamic: userland.dynamic,
-                dynamicParams: userland.dynamicParams,
-              },
-              generateStaticParams: userland.generateStaticParams,
-              segmentPath: pathname,
+  if (isAppPath) {
+    const userland: AppRouteUserlandModule | undefined =
+      components.ComponentMod.routeModule?.userland
+    const generateParams: GenerateParams = userland
+      ? [
+          {
+            config: {
+              revalidate: userland.revalidate,
+              dynamic: userland.dynamic,
+              dynamicParams: userland.dynamicParams,
             },
-          ]
-        : await collectGenerateParams(components.ComponentMod.tree)
+            generateStaticParams: userland.generateStaticParams,
+            segmentPath: pathname,
+          },
+        ]
+      : await collectGenerateParams(components.ComponentMod.tree)
 
-      return await buildAppStaticPaths({
-        page: pathname,
-        generateParams,
-        configFileName: config.configFileName,
-        distDir,
-        requestHeaders,
-        incrementalCacheHandlerPath,
-        serverHooks,
-        staticGenerationAsyncStorage,
-        isrFlushToDisk,
-        fetchCacheKeyPrefix,
-        maxMemoryCacheSize,
-      })
-    }
-
-    return await buildStaticPaths({
+    return await buildAppStaticPaths({
       page: pathname,
-      getStaticPaths: components.getStaticPaths,
+      generateParams,
       configFileName: config.configFileName,
-      locales,
-      defaultLocale,
-    })
-  } finally {
-    setTimeout(() => {
-      // we only want to use each worker once to prevent any invalid
-      // caches
-      process.exit(1)
+      distDir,
+      requestHeaders,
+      incrementalCacheHandlerPath,
+      serverHooks,
+      staticGenerationAsyncStorage,
+      isrFlushToDisk,
+      fetchCacheKeyPrefix,
+      maxMemoryCacheSize,
     })
   }
+
+  return await buildStaticPaths({
+    page: pathname,
+    getStaticPaths: components.getStaticPaths,
+    configFileName: config.configFileName,
+    locales,
+    defaultLocale,
+  })
 }


### PR DESCRIPTION
Since exiting in `setTimeout()` can cause a race condition with sending the result from the worker and we don't want to destroy workers when trying to leverage them as it has a perf impact this ensures we create unique workers per usage and destroy them afterwards. 

x-ref: https://github.com/vercel/next.js/pull/47716
Fixes: https://github.com/vercel/next.js/issues/48061