### PR TITLE
Rename Turbopack/tasks crates to common prefixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "serde",
 ]
@@ -3226,7 +3226,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "next-core",
- "turbo-binding",
+ "turbopack-binding",
  "vergen",
 ]
 
@@ -3252,9 +3252,9 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_core",
- "turbo-binding",
  "turbo-tasks",
  "turbo-tasks-fs",
+ "turbopack-binding",
 ]
 
 [[package]]
@@ -3283,8 +3283,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tungstenite 0.17.3",
- "turbo-binding",
  "turbo-tasks",
+ "turbopack-binding",
  "url",
  "vergen",
  "webbrowser",
@@ -3313,8 +3313,8 @@ dependencies = [
  "testing",
  "tokio",
  "tungstenite 0.17.3",
- "turbo-binding",
  "turbo-tasks",
+ "turbopack-binding",
  "url",
  "webbrowser",
 ]
@@ -3336,7 +3336,7 @@ dependencies = [
  "serde_json",
  "sha1 0.10.5",
  "tracing",
- "turbo-binding",
+ "turbopack-binding",
  "walkdir",
 ]
 
@@ -3363,8 +3363,8 @@ dependencies = [
  "tracing-chrome",
  "tracing-futures",
  "tracing-subscriber",
- "turbo-binding",
  "turbo-tasks",
+ "turbopack-binding",
 ]
 
 [[package]]
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "serde",
@@ -6978,57 +6978,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "turbo-binding"
-version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
-dependencies = [
- "auto-hash-map",
- "mdxjs",
- "modularize_imports",
- "node-file-trace",
- "styled_components",
- "styled_jsx",
- "swc_core",
- "swc_emotion",
- "swc_relay",
- "testing",
- "turbo-malloc",
- "turbo-tasks",
- "turbo-tasks-build",
- "turbo-tasks-bytes",
- "turbo-tasks-env",
- "turbo-tasks-fetch",
- "turbo-tasks-fs",
- "turbo-tasks-hash",
- "turbo-tasks-memory",
- "turbo-tasks-testing",
- "turbopack",
- "turbopack-bench",
- "turbopack-cli-utils",
- "turbopack-core",
- "turbopack-dev",
- "turbopack-dev-server",
- "turbopack-ecmascript",
- "turbopack-ecmascript-plugins",
- "turbopack-env",
- "turbopack-image",
- "turbopack-node",
- "turbopack-static",
- "turbopack-test-utils",
-]
-
-[[package]]
-name = "turbo-malloc"
-version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
-dependencies = [
- "mimalloc",
-]
-
-[[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7058,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7070,7 +7022,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7085,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7099,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7116,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7145,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "base16",
  "hex",
@@ -7157,7 +7109,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7171,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7179,9 +7131,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbo-tasks-malloc"
+version = "0.1.0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
+dependencies = [
+ "mimalloc",
+]
+
+[[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7194,16 +7154,16 @@ dependencies = [
  "priority-queue",
  "rustc-hash",
  "tokio",
- "turbo-malloc",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-hash",
+ "turbo-tasks-malloc",
 ]
 
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7215,7 +7175,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7244,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7272,9 +7232,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbopack-binding"
+version = "0.1.0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
+dependencies = [
+ "auto-hash-map",
+ "mdxjs",
+ "modularize_imports",
+ "node-file-trace",
+ "styled_components",
+ "styled_jsx",
+ "swc_core",
+ "swc_emotion",
+ "swc_relay",
+ "testing",
+ "turbo-tasks",
+ "turbo-tasks-build",
+ "turbo-tasks-bytes",
+ "turbo-tasks-env",
+ "turbo-tasks-fetch",
+ "turbo-tasks-fs",
+ "turbo-tasks-hash",
+ "turbo-tasks-malloc",
+ "turbo-tasks-memory",
+ "turbo-tasks-testing",
+ "turbopack",
+ "turbopack-bench",
+ "turbopack-cli-utils",
+ "turbopack-core",
+ "turbopack-dev",
+ "turbopack-dev-server",
+ "turbopack-ecmascript",
+ "turbopack-ecmascript-plugins",
+ "turbopack-env",
+ "turbopack-image",
+ "turbopack-node",
+ "turbopack-static",
+ "turbopack-test-utils",
+]
+
+[[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7291,7 +7291,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7331,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7374,7 +7374,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7394,6 +7394,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-bytes",
@@ -7408,7 +7409,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7444,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7465,7 +7466,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7481,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7501,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "serde",
@@ -7516,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7531,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7565,7 +7566,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "serde",
@@ -7581,7 +7582,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7592,7 +7593,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230511.2#731d27d8495c63b856a15e0d714b8ae008cecd40"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -8008,7 +8009,7 @@ dependencies = [
  "serde_json",
  "swc_core",
  "tracing",
- "turbo-binding",
+ "turbopack-binding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ swc_core = { version = "0.75.41" }
 testing = { version = "0.33.4" }
 
 # Turbo crates
-turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230510.1" }
+turbo-binding = { package = "turbopack-binding", git = "https://github.com/vercel/turbo.git", tag = "turbopack-230510.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
 turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230510.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ swc_core = { version = "0.75.41" }
 testing = { version = "0.33.4" }
 
 # Turbo crates
-turbo-binding = { package = "turbopack-binding", git = "https://github.com/vercel/turbo.git", tag = "turbopack-230510.1" }
+turbo-binding = { package = "turbopack-binding", git = "https://github.com/vercel/turbo.git", tag = "turbopack-230511.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230510.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230511.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230510.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230511.2" }
 
 # General Deps
 

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -70,7 +70,7 @@ turbo-binding = { workspace = true, features = [
 
 [target.'cfg(not(all(target_os = "linux", target_env = "musl", target_arch = "aarch64")))'.dependencies]
 turbo-binding = { workspace = true, features = [
-  "__turbo_malloc"
+  "__turbo_tasks_malloc"
 ] }
 
 # There are few build targets we can't use native-tls which default features rely on,

--- a/packages/next-swc/crates/next-build/Cargo.toml
+++ b/packages/next-swc/crates/next-build/Cargo.toml
@@ -9,7 +9,7 @@ autobenches = false
 [features]
 native-tls = ["next-core/native-tls"]
 rustls-tls = ["next-core/rustls-tls"]
-custom_allocator = ["turbo-binding/__turbo_malloc", "turbo-binding/__turbo_malloc_custom_allocator"]
+custom_allocator = ["turbo-binding/__turbo_tasks_malloc", "turbo-binding/__turbo_tasks_malloc_custom_allocator"]
 
 [dependencies]
 anyhow = "1.0.47"

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d9347dd5895f5e530fa7935d593e1bdb7bbe87bd",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d9347dd5895f5e530fa7935d593e1bdb7bbe87bd",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230511.2",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230511.2",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230504.3",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230504.3",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d9347dd5895f5e530fa7935d593e1bdb7bbe87bd",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d9347dd5895f5e530fa7935d593e1bdb7bbe87bd",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-dev-tests/Cargo.toml
+++ b/packages/next-swc/crates/next-dev-tests/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { workspace = true, features = ["full"] }
 # sync with chromiumoxide's tungstenite requirement.
 tungstenite = { workspace = true }
 turbo-binding = { workspace = true, features = [
-  "__turbo_malloc",
+  "__turbo_tasks_malloc",
   "__turbo_tasks_memory",
   "__turbo_tasks",
   "__turbo_tasks_fs",

--- a/packages/next-swc/crates/next-dev/Cargo.toml
+++ b/packages/next-swc/crates/next-dev/Cargo.toml
@@ -33,7 +33,7 @@ tokio_console = [
   "turbo-tasks/tokio_tracing",
 ]
 profile = []
-custom_allocator = ["turbo-binding/__turbo_malloc", "turbo-binding/__turbo_malloc_custom_allocator"]
+custom_allocator = ["turbo-binding/__turbo_tasks_malloc", "turbo-binding/__turbo_tasks_malloc_custom_allocator"]
 native-tls = ["next-core/native-tls"]
 rustls-tls = ["next-core/rustls-tls"]
 # Internal only. Enabled when building for the Next.js integration test suite.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,8 +1014,8 @@ importers:
       '@types/react': 18.2.5
       '@types/react-dom': 18.2.3
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230504.3
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230504.3
+      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230511.2
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230511.2
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1027,8 +1027,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230504.3_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230504.3'
+      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230511.2_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230511.2'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -5998,7 +5998,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.2.1
       source-map: 0.7.3
-      webpack: 5.74.0
+      webpack: 5.74.0_@swc+core@1.3.55
     transitivePeerDependencies:
       - supports-color
 
@@ -6668,7 +6668,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64/1.3.55:
@@ -6677,7 +6676,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.3.55:
@@ -6686,7 +6684,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.3.55:
@@ -6695,7 +6692,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl/1.3.55:
@@ -6704,7 +6700,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu/1.3.55:
@@ -6713,7 +6708,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl/1.3.55:
@@ -6722,7 +6716,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.3.55:
@@ -6731,7 +6724,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.3.55:
@@ -6740,7 +6732,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc/1.3.55:
@@ -6749,7 +6740,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core/1.3.55_@swc+helpers@0.5.1:
@@ -6774,7 +6764,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.55
       '@swc/core-win32-ia32-msvc': 1.3.55
       '@swc/core-win32-x64-msvc': 1.3.55
-    dev: true
 
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
@@ -23777,7 +23766,6 @@ packages:
       source-map: 0.6.1
       terser: 5.14.1
       webpack: 5.74.0_@swc+core@1.3.55
-    dev: true
 
   /terser-webpack-plugin/5.2.4_webpack@5.74.0:
     resolution: {integrity: sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==}
@@ -25183,7 +25171,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /websocket-driver/0.7.3:
     resolution: {integrity: sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==}
@@ -25589,9 +25576,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230504.3_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230504.3}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230504.3'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230511.2_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230511.2}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230511.2'
     name: '@vercel/turbopack-dev'
     version: 0.0.0
     dependencies:
@@ -25601,8 +25588,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230504.3':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230504.3}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230511.2':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230511.2}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
See https://github.com/vercel/turbo/pull/4866

This also updates Turbopack to turbopack-230511.2 with the following changes:

* https://github.com/vercel/turbo/pull/4636 <!-- Alex Kirszenberg - Add support for logging events and intervals in the macOS profiler  -->
* https://github.com/vercel/turbo/pull/4793 <!-- OJ Kwon - ci(workflow): enable more test  -->
* https://github.com/vercel/turbo/pull/4886 <!-- OJ Kwon - refactor(ecmascript-plugins): update serverdirective signature  -->
* https://github.com/vercel/turbo/pull/4866 <!-- Alex Kirszenberg - Rename Turbopack/tasks crates to common prefixes  -->