### PR TITLE
fix: better error message with an invalid assetPrefix

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-font-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-font-loader/index.ts
@@ -49,6 +49,15 @@ export default async function nextFontLoader(this: any) {
       postcss: getPostcss,
     } = this.getOptions()
 
+    if (assetPrefix && !/^\/|https?:\/\//.test(assetPrefix)) {
+      const err = new Error(
+        'assetPrefix must start with a leading slash or be an absolute URL(http:// or https://)'
+      )
+      err.name = 'NextFontError'
+      callback(err)
+      return
+    }
+
     /**
      * Emit font files to .next/static/media as [hash].[ext].
      *

--- a/test/integration/font-optimization/fixtures/invalid-assertprefix/next.config.js
+++ b/test/integration/font-optimization/fixtures/invalid-assertprefix/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  assetPrefix: '.',
+}

--- a/test/integration/font-optimization/fixtures/invalid-assertprefix/pages/index.js
+++ b/test/integration/font-optimization/fixtures/invalid-assertprefix/pages/index.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Inter } from 'next/font/google'
+
+const inter = Inter({ subsets: ['latin'] })
+
+const Page = () => {
+  return <div className={inter.className}>Hello</div>
+}
+
+export default Page

--- a/test/integration/font-optimization/test/index.test.js
+++ b/test/integration/font-optimization/test/index.test.js
@@ -314,7 +314,7 @@ describe('Font Optimization', () => {
     })
   })
   describe('invalid configuration', () => {
-    it('should an error if assetPrefix starts with .', async () => {
+    it('should show a proper error if assetPrefix starts with .', async () => {
       const appDir = join(fixturesDir, 'invalid-assertprefix')
       const { stderr } = await nextBuild(appDir, undefined, {
         stderr: true,

--- a/test/integration/font-optimization/test/index.test.js
+++ b/test/integration/font-optimization/test/index.test.js
@@ -313,4 +313,15 @@ describe('Font Optimization', () => {
       )
     })
   })
+  describe('invalid configuration', () => {
+    it('should an error if assetPrefix starts with .', async () => {
+      const appDir = join(fixturesDir, 'invalid-assertprefix')
+      const { stderr } = await nextBuild(appDir, undefined, {
+        stderr: true,
+      })
+      expect(stderr).toContain(
+        'assetPrefix must start with a leading slash or be an absolute URL(http:// or https://)'
+      )
+    })
+  })
 })


### PR DESCRIPTION
fixes #47641

This adds a friendly error for loading a font error caused by the invalid `assetPrefix` setting.

Current:
<img width="747" alt="image" src="https://user-images.githubusercontent.com/250407/236685607-c03b6160-9e8c-4c88-80e1-714f6a140588.png">


This PR:
<img width="890" alt="image" src="https://user-images.githubusercontent.com/250407/236685499-da4c3d69-0f97-458d-8709-dcc43475e0e9.png">


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
