### PR TITLE
Add experimental logging configuration

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -484,6 +484,9 @@ const configSchema = {
             },
           },
         },
+        verboseRequestLogs: {
+          type: 'boolean',
+        },
       },
       type: 'object',
     },

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -484,8 +484,8 @@ const configSchema = {
             },
           },
         },
-        verboseRequestLogs: {
-          type: 'boolean',
+        logging: {
+          type: 'string',
         },
       },
       type: 'object',

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -144,7 +144,7 @@ export interface NextJsWebpackConfig {
 }
 
 export interface ExperimentalConfig {
-  verboseRequestLogs?: boolean
+  logging?: 'verbose'
   appDocumentPreloading?: boolean
   strictNextHead?: boolean
   clientRouterFilter?: boolean
@@ -659,7 +659,6 @@ export const defaultConfig: NextConfig = {
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,
   experimental: {
-    verboseRequestLogs: false,
     appDocumentPreloading: true,
     clientRouterFilter: false,
     clientRouterFilterRedirects: false,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -144,6 +144,7 @@ export interface NextJsWebpackConfig {
 }
 
 export interface ExperimentalConfig {
+  verboseRequestLogs?: boolean
   appDocumentPreloading?: boolean
   strictNextHead?: boolean
   clientRouterFilter?: boolean
@@ -658,6 +659,7 @@ export const defaultConfig: NextConfig = {
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,
   experimental: {
+    verboseRequestLogs: false,
     appDocumentPreloading: true,
     clientRouterFilter: false,
     clientRouterFilterRedirects: false,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1789,7 +1789,7 @@ export default class NextNodeServer extends BaseServer {
               )
             }
             process.stdout.write('\n')
-          } else {
+          } else if (this.nextConfig.experimental.verboseRequestLogs) {
             process.stdout.write(
               `- ${chalk.cyan(req.method || 'GET')} ${req.url} ${
                 res.statusCode

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1789,7 +1789,7 @@ export default class NextNodeServer extends BaseServer {
               )
             }
             process.stdout.write('\n')
-          } else if (this.nextConfig.experimental.verboseRequestLogs) {
+          } else if (this.nextConfig.experimental.logging === 'verbose') {
             process.stdout.write(
               `- ${chalk.cyan(req.method || 'GET')} ${req.url} ${
                 res.statusCode


### PR DESCRIPTION
Only shows fetch request logs by default and allows opting into verbose request timings via experimental config. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1683236293282549)