### PR TITLE
Wait for versioning prompt to show up for stable release

### DIFF
--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -4,6 +4,12 @@ const resolveFrom = require('resolve-from')
 const ansiEscapes = require('ansi-escapes')
 const fetch = require('node-fetch')
 
+function getPromptErrorDetails(rawAssertion, mostRecentChunk) {
+  const assertion = rawAssertion.toString().trim()
+  const mostRecent = (mostRecentChunk || '').trim()
+  return `Waiting for:\n  "${assertion}"\nmost recent chunk was:\n  "${mostRecent}"`
+}
+
 async function waitForPrompt(cp, rawAssertion, timeout = 3000) {
   let assertion
   if (typeof rawAssertion === 'string') {

--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -139,7 +139,6 @@ async function main() {
   } else {
     console.log('Wait for the version prompt to show up')
     await waitForPrompt(child, 'Select a new version')
-    await waitForPrompt(child, 'Changes:')
     console.log('Releasing stable')
     if (semverType === 'minor') {
       console.log('Releasing minor: cursor down > 1\n')
@@ -156,6 +155,7 @@ async function main() {
     }
     console.log('Enter newline')
     child.stdin.write('\n')
+    await waitForPrompt(child, 'Changes:')
     console.log('Enter y')
     child.stdin.write('y\n')
   }

--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -133,14 +133,13 @@ async function main() {
   child.stdout.pipe(process.stdout)
   child.stderr.pipe(process.stderr)
 
-  // Wait for the versioning prompt to show up
-  await waitForPrompt(child, 'Select a new version')
-  await waitForPrompt(child, 'Changes:')
-
   if (isCanary) {
     console.log("Releasing canary: enter 'y'\n")
     child.stdin.write('y\n')
   } else {
+    console.log('Wait for the version prompt to show up')
+    await waitForPrompt(child, 'Select a new version')
+    await waitForPrompt(child, 'Changes:')
     console.log('Releasing stable')
     if (semverType === 'minor') {
       console.log('Releasing minor: cursor down > 1\n')


### PR DESCRIPTION
Wait for the prompt to show up then enter the cursor change or "y" for prompt to avoid write to child process too early

Example
```
Running pnpm release-stable...
Releasing patch: cursor stay
Enter newline
Enter y
Await child process...
> nextjs-project@0.0.0 release-stable /home/runner/work/next.js/next.js
> lerna version --force-publish
lerna notice cli v4.0.0
lerna info ci enabled
lerna info current version 13.3.1-canary.19
lerna WARN force-publish all packages
lerna info Assuming all packages changed
? Select a new version (currently 13.3.1-canary.19) (Use arrow keys)
❯ Patch (13.3.1) 
  Minor (13.4.0) 
  Major (14.0.0) 
  Prepatch (13.3.2-canary.0) 
  Preminor (13.4.0-canary.0) 
  Premajor (14.0.0-canary.0) 
  Custom Prerelease 
  Custom Version ? Select a new version (currently 13.3.1-canary.19) Patch (13.3.1)
Changes:
```