### PR TITLE
Remove useless URLs in srcset

### DIFF
--- a/packages/next/src/client/image.tsx
+++ b/packages/next/src/client/image.tsx
@@ -157,6 +157,19 @@ type ImageElementProps = Omit<ImageProps, 'src' | 'alt' | 'loader'> & {
   setShowAltText: (b: boolean) => void
 }
 
+/**
+ * Returns only widths smaller than imageWidth and the next wider one
+ */
+function onlyRelevantWidths(widths: number[], imageWidth: number | undefined) {
+  if (!imageWidth) return widths
+  const wider = widths.find((s) => s >= imageWidth)
+  const smallerWidths = widths.filter((s) => s < imageWidth)
+  if (wider) {
+    smallerWidths.push(wider)
+  }
+  return smallerWidths
+}
+
 function getWidths(
   { deviceSizes, allSizes }: ImageConfig,
   width: number | undefined,
@@ -169,14 +182,14 @@ function getWidths(
     for (let match; (match = viewportWidthRe.exec(sizes)); match) {
       percentSizes.push(parseInt(match[2]))
     }
+    let widths: number[]
     if (percentSizes.length) {
       const smallestRatio = Math.min(...percentSizes) * 0.01
-      return {
-        widths: allSizes.filter((s) => s >= deviceSizes[0] * smallestRatio),
-        kind: 'w',
-      }
+      widths = allSizes.filter((s) => s >= deviceSizes[0] * smallestRatio)
+    } else {
+      widths = allSizes
     }
-    return { widths: allSizes, kind: 'w' }
+    return { widths: onlyRelevantWidths(widths, width), kind: 'w' }
   }
   if (typeof width !== 'number') {
     return { widths: deviceSizes, kind: 'w' }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

Closes NEXT-
Fixes #

-->
### What?
This PR makes the Image component skip widths in srcset attribute that are useless. For example, when an image is 550px wide and it is meant to cover the viewport, srcset will generate [640, 750, 828, 1080, 1200, 1920, 2048, 3840] sizes, while only 640px is relevant.

### Why?
This improvement will make generated HTML smaller. Additionally, the image optimizer cache will have to do fewer optimizations and keep fewer copies of the same image.
The following component:
`<Image src="/img/divider.png" alt="" sizes="50px" width={50} height={50}/>`
now generates this HTML:
```html
<img alt="" loading="lazy" width="50" height="50" decoding="async" data-nimg="1" style="color:transparent" sizes="100vw" srcset="/_next/image?url=%2Fimg%2Fdivider.png&amp;w=640&amp;q=75 640w, /_next/image?url=%2Fimg%2Fdivider.png&amp;w=750&amp;q=75 750w, /_next/image?url=%2Fimg%2Fdivider.png&amp;w=828&amp;q=75 828w, /_next/image?url=%2Fimg%2Fdivider.png&amp;w=1080&amp;q=75 1080w, /_next/image?url=%2Fimg%2Fdivider.png&amp;w=1200&amp;q=75 1200w, /_next/image?url=%2Fimg%2Fdivider.png&amp;w=1920&amp;q=75 1920w, /_next/image?url=%2Fimg%2Fdivider.png&amp;w=2048&amp;q=75 2048w, /_next/image?url=%2Fimg%2Fdivider.png&amp;w=3840&amp;q=75 3840w" src="/_next/image?url=%2Fimg%2Fdivider.png&amp;w=3840&amp;q=75">
```
After merging this PR, it will generate:
```html
<img alt="" loading="lazy" width="50" height="50" decoding="async" data-nimg="1" style="color:transparent" sizes="100vw" srcset="/_next/image?url=%2Fimg%2Fdivider.png&amp;w=640&amp;q=75 640w" src="/_next/image?url=%2Fimg%2Fdivider.png&amp;w=3840&amp;q=75">
```

### How?
Whenever both `width`  and `sizes` attributes are provided, generated widths will only include values smaller than provided width and the next wider one. Other values are useless because the image optimizer doesn't scale those, it just uses the copy of the input image and converts it to WebP/AVIF.