### PR TITLE
Update server invoke-request

### DIFF
--- a/packages/next/src/server/lib/server-ipc/invoke-request.ts
+++ b/packages/next/src/server/lib/server-ipc/invoke-request.ts
@@ -9,13 +9,6 @@ export const invokeRequest = async (
   },
   readableBody?: import('stream').Readable
 ) => {
-  const parsedUrl = new URL(targetUrl)
-
-  // force localhost to IPv4 as some DNS may
-  // resolve to IPv6 instead
-  if (parsedUrl.hostname === 'localhost') {
-    parsedUrl.hostname = '127.0.0.1'
-  }
   const invokeHeaders = filterReqHeaders({
     ...requestInit.headers,
   }) as IncomingMessage['headers']
@@ -26,7 +19,7 @@ export const invokeRequest = async (
 
       try {
         const invokeReq = http.request(
-          parsedUrl.toString(),
+          targetUrl,
           {
             headers: invokeHeaders,
             method: requestInit.method,


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/50293 we can now avoid this normalizing which isn't as reliable as being able to rely on `localhost` directly since we can't assume it maps to `127.0.0.1` always. 

x-ref: https://github.com/vercel/next.js/actions/runs/5072034311/jobs/9109241689