### PR TITLE
Fix not found issue in i18n example

### DIFF
--- a/examples/app-dir-i18n-routing/middleware.ts
+++ b/examples/app-dir-i18n-routing/middleware.ts
@@ -43,7 +43,7 @@ export function middleware(request: NextRequest) {
 
     // e.g. incoming request is /products
     // The new URL is now /en-US/products
-    return NextResponse.redirect(new URL(`/${locale}/${pathname}`, request.url))
+    return NextResponse.redirect(new URL(`${locale}${pathname}`, request.url))
   }
 }
 


### PR DESCRIPTION
Currently if someone navigates to a route, for example (`https://some-route.com`), the middleware turns the route to: `https://some-route.com/locale//` causing a *404: Not found* error, this occurs because pathname already has the beginning slash (`/route`). `request.url` has the slash at the end so this one is redundant too (`https://some-route.com/`)
