### PR TITLE
Add warning for edge with force-static

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1384,8 +1384,9 @@ export async function isPageStatic({
       let prerenderFallback: boolean | 'blocking' | undefined
       let appConfig: AppConfig = {}
       let isClientComponent: boolean = false
+      const pathIsEdgeRuntime = isEdgeRuntime(pageRuntime)
 
-      if (isEdgeRuntime(pageRuntime)) {
+      if (pathIsEdgeRuntime) {
         const runtime = await getRuntimeContext({
           paths: edgeInfo.files.map((file: string) => path.join(distDir, file)),
           env: edgeInfo.env,
@@ -1502,6 +1503,12 @@ export async function isPageStatic({
           },
           {}
         )
+
+        if (appConfig.dynamic === 'force-static' && pathIsEdgeRuntime) {
+          Log.warn(
+            `Page "${page}" is using runtime = 'edge' which is currently incompatible with dynamic = 'force-static'. Please remove either "runtime" or "force-static" for correct behavior`
+          )
+        }
 
         if (appConfig.dynamic === 'force-dynamic') {
           appConfig.revalidate = 0

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -1270,6 +1270,12 @@ createNextDescribe(
         expect($2('#page-data').text()).toBe(pageData)
         return 'success'
       }, 'success')
+
+      if (isNextStart) {
+        expect(next.cliOutput).toContain(
+          `Page "/variable-revalidate-edge/revalidate-3" is using runtime = 'edge' which is currently incompatible with dynamic = 'force-static'. Please remove either "runtime" or "force-static" for correct behavior`
+        )
+      }
     })
 
     it('should honor fetch cache correctly (edge)', async () => {

--- a/test/e2e/app-dir/app-static/app/variable-revalidate-edge/revalidate-3/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate-edge/revalidate-3/page.js
@@ -1,6 +1,7 @@
 import { cache, use } from 'react'
 
 export const runtime = 'experimental-edge'
+export const dynamic = 'force-static'
 
 export default function Page() {
   const getData = cache(() =>


### PR DESCRIPTION
Currently the edge runtime does not support static generation so this adds a warning when `force-static` is leveraged with `edge-runtime` as it will cause unexpected behavior. Support is being investigated so this isn't a hard error at the moment. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1684783403551589)