### PR TITLE
Fix issues where saving next.config.js too quickly could result in multiple dev servers running at once

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -297,12 +297,9 @@ const nextDev: CliCommand = async (argv) => {
   } else {
     let cleanupFns: (() => Promise<void> | void)[] = []
     const runDevServer = async () => {
-      const id = Math.random()
-      console.log('Starting ', id)
       const oldCleanupFns = cleanupFns
       cleanupFns = []
       await Promise.allSettled(oldCleanupFns.map((fn) => fn()))
-      console.log('finish cleanup ', id)
 
       try {
         let shouldFilter = false

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -297,9 +297,12 @@ const nextDev: CliCommand = async (argv) => {
   } else {
     let cleanupFns: (() => Promise<void> | void)[] = []
     const runDevServer = async () => {
+      const id = Math.random()
+      console.log('Starting ', id)
       const oldCleanupFns = cleanupFns
       cleanupFns = []
       await Promise.allSettled(oldCleanupFns.map((fn) => fn()))
+      console.log('finish cleanup ', id)
 
       try {
         let shouldFilter = false
@@ -325,16 +328,12 @@ const nextDev: CliCommand = async (argv) => {
             return
           }
 
-          const startDir = dir
-          if (newDir) {
-            dir = newDir
-          }
-
           if (devServerTeardown) {
             await devServerTeardown()
             devServerTeardown = undefined
           }
 
+          const startDir = dir
           if (newDir) {
             dir = newDir
             process.env = Object.keys(process.env).reduce((newEnv, key) => {
@@ -378,14 +377,32 @@ const nextDev: CliCommand = async (argv) => {
             process[fd].write(chunk)
           }
 
-          devServerOptions.onStdout = (chunk) => {
-            filterForkErrors(chunk, 'stdout')
+          let resolveCleanup!: (cleanup: () => Promise<void>) => void
+          let cleanupPromise = new Promise<() => Promise<void>>((resolve) => {
+            resolveCleanup = resolve
+          })
+          const cleanupWrapper = async () => {
+            const promise = cleanupPromise
+            cleanupPromise = Promise.resolve(async () => {})
+            const cleanup = await promise
+            await cleanup()
           }
-          devServerOptions.onStderr = (chunk) => {
-            filterForkErrors(chunk, 'stderr')
+          cleanupFns.push(cleanupWrapper)
+          devServerTeardown = cleanupWrapper
+
+          try {
+            devServerOptions.onStdout = (chunk) => {
+              filterForkErrors(chunk, 'stdout')
+            }
+            devServerOptions.onStderr = (chunk) => {
+              filterForkErrors(chunk, 'stderr')
+            }
+            shouldFilter = false
+            resolveCleanup(await startServer(devServerOptions))
+          } finally {
+            // fallback to noop, if not provided
+            resolveCleanup(async () => {})
           }
-          shouldFilter = false
-          devServerTeardown = await startServer(devServerOptions)
 
           if (!config) {
             config = await loadConfig(
@@ -403,7 +420,6 @@ const nextDev: CliCommand = async (argv) => {
             )
           }
         }
-        cleanupFns.push(() => devServerTeardown?.())
 
         await setupFork()
         await preflight()


### PR DESCRIPTION
We were adding filling in our cleanup function after we started our server. So If we restarted while the server was starting, we would fire an empty cleanup function which would lead to the server not being cleaned up (once it starts).

The only slight issue is that it won't watch for changes while cleaning up the previous run (waiting for the server from the last run to start and finish).

fix NEXT-1052