### PR TITLE
Update resolve rule for `@swc/helpers`

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1071,8 +1071,9 @@ export default async function getBaseWebpackConfig(
           }
         : {}),
 
-      '@swc/helpers': path.dirname(
-        require.resolve('@swc/helpers/package.json')
+      '@swc/helpers/_': path.join(
+        path.dirname(require.resolve('@swc/helpers/package.json')),
+        '_'
       ),
 
       setimmediate: 'next/dist/compiled/setimmediate',


### PR DESCRIPTION
### What?

Update resolve rule for `@swc/helpers` => `node_modules/@swc/helpers` to `@swc/helpers/_` => `node_modules/@swc/helpers/_` to select only `@swc/helpers@v0.5.0`.

### Why?

Previous rule make webpack merge `@swc/helpers@v0.4.x` and `@swc/helpers@v0.5.x`

### How?

Closes WEB-948
Fixes #48593
