### PR TITLE
Polyfill `FormData` for Node.js < 18

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -9,6 +9,15 @@ import {
 import RenderResult from '../render-result'
 import { ActionRenderResult } from './action-render-result'
 
+function formDataFromSearchQueryString(query: string) {
+  const searchParams = new URLSearchParams(query)
+  const formData = new FormData()
+  for (const [key, value] of searchParams) {
+    formData.append(key, value)
+  }
+  return formData
+}
+
 export async function handleAction({
   req,
   res,
@@ -77,7 +86,7 @@ export async function handleAction({
           }
 
           if (isFormAction) {
-            const formData = new URLSearchParams(actionData)
+            const formData = formDataFromSearchQueryString(actionData)
             actionId = formData.get('$$id') as string
 
             if (!actionId) {
@@ -112,7 +121,7 @@ export async function handleAction({
             if (!actionId) {
               throw new Error('Invariant: missing action ID.')
             }
-            const formData = new URLSearchParams(actionData)
+            const formData = formDataFromSearchQueryString(actionData)
             formData.delete('$$id')
             bound = [formData]
           } else {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1,5 +1,6 @@
 import './require-hook'
 import './node-polyfill-fetch'
+import './node-polyfill-form'
 import './node-polyfill-web-streams'
 
 import type { TLSSocket } from 'tls'

--- a/packages/next/src/server/node-polyfill-form.ts
+++ b/packages/next/src/server/node-polyfill-form.ts
@@ -1,0 +1,8 @@
+/**
+ * Polyfills `FormData` in the Node.js runtime.
+ */
+
+if (!(global as any).FormData) {
+  const undici = require('next/dist/compiled/undici')
+  ;(global as any).FormData = undici.FormData
+}

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -52,7 +52,7 @@ createNextDescribe(
 
       await check(() => {
         return browser.eval('window.location.pathname + window.location.search')
-      }, '/header?name=test')
+      }, '/header?name=test&constructor=FormData')
     })
 
     it('should support notFound', async () => {

--- a/test/e2e/app-dir/actions/app/server/form.js
+++ b/test/e2e/app-dir/actions/app/server/form.js
@@ -2,7 +2,12 @@ import { redirect, notFound } from 'next/navigation'
 
 async function action(formData) {
   'use server'
-  redirect('/header?name=' + formData.get('name'))
+  redirect(
+    '/header?name=' +
+      formData.get('name') +
+      '&constructor=' +
+      formData.constructor.name
+  )
 }
 
 async function nowhere() {


### PR DESCRIPTION
We currently use `URLSearchParams` to represent `FormData` but it's not really the same thing. And in Node.js 16 there's no `FormData` available so we can polyfill it via Undici.