### PR TITLE
Revert "Error in `next export` when `serverActions` is enabled"

### DIFF
--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -228,12 +228,6 @@ export default async function exportApp(
       )
     }
 
-    if (nextConfig.experimental.serverActions) {
-      throw new ExportError(
-        `Server Actions are not supported with static export.`
-      )
-    }
-
     const customRoutesDetected = ['rewrites', 'redirects', 'headers'].filter(
       (config) => typeof nextConfig[config] === 'function'
     )


### PR DESCRIPTION
Reverts vercel/next.js#49959 since the PR [was failing CI](https://github.com/vercel/next.js/actions/runs/5015634314/jobs/8991545593#step:6:179)
fix NEXT-634