### PR TITLE
Add test case for client sourcemaps

### DIFF
--- a/test/e2e/app-dir/actions/app/client/actions.js
+++ b/test/e2e/app-dir/actions/app/client/actions.js
@@ -11,6 +11,7 @@ export async function dec(value) {
 }
 
 export default async function (value) {
+  console.log('this_is_sensitive_info')
   return value * 2
 }
 

--- a/test/e2e/app-dir/actions/next.config.js
+++ b/test/e2e/app-dir/actions/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
+  productionBrowserSourceMaps: true,
   experimental: {
     serverActions: true,
   },


### PR DESCRIPTION
This PR adds a test case to ensure that the server reference doesn't expose actual content of the original file in its sourcemap.

Closes NEXT-1041.