### PR TITLE
Update telemetry failure logs

### DIFF
--- a/test/integration/telemetry/test/config.test.js
+++ b/test/integration/telemetry/test/config.test.js
@@ -38,7 +38,7 @@ describe('config telemetry', () => {
       expect(event1).toMatch(/"redirectsCount": 1/)
       expect(event1).toMatch(/"middlewareCount": 0/)
     } catch (err) {
-      require('console').error(stderr)
+      require('console').error('failing stderr', stderr, err)
       throw err
     }
   })
@@ -81,7 +81,7 @@ describe('config telemetry', () => {
       expect(event1).toMatch(/"pagesDir": true/)
       expect(event1).toMatch(/"appDir": false/)
     } catch (err) {
-      require('console').error(stderr)
+      require('console').error('failing stderr', stderr, err)
       throw err
     }
 
@@ -146,7 +146,7 @@ describe('config telemetry', () => {
 
         expect(event1).toContain('"nextConfigOutput": "export"')
       } catch (err) {
-        require('console').error(stderr)
+        require('console').error('failing stderr', stderr, err)
         throw err
       }
     } finally {
@@ -190,7 +190,7 @@ describe('config telemetry', () => {
         invocationCount: 1,
       })
     } catch (err) {
-      require('console').error(stderr)
+      require('console').error('failing stderr', stderr, err)
       throw err
     }
   })

--- a/test/integration/telemetry/test/page-features.test.js
+++ b/test/integration/telemetry/test/page-features.test.js
@@ -65,7 +65,7 @@ describe('page features telemetry', () => {
         expect(event1).toMatch(/"pagesDir": true/)
         expect(event1).toMatch(/"turboFlag": true/)
       } catch (err) {
-        require('console').error(stderr)
+        require('console').error('failing stderr', stderr, err)
         throw err
       }
     } finally {
@@ -217,7 +217,7 @@ describe('page features telemetry', () => {
 
         expect(event2).toMatch(/"totalAppPagesCount": 4/)
       } catch (err) {
-        require('console').error(stderr)
+        require('console').error('failing stderr', stderr, err)
         throw err
       }
     } finally {


### PR DESCRIPTION
Gives better insights on failure

x-ref: https://github.com/vercel/next.js/actions/runs/5134979038/jobs/9239784835?pr=50404#step:23:584