### PR TITLE
fix: Remove webpack alias of `@swc/helpers`

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1067,10 +1067,6 @@ export default async function getBaseWebpackConfig(
           }
         : {}),
 
-      '@swc/helpers': path.dirname(
-        require.resolve('@swc/helpers/package.json')
-      ),
-
       setimmediate: 'next/dist/compiled/setimmediate',
     },
     ...(isClient || isEdgeServer


### PR DESCRIPTION
### What?

This PR removes `resolve.alias` for `@swc/helpers`.

### Why?

With `resolve.alias`, webpack merges `@swc/helpers@v0.4` and `@swc/helpers@v0.5`.

### How?

Closes WEB-948
Fixes #48593
