### PR TITLE
fix GlobalError interop and add test case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "serde",
 ]
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "serde",
@@ -6980,7 +6980,7 @@ dependencies = [
 [[package]]
 name = "turbo-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7020,7 +7020,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "mimalloc",
 ]
@@ -7028,7 +7028,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7058,7 +7058,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7070,7 +7070,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7085,7 +7085,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7099,7 +7099,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7116,7 +7116,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7145,7 +7145,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "base16",
  "hex",
@@ -7157,7 +7157,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7171,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7181,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7203,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7215,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7274,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7291,7 +7291,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7331,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7374,7 +7374,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7408,7 +7408,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7444,7 +7444,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "serde",
@@ -7458,7 +7458,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7474,7 +7474,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7494,7 +7494,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "serde",
@@ -7509,7 +7509,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7524,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7558,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "serde",
@@ -7574,7 +7574,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.2#161aa1079155876a3fa3d19a6f4bcd8c662758a4"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230501.3#cfa80273baa74b958576474ac0a17da786e3eb64"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ swc_relay = { version = "0.2.7" }
 testing = { version = "0.33.6" }
 
 # Turbo crates
-turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230501.2" }
+turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230501.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230501.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230501.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230501.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230501.3" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.2",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230501.2",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.3",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230501.3",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/named-client-comp/input/app/layout.tsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/named-client-comp/input/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }: { children: any }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/named-client-comp/input/app/page.tsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/named-client-comp/input/app/page.tsx
@@ -1,0 +1,9 @@
+import { Test } from './test'
+
+export default function Page() {
+  return (
+    <div>
+      <Test />
+    </div>
+  )
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/named-client-comp/input/app/test.tsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/named-client-comp/input/app/test.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function Test() {
+  useEffect(() => {
+    import('@turbo/pack-test-harness').then(() => {
+      it('should allow to import a named export from a client component', () => {})
+    })
+    return () => {}
+  }, [])
+}

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/named-client-comp/input/next.config.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/named-client-comp/input/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+  },
+}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1204,10 +1204,9 @@ export async function renderToHTMLOrFlight(
     const AppRouter =
       ComponentMod.AppRouter as typeof import('../../client/components/app-router').default
 
-    const GlobalError = interopDefault(
+    const GlobalError =
       /** GlobalError can be either the default error boundary or the overwritten app/global-error.js **/
       ComponentMod.GlobalError as typeof import('../../client/components/error-boundary').default
-    )
 
     let serverComponentsInlinedTransformStream: TransformStream<
       Uint8Array,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1018,8 +1018,8 @@ importers:
       '@types/react': 18.0.37
       '@types/react-dom': 18.0.11
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.2
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230501.2
+      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.3
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230501.3
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1031,8 +1031,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.2_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230501.2'
+      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.3_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230501.3'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25574,9 +25574,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.2_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.2}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.2'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.3_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.3}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230501.3'
     name: '@vercel/turbopack-dev'
     version: 0.0.0
     dependencies:
@@ -25586,8 +25586,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230501.2':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230501.2}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230501.3':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230501.3}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

fixes handling of GlobalError interop
adds a test case for client component bug

### Why?

app dir client component interop is broken

### Turbopack changes

* https://github.com/vercel/turbo/pull/4597 <!-- Tobias Koppers - add rspack to our benchmark suite  -->
* https://github.com/vercel/turbo/pull/4761 <!-- Tobias Koppers - Do not use interop logic on proxy modules  -->
