### PR TITLE
Add note about custom distDir to standalone build docs

### DIFF
--- a/docs/advanced-features/output-file-tracing.md
+++ b/docs/advanced-features/output-file-tracing.md
@@ -34,7 +34,7 @@ This will create a folder at `.next/standalone` which can then be deployed on it
 
 Additionally, a minimal `server.js` file is also output which can be used instead of `next start`. This minimal server does not copy the `public` or `.next/static` folders by default as these should ideally be handled by a CDN instead, although these folders can be copied to the `standalone/public` and `standalone/.next/static` folders manually, after which `server.js` file will serve these automatically.
 
-> If a custom [`distDir`](docs/api-reference/next.config.js/setting-a-custom-build-directory.md) has been set, the standalone build can be found at `<distDir>/standalone`. In addition, the static files have to be copied to `standalone/<distDir>/static` if they should be served by the integrated server.
+> **Note:** If a custom [`distDir`](docs/api-reference/next.config.js/setting-a-custom-build-directory.md) has been set, the standalone build can be found at `<distDir>/standalone`. In addition, the static files have to be copied to `standalone/<distDir>/static` if they should be served by the integrated server.
 
 Note: `next.config.js` is read during `next build` and serialized into the `server.js` output file. If the legacy [`serverRuntimeConfig` or `publicRuntimeConfig` options](/docs/api-reference/next.config.js/runtime-configuration.md) are being used, the values will be specific to values at build time.
 

--- a/docs/advanced-features/output-file-tracing.md
+++ b/docs/advanced-features/output-file-tracing.md
@@ -34,6 +34,8 @@ This will create a folder at `.next/standalone` which can then be deployed on it
 
 Additionally, a minimal `server.js` file is also output which can be used instead of `next start`. This minimal server does not copy the `public` or `.next/static` folders by default as these should ideally be handled by a CDN instead, although these folders can be copied to the `standalone/public` and `standalone/.next/static` folders manually, after which `server.js` file will serve these automatically.
 
+> If a custom [`distDir`](docs/api-reference/next.config.js/setting-a-custom-build-directory.md) has been set, the standalone build can be found at `<distDir>/standalone`. In addition, the static files have to be copied to `standalone/<distDir>/static` if they should be served by the integrated server.
+
 Note: `next.config.js` is read during `next build` and serialized into the `server.js` output file. If the legacy [`serverRuntimeConfig` or `publicRuntimeConfig` options](/docs/api-reference/next.config.js/runtime-configuration.md) are being used, the values will be specific to values at build time.
 
 If your project uses [Image Optimization](/docs/basic-features/image-optimization.md) with the default `loader`, you must install `sharp` as a dependency:

--- a/docs/advanced-features/output-file-tracing.md
+++ b/docs/advanced-features/output-file-tracing.md
@@ -34,7 +34,7 @@ This will create a folder at `.next/standalone` which can then be deployed on it
 
 Additionally, a minimal `server.js` file is also output which can be used instead of `next start`. This minimal server does not copy the `public` or `.next/static` folders by default as these should ideally be handled by a CDN instead, although these folders can be copied to the `standalone/public` and `standalone/.next/static` folders manually, after which `server.js` file will serve these automatically.
 
-> **Note**: If a custom [`distDir`](docs/api-reference/next.config.js/setting-a-custom-build-directory.md) has been set, the standalone build can be found at `<distDir>/standalone`. In addition, the static files have to be copied to `standalone/<distDir>/static` if they should be served by the integrated server.
+> **Note**: If [`distDir`](/docs/api-reference/next.config.js/setting-a-custom-build-directory.md) is configured, the standalone build can be found at `<distDir>/standalone`. Additionally, static files should be copied to `standalone/<distDir>/static` if they should be served by the integrated server.
 
 > **Note**: `next.config.js` is read during `next build` and serialized into the `server.js` output file. If the legacy [`serverRuntimeConfig` or `publicRuntimeConfig` options](/docs/api-reference/next.config.js/runtime-configuration.md) are being used, the values will be specific to values at build time.
 


### PR DESCRIPTION

### What?
Add a note that if a custom `distDir` has been set, the standalone build can be found at the specified location and the static files folder has to be copied to the custom location as well.

### Why?
This may be obvious, but such a note would've saved me some minutes, not gonna lie.

### How?
\-
