### PR TITLE
Perf: reduce metadata RSC payload

### DIFF
--- a/packages/next/src/lib/metadata/generate/alternate.tsx
+++ b/packages/next/src/lib/metadata/generate/alternate.tsx
@@ -2,6 +2,7 @@ import type { ResolvedMetadata } from '../types/metadata-interface'
 
 import React from 'react'
 import { AlternateLinkDescriptor } from '../types/alternative-urls-types'
+import { MetaFilter } from './meta'
 
 function AlternateLink({
   descriptor,
@@ -25,48 +26,33 @@ export function AlternatesMetadata({
   alternates: ResolvedMetadata['alternates']
 }) {
   if (!alternates) return null
+
   const { canonical, languages, media, types } = alternates
-  return (
-    <>
-      {canonical ? (
-        <AlternateLink rel="canonical" descriptor={canonical} />
-      ) : null}
-      {languages
-        ? Object.entries(languages).map(([locale, descriptors]) => {
-            return descriptors?.map((descriptor, index) => (
-              <AlternateLink
-                rel="alternate"
-                key={index}
-                hrefLang={locale}
-                descriptor={descriptor}
-              />
-            ))
-          })
-        : null}
-      {media
-        ? Object.entries(media).map(([mediaName, descriptors]) =>
-            descriptors?.map((descriptor, index) => (
-              <AlternateLink
-                rel="alternate"
-                key={index}
-                media={mediaName}
-                descriptor={descriptor}
-              />
-            ))
+
+  return MetaFilter([
+    canonical
+      ? AlternateLink({ rel: 'canonical', descriptor: canonical })
+      : null,
+    languages
+      ? Object.entries(languages).flatMap(([locale, descriptors]) =>
+          descriptors?.map((descriptor) =>
+            AlternateLink({ rel: 'alternate', hrefLang: locale, descriptor })
           )
-        : null}
-      {types
-        ? Object.entries(types).map(([type, descriptors]) =>
-            descriptors?.map((descriptor, index) => (
-              <AlternateLink
-                rel="alternate"
-                key={index}
-                type={type}
-                descriptor={descriptor}
-              />
-            ))
+        )
+      : null,
+    media
+      ? Object.entries(media).flatMap(([mediaName, descriptors]) =>
+          descriptors?.map((descriptor) =>
+            AlternateLink({ rel: 'alternate', media: mediaName, descriptor })
           )
-        : null}
-    </>
-  )
+        )
+      : null,
+    types
+      ? Object.entries(types).flatMap(([type, descriptors]) =>
+          descriptors?.map((descriptor) =>
+            AlternateLink({ rel: 'alternate', type, descriptor })
+          )
+        )
+      : null,
+  ])
 }

--- a/packages/next/src/lib/metadata/generate/basic.tsx
+++ b/packages/next/src/lib/metadata/generate/basic.tsx
@@ -1,76 +1,76 @@
 import type { ResolvedMetadata } from '../types/metadata-interface'
 
 import React from 'react'
-import { Meta, MultiMeta } from './meta'
+import { Meta, MetaFilter, MultiMeta } from './meta'
 
 export function BasicMetadata({ metadata }: { metadata: ResolvedMetadata }) {
-  return (
-    <>
-      <meta charSet="utf-8" />
-      {metadata.title !== null && metadata.title.absolute ? (
-        <title>{metadata.title.absolute}</title>
-      ) : null}
-      <Meta name="description" content={metadata.description} />
-      <Meta name="application-name" content={metadata.applicationName} />
-      {metadata.authors
-        ? metadata.authors.map((author, index) => (
-            <React.Fragment key={index}>
-              {author.url && <link rel="author" href={author.url.toString()} />}
-              <Meta name="author" content={author.name} />
-            </React.Fragment>
-          ))
-        : null}
-      {metadata.manifest ? (
-        <link rel="manifest" href={metadata.manifest.toString()} />
-      ) : null}
-      <Meta name="generator" content={metadata.generator} />
-      <Meta name="keywords" content={metadata.keywords?.join(',')} />
-      <Meta name="referrer" content={metadata.referrer} />
-      {metadata.themeColor
-        ? metadata.themeColor.map((themeColor, index) => (
-            <Meta
-              key={index}
-              name="theme-color"
-              content={themeColor.color}
-              media={themeColor.media}
+  return MetaFilter([
+    <meta key="charset" charSet="utf-8" />,
+    metadata.title !== null && metadata.title.absolute ? (
+      <title key="title">{metadata.title.absolute}</title>
+    ) : null,
+    Meta({ name: 'description', content: metadata.description }),
+    Meta({ name: 'application-name', content: metadata.applicationName }),
+    ...(metadata.authors
+      ? metadata.authors.map((author, index) => [
+          author.url ? (
+            <link
+              key={'author' + index}
+              rel="author"
+              href={author.url.toString()}
             />
-          ))
-        : null}
-      <Meta name="color-scheme" content={metadata.colorScheme} />
-      <Meta name="viewport" content={metadata.viewport} />
-      <Meta name="creator" content={metadata.creator} />
-      <Meta name="publisher" content={metadata.publisher} />
-      <Meta name="robots" content={metadata.robots?.basic} />
-      <Meta name="googlebot" content={metadata.robots?.googleBot} />
-      <Meta name="abstract" content={metadata.abstract} />
-      {metadata.archives
-        ? metadata.archives.map((archive) => (
-            <link rel="archives" href={archive} key={archive} />
-          ))
-        : null}
-      {metadata.assets
-        ? metadata.assets.map((asset) => (
-            <link rel="assets" href={asset} key={asset} />
-          ))
-        : null}
-      {metadata.bookmarks
-        ? metadata.bookmarks.map((bookmark) => (
-            <link rel="bookmarks" href={bookmark} key={bookmark} />
-          ))
-        : null}
-      <Meta name="category" content={metadata.category} />
-      <Meta name="classification" content={metadata.classification} />
-      {metadata.other
-        ? Object.entries(metadata.other).map(([name, content]) => (
-            <Meta
-              key={name}
-              name={name}
-              content={Array.isArray(content) ? content.join(',') : content}
-            />
-          ))
-        : null}
-    </>
-  )
+          ) : null,
+          Meta({ name: 'author', content: author.name }),
+        ])
+      : []),
+    metadata.manifest ? (
+      <link key="manifest" rel="manifest" href={metadata.manifest.toString()} />
+    ) : null,
+    Meta({ name: 'generator', content: metadata.generator }),
+    Meta({ name: 'keywords', content: metadata.keywords?.join(',') }),
+    Meta({ name: 'referrer', content: metadata.referrer }),
+    ...(metadata.themeColor
+      ? metadata.themeColor.map((themeColor) =>
+          Meta({
+            name: 'theme-color',
+            content: themeColor.color,
+            media: themeColor.media,
+          })
+        )
+      : []),
+    Meta({ name: 'color-scheme', content: metadata.colorScheme }),
+    Meta({ name: 'viewport', content: metadata.viewport }),
+    Meta({ name: 'creator', content: metadata.creator }),
+    Meta({ name: 'publisher', content: metadata.publisher }),
+    Meta({ name: 'robots', content: metadata.robots?.basic }),
+    Meta({ name: 'googlebot', content: metadata.robots?.googleBot }),
+    Meta({ name: 'abstract', content: metadata.abstract }),
+    ...(metadata.archives
+      ? metadata.archives.map((archive) => (
+          <link rel="archives" href={archive} key={archive} />
+        ))
+      : []),
+    ...(metadata.assets
+      ? metadata.assets.map((asset) => (
+          <link rel="assets" href={asset} key={asset} />
+        ))
+      : []),
+    ...(metadata.bookmarks
+      ? metadata.bookmarks.map((bookmark) => (
+          <link rel="bookmarks" href={bookmark} key={bookmark} />
+        ))
+      : []),
+    Meta({ name: 'category', content: metadata.category }),
+    Meta({ name: 'classification', content: metadata.classification }),
+    ...(metadata.other
+      ? Object.entries(metadata.other).map(([name, content]) =>
+          Meta({
+            name,
+            content: Array.isArray(content) ? content.join(',') : content,
+          })
+        )
+      : []),
+  ])
 }
 
 export function ItunesMeta({ itunes }: { itunes: ResolvedMetadata['itunes'] }) {
@@ -112,32 +112,31 @@ export function AppleWebAppMeta({
   appleWebApp: ResolvedMetadata['appleWebApp']
 }) {
   if (!appleWebApp) return null
+
   const { capable, title, startupImage, statusBarStyle } = appleWebApp
 
-  return (
-    <>
-      {capable ? (
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-      ) : null}
-      <Meta name="apple-mobile-web-app-title" content={title} />
-      {startupImage
-        ? startupImage.map((image, index) => (
-            <link
-              key={index}
-              href={image.url}
-              media={image.media}
-              rel="apple-touch-startup-image"
-            />
-          ))
-        : null}
-      {statusBarStyle ? (
-        <meta
-          name="apple-mobile-web-app-status-bar-style"
-          content={statusBarStyle}
-        />
-      ) : null}
-    </>
-  )
+  return MetaFilter([
+    capable
+      ? Meta({ name: 'apple-mobile-web-app-capable', content: 'yes' })
+      : null,
+    Meta({ name: 'apple-mobile-web-app-title', content: title }),
+    ...(startupImage
+      ? startupImage.map((image, index) => (
+          <link
+            key={index}
+            href={image.url}
+            media={image.media}
+            rel="apple-touch-startup-image"
+          />
+        ))
+      : []),
+    statusBarStyle
+      ? Meta({
+          name: 'apple-mobile-web-app-status-bar-style',
+          content: statusBarStyle,
+        })
+      : null,
+  ])
 }
 
 export function VerificationMeta({
@@ -147,23 +146,21 @@ export function VerificationMeta({
 }) {
   if (!verification) return null
 
-  return (
-    <>
-      <MultiMeta
-        namePrefix="google-site-verification"
-        contents={verification.google}
-      />
-      <MultiMeta namePrefix="y_key" contents={verification.yahoo} />
-      <MultiMeta
-        namePrefix="yandex-verification"
-        contents={verification.yandex}
-      />
-      <MultiMeta namePrefix="me" contents={verification.me} />
-      {verification.other
-        ? Object.entries(verification.other).map(([key, value], index) => (
-            <MultiMeta key={key + index} namePrefix={key} contents={value} />
-          ))
-        : null}
-    </>
-  )
+  return MetaFilter([
+    MultiMeta({
+      namePrefix: 'google-site-verification',
+      contents: verification.google,
+    }),
+    MultiMeta({ namePrefix: 'y_key', contents: verification.yahoo }),
+    MultiMeta({
+      namePrefix: 'yandex-verification',
+      contents: verification.yandex,
+    }),
+    MultiMeta({ namePrefix: 'me', contents: verification.me }),
+    ...(verification.other
+      ? Object.entries(verification.other).map(([key, value]) =>
+          MultiMeta({ namePrefix: key, contents: value })
+        )
+      : []),
+  ])
 }

--- a/packages/next/src/lib/metadata/generate/icons.tsx
+++ b/packages/next/src/lib/metadata/generate/icons.tsx
@@ -2,6 +2,7 @@ import type { ResolvedMetadata } from '../types/metadata-interface'
 import type { Icon, IconDescriptor } from '../types/metadata-types'
 
 import React from 'react'
+import { MetaFilter } from './meta'
 
 function IconDescriptorLink({ icon }: { icon: IconDescriptor }) {
   const { url, rel = 'icon', ...props } = icon
@@ -27,36 +28,14 @@ export function IconsMetadata({ icons }: { icons: ResolvedMetadata['icons'] }) {
   const appleList = icons.apple
   const otherList = icons.other
 
-  return (
-    <>
-      {shortcutList
-        ? shortcutList.map((icon, index) => (
-            <IconLink
-              key={`shortcut-${index}`}
-              rel="shortcut icon"
-              icon={icon}
-            />
-          ))
-        : null}
-      {iconList
-        ? iconList.map((icon, index) => (
-            <IconLink key={`shortcut-${index}`} rel="icon" icon={icon} />
-          ))
-        : null}
-      {appleList
-        ? appleList.map((icon, index) => (
-            <IconLink
-              key={`apple-${index}`}
-              rel="apple-touch-icon"
-              icon={icon}
-            />
-          ))
-        : null}
-      {otherList
-        ? otherList.map((icon, index) => (
-            <IconDescriptorLink key={`other-${index}`} icon={icon} />
-          ))
-        : null}
-    </>
-  )
+  return MetaFilter([
+    shortcutList
+      ? shortcutList.map((icon) => IconLink({ rel: 'shortcut icon', icon }))
+      : null,
+    iconList ? iconList.map((icon) => IconLink({ rel: 'icon', icon })) : null,
+    appleList
+      ? appleList.map((icon) => IconLink({ rel: 'apple-touch-icon', icon }))
+      : null,
+    otherList ? otherList.map((icon) => IconDescriptorLink({ icon })) : null,
+  ])
 }

--- a/packages/next/src/lib/metadata/generate/meta.tsx
+++ b/packages/next/src/lib/metadata/generate/meta.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { nonNullable } from '../../non-nullable'
 
 export function Meta({
   name,
@@ -14,6 +15,7 @@ export function Meta({
   if (typeof content !== 'undefined' && content !== null && content !== '') {
     return (
       <meta
+        key={(name || property) + ':' + content}
         {...(name ? { name } : { property })}
         {...(media ? { media } : undefined)}
         content={typeof content === 'string' ? content : content.toString()}
@@ -61,19 +63,17 @@ function ExtendMeta({
 }) {
   const keyPrefix = namePrefix || propertyPrefix
   if (!content) return null
-  return (
-    <React.Fragment>
-      {Object.entries(content).map(([k, v], index) => {
-        return typeof v === 'undefined' ? null : (
-          <Meta
-            key={keyPrefix + ':' + k + '_' + index}
-            {...(propertyPrefix && { property: getMetaKey(propertyPrefix, k) })}
-            {...(namePrefix && { name: getMetaKey(namePrefix, k) })}
-            content={typeof v === 'string' ? v : v?.toString()}
-          />
-        )
-      })}
-    </React.Fragment>
+  return MetaFilter(
+    Object.entries(content).map(([k, v], index) => {
+      return typeof v === 'undefined' ? null : (
+        <Meta
+          key={keyPrefix + ':' + k + '_' + index}
+          {...(propertyPrefix && { property: getMetaKey(propertyPrefix, k) })}
+          {...(namePrefix && { name: getMetaKey(namePrefix, k) })}
+          content={typeof v === 'string' ? v : v?.toString()}
+        />
+      )
+    })
   )
 }
 
@@ -90,35 +90,35 @@ export function MultiMeta({
     return null
   }
 
-  const keyPrefix = propertyPrefix || namePrefix
-  return (
-    <>
-      {contents.map((content, index) => {
-        if (
-          typeof content === 'string' ||
-          typeof content === 'number' ||
-          content instanceof URL
-        ) {
-          return (
-            <Meta
-              key={keyPrefix + '_' + index}
-              {...(propertyPrefix
-                ? { property: propertyPrefix }
-                : { name: namePrefix })}
-              content={content}
-            />
-          )
-        } else {
-          return (
-            <ExtendMeta
-              key={keyPrefix + '_' + index}
-              namePrefix={namePrefix}
-              propertyPrefix={propertyPrefix}
-              content={content}
-            />
-          )
-        }
-      })}
-    </>
+  return MetaFilter(
+    contents.map((content) => {
+      if (
+        typeof content === 'string' ||
+        typeof content === 'number' ||
+        content instanceof URL
+      ) {
+        return Meta({
+          ...(propertyPrefix
+            ? { property: propertyPrefix }
+            : { name: namePrefix }),
+          content,
+        })
+      } else {
+        return ExtendMeta({
+          namePrefix,
+          propertyPrefix,
+          content,
+        })
+      }
+    })
+  )
+}
+
+export function MetaFilter<T extends {} | {}[]>(
+  items: (T | null)[]
+): NonNullable<T>[] {
+  return items.filter(
+    (item): item is NonNullable<T> =>
+      nonNullable(item) && !(Array.isArray(item) && item.length === 0)
   )
 }

--- a/packages/next/src/lib/metadata/generate/meta.tsx
+++ b/packages/next/src/lib/metadata/generate/meta.tsx
@@ -25,6 +25,15 @@ export function Meta({
   return null
 }
 
+export function MetaFilter<T extends {} | {}[]>(
+  items: (T | null)[]
+): NonNullable<T>[] {
+  return items.filter(
+    (item): item is NonNullable<T> =>
+      nonNullable(item) && !(Array.isArray(item) && item.length === 0)
+  )
+}
+
 type ExtendMetaContent = Record<
   string,
   undefined | string | URL | number | boolean | null | undefined
@@ -111,14 +120,5 @@ export function MultiMeta({
         })
       }
     })
-  )
-}
-
-export function MetaFilter<T extends {} | {}[]>(
-  items: (T | null)[]
-): NonNullable<T>[] {
-  return items.filter(
-    (item): item is NonNullable<T> =>
-      nonNullable(item) && !(Array.isArray(item) && item.length === 0)
   )
 }

--- a/packages/next/src/lib/metadata/generate/opengraph.tsx
+++ b/packages/next/src/lib/metadata/generate/opengraph.tsx
@@ -1,8 +1,7 @@
 import type { ResolvedMetadata } from '../types/metadata-interface'
 import type { TwitterAppDescriptor } from '../types/twitter-types'
 
-import React from 'react'
-import { Meta, MultiMeta } from './meta'
+import { Meta, MetaFilter, MultiMeta } from './meta'
 
 export function OpenGraphMetadata({
   openGraph,
@@ -17,210 +16,206 @@ export function OpenGraphMetadata({
   if ('type' in openGraph) {
     switch (openGraph.type) {
       case 'website':
-        typedOpenGraph = <Meta property="og:type" content="website" />
+        typedOpenGraph = [Meta({ property: 'og:type', content: 'website' })]
         break
       case 'article':
-        typedOpenGraph = (
-          <>
-            <Meta property="og:type" content="article" />
-            <Meta
-              property="article:published_time"
-              content={openGraph.publishedTime?.toString()}
-            />
-            <Meta
-              property="article:modified_time"
-              content={openGraph.modifiedTime?.toString()}
-            />
-            <Meta
-              property="article:expiration_time"
-              content={openGraph.expirationTime?.toString()}
-            />
-            <MultiMeta
-              propertyPrefix="article:author"
-              contents={openGraph.authors}
-            />
-            <Meta property="article:section" content={openGraph.section} />
-            <MultiMeta propertyPrefix="article:tag" contents={openGraph.tags} />
-          </>
-        )
+        typedOpenGraph = [
+          Meta({ property: 'og:type', content: 'article' }),
+          Meta({
+            property: 'article:published_time',
+            content: openGraph.publishedTime?.toString(),
+          }),
+          Meta({
+            property: 'article:modified_time',
+            content: openGraph.modifiedTime?.toString(),
+          }),
+          Meta({
+            property: 'article:expiration_time',
+            content: openGraph.expirationTime?.toString(),
+          }),
+          MultiMeta({
+            propertyPrefix: 'article:author',
+            contents: openGraph.authors,
+          }),
+          Meta({ property: 'article:section', content: openGraph.section }),
+          MultiMeta({
+            propertyPrefix: 'article:tag',
+            contents: openGraph.tags,
+          }),
+        ]
         break
       case 'book':
-        typedOpenGraph = (
-          <>
-            <Meta property="og:type" content="book" />
-            <Meta property="book:isbn" content={openGraph.isbn} />
-            <Meta
-              property="book:release_date"
-              content={openGraph.releaseDate}
-            />
-            <MultiMeta
-              propertyPrefix="book:author"
-              contents={openGraph.authors}
-            />
-            <MultiMeta propertyPrefix="book:tag" contents={openGraph.tags} />
-          </>
-        )
+        typedOpenGraph = [
+          Meta({ property: 'og:type', content: 'book' }),
+          Meta({ property: 'book:isbn', content: openGraph.isbn }),
+          Meta({
+            property: 'book:release_date',
+            content: openGraph.releaseDate,
+          }),
+          MultiMeta({
+            propertyPrefix: 'book:author',
+            contents: openGraph.authors,
+          }),
+          MultiMeta({ propertyPrefix: 'book:tag', contents: openGraph.tags }),
+        ]
         break
       case 'profile':
-        typedOpenGraph = (
-          <>
-            <Meta property="og:type" content="profile" />
-            <Meta property="profile:first_name" content={openGraph.firstName} />
-            <Meta property="profile:last_name" content={openGraph.lastName} />
-            <Meta property="profile:username" content={openGraph.username} />
-            <Meta property="profile:gender" content={openGraph.gender} />
-          </>
-        )
+        typedOpenGraph = [
+          Meta({ property: 'og:type', content: 'profile' }),
+          Meta({
+            property: 'profile:first_name',
+            content: openGraph.firstName,
+          }),
+          Meta({ property: 'profile:last_name', content: openGraph.lastName }),
+          Meta({ property: 'profile:username', content: openGraph.username }),
+          Meta({ property: 'profile:gender', content: openGraph.gender }),
+        ]
         break
       case 'music.song':
-        typedOpenGraph = (
-          <>
-            <Meta property="og:type" content="music.song" />
-            <Meta
-              property="music:duration"
-              content={openGraph.duration?.toString()}
-            />
-            <MultiMeta
-              propertyPrefix="music:album"
-              contents={openGraph.albums}
-            />
-            <MultiMeta
-              propertyPrefix="music:musician"
-              contents={openGraph.musicians}
-            />
-          </>
-        )
+        typedOpenGraph = [
+          Meta({ property: 'og:type', content: 'music.song' }),
+          Meta({
+            property: 'music:duration',
+            content: openGraph.duration?.toString(),
+          }),
+          MultiMeta({
+            propertyPrefix: 'music:album',
+            contents: openGraph.albums,
+          }),
+          MultiMeta({
+            propertyPrefix: 'music:musician',
+            contents: openGraph.musicians,
+          }),
+        ]
         break
       case 'music.album':
-        typedOpenGraph = (
-          <>
-            <Meta property="og:type" content="music.album" />
-            <MultiMeta propertyPrefix="music:song" contents={openGraph.songs} />
-            <MultiMeta
-              propertyPrefix="music:musician"
-              contents={openGraph.musicians}
-            />
-            <Meta
-              property="music:release_date"
-              content={openGraph.releaseDate}
-            />
-          </>
-        )
+        typedOpenGraph = [
+          Meta({ property: 'og:type', content: 'music.album' }),
+          MultiMeta({
+            propertyPrefix: 'music:song',
+            contents: openGraph.songs,
+          }),
+          MultiMeta({
+            propertyPrefix: 'music:musician',
+            contents: openGraph.musicians,
+          }),
+          Meta({
+            property: 'music:release_date',
+            content: openGraph.releaseDate,
+          }),
+        ]
         break
       case 'music.playlist':
-        typedOpenGraph = (
-          <>
-            <Meta property="og:type" content="music.playlist" />
-            <MultiMeta propertyPrefix="music:song" contents={openGraph.songs} />
-            <MultiMeta
-              propertyPrefix="music:creator"
-              contents={openGraph.creators}
-            />
-          </>
-        )
+        typedOpenGraph = [
+          Meta({ property: 'og:type', content: 'music.playlist' }),
+          MultiMeta({
+            propertyPrefix: 'music:song',
+            contents: openGraph.songs,
+          }),
+          MultiMeta({
+            propertyPrefix: 'music:creator',
+            contents: openGraph.creators,
+          }),
+        ]
         break
       case 'music.radio_station':
-        typedOpenGraph = (
-          <>
-            <Meta property="og:type" content="music.radio_station" />
-            <MultiMeta
-              propertyPrefix="music:creator"
-              contents={openGraph.creators}
-            />
-          </>
-        )
+        typedOpenGraph = [
+          Meta({ property: 'og:type', content: 'music.radio_station' }),
+          MultiMeta({
+            propertyPrefix: 'music:creator',
+            contents: openGraph.creators,
+          }),
+        ]
         break
+
       case 'video.movie':
-        typedOpenGraph = (
-          <>
-            <Meta property="og:type" content="video.movie" />
-            <MultiMeta
-              propertyPrefix="video:actor"
-              contents={openGraph.actors}
-            />
-            <MultiMeta
-              propertyPrefix="video:director"
-              contents={openGraph.directors}
-            />
-            <MultiMeta
-              propertyPrefix="video:writer"
-              contents={openGraph.writers}
-            />
-            <Meta property="video:duration" content={openGraph.duration} />
-            <Meta
-              property="video:release_date"
-              content={openGraph.releaseDate}
-            />
-            <MultiMeta propertyPrefix="video:tag" contents={openGraph.tags} />
-          </>
-        )
+        typedOpenGraph = [
+          Meta({ property: 'og:type', content: 'video.movie' }),
+          MultiMeta({
+            propertyPrefix: 'video:actor',
+            contents: openGraph.actors,
+          }),
+          MultiMeta({
+            propertyPrefix: 'video:director',
+            contents: openGraph.directors,
+          }),
+          MultiMeta({
+            propertyPrefix: 'video:writer',
+            contents: openGraph.writers,
+          }),
+          Meta({ property: 'video:duration', content: openGraph.duration }),
+          Meta({
+            property: 'video:release_date',
+            content: openGraph.releaseDate,
+          }),
+          MultiMeta({ propertyPrefix: 'video:tag', contents: openGraph.tags }),
+        ]
         break
       case 'video.episode':
-        typedOpenGraph = (
-          <>
-            <Meta property="og:type" content="video.episode" />
-            <MultiMeta
-              propertyPrefix="video:actor"
-              contents={openGraph.actors}
-            />
-            <MultiMeta
-              propertyPrefix="video:director"
-              contents={openGraph.directors}
-            />
-            <MultiMeta
-              propertyPrefix="video:writer"
-              contents={openGraph.writers}
-            />
-            <Meta property="video:duration" content={openGraph.duration} />
-            <Meta
-              property="video:release_date"
-              content={openGraph.releaseDate}
-            />
-            <MultiMeta propertyPrefix="video:tag" contents={openGraph.tags} />
-            <Meta property="video:series" content={openGraph.series} />
-          </>
-        )
+        typedOpenGraph = [
+          Meta({ property: 'og:type', content: 'video.episode' }),
+          MultiMeta({
+            propertyPrefix: 'video:actor',
+            contents: openGraph.actors,
+          }),
+          MultiMeta({
+            propertyPrefix: 'video:director',
+            contents: openGraph.directors,
+          }),
+          MultiMeta({
+            propertyPrefix: 'video:writer',
+            contents: openGraph.writers,
+          }),
+          Meta({ property: 'video:duration', content: openGraph.duration }),
+          Meta({
+            property: 'video:release_date',
+            content: openGraph.releaseDate,
+          }),
+          MultiMeta({ propertyPrefix: 'video:tag', contents: openGraph.tags }),
+          Meta({ property: 'video:series', content: openGraph.series }),
+        ]
         break
       case 'video.tv_show':
-        typedOpenGraph = <Meta property="og:type" content="video.tv_show" />
+        typedOpenGraph = [
+          Meta({ property: 'og:type', content: 'video.tv_show' }),
+        ]
         break
       case 'video.other':
-        typedOpenGraph = <Meta property="og:type" content="video.other" />
+        typedOpenGraph = [Meta({ property: 'og:type', content: 'video.other' })]
         break
+
       default:
         throw new Error('Invalid OpenGraph type: ' + (openGraph as any).type)
     }
   }
 
-  return (
-    <>
-      <Meta property="og:determiner" content={openGraph.determiner} />
-      <Meta property="og:title" content={openGraph.title?.absolute} />
-      <Meta property="og:description" content={openGraph.description} />
-      <Meta property="og:url" content={openGraph.url?.toString()} />
-      <Meta property="og:site_name" content={openGraph.siteName} />
-      <Meta property="og:locale" content={openGraph.locale} />
-      <Meta property="og:country_name" content={openGraph.countryName} />
-      <Meta property="og:ttl" content={openGraph.ttl?.toString()} />
-      <MultiMeta propertyPrefix="og:image" contents={openGraph.images} />
-      <MultiMeta propertyPrefix="og:video" contents={openGraph.videos} />
-      <MultiMeta propertyPrefix="og:audio" contents={openGraph.audio} />
-      <MultiMeta propertyPrefix="og:email" contents={openGraph.emails} />
-      <MultiMeta
-        propertyPrefix="og:phone_number"
-        contents={openGraph.phoneNumbers}
-      />
-      <MultiMeta
-        propertyPrefix="og:fax_number"
-        contents={openGraph.faxNumbers}
-      />
-      <MultiMeta
-        propertyPrefix="og:locale:alternate"
-        contents={openGraph.alternateLocale}
-      />
-      {typedOpenGraph}
-    </>
-  )
+  return MetaFilter([
+    Meta({ property: 'og:determiner', content: openGraph.determiner }),
+    Meta({ property: 'og:title', content: openGraph.title?.absolute }),
+    Meta({ property: 'og:description', content: openGraph.description }),
+    Meta({ property: 'og:url', content: openGraph.url?.toString() }),
+    Meta({ property: 'og:site_name', content: openGraph.siteName }),
+    Meta({ property: 'og:locale', content: openGraph.locale }),
+    Meta({ property: 'og:country_name', content: openGraph.countryName }),
+    Meta({ property: 'og:ttl', content: openGraph.ttl?.toString() }),
+    MultiMeta({ propertyPrefix: 'og:image', contents: openGraph.images }),
+    MultiMeta({ propertyPrefix: 'og:video', contents: openGraph.videos }),
+    MultiMeta({ propertyPrefix: 'og:audio', contents: openGraph.audio }),
+    MultiMeta({ propertyPrefix: 'og:email', contents: openGraph.emails }),
+    MultiMeta({
+      propertyPrefix: 'og:phone_number',
+      contents: openGraph.phoneNumbers,
+    }),
+    MultiMeta({
+      propertyPrefix: 'og:fax_number',
+      contents: openGraph.faxNumbers,
+    }),
+    MultiMeta({
+      propertyPrefix: 'og:locale:alternate',
+      contents: openGraph.alternateLocale,
+    }),
+    ...(typedOpenGraph ? typedOpenGraph : []),
+  ])
 }
 
 function TwitterAppItem({
@@ -230,16 +225,14 @@ function TwitterAppItem({
   app: TwitterAppDescriptor
   type: 'iphone' | 'ipad' | 'googleplay'
 }) {
-  return (
-    <>
-      <Meta name={`twitter:app:name:${type}`} content={app.name} />
-      <Meta name={`twitter:app:id:${type}`} content={app.id[type]} />
-      <Meta
-        name={`twitter:app:url:${type}`}
-        content={app.url?.[type]?.toString()}
-      />
-    </>
-  )
+  return MetaFilter([
+    Meta({ name: `twitter:app:name:${type}`, content: app.name }),
+    Meta({ name: `twitter:app:id:${type}`, content: app.id[type] }),
+    Meta({
+      name: `twitter:app:url:${type}`,
+      content: app.url?.[type]?.toString(),
+    }),
+  ])
 }
 
 export function TwitterMetadata({
@@ -250,41 +243,37 @@ export function TwitterMetadata({
   if (!twitter) return null
   const { card } = twitter
 
-  return (
-    <>
-      <Meta name="twitter:card" content={card} />
-      <Meta name="twitter:site" content={twitter.site} />
-      <Meta name="twitter:site:id" content={twitter.siteId} />
-      <Meta name="twitter:creator" content={twitter.creator} />
-      <Meta name="twitter:creator:id" content={twitter.creatorId} />
-      <Meta name="twitter:title" content={twitter.title?.absolute} />
-      <Meta name="twitter:description" content={twitter.description} />
-      <MultiMeta namePrefix="twitter:image" contents={twitter.images} />
-      {card === 'player'
-        ? twitter.players.map((player, index) => (
-            <React.Fragment key={index}>
-              <Meta
-                name="twitter:player"
-                content={player.playerUrl.toString()}
-              />
-              <Meta
-                name="twitter:player:stream"
-                content={player.streamUrl.toString()}
-              />
-              <Meta name="twitter:player:width" content={player.width} />
-              <Meta name="twitter:player:height" content={player.height} />
-            </React.Fragment>
-          ))
-        : null}
-      {card === 'app' ? (
-        <>
-          <TwitterAppItem app={twitter.app} type="iphone" />
-          <TwitterAppItem app={twitter.app} type="ipad" />
-          <TwitterAppItem app={twitter.app} type="googleplay" />
-        </>
-      ) : null}
-    </>
-  )
+  return MetaFilter([
+    Meta({ name: 'twitter:card', content: card }),
+    Meta({ name: 'twitter:site', content: twitter.site }),
+    Meta({ name: 'twitter:site:id', content: twitter.siteId }),
+    Meta({ name: 'twitter:creator', content: twitter.creator }),
+    Meta({ name: 'twitter:creator:id', content: twitter.creatorId }),
+    Meta({ name: 'twitter:title', content: twitter.title?.absolute }),
+    Meta({ name: 'twitter:description', content: twitter.description }),
+    MultiMeta({ namePrefix: 'twitter:image', contents: twitter.images }),
+    ...(card === 'player'
+      ? twitter.players.flatMap((player) => [
+          Meta({
+            name: 'twitter:player',
+            content: player.playerUrl.toString(),
+          }),
+          Meta({
+            name: 'twitter:player:stream',
+            content: player.streamUrl.toString(),
+          }),
+          Meta({ name: 'twitter:player:width', content: player.width }),
+          Meta({ name: 'twitter:player:height', content: player.height }),
+        ])
+      : []),
+    ...(card === 'app'
+      ? [
+          TwitterAppItem({ app: twitter.app, type: 'iphone' }),
+          TwitterAppItem({ app: twitter.app, type: 'ipad' }),
+          TwitterAppItem({ app: twitter.app, type: 'googleplay' }),
+        ]
+      : []),
+  ])
 }
 
 export function AppLinksMeta({
@@ -293,22 +282,20 @@ export function AppLinksMeta({
   appLinks: ResolvedMetadata['appLinks']
 }) {
   if (!appLinks) return null
-  return (
-    <>
-      <MultiMeta propertyPrefix="al:ios" contents={appLinks.ios} />
-      <MultiMeta propertyPrefix="al:iphone" contents={appLinks.iphone} />
-      <MultiMeta propertyPrefix="al:ipad" contents={appLinks.ipad} />
-      <MultiMeta propertyPrefix="al:android" contents={appLinks.android} />
-      <MultiMeta
-        propertyPrefix="al:windows_phone"
-        contents={appLinks.windows_phone}
-      />
-      <MultiMeta propertyPrefix="al:windows" contents={appLinks.windows} />
-      <MultiMeta
-        propertyPrefix="al:windows_universal"
-        contents={appLinks.windows_universal}
-      />
-      <MultiMeta propertyPrefix="al:web" contents={appLinks.web} />
-    </>
-  )
+  return MetaFilter([
+    MultiMeta({ propertyPrefix: 'al:ios', contents: appLinks.ios }),
+    MultiMeta({ propertyPrefix: 'al:iphone', contents: appLinks.iphone }),
+    MultiMeta({ propertyPrefix: 'al:ipad', contents: appLinks.ipad }),
+    MultiMeta({ propertyPrefix: 'al:android', contents: appLinks.android }),
+    MultiMeta({
+      propertyPrefix: 'al:windows_phone',
+      contents: appLinks.windows_phone,
+    }),
+    MultiMeta({ propertyPrefix: 'al:windows', contents: appLinks.windows }),
+    MultiMeta({
+      propertyPrefix: 'al:windows_universal',
+      contents: appLinks.windows_universal,
+    }),
+    MultiMeta({ propertyPrefix: 'al:web', contents: appLinks.web }),
+  ])
 }

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -17,6 +17,7 @@ import {
 } from './generate/opengraph'
 import { IconsMetadata } from './generate/icons'
 import { accumulateMetadata, resolveMetadata } from './resolve-metadata'
+import { MetaFilter } from './generate/meta'
 
 // Generate the actual React elements from the resolved metadata.
 export async function MetadataTree({
@@ -42,18 +43,19 @@ export async function MetadataTree({
   })
   const metadata = await accumulateMetadata(resolvedMetadata, options)
 
-  return (
-    <>
-      <BasicMetadata metadata={metadata} />
-      <AlternatesMetadata alternates={metadata.alternates} />
-      <ItunesMeta itunes={metadata.itunes} />
-      <FormatDetectionMeta formatDetection={metadata.formatDetection} />
-      <VerificationMeta verification={metadata.verification} />
-      <AppleWebAppMeta appleWebApp={metadata.appleWebApp} />
-      <OpenGraphMetadata openGraph={metadata.openGraph} />
-      <TwitterMetadata twitter={metadata.twitter} />
-      <AppLinksMeta appLinks={metadata.appLinks} />
-      <IconsMetadata icons={metadata.icons} />
-    </>
-  )
+  const elements = MetaFilter([
+    BasicMetadata({ metadata }),
+    AlternatesMetadata({ alternates: metadata.alternates }),
+    ItunesMeta({ itunes: metadata.itunes }),
+    FormatDetectionMeta({ formatDetection: metadata.formatDetection }),
+    VerificationMeta({ verification: metadata.verification }),
+    AppleWebAppMeta({ appleWebApp: metadata.appleWebApp }),
+    OpenGraphMetadata({ openGraph: metadata.openGraph }),
+    TwitterMetadata({ twitter: metadata.twitter }),
+    AppLinksMeta({ appLinks: metadata.appLinks }),
+    IconsMetadata({ icons: metadata.icons }),
+  ])
+
+  // Wrap with fragment and key to skip react array-key warnings.
+  return <>{elements}</>
 }


### PR DESCRIPTION
### What
Currently when all the metadata rendered as JSX as server components, all the empty metadata which should be skipped as they're rendered as `null` in JSX, are still included in the RSC payload. This helps reduce the initial html size.

### How

Change the JSX components into function calls, and filter out the nullable component that won't be rendered, then they won't show up in the react tree and be serialized.

Before
```
self.__next_f.push([1, "5:[[[\"$\",\"meta\",null,{\"charSet\":\"utf-8\"}],null,null,null,null,null,null,null,null,null,null,[\"$\",\"meta\",null,{\"name\":\"viewport\",\"content\":\"width=device-width, initial-scale=1\"}],null,null,null,null,null,null,null,null,null,null,[]],[null,null,null,null],null,null,[null,null,null,null,null],null,null,null,null,null]\n"])
```

After
```
self.__next_f.push([1, "5:[[[\"$\",\"meta\",\"charset\",{\"charSet\":\"utf-8\"}],[\"$\",\"meta\",\"viewport:width=device-width, initial-scale=1\",{\"name\":\"viewport\",\"content\":\"width=device-width, initial-scale=1\"}]]]\n"])
```


Closes NEXT-1232