### PR TITLE
fix(ts): make `ReadonlyHeaders` more compatible with `Headers`

### DIFF
--- a/packages/next/src/server/web/spec-extension/adapters/headers.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/headers.ts
@@ -18,12 +18,12 @@ export class ReadonlyHeadersError extends Error {
 }
 
 export type ReadonlyHeaders = Headers & {
-  /** @deprecated Method unavailable on `ReadonlyHeaders`. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
-  append(...args: any[]): never
-  /** @deprecated Method unavailable on `ReadonlyHeaders`. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
-  set(...args: any[]): never
-  /** @deprecated Method unavailable on `ReadonlyHeaders`. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
-  delete(...args: any[]): never
+  /** @deprecated Method unavailable on `ReadonlyHeaders`. Read more: https://nextjs.org/docs/api-reference/headers */
+  append(...args: any[]): void
+  /** @deprecated Method unavailable on `ReadonlyHeaders`. Read more: https://nextjs.org/docs/api-reference/headers */
+  set(...args: any[]): void
+  /** @deprecated Method unavailable on `ReadonlyHeaders`. Read more: https://nextjs.org/docs/api-reference/headers */
+  delete(...args: any[]): void
 }
 export class HeadersAdapter extends Headers {
   private readonly headers: IncomingHttpHeaders

--- a/packages/next/src/server/web/spec-extension/adapters/headers.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/headers.ts
@@ -17,8 +17,14 @@ export class ReadonlyHeadersError extends Error {
   }
 }
 
-export type ReadonlyHeaders = Omit<Headers, 'append' | 'delete' | 'set'>
-
+export type ReadonlyHeaders = Headers & {
+  /** @deprecated Method unavailable on ReadonlyHeaders. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
+  append(...args: any[]): never
+  /** @deprecated Method unavailable on ReadonlyHeaders. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
+  set(...args: any[]): never
+  /** @deprecated Method unavailable on ReadonlyHeaders. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
+  delete(...args: any[]): never
+}
 export class HeadersAdapter extends Headers {
   private readonly headers: IncomingHttpHeaders
 

--- a/packages/next/src/server/web/spec-extension/adapters/headers.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/headers.ts
@@ -18,11 +18,11 @@ export class ReadonlyHeadersError extends Error {
 }
 
 export type ReadonlyHeaders = Headers & {
-  /** @deprecated Method unavailable on ReadonlyHeaders. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
+  /** @deprecated Method unavailable on `ReadonlyHeaders`. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
   append(...args: any[]): never
-  /** @deprecated Method unavailable on ReadonlyHeaders. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
+  /** @deprecated Method unavailable on `ReadonlyHeaders`. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
   set(...args: any[]): never
-  /** @deprecated Method unavailable on ReadonlyHeaders. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
+  /** @deprecated Method unavailable on `ReadonlyHeaders`. Read more: https://beta.nextjs.org/docs/api-reference/cookies */
   delete(...args: any[]): never
 }
 export class HeadersAdapter extends Headers {


### PR DESCRIPTION
### What?

Make it possible to pass `headers()` where the `Headers` type is expected. An example would be `fetch`:

```ts
import { headers } from "next/headers"
// ...
fetch("https://example.com", {
  headers: headers()
})
```

### Why?

`ReadonlyHeaders` _currently omits_ some mutating methods which make sense since they don't make sense. :upside_down_face:. However, it makes it necessary to pass the result anywhere where `Headers` is expected. Since we already throw errors when these methods are called illegally, we can make the type constraint a bit looser to avoid `as any` or `Object.fromEntries(headers())` or similar.

### How?

Mark the unavailable methods as `@deprecated` which will visually mark them in IDEs:

![image](https://user-images.githubusercontent.com/18369201/235621140-3df8b10a-b90f-4ec3-b218-066303bfbc73.png)


Closes NEXT-1075