### PR TITLE
fix: Disable `tracing/release_max_level_off` for wasm, too

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1602,7 +1602,7 @@ jobs:
 
       - name: Build
         if: ${{needs.build.outputs.docsChange == 'nope'}}
-        run: turbo run build-wasm --cache-dir=".turbo" -- --features tracing/release_max_level_info --target nodejs --dev
+        run: turbo run build-wasm --cache-dir=".turbo" -- --target nodejs --dev --features tracing/release_max_level_info
 
       - name: Add target to folder name
         if: ${{needs.build.outputs.docsChange == 'nope'}}

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1537,7 +1537,7 @@ jobs:
         run: node scripts/normalize-version-bump.js
 
       - name: Build
-        run: turbo run build-wasm -- --target ${{ matrix.target }}
+        run: turbo run build-wasm -- --target ${{ matrix.target }} --features tracing/release_max_level_info
 
       - name: Add target to folder name
         run: '[[ -d "packages/next-swc/crates/wasm/pkg" ]] && mv packages/next-swc/crates/wasm/pkg packages/next-swc/crates/wasm/pkg-${{ matrix.target }} || ls packages/next-swc/crates/wasm'
@@ -1602,7 +1602,7 @@ jobs:
 
       - name: Build
         if: ${{needs.build.outputs.docsChange == 'nope'}}
-        run: turbo run build-wasm --cache-dir=".turbo" -- --target nodejs --dev
+        run: turbo run build-wasm --cache-dir=".turbo" -- --features tracing/release_max_level_info --target nodejs --dev
 
       - name: Add target to folder name
         if: ${{needs.build.outputs.docsChange == 'nope'}}

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -23,7 +23,6 @@ path-clean = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = { version = "0.1.37", features = [
-  "release_max_level_off",
   "max_level_off",
 ] }
 wasm-bindgen = { version = "0.2", features = ["enable-interning"] }

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -22,9 +22,7 @@ parking_lot_core = "=0.8.0"
 path-clean = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tracing = { version = "0.1.37", features = [
-  "max_level_off",
-] }
+tracing = { version = "0.1.37" }
 wasm-bindgen = { version = "0.2", features = ["enable-interning"] }
 wasm-bindgen-futures = "0.4.8"
 getrandom = { version = "0.2.5", optional = true, default-features = false }

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -9,7 +9,7 @@
     "build-native-no-plugin": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --js false native",
     "build-native-no-plugin-woa": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --cargo-flags=--no-default-features --features native-tls --js false native",
     "build-native-no-plugin-woa-release": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --release --cargo-flags=--no-default-features --features native-tls,tracing/release_max_level_info --js false native",
-    "build-wasm": "wasm-pack build crates/wasm --scope=next",
+    "build-wasm": "wasm-pack build crates/wasm --scope=next --features tracing/release_max_level_info",
     "cache-build-native": "echo $(ls native)"
   },
   "napi": {

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -9,7 +9,7 @@
     "build-native-no-plugin": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --js false native",
     "build-native-no-plugin-woa": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --cargo-flags=--no-default-features --features native-tls --js false native",
     "build-native-no-plugin-woa-release": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --release --cargo-flags=--no-default-features --features native-tls,tracing/release_max_level_info --js false native",
-    "build-wasm": "wasm-pack build crates/wasm --scope=next --features tracing/release_max_level_info",
+    "build-wasm": "wasm-pack build crates/wasm --scope=next",
     "cache-build-native": "echo $(ls native)"
   },
   "napi": {


### PR DESCRIPTION
### What?

Along with https://github.com/swc-project/plugins/pull/182, this PR will allow using trace-level logging for debugging turboapck.

### Why?

Requested by @sokra 

x-ref: https://vercel.slack.com/archives/C03EWR7LGEN/p1683738076476839

### How?

Closes WEB-1035

