### PR TITLE
Fix CSS module imports not included in root not-found file

### DIFF
--- a/packages/next/src/server/app-render/get-css-inlined-link-tags.tsx
+++ b/packages/next/src/server/app-render/get-css-inlined-link-tags.tsx
@@ -27,13 +27,19 @@ export function getCssInlinedLinkTags(
   }
   const chunks = new Set<string>()
 
+  const isNotFoundPage = /(\/|\\)not-found/.test(filePathWithoutExt)
+
   for (const mod of layoutOrPageCssModules) {
     // We only include the CSS if it's a global CSS, or it is used by this
-    // entrypoint.
-    if (
-      serverCSSForEntries.includes(mod) ||
-      !/\.module\.(css|sass|scss)$/.test(mod)
-    ) {
+    // entrypoint (CSS files that actually affect this layer).
+    const isGlobalCSS = !/\.module\.(css|sass|scss)$/.test(mod)
+
+    // For not-found pages, it will generally match all non-existing entries so
+    // even if `serverCSSForEntries` is empty, we still want to include the CSS.
+    const isImportedByEntry =
+      serverCSSForEntries.includes(mod) || isNotFoundPage
+
+    if (isImportedByEntry || isGlobalCSS) {
       // If the CSS is already injected by a parent layer, we don't need
       // to inject it again.
       if (!injectedCSS.has(mod)) {

--- a/test/e2e/app-dir/app-css/app/not-found.js
+++ b/test/e2e/app-dir/app-css/app/not-found.js
@@ -1,3 +1,5 @@
+import styles from './not-found.module.css'
+
 export default function RootNotFound() {
-  return <h1 className="not-found">Root not found</h1>
+  return <h1 className={'not-found ' + styles.blackBg}>Root not found</h1>
 }

--- a/test/e2e/app-dir/app-css/app/not-found.module.css
+++ b/test/e2e/app-dir/app-css/app/not-found.module.css
@@ -1,0 +1,3 @@
+.blackBg {
+  background-color: black;
+}

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -203,6 +203,20 @@ createNextDescribe(
           ).toBe('rgb(210, 105, 30)')
         })
 
+        it('should include css imported in root not-found.js', async () => {
+          const browser = await next.browser('/random-non-existing-path')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('h1')).color`
+            )
+          ).toBe('rgb(210, 105, 30)')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('h1')).backgroundColor`
+            )
+          ).toBe('rgb(0, 0, 0)')
+        })
+
         it('should include css imported in error.js', async () => {
           const browser = await next.browser('/error/client-component')
           await browser.elementByCss('button').click()


### PR DESCRIPTION
When using the `not-found.js` file to match missed routes, `serverCSSForEntries` will always be empty as the `ComponentMod.pages` itself doesn't contain any actual entry. We need to handle that as a special case.

Closes #48133.