### PR TITLE
Allow setting <Image decoding={...} />

### DIFF
--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -288,13 +288,16 @@ module.exports = {
 }
 ```
 
+### decoding
+
+Defaults to `"async"` but can be overridden [to `"auto"` or `"sync"`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding) if necessary (though this may impact performance).
+
 ## Other Props
 
 Other properties on the `<Image />` component will be passed to the underlying
 `img` element with the exception of the following:
 
 - `srcSet`. Use [Device Sizes](#device-sizes) instead.
-- `decoding`. It is always `"async"`.
 
 ## Configuration Options
 

--- a/packages/next/src/client/image.tsx
+++ b/packages/next/src/client/image.tsx
@@ -412,6 +412,7 @@ const ImageElement = forwardRef<HTMLImageElement | null, ImageElementProps>(
       setShowAltText,
       onLoad,
       onError,
+      decoding,
       ...rest
     },
     forwardedRef
@@ -424,7 +425,7 @@ const ImageElement = forwardRef<HTMLImageElement | null, ImageElementProps>(
         loading={loading}
         width={widthInt}
         height={heightInt}
-        decoding="async"
+        decoding={decoding ?? 'async'}
         data-nimg={fill ? 'fill' : '1'}
         className={className}
         style={{ ...imgStyle, ...blurStyle }}


### PR DESCRIPTION
async was presumably chosen as a default to increase pageload performance, but in some cases, specifying decoding="sync" provides a better UX as the page will flicker less while loading. Allow users to specify this prop while still keeping the default of async.
