### PR TITLE
Fix turbo cache for @next/env

### DIFF
--- a/packages/next-env/package.json
+++ b/packages/next-env/package.json
@@ -16,15 +16,14 @@
   "author": "Next.js Team <support@vercel.com>",
   "license": "MIT",
   "main": "dist/index.js",
-  "types": "types/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
-    "dist",
-    "types"
+    "dist"
   ],
   "scripts": {
     "dev": "ncc build ./index.ts -w -o dist/",
     "prerelease": "rimraf ./dist/",
-    "types": "tsc index.ts --declaration --emitDeclarationOnly --declarationDir types --esModuleInterop",
+    "types": "tsc index.ts --declaration --emitDeclarationOnly --declarationDir dist --esModuleInterop",
     "release": "ncc build ./index.ts -o ./dist/ --minify --no-cache --no-source-map-register",
     "build": "pnpm release && pnpm types",
     "prepublishOnly": "cd ../../ && turbo run build",


### PR DESCRIPTION
While testing workflow changes noticed that when turborepo cache is leveraged the `@next/env` types are missing causing unexpected failures since the types aren't stored in the `dist` folder which is all that is cached for the build step. 

x-ref: https://github.com/vercel/next.js/commits/ijjk/update-ci-workflow