### PR TITLE
packages/font: run update-google-fonts script

### DIFF
--- a/packages/font/src/google/font-data.json
+++ b/packages/font/src/google/font-data.json
@@ -821,6 +821,11 @@
     ],
     "subsets": ["latin", "latin-ext", "vietnamese"]
   },
+  "Aoboshi One": {
+    "weights": ["400"],
+    "styles": ["normal"],
+    "subsets": ["latin", "latin-ext"]
+  },
   "Arapey": {
     "weights": ["400"],
     "styles": ["normal", "italic"],
@@ -2242,6 +2247,11 @@
     "styles": ["normal"],
     "subsets": ["latin", "latin-ext", "vietnamese"]
   },
+  "Cherry Bomb One": {
+    "weights": ["400"],
+    "styles": ["normal"],
+    "subsets": ["latin", "latin-ext", "vietnamese"]
+  },
   "Cherry Cream Soda": {
     "weights": ["400"],
     "styles": ["normal"],
@@ -2313,6 +2323,11 @@
         "defaultValue": 400
       }
     ],
+    "subsets": ["latin", "latin-ext", "vietnamese"]
+  },
+  "Chokokutai": {
+    "weights": ["400"],
+    "styles": ["normal"],
     "subsets": ["latin", "latin-ext", "vietnamese"]
   },
   "Chonburi": {
@@ -4280,7 +4295,7 @@
     "subsets": ["latin", "latin-ext"]
   },
   "Harmattan": {
-    "weights": ["400", "700"],
+    "weights": ["400", "500", "600", "700"],
     "styles": ["normal"],
     "subsets": ["arabic", "latin", "latin-ext"]
   },
@@ -4651,6 +4666,25 @@
     "weights": ["400"],
     "styles": ["normal"],
     "subsets": ["latin", "latin-ext", "vietnamese"]
+  },
+  "Instrument Sans": {
+    "weights": ["400", "500", "600", "700", "variable"],
+    "styles": ["normal", "italic"],
+    "axes": [
+      {
+        "tag": "wdth",
+        "min": 75,
+        "max": 100,
+        "defaultValue": 100
+      },
+      {
+        "tag": "wght",
+        "min": 400,
+        "max": 700,
+        "defaultValue": 400
+      }
+    ],
+    "subsets": ["latin", "latin-ext"]
   },
   "Instrument Serif": {
     "weights": ["400"],
@@ -5973,9 +6007,27 @@
     "subsets": ["latin"]
   },
   "Mada": {
-    "weights": ["200", "300", "400", "500", "600", "700", "900"],
+    "weights": [
+      "200",
+      "300",
+      "400",
+      "500",
+      "600",
+      "700",
+      "800",
+      "900",
+      "variable"
+    ],
     "styles": ["normal"],
-    "subsets": ["arabic", "latin"]
+    "axes": [
+      {
+        "tag": "wght",
+        "min": 200,
+        "max": 900,
+        "defaultValue": 400
+      }
+    ],
+    "subsets": ["arabic", "latin", "latin-ext"]
   },
   "Magra": {
     "weights": ["400", "700"],
@@ -6390,7 +6442,12 @@
   "Monofett": {
     "weights": ["400"],
     "styles": ["normal"],
-    "subsets": ["latin"]
+    "subsets": ["latin", "latin-ext"]
+  },
+  "Monomaniac One": {
+    "weights": ["400"],
+    "styles": ["normal"],
+    "subsets": ["latin", "latin-ext"]
   },
   "Monoton": {
     "weights": ["400"],
@@ -7178,6 +7235,11 @@
     ],
     "subsets": ["cherokee", "latin", "latin-ext"]
   },
