### PR TITLE
Fix image loader file emission path for edge runtime

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2124,8 +2124,8 @@ export default async function getBaseWebpackConfig(
                   not: [new RegExp(WEBPACK_RESOURCE_QUERIES.metadata)],
                 },
                 options: {
-                  isServer: isNodeServer || isEdgeServer,
                   isDev: dev,
+                  compilerType,
                   basePath: config.basePath,
                   assetPrefix: config.assetPrefix,
                 },

--- a/test/integration/next-image-new/default/pages/edge.js
+++ b/test/integration/next-image-new/default/pages/edge.js
@@ -1,0 +1,16 @@
+import Image from 'next/image'
+
+import profilePic from '../public/small.jpg'
+
+export const runtime = 'experimental-edge'
+
+function About() {
+  return (
+    <>
+      <h1>edge</h1>
+      <Image src={profilePic} alt="Picture of the author in edge runtime" />
+    </>
+  )
+}
+
+export default About

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -17,7 +17,8 @@ import {
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
-import { existsSync } from 'fs'
+import fs from 'fs/promises'
+import { pathExists } from 'fs-extra'
 
 const appDir = join(__dirname, '../')
 
@@ -1048,10 +1049,11 @@ function runTests(mode) {
       expect(warnings.length).toBe(1)
     })
   } else {
+    pathExists
     //server-only tests
     it('should not create an image folder in server/chunks', async () => {
       expect(
-        existsSync(join(appDir, '.next/server/chunks/static/media'))
+        await pathExists(join(appDir, '.next/server/chunks/static/media'))
       ).toBeFalsy()
     })
     it('should render as unoptimized with missing src prop', async () => {
@@ -1299,6 +1301,13 @@ function runTests(mode) {
       const computedWidth = await getComputed(browser, id, 'width')
       const computedHeight = await getComputed(browser, id, 'height')
       expect(getRatio(computedHeight, computedWidth)).toBeCloseTo(0.75, 1)
+    })
+
+    it('should create images folder in static/media for edge runtime', async () => {
+      const files = await fs.readdir(join(appDir, '.next/static/media'))
+      expect(files).toEqual(
+        expect.arrayContaining([expect.stringMatching(/small\.\w+\.jpg/)])
+      )
     })
   }
 

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -1049,7 +1049,6 @@ function runTests(mode) {
       expect(warnings.length).toBe(1)
     })
   } else {
-    pathExists
     //server-only tests
     it('should not create an image folder in server/chunks', async () => {
       expect(


### PR DESCRIPTION
[slack-thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1685646762333709?thread_ts=1685643782.265269&cid=C04DUD7EB1B)

Using image in pages SSR emitting the static image files into `<rootDir>/static/media`, which should be located at `<rootDir>/.next/static/media`