### PR TITLE
Fix Windows path in route join (#48603)

### DIFF
--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -56,7 +56,7 @@ export function normalizeMetadataRoute(page: string) {
         page.startsWith('/manifest') ||
         isStaticMetadataFile
 
-      route = path.join(
+      route = path.posix.join(
         dir,
         `${baseName}${suffix ? `-${suffix}` : ''}${ext}`,
         isSingleRoute ? '' : '[[...__metadata_id__]]',


### PR DESCRIPTION
A change here: (#48202) 958150d
Caused a URL to be joined with `path.join`, which on Windows inserts a backslash character. Changing to `path.posix.join` fixes this.

Breaks next build on Windows when paths like `favicon.ico` are in the source dir.

Fixes #48603
