### PR TITLE
Adding missing fields to the `Manifest` type

### DIFF
--- a/packages/next/src/lib/metadata/types/manifest-types.ts
+++ b/packages/next/src/lib/metadata/types/manifest-types.ts
@@ -1,6 +1,36 @@
+type ManifestCategory = 
+    | "books"
+    | "business"
+    | "education"
+    | "entertainment"
+    | "finance"
+    | "fitness"
+    | "food"
+    | "games"
+    | "government"
+    | "health"
+    | "kids"
+    | "lifestyle"
+    | "magazines"
+    | "medical"
+    | "music"
+    | "navigation"
+    | "news"
+    | "personalization"
+    | "photo"
+    | "politics"
+    | "productivity"
+    | "security"
+    | "shopping"
+    | "social"
+    | "sports"
+    | "travel"
+    | "utilities"
+    | "weather" 
+    
 export type Manifest = {
   background_color?: string
-  categories?: string[]
+  categories?: ManifestCategory[]
   description?: string
   display?: 'fullscreen' | 'standalone' | 'minimal-ui' | 'browser'
   display_override?: string[]

--- a/packages/next/src/lib/metadata/types/manifest-types.ts
+++ b/packages/next/src/lib/metadata/types/manifest-types.ts
@@ -1,40 +1,16 @@
-type ManifestCategory = 
-    | "books"
-    | "business"
-    | "education"
-    | "entertainment"
-    | "finance"
-    | "fitness"
-    | "food"
-    | "games"
-    | "government"
-    | "health"
-    | "kids"
-    | "lifestyle"
-    | "magazines"
-    | "medical"
-    | "music"
-    | "navigation"
-    | "news"
-    | "personalization"
-    | "photo"
-    | "politics"
-    | "productivity"
-    | "security"
-    | "shopping"
-    | "social"
-    | "sports"
-    | "travel"
-    | "utilities"
-    | "weather" 
-    
 export type Manifest = {
   background_color?: string
-  categories?: ManifestCategory[]
+  categories?: string[]
   description?: string
   dir?: 'ltr' | 'rtl' | 'auto'
   display?: 'fullscreen' | 'standalone' | 'minimal-ui' | 'browser'
-  display_override?: ('fullscreen' | 'standalone' | 'minimal-ui' | 'browser' | 'window-controls-overlay')[]
+  display_override?: (
+    | 'fullscreen'
+    | 'standalone'
+    | 'minimal-ui'
+    | 'browser'
+    | 'window-controls-overlay'
+  )[]
   file_handlers?: {
     action: string
     accept: {

--- a/packages/next/src/lib/metadata/types/manifest-types.ts
+++ b/packages/next/src/lib/metadata/types/manifest-types.ts
@@ -32,6 +32,7 @@ export type Manifest = {
   background_color?: string
   categories?: ManifestCategory[]
   description?: string
+  dir?: 'ltr' | 'rtl' | 'auto'
   display?: 'fullscreen' | 'standalone' | 'minimal-ui' | 'browser'
   display_override?: ('fullscreen' | 'standalone' | 'minimal-ui' | 'browser' | 'window-controls-overlay')[]
   file_handlers?: {

--- a/packages/next/src/lib/metadata/types/manifest-types.ts
+++ b/packages/next/src/lib/metadata/types/manifest-types.ts
@@ -48,6 +48,7 @@ export type Manifest = {
     purpose?: 'any' | 'maskable' | 'monochrome' | 'badge'
   }[]
   id?: string
+  lang?: string
   launch_handler?: {
     platform?: 'windows' | 'macos' | 'linux'
     url?: string

--- a/packages/next/src/lib/metadata/types/manifest-types.ts
+++ b/packages/next/src/lib/metadata/types/manifest-types.ts
@@ -33,7 +33,7 @@ export type Manifest = {
   categories?: ManifestCategory[]
   description?: string
   display?: 'fullscreen' | 'standalone' | 'minimal-ui' | 'browser'
-  display_override?: string[]
+  display_override?: ('fullscreen' | 'standalone' | 'minimal-ui' | 'browser' | 'window-controls-overlay')[]
   icons?: {
     src: string
     type?: string

--- a/packages/next/src/lib/metadata/types/manifest-types.ts
+++ b/packages/next/src/lib/metadata/types/manifest-types.ts
@@ -34,6 +34,12 @@ export type Manifest = {
   description?: string
   display?: 'fullscreen' | 'standalone' | 'minimal-ui' | 'browser'
   display_override?: ('fullscreen' | 'standalone' | 'minimal-ui' | 'browser' | 'window-controls-overlay')[]
+  file_handlers?: {
+    action: string
+    accept: {
+      [mimeType: string]: string[]
+    }[]
+  }[]
   icons?: {
     src: string
     type?: string


### PR DESCRIPTION
### What?
Some fields were missing from the `Manifest` type.
Types were written according to [MDN](https://developer.mozilla.org/en-US/docs/Web/Manifest) and [W3C](https://www.w3.org/TR/appmanifest/#) documentation.

### Why?
To improve developer experience with the new [File-Based Metadata API](https://nextjs.org/blog/next-13-3#file-based-metadata-api) for Manifest.
