### PR TITLE
Exclude app from `_devPagesManifest.js` in turbopack

### DIFF
--- a/packages/next-swc/crates/next-core/src/manifest.rs
+++ b/packages/next-swc/crates/next-core/src/manifest.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexMap;
 use mime::{APPLICATION_JAVASCRIPT_UTF_8, APPLICATION_JSON};
 use serde::Serialize;
 use turbo_binding::{

--- a/packages/next-swc/crates/next-dev/src/lib.rs
+++ b/packages/next-swc/crates/next-dev/src/lib.rs
@@ -369,7 +369,7 @@ async fn source(
     let static_source =
         StaticAssetsContentSourceVc::new(String::new(), project_path.join("public")).into();
     let manifest_source = DevManifestContentSource {
-        page_roots: vec![app_source, page_source],
+        page_roots: vec![page_source],
         next_config,
     }
     .cell()


### PR DESCRIPTION
### What?
Seems I accidentally included the app root when I initially added it, but apps never have a page loader, so they should be excluded

I also cleaned up the manifest a bit, and it now perfectly matches the one in next.js


Fixes WEB-926
