### PR TITLE
Rename `experimentalReact`

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1143,7 +1143,7 @@ export default async function build(
               ...process.env,
               __NEXT_PRIVATE_PREBUNDLED_REACT:
                 type === 'app'
-                  ? config.experimental.experimentalReact
+                  ? config.experimental.serverActions
                     ? 'experimental'
                     : 'next'
                   : '',

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1955,7 +1955,7 @@ ${
   // to ensure the correctness of the version for app.
   `\
 if (nextConfig && nextConfig.experimental && nextConfig.experimental.appDir) {
-  process.env.__NEXT_PRIVATE_PREBUNDLED_REACT = nextConfig.experimental.experimentalReact ? 'experimental' : 'next'
+  process.env.__NEXT_PRIVATE_PREBUNDLED_REACT = nextConfig.experimental.serverActions ? 'experimental' : 'next'
 }
 `
 }

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -704,8 +704,8 @@ export default async function getBaseWebpackConfig(
   const hasServerComponents = hasAppDir
   const disableOptimizedLoading = true
   const enableTypedRoutes = !!config.experimental.typedRoutes && hasAppDir
-  const experimentalReact = !!config.experimental.experimentalReact && hasAppDir
-  const bundledReactChannel = experimentalReact ? '-experimental' : ''
+  const serverActions = !!config.experimental.serverActions && hasAppDir
+  const bundledReactChannel = serverActions ? '-experimental' : ''
 
   if (isClient) {
     if (
@@ -2307,7 +2307,7 @@ export default async function getBaseWebpackConfig(
               appDir,
               dev,
               isEdgeServer,
-              useExperimentalReact: experimentalReact,
+              useServerActions: serverActions,
             })),
       hasAppDir &&
         !isClient &&

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -152,17 +152,15 @@ export class ClientReferenceEntryPlugin {
       })
     })
 
-    if (this.useServerActions) {
-      compiler.hooks.make.tap(PLUGIN_NAME, (compilation) => {
-        compilation.hooks.processAssets.tap(
-          {
-            name: PLUGIN_NAME,
-            stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
-          },
-          (assets) => this.createActionAssets(compilation, assets)
-        )
-      })
-    }
+    compiler.hooks.make.tap(PLUGIN_NAME, (compilation) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: PLUGIN_NAME,
+          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
+        },
+        (assets) => this.createActionAssets(compilation, assets)
+      )
+    })
   }
 
   async createClientEntries(compiler: webpack.Compiler, compilation: any) {

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -32,13 +32,12 @@ import {
 import { traverseModules, forEachEntryModule } from '../utils'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
 import { getProxiedPluginState } from '../../build-context'
-import { warnOnce } from '../../../shared/lib/utils/warn-once'
 
 interface Options {
   dev: boolean
   appDir: string
   isEdgeServer: boolean
-  useExperimentalReact: boolean
+  useServerActions: boolean
 }
 
 const PLUGIN_NAME = 'ClientEntryPlugin'
@@ -80,14 +79,14 @@ export class ClientReferenceEntryPlugin {
   dev: boolean
   appDir: string
   isEdgeServer: boolean
-  useExperimentalReact: boolean
+  useServerActions: boolean
   assetPrefix: string
 
   constructor(options: Options) {
     this.dev = options.dev
     this.appDir = options.appDir
     this.isEdgeServer = options.isEdgeServer
-    this.useExperimentalReact = options.useExperimentalReact
+    this.useServerActions = options.useServerActions
     this.assetPrefix = !this.dev && !this.isEdgeServer ? '../' : ''
   }
 
@@ -153,15 +152,17 @@ export class ClientReferenceEntryPlugin {
       })
     })
 
