### PR TITLE
Add typescript version to next-info

### DIFF
--- a/packages/next/src/cli/next-info.ts
+++ b/packages/next/src/cli/next-info.ts
@@ -52,7 +52,7 @@ const nextInfo: CliCommand = async (argv) => {
       `
       Description
         Prints relevant details about the current system which can be used to report Next.js bugs
-        
+
       Usage
         $ next info
 
@@ -80,6 +80,7 @@ const nextInfo: CliCommand = async (argv) => {
       eslint-config-next: ${getPackageVersion('eslint-config-next')}
       react: ${getPackageVersion('react')}
       react-dom: ${getPackageVersion('react-dom')}
+      typescript: ${getPackageVersion('typescript')}
 `)
 
   try {


### PR DESCRIPTION
typescript version could be helpful for determing user's problem with ts, especially typing with react