### PR TITLE
Fix CSS ordering issue with HMR

### DIFF
--- a/packages/next/src/client/app-link-gc.ts
+++ b/packages/next/src/client/app-link-gc.ts
@@ -10,7 +10,7 @@ export function linkGc() {
               (node as HTMLLinkElement).tagName === 'LINK'
             ) {
               const link = node as HTMLLinkElement
-              if (link.dataset.precedence === 'next.js') {
+              if (link.dataset.precedence?.startsWith('next')) {
                 const href = link.getAttribute('href')
                 if (href) {
                   const [resource, version] = href.split('?v=')
@@ -19,7 +19,7 @@ export function linkGc() {
                       `link[href^="${resource}"]`
                     ) as NodeListOf<HTMLLinkElement>
                     for (const otherLink of allLinks) {
-                      if (otherLink.dataset.precedence === 'next.js') {
+                      if (otherLink.dataset.precedence?.startsWith('next')) {
                         const otherHref = otherLink.getAttribute('href')
                         if (otherHref) {
                           const [, otherVersion] = otherHref.split('?v=')

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -394,8 +394,11 @@ export async function renderToHTMLOrFlight(
             // During HMR, it's critical to use different `precedence` values
             // for different stylesheets, so their order will be kept.
             // https://github.com/facebook/react/pull/25060
-            const precedence =
-              process.env.NODE_ENV === 'development' ? 'next_' + href : 'next'
+            const precedence = shouldPreload
+              ? process.env.NODE_ENV === 'development'
+                ? 'next_' + href
+                : 'next'
+              : undefined
 
             return (
               <link

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -305,7 +305,7 @@ createNextDescribe(
             // Even if it's deduped by Float, it should still only be included once in the payload.
             // There are 3 matches, one for the rendered <link>, one for float preload and one for the <link> inside flight payload.
             expect(
-              initialHtml.match(/css-duplicate-2\/layout\.css/g).length
+              initialHtml.match(/css-duplicate-2\/layout\.css\?v=/g).length
             ).toBe(3)
           })
 

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -254,6 +254,39 @@ createNextDescribe(
       })
 
       if (isDev) {
+        it.only('should not affect css orders during HMR', async () => {
+          const filePath = 'app/ordering/page.js'
+          const origContent = await next.readFile(filePath)
+
+          // h1 should be red
+          const browser = await next.browser('/ordering')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('h1')).color`
+            )
+          ).toBe('rgb(255, 0, 0)')
+
+          try {
+            await next.patchFile(
+              filePath,
+              origContent.replace('<h1>Hello</h1>', '<h1>Hello!</h1>')
+            )
+
+            // Wait for HMR to trigger
+            await check(
+              () => browser.eval(`document.querySelector('h1').textContent`),
+              'Hello!'
+            )
+            expect(
+              await browser.eval(
+                `window.getComputedStyle(document.querySelector('h1')).color`
+              )
+            ).toBe('rgb(255, 0, 0)')
+          } finally {
+            await next.patchFile(filePath, origContent)
+          }
+        })
+
         describe('multiple entries', () => {
           it('should only inject the same style once if used by different layers', async () => {
             const browser = await next.browser('/css/css-duplicate-2/client')

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -254,7 +254,7 @@ createNextDescribe(
       })
 
       if (isDev) {
-        it.only('should not affect css orders during HMR', async () => {
+        it('should not affect css orders during HMR', async () => {
           const filePath = 'app/ordering/page.js'
           const origContent = await next.readFile(filePath)
 


### PR DESCRIPTION
Closes #48807.

The issue seems to be introduced with recent React Float change, which isn't a real problem but a behavior change. Resources are layered by the `precedence` key and the style insertion logic can be simplified as "insert the new stylesheet right after the existing stylesheet in the same layer". When multiple stylesheets are inserted in the same render pass, their new order will be flipped.

This is a nice feature so we can always maintain the order of resources that might conflict.