### PR TITLE
Use special annotation for `$$bound` if no closure argument is attached

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -1220,16 +1220,14 @@ fn annotate_ident_as_action(
                     optional: false,
                 }),
             }))
+        } else if bound.is_empty() {
+            Lit::Null(Null { span: DUMMY_SP }).into()
         } else {
-            if bound.is_empty() {
-                Lit::Null(Null { span: DUMMY_SP }).into()
-            } else {
-                ArrayLit {
-                    span: DUMMY_SP,
-                    elems: bound,
-                }
-                .into()
+            ArrayLit {
+                span: DUMMY_SP,
+                elems: bound,
             }
+            .into()
         },
     ));
 

--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -1205,7 +1205,8 @@ fn annotate_ident_as_action(
         generate_action_id(file_name, export_name).into(),
     ));
 
-    // myAction.$$bound = [];
+    // myAction.$$bound = [arg1, arg2, arg3];
+    // or myAction.$$bound = null; if there are no bound values.
     annotations.push(annotate(
         &ident,
         "$$bound",
@@ -1220,11 +1221,15 @@ fn annotate_ident_as_action(
                 }),
             }))
         } else {
-            ArrayLit {
-                span: DUMMY_SP,
-                elems: bound,
+            if bound.is_empty() {
+                Lit::Null(Null { span: DUMMY_SP }).into()
+            } else {
+                ArrayLit {
+                    span: DUMMY_SP,
+                    elems: bound,
+                }
+                .into()
             }
-            .into()
         },
     ));
 

