### PR TITLE
fix: edge runtime with `next/legacy/image`

### DIFF
--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -148,7 +148,11 @@ function defaultLoader({
         )
       }
 
-      if (process.env.NODE_ENV !== 'test') {
+      if (
+        process.env.NODE_ENV !== 'test' &&
+        // micromatch isn't compatible with edge runtime
+        process.env.NEXT_RUNTIME !== 'edge'
+      ) {
         // We use dynamic require because this should only error in development
         const { hasMatch } = require('../../shared/lib/match-remote-pattern')
         if (!hasMatch(config.domains, config.remotePatterns, parsedSrc)) {

--- a/test/e2e/app-dir/next-image/app/legacy-edge-runtime/layout.js
+++ b/test/e2e/app-dir/next-image/app/legacy-edge-runtime/layout.js
@@ -1,0 +1,14 @@
+import Image from 'next/legacy/image'
+import testJpg from './test.jpg'
+
+export const runtime = 'experimental-edge'
+
+export default function LegacyEdgeLayout({ children }) {
+  return (
+    <>
+      <h2>app-legacy-edge-layout</h2>
+      <Image id="app-legacy-edge-layout" src={testJpg} quality={53} />
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/next-image/app/legacy-edge-runtime/layout.js
+++ b/test/e2e/app-dir/next-image/app/legacy-edge-runtime/layout.js
@@ -1,5 +1,5 @@
 import Image from 'next/legacy/image'
-import testJpg from './test.jpg'
+import testPng from '../../images/test.png'
 
 export const runtime = 'experimental-edge'
 
@@ -7,7 +7,7 @@ export default function LegacyEdgeLayout({ children }) {
   return (
     <>
       <h2>app-legacy-edge-layout</h2>
-      <Image id="app-legacy-edge-layout" src={testJpg} quality={53} />
+      <Image id="app-legacy-edge-layout" src={testPng} loading="eager" />
       {children}
     </>
   )

--- a/test/e2e/app-dir/next-image/app/legacy-edge-runtime/page.js
+++ b/test/e2e/app-dir/next-image/app/legacy-edge-runtime/page.js
@@ -1,0 +1,11 @@
+import Image from 'next/legacy/image'
+import testJpg from '../../images/test.jpg'
+
+export default function LegacyEdgePage() {
+  return (
+    <>
+      <h2>app-legacy-edge-page</h2>
+      <Image id="app-legacy-edge-page" src={testJpg} quality={54} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/next-image/app/legacy-edge-runtime/page.js
+++ b/test/e2e/app-dir/next-image/app/legacy-edge-runtime/page.js
@@ -1,11 +1,11 @@
 import Image from 'next/legacy/image'
-import testJpg from '../../images/test.jpg'
+import testPng from '../../images/test.png'
 
 export default function LegacyEdgePage() {
   return (
     <>
       <h2>app-legacy-edge-page</h2>
-      <Image id="app-legacy-edge-page" src={testJpg} quality={54} />
+      <Image id="app-legacy-edge-page" src={testPng} loading="eager" />
     </>
   )
 }

--- a/test/e2e/app-dir/next-image/app/legacy/layout.js
+++ b/test/e2e/app-dir/next-image/app/legacy/layout.js
@@ -1,0 +1,12 @@
+import Image from 'next/legacy/image'
+import testJpg from './test.jpg'
+
+export default function LegacyLayout({ children }) {
+  return (
+    <>
+      <h2>app-legacy-layout</h2>
+      <Image id="app-legacy-layout" src={testJpg} quality={50} />
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/next-image/app/legacy/layout.js
+++ b/test/e2e/app-dir/next-image/app/legacy/layout.js
@@ -1,11 +1,11 @@
 import Image from 'next/legacy/image'
-import testJpg from './test.jpg'
+import testPng from '../../images/test.png'
 
 export default function LegacyLayout({ children }) {
   return (
     <>
       <h2>app-legacy-layout</h2>
-      <Image id="app-legacy-layout" src={testJpg} quality={50} />
+      <Image id="app-legacy-layout" src={testPng} loading="eager" />
       {children}
     </>
   )

--- a/test/e2e/app-dir/next-image/app/legacy/page.js
+++ b/test/e2e/app-dir/next-image/app/legacy/page.js
@@ -1,0 +1,11 @@
+import Image from 'next/legacy/image'
+import testJpg from '../../images/test.jpg'
+
+export default function LegacyPage() {
+  return (
+    <>
+      <h2>app-legacy-page</h2>
+      <Image id="app-legacy-page" src={testJpg} quality={51} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/next-image/app/legacy/page.js
+++ b/test/e2e/app-dir/next-image/app/legacy/page.js
@@ -1,11 +1,11 @@
 import Image from 'next/legacy/image'
-import testJpg from '../../images/test.jpg'
+import testPng from '../../images/test.png'
 
 export default function LegacyPage() {
   return (
     <>
       <h2>app-legacy-page</h2>
-      <Image id="app-legacy-page" src={testJpg} quality={51} />
+      <Image id="app-legacy-page" src={testPng} loading="eager" />
     </>
   )
 }

--- a/test/e2e/app-dir/next-image/next-image.test.ts
+++ b/test/e2e/app-dir/next-image/next-image.test.ts
@@ -273,23 +273,23 @@ createNextDescribe(
 
         const res2 = await next.fetch($('#app-legacy-layout').attr('src'))
         expect(res2.status).toBe(200)
-        expect(res2.headers.get('content-type')).toBe('image/jpeg')
+        expect(res2.headers.get('content-type')).toBe('image/png')
 
         const res3 = await next.fetch($('#app-legacy-page').attr('src'))
         expect(res3.status).toBe(200)
-        expect(res3.headers.get('content-type')).toBe('image/jpeg')
+        expect(res3.headers.get('content-type')).toBe('image/png')
       })
 
-      it('should render legacy images in edge runtime at /legacy-edge-runtime route', async () => {
-        const $ = await next.render$('/legacy')
+      it('should render legacy images in edge runtime on /legacy-edge-runtime route', async () => {
+        const $ = await next.render$('/legacy-edge-runtime')
 
         const res2 = await next.fetch($('#app-legacy-edge-layout').attr('src'))
         expect(res2.status).toBe(200)
-        expect(res2.headers.get('content-type')).toBe('image/jpeg')
+        expect(res2.headers.get('content-type')).toBe('image/png')
 
         const res3 = await next.fetch($('#app-legacy-edge-page').attr('src'))
         expect(res3.status).toBe(200)
-        expect(res3.headers.get('content-type')).toBe('image/jpeg')
+        expect(res3.headers.get('content-type')).toBe('image/png')
       })
     })
   }

--- a/test/e2e/app-dir/next-image/next-image.test.ts
+++ b/test/e2e/app-dir/next-image/next-image.test.ts
@@ -283,11 +283,11 @@ createNextDescribe(
       it('should render legacy images in edge runtime at /legacy-edge-runtime route', async () => {
         const $ = await next.render$('/legacy')
 
-        const res2 = await next.fetch($('#app-legacy-layout').attr('src'))
+        const res2 = await next.fetch($('#app-legacy-edge-layout').attr('src'))
         expect(res2.status).toBe(200)
         expect(res2.headers.get('content-type')).toBe('image/jpeg')
 
-        const res3 = await next.fetch($('#app-legacy-page').attr('src'))
+        const res3 = await next.fetch($('#app-legacy-edge-page').attr('src'))
         expect(res3.status).toBe(200)
         expect(res3.headers.get('content-type')).toBe('image/jpeg')
       })

--- a/test/e2e/app-dir/next-image/next-image.test.ts
+++ b/test/e2e/app-dir/next-image/next-image.test.ts
@@ -267,6 +267,30 @@ createNextDescribe(
         expect(res4.status).toBe(200)
         expect(res4.headers.get('content-type')).toBe('image/jpeg')
       })
+
+      it('should render legacy images under /legacy route', async () => {
+        const $ = await next.render$('/legacy')
+
+        const res2 = await next.fetch($('#app-legacy-layout').attr('src'))
+        expect(res2.status).toBe(200)
+        expect(res2.headers.get('content-type')).toBe('image/jpeg')
+
+        const res3 = await next.fetch($('#app-legacy-page').attr('src'))
+        expect(res3.status).toBe(200)
+        expect(res3.headers.get('content-type')).toBe('image/jpeg')
+      })
+
+      it('should render legacy images in edge runtime at /legacy-edge-runtime route', async () => {
+        const $ = await next.render$('/legacy')
+
+        const res2 = await next.fetch($('#app-legacy-layout').attr('src'))
+        expect(res2.status).toBe(200)
+        expect(res2.headers.get('content-type')).toBe('image/jpeg')
+
+        const res3 = await next.fetch($('#app-legacy-page').attr('src'))
+        expect(res3.status).toBe(200)
+        expect(res3.headers.get('content-type')).toBe('image/jpeg')
+      })
     })
   }
 )


### PR DESCRIPTION
- Fixes https://github.com/vercel/next.js/issues/50307
- Related to https://github.com/vercel/next.js/pull/45601

fix #50307
fix NEXT-1237