### PR TITLE
Update next start listening to behave consistently

### DIFF
--- a/packages/next/src/cli/next-start.ts
+++ b/packages/next/src/cli/next-start.ts
@@ -54,7 +54,7 @@ const nextStart: CliCommand = async (argv) => {
   }
 
   const dir = getProjectDir(args._[0])
-  const host = args['--hostname'] || '0.0.0.0'
+  const host = args['--hostname']
   const port = getPort(args)
 
   const keepAliveTimeoutArg: number | undefined = args['--keepAliveTimeout']


### PR DESCRIPTION
Fixes next start listening as it currently behaves in-consistently between dev and start, this shouldn't break any existing behavior as the default is to listen on all interfaces and if it needs to be locked down it still can be. 

x-ref: https://github.com/vercel/next.js/actions/runs/5065560220/jobs/9094296465
