### PR TITLE
fix: Update `@swc/helpers` to `v0.5.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@svgr/webpack": "5.5.0",
     "@swc/cli": "0.1.55",
     "@swc/core": "1.3.51",
-    "@swc/helpers": "0.5.0",
+    "@swc/helpers": "0.5.1",
     "@testing-library/react": "13.0.0",
     "@types/cheerio": "0.22.16",
     "@types/fs-extra": "8.1.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@next/env": "13.3.2-canary.5",
-    "@swc/helpers": "0.5.0",
+    "@swc/helpers": "0.5.1",
     "busboy": "1.6.0",
     "caniuse-lite": "^1.0.30001406",
     "postcss": "8.4.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
       '@svgr/webpack': 5.5.0
       '@swc/cli': 0.1.55
       '@swc/core': 1.3.51
-      '@swc/helpers': 0.5.0
+      '@swc/helpers': 0.5.1
       '@testing-library/react': 13.0.0
       '@types/cheerio': 0.22.16
       '@types/fs-extra': 8.1.0
@@ -218,8 +218,8 @@ importers:
       '@opentelemetry/api': 1.4.1
       '@svgr/webpack': 5.5.0
       '@swc/cli': 0.1.55_@swc+core@1.3.51
-      '@swc/core': 1.3.51_@swc+helpers@0.5.0
-      '@swc/helpers': 0.5.0
+      '@swc/core': 1.3.51_@swc+helpers@0.5.1
+      '@swc/helpers': 0.5.1
       '@testing-library/react': 13.0.0_biqbaboplfbrettd7655fr4n2y
       '@types/cheerio': 0.22.16
       '@types/fs-extra': 8.1.0
@@ -538,7 +538,7 @@ importers:
       '@next/swc': 13.3.2-canary.5
       '@opentelemetry/api': 1.4.1
       '@segment/ajv-human-errors': 2.1.2
-      '@swc/helpers': 0.5.0
+      '@swc/helpers': 0.5.1
       '@taskr/clear': 1.1.0
       '@taskr/esnext': 1.1.0
       '@types/amphtml-validator': 1.0.0
@@ -712,7 +712,7 @@ importers:
       zod: 3.21.4
     dependencies:
       '@next/env': link:../next-env
-      '@swc/helpers': 0.5.0
+      '@swc/helpers': 0.5.1
       busboy: 1.6.0
       caniuse-lite: 1.0.30001406
       fibers: 5.0.3
@@ -6663,7 +6663,7 @@ packages:
       chokidar:
         optional: true
     dependencies:
-      '@swc/core': 1.3.51_@swc+helpers@0.5.0
+      '@swc/core': 1.3.51_@swc+helpers@0.5.1
       commander: 7.2.0
       fast-glob: 3.2.11
       slash: 3.0.0
@@ -6760,7 +6760,7 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core/1.3.51_@swc+helpers@0.5.0:
+  /@swc/core/1.3.51_@swc+helpers@0.5.1:
     resolution: {integrity: sha512-/fdKlrs2NacLeOKrVZjCPfw5GeUIyBcJg0GDBn0+qwC3Y6k85m4aswK1sfRDF3nzyeXXoBr7YBb+/cSdFq9pVw==}
     engines: {node: '>=10'}
     requiresBuild: true
@@ -6770,7 +6770,7 @@ packages:
       '@swc/helpers':
         optional: true
     dependencies:
-      '@swc/helpers': 0.5.0
+      '@swc/helpers': 0.5.1
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.3.51
       '@swc/core-darwin-x64': 1.3.51
@@ -6790,8 +6790,8 @@ packages:
       tslib: 2.4.0
     dev: true
 
-  /@swc/helpers/0.5.0:
-    resolution: {integrity: sha512-SjY/p4MmECVVEWspzSRpQEM3sjR17sP8PbGxELWrT+YZMBfiUyt1MRUNjMV23zohwlG2HYtCQOsCwsTHguXkyg==}
+  /@swc/helpers/0.5.1:
+    resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
       tslib: 2.4.0
 
@@ -23748,7 +23748,7 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@swc/core': 1.3.51_@swc+helpers@0.5.0
+      '@swc/core': 1.3.51_@swc+helpers@0.5.1
       jest-worker: 27.5.1
       p-limit: 3.1.0
       schema-utils: 3.1.1
@@ -24100,7 +24100,7 @@ packages:
         optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.3.51_@swc+helpers@0.5.0
+      '@swc/core': 1.3.51_@swc+helpers@0.5.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3


### PR DESCRIPTION
### What?

Update `@swc/helpers` to `v0.5.1`.

### Why?

Webpack merges `@swc/helpers@v0.4.x` and `@swc/helpers@v0.5.x`, due to `resolve.alias` config in https://github.com/vercel/next.js/blob/2f6ff0dab330b854c43a1773be2fe739c3582419/packages/next/src/build/webpack-config.ts#L1070-L1072

To workaround it, `@swc/helpers@v0.5.1` reexports from entries just like `v0.4`.

### How?

Closes WEB-948
Fixes #48593
