### PR TITLE
Fix actions redirect handling

### DIFF
--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -1,4 +1,4 @@
-const forbiddenHeaders = [
+export const forbiddenHeaders = [
   'accept-encoding',
   'content-length',
   'keepalive',


### PR DESCRIPTION
This ensures we properly strip conflicting headers from being forwarded when handling the redirect request/response in actions. 

x-ref: [slack thread](https://vercel.slack.com/archives/C042LHPJ1NX/p1683218335368759)

Fixes: 

```sh
failed to get redirect response TypeError: fetch failed
    at Object.fetch (node:internal/deps/undici/undici:11413:11) {
  cause: RequestContentLengthMismatchError: Request body length does not match content-length header
      at write (node:internal/deps/undici/undici:9907:41)
      at _resume (node:internal/deps/undici/undici:9885:33)
      at resume (node:internal/deps/undici/undici:9787:7)
      at connect (node:internal/deps/undici/undici:9776:7) {
    code: 'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH'
  }
}
```