### PR TITLE
Revert "land: Include charset=utf-8 with x-component Content-Type header"

### DIFF
--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -5,8 +5,7 @@ export const NEXT_ROUTER_STATE_TREE = 'Next-Router-State-Tree' as const
 export const NEXT_ROUTER_PREFETCH = 'Next-Router-Prefetch' as const
 export const NEXT_URL = 'Next-Url' as const
 export const FETCH_CACHE_HEADER = 'x-vercel-sc-headers' as const
-export const RSC_CONTENT_TYPE_HEADER =
-  'text/x-component; charset=utf-8' as const
+export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
 export const RSC_VARY_HEADER =
   `${RSC}, ${NEXT_ROUTER_STATE_TREE}, ${NEXT_ROUTER_PREFETCH}` as const
 

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -227,26 +227,22 @@ createNextDescribe(
       })
     }
 
-    it('should use text/x-component; charset=utf-8 for flight', async () => {
+    it('should use text/x-component for flight', async () => {
       const res = await next.fetch('/dashboard/deployments/123', {
         headers: {
           ['RSC'.toString()]: '1',
         },
       })
-      expect(res.headers.get('Content-Type')).toBe(
-        'text/x-component; charset=utf-8'
-      )
+      expect(res.headers.get('Content-Type')).toBe('text/x-component')
     })
 
-    it('should use text/x-component; charset=utf-8 for flight with edge runtime', async () => {
+    it('should use text/x-component for flight with edge runtime', async () => {
       const res = await next.fetch('/dashboard', {
         headers: {
           ['RSC'.toString()]: '1',
         },
       })
-      expect(res.headers.get('Content-Type')).toBe(
-        'text/x-component; charset=utf-8'
-      )
+      expect(res.headers.get('Content-Type')).toBe('text/x-component')
     })
 
     it('should return the `vary` header from edge runtime', async () => {

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -2586,7 +2586,7 @@ const runTests = (isDev = false, isTurbo = false) => {
         ],
         rsc: {
           header: 'RSC',
-          contentTypeHeader: 'text/x-component; charset=utf-8',
+          contentTypeHeader: 'text/x-component',
           varyHeader: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
         },
       })

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -1460,7 +1460,7 @@ function runTests({ dev }) {
         ],
         rsc: {
           header: 'RSC',
-          contentTypeHeader: 'text/x-component; charset=utf-8',
+          contentTypeHeader: 'text/x-component',
           varyHeader: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
         },
       })


### PR DESCRIPTION
This change isn't necessary per https://github.com/vercel/next.js/pull/50060#issuecomment-1562897282 and doesn't alleviate the root issue that was attempting to be addressed instead that is related to a different issue upstream which is being investigated. 

Reverts vercel/next.js#50314