### PR TITLE
Fix revalidate: false detection in app

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -289,7 +289,11 @@ export default async function build(
       hasAppDir = Boolean(appDir)
 
       if (isAppDirEnabled && hasAppDir) {
-        if (!process.env.__NEXT_TEST_MODE && ciEnvironment.hasNextSupport) {
+        if (
+          (!process.env.__NEXT_TEST_MODE ||
+            process.env.__NEXT_TEST_MODE === 'e2e') &&
+          ciEnvironment.hasNextSupport
+        ) {
           const requireHook = require.resolve('../server/require-hook')
           const contents = await promises.readFile(requireHook, 'utf8')
           await promises.writeFile(

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -191,9 +191,11 @@ createNextDescribe(
           await waitFor(500)
         }
 
-        expect(next.cliOutput.substring(buildCliOutputIndex)).not.toContain(
-          'rendering index'
-        )
+        if (isNextStart) {
+          expect(next.cliOutput.substring(buildCliOutputIndex)).not.toContain(
+            'rendering index'
+          )
+        }
       })
 
       it.each([

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -23,12 +23,14 @@ createNextDescribe(
   },
   ({ next, isNextDev: isDev, isNextStart, isNextDeploy }) => {
     let prerenderManifest
+    let buildCliOutputIndex = 0
 
     beforeAll(async () => {
       if (isNextStart) {
         prerenderManifest = JSON.parse(
           await next.readFile('.next/prerender-manifest.json')
         )
+        buildCliOutputIndex = next.cliOutput.length
       }
     })
 
@@ -171,6 +173,29 @@ createNextDescribe(
     // On-Demand Revalidate has not effect in dev since app routes
     // aren't considered static until prerendering
     if (!(global as any).isNextDev && !process.env.CUSTOM_CACHE_HANDLER) {
+      it('should not revalidate / when revalidate is not used', async () => {
+        let prevData
+
+        for (let i = 0; i < 5; i++) {
+          const res = await next.fetch('/')
+          const html = await res.text()
+          const $ = cheerio.load(html)
+          const data = $('#page-data').text()
+
+          expect(res.status).toBe(200)
+
+          if (prevData) {
+            expect(prevData).toBe(data)
+            prevData = data
+          }
+          await waitFor(500)
+        }
+
+        expect(next.cliOutput.substring(buildCliOutputIndex)).not.toContain(
+          'rendering index'
+        )
+      })
+
       it.each([
         {
           type: 'edge route handler',
@@ -399,6 +424,9 @@ createNextDescribe(
           'hooks/use-search-params/with-suspense.html',
           'hooks/use-search-params/with-suspense.rsc',
           'hooks/use-search-params/with-suspense/page.js',
+          'index.html',
+          'index.rsc',
+          'page.js',
           'partial-gen-params-no-additional-lang/[lang]/[slug]/page.js',
           'partial-gen-params-no-additional-lang/en/RAND.html',
           'partial-gen-params-no-additional-lang/en/RAND.rsc',
@@ -507,6 +535,11 @@ createNextDescribe(
 
         expect(curManifest.version).toBe(4)
         expect(curManifest.routes).toEqual({
+          '/': {
+            initialRevalidateSeconds: false,
+            srcRoute: '/',
+            dataRoute: '/index.rsc',
+          },
           '/blog/tim': {
             initialRevalidateSeconds: 10,
             srcRoute: '/blog/[author]',
@@ -659,7 +692,7 @@ createNextDescribe(
               'x-next-cache-tags':
                 'thankyounext,/route-handler/revalidate-360-isr/route',
             },
-            initialRevalidateSeconds: false,
+            initialRevalidateSeconds: 10,
             srcRoute: '/route-handler/revalidate-360-isr',
           },
           '/variable-config-revalidate/revalidate-3': {

--- a/test/e2e/app-dir/app-static/app/page.js
+++ b/test/e2e/app-dir/app-static/app/page.js
@@ -1,0 +1,15 @@
+export default async function Page() {
+  console.log('rendering index')
+
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?page'
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="page">/variable-revalidate/revalidate-360</p>
+      <p id="page-data">{data}</p>
+      <p id="now">{Date.now()}</p>
+    </>
+  )
+}

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -85,7 +85,7 @@ export class NextDeployInstance extends NextInstance {
       [
         'deploy',
         '--build-env',
-        'NEXT_PRIVATE_TEST_MODE=1',
+        'NEXT_PRIVATE_TEST_MODE=e2e',
         '--build-env',
         'NEXT_TELEMETRY_DISABLED=1',
         ...additionalEnv,

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -47,7 +47,7 @@ export class NextDevInstance extends NextInstance {
             ...this.env,
             NODE_ENV: '' as any,
             PORT: this.forcedPort || '0',
-            __NEXT_TEST_MODE: '1',
+            __NEXT_TEST_MODE: 'e2e',
             __NEXT_TEST_WITH_DEVTOOL: '1',
           },
         })

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -50,7 +50,7 @@ export class NextStartInstance extends NextInstance {
         ...this.env,
         NODE_ENV: '' as any,
         PORT: this.forcedPort || '0',
-        __NEXT_TEST_MODE: '1',
+        __NEXT_TEST_MODE: 'e2e',
       },
     }
     let buildArgs = ['yarn', 'next', 'build']


### PR DESCRIPTION
When revalidate isn't defined in the tree at all and a fetch without cache/revalidate fields is done we are incorrectly marking the initial revalidate period with a time based value when it should be `false`. This causes pages that should be fully static to revalidate unexpectedly. 

x-ref: [twitter thread](https://twitter.com/diegohaz/status/1655638433795014657)
x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1683566860136879)