### PR TITLE
chore(docs): update next-image-unconfigured-host.md

### DIFF
--- a/errors/next-image-unconfigured-host.md
+++ b/errors/next-image-unconfigured-host.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-One of your pages that leverages the `next/image` component, passed a `src` value that uses a hostname in the URL that isn't defined in the `images.remotePatterns` or `images.domains` in `next.config.js`.
+One of your pages that leverages the `next/image` component, passed a `src` value that uses a hostname in the URL that isn't defined in the `images.remotePatterns` in `next.config.js`.
 
 #### Possible Ways to Fix It
 
@@ -15,7 +15,7 @@ module.exports = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'example.com',
+        hostname: 'assets.example.com',
         port: '',
         pathname: '/account123/**',
       },
@@ -24,16 +24,17 @@ module.exports = {
 }
 ```
 
-If you are using an older version of Next.js prior to 12.3.0, you can use `images.domains` instead:
+#### Fixing older versions of Next.js
 
-```js
-// next.config.js
-module.exports = {
+<details>
+  <summary>Using Next.js prior to 12.3.0?</summary>
+  <p>Older versions of Next.js can configure <code>images.domains</code> instead:</p>
+  <pre><code>module.exports = {
   images: {
     domains: ['assets.example.com'],
   },
-}
-```
+}</code></pre>
+</details>
 
 ### Useful Links
 


### PR DESCRIPTION
We have reports of users scrolling down the the bottom to copy/paste `domains` configuration, instead of using the safer `remotePatterns` configuration at the top.

This PR collapses the older `domains` configuration behind a details toggle since it is only needed for older versions of Next.js prior to 12.3.0