### PR TITLE
Fix duplicated Edge Runtime warnings

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -288,6 +288,12 @@ function getMiddlewareConfig(
 
 const apiRouteWarnings = new LRUCache({ max: 250 })
 function warnAboutExperimentalEdge(apiRoute: string | null) {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.NEXT_PRIVATE_BUILD_WORKER === '1'
+  ) {
+    return
+  }
   if (apiRouteWarnings.has(apiRoute)) {
     return
   }


### PR DESCRIPTION
When we enable `webpackBuildWorker` this module level `const apiRouteWarnings = new LRUCache({ max: 250 })` will be created in 3 workers, so users will see 4 outputs (last one is static optimization):

<img width="740" alt="CleanShot 2023-04-29 at 20 20 38@2x" src="https://user-images.githubusercontent.com/3676859/235318861-2ec12e30-70b2-4b56-8a2e-df08d130c349.png">

This PR fixes that and now there's only 1.