### PR TITLE
Issue #42846: Updated _app.tsx

### DIFF
--- a/packages/next/src/pages/_app.tsx
+++ b/packages/next/src/pages/_app.tsx
@@ -1,46 +1,26 @@
-import React from 'react'
+import App, { AppContext, AppProps } from "next/app";
 
-import type {
-  AppContextType,
-  AppInitialProps,
-  AppPropsType,
-  NextWebVitalsMetric,
-  AppType,
-} from '../shared/lib/utils'
-import type { Router } from '../client/router'
+type MyInitialProps = Pick<AppProps, "Component" | "pageProps"> & {
+  foo: string;
+};
 
-import { loadGetInitialProps } from '../shared/lib/utils'
+const MyApp = ({ Component, pageProps, foo }: MyInitialProps) => {
+  return (
+    <div>
+      <Component {...pageProps} />
+      <hr />
+      <p>{`props.foo: ${foo}`}</p>
+      <p>{`props.pageProps.foo: ${pageProps.foo}`}</p>
+    </div>
+  );
+};
 
-export { AppInitialProps, AppType }
+MyApp.getInitialProps = async (context: AppContext) => {
+  const ctx = await App.getInitialProps(context); // <--another separate issue
+  return {
+    ...ctx,
+    foo: "bar" // TS complains MyApp type is wrong if this line is excluded
+  };
+};
 
-export { NextWebVitalsMetric }
-
-export type AppContext = AppContextType<Router>
-
-export type AppProps<P = any> = AppPropsType<Router, P>
-
-/**
- * `App` component is used for initialize of pages. It allows for overwriting and full control of the `page` initialization.
- * This allows for keeping state between navigation, custom error handling, injecting additional data.
- */
-async function appGetInitialProps({
-  Component,
-  ctx,
-}: AppContext): Promise<AppInitialProps> {
-  const pageProps = await loadGetInitialProps(Component, ctx)
-  return { pageProps }
-}
-
-export default class App<P = any, CP = {}, S = {}> extends React.Component<
-  P & AppProps<CP>,
-  S
-> {
-  static origGetInitialProps = appGetInitialProps
-  static getInitialProps = appGetInitialProps
-
-  render() {
-    const { Component, pageProps } = this.props as AppProps<CP>
-
-    return <Component {...pageProps} />
-  }
-}
+export default MyApp;


### PR DESCRIPTION
There's a TS error on line 13, complaining Property 'foo' does not exist on type 'AppPropsType<any, MyInitialProps>', even though props.foo does exist at runtime.

Also, there's no TS error on line 14, even though props.pageProps.foo does not exist at runtime.
![image](https://user-images.githubusercontent.com/69369581/236682994-e334e964-cf12-4e12-ab7d-68280b7873a3.png)

Update _app.tsx: Now it works fine without any errors.