### PR TITLE
use ws instead of undici.WebSocket

### DIFF
--- a/packages/next/src/server/dev/hot-middleware.ts
+++ b/packages/next/src/server/dev/hot-middleware.ts
@@ -22,7 +22,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
-import type ws from 'ws'
+import type ws from 'next/dist/compiled/ws'
 import { isMiddlewareFilename } from '../../build/utils'
 import type { VersionInfo } from './parse-version-info'
 

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -1,4 +1,4 @@
-import type ws from 'ws'
+import type ws from 'next/dist/compiled/ws'
 import origDebug from 'next/dist/compiled/debug'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type { NextConfigComplete } from '../config-shared'

--- a/packages/next/src/server/node-environment.ts
+++ b/packages/next/src/server/node-environment.ts
@@ -8,14 +8,5 @@ if (typeof (globalThis as any).AsyncLocalStorage !== 'function') {
 }
 
 if (typeof (globalThis as any).WebSocket !== 'function') {
-  let WebSocket
-
-  // undici's WebSocket handling is only available in Node.js >= 18
-  // so fallback to using ws for v16
-  if (Number(process.version.split('.')[0].substring(1)) < 18) {
-    WebSocket = require('next/dist/compiled/ws').WebSocket
-  } else {
-    WebSocket = require('next/dist/compiled/undici').WebSocket
-  }
-  ;(globalThis as any).WebSocket = WebSocket
+  ;(globalThis as any).WebSocket = require('next/dist/compiled/ws').WebSocket
 }

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -235,17 +235,7 @@ async function createModuleContext(options: ModuleContextOptions) {
         ? { strings: true, wasm: true }
         : undefined,
     extend: (context) => {
-      let WebSocket
-
-      // undici's WebSocket handling is only available in Node.js >= 18
-      // so fallback to using ws for v16
-      if (Number(process.version.split('.')[0].substring(1)) < 18) {
-        WebSocket = require('next/dist/compiled/ws').WebSocket
-      } else {
-        WebSocket = require('next/dist/compiled/undici').WebSocket
-      }
-
-      context.WebSocket = WebSocket
+      context.WebSocket = require('next/dist/compiled/ws').WebSocket
       context.process = createProcessPolyfill(options)
 
       Object.defineProperty(context, 'require', {


### PR DESCRIPTION
The `WebSocket` constructor exposed by `undici` is not working against some db connections.

That can be considered kind of expected since `undici` docs is saying it's experimental.

We're working into isolate the issue and report at `undici` repository, but for now, let's just use `ws` for all the node versions.