### PR TITLE
Add failing test for middleware rewriting to external url

### DIFF
--- a/test/e2e/app-dir/external-rewrite/app/layout.tsx
+++ b/test/e2e/app-dir/external-rewrite/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/external-rewrite/app/page.tsx
+++ b/test/e2e/app-dir/external-rewrite/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/external-rewrite/external-rewrite.test.ts
+++ b/test/e2e/app-dir/external-rewrite/external-rewrite.test.ts
@@ -1,0 +1,26 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'external-rewrite',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should work when using GET to an external url', async () => {
+      const res = await next.fetch('/test')
+      const json = await res.json()
+      expect(json.quickstart).toBe('https://pipedream.com/quickstart/')
+    })
+    it('should work when using POST to an external url', async () => {
+      const res = await next.fetch('/test', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ a: 'a', b: 'b', c: 'c', d: 'd', e: 'e' }),
+      })
+      const json = await res.json()
+      expect(json.quickstart).toBe('https://pipedream.com/quickstart/')
+    })
+  }
+)

--- a/test/e2e/app-dir/external-rewrite/middleware.ts
+++ b/test/e2e/app-dir/external-rewrite/middleware.ts
@@ -1,0 +1,11 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+export default function middleware(request: NextRequest) {
+  return NextResponse.rewrite(
+    new URL(request.nextUrl.pathname, 'https://eolmr5jlg1hnlc2.m.pipedream.net')
+  )
+}
+
+export const config = {
+  matcher: ['/test'],
+}

--- a/test/e2e/app-dir/external-rewrite/next.config.js
+++ b/test/e2e/app-dir/external-rewrite/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Adds a failing test for #48040.

The url uses is for requestbin, needs to be replaced to an internal server instead after investigating. This was the easiest way to investigate the requests coming in.

Seems related to https://github.com/http-party/node-http-proxy/issues/1142. Probably reading the request body somewhere before proxying.


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
