### PR TITLE
app router: don't unmount/remount on search param changes

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -564,7 +564,7 @@ export default function OuterLayoutRouter({
               - Passed to the router during rendering to ensure it can be immediately rendered when suspending on a Flight fetch.
           */
           <TemplateContext.Provider
-            key={cacheKey}
+            key={createRouterCacheKey(preservedSegment, true)}
             value={
               <ScrollAndFocusHandler segmentPath={segmentPath}>
                 <ErrorBoundary errorComponent={error} errorStyles={errorStyles}>

--- a/packages/next/src/client/components/router-reducer/create-router-cache-key.ts
+++ b/packages/next/src/client/components/router-reducer/create-router-cache-key.ts
@@ -1,7 +1,12 @@
 import { Segment } from '../../../server/app-render/types'
 
-export function createRouterCacheKey(segment: Segment) {
+export function createRouterCacheKey(
+  segment: Segment,
+  stripSearchParameters: boolean = false
+) {
   return Array.isArray(segment)
     ? `${segment[0]}|${segment[1]}|${segment[2]}`
+    : stripSearchParameters && segment.startsWith('__PAGE__')
+    ? '__PAGE__'
     : segment
 }

--- a/packages/next/src/client/components/router-reducer/create-router-cache-key.ts
+++ b/packages/next/src/client/components/router-reducer/create-router-cache-key.ts
@@ -6,7 +6,7 @@ export function createRouterCacheKey(
 ) {
   return Array.isArray(segment)
     ? `${segment[0]}|${segment[1]}|${segment[2]}`
-    : stripSearchParameters && segment.startsWith('__PAGE__')
+    : withoutSearchParameters && segment.startsWith('__PAGE__')
     ? '__PAGE__'
     : segment
 }

--- a/packages/next/src/client/components/router-reducer/create-router-cache-key.ts
+++ b/packages/next/src/client/components/router-reducer/create-router-cache-key.ts
@@ -2,7 +2,7 @@ import { Segment } from '../../../server/app-render/types'
 
 export function createRouterCacheKey(
   segment: Segment,
-  stripSearchParameters: boolean = false
+  withoutSearchParameters: boolean = false
 ) {
   return Array.isArray(segment)
     ? `${segment[0]}|${segment[1]}|${segment[2]}`

--- a/test/e2e/app-dir/search-params-react-key/app/client-component.js
+++ b/test/e2e/app-dir/search-params-react-key/app/client-component.js
@@ -1,13 +1,18 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import React, { useId } from 'react'
+import React, { useState } from 'react'
 
 export default () => {
   const router = useRouter()
+  const [count, setCount] = useState(0)
+
   return (
     <>
-      <div id="random-number">{useId()}</div>
+      <div id="count">{count}</div>
+      <button id="increment" onClick={() => setCount(count + 1)}>
+        increment
+      </button>
       <button id="push" onClick={() => router.push('/?foo=bar')}>
         push to /?foo=bar
       </button>

--- a/test/e2e/app-dir/search-params-react-key/app/client-component.js
+++ b/test/e2e/app-dir/search-params-react-key/app/client-component.js
@@ -1,0 +1,19 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import React, { useId } from 'react'
+
+export default () => {
+  const router = useRouter()
+  return (
+    <>
+      <div id="random-number">{useId()}</div>
+      <button id="push" onClick={() => router.push('/?foo=bar')}>
+        push to /?foo=bar
+      </button>
+      <button id="replace" onClick={() => router.replace('/?foo=baz')}>
+        replace with /?foo=baz
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/search-params-react-key/app/layout.tsx
+++ b/test/e2e/app-dir/search-params-react-key/app/layout.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+export default function Layout({
+  children,
+}: {
+  children: React.ReactNode
+  params: {}
+}) {
+  return (
+    <html>
+      <head></head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/search-params-react-key/app/page.tsx
+++ b/test/e2e/app-dir/search-params-react-key/app/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import ClientComponent from './client-component'
+
+export default ({ searchParams }) => {
+  return (
+    <div>
+      <div id="search-params">{JSON.stringify(searchParams)}</div>
+      <ClientComponent />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/search-params-react-key/layout-params.test.ts
+++ b/test/e2e/app-dir/search-params-react-key/layout-params.test.ts
@@ -1,0 +1,42 @@
+import { createNextDescribe } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+createNextDescribe(
+  'app dir - search params keys',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should keep the React router instance the same when changing the search params', async () => {
+      const browser = await next.browser('/')
+
+      const searchParams = browser.waitForElementByCss('#search-params').text()
+      const id = await browser.elementByCss('#random-number').text()
+      await browser.elementByCss('#push').click()
+
+      await check(async () => {
+        const newSearchParams = await browser
+          .waitForElementByCss('#search-params')
+          .text()
+        const newId = await browser.elementByCss('#random-number').text()
+
+        return newSearchParams !== searchParams && id === newId
+          ? 'success'
+          : 'retry'
+      }, 'success')
+
+      await browser.elementByCss('#replace').click()
+
+      await check(async () => {
+        const newSearchParams = await browser
+          .waitForElementByCss('#search-params')
+          .text()
+        const newId = await browser.elementByCss('#random-number').text()
+
+        return newSearchParams !== searchParams && id === newId
+          ? 'success'
+          : 'retry'
+      }, 'success')
+    })
+  }
+)

--- a/test/e2e/app-dir/search-params-react-key/layout-params.test.ts
+++ b/test/e2e/app-dir/search-params-react-key/layout-params.test.ts
@@ -11,19 +11,25 @@ createNextDescribe(
       const browser = await next.browser('/')
 
       const searchParams = browser.waitForElementByCss('#search-params').text()
-      const id = await browser.elementByCss('#random-number').text()
+      await browser.elementByCss('#increment').click()
+      await browser.elementByCss('#increment').click()
+
       await browser.elementByCss('#push').click()
 
       await check(async () => {
         const newSearchParams = await browser
           .waitForElementByCss('#search-params')
           .text()
-        const newId = await browser.elementByCss('#random-number').text()
 
-        return newSearchParams !== searchParams && id === newId
+        const count = await browser.waitForElementByCss('#count').text()
+
+        return newSearchParams !== searchParams && count === '2'
           ? 'success'
           : 'retry'
       }, 'success')
+
+      await browser.elementByCss('#increment').click()
+      await browser.elementByCss('#increment').click()
 
       await browser.elementByCss('#replace').click()
 
@@ -31,9 +37,9 @@ createNextDescribe(
         const newSearchParams = await browser
           .waitForElementByCss('#search-params')
           .text()
-        const newId = await browser.elementByCss('#random-number').text()
+        const count = await browser.waitForElementByCss('#count').text()
 
-        return newSearchParams !== searchParams && id === newId
+        return newSearchParams !== searchParams && count === '4'
           ? 'success'
           : 'retry'
       }, 'success')

--- a/test/e2e/app-dir/search-params-react-key/next.config.js
+++ b/test/e2e/app-dir/search-params-react-key/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+  },
+}


### PR DESCRIPTION
Fixes #48471, #48860, #48393, #48004

This PR fixes an issue with the app router where we would unmount and remount the router node if the search param changed, this was a result of a change making the cache key include the search params. We can safely exclude this from the React router key actually so this let's us keep the client component instance stable across server renders

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

link NEXT-1073