### PR TITLE
Forward response to edge runtime for response modification

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -99,7 +99,7 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
     import {IncrementalCache} from 'next/dist/esm/server/lib/incremental-cache'
 
     enhanceGlobals()
-    
+
     const pageType = ${JSON.stringify(pagesType)}
     ${
       isAppDir
@@ -126,7 +126,7 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
       const appRenderToHTML = null
     `
     }
-    
+
     const incrementalCacheHandler = ${
       incrementalCacheHandlerPath
         ? `require("${incrementalCacheHandlerPath}")`

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -920,12 +920,12 @@ export async function renderToHTMLOrFlight(
                 <Component {...props} />
               )}
               {/* This null is currently critical. The wrapped Component can render null and if there was not fragment
-                surrounding it this would look like a pending tree data state on the client which will cause an errror 
+                surrounding it this would look like a pending tree data state on the client which will cause an errror
                 and break the app. Long-term we need to move away from using null as a partial tree identifier since it
                 is a valid return type for the components we wrap. Once we make this change we can safely remove the
                 fragment. The reason the extra null here is required is that fragments which only have 1 child are elided.
                 If the Component above renders null the actual treedata will look like `[null, null]`. If we remove the extra
-                null it will look like `null` (the array is elided) and this is what confuses the client router.            
+                null it will look like `null` (the array is elided) and this is what confuses the client router.
                 TODO-APP update router to use a Symbol for partial tree detection */}
               {null}
             </>

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -361,7 +361,7 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
 
   protected async renderHTML(
     req: WebNextRequest,
-    _res: WebNextResponse,
+    res: WebNextResponse,
     pathname: string,
     query: NextParsedUrlQuery,
     renderOpts: RenderOpts
@@ -379,7 +379,7 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
           headers: req.headers,
           body: req.body,
         } as any,
-        {} as any,
+        res as any,
         pathname,
         query,
         Object.assign(renderOpts, {

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -199,6 +199,18 @@ createNextDescribe(
         await browser.elementByCss('#dec').click()
         await check(() => browser.elementByCss('h1').text(), '3')
       })
+
+      it('should return error response for hoc auth wrappers in edge runtime', async () => {
+        const browser = await next.browser('/header/edge')
+        await await browser.eval(`document.cookie = 'auth=0'`)
+        await browser.elementByCss('#authed').click()
+
+        await check(async () => {
+          const text = await browser.elementByCss('h1').text()
+          console.log('text', text)
+          return text && text.length > 0 ? text : 'failed'
+        }, /Multipart form data is not supported/)
+      })
     })
   }
 )

--- a/test/e2e/app-dir/actions/app/header/edge/page.js
+++ b/test/e2e/app-dir/actions/app/header/edge/page.js
@@ -1,6 +1,6 @@
-import { getCookie, getHeader, setCookie } from './actions'
-import UI from './ui'
-import { validator } from './validator'
+import { getCookie, getHeader, setCookie } from '../actions'
+import UI from '../ui'
+import { validator } from '../validator'
 
 export default function Page() {
   const prefix = 'Prefix:'
@@ -16,3 +16,5 @@ export default function Page() {
     />
   )
 }
+
+export const runtime = 'edge'


### PR DESCRIPTION
For edge runtime, we're modifying `res.statusCode` in actions handler, but we didn't forward the `res` object to it, previously we're using a fake `res` `{}`. This PR fixes it so that the propery status code will be returned to the client

[slack-thread](https://vercel.slack.com/archives/C052S77L05C/p1682988777740609)