### PR TITLE
Fix middleware e2e deploy test

### DIFF
--- a/test/e2e/middleware-general/app/pages/api/edge-search-params.js
+++ b/test/e2e/middleware-general/app/pages/api/edge-search-params.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-export const config = { runtime: 'edge' }
+export const config = { runtime: 'edge', regions: 'auto' }
 
 /**
  * @param {import('next/server').NextRequest}

--- a/test/e2e/middleware-general/app/pages/api/edge-search-params.js
+++ b/test/e2e/middleware-general/app/pages/api/edge-search-params.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-export const config = { runtime: 'edge', regions: 'default' }
+export const config = { runtime: 'edge' }
 
 /**
  * @param {import('next/server').NextRequest}

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -159,7 +159,7 @@ describe('Middleware Runtime', () => {
 
         expect(manifest.functions['/api/edge-search-params']).toHaveProperty(
           'regions',
-          'default'
+          'auto'
         )
       })
 


### PR DESCRIPTION
`default` isn't a valid `region` at this point so this replaces it with `auto`.

Fixes: https://github.com/vercel/next.js/actions/runs/5076047750/jobs/9118043860#step:6:469