### PR TITLE
Fix scroll when loading.js/ts is used

### DIFF
--- a/test/e2e/app-dir/router-autoscroll/app/loading-scroll/loading.tsx
+++ b/test/e2e/app-dir/router-autoscroll/app/loading-scroll/loading.tsx
@@ -1,0 +1,13 @@
+export default function Loading() {
+  return (
+    <>
+      <div id="loading-component">Loading component</div>
+      {
+        // Repeat 500 elements
+        Array.from({ length: 500 }, (_, i) => (
+          <div key={i}>Loading {i}...</div>
+        ))
+      }
+    </>
+  )
+}

--- a/test/e2e/app-dir/router-autoscroll/app/loading-scroll/page.tsx
+++ b/test/e2e/app-dir/router-autoscroll/app/loading-scroll/page.tsx
@@ -1,0 +1,17 @@
+export const dynamic = 'force-dynamic'
+
+export default async function Page() {
+  await new Promise((resolve) => setTimeout(resolve, 5000))
+  return (
+    <>
+      <div style={{ display: 'none' }}>Content that is hidden.</div>
+      <div id="content-that-is-visible">Content which is not hidden.</div>
+      {
+        // Repeat 500 elements
+        Array.from({ length: 500 }, (_, i) => (
+          <div key={i}>{i}</div>
+        ))
+      }
+    </>
+  )
+}

--- a/test/e2e/app-dir/router-autoscroll/app/page.tsx
+++ b/test/e2e/app-dir/router-autoscroll/app/page.tsx
@@ -9,9 +9,16 @@ export default function Page() {
           <div key={i}>{i}</div>
         ))
       }
-      <Link href="/invisible-first-element" id="to-invisible-first-element">
-        To invisible first element
-      </Link>
+      <div>
+        <Link href="/loading-scroll" id="to-loading-scroll">
+          To loading scroll
+        </Link>
+      </div>
+      <div>
+        <Link href="/invisible-first-element" id="to-invisible-first-element">
+          To invisible first element
+        </Link>
+      </div>
     </>
   )
 }

--- a/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+++ b/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -170,6 +170,18 @@ createNextDescribe(
           .waitForElementByCss('#content-that-is-visible')
         await check(() => browser.eval('window.scrollY'), 0)
       })
+
+      it('Should apply scroll when loading.js is used', async () => {
+        const browser = await webdriver(next.url, '/')
+        await browser.eval('window.scrollTo(0, 500)')
+        await browser
+          .elementByCss('#to-loading-scroll')
+          .click()
+          .waitForElementByCss('#loading-component')
+        await check(() => browser.eval('window.scrollY'), 0)
+        await browser.waitForElementByCss('#content-that-is-visible')
+        await check(() => browser.eval('window.scrollY'), 0)
+      })
     })
   }
 )


### PR DESCRIPTION
### What?

Whenever you navigated and a page suspended through `loading` or an error happened caught by `error` in the first level of segments (e.g. `/dashboard` but not `/dashboard/settings`) scroll would not be applied. This happened because the focus and scroll handling component is rendered as part of `InnerLayoutRouter` and the Suspense / Error boundary was rendered **around** `InnerLayoutRouter`. This behavior is incorrect as we still want to immediately scroll to the place where the loading is rendered.

This PR fixes the behavior by allowing the scroll to apply to loading / error too.

### How?

Moved the scrolling component around the loading/error/innerlayout boundary and added tests.

