### PR TITLE
Bump eslint-plugin-import to 2.27.5 to benefit from default export overload fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "eslint": "7.24.0",
     "eslint-config-next": "workspace:*",
     "eslint-plugin-eslint-plugin": "4.3.0",
-    "eslint-plugin-import": "2.22.1",
+    "eslint-plugin-import": "2.27.5",
     "eslint-plugin-jest": "24.3.5",
     "eslint-plugin-jsdoc": "39.6.4",
     "eslint-plugin-react": "7.23.2",


### PR DESCRIPTION
Hi, I noticed Next is using eslint-plugin-import@2.22.1 and I would like to propose bumping that to 2.27.5 since that version fixes an issue where a default export with overloads is incorrectly identified as multiple default exports.

https://github.com/import-js/eslint-plugin-import/issues/1590

None of the sections in the template match, I am just bumping a dependency which will fix an edge case Next users might run into, but I don't think it counts as a bugfix because there was never a bug in Next. I removed the template but I can return it if people think I should treat it as a bugfix and fill in that section of the template.