### PR TITLE
Support postcss.config.mjs

### DIFF
--- a/test/unit/find-config.test.ts
+++ b/test/unit/find-config.test.ts
@@ -15,11 +15,23 @@ describe('find config', () => {
     expect(config).toEqual({ foo: 'bar' })
   })
 
+  // TODO: https://github.com/nodejs/node/issues/35889
+  it.skip('should resolve rc.mjs', async () => {
+    const config = await findConfig(join(fixtureDir, 'config-mjs'), 'test')
+    expect(config).toEqual({ foo: 'bar' })
+  })
+
   it('should resolve .config.json', async () => {
     const config = await findConfig(
       join(fixtureDir, 'config-long-json'),
       'test'
     )
+    expect(config).toEqual({ foo: 'bar' })
+  })
+
+  // TODO: https://github.com/nodejs/node/issues/35889
+  it.skip('should resolve .config.mjs', async () => {
+    const config = await findConfig(join(fixtureDir, 'config-long-mjs'), 'test')
     expect(config).toEqual({ foo: 'bar' })
   })
 

--- a/test/unit/fixtures/config-esm/.testrc.js
+++ b/test/unit/fixtures/config-esm/.testrc.js
@@ -1,0 +1,1 @@
+export default { foo: 'bar' }

--- a/test/unit/fixtures/config-esm/package.json
+++ b/test/unit/fixtures/config-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/unit/fixtures/config-long-esm/package.json
+++ b/test/unit/fixtures/config-long-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/unit/fixtures/config-long-esm/test.config.js
+++ b/test/unit/fixtures/config-long-esm/test.config.js
@@ -1,0 +1,1 @@
+export default { foo: 'bar' }

--- a/test/unit/fixtures/config-long-mjs/test.config.mjs
+++ b/test/unit/fixtures/config-long-mjs/test.config.mjs
@@ -1,0 +1,1 @@
+export default { foo: 'bar' }

--- a/test/unit/fixtures/config-mjs/.testrc.mjs
+++ b/test/unit/fixtures/config-mjs/.testrc.mjs
@@ -1,0 +1,1 @@
+export default { foo: 'bar' }


### PR DESCRIPTION
### What?

postcss.config.* also supports mjs but not Next.js.

### How?

Add mjs support to `findConfig`.