### PR TITLE
fix: TS plugin showing warning for `global-error` file's `reset` prop

### DIFF
--- a/packages/next/src/server/typescript/rules/client-boundary.ts
+++ b/packages/next/src/server/typescript/rules/client-boundary.ts
@@ -40,6 +40,7 @@ const clientBoundary = {
     const diagnostics: ts.Diagnostic[] = []
 
     const isErrorFile = /[\\/]error\.tsx?$/.test(source.fileName)
+    const isGlobalErrorFile = /[\\/]global-error\.tsx?$/.test(source.fileName)
 
     const props = node.parameters?.[0]?.name
     if (props && ts.isObjectBindingPattern(props)) {
@@ -57,7 +58,7 @@ const clientBoundary = {
             // There's a special case for the error file that the `reset` prop is allowed
             // to be a function:
             // https://github.com/vercel/next.js/issues/46573
-            if (!isErrorFile || propName !== 'reset') {
+            if (!(isErrorFile || isGlobalErrorFile) || propName !== 'reset') {
               diagnostics.push({
                 file: source,
                 category: ts.DiagnosticCategory.Warning,


### PR DESCRIPTION
The TS plugin incorrectly gives a warning for the `reset` prop in the `global-error.tsx` file. This was previously reported and fixed for the `error.tsx` file.
- https://github.com/vercel/next.js/issues/46573
- https://github.com/vercel/next.js/pull/46898

---

You can see a reproduction on [CodeSandbox](https://codesandbox.io/p/sandbox/summer-dawn-b0gydg?file=%2Fapp%2Flayout.tsx&selection=%5B%7B%22endColumn%22%3A16%2C%22endLineNumber%22%3A18%2C%22startColumn%22%3A16%2C%22startLineNumber%22%3A18%7D%5D) — `global-error.tsx`'s `reset` prop has the following warning: 

```
Props must be serializable for components in the "use client" entry file, "reset" is invalid. ts(71007)
```

I haven't filed an issue for this yet since this was a simple enough fix, but happy to create one if needed :)
