### PR TITLE
Allow setting `runtime` in layouts in type declarations

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -67,11 +67,7 @@ checkFields<Diff<{
   dynamicParams?: boolean
   fetchCache?: 'auto' | 'force-no-store' | 'only-no-store' | 'default-no-store' | 'default-cache' | 'only-cache' | 'force-cache'
   preferredRegion?: 'auto' | 'global' | 'home' | string | string[]
-  ${
-    options.type === 'page' || options.type === 'route'
-      ? "runtime?: 'nodejs' | 'experimental-edge' | 'edge'"
-      : ''
-  }
+  runtime?: 'nodejs' | 'experimental-edge' | 'edge'
   ${
     options.type === 'route'
       ? ''


### PR DESCRIPTION
Since we're allowing setting `runtime` in layout files, this PR fixes the type guard plugin. Closes #49079.