### PR TITLE
Fix cookies().set missing in types

### DIFF
--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
@@ -12,7 +12,7 @@ import { ReflectAdapter } from './reflect'
 export class ReadonlyRequestCookiesError extends Error {
   constructor() {
     super(
-      'ReadonlyRequestCookies cannot be modified. Read more: https://nextjs.org/docs/api-reference/cookies'
+      'Cookies can only be modified in a Server Action or Route Handler. Read more: https://nextjs.org/docs/app/api-reference/functions/cookies#cookiessetname-value-options'
     )
   }
 
@@ -21,10 +21,7 @@ export class ReadonlyRequestCookiesError extends Error {
   }
 }
 
-export type ReadonlyRequestCookies = Omit<
-  RequestCookies,
-  'clear' | 'delete' | 'set'
->
+export type ReadonlyRequestCookies = Omit<RequestCookies, 'clear' | 'delete'>
 
 export class RequestCookiesAdapter {
   public static seal(cookies: RequestCookies): ReadonlyRequestCookies {


### PR DESCRIPTION
Closes #49259. Note that even if we allow `.set` in the types, it will still error when called in wrong places (such as Server Components).
fix NEXT-1090