-    compiler.hooks.make.tap(PLUGIN_NAME, (compilation) => {
-      compilation.hooks.processAssets.tap(
-        {
-          name: PLUGIN_NAME,
-          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
-        },
-        (assets) => this.createAsset(compilation, assets)
-      )
-    })
+    if (this.useServerActions) {
+      compiler.hooks.make.tap(PLUGIN_NAME, (compilation) => {
+        compilation.hooks.processAssets.tap(
+          {
+            name: PLUGIN_NAME,
+            stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
+          },
+          (assets) => this.createActionAssets(compilation, assets)
+        )
+      })
+    }
   }
 
   async createClientEntries(compiler: webpack.Compiler, compilation: any) {
@@ -241,20 +242,23 @@ export class ClientReferenceEntryPlugin {
       )
 
       if (actionEntryImports.size > 0) {
-        if (!this.useExperimentalReact) {
-          warnOnce(
-            '\nServer Actions require `experimental.experimentalReact` option to be enabled in your Next.js config.\n'
+        if (!this.useServerActions) {
+          compilation.errors.push(
+            new Error(
+              'Server Actions require `experimental.serverActions` option to be enabled in your Next.js config.'
+            )
+          )
+        } else {
+          addActionEntryList.push(
+            this.injectActionEntry({
+              compiler,
+              compilation,
+              actions: actionEntryImports,
+              entryName: name,
+              bundlePath: name,
+            })
           )
         }
-        addActionEntryList.push(
-          this.injectActionEntry({
-            compiler,
-            compilation,
-            actions: actionEntryImports,
-            entryName: name,
-            bundlePath: name,
-          })
-        )
       }
     })
 
@@ -780,7 +784,7 @@ export class ClientReferenceEntryPlugin {
     })
   }
 
-  createAsset(
+  createActionAssets(
     compilation: webpack.Compilation,
     assets: webpack.Compilation['assets']
   ) {

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -44,6 +44,12 @@ export async function handleAction({
     req.method === 'POST'
 
   if (isFetchAction || isFormAction || isMultipartAction) {
+    if (!serverActionsManifest) {
+      throw new Error(
+        'Server Actions require `experimental.serverActions` option to be enabled in your Next.js config.'
+      )
+    }
+
     let bound = []
 
     const workerName = 'app' + pathname

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -44,12 +44,6 @@ export async function handleAction({
     req.method === 'POST'
 
   if (isFetchAction || isFormAction || isMultipartAction) {
-    if (!serverActionsManifest) {
-      throw new Error(
-        'Server Actions require `experimental.serverActions` option to be enabled in your Next.js config.'
-      )
-    }
-
     let bound = []
 
     const workerName = 'app' + pathname

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -286,7 +286,7 @@ const configSchema = {
         appDir: {
           type: 'boolean',
         },
-        experimentalReact: {
+        serverActions: {
           type: 'boolean',
         },
         extensionAlias: {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -275,7 +275,7 @@ export interface ExperimentalConfig {
   /**
    * Enable `react@experimental` channel for the `app` directory.
    */
-  experimentalReact?: boolean
+  serverActions?: boolean
 }
 
 export type ExportPathMap = {

--- a/packages/next/src/server/lib/server-ipc.ts
+++ b/packages/next/src/server/lib/server-ipc.ts
@@ -69,7 +69,7 @@ export const createWorker = (
   ipcPort: number,
   isNodeDebugging: boolean | 'brk' | undefined,
   type: 'pages' | 'app',
-  useExperimentalReact?: boolean
+  useServerActions?: boolean
 ) => {
   const { initialEnv } = require('@next/env') as typeof import('@next/env')
   const { Worker } = require('next/dist/compiled/jest-worker')
@@ -91,7 +91,7 @@ export const createWorker = (
         NODE_ENV: process.env.NODE_ENV,
         ...(type === 'app'
           ? {
-              __NEXT_PRIVATE_PREBUNDLED_REACT: useExperimentalReact
+              __NEXT_PRIVATE_PREBUNDLED_REACT: useServerActions
                 ? 'experimental'
                 : 'next',
             }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -274,7 +274,7 @@ export default class NextNodeServer extends BaseServer {
               ipcPort,
               options.isNodeDebugging,
               'app',
-              this.nextConfig.experimental.experimentalReact
+              this.nextConfig.experimental.serverActions
             )
           }
           this.renderWorkers.pages = createWorker(

--- a/test/e2e/app-dir/actions/next.config.js
+++ b/test/e2e/app-dir/actions/next.config.js
@@ -2,6 +2,6 @@
 module.exports = {
   experimental: {
     appDir: true,
-    experimentalReact: true,
+    serverActions: true,
   },
 }


### PR DESCRIPTION
This PR renames `experimental.experimentalReact` as `experimental.serverActions` and makes it a hard compilation error if it's not set but detected server actions.