### PR TITLE
Fix catch-all edge app route

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -100,7 +100,7 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
 
     enhanceGlobals()
 
-    const pageType = ${JSON.stringify(pagesType)}
+    const pagesType = ${JSON.stringify(pagesType)}
     ${
       isAppDir
         ? `
@@ -145,7 +145,7 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
     const nextFontManifest = self.__NEXT_FONT_MANIFEST
 
     const render = getRender({
-      pageType,
+      pagesType,
       dev: ${dev},
       page: ${JSON.stringify(page)},
       appMod,
@@ -154,6 +154,7 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
       error500Mod,
       Document,
       buildManifest,
+      isAppPath: ${!!isAppDir},
       prerenderManifest,
       appRenderToHTML,
       pagesRenderToHTML,

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../../server/base-http/web'
 import { SERVER_RUNTIME } from '../../../../lib/constants'
 import { PrerenderManifest } from '../../..'
+import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
 
 export function getRender({
   dev,
@@ -78,6 +79,7 @@ export function getRender({
     minimalMode: true,
     webServerConfig: {
       page,
+      normalizedPage: isAppPath ? normalizeAppPath(page) : page,
       pagesType,
       prerenderManifest,
       extendRenderOpts: {
@@ -93,8 +95,6 @@ export function getRender({
       pagesRenderToHTML,
       incrementalCacheHandler,
       loadComponent: async (pathname) => {
-        if (isAppPath) return null
-
         if (pathname === page) {
           return {
             ...baseLoadComponentResult,

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -28,6 +28,7 @@ import { PrerenderManifest } from '../build'
 interface WebServerOptions extends Options {
   webServerConfig: {
     page: string
+    normalizedPage: string
     pagesType: 'app' | 'pages' | 'root'
     loadComponent: (
       pathname: string
@@ -128,12 +129,15 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
   }
   protected getPagesManifest() {
     return {
-      [this.serverOptions.webServerConfig.page]: '',
+      // keep same theme but server path doesn't need to be accurate
+      [this.serverOptions.webServerConfig
+        .normalizedPage]: `server${this.serverOptions.webServerConfig.page}.js`,
     }
   }
   protected getAppPathsManifest() {
+    const page = this.serverOptions.webServerConfig.page
     return {
-      [this.serverOptions.webServerConfig.page]: '',
+      [this.serverOptions.webServerConfig.page]: `app${page}.js`,
     }
   }
   protected getFilesystemPaths() {
@@ -282,8 +286,10 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
 
         // interpolate query information into page for dynamic route
         // so that rewritten paths are handled properly
-        if (pathname !== this.serverOptions.webServerConfig.page) {
-          pathname = this.serverOptions.webServerConfig.page
+        const normalizedPage = this.serverOptions.webServerConfig.normalizedPage
+
+        if (pathname !== normalizedPage) {
+          pathname = normalizedPage
 
           if (isDynamicRoute(pathname)) {
             const routeRegex = getNamedRouteRegex(pathname, false)

--- a/test/e2e/app-dir/app/app/catch-all-edge/[...slug]/page.js
+++ b/test/e2e/app-dir/app/app/catch-all-edge/[...slug]/page.js
@@ -1,0 +1,10 @@
+export const runtime = 'edge'
+
+export default function Page({ params }) {
+  return (
+    <>
+      <p>catch-all edge page</p>
+      <p id="params">{JSON.stringify(params)}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -37,6 +37,15 @@ createNextDescribe(
       })
     }
 
+    it('should work for catch-all edge page', async () => {
+      const html = await next.render('/catch-all-edge/hello123')
+      const $ = cheerio.load(html)
+
+      expect(JSON.parse($('#params').text())).toEqual({
+        slug: ['hello123'],
+      })
+    })
+
     it('should have correct searchParams and params (server)', async () => {
       const html = await next.render('/dynamic/category-1/id-2?query1=value2')
       const $ = cheerio.load(html)


### PR DESCRIPTION
This ensures we properly normalize app pages in the `web-server` so that it doesn't fail to match/interpolate properly. 

Fixes: https://github.com/vercel/next.js/issues/43384