### PR TITLE
Add test case for #49235

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -59,6 +59,26 @@ createNextDescribe(
       }, 'same')
     })
 
+    it('should support headers in client imported actions', async () => {
+      const logs: string[] = []
+      next.on('stdout', (log) => {
+        logs.push(log)
+      })
+      next.on('stderr', (log) => {
+        logs.push(log)
+      })
+
+      const browser = await next.browser('/client')
+      await browser.elementByCss('#get-header').click()
+      await check(() => {
+        return logs.some((log) =>
+          log.includes('accept header: text/x-component')
+        )
+          ? 'yes'
+          : ''
+      }, 'yes')
+    })
+
     it('should support setting cookies in route handlers with the correct overrides', async () => {
       const res = await next.fetch('/handler')
       const setCookieHeader = res.headers.get('set-cookie') as string[]

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -68,6 +68,8 @@ createNextDescribe(
         logs.push(log)
       })
 
+      const currentTimestamp = Date.now()
+
       const browser = await next.browser('/client')
       await browser.elementByCss('#get-header').click()
       await check(() => {
@@ -77,6 +79,10 @@ createNextDescribe(
           ? 'yes'
           : ''
       }, 'yes')
+
+      expect(
+        await browser.eval('+document.cookie.match(/test-cookie=(d+)/)[1]')
+      ).toBeGreaterThanOrEqual(currentTimestamp)
     })
 
     it('should support setting cookies in route handlers with the correct overrides', async () => {

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -81,7 +81,7 @@ createNextDescribe(
       }, 'yes')
 
       expect(
-        await browser.eval('+document.cookie.match(/test-cookie=(d+)/)[1]')
+        await browser.eval('+document.cookie.match(/test-cookie=(\\d+)/)[1]')
       ).toBeGreaterThanOrEqual(currentTimestamp)
     })
 

--- a/test/e2e/app-dir/actions/app/client/actions.js
+++ b/test/e2e/app-dir/actions/app/client/actions.js
@@ -1,6 +1,11 @@
 'use server'
 
 import { redirect } from 'next/navigation'
+import { headers } from 'next/headers'
+
+export async function getHeaders() {
+  console.log('accept header:', headers().get('accept'))
+}
 
 export async function inc(value) {
   return value + 1

--- a/test/e2e/app-dir/actions/app/client/actions.js
+++ b/test/e2e/app-dir/actions/app/client/actions.js
@@ -1,10 +1,11 @@
 'use server'
 
 import { redirect } from 'next/navigation'
-import { headers } from 'next/headers'
+import { headers, cookies } from 'next/headers'
 
 export async function getHeaders() {
   console.log('accept header:', headers().get('accept'))
+  cookies().set('test-cookie', Date.now())
 }
 
 export async function inc(value) {

--- a/test/e2e/app-dir/actions/app/client/page.js
+++ b/test/e2e/app-dir/actions/app/client/page.js
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 
-import double, { inc, dec, redirectAction } from './actions'
+import double, { inc, dec, redirectAction, getHeaders } from './actions'
 
 export default function Counter() {
   const [count, setCount] = useState(0)
@@ -50,6 +50,11 @@ export default function Counter() {
           formAction={() => redirectAction('https://example.com')}
         >
           redirect external
+        </button>
+      </form>
+      <form action={getHeaders}>
+        <button type="submit" id="get-header">
+          submit
         </button>
       </form>
     </div>


### PR DESCRIPTION
This PR adds a test case for `headers()` and `cookies().set()` in Client Component imported actions.