### PR TITLE
Move normalizing of query for edge

### DIFF
--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -105,18 +105,6 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
     res: BaseNextResponse,
     parsedUrl: UrlWithParsedQuery
   ): Promise<void> {
-    for (const key of Object.keys(parsedUrl.query)) {
-      const value = parsedUrl.query[key]
-
-      if (
-        key !== NEXT_QUERY_PARAM_PREFIX &&
-        key.startsWith(NEXT_QUERY_PARAM_PREFIX)
-      ) {
-        const normalizedKey = key.substring(NEXT_QUERY_PARAM_PREFIX.length)
-        parsedUrl.query[normalizedKey] = value
-        delete parsedUrl.query[key]
-      }
-    }
     super.run(req, res, parsedUrl)
   }
   protected async hasPage(page: string) {

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -23,7 +23,6 @@ import { isDynamicRoute } from '../shared/lib/router/utils'
 import { interpolateDynamicPath, normalizeVercelUrl } from './server-utils'
 import { getNamedRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { IncrementalCache } from './lib/incremental-cache'
-import { NEXT_QUERY_PARAM_PREFIX } from '../lib/constants'
 interface WebServerOptions extends Options {
   webServerConfig: {
     page: string

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -16,6 +16,7 @@ import {
   NEXT_ROUTER_STATE_TREE,
   RSC,
 } from '../../client/components/app-router-headers'
+import { NEXT_QUERY_PARAM_PREFIX } from '../../lib/constants'
 
 declare const _ENTRIES: any
 
@@ -69,6 +70,23 @@ export async function adapter(
     headers: params.request.headers,
     nextConfig: params.request.nextConfig,
   })
+
+  for (const key of requestUrl.searchParams.keys()) {
+    const value = requestUrl.searchParams.getAll(key)
+
+    if (
+      key !== NEXT_QUERY_PARAM_PREFIX &&
+      key.startsWith(NEXT_QUERY_PARAM_PREFIX)
+    ) {
+      const normalizedKey = key.substring(NEXT_QUERY_PARAM_PREFIX.length)
+      requestUrl.searchParams.delete(normalizedKey)
+
+      for (const val of value) {
+        requestUrl.searchParams.append(normalizedKey, val)
+      }
+      requestUrl.searchParams.delete(key)
+    }
+  }
 
   // Ensure users only see page requests, never data requests.
   const buildId = requestUrl.buildId


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/48370 this just moves the normalizing to the adapter instead of the web-server so it's in a more specific place. 