### PR TITLE
Fix writeConfigurationDefaults.ts to correctly suggest changes in monorepos

### DIFF
--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -211,10 +211,11 @@ export async function writeConfigurationDefaults(
     // because that will override the parent config's plugins.
     // Instead we have to show a message to the user to add the plugin manually.
     if (
-      plugins.length &&
-      !hasNextPlugin &&
-      'extends' in rawConfig &&
-      (!rawConfig.compilerOptions || !rawConfig.compilerOptions.plugins)
+      !userTsConfig.compilerOptions ||
+      (plugins.length &&
+        !hasNextPlugin &&
+        'extends' in rawConfig &&
+        (!rawConfig.compilerOptions || !rawConfig.compilerOptions.plugins))
     ) {
       console.log(
         `\nYour ${chalk.cyan(
@@ -224,13 +225,7 @@ export async function writeConfigurationDefaults(
         )}\`) manually to your TypeScript configuration. Learn more: https://beta.nextjs.org/docs/configuring/typescript#using-the-typescript-plugin\n`
       )
     } else if (!hasNextPlugin) {
-      if (!userTsConfig.compilerOptions) {
-        userTsConfig.compilerOptions = {}
-      }
-      if (
-        userTsConfig.compilerOptions &&
-        !('plugins' in userTsConfig.compilerOptions)
-      ) {
+      if (!('plugins' in userTsConfig.compilerOptions)) {
         userTsConfig.compilerOptions.plugins = []
       }
       userTsConfig.compilerOptions.plugins.push({ name: 'next' })

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -195,55 +195,64 @@ export async function writeConfigurationDefaults(
 
   // Enable the Next.js typescript plugin.
   if (isAppDirEnabled) {
-    if (userTsConfig.compilerOptions) {
-      // Check if the config or the resolved config has the plugin already.
-      const hasNextPlugin = [
-        ...(Array.isArray(tsOptions.plugins) ? tsOptions.plugins : []),
-        ...(Array.isArray(userTsConfig.compilerOptions.plugins)
-          ? userTsConfig.compilerOptions.plugins
-          : []),
-      ].some(({ name }: { name: string }) => name === 'next')
+    // Check if the config or the resolved config has the plugin already.
+    const plugins = [
+      ...(Array.isArray(tsOptions.plugins) ? tsOptions.plugins : []),
+      ...(userTsConfig.compilerOptions &&
+      Array.isArray(userTsConfig.compilerOptions.plugins)
+        ? userTsConfig.compilerOptions.plugins
+        : []),
+    ]
+    const hasNextPlugin = plugins.some(
+      ({ name }: { name: string }) => name === 'next'
+    )
 
-      // If the TS config extends on another config, we can't add the `plugin` field
-      // because that will override the parent config's plugins.
-      // Instead we have to show a message to the user to add the plugin manually.
+    // If the TS config extends on another config, we can't add the `plugin` field
+    // because that will override the parent config's plugins.
+    // Instead we have to show a message to the user to add the plugin manually.
+    if (
+      plugins.length &&
+      !hasNextPlugin &&
+      'extends' in rawConfig &&
+      (!rawConfig.compilerOptions || !rawConfig.compilerOptions.plugins)
+    ) {
+      console.log(
+        `\nYour ${chalk.cyan(
+          'tsconfig.json'
+        )} extends another configuration, which means we cannot add the Next.js TypeScript plugin automatically. To improve your development experience, we recommend adding the Next.js plugin (\`${chalk.cyan(
+          '"plugins": [{ "name": "next" }]'
+        )}\`) manually to your TypeScript configuration. Learn more: https://beta.nextjs.org/docs/configuring/typescript#using-the-typescript-plugin\n`
+      )
+    } else if (!hasNextPlugin) {
+      if (!userTsConfig.compilerOptions) {
+        userTsConfig.compilerOptions = {}
+      }
       if (
-        !hasNextPlugin &&
-        'extends' in userTsConfig &&
+        userTsConfig.compilerOptions &&
         !('plugins' in userTsConfig.compilerOptions)
       ) {
-        console.log(
-          `\nYour ${chalk.cyan(
-            'tsconfig.json'
-          )} extends another configuration, which means we cannot add the Next.js TypeScript plugin automatically. To improve your development experience, we recommend adding the Next.js plugin (\`${chalk.cyan(
-            '"plugins": [{ "name": "next" }]'
-          )}\`) manually to your TypeScript configuration. Learn more: https://beta.nextjs.org/docs/configuring/typescript#using-the-typescript-plugin\n`
-        )
-      } else if (!hasNextPlugin) {
-        if (!('plugins' in userTsConfig.compilerOptions)) {
-          userTsConfig.compilerOptions.plugins = []
-        }
-        userTsConfig.compilerOptions.plugins.push({ name: 'next' })
-        suggestedActions.push(
-          chalk.cyan('plugins') +
-            ' was updated to add ' +
-            chalk.bold(`{ name: 'next' }`)
-        )
+        userTsConfig.compilerOptions.plugins = []
       }
+      userTsConfig.compilerOptions.plugins.push({ name: 'next' })
+      suggestedActions.push(
+        chalk.cyan('plugins') +
+          ' was updated to add ' +
+          chalk.bold(`{ name: 'next' }`)
+      )
+    }
 
-      // If `strict` is set to `false` or `strictNullChecks` is set to `false`,
-      // then set `strictNullChecks` to `true`.
-      if (
-        hasPagesDir &&
-        isAppDirEnabled &&
-        !userTsConfig.compilerOptions.strict &&
-        !('strictNullChecks' in userTsConfig.compilerOptions)
-      ) {
-        userTsConfig.compilerOptions.strictNullChecks = true
-        suggestedActions.push(
-          chalk.cyan('strictNullChecks') + ' was set to ' + chalk.bold(`true`)
-        )
-      }
+    // If `strict` is set to `false` or `strictNullChecks` is set to `false`,
+    // then set `strictNullChecks` to `true`.
+    if (
+      hasPagesDir &&
+      isAppDirEnabled &&
+      !userTsConfig.compilerOptions.strict &&
+      !('strictNullChecks' in userTsConfig.compilerOptions)
+    ) {
+      userTsConfig.compilerOptions.strictNullChecks = true
+      suggestedActions.push(
+        chalk.cyan('strictNullChecks') + ' was set to ' + chalk.bold(`true`)
+      )
     }
   }
 


### PR DESCRIPTION
Closes #48653. It should either modify the TS config to add the Next.js plugin, or output a log if it can't (to avoid overriding the base config).

<img width="920" alt="CleanShot-2023-04-21-Klqel8BO@2x" src="https://user-images.githubusercontent.com/3676859/233642532-5eed8d5d-d2c5-41e9-99bf-d0eb95685206.png">
