### PR TITLE
Add handling for preferredRegion and layout runtime

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -3,7 +3,6 @@ import type { Middleware, RouteHas } from '../../lib/load-custom-routes'
 
 import path from 'path'
 import { promises as fs } from 'fs'
-import { defaultConfig } from '../../server/config-shared'
 import LRUCache from 'next/dist/compiled/lru-cache'
 import { matcher } from 'next/dist/compiled/micromatch'
 import { ServerRuntime } from 'next/types'
@@ -20,7 +19,7 @@ import { isAPIRoute } from '../../lib/is-api-route'
 import { isEdgeRuntime } from '../../lib/is-edge-runtime'
 import { RSC_MODULE_TYPES } from '../../shared/lib/constants'
 import type { RSCMeta } from '../webpack/loaders/get-module-build-info'
-import { getPageFromPath } from '../entries'
+import { normalizePathSep } from '../../shared/lib/page-path/normalize-path-sep'
 
 export interface MiddlewareConfig {
   matchers: MiddlewareMatcher[]
@@ -444,9 +443,18 @@ export async function getPageStaticInfo(params: {
         const files = await fs.readdir(curPagePath)
 
         for (const file of files) {
-          const cleanedFile = getPageFromPath(
-            file,
-            nextConfig.pageExtensions || defaultConfig?.pageExtensions || []
+          const { defaultConfig } = require('../../server/config-shared')
+          const cleanedFile = normalizePathSep(
+            file.replace(
+              new RegExp(
+                `\\.+(${(
+                  nextConfig.pageExtensions ||
+                  defaultConfig?.pageExtensions ||
+                  []
+                ).join('|')})$`
+              ),
+              ''
+            )
           )
           const newPageFilePath = path.join(curPagePath, file)
 

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -341,7 +341,7 @@ export async function getPageStaticInfo(params: {
   const fileContent = (await tryToReadFile(pageFilePath, !isDev)) || ''
   if (
     (pageType === 'app' &&
-      pageExtensions.includes(path.extname(pageFilePath))) ||
+      pageExtensions.includes(path.extname(pageFilePath).substring(1))) ||
     /runtime|getStaticProps|getServerSideProps|export const config/.test(
       fileContent
     )

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1074,7 +1074,7 @@ export type AppConfig = {
   dynamicParams?: true | false
   dynamic?: 'auto' | 'error' | 'force-static' | 'force-dynamic'
   fetchCache?: 'force-cache' | 'only-cache'
-  preferredRegion?: string
+  preferredRegion?: string | string[]
 }
 export type GenerateParams = Array<{
   config?: AppConfig

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -598,16 +598,18 @@ async function findEntryEdgeFunctionConfig(
       )
     )
     if (typeof pageFilePath === 'string') {
+      const config = await getPageStaticInfo({
+        nextConfig: {},
+        pageFilePath,
+        isDev: false,
+        pageType:
+          pageFilePath.includes('app') && !pageFilePath.includes('middleware')
+            ? 'app'
+            : 'root',
+      })
       return {
         file: pageFilePath,
-        config: (
-          await getPageStaticInfo({
-            nextConfig: {},
-            pageFilePath,
-            isDev: false,
-            pageType: 'root',
-          })
-        ).middleware,
+        config: config.middleware,
       }
     }
   }

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -602,10 +602,11 @@ async function findEntryEdgeFunctionConfig(
         nextConfig: {},
         pageFilePath,
         isDev: false,
-        pageType:
-          pageFilePath.includes('app') && !pageFilePath.includes('middleware')
-            ? 'app'
-            : 'root',
+        pageType: pageFilePath.match(/[/\\]pages[/\\]/)
+          ? 'pages'
+          : pageFilePath.match(/[/\\]app[/\\]/)
+          ? 'app'
+          : 'root',
       })
       return {
         file: pageFilePath,

--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -66,7 +66,7 @@ checkFields<Diff<{
   dynamic?: 'auto' | 'force-dynamic' | 'error' | 'force-static'
   dynamicParams?: boolean
   fetchCache?: 'auto' | 'force-no-store' | 'only-no-store' | 'default-no-store' | 'default-cache' | 'only-cache' | 'force-cache'
-  preferredRegion?: 'auto' | 'home' | 'edge'
+  preferredRegion?: 'all' | string | string[]
   ${
     options.type === 'page' || options.type === 'route'
       ? "runtime?: 'nodejs' | 'experimental-edge' | 'edge'"

--- a/test/e2e/app-dir/app/app/(rootonly)/dashboard/hello/page.js
+++ b/test/e2e/app-dir/app/app/(rootonly)/dashboard/hello/page.js
@@ -7,3 +7,4 @@ export default function HelloPage(props) {
 }
 
 export const runtime = 'experimental-edge'
+export const preferredRegion = ['iad1', 'sfo1']

--- a/test/e2e/app-dir/app/app/dashboard/layout.js
+++ b/test/e2e/app-dir/app/app/dashboard/layout.js
@@ -9,3 +9,5 @@ export default function DashboardLayout(props) {
     </div>
   )
 }
+
+export const preferredRegion = 'iad1'

--- a/test/e2e/app-dir/app/app/slow-page-no-loading/page.js
+++ b/test/e2e/app-dir/app/app/slow-page-no-loading/page.js
@@ -14,3 +14,4 @@ export default function SlowPage(props) {
 }
 
 export const runtime = 'experimental-edge'
+export const preferredRegion = 'all'

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -10,6 +10,24 @@ createNextDescribe(
     files: __dirname,
   },
   ({ next, isNextDev: isDev, isNextStart, isNextDeploy }) => {
+    if (isNextStart) {
+      it('should have correct preferredRegion values in manifest', async () => {
+        const middlewareManifest = JSON.parse(
+          await next.readFile('.next/server/middleware-manifest.json')
+        )
+        expect(
+          middlewareManifest.functions['/(rootonly)/dashboard/hello/page']
+            .regions
+        ).toEqual(['iad1', 'sfo1'])
+        expect(middlewareManifest.functions['/dashboard/page'].regions).toEqual(
+          'iad1'
+        )
+        expect(
+          middlewareManifest.functions['/slow-page-no-loading/page'].regions
+        ).toBeUndefined()
+      })
+    }
+
     it('should have correct searchParams and params (server)', async () => {
       const html = await next.render('/dynamic/category-1/id-2?query1=value2')
       const $ = cheerio.load(html)


### PR DESCRIPTION
This ensures we properly honor the `export const preferredRegion` config in `app` and also ensures we check parent layouts for `preferredRegion` or `runtime` if not already defined on the page itself.  

Fixes: https://github.com/vercel/next.js/issues/48905
Fixes: NEXT-880