### PR TITLE
Docs: add Koyeb to deployment options

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -100,6 +100,7 @@ The following services support Next.js `v12+`. Below, you’ll find examples or 
 - [Digital Ocean App Platform](https://docs.digitalocean.com/tutorials/app-nextjs-deploy/)
 - [Google Cloud Run](https://github.com/vercel/next.js/tree/canary/examples/with-docker)
 - [Heroku](https://elements.heroku.com/buildpacks/mars/heroku-nextjs)
+- [Koyeb](https://www.koyeb.com/docs/deploy/nextjs)
 - [Railway](https://docs.railway.app/getting-started)
 - [Render](https://render.com/docs/deploy-nextjs-app)
 


### PR DESCRIPTION
### What?

Adds [Koyeb](https://www.koyeb.com/) as an option in the Managed Server section of the Deployment doc.  Links to a guide in Koyeb's docs on how to deploy Next.js applications on the platform.

### Why?

Grow the list of providers set up to run Next.js applications.

