### PR TITLE
Ensure require-hook env is set properly on deploy

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -283,6 +283,15 @@ export default async function build(
 
       if (isAppDirEnabled) {
         process.env.NEXT_PREBUNDLED_REACT = '1'
+
+        if (!process.env.__NEXT_TEST_MODE && ciEnvironment.hasNextSupport) {
+          const requireHook = require.resolve('../server/require-hook')
+          const contents = await promises.readFile(requireHook, 'utf8')
+          await promises.writeFile(
+            requireHook,
+            `process.env.__NEXT_PRIVATE_PREBUNDLED_REACT = '1'\n${contents}`
+          )
+        }
       }
 
       const { pagesDir, appDir } = findPagesDir(dir, isAppDirEnabled)


### PR DESCRIPTION
This ensures we set the pre-bundled react env variable early enough when in a deploy environment as otherwise incorrect react versions could be initialized with app directory. 

Test deployment with fix can be seen here https://metadata-dynamic-lsbqdamud-vtest314-ijjk-testing.vercel.app/dynamic/test

This re-adds the patch we were doing before https://github.com/vercel/next.js/commit/b5f7f8448560d4ec6bc875cbffe3aa18da8971cf#diff-90d1d5f446bdf243be25cc4ea2295a9c91508859d655e51d5ec4a3562d3a24d9

No additional tests were added here as existing e2e deploy tests were failing without this. 

Fixes: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1682546721052149)
Fixes: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1682539142269669)
Fixes: https://github.com/vercel/next.js/issues/48872

