### PR TITLE
interception route: fix route groups breaking the referrer computation

### DIFF
--- a/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
@@ -1,0 +1,60 @@
+import { computeChangedPath } from './compute-changed-path'
+
+describe('computeChangedPath', () => {
+  it('should return the correct path', () => {
+    expect(
+      computeChangedPath(
+        [
+          '',
+          {
+            children: [
+              '(marketing)',
+              {
+                children: ['__PAGE__', {}],
+                modal: [
+                  '(...)stats',
+                  {
+                    children: [
+                      ['key', 'github', 'd'],
+                      {
+                        children: ['__PAGE__', {}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ],
+        [
+          '',
+          {
+            children: [
+              '(marketing)',
+              {
+                children: ['__PAGE__', {}],
+                modal: [
+                  '(...)stats',
+                  {
+                    children: [
+                      ['key', 'github', 'd'],
+                      {
+                        children: ['__PAGE__', {}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+      )
+    ).toBe('/')
+  })
+})

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -11,13 +11,18 @@ const segmentToPathname = (segment: Segment): string => {
 }
 
 function normalizePathname(pathname: string): string {
-  return pathname.split('/').reduce((acc, segment) => {
-    if (segment === '' || (segment.startsWith('(') && segment.endsWith(')'))) {
-      return acc
-    }
+  return (
+    pathname.split('/').reduce((acc, segment) => {
+      if (
+        segment === '' ||
+        (segment.startsWith('(') && segment.endsWith(')'))
+      ) {
+        return acc
+      }
 
-    return `${acc}/${segment}`
-  }, '')
+      return `${acc}/${segment}`
+    }, '') || '/'
+  )
 }
 
 export function extractPathFromFlightRouterState(


### PR DESCRIPTION
This PR fixes a bug during path normalisation where `/(foo)/` would break because it would return `` per the function logic. A simple fix is to just ensure we always return a `/` as the default if the normalisation returns an empty string.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

link NEXT-1118