### PR TITLE
Add root detection utils

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -17,6 +17,7 @@ import { traceGlobals } from '../trace/shared'
 import { Telemetry } from '../telemetry/storage'
 import loadConfig from '../server/config'
 import { findPagesDir } from '../lib/find-pages-dir'
+import { findRootDir } from '../lib/find-root'
 import { fileExists } from '../lib/file-exists'
 import { getNpxCommand } from '../lib/helpers/get-npx-command'
 import Watchpack from 'next/dist/compiled/watchpack'
@@ -275,7 +276,7 @@ const nextDev: CliCommand = async (argv) => {
     let server = bindings.turbo.startDev({
       ...devServerOptions,
       showAll: args['--show-all'] ?? false,
-      root: args['--root'] ?? rawNextConfig.experimental?.outputFileTracingRoot,
+      root: args['--root'] ?? findRootDir(dir),
     })
     // Start preflight after server is listening and ignore errors:
     preflight().catch(() => {})

--- a/packages/next/src/lib/find-root.ts
+++ b/packages/next/src/lib/find-root.ts
@@ -1,0 +1,13 @@
+import { dirname } from 'path'
+import findUp from 'next/dist/compiled/find-up'
+
+export function findRootLockFile(cwd: string) {
+  return findUp.sync(['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock'], {
+    cwd,
+  })
+}
+
+export function findRootDir(cwd: string) {
+  const lockFile = findRootLockFile(cwd)
+  return lockFile ? dirname(lockFile) : undefined
+}

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1,13 +1,5 @@
 import { existsSync } from 'fs'
-import {
-  basename,
-  extname,
-  join,
-  relative,
-  isAbsolute,
-  resolve,
-  dirname,
-} from 'path'
+import { basename, extname, join, relative, isAbsolute, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import { Agent as HttpAgent } from 'http'
 import { Agent as HttpsAgent } from 'https'
@@ -28,6 +20,7 @@ import { loadWebpackHook } from './config-utils'
 import { ImageConfig, imageConfigDefault } from '../shared/lib/image-config'
 import { loadEnvConfig, updateInitialEnv } from '@next/env'
 import { flushAndExit } from '../telemetry/flush-and-exit'
+import { findRootDir } from '../lib/find-root'
 
 export { DomainLocale, NextConfig, normalizeConfig } from './config-shared'
 
@@ -468,21 +461,16 @@ function assignDefaults(
 
   // use the closest lockfile as tracing root
   if (!result.experimental?.outputFileTracingRoot) {
-    const lockFiles: string[] = [
-      'package-lock.json',
-      'yarn.lock',
-      'pnpm-lock.yaml',
-    ]
-    const foundLockfile = findUp.sync(lockFiles, { cwd: dir })
+    let rootDir = findRootDir(dir)
 
-    if (foundLockfile) {
+    if (rootDir) {
       if (!result.experimental) {
         result.experimental = {}
       }
       if (!defaultConfig.experimental) {
         defaultConfig.experimental = {}
       }
-      result.experimental.outputFileTracingRoot = dirname(foundLockfile)
+      result.experimental.outputFileTracingRoot = rootDir
       defaultConfig.experimental.outputFileTracingRoot =
         result.experimental.outputFileTracingRoot
     }


### PR DESCRIPTION
A previous [PR](https://github.com/vercel/next.js/pull/49110#discussion_r1183282878) tried to reuse `rawNextConfig.experimental.outputFileTracingRoot` before invoking Turbopack, but that will always be undefined because `assignDefaults` hasn't been called yet. This creates a shared utility to be reused.