### PR TITLE
disable test case for Turbopack

### DIFF
--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -23,8 +23,8 @@ createNextDescribe(
       'server-only': 'latest',
     },
   },
-  ({ next, isNextDev, isNextStart }) => {
-    if (isNextDev) {
+  ({ next, isNextDev, isNextStart, isTurbopack }) => {
+    if (isNextDev && !isTurbopack) {
       it('should have correct client references keys in manifest', async () => {
         await next.render('/')
         await check(async () => {

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -212,6 +212,7 @@ export function createNextDescribe(
     isNextDev: boolean
     isNextDeploy: boolean
     isNextStart: boolean
+    isTurbopack: boolean
     next: NextInstance
   }) => void
 ): void {
@@ -242,6 +243,13 @@ export function createNextDescribe(
     fn({
       get isNextDev(): boolean {
         return Boolean((global as any).isNextDev)
+      },
+      get isTurbopack(): boolean {
+        return Boolean(
+          (global as any).isNextDev &&
+            !process.env.TEST_WASM &&
+            (options.turbo ?? shouldRunTurboDevTest())
+        )
       },
 
       get isNextDeploy(): boolean {


### PR DESCRIPTION
### What?

This test case was never passing and accidentally enabled for Turbopack.

We could disable the whole test suite, but since only one test case is affected we can also disable only that one.
