### PR TITLE
feat: allow “bundler” moduleResolution

### DIFF
--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -68,6 +68,7 @@ function getDesiredCompilerOptions(
         (ts.ModuleResolutionKind as any).Node12,
         ts.ModuleResolutionKind.Node16,
         ts.ModuleResolutionKind.NodeNext,
+        (ts.ModuleResolutionKind as any).Bundler,
       ].filter((val) => typeof val !== 'undefined'),
       value: 'node',
       reason: 'to match webpack resolution',


### PR DESCRIPTION
fixes #47858

Small change to allow the bundler `moduleResolution` option (introduced in typescript 5).

I don't think a test can be added until the root TS version is upgraded to v5, but please let me know if there is something I should cover!

link NEXT-1281