### PR TITLE
Fix static opt of routes generation for static metadata files

### DIFF
--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -32,8 +32,7 @@ export function normalizeMetadataRoute(page: string) {
   let route = page
   if (isMetadataRoute(page)) {
     // Remove the file extension, e.g. /route-path/robots.txt -> /route-path
-    const { dir, name: baseName, ext } = path.parse(page)
-    const pathnamePrefix = page.slice(0, -(baseName.length + 1))
+    const pathnamePrefix = page.slice(0, -(path.basename(page).length + 1))
     const suffix = getMetadataRouteSuffix(pathnamePrefix)
 
     if (route === '/sitemap') {
@@ -48,7 +47,8 @@ export function normalizeMetadataRoute(page: string) {
     // Support both /<metadata-route.ext> and custom routes /<metadata-route>/route.ts.
     // If it's a metadata file route, we need to append /[id]/route to the page.
     if (!route.endsWith('/route')) {
-      const isStaticMetadataFile = isMetadataRouteFile(page, [], true)
+      const isStaticMetadataFile = isMetadataRouteFile(route, [], true)
+      const { dir, name: baseName, ext } = path.parse(route)
 
       const isSingleRoute =
         page.startsWith('/sitemap') ||

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,4 @@
 !node_modules
 .vscode
+
+e2e/**/tsconfig.json

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -782,6 +782,28 @@ createNextDescribe(
       }
     })
 
+    if (isNextStart) {
+      describe('static optimization', () => {
+        it('should build static files into static route', async () => {
+          expect(
+            await next.hasFile(
+              '.next/server/app/opengraph/static/opengraph-image.png.meta'
+            )
+          ).toBe(true)
+          expect(
+            await next.hasFile(
+              '.next/server/app/opengraph/static/opengraph-image.png.body'
+            )
+          ).toBe(true)
+          expect(
+            await next.hasFile(
+              '.next/server/app/opengraph/static/opengraph-image.png/[[...__metadata_id__]]/route.js'
+            )
+          ).toBe(false)
+        })
+      })
+    }
+
     describe('react cache', () => {
       it('should have same title and page value on initial load', async () => {
         const browser = await next.browser('/cache-deduping')

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -384,6 +384,9 @@ export class NextInstance {
   }
 
   // TODO: block these in deploy mode
+  public async hasFile(filename: string) {
+    return fs.pathExists(path.join(this.testDir, filename))
+  }
   public async readFile(filename: string) {
     return fs.readFile(path.join(this.testDir, filename), 'utf8')
   }


### PR DESCRIPTION
x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1681781435607369)

For static metadata files, we should always generate static routes instead of generate dynamic routes, so that they won't be deployed as serverless functions which executing file reading in deployment