### PR TITLE
Add `pg` (Postgres) to server components external packages.

### DIFF
--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -19,6 +19,7 @@
   "mongodb",
   "next-mdx-remote",
   "next-seo",
+  "pg",
   "postcss",
   "prettier",
   "prisma",

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -151,7 +151,7 @@ export interface ExperimentalConfig {
   externalDir?: boolean
   /**
    * The App Router (app directory) enables support for layouts, Server Components, streaming, and colocated data fetching.
-   * @see https://beta.nextjs.org/docs/api-reference/next.config.js#appdir
+   * @see https://beta.nextjs.org/docs/api-reference/next-config#appdir
    */
   appDir?: boolean
   amp?: {
@@ -195,7 +195,7 @@ export interface ExperimentalConfig {
 
   /**
    * A list of packages that should be treated as external in the RSC server build.
-   * @see https://beta.nextjs.org/docs/api-reference/next.config.js#servercomponentsexternalpackages
+   * @see https://beta.nextjs.org/docs/api-reference/next-config#servercomponentsexternalpackages
    */
   serverComponentsExternalPackages?: string[]
 
@@ -222,14 +222,14 @@ export interface ExperimentalConfig {
 
   /**
    * For use with `@next/mdx`. Compile MDX files using the new Rust compiler.
-   * @see https://beta.nextjs.org/docs/api-reference/next.config.js#mdxrs
+   * @see https://beta.nextjs.org/docs/api-reference/next-config#mdxrs
    */
   mdxRs?: boolean
 
   /**
    * Generate Route types and enable type checking for Link and Router.push, etc.
    * This option requires `appDir` to be enabled first.
-   * @see https://beta.nextjs.org/docs/api-reference/next.config.js#typedroutes
+   * @see https://beta.nextjs.org/docs/api-reference/next-config#typedroutes
    */
   typedRoutes?: boolean
 


### PR DESCRIPTION
While exploring using [Drizzle](https://github.com/drizzle-team/drizzle-orm/blob/main/drizzle-orm/src/pg-core/README.md#using-drizzle-orm-in-nextjs-app-router) with the App Router, I noticed they have a callout for needing to explicitly add `pg` to `serverComponentsExternalPackages`.

Adding `pg` here prevents manually needing to modify your configuration.