### PR TITLE
Update App Route Signature

### DIFF
--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -395,8 +395,7 @@ export default async function exportPage({
           // Create the context for the handler. This contains the params from
           // the route and the context for the request.
           const context: AppRouteRouteHandlerContext = {
-            // Query contains the route parameters.
-            params: query,
+            params,
             staticGenerationContext: {
               nextExport: true,
               supportsDynamicHTML: false,

--- a/packages/next/src/server/future/route-matchers/route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/route-matcher.ts
@@ -4,13 +4,12 @@ import type { RouteDefinition } from '../route-definitions/route-definition'
 import { isDynamicRoute } from '../../../shared/lib/router/utils'
 import {
   getRouteMatcher,
-  type Params,
   type RouteMatchFn,
 } from '../../../shared/lib/router/utils/route-matcher'
 import { getRouteRegex } from '../../../shared/lib/router/utils/route-regex'
 
 type RouteMatchResult = {
-  params?: Params
+  params?: Record<string, string | string[]>
 }
 
 export class RouteMatcher<D extends RouteDefinition = RouteDefinition> {

--- a/packages/next/src/server/future/route-matches/route-match.ts
+++ b/packages/next/src/server/future/route-matches/route-match.ts
@@ -1,5 +1,4 @@
-import { Params } from '../../../shared/lib/router/utils/route-matcher'
-import { RouteDefinition } from '../route-definitions/route-definition'
+import type { RouteDefinition } from '../route-definitions/route-definition'
 
 /**
  * RouteMatch is the resolved match for a given request. This will contain all
@@ -13,5 +12,5 @@ export interface RouteMatch<D extends RouteDefinition = RouteDefinition> {
    * the incoming request pathname. If a route match is returned without any
    * params, it should be considered a static route.
    */
-  readonly params?: Params
+  readonly params: Record<string, string | string[]> | undefined
 }

--- a/packages/next/src/server/future/route-modules/app-route/helpers/proxy-request.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/proxy-request.ts
@@ -16,7 +16,7 @@ export function proxyRequest(
     readonly headerHooks: typeof HeaderHooks
     readonly staticGenerationBailout: typeof StaticGenerationBailout
   }
-): Request {
+): NextRequest {
   function handleNextUrlBailout(prop: string | symbol) {
     switch (prop) {
       case 'search':

--- a/packages/next/src/server/future/route-modules/app-route/module.ts
+++ b/packages/next/src/server/future/route-modules/app-route/module.ts
@@ -56,13 +56,13 @@ export type AppRouteHandlerFn = (
   /**
    * Incoming request object.
    */
-  req: Request,
+  req: NextRequest,
   /**
    * Context properties on the request (including the parameters if this was a
    * dynamic route).
    */
   ctx: AppRouteHandlerFnContext
-) => Response
+) => Promise<Response> | Response
 
 /**
  * AppRouteHandlers describes the handlers for app routes that is provided by

--- a/packages/next/src/server/future/route-modules/app-route/module.ts
+++ b/packages/next/src/server/future/route-modules/app-route/module.ts
@@ -1,4 +1,3 @@
-import type { Params } from '../../../../shared/lib/router/utils/route-matcher'
 import type { NextConfig } from '../../../config-shared'
 import type { AppRouteRouteDefinition } from '../../route-definitions/app-route-route-definition'
 import type { AppConfig } from '../../../../build/utils'
@@ -45,8 +44,8 @@ export interface AppRouteRouteHandlerContext extends RouteModuleHandleContext {
  * AppRouteHandlerFnContext is the context that is passed to the handler as the
  * second argument.
  */
-interface AppRouteHandlerFnContext {
-  params?: Params
+type AppRouteHandlerFnContext = {
+  params?: Record<string, string | string[]>
 }
 
 /**

--- a/packages/next/src/server/future/route-modules/route-module.ts
+++ b/packages/next/src/server/future/route-modules/route-module.ts
@@ -1,6 +1,5 @@
 import type { RouteDefinition } from '../route-definitions/route-definition'
 import type { NextRequest } from '../../web/spec-extension/request'
-import type { Params } from '../../../shared/lib/router/utils/route-matcher'
 
 // These are imported weirdly like this because of the way that the bundling
 // works. We need to import the built files from the dist directory, but we
@@ -34,7 +33,7 @@ export interface RouteModuleHandleContext {
    * Any matched parameters for the request. This is only defined for dynamic
    * routes.
    */
-  params: Params | undefined
+  params: Record<string, string | string[]> | undefined
 }
 
 /**

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -2100,7 +2100,10 @@ export default class NextNodeServer extends BaseServer {
       )
     }
 
-    const page: { name?: string; params?: { [key: string]: string } } = {}
+    const page: {
+      name?: string
+      params?: { [key: string]: string | string[] }
+    } = {}
 
     const match = await this.matchers.match(normalizedPathname, options)
     if (match) {

--- a/packages/next/src/server/web/types.ts
+++ b/packages/next/src/server/web/types.ts
@@ -23,7 +23,7 @@ export interface RequestData {
   }
   page?: {
     name?: string
-    params?: { [key: string]: string }
+    params?: { [key: string]: string | string[] }
   }
   url: string
   body?: ReadableStream<Uint8Array>


### PR DESCRIPTION
This updates the app route handler signature to be more correct to prevent the issue with type casting:

```diff
- (request: Request, ctx) => Response
+ (request: NextRequest, ctx) => Promise<Response> | Response
```

This also ensures that the context paramter has the correct types:

```diff
type AppRouteHandlerFnContext = {
-   params?: { [param: string]: any }
+   params?: Record<string, string | string[]>
}
```