### PR TITLE
Clean up standalone server options

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1978,7 +1978,6 @@ server.listen(currentPort, async (err) => {
     port: currentPort,
     hostname,
     dir,
-    conf: nextConfig,
   })
 
   console.log(

--- a/packages/next/src/server/lib/render-server-standalone.ts
+++ b/packages/next/src/server/lib/render-server-standalone.ts
@@ -10,11 +10,13 @@ const renderServerPath = require.resolve('./render-server')
 export const createServerHandler = async ({
   port,
   hostname,
+  dev = false,
   dir,
   minimalMode,
 }: {
   port: number
   hostname: string
+  dev?: boolean
   dir: string
   minimalMode: boolean
 }) => {
@@ -60,7 +62,7 @@ export const createServerHandler = async ({
   const { port: routerPort } = await routerWorker.initialize({
     dir,
     port,
-    dev: false,
+    dev,
     hostname,
     minimalMode,
     workerType: 'router',

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -122,7 +122,6 @@ export async function initialize(opts: {
           hostname,
           customServer: false,
           httpServer: server,
-          port: opts.port,
         })
 
         requestHandler = app.getRequestHandler()


### PR DESCRIPTION
This updates the options of `createServerHandler` in `render-server-standalone`, as a preparation for #49355. Eventually we need an update in the docs to use the new standalone server instance, instead of exposing `NextServer`.