### PR TITLE
Improve types for internal routes in build process.

### DIFF
--- a/packages/next/src/lib/load-custom-routes.ts
+++ b/packages/next/src/lib/load-custom-routes.ts
@@ -44,6 +44,7 @@ export type Redirect = {
   locale?: false
   has?: RouteHas[]
   missing?: RouteHas[]
+  internal?: true // used to indicate this is a redirect from a custom route
 } & (
   | {
       statusCode?: never
@@ -688,14 +689,14 @@ export default async function loadCustomRoutes(
               key: 'x-nextjs-data',
             },
           ],
-        } as Redirect,
+        },
         {
           source: '/:notfile((?!\\.well-known(?:/.*)?)(?:[^/]+/)*[^/\\.]+)',
           destination: '/:notfile/',
           permanent: true,
           locale: config.i18n ? false : undefined,
           internal: true,
-        } as Redirect
+        }
       )
       if (config.basePath) {
         redirects.unshift({
@@ -705,7 +706,7 @@ export default async function loadCustomRoutes(
           basePath: false,
           locale: config.i18n ? false : undefined,
           internal: true,
-        } as Redirect)
+        })
       }
     } else {
       redirects.unshift({
@@ -714,7 +715,7 @@ export default async function loadCustomRoutes(
         permanent: true,
         locale: config.i18n ? false : undefined,
         internal: true,
-      } as Redirect)
+      })
       if (config.basePath) {
         redirects.unshift({
           source: config.basePath + '/',
@@ -723,7 +724,7 @@ export default async function loadCustomRoutes(
           basePath: false,
           locale: config.i18n ? false : undefined,
           internal: true,
-        } as Redirect)
+        })
       }
     }
   }


### PR DESCRIPTION
# Improve types for internal routes in build file

### What?
Removes unnecessary typescript `any`'s in the build process, also fix some comments which weren't correct.
Renamed param `r` to route as it could be interpreted as 'route', 'rewrite' or 'redirect'.

### Why?
When looking through the build file I saw some `any`'s which seemed not necessary and made the code more prone to errors and developer mistakes. If a property like `internal` can be added to an object, the types should reflect this and not mark them as `any` or typecast them to the same type.
