### PR TITLE
Add a generic type for unstable_cache

### DIFF
--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -5,15 +5,14 @@ import {
 
 type Callback = (...args: any[]) => Promise<any>
 
-// TODO: generic callback type?
-export function unstable_cache(
-  cb: Callback,
+export function unstable_cache<T extends Callback>(
+  cb: T,
   keyParts: string[],
   options: {
     revalidate: number | false
     tags?: string[]
   }
-): Callback {
+): T {
   const joinedKey = cb.toString() + '-' + keyParts.join(', ')
   const staticGenerationAsyncStorage = (
     fetch as any
@@ -34,7 +33,7 @@ export function unstable_cache(
     )
   }
 
-  return async (...args: any[]) => {
+  const cachedCb = async (...args: any[]) => {
     // We override the default fetch cache handling inside of the
     // cache callback so that we only cache the specific values returned
     // from the callback instead of also caching any fetches done inside
@@ -131,4 +130,6 @@ export function unstable_cache(
       }
     )
   }
+  // TODO: once AsyncLocalStorage.run() returns the correct types this override will no longer be necessary
+  return cachedCb as unknown as T
 }


### PR DESCRIPTION
## For Contributors

I know it's an unstable api but this just makes it easier to test with. This uses the type of the callback to `unstable_cache` as the return type of `unstable_cache`.
