### PR TITLE
Fix port value for metadataBase

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -187,6 +187,7 @@ export async function startServer({
           env: {
             FORCE_COLOR: '1',
             ...((initialEnv || process.env) as typeof process.env),
+            PORT: port + '',
             NODE_OPTIONS: getNodeOptionsWithoutInspect().trim(),
           },
         },

--- a/test/development/basic/project-directory-rename.test.ts
+++ b/test/development/basic/project-directory-rename.test.ts
@@ -18,8 +18,9 @@ describe('Project Directory Renaming', () => {
         `,
       },
       skipStart: true,
+      forcedPort: (await findPort()) + '',
     })
-    next.forcedPort = (await findPort()) + ''
+
     await next.start()
   })
   afterAll(() => next.destroy())

--- a/test/e2e/app-dir/metadata-missing-metadata-base/index.test.ts
+++ b/test/e2e/app-dir/metadata-missing-metadata-base/index.test.ts
@@ -1,18 +1,21 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
-import { fetchViaHTTP } from 'next-test-utils'
+import { fetchViaHTTP, findPort } from 'next-test-utils'
 
 describe('app dir - metadata missing metadataBase', () => {
   let next: NextInstance
+  let port: number
 
   if ((global as any).isNextDeploy) {
     return it('should skip for deploy', () => {})
   }
 
   beforeAll(async () => {
+    port = await findPort()
     next = await createNext({
       skipStart: true,
       files: new FileRef(__dirname),
+      forcedPort: port + '',
     })
   })
   afterAll(() => next.destroy())
@@ -23,7 +26,7 @@ describe('app dir - metadata missing metadataBase', () => {
     expect(next.cliOutput).toInclude(
       'metadata.metadataBase is not set for resolving social open graph or twitter images, fallbacks to'
     )
-    expect(next.cliOutput).toInclude('"http://localhost:')
+    expect(next.cliOutput).toInclude(`"http://localhost:${port}`)
     expect(next.cliOutput).toInclude(
       '. See https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase'
     )

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -32,6 +32,7 @@ export interface NextInstanceOpts {
   env?: Record<string, string>
   dirSuffix?: string
   turbo?: boolean
+  forcedPort?: string
 }
 
 /**


### PR DESCRIPTION
metadataBase is using `process.env.PORT` to construct a host when there's no `metadataBase` specified in layout. Dev server needs to pass down the PORT env from the parent prcoess.

Fixes #49807
Fixes #49859
Closes #49889