### PR TITLE
Fix mixed no-cache fetch handling

### DIFF
--- a/packages/next/src/client/components/static-generation-async-storage.ts
+++ b/packages/next/src/client/components/static-generation-async-storage.ts
@@ -42,6 +42,9 @@ export interface StaticGenerationStore {
     status: number
     cacheStatus: 'hit' | 'miss'
   }>
+
+  usedHeaders?: boolean
+  isNonStaticMethod?: boolean
 }
 
 export type StaticGenerationAsyncStorage =

--- a/packages/next/src/client/components/static-generation-bailout.ts
+++ b/packages/next/src/client/components/static-generation-bailout.ts
@@ -29,6 +29,9 @@ export const staticGenerationBailout: StaticGenerationBailout = (
   }
 
   if (staticGenerationStore) {
+    if (reason === 'headers' || reason === 'cookies') {
+      staticGenerationStore.usedHeaders = true
+    }
     staticGenerationStore.revalidate = 0
   }
 

--- a/packages/next/src/server/future/route-modules/app-route/module.ts
+++ b/packages/next/src/server/future/route-modules/app-route/module.ts
@@ -275,6 +275,7 @@ export class AppRouteRouteModule extends RouteModule<
                 // Check to see if we should bail out of static generation based on
                 // having non-static methods.
                 if (this.nonStaticMethods) {
+                  staticGenerationStore.isNonStaticMethod = true
                   this.staticGenerationBailout(
                     `non-static methods used ${this.nonStaticMethods.join(
                       ', '

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -44,6 +44,7 @@ function trackFetchMetric(
 
   // don't add metric if one already exists for the fetch
   if (
+    ctx.cacheStatus !== 'miss' &&
     staticGenerationStore.fetchMetrics.some((metric) => {
       return dedupeFields.every(
         (field) => (metric as any)[field] === (ctx as any)[field]
@@ -195,7 +196,8 @@ export function patchFetch({
         // e.g. if cookies() is used before an authed/POST fetch
         const autoNoCache =
           (hasUnCacheableHeader || isUnCacheableMethod) &&
-          staticGenerationStore.revalidate === 0
+          (staticGenerationStore.usedHeaders ||
+            staticGenerationStore.isNonStaticMethod)
 
         if (isForceNoStore) {
           revalidate = 0
@@ -223,6 +225,7 @@ export function patchFetch({
             revalidate = 0
           } else {
             revalidate =
+              staticGenerationStore.revalidate === 0 ||
               typeof staticGenerationStore.revalidate === 'boolean' ||
               typeof staticGenerationStore.revalidate === 'undefined'
                 ? false

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -428,6 +428,7 @@ createNextDescribe(
           'hooks/use-search-params/with-suspense/page.js',
           'index.html',
           'index.rsc',
+          'mixed-no-cache/page.js',
           'page.js',
           'partial-gen-params-no-additional-lang/[lang]/[slug]/page.js',
           'partial-gen-params-no-additional-lang/en/RAND.html',
@@ -838,6 +839,29 @@ createNextDescribe(
         )
       })
     }
+
+    it('should properly cache with no-store fetch', async () => {
+      const res = await next.fetch('/mixed-no-cache')
+      expect(res.status).toBe(200)
+
+      let prevHtml = await res.text()
+      let prev$ = cheerio.load(prevHtml)
+
+      await check(async () => {
+        const curRes = await next.fetch('/mixed-no-cache')
+        expect(curRes.status).toBe(200)
+
+        const curHtml = await curRes.text()
+        const cur$ = cheerio.load(curHtml)
+
+        expect(prev$('#data1').text()).toBe(cur$('#data1').text())
+        expect(prev$('#data2').text()).not.toBe(cur$('#data2').text())
+        expect(prev$('#data3').text()).toBe(cur$('#data3').text())
+        expect(prev$('#data4').text()).toBe(cur$('#data4').text())
+
+        return 'success'
+      }, 'success')
+    })
 
     if (isDev) {
       it('should bypass fetch cache with cache-control: no-cache', async () => {

--- a/test/e2e/app-dir/app-static/app/mixed-no-cache/page.js
+++ b/test/e2e/app-dir/app-static/app/mixed-no-cache/page.js
@@ -1,0 +1,27 @@
+export default async function Home() {
+  const data1 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random'
+  ).then((res) => res.text())
+  const data2 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      cache: 'no-store',
+    }
+  ).then((res) => res.text())
+  const data3 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?a'
+  ).then((res) => res.text())
+  const data4 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?b'
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p>hello wolrd</p>
+      <p id="data1">{data1}</p>
+      <p id="data2">{data2}</p>
+      <p id="data3">{data3}</p>
+      <p id="data4">{data4}</p>
+    </>
+  )
+}


### PR DESCRIPTION
This ensures a fetch with `cache: 'no-store'` doesn't cause successive fetches to incorrectly bypass the cache. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1683732826894469)