### PR TITLE
refactor(next-core): remove ast cloning in custom transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "serde",
 ]
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "serde",
@@ -6980,7 +6980,7 @@ dependencies = [
 [[package]]
 name = "turbo-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7020,7 +7020,7 @@ dependencies = [
 [[package]]
 name = "turbo-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "mimalloc",
 ]
@@ -7028,7 +7028,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7058,7 +7058,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7070,7 +7070,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7085,7 +7085,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7099,7 +7099,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7116,7 +7116,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7145,7 +7145,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "base16",
  "hex",
@@ -7157,7 +7157,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7171,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7181,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7203,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7215,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7274,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7291,7 +7291,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7331,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7374,7 +7374,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7408,7 +7408,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7444,11 +7444,15 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "async-trait",
+ "indexmap",
+ "modularize_imports",
  "serde",
+ "styled_components",
+ "styled_jsx",
  "swc_core",
  "swc_emotion",
  "swc_relay",
@@ -7461,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7477,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7497,7 +7501,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "serde",
@@ -7512,7 +7516,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7527,7 +7531,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7561,7 +7565,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "serde",
@@ -7577,7 +7581,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7588,7 +7592,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230508.2#b9e5e6d750c048bb083bfa60941554c479f6685f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230510.1#95be42aa8a2e9d55207fd8ca8da5e247c2f7f322"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ swc_core = { version = "0.75.41" }
 testing = { version = "0.33.4" }
 
 # Turbo crates
-turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230508.2" }
+turbo-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230510.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230508.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230510.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230508.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230510.1" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
@@ -9,10 +9,6 @@ pub use next_dynamic::get_next_dynamic_transform_rule;
 pub use next_font::get_next_font_transform_rule;
 pub use next_strip_page_exports::get_next_pages_transforms_rule;
 pub use relay::get_relay_transform_plugin;
-use swc_core::{
-    common::util::take::Take,
-    ecma::ast::{Module, ModuleItem, Program},
-};
 use turbo_binding::turbopack::{
     core::reference_type::{ReferenceType, UrlReferenceSubType},
     turbopack::module_options::{ModuleRule, ModuleRuleCondition, ModuleRuleEffect, ModuleType},
@@ -52,19 +48,4 @@ pub(crate) fn module_rule_match_js_no_url() -> ModuleRuleCondition {
             ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
         ]),
     ])
-}
-
-pub(crate) fn unwrap_module_program(program: &mut Program) -> Program {
-    match program {
-        Program::Module(module) => Program::Module(module.take()),
-        Program::Script(s) => Program::Module(Module {
-            span: s.span,
-            body: s
-                .body
-                .iter()
-                .map(|stmt| ModuleItem::Stmt(stmt.clone()))
-                .collect(),
-            shebang: s.shebang.clone(),
-        }),
-    }
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/modularize_imports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/modularize_imports.rs
@@ -77,11 +77,7 @@ impl ModularizeImportsTransformer {
 
 #[async_trait]
 impl CustomTransformer for ModularizeImportsTransformer {
-    async fn transform(
-        &self,
-        program: &mut Program,
-        _ctx: &TransformContext<'_>,
-    ) -> Result<Option<Program>> {
+    async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
         let p = std::mem::replace(program, Program::Module(Module::dummy()));
         *program = p.fold_with(&mut modularize_imports(
             turbo_binding::swc::custom_transform::modularize_imports::Config {
@@ -89,6 +85,6 @@ impl CustomTransformer for ModularizeImportsTransformer {
             },
         ));
 
-        Ok(None)
+        Ok(())
     }
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -58,11 +58,7 @@ struct NextJsDynamic {
 
 #[async_trait]
 impl CustomTransformer for NextJsDynamic {
-    async fn transform(
-        &self,
-        program: &mut Program,
-        ctx: &TransformContext<'_>,
-    ) -> Result<Option<Program>> {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         let p = std::mem::replace(program, Program::Module(Module::dummy()));
         *program = p.fold_with(&mut next_dynamic(
             self.is_development,
@@ -73,6 +69,6 @@ impl CustomTransformer for NextJsDynamic {
             self.pages_dir.clone(),
         ));
 
-        Ok(None)
+        Ok(())
     }
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_font.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_font.rs
@@ -38,17 +38,13 @@ struct NextJsFont {
 
 #[async_trait]
 impl CustomTransformer for NextJsFont {
-    async fn transform(
-        &self,
-        program: &mut Program,
-        ctx: &TransformContext<'_>,
-    ) -> Result<Option<Program>> {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         let mut next_font = next_transform_font::next_font_loaders(next_transform_font::Config {
             font_loaders: self.font_loaders.clone(),
             relative_file_path_from_root: ctx.file_name_str.into(),
         });
 
         program.visit_mut_with(&mut next_font);
-        Ok(None)
+        Ok(())
     }
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -61,11 +61,7 @@ struct NextJsStripPageExports {
 
 #[async_trait]
 impl CustomTransformer for NextJsStripPageExports {
-    async fn transform(
-        &self,
-        program: &mut Program,
-        _ctx: &TransformContext<'_>,
-    ) -> Result<Option<Program>> {
+    async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
         // TODO(alexkirsz) Connect the eliminated_packages to telemetry.
         let eliminated_packages = Default::default();
 
@@ -75,6 +71,6 @@ impl CustomTransformer for NextJsStripPageExports {
             eliminated_packages,
         ));
 
-        Ok(None)
+        Ok(())
     }
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -1,7 +1,13 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use next_transform_strip_page_exports::{next_transform_strip_page_exports, ExportFilter};
-use swc_core::ecma::{ast::Program, visit::FoldWith};
+use swc_core::{
+    common::util::take::Take,
+    ecma::{
+        ast::{Module, Program},
+        visit::FoldWith,
+    },
+};
 use turbo_binding::{
     turbo::tasks_fs::FileSystemPathVc,
     turbopack::{
@@ -13,7 +19,7 @@ use turbo_binding::{
     },
 };
 
-use super::{module_rule_match_js_no_url, unwrap_module_program};
+use super::module_rule_match_js_no_url;
 
 /// Returns a rule which applies the Next.js page export stripping transform.
 pub async fn get_next_pages_transforms_rule(
@@ -63,9 +69,12 @@ impl CustomTransformer for NextJsStripPageExports {
         // TODO(alexkirsz) Connect the eliminated_packages to telemetry.
         let eliminated_packages = Default::default();
 
-        let module_program = unwrap_module_program(program);
-        Ok(Some(module_program.fold_with(
-            &mut next_transform_strip_page_exports(self.export_filter, eliminated_packages),
-        )))
+        let p = std::mem::replace(program, Program::Module(Module::dummy()));
+        *program = p.fold_with(&mut next_transform_strip_page_exports(
+            self.export_filter,
+            eliminated_packages,
+        ));
+
+        Ok(None)
     }
 }


### PR DESCRIPTION
### What?

- closes WEB-1024.

Minor refactoring to avoid explicit AST cloning. Still visitors are using fold though.

### Turbopack changes

* https://github.com/vercel/turbo/pull/4869
* https://github.com/vercel/turbo/pull/4879
* https://github.com/vercel/turbo/pull/4881