### PR TITLE
Use route metadata to trace in node-file-trace

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -145,7 +145,7 @@ export function getPageFromPath(pagePath: string, pageExtensions: string[]) {
   return page === '' ? '/' : page
 }
 
-function getPageFilePath({
+export function getPageFilePath({
   absolutePagePath,
   pagesDir,
   appDir,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2205,7 +2205,9 @@ export default async function getBaseWebpackConfig(
         new (require('./webpack/plugins/next-trace-entrypoints-plugin')
           .TraceEntryPointsPlugin as typeof import('./webpack/plugins/next-trace-entrypoints-plugin').TraceEntryPointsPlugin)(
           {
-            appDir: dir,
+            rootDir: dir,
+            appDir: appDir,
+            pagesDir: pagesDir,
             esmExternals: config.experimental.esmExternals,
             outputFileTracingRoot: config.experimental.outputFileTracingRoot,
             appDirEnabled: hasAppDir,

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -129,8 +129,8 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
   public turbotraceContext: TurbotraceContext = {}
 
   private rootDir: string
-  private appDir: string
-  private pagesDir: string
+  private appDir: string | undefined
+  private pagesDir: string | undefined
   private appDirEnabled?: boolean
   private tracingRoot: string
   private entryTraces: Map<string, Set<string>>
@@ -150,8 +150,8 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
     turbotrace,
   }: {
     rootDir: string
-    appDir: string
-    pagesDir: string
+    appDir: string | undefined
+    pagesDir: string | undefined
     appDirEnabled?: boolean
     traceIgnores?: string[]
     outputFileTracingRoot?: string
@@ -362,8 +362,9 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
 
                         // Ensures we don't handle non-pages.
                         if (
-                          absolutePath.startsWith(this.pagesDir) ||
-                          absolutePath.startsWith(this.appDir)
+                          (this.pagesDir &&
+                            absolutePath.startsWith(this.pagesDir)) ||
+                          (this.appDir && absolutePath.startsWith(this.appDir))
                         ) {
                           entryModMap.set(absolutePath, entryMod)
                           entryNameMap.set(absolutePath, name)


### PR DESCRIPTION
## What?

Changes the logic for running node-file-trace to no longer rely on parsing the webpack request. Instead using the module metadata set in each loader to generate the path.

## How?

The `route` metadata is already provided on all entry loaders since I added `preferredRegion` support, this can now leverage `route` as well to generate the required path.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
