### PR TITLE
Update prerender-error.md

### DIFF
--- a/errors/prerender-error.md
+++ b/errors/prerender-error.md
@@ -12,3 +12,4 @@ While prerendering a page an error occurred. This can occur for many reasons fro
 - Check for any out of date modules that you might be relying on
 - Make sure your component handles `fallback` if it is enabled in `getStaticPaths`. [Fallback docs](https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#fallback-false)
 - Make sure you are not trying to export (`output: 'export'` or `next export`) pages that have server-side rendering enabled [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props)
+- You may have used `nextjs` methods under an unknown module, such as `route.push`, `route.replace`, etc. Please make sure your module functions run after `nextjs` is initialized. Using `route.isReady` gives you more control over what your function code executes after initializing `nextjs`


### PR DESCRIPTION
During the function development some time ago, we found that there was a similar error report. It said that there was another abnormal pre-rendered page route. After a series of investigations according to the document, we found that the modules under the routing folder referenced a large number of next. replace and push, this may be an error caused when the current route route has not been initialized, we can solve this problem by adding isReady judgment at the root route of the folder, adding this information may also better help other developers to troubleshoot Problems with pre-rendering.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
