### PR TITLE
fix: `metadataBase` is ignored when `openGraph.images` has a URL

### DIFF
--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -14,6 +14,8 @@ function createLocalMetadataBase() {
 export function getSocialImageFallbackMetadataBase(
   metadataBase: URL | null
 ): URL | null {
+  if (metadataBase) return metadataBase
+
   const isMetadataBaseMissing = !metadataBase
   const defaultMetadataBase = createLocalMetadataBase()
   const deploymentUrl =


### PR DESCRIPTION
### What?

`metadataBase` is ignored when `openGraph.images` has a URL.

### Why?
The `getSocialImageFallbackMetadataBase` function ignores the given URL and returns `fallbackMetadata`.

### How?
This PR makes the `getSocialImageFallbackMetadataBase` function return the given URL if provided.


Fixes #49807


