### PR TITLE
Fix blank screen error when using middleware

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -232,22 +232,12 @@ export default class NextNodeServer extends BaseServer {
       process.env.__NEXT_SCRIPT_WORKERS = JSON.stringify(true)
     }
 
-    if (this.getMiddleware()) {
-      const compression = require('next/dist/compiled/compression')
-
-      this.compression = compression({
-        filter: (req: NodeNextRequest, res: NodeNextResponse) => {
-          if (!this.nextConfig.compress) {
-            return false
-          }
-
-          return compression.filter(req, res)
-        },
+    const middleware = this.getMiddleware()
+    if (this.nextConfig.compress || middleware) {
+      this.compression = require('next/dist/compiled/compression')({
+        filter:
+          !this.nextConfig.compress && middleware ? () => false : undefined,
       })
-    } else {
-      if (this.nextConfig.compress) {
-        this.compression = require('next/dist/compiled/compression')()
-      }
     }
 
     if (!this.minimalMode) {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -232,8 +232,22 @@ export default class NextNodeServer extends BaseServer {
       process.env.__NEXT_SCRIPT_WORKERS = JSON.stringify(true)
     }
 
-    if (this.nextConfig.compress) {
-      this.compression = require('next/dist/compiled/compression')()
+    if (this.getMiddleware()) {
+      const compression = require('next/dist/compiled/compression')
+
+      this.compression = compression({
+        filter: (req: NodeNextRequest, res: NodeNextResponse) => {
+          if (!this.nextConfig.compress) {
+            return false
+          }
+
+          return compression.filter(req, res)
+        },
+      })
+    } else {
+      if (this.nextConfig.compress) {
+        this.compression = require('next/dist/compiled/compression')()
+      }
     }
 
     if (!this.minimalMode) {


### PR DESCRIPTION
#50320
When using middleware, if this.compression is not executed, a blank screen is displayed.

This is a temporary workaround.