### PR TITLE
chore: update examples to use draft mode

### DIFF
--- a/examples/cms-agilitycms/pages/api/exit-preview.ts
+++ b/examples/cms-agilitycms/pages/api/exit-preview.ts
@@ -4,8 +4,8 @@ export default async function handler(
   _req: NextApiRequest,
   res: NextApiResponse
 ) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-agilitycms/pages/api/preview.ts
+++ b/examples/cms-agilitycms/pages/api/preview.ts
@@ -19,8 +19,8 @@ export default async function handler(
     return res.status(401).end(`${validationResp.message}`)
   }
 
-  //enable preview mode
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the slug
   if (!('slug' in validationResp)) {

--- a/examples/cms-builder-io/pages/api/exit-preview.js
+++ b/examples/cms-builder-io/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-contentful/pages/api/exit-preview.js
+++ b/examples/cms-contentful/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-contentful/pages/api/preview.js
+++ b/examples/cms-contentful/pages/api/preview.js
@@ -15,8 +15,8 @@ export default async function preview(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-cosmic/pages/api/exit-preview.ts
+++ b/examples/cms-cosmic/pages/api/exit-preview.ts
@@ -1,6 +1,6 @@
 export default function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-cosmic/pages/api/preview.ts
+++ b/examples/cms-cosmic/pages/api/preview.ts
@@ -18,8 +18,8 @@ export default async function preview(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-datocms/pages/api/exit-preview.js
+++ b/examples/cms-datocms/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-datocms/pages/api/preview.js
+++ b/examples/cms-datocms/pages/api/preview.js
@@ -18,8 +18,8 @@ export default async function preview(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-dotcms/pages/api/exit-preview.tsx
+++ b/examples/cms-dotcms/pages/api/exit-preview.tsx
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-dotcms/pages/api/preview.tsx
+++ b/examples/cms-dotcms/pages/api/preview.tsx
@@ -15,8 +15,8 @@ export default async function preview(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   const url = `/posts/${post.post.urlTitle}`

--- a/examples/cms-drupal/pages/api/exit-preview.js
+++ b/examples/cms-drupal/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-enterspeed/pages/api/exit-preview.js
+++ b/examples/cms-enterspeed/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-enterspeed/pages/api/preview.js
+++ b/examples/cms-enterspeed/pages/api/preview.js
@@ -9,7 +9,7 @@ export default async function preview(req, res) {
     return res.status(401).json({ message: 'Invalid token' })
   }
 
-  res.setPreviewData({})
+  res.setDraftMode({ enable: true })
 
   res.redirect('/')
 }

--- a/examples/cms-ghost/pages/api/exit-preview.js
+++ b/examples/cms-ghost/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-ghost/pages/api/preview.js
+++ b/examples/cms-ghost/pages/api/preview.js
@@ -18,8 +18,8 @@ export default async function preview(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-graphcms/pages/api/exit-preview.js
+++ b/examples/cms-graphcms/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function handler(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-graphcms/pages/api/preview.js
+++ b/examples/cms-graphcms/pages/api/preview.js
@@ -18,8 +18,8 @@ export default async function handler(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-kontent-ai/pages/api/exit-preview.ts
+++ b/examples/cms-kontent-ai/pages/api/exit-preview.ts
@@ -1,8 +1,8 @@
 import { NextApiResponse } from 'next'
 
 export default async function exit(_: any, res: NextApiResponse) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-kontent-ai/pages/api/preview.ts
+++ b/examples/cms-kontent-ai/pages/api/preview.ts
@@ -24,8 +24,8 @@ export default async function preview(
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Preview Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-plasmic/pages/api/exit-preview.ts
+++ b/examples/cms-plasmic/pages/api/exit-preview.ts
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-plasmic/pages/api/preview.ts
+++ b/examples/cms-plasmic/pages/api/preview.ts
@@ -19,8 +19,8 @@ export default async function preview(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-prepr/pages/api/exit-preview.js
+++ b/examples/cms-prepr/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function handler(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-prepr/pages/api/preview.js
+++ b/examples/cms-prepr/pages/api/preview.js
@@ -15,8 +15,8 @@ export default async function handler(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-sanity/pages/api/exit-preview.js
+++ b/examples/cms-sanity/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-sanity/pages/api/preview.js
+++ b/examples/cms-sanity/pages/api/preview.js
@@ -2,8 +2,8 @@ import { postBySlugQuery } from '../../lib/queries'
 import { previewClient } from '../../lib/sanity.server'
 
 function redirectToPreview(res, Location) {
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
   // Redirect to a preview capable route
   res.writeHead(307, { Location })
   res.end()

--- a/examples/cms-storyblok/pages/api/exit-preview.js
+++ b/examples/cms-storyblok/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-storyblok/pages/api/preview.js
+++ b/examples/cms-storyblok/pages/api/preview.js
@@ -18,8 +18,8 @@ export default async function preview(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-takeshape/pages/api/exit-preview.js
+++ b/examples/cms-takeshape/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-takeshape/pages/api/preview.js
+++ b/examples/cms-takeshape/pages/api/preview.js
@@ -18,8 +18,8 @@ export default async function preview(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-umbraco-heartcore/pages/api/exit-preview.js
+++ b/examples/cms-umbraco-heartcore/pages/api/exit-preview.js
@@ -1,6 +1,6 @@
 export default async function handler(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-umbraco-heartcore/pages/api/preview.js
+++ b/examples/cms-umbraco-heartcore/pages/api/preview.js
@@ -18,8 +18,8 @@ export default async function handler(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-webiny/pages/api/exit-preview.ts
+++ b/examples/cms-webiny/pages/api/exit-preview.ts
@@ -1,6 +1,6 @@
 export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })

--- a/examples/cms-webiny/pages/api/preview.ts
+++ b/examples/cms-webiny/pages/api/preview.ts
@@ -15,8 +15,8 @@ export default async function preview(req, res) {
     return res.status(401).json({ message: 'Invalid slug' })
   }
 
-  // Enable Preview Mode by setting the cookies
-  res.setPreviewData({})
+  // Enable Draft Mode by setting the cookie
+  res.setDraftMode({ enable: true })
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities

--- a/examples/cms-wordpress/pages/api/exit-preview.ts
+++ b/examples/cms-wordpress/pages/api/exit-preview.ts
@@ -1,8 +1,8 @@
 import { NextApiResponse } from 'next'
 
 export default async function exit(_, res: NextApiResponse) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData()
+  // Exit Draft Mode by removing the cookie
+  res.setDraftMode({ enable: false })
 
   // Redirect the user back to the index page.
   res.writeHead(307, { Location: '/' })


### PR DESCRIPTION
This PR updates the examples to use Draft Mode introduced in [Next.js 13.4](https://nextjs.org/blog/next-13-4)

fix NEXT-1153