### PR TITLE
Fix serving images referenced from app directory

### DIFF
--- a/packages/next-swc/crates/next-dev/src/lib.rs
+++ b/packages/next-swc/crates/next-dev/src/lib.rs
@@ -389,10 +389,7 @@ async fn source(
     let main_source = main_source.into();
     let source_maps = SourceMapContentSourceVc::new(main_source).into();
     let source_map_trace = NextSourceMapTraceContentSourceVc::new(main_source).into();
-    let img_source = NextImageContentSourceVc::new(
-        CombinedContentSourceVc::new(vec![static_source, page_source]).into(),
-    )
-    .into();
+    let img_source = NextImageContentSourceVc::new(main_source).into();
     let router_source = NextRouterContentSourceVc::new(
         main_source,
         execution_context,


### PR DESCRIPTION
### What?

Fixes serving images that are referenced by JS files inside the `/app` directory. 

### Why?

### How?

The `NextImageContentSource` attempts to fetch the image out of it's inner content source, and before we were only providing it with the `/public` and `/pages` directory's respective sources.

Re: https://vercel.slack.com/archives/C046HAU4H7F/p1683220799917649