### PR TITLE
Only read digest from error instance

### DIFF
--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -509,7 +509,6 @@ function renderReactElement(
   if (!reactRoot) {
     // Unlike with createRoot, you don't need a separate root.render() call here
     reactRoot = ReactDOM.hydrateRoot(domEl, reactEl, {
-      // @ts-expect-error Missing errorInfo in @types/react
       onRecoverableError,
     })
     // TODO: Remove shouldHydrate variable when React 18 is stable as it can depend on `reactRoot` existing

--- a/packages/next/src/client/on-recoverable-error.ts
+++ b/packages/next/src/client/on-recoverable-error.ts
@@ -1,8 +1,6 @@
 import { NEXT_DYNAMIC_NO_SSR_CODE } from '../shared/lib/lazy-dynamic/no-ssr-error'
 
-export default function onRecoverableError(err: any, errorInfo: any) {
-  const digest = err.digest || errorInfo.digest
-
+export default function onRecoverableError(err: any) {
   // Using default react onRecoverableError
   // x-ref: https://github.com/facebook/react/blob/d4bc16a7d69eb2ea38a88c8ac0b461d5f72cdcab/packages/react-dom/src/client/ReactDOMRoot.js#L83
   const defaultOnRecoverableError =
@@ -15,6 +13,6 @@ export default function onRecoverableError(err: any, errorInfo: any) {
         }
 
   // Skip certain custom errors which are not expected to be reported on client
-  if (digest === NEXT_DYNAMIC_NO_SSR_CODE) return
+  if (err.digest === NEXT_DYNAMIC_NO_SSR_CODE) return
   defaultOnRecoverableError(err)
 }


### PR DESCRIPTION
## What?

Changes onRecoverableError to no longer read `errorInfo.digest`. In an earlier version of react@next the digest was provided on the errorInfo object but this is no longer the case and triggers a warning when read.


Fixes https://twitter.com/devcassa/status/1653505341194137600

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
