### PR TITLE
perf: tree-shake out OTL from edge ssr bundle

### DIFF
--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -17,7 +17,10 @@ let api: typeof import('next/dist/compiled/@opentelemetry/api')
 // @opentelemetry/tracing that is used, and we don't want to force users to use
 // the version that is bundled with Next.js.
 // the API is ~stable, so this should be fine
-if (process.env.NEXT_RUNTIME !== 'edge') {
+
+// For edge as @opentelemetry/api can be aliased to built-in version
+// if there's no user-land version installed
+if (process.env.NEXT_RUNTIME === 'edge') {
   api = require('@opentelemetry/api')
 } else {
   try {

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -17,15 +17,17 @@ let api: typeof import('next/dist/compiled/@opentelemetry/api')
 // @opentelemetry/tracing that is used, and we don't want to force users to use
 // the version that is bundled with Next.js.
 // the API is ~stable, so this should be fine
-try {
+if (process.env.NEXT_RUNTIME !== 'edge') {
   api = require('@opentelemetry/api')
-} catch {
-  if (process.env.NEXT_RUNTIME !== 'edge') {
+} else {
+  try {
+    api = require('@opentelemetry/api')
+  } catch {
     api = require('next/dist/compiled/@opentelemetry/api')
   }
 }
 
-const { context, trace, SpanStatusCode, SpanKind } = api!
+const { context, trace, SpanStatusCode, SpanKind } = api
 
 const isPromise = <T>(p: any): p is Promise<T> => {
   return p !== null && typeof p === 'object' && typeof p.then === 'function'

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -19,8 +19,10 @@ let api: typeof import('next/dist/compiled/@opentelemetry/api')
 // the API is ~stable, so this should be fine
 try {
   api = require('@opentelemetry/api')
-} catch (err) {
-  api = require('next/dist/compiled/@opentelemetry/api')
+} catch {
+  if (process.env.NEXT_RUNTIME !== 'edge') {
+    api = require('next/dist/compiled/@opentelemetry/api')
+  }
 }
 
 const { context, trace, SpanStatusCode, SpanKind } = api

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -25,7 +25,7 @@ try {
   }
 }
 
-const { context, trace, SpanStatusCode, SpanKind } = api
+const { context, trace, SpanStatusCode, SpanKind } = api!
 
 const isPromise = <T>(p: any): p is Promise<T> => {
   return p !== null && typeof p === 'object' && typeof p.then === 'function'


### PR DESCRIPTION
For edge runtime we should only bundle 1 OTL bundle. We already have alias logic to make sure the 1st one is alias to precompiled OTL if there's no one install, so for edge runtime there's no need to fallback.

This change tree shakes 24KB out from the bundle

#### Before
![image](https://github.com/vercel/next.js/assets/4800338/f62ff44e-b801-4f52-a317-6b7f49fb5248)
<img width="648" alt="image" src="https://github.com/vercel/next.js/assets/4800338/d3c6a717-b679-467f-a2a7-075670a2e7a0">


#### After
![image](https://github.com/vercel/next.js/assets/4800338/d5c86cc2-edbf-460d-83a7-0551a3a47088)
<img width="636" alt="image" src="https://github.com/vercel/next.js/assets/4800338/c0d62da8-fa19-499d-80aa-0b2faaaf29e3">

