### PR TITLE
chore: Use `moduleDetection` set to force in create-next-app TS templates

### DIFF
--- a/packages/create-next-app/templates/app-tw/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app-tw/ts/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "moduleDetection": "force",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/packages/create-next-app/templates/app/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app/ts/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "moduleDetection": "force",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/packages/create-next-app/templates/default-tw/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default-tw/ts/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "moduleDetection": "force",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/packages/create-next-app/templates/default/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default/ts/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "moduleDetection": "force",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
## For Contributors

### What?

Up to Typescript 4.9.5, having a module with no imports/exports was labelled as an error. Because of the `isolatedModules`
flag being set to true.

However, as of 5.x.x, this has changed, and how TypeScript detects modules is not the same anymore.

I came into contact with this behaviour change in: https://github.com/vercel/next.js/discussions/50684, I've expanded a bit more in that discussion.

### Why?

In TS 5.x.x a file like this:

```ts
// foo.ts
interface Foo {
  bar(): void;
}
```

Makes it so that we can access `Foo` anywhere. Unless we opt-in this file into module land (with an `import` or `export` expression/statement).

This was not possible up to 4.9.5, where it'd fail with error:

```console
'foo.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module.

1 interface Foo {
  ~~~~~~~~~
```

### How?

This PR proposes introducing `"moduleDetection": "force",`, to opt-in files as modules, in projects made with create-next-app. 

This is not final of course. There's a reason why the TS has introduced this change:

- https://github.com/microsoft/TypeScript/issues/53683#issuecomment-1499441195

> Scripts are no longer errors in `isolatedModules` unless they use global namespace declarations, which is the only kind of construct that is not safe to single-file transpile. See the motivating issue #46295, design discussion in #51813, and implementation at [cf5c284](https://github.com/microsoft/TypeScript/commit/cf5c28494bd7d2d354beb13ac24197254a4c0bd6) as part of #52203.

Perhaps we should include `"moduleDetection": "auto",` instead, which is the default, and append a section to the README, saying that to avoid the issue described above, one has to change that "force". 

One has to also wonder if there's actually any potential "danger" of types becoming globally available like that. 

I tried to include everything I've been able to gather with respect to this "change in behaviour".

Please feel free to dismiss and close the PR unilaterally if you think it is a non-issue.


