### PR TITLE
Update RSC stream decoding

### DIFF
--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -5,8 +5,7 @@ export const NEXT_ROUTER_STATE_TREE = 'Next-Router-State-Tree' as const
 export const NEXT_ROUTER_PREFETCH = 'Next-Router-Prefetch' as const
 export const NEXT_URL = 'Next-Url' as const
 export const FETCH_CACHE_HEADER = 'x-vercel-sc-headers' as const
-export const RSC_CONTENT_TYPE_HEADER =
-  'text/x-component; charset=utf-8' as const
+export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
 export const RSC_VARY_HEADER =
   `${RSC}, ${NEXT_ROUTER_STATE_TREE}, ${NEXT_ROUTER_PREFETCH}` as const
 

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -61,7 +61,7 @@ export function useFlightResponse(
         flightResponseRef.current = null
         writer.close()
       } else {
-        const responsePartial = decodeText(value, textDecoder)
+        const responsePartial = decodeText(value, textDecoder, false)
         const scripts = `${startScriptTag}self.__next_f.push(${htmlEscapeJsonString(
           JSON.stringify([1, responsePartial])
         )})</script>`

--- a/packages/next/src/server/stream-utils/encode-decode.ts
+++ b/packages/next/src/server/stream-utils/encode-decode.ts
@@ -5,7 +5,7 @@ export function encodeText(input: string) {
 export function decodeText(
   input: Uint8Array | undefined,
   textDecoder: TextDecoder,
-  isStream = true
+  isFinalChunk: boolean
 ) {
-  return textDecoder.decode(input, { stream: isStream })
+  return textDecoder.decode(input, { stream: !isFinalChunk })
 }

--- a/packages/next/src/server/stream-utils/encode-decode.ts
+++ b/packages/next/src/server/stream-utils/encode-decode.ts
@@ -4,7 +4,8 @@ export function encodeText(input: string) {
 
 export function decodeText(
   input: Uint8Array | undefined,
-  textDecoder: TextDecoder
+  textDecoder: TextDecoder,
+  isStream = true
 ) {
-  return textDecoder.decode(input, { stream: true })
+  return textDecoder.decode(input, { stream: isStream })
 }

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -21,7 +21,7 @@ export const streamToBufferedResult = async (
 
   const writable = {
     write(chunk: any) {
-      renderChunks.push(decodeText(chunk, textDecoder))
+      renderChunks.push(decodeText(chunk, textDecoder, false))
     },
     end() {
       // ensure we flush final bytes
@@ -102,7 +102,7 @@ export async function streamToString(
       return bufferedString
     }
 
-    bufferedString += decodeText(value, textDecoder)
+    bufferedString += decodeText(value, textDecoder, false)
   }
 }
 
@@ -191,7 +191,7 @@ function createHeadInsertionTransformStream(
         controller.enqueue(chunk)
         freezing = true
       } else {
-        const content = decodeText(chunk, textDecoder, false)
+        const content = decodeText(chunk, textDecoder, true)
         const index = content.indexOf('</head>')
         if (index !== -1) {
           const insertedHeadContent =
@@ -310,7 +310,7 @@ export function createSuffixStream(
         return controller.enqueue(chunk)
       }
 
-      let content = decodeText(chunk, textDecoder)
+      let content = decodeText(chunk, textDecoder, false)
       if (content.endsWith(suffix)) {
         foundSuffix = true
         content += textDecoder.decode()
@@ -339,7 +339,7 @@ export function createRootLayoutValidatorStream(
   return new TransformStream({
     async transform(chunk, controller) {
       if (!foundHtml || !foundBody) {
-        const content = decodeText(chunk, textDecoder)
+        const content = decodeText(chunk, textDecoder, false)
         if (!foundHtml && content.includes('<html')) {
           foundHtml = true
         }

--- a/test/e2e/app-dir/app/app/dashboard/page.js
+++ b/test/e2e/app-dir/app/app/dashboard/page.js
@@ -11,6 +11,7 @@ export default function DashboardPage(props) {
       </p>
       <p className="bold">BOLD</p>
       <p className="green">this is green</p>
+      <p className="emojis">{`abc 🚀`}</p>
       <ClientComp />
     </>
   )

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -227,26 +227,22 @@ createNextDescribe(
       })
     }
 
-    it('should use text/x-component; charset=utf-8 for flight', async () => {
+    it('should use text/x-component for flight', async () => {
       const res = await next.fetch('/dashboard/deployments/123', {
         headers: {
           ['RSC'.toString()]: '1',
         },
       })
-      expect(res.headers.get('Content-Type')).toBe(
-        'text/x-component; charset=utf-8'
-      )
+      expect(res.headers.get('Content-Type')).toBe('text/x-component')
     })
 
-    it('should use text/x-component; charset=utf-8 for flight with edge runtime', async () => {
+    it('should use text/x-component for flight with edge runtime', async () => {
       const res = await next.fetch('/dashboard', {
         headers: {
           ['RSC'.toString()]: '1',
         },
       })
-      expect(res.headers.get('Content-Type')).toBe(
-        'text/x-component; charset=utf-8'
-      )
+      expect(res.headers.get('Content-Type')).toBe('text/x-component')
     })
 
     it('should return the `vary` header from edge runtime', async () => {

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -2586,7 +2586,7 @@ const runTests = (isDev = false, isTurbo = false) => {
         ],
         rsc: {
           header: 'RSC',
-          contentTypeHeader: 'text/x-component; charset=utf-8',
+          contentTypeHeader: 'text/x-component',
           varyHeader: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
         },
       })

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -1460,7 +1460,7 @@ function runTests({ dev }) {
         ],
         rsc: {
           header: 'RSC',
-          contentTypeHeader: 'text/x-component; charset=utf-8',
+          contentTypeHeader: 'text/x-component',
           varyHeader: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
         },
       })


### PR DESCRIPTION
It seems we are potentially failing to decode/encode RSC chunks when certain characters are used. Initial hypothesis was this is related to missing charset in the content-type header so potentially this is related to previous thread of encoding issues. 


https://github.com/vercel/next.js/assets/22380829/3360c9d4-b9f9-4f78-8554-8b694f0f1ab6


x-ref: https://github.com/vercel/next.js/pull/50060
x-ref: https://github.com/vercel/next.js/pull/46564#discussion_r1120865976
