### PR TITLE
Restrict `useOptimistic` and `useFormStatus` APIs on the server layer

### DIFF
--- a/packages/next-swc/crates/core/src/react_server_components.rs
+++ b/packages/next-swc/crates/core/src/react_server_components.rs
@@ -572,6 +572,8 @@ pub fn server_components<C: Comments>(
             JsWord::from("findDOMNode"),
             JsWord::from("flushSync"),
             JsWord::from("unstable_batchedUpdates"),
+            JsWord::from("experimental_useFormStatus"),
+            JsWord::from("experimental_useOptimistic"),
         ],
         invalid_server_react_apis: vec![
             JsWord::from("Component"),

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-dom-api/input.js
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-dom-api/input.js
@@ -1,5 +1,10 @@
 import { findDOMNode, flushSync, unstable_batchedUpdates } from 'react-dom'
 
+import {
+  experimental_useOptimistic as useOptimistic,
+  experimental_useFormStatus,
+} from 'react-dom'
+
 export default function () {
   return null
 }

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-dom-api/output.js
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-dom-api/output.js
@@ -1,4 +1,5 @@
 import { findDOMNode, flushSync, unstable_batchedUpdates } from 'react-dom';
+import { experimental_useOptimistic as useOptimistic, experimental_useFormStatus } from 'react-dom';
 export default function() {
     return null;
 }

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-dom-api/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/react-dom-api/output.stderr
@@ -16,3 +16,19 @@
  1 | import { findDOMNode, flushSync, unstable_batchedUpdates } from 'react-dom'
    :                                  ^^^^^^^^^^^^^^^^^^^^^^^
    `----
+
+  x NEXT_RSC_ERR_REACT_API: experimental_useOptimistic
+   ,-[input.js:3:1]
+ 3 | import {
+ 4 |   experimental_useOptimistic as useOptimistic,
+   :   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 5 |   experimental_useFormStatus,
+   `----
+
+  x NEXT_RSC_ERR_REACT_API: experimental_useFormStatus
+   ,-[input.js:4:1]
+ 4 |   experimental_useOptimistic as useOptimistic,
+ 5 |   experimental_useFormStatus,
+   :   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 6 | } from 'react-dom'
+   `----


### PR DESCRIPTION
This PR extends `invalid_server_react_dom_apis` with `experimental_useOptimistic` and `experimental_useFormStatus` to create early compile-time errors.