### PR TITLE
Implement MutableRequestCookies in server entries

### DIFF
--- a/packages/next/src/client/components/action-async-storage.ts
+++ b/packages/next/src/client/components/action-async-storage.ts
@@ -1,47 +1,10 @@
 import type { AsyncLocalStorage } from 'async_hooks'
+import { createAsyncLocalStorage } from './async-local-storage'
 
 export interface ActionStore {
   readonly isAction: boolean
 }
 
 export type ActionAsyncStorage = AsyncLocalStorage<ActionStore>
-
-let createAsyncLocalStorage: () => ActionAsyncStorage
-if (process.env.NEXT_RUNTIME === 'edge') {
-  createAsyncLocalStorage = () => {
-    let store: ActionStore | undefined
-    return {
-      disable() {
-        throw new Error(
-          'Invariant: AsyncLocalStorage accessed in runtime where it is not available'
-        )
-      },
-      getStore() {
-        return store
-      },
-      async run<R>(s: ActionStore, fn: () => R): Promise<R> {
-        store = s
-        try {
-          return await fn()
-        } finally {
-          store = undefined
-        }
-      },
-      exit() {
-        throw new Error(
-          'Invariant: AsyncLocalStorage accessed in runtime where it is not available'
-        )
-      },
-      enterWith() {
-        throw new Error(
-          'Invariant: AsyncLocalStorage accessed in runtime where it is not available'
-        )
-      },
-    } as ActionAsyncStorage
-  }
-} else {
-  createAsyncLocalStorage =
-    require('./async-local-storage').createAsyncLocalStorage
-}
 
 export const actionAsyncStorage: ActionAsyncStorage = createAsyncLocalStorage()

--- a/packages/next/src/client/components/action-async-storage.ts
+++ b/packages/next/src/client/components/action-async-storage.ts
@@ -2,7 +2,8 @@ import type { AsyncLocalStorage } from 'async_hooks'
 import { createAsyncLocalStorage } from './async-local-storage'
 
 export interface ActionStore {
-  readonly isAction: boolean
+  readonly isAction?: boolean
+  readonly isAppRoute?: boolean
 }
 
 export type ActionAsyncStorage = AsyncLocalStorage<ActionStore>

--- a/packages/next/src/client/components/headers.ts
+++ b/packages/next/src/client/components/headers.ts
@@ -44,7 +44,10 @@ export function cookies() {
   }
 
   const asyncActionStore = actionAsyncStorage.getStore()
