### PR TITLE
Make NextResponse.json generic for strongly typed responses

### DIFF
--- a/packages/next/src/server/web/spec-extension/response.ts
+++ b/packages/next/src/server/web/spec-extension/response.ts
@@ -66,7 +66,7 @@ export class NextResponse extends Response {
     return this[INTERNALS].cookies
   }
 
-  static json(body: any, init?: ResponseInit): NextResponse {
+  static json<T>(body: T, init?: ResponseInit): NextResponse {
     // @ts-expect-error This is not in lib/dom right now, and we can't augment it.
     const response: Response = Response.json(body, init)
     return new NextResponse(response.body, response)


### PR DESCRIPTION
### What?
Make NextResponse.json a generic for body prop
### Why?
So that users can optionally enforce a return type in their endpoints. Useful when trying to implement end to end type safety.
### How?
Remove any from body prop and make it of type <T>

