### PR TITLE
Introduce NextMode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "serde",
 ]
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "serde",
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7079,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7108,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "base16",
  "hex",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7134,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7144,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "mimalloc",
 ]
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7186,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7216,7 +7216,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7246,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7286,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7303,7 +7303,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7330,7 +7330,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7343,7 +7343,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7365,7 +7365,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7386,7 +7386,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7421,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7457,7 +7457,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7478,7 +7478,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7494,7 +7494,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7514,7 +7514,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "serde",
@@ -7529,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7544,7 +7544,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7578,7 +7578,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "serde",
@@ -7594,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7605,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230517.2#4d39f01a5f06e7e9b670cc55bd544c64088b77e7"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "serde",
 ]
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "serde",
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7079,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7108,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "base16",
  "hex",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7134,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7144,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "mimalloc",
 ]
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7186,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7215,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7285,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7329,7 +7329,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7364,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7385,7 +7385,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7420,7 +7420,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7456,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7493,7 +7493,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7513,7 +7513,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "serde",
@@ -7528,7 +7528,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7543,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7577,7 +7577,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "serde",
@@ -7593,7 +7593,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7604,7 +7604,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230516.1#7869188e5925ffb3c7a5723dc26c96bd53d3f9b7"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "serde",
 ]
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "serde",
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7079,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7108,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "base16",
  "hex",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7134,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7144,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "mimalloc",
 ]
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7186,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7215,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7285,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7329,7 +7329,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7364,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7385,7 +7385,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7420,7 +7420,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7456,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7493,7 +7493,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7513,7 +7513,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "serde",
@@ -7528,7 +7528,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7543,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7577,7 +7577,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "serde",
@@ -7593,7 +7593,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7604,7 +7604,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "serde",
 ]
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "serde",
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7079,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7108,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "base16",
  "hex",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7134,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7144,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "mimalloc",
 ]
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7186,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7199,6 +7199,7 @@ dependencies = [
  "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
+ "turbo-tasks-env",
  "turbo-tasks-fs",
  "turbopack-core",
  "turbopack-css",
@@ -7215,7 +7216,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7245,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7285,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7302,7 +7303,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7329,7 +7330,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7342,7 +7343,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7364,7 +7365,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7385,7 +7386,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7420,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7456,7 +7457,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7477,7 +7478,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7493,7 +7494,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7513,7 +7514,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "serde",
@@ -7528,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7543,7 +7544,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7577,7 +7578,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "serde",
@@ -7593,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7604,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "serde",
 ]
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "serde",
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7079,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7108,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "base16",
  "hex",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7134,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7144,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "mimalloc",
 ]
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7186,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7216,7 +7216,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7246,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7286,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7303,7 +7303,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7330,7 +7330,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7343,7 +7343,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7365,7 +7365,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7386,7 +7386,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7421,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7457,7 +7457,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7478,7 +7478,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7494,7 +7494,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7514,7 +7514,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "serde",
@@ -7529,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7544,7 +7544,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7578,7 +7578,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "serde",
@@ -7594,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7605,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#d4b100a116a0c76b43ecbbdc734ee8dd500408b0"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#46b00fb18e84377ed0fb6304a0d534501ab05a66"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "serde",
 ]
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "serde",
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7079,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7108,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "base16",
  "hex",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7134,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7144,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "mimalloc",
 ]
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7186,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7215,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7285,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7329,7 +7329,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7364,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7385,7 +7385,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7420,7 +7420,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7456,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7493,7 +7493,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7513,7 +7513,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "serde",
@@ -7528,7 +7528,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7543,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7577,7 +7577,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "serde",
@@ -7593,7 +7593,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7604,7 +7604,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4"
+source = "git+https://github.com/vercel/turbo.git?branch=alexkirsz/web-397-next-mode#a57f16a298e6a288823505f24ce57c9fa04579ea"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ swc_core = { version = "0.76.6" }
 testing = { version = "0.33.10" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "alexkirsz/web-397-next-mode" } # last tag: "turbopack-230516.1"
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230517.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "alexkirsz/web-397-next-mode" } # last tag: "turbopack-230516.1"
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230517.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "alexkirsz/web-397-next-mode" } # last tag: "turbopack-230516.1"
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230517.2" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ swc_core = { version = "0.76.6" }
 testing = { version = "0.33.10" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230516.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "alexkirsz/web-397-next-mode" } # last tag: "turbopack-230516.1"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230516.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "alexkirsz/web-397-next-mode" } # last tag: "turbopack-230516.1"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230516.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "alexkirsz/web-397-next-mode" } # last tag: "turbopack-230516.1"
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?a57f16a298e6a288823505f24ce57c9fa04579ea",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?46b00fb18e84377ed0fb6304a0d534501ab05a66",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?46b00fb18e84377ed0fb6304a0d534501ab05a66",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230517.2",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230517.2",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?a57f16a298e6a288823505f24ce57c9fa04579ea",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230516.1",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230516.1",
+    "@vercel/turbopack-dev": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/src/build/client/bootstrap.ts
+++ b/packages/next-swc/crates/next-core/js/src/build/client/bootstrap.ts
@@ -1,0 +1,2 @@
+import './shims'
+import 'next/dist/client/next'