-  if (asyncActionStore && asyncActionStore.isAction) {
+  if (
+    asyncActionStore &&
+    (asyncActionStore.isAction || asyncActionStore.isAppRoute)
+  ) {
     return requestStore.mutableCookies
   }
 

--- a/packages/next/src/client/components/headers.ts
+++ b/packages/next/src/client/components/headers.ts
@@ -2,6 +2,7 @@ import { RequestCookiesAdapter } from '../../server/web/spec-extension/adapters/
 import { HeadersAdapter } from '../../server/web/spec-extension/adapters/headers'
 import { RequestCookies } from '../../server/web/spec-extension/cookies'
 import { requestAsyncStorage } from './request-async-storage'
+import { actionAsyncStorage } from './action-async-storage'
 import { staticGenerationBailout } from './static-generation-bailout'
 
 export function headers() {
@@ -40,6 +41,11 @@ export function cookies() {
     throw new Error(
       `Invariant: Method expects to have requestAsyncStorage, none available`
     )
+  }
+
+  const asyncActionStore = actionAsyncStorage.getStore()
+  if (asyncActionStore && asyncActionStore.isAction) {
+    return requestStore.mutableCookies
   }
 
   return requestStore.cookies

--- a/packages/next/src/client/components/request-async-storage.ts
+++ b/packages/next/src/client/components/request-async-storage.ts
@@ -1,4 +1,5 @@
 import type { AsyncLocalStorage } from 'async_hooks'
+import type { RequestCookies } from '../../server/web/spec-extension/cookies'
 import type { PreviewData } from '../../../types'
 import type { ReadonlyHeaders } from '../../server/web/spec-extension/adapters/headers'
 import type { ReadonlyRequestCookies } from '../../server/web/spec-extension/adapters/request-cookies'
@@ -8,6 +9,7 @@ import { createAsyncLocalStorage } from './async-local-storage'
 export interface RequestStore {
   readonly headers: ReadonlyHeaders
   readonly cookies: ReadonlyRequestCookies
+  readonly mutableCookies: RequestCookies
   readonly previewData: PreviewData
 }
 

--- a/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
@@ -14,6 +14,7 @@ import {
   type ReadonlyHeaders,
 } from '../web/spec-extension/adapters/headers'
 import {
+  MutableRequestCookiesAdapter,
   RequestCookiesAdapter,
   type ReadonlyRequestCookies,
 } from '../web/spec-extension/adapters/request-cookies'
@@ -33,6 +34,14 @@ function getCookies(
 ): ReadonlyRequestCookies {
   const cookies = new RequestCookies(HeadersAdapter.from(headers))
   return RequestCookiesAdapter.seal(cookies)
+}
+
+function getMutableCookies(
+  headers: Headers | IncomingHttpHeaders,
+  res: ServerResponse | BaseNextResponse | undefined
+): RequestCookies {
+  const cookies = new RequestCookies(HeadersAdapter.from(headers))
+  return MutableRequestCookiesAdapter.seal(cookies, res)
 }
 
 /**
@@ -80,6 +89,7 @@ export const RequestAsyncStorageWrapper: AsyncStorageWrapper<
     const cache: {
       headers?: ReadonlyHeaders
       cookies?: ReadonlyRequestCookies
+      mutableCookies?: RequestCookies
     } = {}
 
     const store: RequestStore = {
@@ -100,6 +110,12 @@ export const RequestAsyncStorageWrapper: AsyncStorageWrapper<
         }
 
         return cache.cookies
+      },
+      get mutableCookies() {
+        if (!cache.mutableCookies) {
+          cache.mutableCookies = getMutableCookies(req.headers, res)
+        }
+        return cache.mutableCookies
       },
       previewData,
     }

--- a/packages/next/src/server/future/route-modules/route-module.ts
+++ b/packages/next/src/server/future/route-modules/route-module.ts
@@ -15,6 +15,8 @@ const headerHooks =
   require('next/dist/client/components/headers') as typeof import('../../../client/components/headers')
 const { staticGenerationBailout } =
   require('next/dist/client/components/static-generation-bailout') as typeof import('../../../client/components/static-generation-bailout')
+const { actionAsyncStorage } =
+  require('next/dist/client/components/action-async-storage') as typeof import('../../../client/components/action-async-storage')
 
 /**
  * RouteModuleOptions is the options that are passed to the route module, other
@@ -71,6 +73,12 @@ export abstract class RouteModule<
    * the underlying static generation storage.
    */
   public readonly staticGenerationBailout = staticGenerationBailout
+
+  /**
+   * A reference to the mutation related async storage, such as mutations of
+   * cookies.
+   */
+  public readonly actionAsyncStorage = actionAsyncStorage
 
   /**
    * The userland module. This is the module that is exported from the user's

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
@@ -1,4 +1,7 @@
 import type { RequestCookies } from '../cookies'
+import type { BaseNextResponse } from '../../../base-http'
+import type { ServerResponse } from 'http'
+
 import { ReflectAdapter } from './reflect'
 
 /**
@@ -30,6 +33,86 @@ export class RequestCookiesAdapter {
           case 'delete':
           case 'set':
             return ReadonlyRequestCookiesError.callable
+          default:
+            return ReflectAdapter.get(target, prop, receiver)
+        }
+      },
+    })
+  }
+}
+
+export class MutableRequestCookiesAdapter {
+  public static seal(
+    cookies: RequestCookies,
+    res: ServerResponse | BaseNextResponse | undefined
+  ): RequestCookies {
+    const modifiedCookies = new Set<string>()
+    const updateResponseCookies = () => {
+      const allCookies = cookies.getAll()
+      const values = allCookies
+        .filter((c) => modifiedCookies.has(c.name))
+        .map((c) => `${c.name}=${c.value}`)
+      if (!res) {
+        throw new Error('invariant: Cannot modify the response cookie')
+      }
+      res.setHeader('Set-Cookie', values)
+    }
+
+    return new Proxy(cookies, {
+      get(target, prop, receiver) {
+        switch (prop) {
+          // TODO: Throw error if trying to set a cookie after the response
+          // headers have been set.
+          case 'clear':
+            return function () {
+              for (const c of cookies.getAll()) {
+                modifiedCookies.add(c.name)
+              }
+              try {
+                return cookies.clear()
+              } finally {
+                updateResponseCookies()
+              }
+            }
+          case 'delete':
+            return function (names: string | string[]) {
+              if (Array.isArray(names)) {
+                names.forEach((name) => modifiedCookies.add(name))
+              } else {
+                modifiedCookies.add(names)
+              }
+              try {
+                return cookies.delete(names)
+              } finally {
+                updateResponseCookies()
+              }
+            }
+          case 'set':
+            return function (
+              ...args:
+                | [string, string]
+                | [
+                    options: NonNullable<
+                      ReturnType<InstanceType<typeof RequestCookies>['get']>
+                    >
+                  ]
+            ) {
+              const [key, value] = args
+              if (typeof key === 'string') {
+                modifiedCookies.add(key)
+                try {
+                  return cookies.set(key, value!)
+                } finally {
+                  updateResponseCookies()
+                }
+              }
+              modifiedCookies.add(key.name)
+              try {
+                return cookies.set(key)
+              } finally {
+                updateResponseCookies()
+              }
+            }
           default:
             return ReflectAdapter.get(target, prop, receiver)
         }

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -54,6 +54,14 @@ createNextDescribe(
       }, 'same')
     })
 
+    it('should support setting cookies in route handlers with the correct overrides', async () => {
+      const res = await next.fetch('/handler')
+      const setCookieHeader = res.headers.get('set-cookie')
+      expect(setCookieHeader).toInclude('bar=bar2;')
+      expect(setCookieHeader).toInclude('baz=baz2;')
+      expect(setCookieHeader).toInclude('foo=foo1;')
+    })
+
     it('should support formData and redirect', async () => {
       const browser = await next.browser('/server')
 

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -42,6 +42,16 @@ createNextDescribe(
         const res = (await browser.elementByCss('h1').text()) || ''
         return res.includes('Mozilla') ? 'UA' : ''
       }, 'UA')
+
+      // Set cookies
+      await browser.elementByCss('#setCookie').click()
+      await check(async () => {
+        const res = (await browser.elementByCss('h1').text()) || ''
+        const id = res.split(':')
+        return id[0] === id[1] && id[0] === id[2] && id[0]
+          ? 'same'
+          : 'different'
+      }, 'same')
     })
 
     it('should support formData and redirect', async () => {

--- a/test/e2e/app-dir/actions/app/handler/route.js
+++ b/test/e2e/app-dir/actions/app/handler/route.js
@@ -1,0 +1,12 @@
+import { cookies } from 'next/headers'
+
+export const GET = async () => {
+  cookies().set('foo', 'foo1')
+  cookies().set('bar', 'bar1')
+  return new Response('Hello, world!', {
+    headers: [
+      ['Set-Cookie', 'bar=bar2'],
+      ['Set-Cookie', 'baz=baz2'],
+    ],
+  })
+}

--- a/test/e2e/app-dir/actions/app/header/actions.js
+++ b/test/e2e/app-dir/actions/app/header/actions.js
@@ -9,3 +9,8 @@ export async function getCookie(name) {
 export async function getHeader(name) {
   return headers().get(name)
 }
+
+export async function setCookie(name, value) {
+  cookies().set(name, value)
+  return cookies().get(name)
+}

--- a/test/e2e/app-dir/actions/app/header/page.js
+++ b/test/e2e/app-dir/actions/app/header/page.js
@@ -1,6 +1,6 @@
 import UI from './ui'
 
-import { getCookie, getHeader } from './actions'
+import { getCookie, getHeader, setCookie } from './actions'
 import { validator } from './validator'
 
 export default function Page() {
@@ -9,6 +9,7 @@ export default function Page() {
     <UI
       getCookie={getCookie}
       getHeader={getHeader}
+      setCookie={setCookie}
       getAuthedUppercase={validator(async (str) => {
         'use server'
         return prefix + ' ' + str.toUpperCase()

--- a/test/e2e/app-dir/actions/app/header/ui.js
+++ b/test/e2e/app-dir/actions/app/header/ui.js
@@ -2,7 +2,12 @@
 
 import { useState } from 'react'
 
-export default function UI({ getCookie, getHeader, getAuthedUppercase }) {
+export default function UI({
+  getCookie,
+  getHeader,
+  setCookie,
+  getAuthedUppercase,
+}) {
   const [result, setResult] = useState('')
 
   return (
@@ -19,6 +24,23 @@ export default function UI({ getCookie, getHeader, getAuthedUppercase }) {
         }}
       >
         getCookie
+      </button>
+      <button
+        id="setCookie"
+        onClick={async () => {
+          // set cookie on server side
+          const random = Math.random()
+          const res = await setCookie('random-server', random)
+          setResult(
+            random +
+              ':' +
+              res.value +
+              ':' +
+              document.cookie.match(/random-server=([^;]+)/)?.[1]
+          )
+        }}
+      >
+        setCookie
       </button>
       <button
         id="header"


### PR DESCRIPTION
Similar to #47922 but based off the latest server implementation and #48626:

> This PR implements the MutableRequestCookies instance for cookies() based on the current async context, so we can allow setting cookies in certain places such as Server Functions and Route handlers. Note that to support Route Handlers, we need to also implement the logic of merging Response's Set-Cookie header and the cookies() mutations, hence it's not included in this PR.
>
> fix [NEXT-942](https://linear.app/vercel/issue/NEXT-942)

This PR also adds the same support for Custom Routes.

cc @styfle.

fix NEXT-942, fix NEXT-941.