### PR TITLE
Fix edge case in the CJS optimizer

### DIFF
--- a/packages/next-swc/crates/core/tests/fixture/cjs-optimize/not-processed-4/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/cjs-optimize/not-processed-4/input.js
@@ -1,0 +1,4 @@
+const foo = require('next/server')
+const bar = foo
+
+console.log(bar)

--- a/packages/next-swc/crates/core/tests/fixture/cjs-optimize/not-processed-4/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/cjs-optimize/not-processed-4/output.js
@@ -1,0 +1,4 @@
+const foo = require('next/server');
+const bar = foo;
+
+console.log(bar);


### PR DESCRIPTION
Previously we are ignoring idents in all var declarators in the check, so it's still possible to fail in some edge cases. CC @kdy1 