### PR TITLE
Remove old-space-size filtering from dev server

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -187,11 +187,7 @@ export async function startServer({
           env: {
             FORCE_COLOR: '1',
             ...((initialEnv || process.env) as typeof process.env),
-            // we don't pass down NODE_OPTIONS as it can
-            // extra memory usage
-            NODE_OPTIONS: getNodeOptionsWithoutInspect()
-              .replace(/--max-old-space-size=[\d]{1,}/, '')
-              .trim(),
+            NODE_OPTIONS: getNodeOptionsWithoutInspect().trim(),
           },
         },
         exposedMethods: ['initialize'],


### PR DESCRIPTION
We shouldn't filter this from the router worker as this is where the dev server runs and should be able to allocate more memory. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04MEB9L9RQ/p1683823794069839?thread_ts=1683756338.246099&cid=C04MEB9L9RQ)