### PR TITLE
parallel routes: fix catch-all routes taking precedence in dev

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2044,8 +2044,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
     let page = pathname
     if (isAppPath) {
-      // When it's an array, we need to pass all parallel routes to the loader.
-      page = appPaths[0]
+      // the last item in the array is the root page, if there are parallel routes
+      page = appPaths[appPaths.length - 1]
     }
 
     const result = await this.findPageComponents({

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/@slot/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/@slot/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'slot catchall'
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/@slot/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/@slot/default.tsx
@@ -1,0 +1,7 @@
+export default function Default() {
+  return (
+    <div>
+      <div>Default</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/@slot/foo/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/@slot/foo/page.tsx
@@ -1,0 +1,3 @@
+export default function Foo() {
+  return 'foo slot'
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'main catchall'
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/foo/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/foo/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'foo'
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/layout.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default function Layout({ children, slot }) {
+  return (
+    <div>
+      <div>Main content</div>
+      <div id="main">{children}</div>
+      <div>
+        Slot content:
+        <div id="slot-content">{slot}</div>
+      </div>
+
+      <div>
+        <Link href="/parallel-catchall/foo">foo</Link>
+      </div>
+      <div>
+        <Link href="/parallel-catchall/bar">catchall bar</Link>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <div>Page</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -255,6 +255,37 @@ createNextDescribe(
         // check that we didn't scroll back to the top
         await check(() => browser.eval('window.scrollY'), position)
       })
+
+      it('should apply the catch-all route to the parallel route if no matching route is found', async () => {
+        const browser = await next.browser('/parallel-catchall')
+
+        await browser.elementByCss('[href="/parallel-catchall/bar"]').click()
+        await check(
+          () => browser.waitForElementByCss('#main').text(),
+          'main catchall'
+        )
+        await check(
+          () => browser.waitForElementByCss('#slot-content').text(),
+          'slot catchall'
+        )
+
+        await browser.elementByCss('[href="/parallel-catchall/foo"]').click()
+        await check(() => browser.waitForElementByCss('#main').text(), 'foo')
+        await check(
+          () => browser.waitForElementByCss('#slot-content').text(),
+          'foo slot'
+        )
+
+        await browser.elementByCss('[href="/parallel-catchall/bar"]').click()
+        await check(
+          () => browser.waitForElementByCss('#main').text(),
+          'main catchall'
+        )
+        await check(
+          () => browser.waitForElementByCss('#slot-content').text(),
+          'slot catchall'
+        )
+      })
     })
 
     describe('route intercepting', () => {


### PR DESCRIPTION
This PR fixes a bug in dev with parallel routes when the given conditions were met:
- you have a catch-all route and a more specific route
- you navigated to a catch-all route
- you navigate to the specific route that should take priority over the catch-all

in this case, the route renderer would try to match with an incorrect slot path and fallback to the catch all path

the fix makes the route renderer use the correct path, aka the last path of the appPaths arrays for a given route

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

link NEXT-1019