### PR TITLE
Using CDN like CloudFront, CloudFlare on App Directory breaks everything

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -66,7 +66,11 @@ export async function fetchServerResponse(
         }
       }
     }
-    const res = await fetch(fetchUrl, {
+    
+    const cloneUrl = fetchUrl.searchParams ? new URL(fetchUrl.toString()) : new URL(fetchUrl);
+    if (!cloneUrl.searchParams.has('rscQuery')) cloneUrl.searchParams.append('rscQuery', true)
+  
+    const res = await fetch(cloneUrl, {
       // Backwards compat for older browsers. `same-origin` is the default in modern browsers.
       credentials: 'same-origin',
       headers,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -67,7 +67,10 @@ export async function fetchServerResponse(
       }
     }
     
+    // without cloning the URL any link that you click on will add the `rscQuery` to the url you are visting.
     const cloneUrl = fetchUrl.searchParams ? new URL(fetchUrl.toString()) : new URL(fetchUrl);
+
+    // this can probably be removed, I was doing all of this with patch-package and ran into some issues without having proper TS support in node_modules when implementing the patch
     if (!cloneUrl.searchParams.has('rscQuery')) cloneUrl.searchParams.append('rscQuery', true)
   
     const res = await fetch(cloneUrl, {


### PR DESCRIPTION
Hello this is my first PR, sorry about the mess :)

### What?

With  app directory being used for production app, we want to add CDN to cache HTML responses (yes we can leverage static rendering etc. + we are self hosting on AWS).

Hovewer we still ideally want to cache the HTML on a CDN, hovewer we ran into and issue where the same url for the page can return 2 payload depending on the content-type, with CloudFront and CloudFlare you can't cache on level of mime types. So we can't cache the RSC payload with x-component type and the HTML output with mime type HTML separately. This results into several errors when the RSC payload is replaced with HTML that was cached from CDN and router doesn't find HTML to match the spec of x-component and starts doing infinite loop of page refreshes.

Some screenshots of the cached payload and the errors statis that RSC is not matching what it should be and causing a page reloads infinitely.

![image](https://user-images.githubusercontent.com/24235083/235897398-ede15be7-4092-4949-aec1-fe84695170f6.png)

This got cached on CDN first, returning just the RSC payload instead of HTML, after a while it started returning normal HTML but causing those RSC fetch fail errors.

![image](https://user-images.githubusercontent.com/24235083/235897452-8ed75f4e-6f9e-4fbe-8412-5b5e533acbc2.png)


 

### Reproduce?
To reproduce create any app directory project with server components and add a CDN in front of it.


### Why?

We want to leverage selfhosted next app director to use CDNs like CloudFront and CloudFlare.

### How?

Add `rscQuery` query param to differ between RSC payload and HTML payload for CDN caching purposes. This is totally not the best solution but allowed use to have set of 2 different urls that we can cache on URL basis. I am not sure if adding this rscQuery prop doesn't break anything internally but we tested this on project that will be shipped soon and we ran into 0 issues, but again this is a "patch" level fix, the problem is more complicated probably.

