### PR TITLE
Lazy DevHtmlAsset chunk generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "serde",
 ]
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "serde",
@@ -6972,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "turbo-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7011,7 +7011,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "mimalloc",
 ]
@@ -7019,7 +7019,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7049,7 +7049,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7061,7 +7061,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7090,7 +7090,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7107,7 +7107,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7136,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "base16",
  "hex",
@@ -7148,7 +7148,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7162,7 +7162,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7172,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7194,7 +7194,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7206,7 +7206,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7234,7 +7234,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7264,7 +7264,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7281,7 +7281,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7321,7 +7321,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7343,7 +7343,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7364,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7434,7 +7434,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7450,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "serde",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7498,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "serde",
@@ -7548,7 +7548,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7559,7 +7559,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230420.2#56c3da313775fb12793cd13bba75698f37f8ab36"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ swc_relay = { version = "0.2.5" }
 testing = { version = "0.33.4" }
 
 # Turbo crates
-turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230420.2" }
+turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230424.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230420.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230424.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230420.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230424.2" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230420.2",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230420.2",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230424.2",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230424.2",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/src/fallback.rs
+++ b/packages/next-swc/crates/next-core/src/fallback.rs
@@ -5,7 +5,6 @@ use turbo_binding::{
     turbo::{tasks_env::ProcessEnvVc, tasks_fs::FileSystemPathVc},
     turbopack::{
         core::{
-            chunk::{ChunkableAsset, ChunkingContext},
             compile_time_info::CompileTimeInfoVc,
             context::AssetContextVc,
             resolve::{options::ImportMap, origin::PlainResolveOriginVc},
@@ -85,9 +84,10 @@ pub async fn get_fallback_page(
 
     Ok(DevHtmlAssetVc::new(
         dev_server_root.join("fallback.html"),
-        vec![chunking_context.evaluated_chunk_group(
-            module.as_root_chunk(chunking_context),
-            runtime_entries.with_entry(module.into()),
+        vec![(
+            module.into(),
+            chunking_context,
+            Some(runtime_entries.with_entry(module.into())),
         )],
     ))
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1010,8 +1010,8 @@ importers:
       '@types/react': 18.0.37
       '@types/react-dom': 18.0.11
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230420.2
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230420.2
+      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230424.2
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230424.2
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1023,8 +1023,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230420.2_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230420.2'
+      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230424.2_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230424.2'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -6006,7 +6006,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.2.1
       source-map: 0.7.3
-      webpack: 5.74.0
+      webpack: 5.74.0_@swc+core@1.3.51
     transitivePeerDependencies:
       - supports-color
 
@@ -6676,7 +6676,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64/1.3.51:
@@ -6685,7 +6684,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.3.51:
@@ -6694,7 +6692,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.3.51:
@@ -6703,7 +6700,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl/1.3.51:
@@ -6712,7 +6708,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu/1.3.51:
@@ -6721,7 +6716,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl/1.3.51:
@@ -6730,7 +6724,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.3.51:
@@ -6739,7 +6732,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.3.51:
@@ -6748,7 +6740,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc/1.3.51:
@@ -6757,7 +6748,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core/1.3.51_@swc+helpers@0.5.0:
@@ -6782,7 +6772,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.51
       '@swc/core-win32-ia32-msvc': 1.3.51
       '@swc/core-win32-x64-msvc': 1.3.51
-    dev: true
 
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
@@ -23756,7 +23745,6 @@ packages:
       source-map: 0.6.1
       terser: 5.14.1
       webpack: 5.74.0_@swc+core@1.3.51
-    dev: true
 
   /terser-webpack-plugin/5.2.4_webpack@5.74.0:
     resolution: {integrity: sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==}
@@ -25162,7 +25150,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /websocket-driver/0.7.3:
     resolution: {integrity: sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==}
@@ -25568,9 +25555,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230420.2_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230420.2}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230420.2'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230424.2_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230424.2}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230424.2'
     name: '@vercel/turbopack-dev'
     version: 0.0.0
     dependencies:
@@ -25580,8 +25567,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230420.2':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230420.2}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230424.2':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230424.2}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
This fixes a perf regression introduced in the chunking refactor, where we would be eagerly generating all assets from the web entry and fallback sources.

See https://github.com/vercel/turbo/pull/4679

This also brings the following updates from vercel/turbo:

* https://github.com/vercel/turbo/pull/4669 <!-- Tobias Koppers - make the invalidation reason easier to read  -->
* https://github.com/vercel/turbo/pull/4670 <!-- Tobias Koppers - dev-server content might change any time, we can't cache them  -->
* https://github.com/vercel/turbo/pull/4653 <!-- OJ Kwon - fix(ecmascript): displayname for styled_components  -->
* https://github.com/vercel/turbo/pull/4679 <!-- Alex Kirszenberg - Lazy DevHtmlAsset chunk generation  --> (this change)