### PR TITLE
interception routes: fix production rewrites

### DIFF
--- a/packages/next/src/lib/generate-interception-routes-rewrites.ts
+++ b/packages/next/src/lib/generate-interception-routes-rewrites.ts
@@ -1,6 +1,7 @@
 import { pathToRegexp } from 'next/dist/compiled/path-to-regexp'
 import { NEXT_URL } from '../client/components/app-router-headers'
 import {
+  INTERCEPTION_ROUTE_MARKERS,
   extractInterceptionRouteInformation,
   isInterceptionRouteAppPath,
 } from '../server/future/helpers/interception-routes'
@@ -9,6 +10,31 @@ import { Rewrite } from './load-custom-routes'
 // a function that converts normalised paths (e.g. /foo/[bar]/[baz]) to the format expected by pathToRegexp (e.g. /foo/:bar/:baz)
 function toPathToRegexpPath(path: string): string {
   return path.replace(/\[([^\]]+)\]/g, ':$1')
+}
+
+// for interception routes we don't have access to the dynamic segments from the
+// referrer route so we mark them as noop for the app renderer so that it
+// can retrieve them from the router state later on. This also allows us to
+// compile the route properly with path-to-regexp, otherwise it will throw
+function voidParamsBeforeInterceptionMarker(path: string): string {
+  let newPath = []
+
+  let foundInterceptionMarker = false
+  for (const segment of path.split('/')) {
+    if (
+      INTERCEPTION_ROUTE_MARKERS.find((marker) => segment.startsWith(marker))
+    ) {
+      foundInterceptionMarker = true
+    }
+
+    if (segment.startsWith(':') && !foundInterceptionMarker) {
+      newPath.push('__NEXT_EMPTY_PARAM__')
+    } else {
+      newPath.push(segment)
+    }
+  }
+
+  return newPath.join('/')
 }
 
 export function generateInterceptionRoutesRewrites(
@@ -26,7 +52,9 @@ export function generateInterceptionRoutesRewrites(
       }/(.*)?`
 
       const normalizedInterceptedRoute = toPathToRegexpPath(interceptedRoute)
-      const normalizedAppPath = toPathToRegexpPath(appPath)
+      const normalizedAppPath = voidParamsBeforeInterceptionMarker(
+        toPathToRegexpPath(appPath)
+      )
 
       // pathToRegexp returns a regex that matches the path, but we need to
       // convert it to a string that can be used in a header value

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -231,23 +231,16 @@ export function prepareDestination(args: {
 
   let newUrl
 
-  // for interception routes we don't have access to the dynamic segments from the
-  // referrer route so we mark them as noop for the app renderer so that it
-  // can retrieve them from the router state later on. This also allows us to
-  // compile the route properly with path-to-regexp, otherwise it will throw
-  // The compiler also thinks that the interception route marker is an unnamed param, hence '0',
+  // The compiler also that the interception route marker is an unnamed param, hence '0',
   // so we need to add it to the params object.
   if (isInterceptionRouteAppPath(destPath)) {
-    main: for (const segment of destPath.split('/')) {
-      for (const marker of INTERCEPTION_ROUTE_MARKERS) {
-        if (segment.startsWith(marker)) {
-          args.params['0'] = marker
-          break main
-        }
-      }
-      if (segment.startsWith(':')) {
-        const param = segment.slice(1)
-        args.params[param] = '__NEXT_EMPTY_PARAM__'
+    for (const segment of destPath.split('/')) {
+      const marker = INTERCEPTION_ROUTE_MARKERS.find((m) =>
+        segment.startsWith(m)
+      )
+      if (marker) {
+        args.params['0'] = marker
+        break
       }
     }
   }

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -5,8 +5,6 @@ createNextDescribe(
   'parallel-routes-and-interception',
   {
     files: __dirname,
-    // TODO: remove after deployment handling is updated
-    skipDeployment: true,
   },
   ({ next }) => {
     describe('parallel routes', () => {


### PR DESCRIPTION
This PR fixes a bug with interception where the rewritten path passed an incorrect segment data on production, resulting in a 404.

The fix consists of moving the rewrite pre-processing step that rewrites the dynamic segment from the originating path to when we actually generate the rewrite. This is needed because that step does not run on production. Now it does and signals correctly to the app-render that the value for the segment can be determined from the path.

Also enables prod testing, which I had forgotten to enable.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

fix #48406
link NEXT-1017