### PR TITLE
next/font: tolerate missing unused fields in capsize map

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/font_fallback.rs
@@ -24,24 +24,18 @@ use crate::{
 };
 
 /// An entry in the Google fonts metrics map
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct FontMetricsMapEntry {
-    #[allow(unused)]
-    family_name: String,
     category: String,
-    #[allow(unused)]
-    cap_height: i32,
     ascent: i32,
     descent: i32,
     line_gap: u32,
     units_per_em: u32,
-    #[allow(unused)]
-    x_height: i32,
     x_width_avg: f64,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub(super) struct FontMetricsMap(pub HashMap<String, FontMetricsMapEntry>);
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]
@@ -61,49 +55,44 @@ pub(super) async fn get_font_fallback(
         Some(fallback) => FontFallback::Manual(StringsVc::cell(fallback.clone())).cell(),
         None => {
             let metrics_json =
-                load_next_json(context, "/dist/server/capsize-font-metrics.json").await;
-            match metrics_json {
-                Ok(metrics_json) => {
-                    let fallback = lookup_fallback(
-                        &options.font_family,
-                        metrics_json,
-                        options.adjust_font_fallback,
-                    );
+                load_next_json(context, "/dist/server/capsize-font-metrics.json").await?;
+            let fallback = lookup_fallback(
+                &options.font_family,
+                metrics_json,
+                options.adjust_font_fallback,
+            );
 
-                    match fallback {
-                        Ok(fallback) => FontFallback::Automatic(
-                            AutomaticFontFallback {
-                                scoped_font_family: get_scoped_font_family(
-                                    FontFamilyType::Fallback.cell(),
-                                    options_vc.font_family(),
-                                    request_hash,
-                                ),
-                                local_font_family: StringVc::cell(fallback.font_family),
-                                adjustment: fallback.adjustment,
-                            }
-                            .cell(),
-                        )
-                        .cell(),
-                        Err(_) => {
-                            NextFontIssue {
-                                path: context,
-                                title: StringVc::cell(format!(
-                                    "Failed to find font override values for font `{}`",
-                                    &options.font_family,
-                                )),
-                                description: StringVc::cell(
-                                    "Skipping generating a fallback font.".to_owned(),
-                                ),
-                                severity: IssueSeverity::Warning.cell(),
-                            }
-                            .cell()
-                            .as_issue()
-                            .emit();
-                            FontFallback::Error.cell()
-                        }
+            match fallback {
+                Ok(fallback) => FontFallback::Automatic(
+                    AutomaticFontFallback {
+                        scoped_font_family: get_scoped_font_family(
+                            FontFamilyType::Fallback.cell(),
+                            options_vc.font_family(),
+                            request_hash,
+                        ),
+                        local_font_family: StringVc::cell(fallback.font_family),
+                        adjustment: fallback.adjustment,
                     }
+                    .cell(),
+                )
+                .cell(),
+                Err(_) => {
+                    NextFontIssue {
+                        path: context,
+                        title: StringVc::cell(format!(
+                            "Failed to find font override values for font `{}`",
+                            &options.font_family,
+                        )),
+                        description: StringVc::cell(
+                            "Skipping generating a fallback font.".to_owned(),
+                        ),
+                        severity: IssueSeverity::Warning.cell(),
+                    }
+                    .cell()
+                    .as_issue()
+                    .emit();
+                    FontFallback::Error.cell()
                 }
-                Err(_) => FontFallback::Error.cell(),
             }
         }
     })


### PR DESCRIPTION
Some font entries in capsize do not include fields like `cap_height` and `x_height`. Since these are unused by next/font, remove these from the serde structure entirely.

Additionally, this makes it so that failing to read or deserialize the capsize map results in an `Error` rather than a `FontFallbackError`, which causes a build failure rather than silently omitting a fallback font. `next/font` should always include this map, and it obscured the real issue here. However, a missing entry in this map _should_ result in omitting a fallback.
