### PR TITLE
fixes #48040 missing request body on middleware rewrite

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -368,7 +368,12 @@ export default class NextNodeServer extends BaseServer {
     loadEnvConfig(
       this.dir,
       dev,
-      silent ? { info: () => {}, error: () => {} } : Log,
+      silent
+        ? {
+            info: () => {},
+            error: () => {},
+          }
+        : Log,
       forceReload
     )
   }
@@ -726,6 +731,7 @@ export default class NextNodeServer extends BaseServer {
   }
 
   private _validFilesystemPathSet: Set<string> | null = null
+
   protected getFilesystemPaths(): Set<string> {
     if (this._validFilesystemPathSet) {
       return this._validFilesystemPathSet
@@ -2233,6 +2239,7 @@ export default class NextNodeServer extends BaseServer {
    * so that we can run it.
    */
   protected async ensureMiddleware() {}
+
   protected async ensureEdgeFunction(_params: {
     page: string
     appPaths: string[] | null
@@ -2495,11 +2502,11 @@ export default class NextNodeServer extends BaseServer {
                     }
                   }
 
-                  //we want to proxy the rewrite later, do skip this
                   const rewrite = result.response.headers.get(
                     'x-middleware-rewrite'
                   )
 
+                  //we want to proxy the rewrite later, do nothing here
                   if (!rewrite) {
                     res.statusCode = result.response.status
                     for await (const chunk of result.response.body ||
@@ -2706,6 +2713,7 @@ export default class NextNodeServer extends BaseServer {
   }
 
   private _cachedPreviewManifest: PrerenderManifest | undefined
+
   protected getPrerenderManifest(): PrerenderManifest {
     if (this._cachedPreviewManifest) {
       return this._cachedPreviewManifest

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -2494,14 +2494,22 @@ export default class NextNodeServer extends BaseServer {
                       res.setHeader(key, value as string | string[])
                     }
                   }
-                  res.statusCode = result.response.status
-                  for await (const chunk of result.response.body ||
-                    ([] as any)) {
-                    this.streamResponseChunk(res as NodeNextResponse, chunk)
-                  }
-                  res.send()
-                  return {
-                    finished: true,
+
+                  //we want to proxy the rewrite later, do skip this
+                  const rewrite = result.response.headers.get(
+                    'x-middleware-rewrite'
+                  )
+
+                  if (!rewrite) {
+                    res.statusCode = result.response.status
+                    for await (const chunk of result.response.body ||
+                      ([] as any)) {
+                      this.streamResponseChunk(res as NodeNextResponse, chunk)
+                    }
+                    res.send()
+                    return {
+                      finished: true,
+                    }
                   }
                 }
               }

--- a/test/e2e/app-dir/external-rewrite/app/layout.tsx
+++ b/test/e2e/app-dir/external-rewrite/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/external-rewrite/app/page.tsx
+++ b/test/e2e/app-dir/external-rewrite/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/external-rewrite/external-rewrite.test.ts
+++ b/test/e2e/app-dir/external-rewrite/external-rewrite.test.ts
@@ -7,9 +7,16 @@ createNextDescribe(
   },
   ({ next }) => {
     it('should work when using GET to an external url', async () => {
-      const res = await next.fetch('/test')
+      const res = await next.fetch('/test', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
       const json = await res.json()
-      expect(json.quickstart).toBe('https://pipedream.com/quickstart/')
+
+      expect(json.receivedMethod).toBe('GET')
     })
     it('should work when using POST to an external url', async () => {
       const res = await next.fetch('/test', {
@@ -19,8 +26,10 @@ createNextDescribe(
         },
         body: JSON.stringify({ a: 'a', b: 'b', c: 'c', d: 'd', e: 'e' }),
       })
+
       const json = await res.json()
-      expect(json.quickstart).toBe('https://pipedream.com/quickstart/')
+
+      expect(json.receivedBody.a).toBe('a')
     })
   }
 )

--- a/test/e2e/app-dir/external-rewrite/external-rewrite.test.ts
+++ b/test/e2e/app-dir/external-rewrite/external-rewrite.test.ts
@@ -1,0 +1,26 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'external-rewrite',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should work when using GET to an external url', async () => {
+      const res = await next.fetch('/test')
+      const json = await res.json()
+      expect(json.quickstart).toBe('https://pipedream.com/quickstart/')
+    })
+    it('should work when using POST to an external url', async () => {
+      const res = await next.fetch('/test', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ a: 'a', b: 'b', c: 'c', d: 'd', e: 'e' }),
+      })
+      const json = await res.json()
+      expect(json.quickstart).toBe('https://pipedream.com/quickstart/')
+    })
+  }
+)

--- a/test/e2e/app-dir/external-rewrite/middleware.ts
+++ b/test/e2e/app-dir/external-rewrite/middleware.ts
@@ -1,0 +1,11 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+export default function middleware(request: NextRequest) {
+  return NextResponse.rewrite(
+    new URL(request.nextUrl.pathname, 'https://eolmr5jlg1hnlc2.m.pipedream.net')
+  )
+}
+
+export const config = {
+  matcher: ['/test'],
+}

--- a/test/e2e/app-dir/external-rewrite/middleware.ts
+++ b/test/e2e/app-dir/external-rewrite/middleware.ts
@@ -1,9 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server'
 
 export default function middleware(request: NextRequest) {
-  return NextResponse.rewrite(
-    new URL(request.nextUrl.pathname, 'https://eolmr5jlg1hnlc2.m.pipedream.net')
-  )
+  return NextResponse.rewrite('https://eo41ymfgtk9iki5.m.pipedream.net')
 }
 
 export const config = {

--- a/test/e2e/app-dir/external-rewrite/next.config.js
+++ b/test/e2e/app-dir/external-rewrite/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Rewrite is missing body as proxy is never called for the rewrite. The error exists since 13.2.5-canary.27 caused by the changes made in #47208

fixes #48040 
link NEXT-1104