### PR TITLE
feat(turbopack): support modularizeImports next.js config

### DIFF
--- a/packages/next-swc/crates/next-core/Cargo.toml
+++ b/packages/next-swc/crates/next-core/Cargo.toml
@@ -22,6 +22,7 @@ indoc = { workspace = true }
 allsorts = { workspace = true }
 futures = { workspace = true }
 turbo-binding = { workspace = true, features = [
+  "__swc_transform_modularize_imports",
   "__feature_auto_hash_map",
   "__turbo_tasks",
   "__turbo_tasks_bytes",
@@ -36,19 +37,20 @@ turbo-binding = { workspace = true, features = [
   "__turbopack_ecmascript",
   "__turbopack_env",
   "__turbopack_node",
-  ] }
+] }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 next-transform-strip-page-exports = { workspace = true }
 next-transform-font = { workspace = true }
 next-transform-dynamic = { workspace = true }
 
-swc_core = { workspace = true, features = ["ecma_ast", "common"] }
+swc_core = { workspace = true, features = [
+  "ecma_ast",
+  "common",
+] }
 
 [build-dependencies]
-turbo-binding = { workspace = true, features = [
-  "__turbo_tasks_build"
-]}
+turbo-binding = { workspace = true, features = ["__turbo_tasks_build"] }
 
 [features]
 next-font-local = []
@@ -61,4 +63,3 @@ dynamic_embed_contents = [
   "turbo-binding/__turbo_tasks_fs_dynamic_embed_contents",
   "turbo-binding/__turbopack_dev_dynamic_embed_contents",
 ]
-

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -147,7 +147,7 @@ pub async fn get_client_module_options_context(
     ty: Value<ClientContextType>,
     next_config: NextConfigVc,
 ) -> Result<ModuleOptionsContextVc> {
-    let custom_rules = get_next_client_transforms_rules(ty.into_value()).await?;
+    let custom_rules = get_next_client_transforms_rules(next_config, ty.into_value()).await?;
     let resolve_options_context =
         get_client_resolve_options_context(project_path, ty, next_config, execution_context);
     let enable_react_refresh =

--- a/packages/next-swc/crates/next-core/src/next_client/transforms.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/transforms.rs
@@ -4,18 +4,25 @@ use turbo_binding::turbopack::turbopack::module_options::ModuleRule;
 
 use crate::{
     next_client::context::ClientContextType,
+    next_config::NextConfigVc,
     next_shared::transforms::{
         get_next_dynamic_transform_rule, get_next_font_transform_rule,
-        get_next_pages_transforms_rule,
+        get_next_modularize_imports_rule, get_next_pages_transforms_rule,
     },
 };
 
 /// Returns a list of module rules which apply client-side, Next.js-specific
 /// transforms.
 pub async fn get_next_client_transforms_rules(
+    next_config: NextConfigVc,
     context_ty: ClientContextType,
 ) -> Result<Vec<ModuleRule>> {
     let mut rules = vec![];
+
+    let modularize_imports_config = &next_config.await?.modularize_imports;
+    if let Some(modularize_imports_config) = modularize_imports_config {
+        rules.push(get_next_modularize_imports_rule(modularize_imports_config));
+    }
 
     rules.push(get_next_font_transform_rule());
 

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -41,7 +41,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::json::parse_json_with_source_context;
 
-use crate::embed_js::next_asset;
+use crate::{embed_js::next_asset, next_shared::transforms::ModularizeImportPackageConfig};
 
 #[turbo_tasks::value(serialization = "custom", eq = "manual")]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -57,6 +57,7 @@ pub struct NextConfig {
     pub react_strict_mode: Option<bool>,
     pub rewrites: Rewrites,
     pub transpile_packages: Option<Vec<String>>,
+    pub modularize_imports: Option<IndexMap<String, ModularizeImportPackageConfig>>,
 
     // Partially supported
     pub compiler: Option<CompilerConfig>,
@@ -385,7 +386,6 @@ pub struct ExperimentalConfig {
     legacy_browsers: Option<bool>,
     manual_client_base_path: Option<bool>,
     middleware_prefetch: Option<MiddlewarePrefetchType>,
-    modularize_imports: Option<serde_json::Value>,
     new_next_link_behavior: Option<bool>,
     next_script_workers: Option<bool>,
     optimistic_client_cache: Option<bool>,

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -209,7 +209,7 @@ pub async fn get_server_module_options_context(
     ty: Value<ServerContextType>,
     next_config: NextConfigVc,
 ) -> Result<ModuleOptionsContextVc> {
-    let custom_rules = get_next_server_transforms_rules(ty.into_value()).await?;
+    let custom_rules = get_next_server_transforms_rules(next_config, ty.into_value()).await?;
     let foreign_code_context_condition = foreign_code_context_condition(next_config).await?;
     let enable_postcss_transform = Some(PostCssTransformOptions {
         postcss_package: Some(get_postcss_package_mapping(project_path)),

--- a/packages/next-swc/crates/next-core/src/next_server/transforms.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/transforms.rs
@@ -3,19 +3,27 @@ use next_transform_strip_page_exports::ExportFilter;
 use turbo_binding::turbopack::turbopack::module_options::ModuleRule;
 
 use crate::{
+    next_config::NextConfigVc,
     next_server::context::ServerContextType,
     next_shared::transforms::{
         get_next_dynamic_transform_rule, get_next_font_transform_rule,
-        get_next_pages_transforms_rule,
+        get_next_modularize_imports_rule, get_next_pages_transforms_rule,
     },
 };
 
 /// Returns a list of module rules which apply server-side, Next.js-specific
 /// transforms.
 pub async fn get_next_server_transforms_rules(
+    next_config: NextConfigVc,
     context_ty: ServerContextType,
 ) -> Result<Vec<ModuleRule>> {
-    let mut rules = vec![get_next_font_transform_rule()];
+    let mut rules = vec![];
+
+    let modularize_imports_config = &next_config.await?.modularize_imports;
+    if let Some(modularize_imports_config) = modularize_imports_config {
+        rules.push(get_next_modularize_imports_rule(modularize_imports_config));
+    }
+    rules.push(get_next_font_transform_rule());
 
     let (is_server_components, pages_dir) = match context_ty {
         ServerContextType::Pages { pages_dir } => (false, Some(pages_dir)),

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -7,6 +7,7 @@ const supportedTurbopackNextConfigOptions = [
   'configFileName',
   'env',
   'experimental.appDir',
+  'modularizeImports',
   'compiler.emotion',
   'compiler.styledComponents',
   'experimental.serverComponentsExternalPackages',


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change



### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Attempt to close WEB-920.

This PR implements next.config.js's `modularizeImports` option to turbopack. It tries to read next.config.js, and then apply transforms as same as `next-swc` does. Internally it interops betwen next.config.js's PackageConfig to swc's PackageConfigs, as it doesn't have necessary attributes for the Vcs / deserialization.
