### PR TITLE
Add missing config vars into Webpack cache key

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2489,6 +2489,8 @@ export default async function getBaseWebpackConfig(
     optimizeCss: config.experimental.optimizeCss,
     nextScriptWorkers: config.experimental.nextScriptWorkers,
     scrollRestoration: config.experimental.scrollRestoration,
+    serverActions: config.experimental.serverActions,
+    typedRoutes: config.experimental.typedRoutes,
     basePath: config.basePath,
     pageEnv: config.experimental.pageEnv,
     excludeDefaultMomentLocales: config.excludeDefaultMomentLocales,


### PR DESCRIPTION
Add missing `serverActions` and `typedRoutes` to the Webpack config cache key as they can affect the build assets.