+  "Noto Sans Chorasmian": {
+    "weights": ["400"],
+    "styles": ["normal"],
+    "subsets": ["chorasmian", "latin", "latin-ext"]
+  },
   "Noto Sans Coptic": {
     "weights": ["400"],
     "styles": ["normal"],
@@ -7279,7 +7341,7 @@
   "Noto Sans Elbasan": {
     "weights": ["400"],
     "styles": ["normal"],
-    "subsets": ["elbasan"]
+    "subsets": ["elbasan", "latin", "latin-ext"]
   },
   "Noto Sans Elymaic": {
     "weights": ["400"],
@@ -7502,7 +7564,7 @@
   "Noto Sans Inscriptional Parthian": {
     "weights": ["400"],
     "styles": ["normal"],
-    "subsets": ["inscriptional-parthian"]
+    "subsets": ["inscriptional-parthian", "latin", "latin-ext"]
   },
   "Noto Sans JP": {
     "weights": [
@@ -7931,6 +7993,24 @@
     "weights": ["400"],
     "styles": ["normal"],
     "subsets": ["nabataean"]
+  },
+  "Noto Sans Nag Mundari": {
+    "weights": ["400", "500", "600", "700", "variable"],
+    "styles": ["normal"],
+    "axes": [
+      {
+        "tag": "wght",
+        "min": 400,
+        "max": 700,
+        "defaultValue": 400
+      }
+    ],
+    "subsets": ["latin", "latin-ext", "nag-mundari"]
+  },
+  "Noto Sans Nandinagari": {
+    "weights": ["400"],
+    "styles": ["normal"],
+    "subsets": ["latin", "latin-ext", "nandinagari"]
   },
   "Noto Sans New Tai Lue": {
     "weights": ["400", "500", "600", "700", "variable"],
@@ -8445,7 +8525,7 @@
   "Noto Sans Ugaritic": {
     "weights": ["400"],
     "styles": ["normal"],
-    "subsets": ["ugaritic"]
+    "subsets": ["latin", "latin-ext", "ugaritic"]
   },
   "Noto Sans Vai": {
     "weights": ["400"],
@@ -9029,7 +9109,7 @@
   "Noto Serif Tangut": {
     "weights": ["400"],
     "styles": ["normal"],
-    "subsets": ["tangut"]
+    "subsets": ["latin", "latin-ext", "tangut"]
   },
   "Noto Serif Telugu": {
     "weights": [
@@ -9136,9 +9216,17 @@
     "subsets": ["yezidi"]
   },
   "Noto Traditional Nushu": {
-    "weights": ["400"],
+    "weights": ["300", "400", "500", "600", "700", "variable"],
     "styles": ["normal"],
-    "subsets": ["nushu"]
+    "axes": [
+      {
+        "tag": "wght",
+        "min": 300,
+        "max": 700,
+        "defaultValue": 400
+      }
+    ],
+    "subsets": ["latin", "latin-ext", "nushu"]
   },
   "Nova Cut": {
     "weights": ["400"],
@@ -9795,6 +9883,31 @@
     "styles": ["normal"],
     "subsets": ["latin", "latin-ext", "vietnamese"]
   },
+  "Playfair": {
+    "weights": ["300", "400", "500", "600", "700", "800", "900", "variable"],
+    "styles": ["normal", "italic"],
+    "axes": [
+      {
+        "tag": "opsz",
+        "min": 5,
+        "max": 1200,
+        "defaultValue": 12
+      },
+      {
+        "tag": "wdth",
+        "min": 87.5,
+        "max": 112.5,
+        "defaultValue": 100
+      },
+      {
+        "tag": "wght",
+        "min": 300,
+        "max": 900,
+        "defaultValue": 400
+      }
+    ],
+    "subsets": ["cyrillic", "cyrillic-ext", "latin", "latin-ext", "vietnamese"]
+  },
   "Playfair Display": {
     "weights": ["400", "500", "600", "700", "800", "900", "variable"],
     "styles": ["normal", "italic"],
@@ -10084,7 +10197,7 @@
         "defaultValue": 400
       }
     ],
-    "subsets": ["latin", "latin-ext", "vietnamese"]
+    "subsets": ["canadian-aboriginal", "latin", "latin-ext", "vietnamese"]
   },
   "Radley": {
     "weights": ["400"],
@@ -11032,7 +11145,7 @@
     "subsets": ["cyrillic", "cyrillic-ext", "latin", "latin-ext"]
   },
   "Scheherazade New": {
-    "weights": ["400", "700"],
+    "weights": ["400", "500", "600", "700"],
     "styles": ["normal"],
     "subsets": ["arabic", "latin", "latin-ext"]
   },
@@ -11290,6 +11403,11 @@
     "weights": ["400"],
     "styles": ["normal"],
     "subsets": ["latin"]
+  },
+  "Slackside One": {
+    "weights": ["400"],
+    "styles": ["normal"],
+    "subsets": ["latin", "latin-ext"]
   },
   "Smokum": {
     "weights": ["400"],
@@ -12280,6 +12398,11 @@
     "styles": ["normal"],
     "subsets": ["latin", "latin-ext"]
   },
+  "Tsukimi Rounded": {
+    "weights": ["300", "400", "500", "600", "700"],
+    "styles": ["normal"],
+    "subsets": ["latin", "latin-ext"]
+  },
   "Tulpen One": {
     "weights": ["400"],
     "styles": ["normal"],
@@ -12629,6 +12752,32 @@
     "weights": ["400"],
     "styles": ["normal"],
     "subsets": ["latin"]
+  },
+  "Wix Madefor Display": {
+    "weights": ["400", "500", "600", "700", "800", "variable"],
+    "styles": ["normal"],
+    "axes": [
+      {
+        "tag": "wght",
+        "min": 400,
+        "max": 800,
+        "defaultValue": 400
+      }
+    ],
+    "subsets": ["cyrillic", "cyrillic-ext", "latin", "latin-ext", "vietnamese"]
+  },
+  "Wix Madefor Text": {
+    "weights": ["400", "500", "600", "700", "800", "variable"],
+    "styles": ["normal", "italic"],
+    "axes": [
+      {
+        "tag": "wght",
+        "min": 400,
+        "max": 800,
+        "defaultValue": 400
+      }
+    ],
+    "subsets": ["cyrillic", "cyrillic-ext", "latin", "latin-ext", "vietnamese"]
   },
   "Work Sans": {
     "weights": [

--- a/packages/font/src/google/index.ts
+++ b/packages/font/src/google/index.ts
@@ -1246,6 +1246,18 @@ export declare function Anybody<
   subsets?: Array<'latin' | 'latin-ext' | 'vietnamese'>
   axes?: 'wdth'[]
 }): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Aoboshi_One<
+  T extends CssVariable | undefined = undefined
+>(options: {
+  weight: '400' | Array<'400'>
+  style?: 'normal' | Array<'normal'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<'latin' | 'latin-ext'>
+}): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Arapey<
   T extends CssVariable | undefined = undefined
 >(options: {
@@ -3962,6 +3974,18 @@ export declare function Cherish<
   adjustFontFallback?: boolean
   subsets?: Array<'latin' | 'latin-ext' | 'vietnamese'>
 }): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Cherry_Bomb_One<
+  T extends CssVariable | undefined = undefined
+>(options: {
+  weight: '400' | Array<'400'>
+  style?: 'normal' | Array<'normal'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<'latin' | 'latin-ext' | 'vietnamese'>
+}): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Cherry_Cream_Soda<
   T extends CssVariable | undefined = undefined
 >(options: {
@@ -4065,6 +4089,18 @@ export declare function Chivo_Mono<
         '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900'
       >
   style?: 'normal' | 'italic' | Array<'normal' | 'italic'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<'latin' | 'latin-ext' | 'vietnamese'>
+}): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Chokokutai<
+  T extends CssVariable | undefined = undefined
+>(options: {
+  weight: '400' | Array<'400'>
+  style?: 'normal' | Array<'normal'>
   display?: Display
   variable?: T
   preload?: boolean
@@ -7697,7 +7733,7 @@ export declare function Happy_Monkey<
 export declare function Harmattan<
   T extends CssVariable | undefined = undefined
 >(options: {
-  weight: '400' | '700' | Array<'400' | '700'>
+  weight: '400' | '500' | '600' | '700' | Array<'400' | '500' | '600' | '700'>
   style?: 'normal' | Array<'normal'>
   display?: Display
   variable?: T
@@ -8540,6 +8576,25 @@ export declare function Inspiration<
   fallback?: string[]
   adjustFontFallback?: boolean
   subsets?: Array<'latin' | 'latin-ext' | 'vietnamese'>
+}): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Instrument_Sans<
+  T extends CssVariable | undefined = undefined
+>(options?: {
+  weight?:
+    | '400'
+    | '500'
+    | '600'
+    | '700'
+    | 'variable'
+    | Array<'400' | '500' | '600' | '700'>
+  style?: 'normal' | 'italic' | Array<'normal' | 'italic'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<'latin' | 'latin-ext'>
+  axes?: 'wdth'[]
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Instrument_Serif<
   T extends CssVariable | undefined = undefined
@@ -10920,23 +10975,25 @@ export declare function Macondo_Swash_Caps<
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Mada<
   T extends CssVariable | undefined = undefined
->(options: {
-  weight:
+>(options?: {
+  weight?:
     | '200'
     | '300'
     | '400'
     | '500'
     | '600'
     | '700'
+    | '800'
     | '900'
-    | Array<'200' | '300' | '400' | '500' | '600' | '700' | '900'>
+    | 'variable'
+    | Array<'200' | '300' | '400' | '500' | '600' | '700' | '800' | '900'>
   style?: 'normal' | Array<'normal'>
   display?: Display
   variable?: T
   preload?: boolean
   fallback?: string[]
   adjustFontFallback?: boolean
-  subsets?: Array<'arabic' | 'latin'>
+  subsets?: Array<'arabic' | 'latin' | 'latin-ext'>
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Magra<
   T extends CssVariable | undefined = undefined
@@ -11820,7 +11877,19 @@ export declare function Monofett<
   preload?: boolean
   fallback?: string[]
   adjustFontFallback?: boolean
-  subsets?: Array<'latin'>
+  subsets?: Array<'latin' | 'latin-ext'>
+}): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Monomaniac_One<
+  T extends CssVariable | undefined = undefined
+>(options: {
+  weight: '400' | Array<'400'>
+  style?: 'normal' | Array<'normal'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<'latin' | 'latin-ext'>
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Monoton<
   T extends CssVariable | undefined = undefined
@@ -13163,6 +13232,18 @@ export declare function Noto_Sans_Cherokee<
   adjustFontFallback?: boolean
   subsets?: Array<'cherokee' | 'latin' | 'latin-ext'>
 }): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Noto_Sans_Chorasmian<
+  T extends CssVariable | undefined = undefined
+>(options: {
+  weight: '400' | Array<'400'>
+  style?: 'normal' | Array<'normal'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<'chorasmian' | 'latin' | 'latin-ext'>
+}): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Noto_Sans_Coptic<
   T extends CssVariable | undefined = undefined
 >(options: {
@@ -13305,7 +13386,7 @@ export declare function Noto_Sans_Elbasan<
   preload?: boolean
   fallback?: string[]
   adjustFontFallback?: boolean
-  subsets?: Array<'elbasan'>
+  subsets?: Array<'elbasan' | 'latin' | 'latin-ext'>
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Noto_Sans_Elymaic<
   T extends CssVariable | undefined = undefined
@@ -13604,7 +13685,7 @@ export declare function Noto_Sans_Inscriptional_Parthian<
   preload?: boolean
   fallback?: string[]
   adjustFontFallback?: boolean
-  subsets?: Array<'inscriptional-parthian'>
+  subsets?: Array<'inscriptional-parthian' | 'latin' | 'latin-ext'>
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Noto_Sans_JP<
   T extends CssVariable | undefined = undefined
@@ -14246,6 +14327,36 @@ export declare function Noto_Sans_Nabataean<
   fallback?: string[]
   adjustFontFallback?: boolean
   subsets?: Array<'nabataean'>
+}): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Noto_Sans_Nag_Mundari<
+  T extends CssVariable | undefined = undefined
+>(options?: {
+  weight?:
+    | '400'
+    | '500'
+    | '600'
+    | '700'
+    | 'variable'
+    | Array<'400' | '500' | '600' | '700'>
+  style?: 'normal' | Array<'normal'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<'latin' | 'latin-ext' | 'nag-mundari'>
+}): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Noto_Sans_Nandinagari<
+  T extends CssVariable | undefined = undefined
+>(options: {
+  weight: '400' | Array<'400'>
+  style?: 'normal' | Array<'normal'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<'latin' | 'latin-ext' | 'nandinagari'>
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Noto_Sans_New_Tai_Lue<
   T extends CssVariable | undefined = undefined
@@ -15100,7 +15211,7 @@ export declare function Noto_Sans_Ugaritic<
   preload?: boolean
   fallback?: string[]
   adjustFontFallback?: boolean
-  subsets?: Array<'ugaritic'>
+  subsets?: Array<'latin' | 'latin-ext' | 'ugaritic'>
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Noto_Sans_Vai<
   T extends CssVariable | undefined = undefined
@@ -15814,7 +15925,7 @@ export declare function Noto_Serif_Tangut<
   preload?: boolean
   fallback?: string[]
   adjustFontFallback?: boolean
-  subsets?: Array<'tangut'>
+  subsets?: Array<'latin' | 'latin-ext' | 'tangut'>
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Noto_Serif_Telugu<
   T extends CssVariable | undefined = undefined
@@ -15930,15 +16041,22 @@ export declare function Noto_Serif_Yezidi<
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Noto_Traditional_Nushu<
   T extends CssVariable | undefined = undefined
->(options: {
-  weight: '400' | Array<'400'>
+>(options?: {
+  weight?:
+    | '300'
+    | '400'
+    | '500'
+    | '600'
+    | '700'
+    | 'variable'
+    | Array<'300' | '400' | '500' | '600' | '700'>
   style?: 'normal' | Array<'normal'>
   display?: Display
   variable?: T
   preload?: boolean
   fallback?: string[]
   adjustFontFallback?: boolean
-  subsets?: Array<'nushu'>
+  subsets?: Array<'latin' | 'latin-ext' | 'nushu'>
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Nova_Cut<
   T extends CssVariable | undefined = undefined
@@ -17095,6 +17213,30 @@ export declare function Playball<
   adjustFontFallback?: boolean
   subsets?: Array<'latin' | 'latin-ext' | 'vietnamese'>
 }): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Playfair<
+  T extends CssVariable | undefined = undefined
+>(options?: {
+  weight?:
+    | '300'
+    | '400'
+    | '500'
+    | '600'
+    | '700'
+    | '800'
+    | '900'
+    | 'variable'
+    | Array<'300' | '400' | '500' | '600' | '700' | '800' | '900'>
+  style?: 'normal' | 'italic' | Array<'normal' | 'italic'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<
+    'cyrillic' | 'cyrillic-ext' | 'latin' | 'latin-ext' | 'vietnamese'
+  >
+  axes?: ('opsz' | 'wdth')[]
+}): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Playfair_Display<
   T extends CssVariable | undefined = undefined
 >(options?: {
@@ -17700,7 +17842,7 @@ export declare function Radio_Canada<
   preload?: boolean
   fallback?: string[]
   adjustFontFallback?: boolean
-  subsets?: Array<'latin' | 'latin-ext' | 'vietnamese'>
+  subsets?: Array<'canadian-aboriginal' | 'latin' | 'latin-ext' | 'vietnamese'>
   axes?: 'wdth'[]
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Radley<
@@ -19349,7 +19491,7 @@ export declare function Scada<
 export declare function Scheherazade_New<
   T extends CssVariable | undefined = undefined
 >(options: {
-  weight: '400' | '700' | Array<'400' | '700'>
+  weight: '400' | '500' | '600' | '700' | Array<'400' | '500' | '600' | '700'>
   style?: 'normal' | Array<'normal'>
   display?: Display
   variable?: T
@@ -19893,6 +20035,18 @@ export declare function Slackey<
   fallback?: string[]
   adjustFontFallback?: boolean
   subsets?: Array<'latin'>
+}): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Slackside_One<
+  T extends CssVariable | undefined = undefined
+>(options: {
+  weight: '400' | Array<'400'>
+  style?: 'normal' | Array<'normal'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<'latin' | 'latin-ext'>
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Smokum<
   T extends CssVariable | undefined = undefined
@@ -21637,6 +21791,24 @@ export declare function Trykker<
   adjustFontFallback?: boolean
   subsets?: Array<'latin' | 'latin-ext'>
 }): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Tsukimi_Rounded<
+  T extends CssVariable | undefined = undefined
+>(options: {
+  weight:
+    | '300'
+    | '400'
+    | '500'
+    | '600'
+    | '700'
+    | Array<'300' | '400' | '500' | '600' | '700'>
+  style?: 'normal' | Array<'normal'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<'latin' | 'latin-ext'>
+}): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Tulpen_One<
   T extends CssVariable | undefined = undefined
 >(options: {
@@ -22308,6 +22480,48 @@ export declare function Wire_One<
   fallback?: string[]
   adjustFontFallback?: boolean
   subsets?: Array<'latin'>
+}): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Wix_Madefor_Display<
+  T extends CssVariable | undefined = undefined
+>(options?: {
+  weight?:
+    | '400'
+    | '500'
+    | '600'
+    | '700'
+    | '800'
+    | 'variable'
+    | Array<'400' | '500' | '600' | '700' | '800'>
+  style?: 'normal' | Array<'normal'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<
+    'cyrillic' | 'cyrillic-ext' | 'latin' | 'latin-ext' | 'vietnamese'
+  >
+}): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Wix_Madefor_Text<
+  T extends CssVariable | undefined = undefined
+>(options?: {
+  weight?:
+    | '400'
+    | '500'
+    | '600'
+    | '700'
+    | '800'
+    | 'variable'
+    | Array<'400' | '500' | '600' | '700' | '800'>
+  style?: 'normal' | 'italic' | Array<'normal' | 'italic'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<
+    'cyrillic' | 'cyrillic-ext' | 'latin' | 'latin-ext' | 'vietnamese'
+  >
 }): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Work_Sans<
   T extends CssVariable | undefined = undefined

--- a/scripts/update-google-fonts.js
+++ b/scripts/update-google-fonts.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs/promises')
 const path = require('path')
 const fetch = require('node-fetch')


### PR DESCRIPTION
### What?
Updates supported google fonts by using the provided script

### Why?
Recently added fonts are not supported with next/font, like https://fonts.google.com/specimen/Instrument+Sans 

### How?
```
node scripts/update-google-fonts.js
```

(or with my shebang change, ./scripts/update-google-fonts.js)