### PR TITLE
Fix instrumentation.js initialization in prod on Vercel

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -334,7 +334,7 @@ export default class NextNodeServer extends BaseServer {
       this.nextConfig.experimental.instrumentationHook
     ) {
       try {
-        const instrumentationHook = await require(join(
+        const instrumentationHook = await require(resolve(
           this.serverOptions.dir || '.',
           this.serverOptions.conf.distDir!,
           'server',


### PR DESCRIPTION
If `this.serverOptions.dir` is `'.'` or missing (which seems to be the case in Vercel's `___next_launcher.cjs`), this code was calling `require(join('.', '.next', 'server', 'instrumentation'))` which is `require('.next/server/instrumentation')`; notably, require treats this differently from `require('./.next/server/instrumentation')`, which is actually what we need here.

Use `path.resolve` instead so that we pass an absolute path to `require`, which I confirmed fixes the issue.