### PR TITLE
Fix require-hook with just pages on deploy

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -283,8 +283,12 @@ export default async function build(
 
       const publicDir = path.join(dir, 'public')
       const isAppDirEnabled = !!config.experimental.appDir
+      const { pagesDir, appDir } = findPagesDir(dir, isAppDirEnabled)
+      NextBuildContext.pagesDir = pagesDir
+      NextBuildContext.appDir = appDir
+      hasAppDir = Boolean(appDir)
 
-      if (isAppDirEnabled) {
+      if (isAppDirEnabled && hasAppDir) {
         if (!process.env.__NEXT_TEST_MODE && ciEnvironment.hasNextSupport) {
           const requireHook = require.resolve('../server/require-hook')
           const contents = await promises.readFile(requireHook, 'utf8')
@@ -296,11 +300,6 @@ export default async function build(
           )
         }
       }
-
-      const { pagesDir, appDir } = findPagesDir(dir, isAppDirEnabled)
-      NextBuildContext.pagesDir = pagesDir
-      NextBuildContext.appDir = appDir
-      hasAppDir = Boolean(appDir)
 
       const isSrcDir = path
         .relative(dir, pagesDir || appDir || '')


### PR DESCRIPTION
This ensures we only enable the require hook for the prebundled react version when the app directory is actually present on deploy. A follow-up fix will remove the need for this entirely so the prebundled version of react can be used specifically for app router paths without affecting pages paths. 

Fixes: https://github.com/vercel/next.js/issues/49261
x-ref: [slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1683270303879559)