### PR TITLE
Fix issue where nextP is not replaced in searchParams

### DIFF
--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -97,7 +97,10 @@ export async function adapter(
     nextConfig: params.request.nextConfig,
   })
 
-  for (const key of requestUrl.searchParams.keys()) {
+  // Iterator uses an index to keep track of the current iteration. Because of deleting and appending below we can't just use the iterator.
+  // Instead we use the keys before iteration.
+  const keys = [...requestUrl.searchParams.keys()]
+  for (const key of keys) {
     const value = requestUrl.searchParams.getAll(key)
 
     if (


### PR DESCRIPTION
## What?

Fixes a bug with iterating over the searchParams while `delete` and `append` are used.

This is the minimal example of what happened:

```js
const searchParams = new URLSearchParams('a=valueA&b=valueB&c=valueC')

for(const key of searchParams.keys()) {
    console.log(key)
    if(key === 'b') {
      searchParams.delete('b')
      searchParams.append('bb', 'valueBB')
    }
}
```

Output is:

```
a
b
bb
```

Instead of:

```
a
b
c
bb
```

The reason seems to be that the iterator uses an internal count while iterating, e.g. the implementation in JavaScriptCore: https://github.com/WebKit/WebKit/blob/0743137c2f4f602963fc409ebc56ecd6690d204d/Source/WebCore/html/URLSearchParams.cpp#L155-L163


This can't be reproduced with `new Map()` or `new Set()`.

This PR fixes it by only iterating over the keys that are known before the loop starts.

Fixes an issue [reported by users](https://vercel.slack.com/archives/C03S8ED1DKM/p1683007482211449).

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
