### PR TITLE
Allow export decl with any init value in the actions compiler

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -714,6 +714,15 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                 self.exported_idents.extend(
                                     ids.into_iter().map(|id| (id.clone(), id.0.to_string())),
                                 );
+
+                                for decl in &mut var.decls {
+                                    if let Some(init) = &decl.init {
+                                        if let Expr::Lit(_) = &**init {
+                                            // It's not allowed to export any literal.
+                                            disallowed_export_span = *span;
+                                        }
+                                    }
+                                }
                             }
                             _ => {
                                 disallowed_export_span = *span;

--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -711,22 +711,10 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                             Decl::Var(var) => {
                                 // export const foo = 1
                                 let ids: Vec<Id> = collect_idents_in_var_decls(&var.decls);
+                                println!("exported_idents: {:?}", ids);
                                 self.exported_idents.extend(
                                     ids.into_iter().map(|id| (id.clone(), id.0.to_string())),
                                 );
-
-                                for decl in &mut var.decls {
-                                    if let Some(init) = &decl.init {
-                                        match &**init {
-                                            Expr::Fn(_f) => {}
-                                            Expr::Arrow(_a) => {}
-                                            Expr::Call(_c) => {}
-                                            _ => {
-                                                disallowed_export_span = *span;
-                                            }
-                                        }
-                                    }
-                                }
                             }
                             _ => {
                                 disallowed_export_span = *span;

--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -711,7 +711,6 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                             Decl::Var(var) => {
                                 // export const foo = 1
                                 let ids: Vec<Id> = collect_idents_in_var_decls(&var.decls);
-                                println!("exported_idents: {:?}", ids);
                                 self.exported_idents.extend(
                                     ids.into_iter().map(|id| (id.clone(), id.0.to_string())),
                                 );

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/client/3/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/client/3/input.js
@@ -1,0 +1,5 @@
+'use server'
+
+export const { sampleFunction } = someObject
+export const { sampleFunction2 } = fn()
+export let { 0: sampleFunction3, 1: sampleFunction4 } = [g(), g()]

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/client/3/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/client/3/output.js
@@ -1,0 +1,6 @@
+/* __next_internal_action_entry_do_not_use__ sampleFunction,sampleFunction2,sampleFunction3,sampleFunction4 */ import __create_action_proxy__ from "private-next-rsc-action-proxy";
+import createServerReference from "private-next-rsc-action-client-wrapper";
+export const sampleFunction = createServerReference("bd336abe00c3c59da66acb696fc8e151d8e54ea4");
+export const sampleFunction2 = createServerReference("a0c73dd6f5af839e3335c6b19262ecb86cca6af4");
+export const sampleFunction3 = createServerReference("d4f2e95bc745b6500b439c0847003511748c8ece");
+export const sampleFunction4 = createServerReference("f03b256ee88a51700367acee3082894e25e6e7d9");


### PR DESCRIPTION
Because of the flexibility of export declarations, we can't know the exact export type of exported values so we should allow all of them. Especially when we already have runtime checks.
fix #49378
fix NEXT-1137