--- a/packages/next-swc/crates/core/tests/errors/server-actions/1/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/1/output.js
@@ -5,5 +5,5 @@ ensureServerEntryExports([
 ]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
-foo.$$bound = [];
+foo.$$bound = null;
 foo.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/errors/server-actions/12/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/12/output.js
@@ -5,5 +5,5 @@ ensureServerEntryExports([
 ]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
-foo.$$bound = [];
+foo.$$bound = null;
 foo.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/errors/server-actions/13/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/13/output.js
@@ -6,5 +6,5 @@ ensureServerEntryExports([
 ]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
-foo.$$bound = [];
+foo.$$bound = null;
 foo.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/errors/server-actions/2/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/2/output.js
@@ -6,5 +6,5 @@ ensureServerEntryExports([
 ]);
 bar.$$typeof = Symbol.for("react.server.reference");
 bar.$$id = "ac840dcaf5e8197cb02b7f3a43c119b7a770b272";
-bar.$$bound = [];
+bar.$$bound = null;
 bar.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/errors/server-actions/3/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/3/output.js
@@ -5,5 +5,5 @@ ensureServerEntryExports([
 ]);
 x.$$typeof = Symbol.for("react.server.reference");
 x.$$id = "b78c261f135a7a852508c2920bd7228020ff4bd7";
-x.$$bound = [];
+x.$$bound = null;
 x.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/errors/server-actions/7/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/7/output.js
@@ -1,3 +1,3 @@
-/* __next_internal_action_entry_do_not_use__ $$ACTION_1 */ const foo = ($$ACTION_0 = ()=>$$ACTION_1($$ACTION_0.$$bound), $$ACTION_0.$$typeof = Symbol.for("react.server.reference"), $$ACTION_0.$$id = "188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_0.$$bound = [], $$ACTION_0);
+/* __next_internal_action_entry_do_not_use__ $$ACTION_1 */ const foo = ($$ACTION_0 = ()=>$$ACTION_1($$ACTION_0.$$bound), $$ACTION_0.$$typeof = Symbol.for("react.server.reference"), $$ACTION_0.$$id = "188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_0.$$bound = null, $$ACTION_0);
 export const $$ACTION_1 = (closure)=>{};
 var $$ACTION_0;

--- a/packages/next-swc/crates/core/tests/errors/server-actions/8/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/8/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ $$ACTION_1 */ const foo = ($$ACTION_0 = async ()=>$$ACTION_1($$ACTION_0.$$bound), $$ACTION_0.$$typeof = Symbol.for("react.server.reference"), $$ACTION_0.$$id = "188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_0.$$bound = [], $$ACTION_0);
+/* __next_internal_action_entry_do_not_use__ $$ACTION_1 */ const foo = ($$ACTION_0 = async ()=>$$ACTION_1($$ACTION_0.$$bound), $$ACTION_0.$$typeof = Symbol.for("react.server.reference"), $$ACTION_0.$$id = "188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_0.$$bound = null, $$ACTION_0);
 export const $$ACTION_1 = async (closure)=>{
     'use strict';
 };

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/10/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/10/output.js
@@ -5,5 +5,5 @@ ensureServerEntryExports([
 ]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
-foo.$$bound = [];
+foo.$$bound = null;
 foo.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/11/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/11/output.js
@@ -5,5 +5,5 @@ ensureServerEntryExports([
 ]);
 $$ACTION_0.$$typeof = Symbol.for("react.server.reference");
 $$ACTION_0.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
-$$ACTION_0.$$bound = [];
+$$ACTION_0.$$bound = null;
 $$ACTION_0.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/12/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/12/output.js
@@ -6,5 +6,5 @@ ensureServerEntryExports([
 ]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
-foo.$$bound = [];
+foo.$$bound = null;
 foo.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/13/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/13/output.js
@@ -9,9 +9,9 @@ ensureServerEntryExports([
 ]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
-foo.$$bound = [];
+foo.$$bound = null;
 foo.$$with_bound = false;
 bar.$$typeof = Symbol.for("react.server.reference");
 bar.$$id = "ac840dcaf5e8197cb02b7f3a43c119b7a770b272";
-bar.$$bound = [];
+bar.$$bound = null;
 bar.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/14/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/14/output.js
@@ -7,5 +7,5 @@ ensureServerEntryExports([
 ]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
-foo.$$bound = [];
+foo.$$bound = null;
 foo.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/15/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/15/output.js
@@ -8,5 +8,5 @@ ensureServerEntryExports([
 ]);
 $$ACTION_0.$$typeof = Symbol.for("react.server.reference");
 $$ACTION_0.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
-$$ACTION_0.$$bound = [];
+$$ACTION_0.$$bound = null;
 $$ACTION_0.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/17/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/17/output.js
@@ -8,9 +8,9 @@ ensureServerEntryExports([
 ]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
-foo.$$bound = [];
+foo.$$bound = null;
 foo.$$with_bound = false;
 bar.$$typeof = Symbol.for("react.server.reference");
 bar.$$id = "ac840dcaf5e8197cb02b7f3a43c119b7a770b272";
-bar.$$bound = [];
+bar.$$bound = null;
 bar.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/2/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/2/output.js
@@ -3,7 +3,7 @@
 }
 myAction.$$typeof = Symbol.for("react.server.reference");
 myAction.$$id = "6d53ce510b2e36499b8f56038817b9bad86cabb4";
-myAction.$$bound = [];
+myAction.$$bound = null;
 myAction.$$with_bound = false;
 export const $$ACTION_0 = myAction;
 export default function Page() {

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/20/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/20/output.js
@@ -8,5 +8,5 @@ ensureServerEntryExports([
 ]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
-foo.$$bound = [];
+foo.$$bound = null;
 foo.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/21/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/21/output.js
@@ -12,9 +12,9 @@ export async function $$ACTION_1(closure, z = closure[1]) {
     return x + closure[0] + z;
 }
 var $$ACTION_0;
-validator(($$ACTION_2 = async ()=>$$ACTION_3($$ACTION_2.$$bound), $$ACTION_2.$$typeof = Symbol.for("react.server.reference"), $$ACTION_2.$$id = "56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_2.$$bound = [], $$ACTION_2));
+validator(($$ACTION_2 = async ()=>$$ACTION_3($$ACTION_2.$$bound), $$ACTION_2.$$typeof = Symbol.for("react.server.reference"), $$ACTION_2.$$id = "56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_2.$$bound = null, $$ACTION_2));
 export const $$ACTION_3 = async (closure)=>{};
 var $$ACTION_2;
-another(validator(($$ACTION_4 = async ()=>$$ACTION_5($$ACTION_4.$$bound), $$ACTION_4.$$typeof = Symbol.for("react.server.reference"), $$ACTION_4.$$id = "1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", $$ACTION_4.$$bound = [], $$ACTION_4)));
+another(validator(($$ACTION_4 = async ()=>$$ACTION_5($$ACTION_4.$$bound), $$ACTION_4.$$typeof = Symbol.for("react.server.reference"), $$ACTION_4.$$id = "1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", $$ACTION_4.$$bound = null, $$ACTION_4)));
 export const $$ACTION_5 = async (closure)=>{};
 var $$ACTION_4;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/22/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/22/output.js
@@ -9,9 +9,9 @@ ensureServerEntryExports([
 ]);
 action.$$typeof = Symbol.for("react.server.reference");
 action.$$id = "f14702b5a021dd117f7ec7a3c838f397c2046d3b";
-action.$$bound = [];
+action.$$bound = null;
 action.$$with_bound = false;
 $$ACTION_0.$$typeof = Symbol.for("react.server.reference");
 $$ACTION_0.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
-$$ACTION_0.$$bound = [];
+$$ACTION_0.$$bound = null;
 $$ACTION_0.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/3/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/3/output.js
@@ -8,5 +8,5 @@ ensureServerEntryExports([
 ]);
 myAction.$$typeof = Symbol.for("react.server.reference");
 myAction.$$id = "e10665baac148856374b2789aceb970f66fec33e";
-myAction.$$bound = [];
+myAction.$$bound = null;
 myAction.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/4/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/4/output.js
@@ -13,13 +13,13 @@ ensureServerEntryExports([
 ]);
 a.$$typeof = Symbol.for("react.server.reference");
 a.$$id = "6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d";
-a.$$bound = [];
+a.$$bound = null;
 a.$$with_bound = false;
 b.$$typeof = Symbol.for("react.server.reference");
 b.$$id = "d1f7eb64271d7c601dfef7d4d7053de1c2ca4338";
-b.$$bound = [];
+b.$$bound = null;
 b.$$with_bound = false;
 c.$$typeof = Symbol.for("react.server.reference");
 c.$$id = "1ab723c80dcca470e0410b4b2a2fc2bf21f41476";
-c.$$bound = [];
+c.$$bound = null;
 c.$$with_bound = false;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/8/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/8/output.js
@@ -5,7 +5,7 @@
 }
 myAction.$$typeof = Symbol.for("react.server.reference");
 myAction.$$id = "6d53ce510b2e36499b8f56038817b9bad86cabb4";
-myAction.$$bound = [];
+myAction.$$bound = null;
 myAction.$$with_bound = false;
 export const $$ACTION_0 = myAction;
 export default function Page() {

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/9/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/9/output.js
@@ -13,13 +13,13 @@ ensureServerEntryExports([
 ]);
 foo.$$typeof = Symbol.for("react.server.reference");
 foo.$$id = "ab21efdafbe611287bc25c0462b1e0510d13e48b";
-foo.$$bound = [];
+foo.$$bound = null;
 foo.$$with_bound = false;
 bar.$$typeof = Symbol.for("react.server.reference");
 bar.$$id = "050e3854b72b19e3c7e3966a67535543a90bf7e0";
-bar.$$bound = [];
+bar.$$bound = null;
 bar.$$with_bound = false;
 qux.$$typeof = Symbol.for("react.server.reference");
 qux.$$id = "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d";
-qux.$$bound = [];
+qux.$$bound = null;
 qux.$$with_bound = false;


### PR DESCRIPTION
Currently we are always use an array for the `.$$bound` field of an action even if it's empty. This PR updates the transform to generate `null` in that case so we can do further optimizations. Note that `[]` and `null` are slightly different here similar to `f.bind`.