### PR TITLE
Allow override icon rel

### DIFF
--- a/packages/next/src/lib/metadata/generate/icons.tsx
+++ b/packages/next/src/lib/metadata/generate/icons.tsx
@@ -11,7 +11,7 @@ function IconDescriptorLink({ icon }: { icon: IconDescriptor }) {
 
 function IconLink({ rel, icon }: { rel?: string; icon: Icon }) {
   if (typeof icon === 'object' && !(icon instanceof URL)) {
-    if (rel) icon.rel = rel
+    if (!icon.rel && rel) icon.rel = rel
     return <IconDescriptorLink icon={icon} />
   } else {
     const href = icon.toString()

--- a/test/e2e/app-dir/metadata/app/icons/descriptor/page.tsx
+++ b/test/e2e/app-dir/metadata/app/icons/descriptor/page.tsx
@@ -4,7 +4,11 @@ export default function page() {
 
 export const metadata = {
   icons: {
-    icon: [{ url: '/icon.png' }, new URL('/icon.png', 'https://example.com')],
+    icon: [
+      { url: '/icon.png' },
+      new URL('/icon.png', 'https://example.com'),
+      { url: '/icon2.png', rel: 'apple-touch-icon' }, // override icon rel
+    ],
     shortcut: ['/shortcut-icon.png'],
     apple: [
       { url: '/apple-icon.png' },

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -535,6 +535,7 @@ createNextDescribe(
           'https://example.com/icon.png',
         ])
         await checkLink(browser, 'apple-touch-icon', [
+          '/icon2.png',
           '/apple-icon.png',
           '/apple-icon-x3.png',
         ])


### PR DESCRIPTION
Fixes #48392

When passing down `Array<IconDescriptor>`, it should allow overriding `rel` prop of icon instead of always picking the default one
fix NEXT-1085