### PR TITLE
fix: a11y issues in react-dev-overlay

### DIFF
--- a/packages/react-dev-overlay/src/internal/components/LeftRightDialogHeader/LeftRightDialogHeader.tsx
+++ b/packages/react-dev-overlay/src/internal/components/LeftRightDialogHeader/LeftRightDialogHeader.tsx
@@ -114,6 +114,7 @@ const LeftRightDialogHeader: React.FC<LeftRightDialogHeaderProps> =
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
             >
+              <title>previous</title>
               <path
                 d="M6.99996 1.16666L1.16663 6.99999L6.99996 12.8333M12.8333 6.99999H1.99996H12.8333Z"
                 stroke="currentColor"
@@ -135,6 +136,7 @@ const LeftRightDialogHeader: React.FC<LeftRightDialogHeaderProps> =
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
             >
+              <title>next</title>
               <path
                 d="M6.99996 1.16666L12.8333 6.99999L6.99996 12.8333M1.16663 6.99999H12H1.16663Z"
                 stroke="currentColor"

--- a/packages/react-dev-overlay/src/internal/container/Errors.tsx
+++ b/packages/react-dev-overlay/src/internal/container/Errors.tsx
@@ -329,11 +329,12 @@ export const styles = css`
     color: var(--color-ansi-red);
   }
 
-  .nextjs-container-errors-body > h5:not(:first-child) {
+  .nextjs-container-errors-body > h2:not(:first-child) {
     margin-top: calc(var(--size-gap-double) + var(--size-gap));
   }
-  .nextjs-container-errors-body > h5 {
+  .nextjs-container-errors-body > h2 {
     margin-bottom: var(--size-gap);
+    font-size: var(--size-font-big);
   }
 
   .nextjs-toast-errors-parent {

--- a/packages/react-dev-overlay/src/internal/container/RuntimeError.tsx
+++ b/packages/react-dev-overlay/src/internal/container/RuntimeError.tsx
@@ -40,9 +40,9 @@ const CallStackFrame: React.FC<{
 
   return (
     <div data-nextjs-call-stack-frame>
-      <h6 data-nextjs-frame-expanded={Boolean(frame.expanded)}>
+      <h3 data-nextjs-frame-expanded={Boolean(frame.expanded)}>
         {f.methodName}
-      </h6>
+      </h3>
       <div
         data-has-source={hasSource ? 'true' : undefined}
         tabIndex={hasSource ? 10 : undefined}
@@ -126,7 +126,7 @@ const RuntimeError: React.FC<RuntimeErrorProps> = function RuntimeError({
     <React.Fragment>
       {firstFrame ? (
         <React.Fragment>
-          <h5>Source</h5>
+          <h2>Source</h2>
           {leadingFrames.map((frame, index) => (
             <CallStackFrame
               key={`leading-frame-${index}-${all}`}
@@ -142,10 +142,10 @@ const RuntimeError: React.FC<RuntimeErrorProps> = function RuntimeError({
 
       {error.componentStack ? (
         <>
-          <h5>Component Stack</h5>
+          <h2>Component Stack</h2>
           {error.componentStack.map((component, index) => (
             <div key={index} data-nextjs-component-stack-frame>
-              <h6>{component}</h6>
+              <h3>{component}</h3>
             </div>
           ))}
         </>
@@ -153,7 +153,7 @@ const RuntimeError: React.FC<RuntimeErrorProps> = function RuntimeError({
 
       {visibleCallStackFrames.length ? (
         <React.Fragment>
-          <h5>Call Stack</h5>
+          <h2>Call Stack</h2>
           {visibleCallStackFrames.map((frame, index) => (
             <CallStackFrame key={`call-stack-${index}-${all}`} frame={frame} />
           ))}
@@ -191,14 +191,15 @@ export const styles = css`
     margin-bottom: var(--size-gap-double);
   }
 
-  [data-nextjs-call-stack-frame] > h6,
-  [data-nextjs-component-stack-frame] > h6 {
+  [data-nextjs-call-stack-frame] > h3,
+  [data-nextjs-component-stack-frame] > h3 {
     margin-top: 0;
     margin-bottom: var(--size-gap);
     font-family: var(--font-stack-monospace);
+    font-size: var(--size-font);
     color: #222;
   }
-  [data-nextjs-call-stack-frame] > h6[data-nextjs-frame-expanded='false'] {
+  [data-nextjs-call-stack-frame] > h3[data-nextjs-frame-expanded='false'] {
     color: #666;
   }
   [data-nextjs-call-stack-frame] > div {


### PR DESCRIPTION
This is a part of fix of #47351

This fixes two issues #47351 mentioned.

1. Buttons must have discernible text
  - https://dequeuniversity.com/rules/axe/4.6/button-name?application=axe-puppeteer

Before:
<img width="549" alt="Screenshot 2023-05-08 at 22 37 00" src="https://user-images.githubusercontent.com/250407/236839743-3383aea0-f59a-4f2a-9dff-f24de692a97c.png">

This PR:
<img width="447" alt="Screenshot 2023-05-08 at 22 38 50" src="https://user-images.githubusercontent.com/250407/236839785-3b29b74e-e4db-4ff3-a87c-b69712196264.png">

You can see the accessibility name.

3. Heading levels should only increase by one
  - https://dequeuniversity.com/rules/axe/4.6/heading-order?application=axe-puppeteer

I didn't fix the following issue in this PR because it caused the change in appearance for the overlay.
I'll fix it as another PR.

2. Elements must have sufficient color contrast
  - https://dequeuniversity.com/rules/axe/4.6/color-contrast?application=axe-puppeteer

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
