### PR TITLE
Improve create-next-app docs

### DIFF
--- a/docs/api-reference/create-next-app.md
+++ b/docs/api-reference/create-next-app.md
@@ -56,14 +56,26 @@ Options:
   --eslint
 
     Initialize with ESLint config.
+    
+  --no-eslint
+  
+    Initialize without ESLint config.
 
   --experimental-app
 
     Initialize as a `app/` directory project.
+    
+  --no-experimental-app
+    
+    Initialize without `app/` directory.
 
   --src-dir
 
     Initialize inside a `src/` directory.
+    
+  --no-src-dir
+  
+    Initialize without a `src/` directory.
 
   --import-alias <alias-to-configure>
 


### PR DESCRIPTION
# Documentation added

Documentation for some options of `create-next-app` was missing. This PR fixes this. 

Using the command line it is possible to generate app without interactive prompts:

```
> npx create-next-app@latest test1 --ts --use-npm --tailwind  --import-alias "@/*"  --no-eslint  --no-src-dir --no-experimental-app

Creating a new Next.js app in /Users/user/src/test1.

Using npm.

Initializing project with template: default-tw 

Installing dependencies:
- react
- react-dom
- next
- typescript
- @types/react
- @types/node
- @types/react-dom
- tailwindcss
- postcss
- autoprefixer

Success! Created test1 at /Users/user/src/test1
```

# Why?

Only some options were documented, e.g. "--src-dir" without documentation for "--no-src-dir" which makes a person guess those options. By looking at the code of `create-next-app`, one can see missing options, which were added here for better documentation.

https://github.com/vercel/next.js/blob/2d420f01a98ae6711fc0151bc3b07fb9d3053a80/packages/create-next-app/index.ts#L322
