### PR TITLE
Use rimraf for cross platform assets removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "new-error": "plop error",
     "new-test": "plop test",
-    "clean": "lerna clean -y && lerna bootstrap && lerna run clean && lerna exec 'rm -rf ./dist'",
+    "clean": "lerna clean -y && lerna bootstrap && lerna run clean",
     "build": "turbo run build",
     "lerna": "lerna",
     "dev": "turbo run dev --parallel",
@@ -45,7 +45,7 @@
     "next-with-deps": "./scripts/next-with-deps.sh",
     "next": "cross-env NEXT_TELEMETRY_DISABLED=1 node --trace-deprecation --enable-source-maps packages/next/dist/bin/next",
     "next-no-sourcemaps": "cross-env NEXT_TELEMETRY_DISABLED=1 node --trace-deprecation packages/next/dist/bin/next",
-    "clean-trace-jaeger": "rm -rf test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",
+    "clean-trace-jaeger": "rimraf test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",
     "debug": "cross-env NEXT_TELEMETRY_DISABLED=1 node --inspect packages/next/dist/bin/next",
     "postinstall": "git config index.skipHash false && node scripts/install-native.mjs",
     "version": "npx pnpm@7.24.3 install --no-frozen-lockfile && IS_PUBLISH=yes ./scripts/check-pre-compiled.sh && git add .",

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -3,7 +3,7 @@
   "version": "13.4.2-canary.3",
   "private": true,
   "scripts": {
-    "clean": "rm -rf ./native/*",
+    "clean": "rimraf ./native/*",
     "build-native": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --features plugin,rustls-tls --js false native",
     "build-native-woa": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --cargo-flags=--no-default-features --features plugin,native-tls --js false native",
     "build-native-no-plugin": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --js false native",


### PR DESCRIPTION
We've already switched to `rimraf` in #44011 for windows compatibility, this PR changed the left packages clean commands to use `rimraf`

Closes #42433