### PR TITLE
build(cargo): bump up turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "serde",
 ]
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "serde",
@@ -6972,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "turbo-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7011,7 +7011,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "mimalloc",
 ]
@@ -7019,7 +7019,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7049,7 +7049,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7061,7 +7061,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7090,7 +7090,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7107,7 +7107,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7136,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "base16",
  "hex",
@@ -7148,7 +7148,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7162,7 +7162,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7172,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7194,7 +7194,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7206,7 +7206,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7234,7 +7234,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7264,7 +7264,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7281,7 +7281,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7321,7 +7321,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7343,7 +7343,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7364,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7434,7 +7434,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7450,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "serde",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7498,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "serde",
@@ -7548,7 +7548,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7559,7 +7559,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230424.2#d23fc177ac6fd5c5135bc6ba197dc3a15c6c6dd1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230425.2#f56af36e8319f1dbf587738b15c9c13566bb5d15"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ swc_relay = { version = "0.2.5" }
 testing = { version = "0.33.4" }
 
 # Turbo crates
-turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230424.2" }
+turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230425.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230424.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230425.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230424.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230425.2" }
 
 # General Deps
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change



### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

WEB-841. We have internal logics to emit issues for unsupported pkg (`@vercel/og`) already, however it was not being reported. Latest turbopack seems to fix it and reports it correctly.