### PR TITLE
Fix extra block element in body

### DIFF
--- a/packages/next/src/client/components/app-router-announcer.tsx
+++ b/packages/next/src/client/components/app-router-announcer.tsx
@@ -11,6 +11,7 @@ function getAnnouncerNode() {
     return existingAnnouncer.shadowRoot.childNodes[0] as HTMLElement
   } else {
     const container = document.createElement(ANNOUNCER_TYPE)
+    container.style.cssText = 'position:absolute'
     const announcer = document.createElement('div')
     announcer.setAttribute('aria-live', 'assertive')
     announcer.setAttribute('id', ANNOUNCER_ID)


### PR DESCRIPTION
This PR adds `position: absolute` to the router announcer container so it won't affect the  layout of siblings / parents.

Closes #48087.