--- a/packages/next-swc/crates/next-core/js/src/build/client/bootstrap.ts
+++ b/packages/next-swc/crates/next-core/js/src/build/client/bootstrap.ts
@@ -1,2 +1,6 @@
+/**
+ * This is the runtime entry point for Next.js client-side bundles.
+ */
+
 import './shims'
 import 'next/dist/client/next'

--- a/packages/next-swc/crates/next-core/js/src/build/client/shims.ts
+++ b/packages/next-swc/crates/next-core/js/src/build/client/shims.ts
@@ -1,0 +1,11 @@
+import '../shims'
+
+// Next uses __webpack_require__ extensively.
+globalThis.__webpack_require__ = (name) => {
+  console.error(
+    `__webpack_require__ is not implemented (when requiring ${name})`
+  )
+}
+
+// initialize() needs `__webpack_public_path__` to be defined.
+globalThis.__webpack_public_path__ = undefined

--- a/packages/next-swc/crates/next-core/js/src/build/shims.ts
+++ b/packages/next-swc/crates/next-core/js/src/build/shims.ts
@@ -1,0 +1,3 @@
+// This ensures Next.js uses React 18's APIs (hydrateRoot) instead of React 17's
+// (hydrate).
+process.env.__NEXT_REACT_ROOT = "true";

--- a/packages/next-swc/crates/next-core/js/src/build/shims.ts
+++ b/packages/next-swc/crates/next-core/js/src/build/shims.ts
@@ -1,3 +1,3 @@
 // This ensures Next.js uses React 18's APIs (hydrateRoot) instead of React 17's
 // (hydrate).
-process.env.__NEXT_REACT_ROOT = "true";
+process.env.__NEXT_REACT_ROOT = 'true'

