### PR TITLE
[DO NOT MERGE] test: temporary disable flaky checking

### DIFF
--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -413,6 +413,7 @@ describe('app dir - rsc basics', () => {
       await resolveStreamResponse(response, (_, result) => {
         gotInlinedData = result.includes('self.__next_f=')
         gotData = result.includes('next_streaming_data')
+        console.log('result', result)
         if (!gotFallback) {
           gotFallback = result.includes('next_streaming_fallback')
           if (gotFallback) {
@@ -422,6 +423,7 @@ describe('app dir - rsc basics', () => {
         }
       })
 
+      expect(gotFallback).toBe('impossible')
       expect(gotFallback).toBe(true)
       expect(gotData).toBe(true)
       expect(gotInlinedData).toBe(true)
@@ -448,8 +450,7 @@ describe('app dir - rsc basics', () => {
     expect(versionApp).toInclude('-canary-')
   })
 
-  // disable this flaky test
-  it.skip('should support partial hydration with inlined server data in browser', async () => {
+  it('should support partial hydration with inlined server data in browser', async () => {
     // Should end up with "next_streaming_data".
     const browser = await next.browser('/partial-hydration', {
       waitHydration: false,

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -410,18 +410,22 @@ describe('app dir - rsc basics', () => {
       let gotData = false
       let gotInlinedData = false
 
-      await resolveStreamResponse(response, (_, result) => {
-        gotInlinedData = result.includes('self.__next_f=')
-        gotData = result.includes('next_streaming_data')
-        console.log('result', result)
+      process.stdout.write('resolveStreamResponse')
+      await resolveStreamResponse(response, (_, chunk) => {
+        process.stdout.write('resolveStreamResponse:callback')
+        gotInlinedData = chunk.includes('self.__next_f=')
+        gotData = chunk.includes('next_streaming_data')
+        // console.log('console:chunk', chunk)
+        process.stdout.write('stdout:chunk ' + chunk + '\n')
         if (!gotFallback) {
-          gotFallback = result.includes('next_streaming_fallback')
+          gotFallback = chunk.includes('next_streaming_fallback')
           if (gotFallback) {
             expect(gotData).toBe(false)
             expect(gotInlinedData).toBe(false)
           }
         }
       })
+      process.stdout.write('resolveStreamResponse:end')
 
       expect(gotFallback).toBe('impossible')
       expect(gotFallback).toBe(true)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
