### PR TITLE
Update targetUrl for invoke-request

### DIFF
--- a/packages/next/src/server/lib/server-ipc/invoke-request.ts
+++ b/packages/next/src/server/lib/server-ipc/invoke-request.ts
@@ -9,13 +9,6 @@ export const invokeRequest = async (
   },
   readableBody?: import('stream').Readable
 ) => {
-  const parsedUrl = new URL(targetUrl)
-
-  // force localhost to IPv4 as some DNS may
-  // resolve to IPv6 instead
-  if (parsedUrl.hostname === 'localhost') {
-    parsedUrl.hostname = '127.0.0.1'
-  }
   const invokeHeaders = filterReqHeaders({
     ...requestInit.headers,
   }) as IncomingMessage['headers']
@@ -26,7 +19,7 @@ export const invokeRequest = async (
 
       try {
         const invokeReq = http.request(
-          parsedUrl.toString(),
+          targetUrl,
           {
             headers: invokeHeaders,
             method: requestInit.method,


### PR DESCRIPTION
From testing seems we can't lock localhost to `127.0.0.1` in some setups for the internal invoke-request handling so this reverts that.  

x-ref: https://github.com/vercel/next.js/actions/runs/5065416733/jobs/9094017768