### PR TITLE
Compile Next.js core client-side files using default target

### DIFF
--- a/packages/next/src/shared/lib/constants.ts
+++ b/packages/next/src/shared/lib/constants.ts
@@ -1,3 +1,7 @@
+import MODERN_BROWSERSLIST_TARGET from './modern-browserslist-target'
+
+export { MODERN_BROWSERSLIST_TARGET }
+
 export type ValueOf<T> = Required<T>[keyof T]
 
 export const COMPILER_NAMES = {
@@ -47,19 +51,6 @@ export const CLIENT_PUBLIC_FILES_PATH = 'public'
 export const CLIENT_STATIC_FILES_PATH = 'static'
 export const CLIENT_STATIC_FILES_RUNTIME = 'runtime'
 export const STRING_LITERAL_DROP_BUNDLE = '__NEXT_DROP_CLIENT_FILE__'
-/**
- * These are the browser versions that support all of the following:
- * static import: https://caniuse.com/es6-module
- * dynamic import: https://caniuse.com/es6-module-dynamic-import
- * import.meta: https://caniuse.com/mdn-javascript_operators_import_meta
- */
-export const MODERN_BROWSERSLIST_TARGET = [
-  'chrome 64',
-  'edge 79',
-  'firefox 67',
-  'opera 51',
-  'safari 12',
-]
 export const NEXT_BUILTIN_DOCUMENT = '__NEXT_BUILTIN_DOCUMENT__'
 export const NEXT_CLIENT_SSR_ENTRY_SUFFIX = '.__sc_client__'
 

--- a/packages/next/src/shared/lib/modern-browserslist-target.d.ts
+++ b/packages/next/src/shared/lib/modern-browserslist-target.d.ts
@@ -1,3 +1,4 @@
+// Keep in sync with the `.js` file.
 declare const MODERN_BROWSERSLIST_TARGET: [
   'chrome 64',
   'edge 79',

--- a/packages/next/src/shared/lib/modern-browserslist-target.d.ts
+++ b/packages/next/src/shared/lib/modern-browserslist-target.d.ts
@@ -1,0 +1,9 @@
+declare const MODERN_BROWSERSLIST_TARGET: [
+  'chrome 64',
+  'edge 79',
+  'firefox 67',
+  'opera 51',
+  'safari 12'
+]
+
+export default MODERN_BROWSERSLIST_TARGET

--- a/packages/next/src/shared/lib/modern-browserslist-target.js
+++ b/packages/next/src/shared/lib/modern-browserslist-target.js
@@ -1,0 +1,17 @@
+// Note: This file is JS because it's used by the taskfile-swc.js file, which is JS.
+// Keep file changes in sync with the corresponding `.d.ts` files.
+/**
+ * These are the browser versions that support all of the following:
+ * static import: https://caniuse.com/es6-module
+ * dynamic import: https://caniuse.com/es6-module-dynamic-import
+ * import.meta: https://caniuse.com/mdn-javascript_operators_import_meta
+ */
+const MODERN_BROWSERSLIST_TARGET = [
+  'chrome 64',
+  'edge 79',
+  'firefox 67',
+  'opera 51',
+  'safari 12',
+]
+
+module.exports = MODERN_BROWSERSLIST_TARGET

--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -1,6 +1,8 @@
 // taskr babel plugin with Babel 7 support
 // https://github.com/lukeed/taskr/pull/305
 
+const MODERN_BROWSERSLIST_TARGET = require('./src/shared/lib/modern-browserslist-target')
+
 const path = require('path')
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -25,17 +27,18 @@ module.exports = function (task) {
       if (file.base.endsWith('.d.ts') || file.base.endsWith('.json')) return
 
       const isClient = serverOrClient === 'client'
-
       /** @type {import('@swc/core').Options} */
       const swcClientOptions = {
         module: {
           type: esm ? 'es6' : 'commonjs',
           ignoreDynamic: true,
         },
+        env: {
+          targets: MODERN_BROWSERSLIST_TARGET,
+        },
         jsc: {
           loose: true,
           externalHelpers: true,
-          target: 'es2016',
           parser: {
             syntax: 'typescript',
             dynamicImport: true,


### PR DESCRIPTION
### What?

Compiles Next.js core files using the same default target as client-side files, ensuring that `async`/`await` and such are not turned into generators.

The client-side files are all opted into compilation during dev/build already so if you create a browserslist config that will still apply in the same way. This change only changes the output of the core files.

### How?

Moved the default we use in Next.js into a separate `.js` file so that it can be imported from the taskfile-swc plugin, this way we're using the same defaults.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
