### PR TITLE
interception routes: support middleware rewrites

### DIFF
--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -10,6 +10,16 @@ const segmentToPathname = (segment: Segment): string => {
   return segment[1]
 }
 
+function normalizePathname(pathname: string): string {
+  return pathname.split('/').reduce((acc, segment) => {
+    if (segment === '' || (segment.startsWith('(') && segment.endsWith(')'))) {
+      return acc
+    }
+
+    return `${acc}/${segment}`
+  }, '')
+}
+
 export function extractPathFromFlightRouterState(
   flightRouterState: FlightRouterState
 ): string | undefined {
@@ -47,10 +57,8 @@ export function extractPathFromFlightRouterState(
     }
   }
 
-  const finalPath = path.join('/')
-
-  // it'll end up including a trailing slash because of '__PAGE__'
-  return finalPath.endsWith('/') ? finalPath.slice(0, -1) : finalPath
+  // TODO-APP: optimise this, it's not ideal to join and split
+  return normalizePathname(path.join('/'))
 }
 
 function computeChangedPathImpl(
@@ -103,11 +111,5 @@ export function computeChangedPath(
   }
 
   // lightweight normalization to remove route groups
-  return changedPath.split('/').reduce((acc, segment) => {
-    if (segment === '' || (segment.startsWith('(') && segment.endsWith(')'))) {
-      return acc
-    }
-
-    return `${acc}/${segment}`
-  }, '')
+  return normalizePathname(changedPath)
 }

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -5,6 +5,7 @@ import type { FlightRouterState } from '../../../server/app-render/types'
 import { CacheStates } from '../../../shared/lib/app-router-context'
 import { createHrefFromUrl } from './create-href-from-url'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
+import { extractPathFromFlightRouterState } from './compute-changed-path'
 
 export interface InitialRouterStateParameters {
   initialTree: FlightRouterState
@@ -51,6 +52,9 @@ export function createInitialRouterState({
         ? // window.location does not have the same type as URL but has all the fields createHrefFromUrl needs.
           createHrefFromUrl(location)
         : initialCanonicalUrl,
-    nextUrl: location?.pathname ?? null,
+    nextUrl:
+      // the || operator is intentional, the pathname can be an empty string
+      (extractPathFromFlightRouterState(initialTree) || location?.pathname) ??
+      null,
   }
 }

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/@modal/(.)feed/page.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/@modal/(.)feed/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'intercepted'
+}

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/@modal/default.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/@modal/default.tsx
@@ -1,0 +1,1 @@
+export default () => null

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/feed/page.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/feed/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'not intercepted'
+}

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/layout.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/layout.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Layout({ children, modal, params }) {
+  return (
+    <>
+      <div>
+        <Link href="/feed">feed</Link>
+      </div>
+      <div>{params.lang}</div>
+      <div id="children">{children}</div>
+      <div id="modal">{modal}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/page.ts
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/page.ts
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'root'
+}

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/layout.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/layout.tsx
@@ -1,0 +1,10 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>
+        <div>{children}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/page.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'should not be rendered'
+}

--- a/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
+++ b/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
@@ -1,0 +1,35 @@
+import { createNextDescribe } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+createNextDescribe(
+  'interception-middleware-rewrite',
+  {
+    files: __dirname,
+    // TODO: remove after deployment handling is updated
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should support intercepting routes with a middleware rewrite', async () => {
+      const browser = await next.browser('/')
+
+      await check(() => browser.waitForElementByCss('#children').text(), 'root')
+
+      await check(
+        () =>
+          browser
+            .elementByCss('[href="/feed"]')
+            .click()
+            .waitForElementByCss('#modal')
+            .text(),
+        'intercepted'
+      )
+
+      await check(
+        () => browser.refresh().waitForElementByCss('#children').text(),
+        'not intercepted'
+      )
+
+      await check(() => browser.waitForElementByCss('#modal').text(), '')
+    })
+  }
+)

--- a/test/e2e/app-dir/interception-middleware-rewrite/middleware.ts
+++ b/test/e2e/app-dir/interception-middleware-rewrite/middleware.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+
+export default function middleware(req) {
+  if (!req.nextUrl.pathname.startsWith('/en')) {
+    return NextResponse.rewrite(new URL(`/en${req.nextUrl.pathname}`, req.url))
+  }
+}
+
+export const config = {
+  matcher: [
+    '/((?!api|_next/static|favicon|.well-known|auth|sitemap|robots.txt|files).*)',
+  ],
+}

--- a/test/e2e/app-dir/interception-middleware-rewrite/next.config.js
+++ b/test/e2e/app-dir/interception-middleware-rewrite/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: { appDir: true },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/interception-middleware-rewrite/tsconfig.json
+++ b/test/e2e/app-dir/interception-middleware-rewrite/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR fixes an edge case when using interception routes and rewrites. The issue was that the default state of the router tree incorrectly assumed that the base pathname would be the referrer URL for the interception but it turns out the tree/what we want to intercept can be different in the case of a rewrite.

The fix consists of using the same method that we use to extract the pathname from the current tree so that we can get the correct referrer pathname.

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

fix #48396
link NEXT-1018