### PR TITLE
refactor: Move transforms and compile time info into `EcmascriptOption`

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "serde",
 ]
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "serde",
@@ -6688,7 +6688,7 @@ dependencies = [
 [[package]]
 name = "turbo-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -6725,7 +6725,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "mimalloc",
 ]
@@ -6733,7 +6733,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6763,7 +6763,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6790,7 +6790,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6804,7 +6804,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -6821,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6850,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "base16",
  "hex",
@@ -6862,7 +6862,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -6876,7 +6876,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6886,7 +6886,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6908,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -6920,7 +6920,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6946,7 +6946,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -6976,7 +6976,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -6993,7 +6993,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7020,7 +7020,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7055,7 +7055,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7075,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7109,7 +7109,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7145,7 +7145,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7161,7 +7161,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "serde",
@@ -7176,7 +7176,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7191,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7225,7 +7225,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "serde",
@@ -7241,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7252,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230414.4#f09057dac5eee416fdfe04c02b1e51b478d189bc"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/web-726-move-transforms-and-compile_time_info#348d53ea65867a556e5e1569f9581e9a5622527d"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/packages/next-swc/Cargo.toml
+++ b/packages/next-swc/Cargo.toml
@@ -47,11 +47,11 @@ swc_emotion = { version = "0.29.10" }
 testing = { version = "0.31.31" }
 
 # Turbo crates
-turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230414.4" }
+turbo-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/web-726-move-transforms-and-compile_time_info" } # last tag: "turbopack-230414.4"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230414.4" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/web-726-move-transforms-and-compile_time_info" } # last tag: "turbopack-230414.4"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230414.4" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/web-726-move-transforms-and-compile_time_info" } # last tag: "turbopack-230414.4"
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230414.4",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230414.4",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?348d53ea65867a556e5e1569f9581e9a5622527d",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?348d53ea65867a556e5e1569f9581e9a5622527d",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1012,8 +1012,8 @@ importers:
       '@types/react': ^18.0.26
       '@types/react-dom': ^18.0.9
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230414.4
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230414.4
+      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?348d53ea65867a556e5e1569f9581e9a5622527d
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?348d53ea65867a556e5e1569f9581e9a5622527d
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1025,8 +1025,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230414.4_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230414.4'
+      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?348d53ea65867a556e5e1569f9581e9a5622527d_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?348d53ea65867a556e5e1569f9581e9a5622527d'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -5986,7 +5986,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.2.1
       source-map: 0.7.3
-      webpack: 5.74.0
+      webpack: 5.74.0_@swc+core@1.2.203
     transitivePeerDependencies:
       - supports-color
 
@@ -6652,7 +6652,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-android-arm64/1.2.203:
@@ -6661,7 +6660,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-arm64/1.2.203:
@@ -6670,7 +6668,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64/1.2.203:
@@ -6679,7 +6676,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-freebsd-x64/1.2.203:
@@ -6688,7 +6684,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.2.203:
@@ -6697,7 +6692,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.2.203:
@@ -6706,7 +6700,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl/1.2.203:
@@ -6715,7 +6708,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu/1.2.203:
@@ -6724,7 +6716,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl/1.2.203:
@@ -6733,7 +6724,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.2.203:
@@ -6742,7 +6732,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.2.203:
@@ -6751,7 +6740,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc/1.2.203:
@@ -6760,7 +6748,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core/1.2.203:
@@ -6781,7 +6768,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.2.203
       '@swc/core-win32-ia32-msvc': 1.2.203
       '@swc/core-win32-x64-msvc': 1.2.203
-    dev: true
 
   /@swc/helpers/0.4.11:
     resolution: {integrity: sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==}
@@ -23779,7 +23765,6 @@ packages:
       source-map: 0.6.1
       terser: 5.14.1
       webpack: 5.74.0_@swc+core@1.2.203
-    dev: true
 
   /terser-webpack-plugin/5.2.4_webpack@5.74.0:
     resolution: {integrity: sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==}
@@ -25185,7 +25170,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /websocket-driver/0.7.3:
     resolution: {integrity: sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==}
@@ -25583,9 +25567,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230414.4_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230414.4}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230414.4'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?348d53ea65867a556e5e1569f9581e9a5622527d_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?348d53ea65867a556e5e1569f9581e9a5622527d}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?348d53ea65867a556e5e1569f9581e9a5622527d'
     name: '@vercel/turbopack-dev'
     version: 0.0.0
     dependencies:
@@ -25595,8 +25579,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230414.4':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230414.4}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?348d53ea65867a556e5e1569f9581e9a5622527d':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?348d53ea65867a556e5e1569f9581e9a5622527d}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION

### What?

This PR reflects feedback from https://github.com/vercel/turbo/pull/3338. (https://github.com/vercel/turbo/pull/3338#discussion_r1138234264)

turbopack counterpart: https://github.com/vercel/turbo/pull/4596

### Why?

### How?

 - Closes WEB-726

