### PR TITLE
Revert "ci(workflow): enable datadog traces for the tests"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,8 +23,6 @@ env:
   # we build a dev binary for use in CI so skip downloading
   # canary next-swc binaries in the monorepo
   NEXT_SKIP_NATIVE_POSTINSTALL: 1
-  DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
-  DATADOG_TRACE_NEXTJS_TEST: 'true'
   TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN }}
   NEXT_TEST_JOB: 1
 

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -41,8 +41,6 @@ env:
   # we build a dev binary for use in CI so skip downloading
   # canary next-swc binaries in the monorepo
   NEXT_SKIP_NATIVE_POSTINSTALL: 1
-  DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
-  DATADOG_TRACE_NEXTJS_TEST: 'true'
   TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN }}
   NEXT_TEST_JOB: 1
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -322,23 +322,6 @@ async function main() {
 
       const shouldRecordTestWithReplay = process.env.RECORD_REPLAY && isRetry
 
-      const traceEnv =
-        process.env.DATADOG_API_KEY && process.env.DATADOG_TRACE_NEXTJS_TEST
-          ? {
-              DD_API_KEY: process.env.DATADOG_API_KEY,
-              DD_CIVISIBILITY_AGENTLESS_ENABLED: 'true',
-              DD_ENV: 'ci',
-              DD_SERVICE: 'nextjs',
-              NODE_OPTIONS: !!process.env.DATADOG_API_KEY
-                ? '-r dd-trace/ci/init'
-                : undefined,
-            }
-          : {}
-
-      if (traceEnv.DD_API_KEY) {
-        console.log(`Running test with Datadog tracing enabled`)
-      }
-
       const child = spawn(
         jestPath,
         [
@@ -358,7 +341,6 @@ async function main() {
           stdio: ['ignore', 'pipe', 'pipe'],
           env: {
             ...process.env,
-            ...traceEnv,
             RECORD_REPLAY: shouldRecordTestWithReplay,
             // run tests in headless mode by default
             HEADLESS: 'true',


### PR DESCRIPTION
Reverts vercel/next.js#50619

Seeing some weird failure supposed to not occur since we never enabled this 

https://github.com/vercel/next.js/actions/runs/5181685987/jobs/9337538270?pr=50600

Investigating after reverting.