### PR TITLE
Update compilation target of @next/react-dev-overlay

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -503,7 +503,7 @@ export async function ncc_next__react_dev_overlay(task, opts) {
       precompiled: false,
       packageName: '@next/react-dev-overlay',
       externals: overlayExternals,
-      target: 'es2018',
+      target: 'es5',
     })
     .target('dist/compiled/@next/react-dev-overlay/dist')
 


### PR DESCRIPTION
Closes #48627.