### PR TITLE
Polyfill `Blob` for Node.js < 18

### DIFF
--- a/packages/next/src/server/node-polyfill-form.ts
+++ b/packages/next/src/server/node-polyfill-form.ts
@@ -1,9 +1,15 @@
 /**
- * Polyfills `FormData` in the Node.js runtime.
+ * Polyfills `FormData` and `Blob` in the Node.js runtime.
  */
 
 if (!(global as any).FormData) {
   const { FormData } =
     require('next/dist/compiled/@edge-runtime/primitives/fetch') as typeof import('next/dist/compiled/@edge-runtime/primitives/fetch')
   ;(global as any).FormData = FormData
+}
+
+if (!(global as any).Blob) {
+  const { Blob } =
+    require('next/dist/compiled/@edge-runtime/primitives/blob') as typeof import('next/dist/compiled/@edge-runtime/primitives/blob')
+  ;(global as any).Blob = Blob
 }


### PR DESCRIPTION
Since `react-server-dom-webpack-server.node` uses `Blob`, we need to polyfill it for Node.js 16.