### PR TITLE
fix: bump minimum Node.js version to 16.8.0

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ If you have questions about anything related to Next.js, you're always welcome t
 
 #### System Requirements
 
-- [Node.js 14.18.0](https://nodejs.org/) or newer
+- [Node.js 16.8.0](https://nodejs.org/) or newer
 - MacOS, Windows (including WSL), and Linux are supported
 
 ## Automatic Setup

--- a/packages/create-next-app/package.json
+++ b/packages/create-next-app/package.json
@@ -55,6 +55,6 @@
     "validate-npm-package-name": "3.0.0"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=16.8.0"
   }
 }

--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -70,8 +70,9 @@ module.exports = function (task) {
         },
         env: {
           targets: {
-            // follow the version defined in packages/next/package.json#engine
-            node: '14.18.0',
+            // Should match version defined in packages/next/package.json#engine
+            // Should also match NODE_16_VERSION in packages/next/src/server/config.ts
+            node: '16.8.0',
           },
         },
         jsc: {


### PR DESCRIPTION
We bumped `undici` fetch which has a minimum version of 16.8.0 so we need to make sure `next` and `create-next-app` also have the same minimum version.

Since 14.x reaches End-of-Life on [2023-04-30](https://github.com/nodejs/Release), we can drop support for 14 in the next release.

See also:

- Related to #48870
- Related #48941

