### PR TITLE
clarity on _document <Head>

### DIFF
--- a/docs/advanced-features/custom-document.md
+++ b/docs/advanced-features/custom-document.md
@@ -44,7 +44,7 @@ Or add a `className` to the `body` tag:
 
 ## Caveats
 
-- The `<Head />` component used in `_document` is not the same as [`next/head`](/docs/api-reference/next/head.md). The `<Head />` component used here should only be used for any `<head>` code that is common for all pages. For all other cases, such as `<title>` tags, we recommend using [`next/head`](/docs/api-reference/next/head.md) in your pages or components.
+- The `<Head />` component used in `_document` is not the same as [`next/head`](/docs/api-reference/next/head.md), do not add <meta> or <title> tags here.
 - React components outside of `<Main />` will not be initialized by the browser. Do _not_ add application logic here or custom CSS (like `styled-jsx`). If you need shared components in all your pages (like a menu or a toolbar), read [Layouts](/docs/basic-features/layouts.md) instead.
 - `Document` currently does not support Next.js [Data Fetching methods](/docs/basic-features/data-fetching/overview.md) like [`getStaticProps`](/docs/basic-features/data-fetching/get-static-props.md) or [`getServerSideProps`](/docs/basic-features/data-fetching/get-server-side-props.md).
 


### PR DESCRIPTION
Fix _document head usage.

### What?

Fix clarity on to avoid using the _document Head for meta tags, scripts, or titles.

### Why?

Using the Head component here and the _app.js causes duplicate utf-8 meta tags.