### PR TITLE
Update unstable_cache key to include args

### DIFF
--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -16,9 +16,6 @@ export function unstable_cache<T extends Callback>(
     tags?: string[]
   } = {}
 ): T {
-  const joinedKey =
-    keyParts && keyParts.length > 0 ? keyParts.join(',') : cb.toString()
-
   const staticGenerationAsyncStorage: StaticGenerationAsyncStorage =
     (fetch as any).__nextGetStaticStore?.() || _staticGenerationAsyncStorage
 
@@ -32,16 +29,20 @@ export function unstable_cache<T extends Callback>(
 
   if (!incrementalCache) {
     throw new Error(
-      `Invariant: incrementalCache missing in unstable_cache ${joinedKey}`
+      `Invariant: incrementalCache missing in unstable_cache ${cb.toString()}`
     )
   }
   if (options.revalidate === 0) {
     throw new Error(
-      `Invariant revalidate: 0 can not be passed to unstable_cache(), must be "false" or "> 0" ${joinedKey}`
+      `Invariant revalidate: 0 can not be passed to unstable_cache(), must be "false" or "> 0" ${cb.toString()}`
     )
   }
 
   const cachedCb = async (...args: any[]) => {
+    const joinedKey = `${cb.toString()}-${
+      Array.isArray(keyParts) && keyParts.join(',')
+    }-${JSON.stringify(args)}`
+
     // We override the default fetch cache handling inside of the
     // cache callback so that we only cache the specific values returned
     // from the callback instead of also caching any fetches done inside


### PR DESCRIPTION
As discussed this includes arguments passed to `unstable_cache` to cacheKey automatically so users don't have to remember to do this manually.  