### PR TITLE
Prefer realpathSync.native over realpathSync

### DIFF
--- a/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
+++ b/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
@@ -1,6 +1,6 @@
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { clearModuleContext } from '../../../server/web/sandbox'
-import { realpathSync } from 'fs'
+import { realpathSync } from '../../../lib/realpath'
 import path from 'path'
 import isError from '../../../lib/is-error'
 

--- a/packages/next/src/lib/get-project-dir.ts
+++ b/packages/next/src/lib/get-project-dir.ts
@@ -1,13 +1,13 @@
-import fs from 'fs'
 import path from 'path'
 import { commands } from './commands'
 import * as Log from '../build/output/log'
 import { detectTypo } from './detect-typo'
+import { realpathSync } from './realpath'
 
 export function getProjectDir(dir?: string) {
   try {
     const resolvedDir = path.resolve(dir || '.')
-    const realDir = fs.realpathSync.native(resolvedDir)
+    const realDir = realpathSync(resolvedDir)
 
     if (
       resolvedDir !== realDir &&

--- a/packages/next/src/lib/realpath.ts
+++ b/packages/next/src/lib/realpath.ts
@@ -1,0 +1,9 @@
+import fs from 'fs'
+
+const isWindows = process.platform === 'win32'
+
+// Interesting learning from this, that fs.realpathSync is 70x slower than fs.realpathSync.native:
+// https://sun0day.github.io/blog/vite/why-vite4_3-is-faster.html#fs-realpathsync-issue
+// https://github.com/nodejs/node/issues/2680
+// However, we can't use fs.realpathSync.native on Windows due to behavior differences.
+export const realpathSync = isWindows ? fs.realpathSync : fs.realpathSync.native

--- a/packages/next/src/lib/resolve-from.ts
+++ b/packages/next/src/lib/resolve-from.ts
@@ -1,7 +1,7 @@
 // source: https://github.com/sindresorhus/resolve-from
-import fs from 'fs'
 import path from 'path'
 import isError from './is-error'
+import { realpathSync } from './realpath'
 
 const Module = require('module')
 
@@ -23,7 +23,7 @@ export const resolveFrom = (
   }
 
   try {
-    fromDirectory = fs.realpathSync(fromDirectory)
+    fromDirectory = realpathSync(fromDirectory)
   } catch (error: unknown) {
     if (isError(error) && error.code === 'ENOENT') {
       fromDirectory = path.resolve(fromDirectory)


### PR DESCRIPTION
Interesting learning from [this](https://sun0day.github.io/blog/vite/why-vite4_3-is-faster.html#fs-realpathsync-issue), that `fs.realpathSync` is 70x slower than `fs.realpathSync.native`. Kudos to the Vite team!