### PR TITLE
fix: explicit undefined typecheck

### DIFF
--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -117,7 +117,7 @@ function createProcessPolyfill(options: Pick<ModuleContextOptions, 'env'>) {
     if (key === 'env') continue
     Object.defineProperty(processPolyfill, key, {
       get() {
-        if (overridenValue[key]) {
+        if (overridenValue[key] !== undefined) {
           return overridenValue[key]
         }
         if (typeof (process as any)[key] === 'function') {


### PR DESCRIPTION
The current implementation is throwing wrongly if you set a falsy JS value (like `0` or `null`)

So right now this is fail even it's a legit implementation: `process.counter = 0`