### PR TITLE
Update id config handling

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -270,6 +270,9 @@ const configSchema = {
         craCompat: {
           type: 'boolean',
         },
+        useDeploymentId: {
+          type: 'boolean',
+        },
         useDeploymentIdServerActions: {
           type: 'boolean',
         },

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -144,6 +144,7 @@ export interface NextJsWebpackConfig {
 }
 
 export interface ExperimentalConfig {
+  useDeploymentId?: boolean
   useDeploymentIdServerActions?: boolean
   deploymentId?: string
   logging?: 'verbose'
@@ -662,8 +663,9 @@ export const defaultConfig: NextConfig = {
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,
   experimental: {
+    useDeploymentId: false,
+    deploymentId: undefined,
     useDeploymentIdServerActions: false,
-    deploymentId: process.env.NEXT_DEPLOYMENT_ID || '',
     appDocumentPreloading: undefined,
     clientRouterFilter: false,
     clientRouterFilterRedirects: false,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -459,6 +459,14 @@ function assignDefaults(
     }
   }
 
+  // only leverage deploymentId
+  if (result.experimental?.useDeploymentId && process.env.NEXT_DEPLOYMENT_ID) {
+    if (!result.experimental) {
+      result.experimental = {}
+    }
+    result.experimental.deploymentId = process.env.NEXT_DEPLOYMENT_ID
+  }
+
   // use the closest lockfile as tracing root
   if (!result.experimental?.outputFileTracingRoot) {
     let rootDir = findRootDir(dir)

--- a/test/production/deployment-id-handling/deployment-id-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-handling.test.ts
@@ -10,6 +10,11 @@ createNextDescribe(
     env: {
       NEXT_DEPLOYMENT_ID: deploymentId,
     },
+    nextConfig: {
+      experimental: {
+        useDeploymentId: true,
+      },
+    },
   },
   ({ next }) => {
     it.each([


### PR DESCRIPTION
Adds a separate flag for leveraging the env variable. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04TNLL0LSK/p1685816709509329)