--- a/packages/next-swc/crates/next-core/js/src/entry/next-hydrate.tsx
+++ b/packages/next-swc/crates/next-core/js/src/entry/next-hydrate.tsx
@@ -33,7 +33,6 @@ async function loadPageChunk(assetPrefix: string, chunkData: ChunkData) {
 
   window.next = {
     version: version || '',
-    // @ts-expect-error
     get router() {
       return router
     },

--- a/packages/next-swc/crates/next-core/js/types/globals.d.ts
+++ b/packages/next-swc/crates/next-core/js/types/globals.d.ts
@@ -1,3 +1,6 @@
+import type { Router } from 'next/dist/client/router'
+import type { MittEmitter } from 'next/dist/shared/lib/mitt'
+
 declare global {
   type ChunkData =
     | string
@@ -20,7 +23,9 @@ declare global {
   )[]
   var next: {
     version: string
-    appDir: boolean
+    appDir?: boolean
+    router?: Router
+    emitter?: MittEmitter<string>
   }
 
   function __turbopack_load_page_chunks__(

--- a/packages/next-swc/crates/next-core/src/app_source.rs
+++ b/packages/next-swc/crates/next-core/src/app_source.rs
@@ -1039,6 +1039,7 @@ import {}, {{ chunks as {} }} from "COMPONENT_{}";
                 Value::new(EcmascriptModuleAssetType::Typescript),
                 EcmascriptInputTransformsVc::cell(vec![
                     EcmascriptInputTransform::React {
+                        // The App source is currently only used in the development mode.
                         development: true,
                         refresh: false,
                         import_source: OptionStringVc::cell(None),

--- a/packages/next-swc/crates/next-core/src/app_source.rs
+++ b/packages/next-swc/crates/next-core/src/app_source.rs
@@ -74,6 +74,7 @@ use crate::{
     embed_js::{next_asset, next_js_file, next_js_file_path},
     env::env_for_js,
     fallback::get_fallback_page,
+    mode::NextMode,
     next_client::{
         context::{
             get_client_assets_path, get_client_chunking_context, get_client_compile_time_info,
@@ -139,6 +140,7 @@ async fn next_client_transition(
     next_config: NextConfigVc,
 ) -> Result<TransitionVc> {
     let ty = Value::new(ClientContextType::App { app_dir });
+    let mode = NextMode::Development;
     let client_chunking_context = get_client_chunking_context(
         project_path,
         server_root,
@@ -150,12 +152,13 @@ async fn next_client_transition(
         execution_context,
         client_compile_time_info.environment(),
         ty,
+        mode,
         next_config,
     );
     let client_runtime_entries =
-        get_client_runtime_entries(project_path, env, ty, next_config, execution_context);
+        get_client_runtime_entries(project_path, env, ty, mode, next_config, execution_context);
     let client_resolve_options_context =
-        get_client_resolve_options_context(project_path, ty, next_config, execution_context);
+        get_client_resolve_options_context(project_path, ty, mode, next_config, execution_context);
 
     Ok(NextClientTransition {
         is_app: true,
@@ -179,20 +182,23 @@ fn next_ssr_client_module_transition(
     server_addr: ServerAddrVc,
 ) -> TransitionVc {
     let ty = Value::new(ServerContextType::AppSSR { app_dir });
+    let mode = NextMode::Development;
     NextSSRClientModuleTransition {
         ssr_module_options_context: get_server_module_options_context(
             project_path,
             execution_context,
             ty,
+            mode,
             next_config,
         ),
         ssr_resolve_options_context: get_server_resolve_options_context(
             project_path,
             ty,
+            mode,
             next_config,
             execution_context,
         ),
-        ssr_environment: get_server_compile_time_info(ty, process_env, server_addr),
+        ssr_environment: get_server_compile_time_info(ty, mode, process_env, server_addr),
     }
     .cell()
     .into()
@@ -209,11 +215,12 @@ fn next_layout_entry_transition(
     server_addr: ServerAddrVc,
 ) -> TransitionVc {
     let ty = Value::new(ServerContextType::AppRSC { app_dir });
-    let rsc_compile_time_info = get_server_compile_time_info(ty, process_env, server_addr);
+    let mode = NextMode::Development;
+    let rsc_compile_time_info = get_server_compile_time_info(ty, mode, process_env, server_addr);
     let rsc_resolve_options_context =
-        get_server_resolve_options_context(project_path, ty, next_config, execution_context);
+        get_server_resolve_options_context(project_path, ty, mode, next_config, execution_context);
     let rsc_module_options_context =
-        get_server_module_options_context(project_path, execution_context, ty, next_config);
+        get_server_module_options_context(project_path, execution_context, ty, mode, next_config);
 
     NextServerComponentTransition {
         rsc_compile_time_info,
@@ -284,6 +291,7 @@ fn app_context(
     output_path: FileSystemPathVc,
 ) -> AssetContextVc {
     let next_server_to_client_transition = NextServerToClientTransition { ssr }.cell().into();
+    let mode = NextMode::Development;
 
     let mut transitions = HashMap::new();
     transitions.insert(
@@ -333,6 +341,7 @@ fn app_context(
             project_path,
             execution_context,
             client_ty,
+            mode,
             server_root,
             client_compile_time_info,
             next_config,
@@ -354,9 +363,21 @@ fn app_context(
     let ssr_ty = Value::new(ServerContextType::AppSSR { app_dir });
     ModuleAssetContextVc::new(
         TransitionsByNameVc::cell(transitions),
-        get_server_compile_time_info(ssr_ty, env, server_addr),
-        get_server_module_options_context(project_path, execution_context, ssr_ty, next_config),
-        get_server_resolve_options_context(project_path, ssr_ty, next_config, execution_context),
+        get_server_compile_time_info(ssr_ty, mode, env, server_addr),
+        get_server_module_options_context(
+            project_path,
+            execution_context,
+            ssr_ty,
+            mode,
+            next_config,
+        ),
+        get_server_resolve_options_context(
+            project_path,
+            ssr_ty,
+            mode,
+            next_config,
+            execution_context,
+        ),
     )
     .into()
 }
@@ -381,7 +402,8 @@ pub async fn create_app_source(
     let entrypoints = get_entrypoints(app_dir, next_config.page_extensions());
     let metadata = get_global_metadata(app_dir, next_config.page_extensions());
 
-    let client_compile_time_info = get_client_compile_time_info(browserslist_query);
+    let client_compile_time_info =
+        get_client_compile_time_info(NextMode::Development, browserslist_query);
 
     let context_ssr = app_context(
         project_path,
@@ -1017,6 +1039,7 @@ import {}, {{ chunks as {} }} from "COMPONENT_{}";
                 Value::new(EcmascriptModuleAssetType::Typescript),
                 EcmascriptInputTransformsVc::cell(vec![
                     EcmascriptInputTransform::React {
+                        development: true,
                         refresh: false,
                         import_source: OptionStringVc::cell(None),
                         runtime: OptionStringVc::cell(None),

--- a/packages/next-swc/crates/next-core/src/fallback.rs
+++ b/packages/next-swc/crates/next-core/src/fallback.rs
@@ -20,6 +20,7 @@ use turbopack_binding::{
 };
 
 use crate::{
+    mode::NextMode,
     next_client::context::{
         get_client_chunking_context, get_client_module_options_context,
         get_client_resolve_options_context, get_client_runtime_entries, ClientContextType,
@@ -39,13 +40,15 @@ pub async fn get_fallback_page(
     next_config: NextConfigVc,
 ) -> Result<DevHtmlAssetVc> {
     let ty = Value::new(ClientContextType::Fallback);
+    let mode = NextMode::Development;
     let resolve_options_context =
-        get_client_resolve_options_context(project_path, ty, next_config, execution_context);
+        get_client_resolve_options_context(project_path, ty, mode, next_config, execution_context);
     let module_options_context = get_client_module_options_context(
         project_path,
         execution_context,
         client_compile_time_info.environment(),
         ty,
+        mode,
         next_config,
     );
     let chunking_context = get_client_chunking_context(
@@ -54,7 +57,8 @@ pub async fn get_fallback_page(
         client_compile_time_info.environment(),
         ty,
     );
-    let entries = get_client_runtime_entries(project_path, env, ty, next_config, execution_context);
+    let entries =
+        get_client_runtime_entries(project_path, env, ty, mode, next_config, execution_context);
 
     let mut import_map = ImportMap::empty();
     insert_next_shared_aliases(

--- a/packages/next-swc/crates/next-core/src/lib.rs
+++ b/packages/next-swc/crates/next-core/src/lib.rs
@@ -13,6 +13,7 @@ mod embed_js;
 pub mod env;
 mod fallback;
 pub mod manifest;
+pub mod mode;
 mod next_build;
 pub mod next_client;
 mod next_client_chunks;

--- a/packages/next-swc/crates/next-core/src/mode.rs
+++ b/packages/next-swc/crates/next-core/src/mode.rs
@@ -1,0 +1,28 @@
+use turbo_tasks::TaskInput;
+
+/// The mode in which Next.js is running.
+#[derive(Debug, Copy, Clone, TaskInput)]
+pub enum NextMode {
+    /// `next dev`
+    Development,
+    /// `next build`
+    Build,
+}
+
+impl NextMode {
+    /// Returns the NODE_ENV value for the current mode.
+    pub fn node_env(&self) -> &'static str {
+        match self {
+            NextMode::Development => "development",
+            NextMode::Build => "production",
+        }
+    }
+
+    /// Returns true if the development React runtime should be used.
+    pub fn is_react_development(&self) -> bool {
+        match self {
+            NextMode::Development => true,
+            NextMode::Build => false,
+        }
+    }
+}

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -69,7 +69,7 @@ use crate::{
     util::foreign_code_context_condition,
 };
 
-pub fn defines(mode: NextMode) -> CompileTimeDefines {
+fn defines(mode: NextMode) -> CompileTimeDefines {
     compile_time_defines!(
         process.turbopack = true,
         process.env.NODE_ENV = mode.node_env(),
@@ -82,12 +82,12 @@ pub fn defines(mode: NextMode) -> CompileTimeDefines {
 }
 
 #[turbo_tasks::function]
-pub fn next_client_defines(mode: NextMode) -> CompileTimeDefinesVc {
+fn next_client_defines(mode: NextMode) -> CompileTimeDefinesVc {
     defines(mode).cell()
 }
 
 #[turbo_tasks::function]
-pub async fn next_client_free_vars(mode: NextMode) -> Result<FreeVarReferencesVc> {
+async fn next_client_free_vars(mode: NextMode) -> Result<FreeVarReferencesVc> {
     Ok(free_var_references!(
         ..defines(mode).into_iter(),
         Buffer = FreeVarReference::EcmaScriptModule {

--- a/packages/next-swc/crates/next-core/src/next_client/transition.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/transition.rs
@@ -83,6 +83,7 @@ impl Transition for NextClientTransition {
                         use_define_for_class_fields: false,
                     },
                     EcmascriptInputTransform::React {
+                        development: true,
                         refresh: false,
                         import_source: OptionStringVc::cell(None),
                         runtime: OptionStringVc::cell(None),

--- a/packages/next-swc/crates/next-core/src/next_client/transition.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/transition.rs
@@ -83,6 +83,8 @@ impl Transition for NextClientTransition {
                         use_define_for_class_fields: false,
                     },
                     EcmascriptInputTransform::React {
+                        // The Next Client transition is currently only used from the App and Page
+                        // sources, which are only used in the development mode.
                         development: true,
                         refresh: false,
                         import_source: OptionStringVc::cell(None),

--- a/packages/next-swc/crates/next-core/src/next_client_chunks/client_chunks_transition.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_chunks/client_chunks_transition.rs
@@ -17,6 +17,7 @@ use turbopack_binding::{
 
 use super::with_chunks::WithChunksAsset;
 use crate::{
+    mode::NextMode,
     next_client::context::{
         get_client_chunking_context, get_client_module_options_context,
         get_client_resolve_options_context, ClientContextType,
@@ -40,6 +41,7 @@ impl NextClientChunksTransitionVc {
         project_path: FileSystemPathVc,
         execution_context: ExecutionContextVc,
         ty: Value<ClientContextType>,
+        mode: NextMode,
         server_root: FileSystemPathVc,
         client_compile_time_info: CompileTimeInfoVc,
         next_config: NextConfigVc,
@@ -56,6 +58,7 @@ impl NextClientChunksTransitionVc {
             execution_context,
             client_compile_time_info.environment(),
             ty,
+            mode,
             next_config,
         );
         NextClientChunksTransition {
@@ -64,6 +67,7 @@ impl NextClientChunksTransitionVc {
             client_resolve_options_context: get_client_resolve_options_context(
                 project_path,
                 ty,
+                mode,
                 next_config,
                 execution_context,
             ),

--- a/packages/next-swc/crates/next-core/src/next_client_component/server_to_client_transition.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_component/server_to_client_transition.rs
@@ -60,6 +60,7 @@ impl Transition for NextServerToClientTransition {
                     use_define_for_class_fields: false,
                 },
                 EcmascriptInputTransform::React {
+                    development: true,
                     refresh: false,
                     import_source: OptionStringVc::cell(None),
                     runtime: OptionStringVc::cell(None),

--- a/packages/next-swc/crates/next-core/src/next_client_component/server_to_client_transition.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_component/server_to_client_transition.rs
@@ -60,6 +60,8 @@ impl Transition for NextServerToClientTransition {
                     use_define_for_class_fields: false,
                 },
                 EcmascriptInputTransform::React {
+                    // The server-to-client transition is currently only used from the App source,
+                    // which are only used in the development mode.
                     development: true,
                     refresh: false,
                     import_source: OptionStringVc::cell(None),

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -42,9 +42,7 @@ use turbopack_binding::{
     },
 };
 
-use crate::{
-    embed_js::next_asset, mode::NextMode, next_shared::transforms::ModularizeImportPackageConfig,
-};
+use crate::{embed_js::next_asset, next_shared::transforms::ModularizeImportPackageConfig};
 
 #[turbo_tasks::value(serialization = "custom", eq = "manual")]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -38,12 +38,12 @@ fn defines() -> CompileTimeDefines {
 }
 
 #[turbo_tasks::function]
-pub fn next_edge_defines() -> CompileTimeDefinesVc {
+fn next_edge_defines() -> CompileTimeDefinesVc {
     defines().cell()
 }
 
 #[turbo_tasks::function]
-pub fn next_edge_free_vars(project_path: FileSystemPathVc) -> FreeVarReferencesVc {
+fn next_edge_free_vars(project_path: FileSystemPathVc) -> FreeVarReferencesVc {
     free_var_references!(
         ..defines().into_iter(),
         Buffer = FreeVarReference::EcmaScriptModule {

--- a/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
@@ -438,7 +438,7 @@ async fn get_mock_stylesheet(
         project_path,
         chunking_context,
     } = *execution_context.await?;
-    let context = node_evaluate_asset_context(project_path, None, None);
+    let context = node_evaluate_asset_context(execution_context, None, None);
     let loader_path = mock_fs.root().join("loader.js");
     let mocked_response_asset = EcmascriptModuleAssetVc::new(
         VirtualAssetVc::new(

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -224,12 +224,12 @@ fn defines(mode: NextMode) -> CompileTimeDefines {
 }
 
 #[turbo_tasks::function]
-pub fn next_server_defines(mode: NextMode) -> CompileTimeDefinesVc {
+fn next_server_defines(mode: NextMode) -> CompileTimeDefinesVc {
     defines(mode).cell()
 }
 
 #[turbo_tasks::function]
-pub async fn next_server_free_vars(mode: NextMode) -> Result<FreeVarReferencesVc> {
+async fn next_server_free_vars(mode: NextMode) -> Result<FreeVarReferencesVc> {
     Ok(free_var_references!(..defines(mode).into_iter()).cell())
 }
 

--- a/packages/next-swc/crates/next-core/src/page_source.rs
+++ b/packages/next-swc/crates/next-core/src/page_source.rs
@@ -850,6 +850,7 @@ impl SsrEntryVc {
                         use_define_for_class_fields: false,
                     },
                     EcmascriptInputTransform::React {
+                        // The Page source is currently only used in the development mode.
                         development: true,
                         refresh: false,
                         import_source: OptionStringVc::cell(None),

--- a/packages/next-swc/crates/next-core/src/page_source.rs
+++ b/packages/next-swc/crates/next-core/src/page_source.rs
@@ -52,6 +52,7 @@ use crate::{
     embed_js::next_asset,
     env::env_for_js,
     fallback::get_fallback_page,
+    mode::NextMode,
     next_client::{
         context::{
             get_client_assets_path, get_client_chunking_context, get_client_compile_time_info,
@@ -105,20 +106,27 @@ pub async fn create_page_source(
         (project_root.join("pages"), None)
     };
 
+    let mode = NextMode::Development;
     let client_ty = Value::new(ClientContextType::Pages { pages_dir });
     let server_ty = Value::new(ServerContextType::Pages { pages_dir });
     let server_data_ty = Value::new(ServerContextType::PagesData { pages_dir });
 
-    let client_compile_time_info = get_client_compile_time_info(browserslist_query);
+    let client_compile_time_info = get_client_compile_time_info(mode, browserslist_query);
     let client_module_options_context = get_client_module_options_context(
         project_root,
         execution_context,
         client_compile_time_info.environment(),
         client_ty,
+        mode,
         next_config,
     );
-    let client_resolve_options_context =
-        get_client_resolve_options_context(project_root, client_ty, next_config, execution_context);
+    let client_resolve_options_context = get_client_resolve_options_context(
+        project_root,
+        client_ty,
+        mode,
+        next_config,
+        execution_context,
+    );
 
     let client_chunking_context = get_client_chunking_context(
         project_root,
@@ -127,8 +135,14 @@ pub async fn create_page_source(
         client_ty,
     );
 
-    let client_runtime_entries =
-        get_client_runtime_entries(project_root, env, client_ty, next_config, execution_context);
+    let client_runtime_entries = get_client_runtime_entries(
+        project_root,
+        env,
+        client_ty,
+        mode,
+        next_config,
+        execution_context,
+    );
 
     let next_client_transition = NextClientTransition {
         is_app: false,
@@ -175,17 +189,28 @@ pub async fn create_page_source(
     .cell()
     .into();
 
-    let server_compile_time_info = get_server_compile_time_info(server_ty, env, server_addr);
-    let server_resolve_options_context =
-        get_server_resolve_options_context(project_root, server_ty, next_config, execution_context);
+    let server_compile_time_info = get_server_compile_time_info(server_ty, mode, env, server_addr);
+    let server_resolve_options_context = get_server_resolve_options_context(
+        project_root,
+        server_ty,
+        mode,
+        next_config,
+        execution_context,
+    );
 
-    let server_module_options_context =
-        get_server_module_options_context(project_root, execution_context, server_ty, next_config);
+    let server_module_options_context = get_server_module_options_context(
+        project_root,
+        execution_context,
+        server_ty,
+        mode,
+        next_config,
+    );
 
     let server_data_module_options_context = get_server_module_options_context(
         project_root,
         execution_context,
         server_data_ty,
+        mode,
         next_config,
     );
 
@@ -199,6 +224,7 @@ pub async fn create_page_source(
                     project_root,
                     execution_context,
                     client_ty,
+                    mode,
                     client_root,
                     client_compile_time_info,
                     next_config,
@@ -824,6 +850,7 @@ impl SsrEntryVc {
                         use_define_for_class_fields: false,
                     },
                     EcmascriptInputTransform::React {
+                        development: true,
                         refresh: false,
                         import_source: OptionStringVc::cell(None),
                         runtime: OptionStringVc::cell(None),

--- a/packages/next-swc/crates/next-core/src/router.rs
+++ b/packages/next-swc/crates/next-core/src/router.rs
@@ -47,6 +47,7 @@ use turbopack_binding::{
 use crate::{
     asset_helpers::as_es_module_asset,
     embed_js::next_asset,
+    mode::NextMode,
     next_config::NextConfigVc,
     next_edge::{
         context::{get_edge_compile_time_info, get_edge_resolve_options_context},
@@ -277,6 +278,7 @@ fn edge_transition_map(
         project_path,
         execution_context,
         Value::new(ServerContextType::Middleware),
+        NextMode::Development,
         next_config,
     );
 
@@ -362,6 +364,7 @@ async fn route_internal(
             next_config,
             execution_context,
         )),
+        "development".to_string(),
     );
 
     let configs = config_assets(context, project_path, next_config.page_extensions());

--- a/packages/next-swc/crates/next-core/src/router.rs
+++ b/packages/next-swc/crates/next-core/src/router.rs
@@ -355,7 +355,7 @@ async fn route_internal(
     } = *execution_context.await?;
 
     let context = node_evaluate_asset_context(
-        project_path,
+        execution_context,
         Some(get_next_build_import_map()),
         Some(edge_transition_map(
             server_addr,
@@ -364,7 +364,6 @@ async fn route_internal(
             next_config,
             execution_context,
         )),
-        "development".to_string(),
     );
 
     let configs = config_assets(context, project_path, next_config.page_extensions());

--- a/packages/next-swc/crates/next-core/src/transform_options.rs
+++ b/packages/next-swc/crates/next-core/src/transform_options.rs
@@ -19,6 +19,8 @@ use turbopack_binding::{
     },
 };
 
+use crate::mode::NextMode;
+
 async fn get_typescript_options(
     project_path: FileSystemPathVc,
 ) -> Option<Vec<(FileJsonContentVc, AssetVc)>> {
@@ -123,6 +125,7 @@ pub async fn get_decorators_transform_options(
 #[turbo_tasks::function]
 pub async fn get_jsx_transform_options(
     project_path: FileSystemPathVc,
+    mode: NextMode,
     resolve_options_context: Option<ResolveOptionsContextVc>,
 ) -> Result<JsxTransformOptionsVc> {
     let tsconfig = get_typescript_options(project_path).await;
@@ -140,6 +143,7 @@ pub async fn get_jsx_transform_options(
     // jsconfig, it forces overrides into automatic runtime instead.
     // [TODO]: we need to emit / validate config message like next.js devserver does
     let react_transform_options = JsxTransformOptions {
+        development: mode.is_react_development(),
         import_source: None,
         runtime: Some("automatic".to_string()),
         react_refresh: enable_react_refresh,

--- a/packages/next-swc/crates/next-core/src/web_entry_source.rs
+++ b/packages/next-swc/crates/next-core/src/web_entry_source.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Result};
-use turbo_tasks_fs::FileSystem;
 use turbopack_binding::{
     turbo::{
         tasks::{TryJoinIterExt, Value},
@@ -18,7 +17,8 @@ use turbopack_binding::{
             },
             free_var_references,
             reference_type::{EntryReferenceSubType, ReferenceType},
-            resolve::{origin::PlainResolveOriginVc, parse::RequestVc, pattern::Pattern},
+            resolve::{origin::PlainResolveOriginVc, parse::RequestVc},
+            source_asset::SourceAssetVc,
         },
         dev::react_refresh::assert_can_resolve_react_refresh,
         dev_server::{

--- a/packages/next-swc/crates/next-core/src/web_entry_source.rs
+++ b/packages/next-swc/crates/next-core/src/web_entry_source.rs
@@ -35,7 +35,7 @@ use crate::{
     mode::NextMode,
     next_client::{
         context::{
-            get_client_asset_context, get_client_chunking_context, get_client_compile_time_info,
+            get_client_asset_context, get_client_chunking_context,
             get_client_resolve_options_context, ClientContextType,
         },
         runtime_entry::{RuntimeEntriesVc, RuntimeEntry},
@@ -51,12 +51,12 @@ fn defines() -> CompileTimeDefines {
 }
 
 #[turbo_tasks::function]
-pub fn web_defines() -> CompileTimeDefinesVc {
+fn web_defines() -> CompileTimeDefinesVc {
     defines().cell()
 }
 
 #[turbo_tasks::function]
-pub async fn web_free_vars() -> Result<FreeVarReferencesVc> {
+async fn web_free_vars() -> Result<FreeVarReferencesVc> {
     Ok(free_var_references!(..defines().into_iter()).cell())
 }
 
@@ -123,7 +123,7 @@ pub async fn create_web_entry_source(
 ) -> Result<ContentSourceVc> {
     let ty = Value::new(ClientContextType::Other);
     let mode = NextMode::Development;
-    let compile_time_info = get_client_compile_time_info(mode, browserslist_query);
+    let compile_time_info = get_compile_time_info(browserslist_query);
     let context = get_client_asset_context(
         project_root,
         execution_context,

--- a/packages/next-swc/crates/next-core/src/web_entry_source.rs
+++ b/packages/next-swc/crates/next-core/src/web_entry_source.rs
@@ -31,7 +31,7 @@ use turbopack_binding::{
 };
 
 use crate::{
-    embed_js::next_js_fs,
+    embed_js::next_js_file_path,
     mode::NextMode,
     next_client::{
         context::{
@@ -104,13 +104,8 @@ async fn get_web_runtime_entries(
     };
 
     runtime_entries.push(
-        RuntimeEntry::Request(
-            RequestVc::parse(Value::new(Pattern::Constant(
-                "./dev/bootstrap.ts".to_string(),
-            ))),
-            next_js_fs().root().join("_"),
-        )
-        .cell(),
+        RuntimeEntry::Source(SourceAssetVc::new(next_js_file_path("dev/bootstrap.ts")).into())
+            .cell(),
     );
 
     Ok(RuntimeEntriesVc::cell(runtime_entries))

--- a/packages/next-swc/crates/next-dev/src/lib.rs
+++ b/packages/next-swc/crates/next-dev/src/lib.rs
@@ -21,9 +21,10 @@ use dunce::canonicalize;
 use indexmap::IndexMap;
 use next_core::{
     app_structure::find_app_dir_if_enabled, create_app_source, create_page_source,
-    create_web_entry_source, manifest::DevManifestContentSource, next_config::load_next_config,
-    next_image::NextImageContentSourceVc, pages_structure::find_pages_structure,
-    router_source::NextRouterContentSourceVc, source_map::NextSourceMapTraceContentSourceVc,
+    create_web_entry_source, manifest::DevManifestContentSource, mode::NextMode,
+    next_config::load_next_config, next_image::NextImageContentSourceVc,
+    pages_structure::find_pages_structure, router_source::NextRouterContentSourceVc,
+    source_map::NextSourceMapTraceContentSourceVc,
 };
 use owo_colors::OwoColorize;
 use turbo_tasks::{
@@ -312,7 +313,10 @@ async fn source(
 
     let execution_context = ExecutionContextVc::new(project_path, build_chunking_context, env);
 
-    let next_config = load_next_config(execution_context.with_layer("next_config"));
+    let next_config = load_next_config(
+        execution_context.with_layer("next_config"),
+        NextMode::Development,
+    );
 
     let output_root = output_fs.root().join(".next/server");
 

--- a/packages/next-swc/crates/next-dev/src/lib.rs
+++ b/packages/next-swc/crates/next-dev/src/lib.rs
@@ -21,10 +21,9 @@ use dunce::canonicalize;
 use indexmap::IndexMap;
 use next_core::{
     app_structure::find_app_dir_if_enabled, create_app_source, create_page_source,
-    create_web_entry_source, manifest::DevManifestContentSource, mode::NextMode,
-    next_config::load_next_config, next_image::NextImageContentSourceVc,
-    pages_structure::find_pages_structure, router_source::NextRouterContentSourceVc,
-    source_map::NextSourceMapTraceContentSourceVc,
+    create_web_entry_source, manifest::DevManifestContentSource, next_config::load_next_config,
+    next_image::NextImageContentSourceVc, pages_structure::find_pages_structure,
+    router_source::NextRouterContentSourceVc, source_map::NextSourceMapTraceContentSourceVc,
 };
 use owo_colors::OwoColorize;
 use turbo_tasks::{

--- a/packages/next-swc/crates/next-dev/src/lib.rs
+++ b/packages/next-swc/crates/next-dev/src/lib.rs
@@ -313,10 +313,7 @@ async fn source(
 
     let execution_context = ExecutionContextVc::new(project_path, build_chunking_context, env);
 
-    let next_config = load_next_config(
-        execution_context.with_layer("next_config"),
-        NextMode::Development,
-    );
+    let next_config = load_next_config(execution_context.with_layer("next_config"));
 
     let output_root = output_fs.root().join(".next/server");
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,8 +1014,8 @@ importers:
       '@types/react': 18.2.5
       '@types/react-dom': 18.2.3
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0
+      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?46b00fb18e84377ed0fb6304a0d534501ab05a66
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1027,8 +1027,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0'
+      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?46b00fb18e84377ed0fb6304a0d534501ab05a66'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25576,9 +25576,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66'
     name: '@vercel/turbopack-dev'
     version: 0.0.0
     dependencies:
@@ -25588,8 +25588,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?46b00fb18e84377ed0fb6304a0d534501ab05a66':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?46b00fb18e84377ed0fb6304a0d534501ab05a66}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,8 +1014,8 @@ importers:
       '@types/react': 18.2.5
       '@types/react-dom': 18.2.3
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4
+      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?a57f16a298e6a288823505f24ce57c9fa04579ea
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1027,8 +1027,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4'
+      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?a57f16a298e6a288823505f24ce57c9fa04579ea'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25576,9 +25576,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea'
     name: '@vercel/turbopack-dev'
     version: 0.0.0
     dependencies:
@@ -25588,8 +25588,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?a57f16a298e6a288823505f24ce57c9fa04579ea':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?a57f16a298e6a288823505f24ce57c9fa04579ea}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,8 +1014,8 @@ importers:
       '@types/react': 18.2.5
       '@types/react-dom': 18.2.3
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323
+      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1027,8 +1027,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323'
+      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25576,9 +25576,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0'
     name: '@vercel/turbopack-dev'
     version: 0.0.0
     dependencies:
@@ -25588,8 +25588,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?d4b100a116a0c76b43ecbbdc734ee8dd500408b0}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,8 +1014,8 @@ importers:
       '@types/react': 18.2.5
       '@types/react-dom': 18.2.3
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230516.1
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230516.1
+      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1027,8 +1027,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230516.1_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230516.1'
+      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -5998,7 +5998,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.2.1
       source-map: 0.7.3
-      webpack: 5.74.0
+      webpack: 5.74.0_@swc+core@1.3.55
     transitivePeerDependencies:
       - supports-color
 
@@ -6668,7 +6668,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64/1.3.55:
@@ -6677,7 +6676,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.3.55:
@@ -6686,7 +6684,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.3.55:
@@ -6695,7 +6692,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl/1.3.55:
@@ -6704,7 +6700,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu/1.3.55:
@@ -6713,7 +6708,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl/1.3.55:
@@ -6722,7 +6716,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.3.55:
@@ -6731,7 +6724,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.3.55:
@@ -6740,7 +6732,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc/1.3.55:
@@ -6749,7 +6740,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core/1.3.55_@swc+helpers@0.5.1:
@@ -6774,7 +6764,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.55
       '@swc/core-win32-ia32-msvc': 1.3.55
       '@swc/core-win32-x64-msvc': 1.3.55
-    dev: true
 
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
@@ -23777,7 +23766,6 @@ packages:
       source-map: 0.6.1
       terser: 5.14.1
       webpack: 5.74.0_@swc+core@1.3.55
-    dev: true
 
   /terser-webpack-plugin/5.2.4_webpack@5.74.0:
     resolution: {integrity: sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==}
@@ -25183,7 +25171,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /websocket-driver/0.7.3:
     resolution: {integrity: sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==}
@@ -25589,9 +25576,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230516.1_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230516.1}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230516.1'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4'
     name: '@vercel/turbopack-dev'
     version: 0.0.0
     dependencies:
@@ -25601,8 +25588,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230516.1':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230516.1}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?81f5e0105634fe3f6fd3d8aed8ad5c19e5f2b2c4}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,8 +1014,8 @@ importers:
       '@types/react': 18.2.5
       '@types/react-dom': 18.2.3
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?46b00fb18e84377ed0fb6304a0d534501ab05a66
+      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230517.2
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230517.2
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1027,8 +1027,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?46b00fb18e84377ed0fb6304a0d534501ab05a66'
+      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230517.2_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230517.2'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25576,9 +25576,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?46b00fb18e84377ed0fb6304a0d534501ab05a66'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230517.2_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230517.2}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?turbopack-230517.2'
     name: '@vercel/turbopack-dev'
     version: 0.0.0
     dependencies:
@@ -25588,8 +25588,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?46b00fb18e84377ed0fb6304a0d534501ab05a66':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?46b00fb18e84377ed0fb6304a0d534501ab05a66}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230517.2':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230517.2}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,8 +1014,8 @@ importers:
       '@types/react': 18.2.5
       '@types/react-dom': 18.2.3
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?a57f16a298e6a288823505f24ce57c9fa04579ea
+      '@vercel/turbopack-dev': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1027,8 +1027,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?a57f16a298e6a288823505f24ce57c9fa04579ea'
+      '@vercel/turbopack-dev': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25576,9 +25576,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?a57f16a298e6a288823505f24ce57c9fa04579ea'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-dev/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323'
     name: '@vercel/turbopack-dev'
     version: 0.0.0
     dependencies:
@@ -25588,8 +25588,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?a57f16a298e6a288823505f24ce57c9fa04579ea':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?a57f16a298e6a288823505f24ce57c9fa04579ea}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?f919d0e14ec1ffafed9fbe5eacd0a9d3119dd323}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
This introduces a `NextMode` enum that controls which mode Next.js Turbo is currently running in:
* `NextMode::Development`: `next dev`
* `NextMode::Build`: `next build`

Requires https://github.com/vercel/turbo/pull/4972

This also update Turbopack to `turbopack-230517.2` with the following changes:

* https://github.com/vercel/turbo/pull/4972 <!-- Alex Kirszenberg - Configure React development flag, inherit NODE_ENV from execution context  -->