### PR TITLE
fix(turbopack/transform_options): enforce default react runtime

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -158,7 +158,7 @@ pub async fn get_client_module_options_context(
     let tsconfig = get_typescript_transform_options(project_path);
     let decorators_options = get_decorators_transform_options(project_path);
     let mdx_rs_options = *next_config.mdx_rs().await?;
-    let jsx_runtime_options = get_jsx_transform_options(project_path, mdx_rs_options);
+    let jsx_runtime_options = get_jsx_transform_options(project_path);
     let enable_webpack_loaders = {
         let options = &*next_config.webpack_loaders_options().await?;
         let loaders_options = WebpackLoadersOptions {

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -235,7 +235,7 @@ pub async fn get_server_module_options_context(
     let tsconfig = get_typescript_transform_options(project_path);
     let decorators_options = get_decorators_transform_options(project_path);
     let mdx_rs_options = *next_config.mdx_rs().await?;
-    let jsx_runtime_options = get_jsx_transform_options(project_path, mdx_rs_options);
+    let jsx_runtime_options = get_jsx_transform_options(project_path);
     let enable_emotion = *get_emotion_compiler_config(next_config).await?;
     let enable_styled_components = *get_styled_components_compiler_config(next_config).await?;
 

--- a/packages/next-swc/crates/next-core/src/transform_options.rs
+++ b/packages/next-swc/crates/next-core/src/transform_options.rs
@@ -123,9 +123,17 @@ pub async fn get_decorators_transform_options(
 #[turbo_tasks::function]
 pub async fn get_jsx_transform_options(
     project_path: FileSystemPathVc,
-    is_mdx_rs_enabled: bool,
 ) -> Result<JsxTransformOptionsVc> {
     let tsconfig = get_typescript_options(project_path).await;
+
+    // [NOTE]: ref: WEB-901
+    // next.js does not allow to overriding react runtime config via tsconfig /
+    // jsconfig, it forces overrides into automatic runtime instead.
+    // [TODO]: we need to emit / validate config message as same as next.js devserver does
+    let react_transform_options = JsxTransformOptions {
+        import_source: None,
+        runtime: Some("automatic".to_string()),
+    };
 
     let react_transform_options = if let Some(tsconfig) = tsconfig {
         read_from_tsconfigs(&tsconfig, |json, _| {
@@ -133,35 +141,15 @@ pub async fn get_jsx_transform_options(
                 .as_str()
                 .map(|s| s.to_string());
 
-            // interop between tsconfig's jsx to swc's jsx runtime configuration. Swc's jsx
-            // runtime is a subset of tsconfig's jsx.
-            let runtime = if let Some(jsx_runtime) = json["compilerOptions"]["jsx"].as_str() {
-                match jsx_runtime {
-                    "react" => Some("classic".to_string()),
-                    "react-jsx" => Some("automatic".to_string()),
-                    "react-jsxdev" => Some("automatic".to_string()),
-                    _ => None,
-                }
-            } else {
-                None
-            };
-
             Some(JsxTransformOptions {
                 import_source: jsx_import_source,
-                runtime,
+                ..react_transform_options.clone()
             })
         })
         .await?
         .unwrap_or_default()
-    } else if is_mdx_rs_enabled {
-        // Mdx can implicitly includes jsx components, trying to enable jsx with default
-        // if jsx is not explicitly enabled
-        JsxTransformOptions {
-            import_source: None,
-            runtime: None,
-        }
     } else {
-        Default::default()
+        react_transform_options
     };
 
     Ok(react_transform_options.cell())

--- a/packages/next-swc/crates/next-core/src/transform_options.rs
+++ b/packages/next-swc/crates/next-core/src/transform_options.rs
@@ -129,7 +129,7 @@ pub async fn get_jsx_transform_options(
     // [NOTE]: ref: WEB-901
     // next.js does not allow to overriding react runtime config via tsconfig /
     // jsconfig, it forces overrides into automatic runtime instead.
-    // [TODO]: we need to emit / validate config message as same as next.js devserver does
+    // [TODO]: we need to emit / validate config message like next.js devserver does
     let react_transform_options = JsxTransformOptions {
         import_source: None,
         runtime: Some("automatic".to_string()),


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change




### How?

Closes NEXT-
Fixes #

-->

### What?

This PR enforces turbopack uses `automatic` jsx runtime.

- closes WEB-901.

### Why?

If you set `ts|jsconfig`'s `jsx` to any custom value, you'll encounter next.js message

```
The following mandatory changes were made to your tsconfig.json:

	- jsx was set to preserve (next.js implements its own optimized jsx transform)
```

Then internally transform sets jsx to use automatic runtime instead. In case of turbopack, its transform pass is embedded so instead of setting it to preserve falls back to automatic by default. PR doesn't handle validations / or emitting user friendly messages yet, just enforce runtime config regardless of how user sets it.

There maybe some additional followups to mimic exact transform existing next.js does.