### PR TITLE
Fix CSS duplication related problems

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -135,7 +135,13 @@ function deduplicateCSSImportsForEntry(mergedCSSimports: CssImports) {
   for (const [entryName, cssImports] of sortedCSSImports) {
     for (const cssImport of cssImports) {
       if (trackedCSSImports.has(cssImport)) continue
-      trackedCSSImports.add(cssImport)
+
+      // Only track CSS imports that are in files that can inherit CSS.
+      const filename = path.parse(entryName).name
+      if (['template', 'layout'].includes(filename)) {
+        trackedCSSImports.add(cssImport)
+      }
+
       if (!dedupedCSSImports[entryName]) {
         dedupedCSSImports[entryName] = []
       }

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -317,7 +317,8 @@ export class ClientReferenceEntryPlugin {
             ...clientEntryToInject,
             clientImports: [
               ...clientEntryToInject.clientComponentImports,
-              ...dedupedCSSImports[clientEntryToInject.absolutePagePath],
+              ...(dedupedCSSImports[clientEntryToInject.absolutePagePath] ||
+                []),
             ],
           })
         )

--- a/test/e2e/app-dir/app-css/app/css/css-conflict-layers/blue-button.js
+++ b/test/e2e/app-dir/app-css/app/css/css-conflict-layers/blue-button.js
@@ -1,0 +1,6 @@
+import { Button } from './button'
+import styles from './blue-button.module.css'
+
+export function BlueButton() {
+  return <Button className={'btn-blue ' + styles['blue-button']}>Button</Button>
+}

--- a/test/e2e/app-dir/app-css/app/css/css-conflict-layers/blue-button.module.css
+++ b/test/e2e/app-dir/app-css/app/css/css-conflict-layers/blue-button.module.css
@@ -1,0 +1,4 @@
+.blue-button {
+  color: white;
+  background: blue;
+}

--- a/test/e2e/app-dir/app-css/app/css/css-conflict-layers/button.js
+++ b/test/e2e/app-dir/app-css/app/css/css-conflict-layers/button.js
@@ -1,0 +1,5 @@
+import styles from './button.module.css'
+
+export function Button({ className = '' }) {
+  return <div className={'btn ' + styles.button + ' ' + className}>Button</div>
+}

--- a/test/e2e/app-dir/app-css/app/css/css-conflict-layers/button.module.css
+++ b/test/e2e/app-dir/app-css/app/css/css-conflict-layers/button.module.css
@@ -1,0 +1,5 @@
+.button {
+  display: inline-block;
+  border: 1px solid black;
+  background: white;
+}

--- a/test/e2e/app-dir/app-css/app/css/css-conflict-layers/layout.js
+++ b/test/e2e/app-dir/app-css/app/css/css-conflict-layers/layout.js
@@ -1,0 +1,12 @@
+import { BlueButton } from './blue-button'
+
+export default function ServerLayout({ children }) {
+  return (
+    <>
+      <div>
+        Blue Button: <BlueButton />
+      </div>
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-css/app/css/css-conflict-layers/page.css
+++ b/test/e2e/app-dir/app-css/app/css/css-conflict-layers/page.css
@@ -1,0 +1,3 @@
+body {
+  font-size: large;
+}

--- a/test/e2e/app-dir/app-css/app/css/css-conflict-layers/page.js
+++ b/test/e2e/app-dir/app-css/app/css/css-conflict-layers/page.js
@@ -1,0 +1,13 @@
+import './page.css'
+
+import { Button } from './button'
+
+export default function Page() {
+  return (
+    <>
+      <div>
+        Button: <Button />
+      </div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -347,6 +347,24 @@ createNextDescribe(
             ).toBe(1)
           })
 
+          it('should deduplicate styles on the module level', async () => {
+            const browser = await next.browser('/css/css-conflict-layers')
+            await check(
+              () =>
+                browser.eval(
+                  `window.getComputedStyle(document.querySelector('.btn:not(.btn-blue)')).backgroundColor`
+                ),
+              'rgb(255, 255, 255)'
+            )
+            await check(
+              () =>
+                browser.eval(
+                  `window.getComputedStyle(document.querySelector('.btn.btn-blue')).backgroundColor`
+                ),
+              'rgb(0, 0, 255)'
+            )
+          })
+
           it('should only include the same style once in the flight data', async () => {
             const initialHtml = await next.render('/css/css-duplicate-2/server')
 


### PR DESCRIPTION
This PR fixes a couple of categories of CSS issues in App Router, that come from the same root cause.

### 1. Duplicated styles being loaded in different layers

This issue has been described in https://github.com/vanilla-extract-css/vanilla-extract/issues/1088#issuecomment-1563931144. If a CSS module (or a global CSS) is referenced in multiple layers (e.g. a layout and a page), it will be bundled into multiple CSS assets because each layer is considered as a separate entry.

<img width="1141" alt="CleanShot-2023-05-26-GoB9Rhcs@2x" src="https://github.com/vercel/next.js/assets/3676859/8e0f5346-ee64-4553-950a-7fb44f769efc">

As explained in that issue, we have to bundle all CSS modules into one chunk to avoid a big number of requests.

### 2. CSS ordering issues (conflicts)

This is likely causing https://github.com/vercel/next.js/issues/48120. When the layer-based bundling and ordering logic applies to CSS, it can potentially cause non-deterministic order. In this example, button A in the layout should be in blue. However when button B is imported by the page, button A becomes red. This is an inconsistent experience and can be hard to debug and fix.

<img width="1090" alt="CleanShot-2023-05-26-Ar4MN5rP@2x" src="https://github.com/vercel/next.js/assets/3676859/4328d5d7-23af-4c42-bedf-30f8f062d96a">
