### PR TITLE
Fix free port handling

### DIFF
--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -136,6 +136,6 @@ export async function initialize(opts: {
         return reject(err)
       }
     })
-    server.listen((await getFreePort()) + 1, opts.hostname)
+    server.listen(await getFreePort(), opts.hostname)
   })
 }

--- a/packages/next/src/server/lib/server-ipc/index.ts
+++ b/packages/next/src/server/lib/server-ipc/index.ts
@@ -4,7 +4,7 @@ import { getNodeOptionsWithoutInspect } from '../utils'
 import { deserializeErr, errorToJSON } from '../../render'
 import crypto from 'crypto'
 import isError from '../../../lib/is-error'
-import { genRenderExecArgv } from '../worker-utils'
+import { genRenderExecArgv, getFreePort } from '../worker-utils'
 
 // we can't use process.send as jest-worker relies on
 // it already and can cause unexpected message errors
@@ -116,7 +116,9 @@ export const createWorker = async (
             }
           : {}),
       },
-      execArgv: isNodeDebugging ? genRenderExecArgv(type) : undefined,
+      execArgv: isNodeDebugging
+        ? genRenderExecArgv(await getFreePort(), type)
+        : undefined,
     },
     exposedMethods: [
       'initialize',

--- a/packages/next/src/server/lib/server-ipc/invoke-request.ts
+++ b/packages/next/src/server/lib/server-ipc/invoke-request.ts
@@ -26,7 +26,7 @@ export const invokeRequest = async (
 
       try {
         const invokeReq = http.request(
-          targetUrl,
+          parsedUrl.toString(),
           {
             headers: invokeHeaders,
             method: requestInit.method,

--- a/packages/next/src/server/lib/worker-utils.ts
+++ b/packages/next/src/server/lib/worker-utils.ts
@@ -17,7 +17,7 @@ export const getFreePort = async (): Promise<number> => {
   })
 }
 
-export const genRenderExecArgv = (type: 'pages' | 'app') => {
+export const genRenderExecArgv = (debugPort: number, type: 'pages' | 'app') => {
   const isDebugging =
     process.execArgv.some((localArg) => localArg.startsWith('--inspect')) ||
     process.env.NODE_OPTIONS?.match?.(/--inspect(=\S+)?( |$)/)
@@ -25,21 +25,6 @@ export const genRenderExecArgv = (type: 'pages' | 'app') => {
   const isDebuggingWithBrk =
     process.execArgv.some((localArg) => localArg.startsWith('--inspect-brk')) ||
     process.env.NODE_OPTIONS?.match?.(/--inspect-brk(=\S+)?( |$)/)
-
-  let debugPort = (() => {
-    const debugPortStr =
-      process.execArgv
-        .find(
-          (localArg) =>
-            localArg.startsWith('--inspect') ||
-            localArg.startsWith('--inspect-brk')
-        )
-        ?.split('=')[1] ??
-      process.env.NODE_OPTIONS?.match?.(/--inspect(-brk)?(=(\S+))?( |$)/)?.[3]
-    return debugPortStr ? parseInt(debugPortStr, 10) : 9229
-  })()
-
-  debugPort += type === 'pages' ? 2 : 3
 
   if (isDebugging || isDebuggingWithBrk) {
     Log.info(


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/48019 ensures we don't use arbitrary ports by incrementing favoring always getting a fresh free port instead. Also favors exact address for internal IPC requests instead of `localhost`. 