### PR TITLE
Add missing `repository` prop to package.json

### DIFF
--- a/packages/next-swc/crates/napi/npm/darwin-arm64/package.json
+++ b/packages/next-swc/crates/napi/npm/darwin-arm64/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@next/swc-darwin-arm64",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/next.js",
+    "directory": "packages/next-swc/crates/napi/npm/darwin-arm64"
+  },
   "os": [
     "darwin"
   ],

--- a/packages/next-swc/crates/napi/npm/darwin-x64/package.json
+++ b/packages/next-swc/crates/napi/npm/darwin-x64/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@next/swc-darwin-x64",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/next.js",
+    "directory": "packages/next-swc/crates/napi/npm/darwin-x64"
+  },
   "os": [
     "darwin"
   ],

--- a/packages/next-swc/crates/napi/npm/linux-arm64-gnu/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@next/swc-linux-arm64-gnu",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/next.js",
+    "directory": "packages/next-swc/crates/napi/npm/linux-arm64-gnu"
+  },
   "os": [
     "linux"
   ],

--- a/packages/next-swc/crates/napi/npm/linux-arm64-musl/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-musl/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@next/swc-linux-arm64-musl",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/next.js",
+    "directory": "packages/next-swc/crates/napi/npm/linux-arm64-musl"
+  },
   "os": [
     "linux"
   ],

--- a/packages/next-swc/crates/napi/npm/linux-x64-gnu/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@next/swc-linux-x64-gnu",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/next.js",
+    "directory": "packages/next-swc/crates/napi/npm/linux-x64-gnu"
+  },
   "os": [
     "linux"
   ],

--- a/packages/next-swc/crates/napi/npm/linux-x64-musl/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-x64-musl/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@next/swc-linux-x64-musl",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/next.js",
+    "directory": "packages/next-swc/crates/napi/npm/linux-x64-musl"
+  },
   "os": [
     "linux"
   ],

--- a/packages/next-swc/crates/napi/npm/win32-arm64-msvc/package.json
+++ b/packages/next-swc/crates/napi/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@next/swc-win32-arm64-msvc",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/next.js",
+    "directory": "packages/next-swc/crates/napi/npm/win32-arm64-msvc"
+  },
   "os": [
     "win32"
   ],

--- a/packages/next-swc/crates/napi/npm/win32-ia32-msvc/package.json
+++ b/packages/next-swc/crates/napi/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@next/swc-win32-ia32-msvc",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/next.js",
+    "directory": "packages/next-swc/crates/napi/npm/win32-ia32-msvc"
+  },
   "os": [
     "win32"
   ],

--- a/packages/next-swc/crates/napi/npm/win32-x64-msvc/package.json
+++ b/packages/next-swc/crates/napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@next/swc-win32-x64-msvc",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/next.js",
+    "directory": "packages/next-swc/crates/napi/npm/win32-x64-msvc"
+  },
   "os": [
     "win32"
   ],


### PR DESCRIPTION
This should fix the following error:

```
npm ERR! 422 Unprocessable Entity - PUT https://registry.npmjs.org/@next%2fswc-darwin-x64 - Failed to validate repository information: package.json: "repository.url" is "undefined", expected to match "git+https://github.com/vercel/next.js" from provenance
```
https://github.com/vercel/next.js/actions/runs/4787411938/jobs/8512829488#step:10:74

- Related to https://github.com/vercel/next.js/pull/48757