### PR TITLE
Add playwright to external package list

### DIFF
--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -23,6 +23,7 @@
   "postcss",
   "prettier",
   "prisma",
+  "playwright",
   "rimraf",
   "sharp",
   "shiki",


### PR DESCRIPTION
Add playwright to the list of packages that can't be bundled,

[related](https://github.com/vercel/next.js/pull/49597)