### PR TITLE
fix: Adding search field decorator

### DIFF
--- a/examples/with-tigris/db/models/todoItems.ts
+++ b/examples/with-tigris/db/models/todoItems.ts
@@ -1,6 +1,7 @@
 import {
   Field,
   PrimaryKey,
+  SearchField,
   TigrisCollection,
   TigrisCollectionType,
   TigrisDataTypes,
@@ -11,6 +12,7 @@ export class TodoItem implements TigrisCollectionType {
   @PrimaryKey(TigrisDataTypes.INT32, { order: 1, autoGenerate: true })
   id!: number
 
+  @SearchField()
   @Field()
   text!: string
 


### PR DESCRIPTION
### Updating Tigris example

- [x] The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- [x] Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md