### PR TITLE
Optimize next-app-loader resolving speed

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -28,7 +28,7 @@ import {
   PAGES_DIR_ALIAS,
   INSTRUMENTATION_HOOK_FILENAME,
 } from '../lib/constants'
-import { fileExists } from '../lib/file-exists'
+import { FileType, fileExists } from '../lib/file-exists'
 import { findPagesDir } from '../lib/find-pages-dir'
 import loadCustomRoutes, {
   CustomRoutes,
@@ -588,7 +588,7 @@ export default async function build(
           for (const page in mappedPages) {
             const hasPublicPageFile = await fileExists(
               path.join(publicDir, page === '/' ? '/index' : page),
-              'file'
+              FileType.File
             )
             if (hasPublicPageFile) {
               conflictingPublicFiles.push(page)

--- a/packages/next/src/build/webpack/loaders/metadata/discover.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/discover.ts
@@ -1,4 +1,3 @@
-import type webpack from 'webpack'
 import type {
   CollectingMetadata,
   PossibleStaticMetadataFileNameConvention,
@@ -7,6 +6,7 @@ import path from 'path'
 import { stringify } from 'querystring'
 import { STATIC_METADATA_IMAGES } from '../../../../lib/metadata/is-metadata-route'
 import { WEBPACK_RESOURCE_QUERIES } from '../../../../lib/constants'
+import { MetadataResolver } from '../next-app-loader'
 
 const METADATA_TYPE = 'metadata'
 
@@ -16,16 +16,14 @@ async function enumMetadataFiles(
   filename: string,
   extensions: readonly string[],
   {
-    resolvePath,
-    loaderContext,
+    metadataResolver,
     // When set to true, possible filename without extension could: icon, icon0, ..., icon9
     numericSuffix,
   }: {
-    resolvePath: (pathname: string) => Promise<string>
-    loaderContext: webpack.LoaderContext<any>
+    metadataResolver: MetadataResolver
     numericSuffix: boolean
   }
-) {
+): Promise<string[]> {
   const collectedFiles: string[] = []
 
   const possibleFileNames = [filename].concat(
@@ -36,19 +34,9 @@ async function enumMetadataFiles(
       : []
   )
   for (const name of possibleFileNames) {
-    for (const ext of extensions) {
-      const pathname = path.join(dir, `${name}.${ext}`)
-      try {
-        const resolved = await resolvePath(pathname)
-        loaderContext.addDependency(resolved)
-
-        collectedFiles.push(resolved)
-      } catch (err: any) {
-        if (!err.message.includes("Can't resolve")) {
-          throw err
-        }
-        loaderContext.addMissingDependency(pathname)
-      }
+    const resolved = await metadataResolver(path.join(dir, name), extensions)
+    if (resolved) {
+      collectedFiles.push(resolved)
     }
   }
 
@@ -59,16 +47,14 @@ export async function createStaticMetadataFromRoute(
   resolvedDir: string,
   {
     segment,
-    resolvePath,
+    metadataResolver,
     isRootLayoutOrRootPage,
-    loaderContext,
     pageExtensions,
     basePath,
   }: {
     segment: string
-    resolvePath: (pathname: string) => Promise<string>
+    metadataResolver: MetadataResolver
     isRootLayoutOrRootPage: boolean
-    loaderContext: webpack.LoaderContext<any>
     pageExtensions: string[]
     basePath: string
   }
@@ -82,11 +68,6 @@ export async function createStaticMetadataFromRoute(
     manifest: undefined,
   }
 
-  const opts = {
-    resolvePath,
-    loaderContext,
-  }
-
   async function collectIconModuleIfExists(
     type: PossibleStaticMetadataFileNameConvention
   ) {
@@ -96,7 +77,7 @@ export async function createStaticMetadataFromRoute(
         resolvedDir,
         'manifest',
         staticManifestExtension.concat(pageExtensions),
-        { ...opts, numericSuffix: false }
+        { metadataResolver, numericSuffix: false }
       )
       if (manifestFile.length > 0) {
         hasStaticMetadataFiles = true
@@ -116,7 +97,7 @@ export async function createStaticMetadataFromRoute(
         ...STATIC_METADATA_IMAGES[type].extensions,
         ...(type === 'favicon' ? [] : pageExtensions),
       ],
-      { ...opts, numericSuffix: true }
+      { metadataResolver, numericSuffix: true }
     )
     resolvedMetadataFiles
       .sort((a, b) => a.localeCompare(b))

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -52,7 +52,9 @@ const GLOBAL_ERROR_FILE_TYPE = 'global-error'
 const PAGE_SEGMENT = 'page$'
 
 type DirResolver = (pathToResolve: string) => string
-type PathResolver = (pathname: string) => Promise<string | undefined>
+type PathResolver = (
+  pathname: string
+) => Promise<string | undefined> | string | undefined
 export type MetadataResolver = (
   pathname: string,
   extensions: readonly string[]
@@ -72,14 +74,14 @@ async function createAppRouteCode({
   name,
   page,
   pagePath,
-  resolver,
+  resolveAppRoute,
   pageExtensions,
   nextConfigOutput,
 }: {
   name: string
   page: string
   pagePath: string
-  resolver: PathResolver
+  resolveAppRoute: PathResolver
   pageExtensions: string[]
   nextConfigOutput: NextConfig['output']
 }): Promise<string> {
@@ -89,7 +91,7 @@ async function createAppRouteCode({
 
   // This, when used with the resolver will give us the pathname to the built
   // route handler file.
-  let resolvedPagePath = await resolver(routePath)
+  let resolvedPagePath = await resolveAppRoute(routePath)
   if (!resolvedPagePath) {
     throw new Error(
       `Invariant: could not resolve page path for ${name} at ${routePath}`
@@ -479,6 +481,10 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
     return createAbsolutePath(appDir, pathToResolve)
   }
 
+  const resolveAppRoute: PathResolver = (pathToResolve) => {
+    return createAbsolutePath(appDir, pathToResolve)
+  }
+
   const resolver: PathResolver = async (pathname) => {
     const absolutePath = createAbsolutePath(appDir, pathname)
 
@@ -512,7 +518,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
       page: loaderOptions.page,
       name,
       pagePath,
-      resolver,
+      resolveAppRoute,
       pageExtensions,
       nextConfigOutput,
     })

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -496,7 +496,8 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
     const absolutePath = createAbsolutePath(appDir, pathname)
 
     for (const ext of exts) {
-      const absolutePathWithExtension = `${absolutePath}${ext}`
+      // Compared to `resolver` above the exts do not have the `.` included already, so it's added here.
+      const absolutePathWithExtension = `${absolutePath}.${ext}`
       if (await fileExists(absolutePathWithExtension, FileType.File)) {
         return absolutePathWithExtension
       } else {

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -18,7 +18,7 @@ import { Telemetry } from '../telemetry/storage'
 import loadConfig from '../server/config'
 import { findPagesDir } from '../lib/find-pages-dir'
 import { findRootDir } from '../lib/find-root'
-import { fileExists } from '../lib/file-exists'
+import { fileExists, FileType } from '../lib/file-exists'
 import { getNpxCommand } from '../lib/helpers/get-npx-command'
 import Watchpack from 'next/dist/compiled/watchpack'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
@@ -161,7 +161,7 @@ const nextDev: CliCommand = async (argv) => {
   dir = getProjectDir(process.env.NEXT_PRIVATE_DEV_DIR || args._[0])
 
   // Check if pages dir exists and warn if not
-  if (!(await fileExists(dir, 'directory'))) {
+  if (!(await fileExists(dir, FileType.Directory))) {
     printAndExit(`> No such directory exists as the project root: ${dir}`)
   }
 

--- a/packages/next/src/lib/file-exists.ts
+++ b/packages/next/src/lib/file-exists.ts
@@ -1,15 +1,20 @@
 import { constants, promises } from 'fs'
 import isError from './is-error'
 
+export enum FileType {
+  File = 'file',
+  Directory = 'directory',
+}
+
 export async function fileExists(
   fileName: string,
-  type?: 'file' | 'directory'
+  type?: FileType
 ): Promise<boolean> {
   try {
-    if (type === 'file') {
+    if (type === FileType.File) {
       const stats = await promises.stat(fileName)
       return stats.isFile()
-    } else if (type === 'directory') {
+    } else if (type === FileType.Directory) {
       const stats = await promises.stat(fileName)
       return stats.isDirectory()
     } else {

--- a/packages/next/src/lib/verify-partytown-setup.ts
+++ b/packages/next/src/lib/verify-partytown-setup.ts
@@ -6,7 +6,7 @@ import {
   hasNecessaryDependencies,
   NecessaryDependencies,
 } from './has-necessary-dependencies'
-import { fileExists } from './file-exists'
+import { fileExists, FileType } from './file-exists'
 import { FatalError } from './fatal-error'
 import { recursiveDelete } from './recursive-delete'
 import * as Log from '../build/output/log'
@@ -44,7 +44,10 @@ async function copyPartytownStaticFiles(
   staticDir: string
 ) {
   const partytownLibDir = path.join(staticDir, '~partytown')
-  const hasPartytownLibDir = await fileExists(partytownLibDir, 'directory')
+  const hasPartytownLibDir = await fileExists(
+    partytownLibDir,
+    FileType.Directory
+  )
 
   if (hasPartytownLibDir) {
     await recursiveDelete(partytownLibDir)


### PR DESCRIPTION
## What?

We recently implemented an optimized resolving method for `app` in Turbopack, this ports some of the main changes in that resolving logic to optimize `next-app-loader` which during compilation resolves the tree structure that we use to render in `app-render.tsx`.

Here's the results for a page that is nested a few levels deep on vercel.com using App Router. These results only cover `next-app-loader`, not any modules compiled below it.

### Before

<img width="671" alt="CleanShot 2023-06-03 at 22 36 26@2x" src="https://github.com/vercel/next.js/assets/6324199/0edeb060-2460-4a7d-95a7-1c22ea26a065">

### After

<img width="673" alt="CleanShot 2023-06-03 at 22 55 10@2x" src="https://github.com/vercel/next.js/assets/6324199/f40964fc-b169-4d95-8711-73cbff3ec76a">


## Raw numbers

<table>
<tr>
 <td>Before</td>
 <td>After</td>
 <td>Delta</td>
 <td>Delta (percent)</td>
</tr>
<tr>
 <td>1.620 ms</td>
 <td>76.39 ms</td>
 <td>-1.543.61 ms</td>
  <td>-95.2%</td>
</tr>
</table>

## How?

Changed the resolving logic to use `fileExists`, looping over the provided pageExtensions.
For Turbopack we have a process that does only one pass for generating all trees. That also only reads directories instead of checking individual files, which is even better (<5ms for generating all possible trees) but this PR is a quick win that has a big impact already without refactoring the entire entries generation in webpack.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation or adding/fixing Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
