### PR TITLE
Docs: remove unstable app dir annotation

### DIFF
--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -122,7 +122,7 @@ npx next start --keepAliveTimeout 70000
 
 ## Lint
 
-`next lint` runs ESLint for all files in the `pages/`, `app` (only if the experimental `appDir` feature is enabled), `components/`, `lib/`, and `src/` directories. It also
+`next lint` runs ESLint for all files in the `pages/`, `app/`, `components/`, `lib/`, and `src/` directories. It also
 provides a guided setup to install any required dependencies if ESLint is not already configured in
 your application.
 


### PR DESCRIPTION
### What?
Remove unstable app directory annotation in cli lint documentation.

### Why?
App directory is stable since 13.4.

### How?
Removed annotation.