### PR TITLE
Fix static workers distributing

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1189,20 +1189,6 @@ export default async function build(
             },
           },
           enableWorkerThreads: config.experimental.workerThreads,
-          computeWorkerKey(method, ...args) {
-            if (method === 'exportPage') {
-              const typedArgs = args as Parameters<
-                typeof import('./worker').exportPage
-              >
-              return typedArgs[0].pathMap.page
-            } else if (method === 'isPageStatic') {
-              const typedArgs = args as Parameters<
-                typeof import('./worker').isPageStatic
-              >
-              return typedArgs[0].originalAppPath || typedArgs[0].page
-            }
-            return method
-          },
           exposedMethods: sharedPool
             ? [
                 'hasCustomGetInitialProps',


### PR DESCRIPTION
This removes the `computeWorkerKey` from our static workers as this doesn't work in practice as efficiently as we hoped since a single page can have thousands of paths to render which won't be distributed to separate workers if the same worker key is returned.

Fixes: https://github.com/vercel/next.js/issues/49593

**Before**
![before](https://github.com/vercel/next.js/assets/22380829/da1e0a03-8b15-42a6-a2ac-6e4ff29c350d)


**After**
![after](https://github.com/vercel/next.js/assets/22380829/b27354f6-bcdb-4cad-888c-7d6b143e0ee2)

