### PR TITLE
refactor: Fix binary bloat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "serde",
 ]
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "serde",
@@ -7125,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7168,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7183,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7197,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "base16",
  "hex",
@@ -7256,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7280,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "mimalloc",
 ]
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7476,7 +7476,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7535,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7570,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7626,7 +7626,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "serde",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "serde",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -7790,7 +7790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.4.6",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "serde",
 ]
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "serde",
@@ -7125,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7168,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7183,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7197,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "base16",
  "hex",
@@ -7256,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7280,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "mimalloc",
 ]
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7476,7 +7476,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7535,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7570,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7626,7 +7626,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "serde",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "serde",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -7790,7 +7790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "serde",
 ]
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "serde",
@@ -7125,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7168,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7183,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7197,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "base16",
  "hex",
@@ -7256,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7280,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "mimalloc",
 ]
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7476,7 +7476,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7535,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7570,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7626,7 +7626,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "serde",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "serde",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -7790,7 +7790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.4.6",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "serde",
 ]
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "serde",
@@ -7125,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7168,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7183,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7197,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "base16",
  "hex",
@@ -7256,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7280,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "mimalloc",
 ]
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7476,7 +7476,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7535,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7570,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7626,7 +7626,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "serde",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "serde",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#ba0ff572a8868e22e210b8298dd1fb28ec0503b3"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#20d011c6674aae6688e8460c7746d0cfc72da109"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -7790,7 +7790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "serde",
 ]
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "serde",
@@ -7125,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7168,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7183,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7197,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "base16",
  "hex",
@@ -7256,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7280,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "mimalloc",
 ]
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7476,7 +7476,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7535,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7570,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7626,7 +7626,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "serde",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "serde",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#b2667feb85da94793e9643f2d22ab4080bdfbbd6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/compile-time#8bc5b648fbc3cee9127076f5219b46a62ef3d80e"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ swc_core = { version = "0.76.46" }
 testing = { version = "0.33.13" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230612.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/compile-time" } # last tag: "turbopack-230612.1"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230612.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/compile-time" } # last tag: "turbopack-230612.1"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230612.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/compile-time" } # last tag: "turbopack-230612.1"
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ opt-level = 2
 debug-assertions = false
 
 [profile.release]
-lto = true
+# lto = true
 
 [workspace.dependencies]
 # Workspace crates

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 default = ["rustls-tls"]

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230612.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?ba0ff572a8868e22e210b8298dd1fb28ec0503b3",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?ba0ff572a8868e22e210b8298dd1fb28ec0503b3",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -982,8 +982,8 @@ importers:
       '@types/react': 18.2.7
       '@types/react-dom': 18.2.4
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-ecmascript-runtime': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230612.1
+      '@vercel/turbopack-ecmascript-runtime': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?ba0ff572a8868e22e210b8298dd1fb28ec0503b3
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?ba0ff572a8868e22e210b8298dd1fb28ec0503b3
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -995,8 +995,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-ecmascript-runtime': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230612.1'
+      '@vercel/turbopack-ecmascript-runtime': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?ba0ff572a8868e22e210b8298dd1fb28ec0503b3_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?ba0ff572a8868e22e210b8298dd1fb28ec0503b3'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -6114,7 +6114,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.2.1
       source-map: 0.7.3
-      webpack: 5.86.0
+      webpack: 5.86.0_@swc+core@1.3.55
     transitivePeerDependencies:
       - supports-color
 
@@ -6788,7 +6788,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64/1.3.55:
@@ -6797,7 +6796,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.3.55:
@@ -6806,7 +6804,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.3.55:
@@ -6815,7 +6812,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl/1.3.55:
@@ -6824,7 +6820,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu/1.3.55:
@@ -6833,7 +6828,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl/1.3.55:
@@ -6842,7 +6836,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.3.55:
@@ -6851,7 +6844,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.3.55:
@@ -6860,7 +6852,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc/1.3.55:
@@ -6869,7 +6860,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core/1.3.55_@swc+helpers@0.5.1:
@@ -6894,7 +6884,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.55
       '@swc/core-win32-ia32-msvc': 1.3.55
       '@swc/core-win32-x64-msvc': 1.3.55
-    dev: true
 
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
@@ -23793,7 +23782,6 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.17.7
       webpack: 5.86.0_@swc+core@1.3.55
-    dev: true
 
   /terser/5.10.0:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
@@ -25151,7 +25139,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /websocket-driver/0.7.3:
     resolution: {integrity: sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==}
@@ -25560,9 +25547,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?ba0ff572a8868e22e210b8298dd1fb28ec0503b3_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?ba0ff572a8868e22e210b8298dd1fb28ec0503b3}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?ba0ff572a8868e22e210b8298dd1fb28ec0503b3'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:
@@ -25573,8 +25560,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230612.1':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230612.1}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?ba0ff572a8868e22e210b8298dd1fb28ec0503b3':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?ba0ff572a8868e22e210b8298dd1fb28ec0503b3}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

Reduce the binary size. This PR will be used to profile the binary size after pathcing turbopack.

### Why?

The binary size is way too big.

### How?

The original binary size on the m1 mac is `153.6MiB` .

Related PRs:

 - https://github.com/vercel/turbo/pull/5102. After this PR: `153.2MiB`
 - https://github.com/vercel/turbo/pull/5094. After this PR: `153.1MiB`
 - https://github.com/vercel/next.js/pull/50673: With `-Zshare-generics=y`:  `132.9MiB`
 - https://github.com/swc-project/swc/pull/7483, https://github.com/swc-project/swc/pull/7489, https://github.com/swc-project/swc/pull/7490: `132.4MiB` 

---

Restart: `132.4MiB`