### PR TITLE
Ensure NEXT_DYNAMIC_NO_SSR_CODE has a unique name

### DIFF
--- a/packages/next/src/shared/lib/lazy-dynamic/no-ssr-error.ts
+++ b/packages/next/src/shared/lib/lazy-dynamic/no-ssr-error.ts
@@ -1,3 +1,3 @@
 // This has to be a shared module which is shared between client component error boundary and dynamic component
 
-export const NEXT_DYNAMIC_NO_SSR_CODE = 'DYNAMIC_SERVER_USAGE'
+export const NEXT_DYNAMIC_NO_SSR_CODE = 'NEXT_DYNAMIC_NO_SSR_CODE'

--- a/test/e2e/app-dir/deopted-into-client-rendering-warning/app/layout.tsx
+++ b/test/e2e/app-dir/deopted-into-client-rendering-warning/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/deopted-into-client-rendering-warning/app/page.tsx
+++ b/test/e2e/app-dir/deopted-into-client-rendering-warning/app/page.tsx
@@ -1,0 +1,5 @@
+import { cookies } from 'next/headers'
+export default function Home() {
+  cookies()
+  return null
+}

--- a/test/e2e/app-dir/deopted-into-client-rendering-warning/deopted-into-client-rendering-warning.test.ts
+++ b/test/e2e/app-dir/deopted-into-client-rendering-warning/deopted-into-client-rendering-warning.test.ts
@@ -1,0 +1,12 @@
+import { nextBuild } from 'next-test-utils'
+
+it('should not show deopted into client rendering warning', async () => {
+  const output = await nextBuild(__dirname, undefined, {
+    stdout: true,
+    stderr: true,
+  })
+  expect(output.code).toBe(0)
+  expect(output.stderr).not.toContain(
+    `Entire page / deopted into client-side rendering.`
+  )
+})

--- a/test/e2e/app-dir/deopted-into-client-rendering-warning/next.config.js
+++ b/test/e2e/app-dir/deopted-into-client-rendering-warning/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
## What?

Ensures `NEXT_DYNAMIC_NO_SSR_CODE` has a unique error code value, this accidentally had the value for dynamic server usage (e.g. calling cookies()) which caused the warning to be shown as shown in #48442.

## How?

Changed the digest value to something unique.


Fixes NEXT-1125
Fixes #48442

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
