### PR TITLE
chore: Enable `share-generics`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,6 +16,7 @@ linker = "aarch64-linux-musl-gcc"
 rustflags = [
   "--cfg",
   "tokio_unstable",
+  "-Zshare-generics=y",
   "-Csymbol-mangling-version=v0",
   "-Ctarget-feature=-crt-static",
   "-Clink-arg=-lgcc",
@@ -28,6 +29,7 @@ linker = "arm-linux-gnueabihf-gcc"
 rustflags = [
   "--cfg",
   "tokio_unstable",
+  "-Zshare-generics=y",
   "-Csymbol-mangling-version=v0",
   "-Aclippy::too_many_arguments",
 ]


### PR DESCRIPTION
### What?

Reduce the binary size by enabling `-Zshare-generics`.

### Why?

The binary size is way too big.

### How?

`153.6MiB`  => `132.9MiB`

(Apple silicon)


---

Closes WEB-1144

Turbopack counterpart: https://github.com/vercel/turbo/pull/5121