### PR TITLE
disable optimistic_updates

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -6,7 +6,7 @@ automerge_label = "ready to land"
 require_automerge_label = false
 method = "squash"
 delete_branch_on_merge = true
-optimistic_updates = true
+optimistic_updates = false
 prioritize_ready_to_merge = true
 notify_on_conflict = false
 


### PR DESCRIPTION
### What?

disable optimistic_updates

So it no longer does that:

> If Kodiak is merging an out-of-date pull request that has running status checks, update the pull request's branch without waiting for the running status checks to finish.

The problem with that is that it cancels running checks and restarts them.

Instead it waits for all running status checks before updating the PR.

### Why?

This should avoid the case where a PR is updated again and again without yielding a result.

It also saves some CI cost

And it allows CI to finish and fill up the turborepo cache, which can potentially used for the next run.
