### PR TITLE
Fix failing test on `canary` branch

### DIFF
--- a/test/e2e/switchable-runtime/app/layout.js
+++ b/test/e2e/switchable-runtime/app/layout.js
@@ -1,6 +1,4 @@
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Root({ children }) {
   return (


### PR DESCRIPTION
Not sure when it was introduced (this was a warning before), but it's failing on `canary` right now: https://github.com/vercel/next.js/actions/runs/4851306015/jobs/8645117315