### PR TITLE
feat(turbopack): support next.config.js basepath

### DIFF
--- a/packages/next-swc/crates/next-core/src/env.rs
+++ b/packages/next-swc/crates/next-core/src/env.rs
@@ -61,6 +61,15 @@ pub async fn env_for_js(
         map.insert("__NEXT_STRICT_MODE_APP".to_string(), "true".to_string());
     }
 
+    // BasePath calculation is based on this env variable
+    // https://github.com/vercel/next.js/blob/7fa4946b4254906f466cfe556ee00102b73b7b0c/packages/next/src/client/add-base-path.ts#L4
+    if let Some(base_path) = &next_config.base_path {
+        map.insert(
+            "__NEXT_ROUTER_BASEPATH".to_string(),
+            serde_json::to_string(base_path)?,
+        );
+    }
+
     if !test_mode.is_empty() {
         map.insert("__NEXT_TEST_MODE".to_string(), "true".to_string());
     }

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -36,7 +36,7 @@ use turbo_binding::{
     },
 };
 use turbo_tasks::{
-    primitives::{BoolVc, StringsVc},
+    primitives::{BoolVc, OptionStringVc, StringsVc},
     trace::TraceRawVcs,
     CompletionVc, Value,
 };
@@ -59,6 +59,7 @@ pub struct NextConfig {
     pub rewrites: Rewrites,
     pub transpile_packages: Option<Vec<String>>,
     pub modularize_imports: Option<IndexMap<String, ModularizeImportPackageConfig>>,
+    pub base_path: Option<String>,
 
     // Partially supported
     pub compiler: Option<CompilerConfig>,
@@ -70,7 +71,6 @@ pub struct NextConfig {
     amp: AmpConfig,
     analytics_id: String,
     asset_prefix: String,
-    base_path: String,
     clean_dist_dir: bool,
     compress: bool,
     dev_indicators: DevIndicatorsConfig,
@@ -585,6 +585,11 @@ impl NextConfigVc {
         Ok(BoolVc::cell(
             self.await?.experimental.mdx_rs.unwrap_or(false),
         ))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn base_path(self) -> Result<OptionStringVc> {
+        Ok(OptionStringVc::cell(self.await?.base_path.clone()))
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change



### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Closes WEB-1005

This PR sets `__NEXT_ROUTER_BASEPATH`, let basepath calculation (i.e <Link>) correctly consumes it. PR makes test `test/e2e/app-dir/app-basepath/index.test.ts` pass with Turbopack.
