### PR TITLE
Update PR stats next-swc build

### DIFF
--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -59,6 +59,10 @@ jobs:
             turbo-${{ github.job }}-${{ github.ref_name }}-${{ steps.get-week.outputs.WEEK }}-
             turbo-${{ github.job }}-canary-${{ steps.get-week.outputs.WEEK }}-
 
+      - name: Make more disk space
+        continue-on-error: true
+        run: sudo rm -rf /usr/local/lib/android
+
       - name: Build in docker
         uses: addnab/docker-run-action@v3
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}


### PR DESCRIPTION
This is still using the dev build of `next-swc` which uses up more disk space so adds the free-up disk space step from previous workflow. 

x-ref: https://github.com/vercel/next.js/actions/runs/5183623872/jobs/9341729073?pr=50820
x-ref: https://github.com/vercel/next.js/actions/runs/5179335311/jobs/9332066554?pr=50615