### PR TITLE
Do not allow type Promise for props in GetServerSidePropsResult

### DIFF
--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -249,7 +249,7 @@ export type GetServerSidePropsContext<
  * @link https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#getserversideprops-return-values
  */
 export type GetServerSidePropsResult<Props> =
-  | { props: Props | Promise<Props> }
+  | { props: Props }
   | { redirect: Redirect }
   | { notFound: true }
 


### PR DESCRIPTION
A few type definitions were changed here #46046, including GetServerSidePropsResult. Within getServerSideProps, async functions have to be awaited; results are collected in the props object, which is then forwarded to the page. It does not make sense to return a Promise, which later has to be resolved into props within a page; it has to be an object identical to the props interface in GetStaticPropsResult. Fixes #48886
