### PR TITLE
Skip handler for POST requests when no action ID is found

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -95,7 +95,8 @@ export async function handleAction({
               actionId = formData.get('$$id') as string
 
               if (!actionId) {
-                throw new Error('Invariant: missing action ID.')
+                // Return if no action ID is found, it could be a regular POST request
+                return
               }
               formData.delete('$$id')
               bound = [formData]
@@ -124,7 +125,8 @@ export async function handleAction({
             if (isFormAction) {
               actionId = actionData.$$id as string
               if (!actionId) {
-                throw new Error('Invariant: missing action ID.')
+                // Return if no action ID is found, it could be a regular POST request
+                return
               }
               const formData = formDataFromSearchQueryString(actionData)
               formData.delete('$$id')


### PR DESCRIPTION
Closes #48204. This shouldn't be a hard error but we should just silently ignore.