### PR TITLE
Add ignores to fix jest-haste failures

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ const customJestConfig = {
     '<rootDir>/../packages/next/src/',
     '<rootDir>/../packages/font/src/',
   ],
+  modulePathIgnorePatterns: ['/\\.next/'],
   modulePaths: ['<rootDir>/lib'],
   transformIgnorePatterns: ['/next[/\\\\]dist/', '/\\.next/'],
   globals: {

--- a/run-tests.js
+++ b/run-tests.js
@@ -458,16 +458,7 @@ async function main() {
           )
           break
         } catch (err) {
-          // jest-hast-map can cause a false failure do to
-          // the .next/package.json generated
-          const isJestHasteError =
-            (err.output?.includes('Error: Cannot parse') ||
-              err.output?.includes(
-                'Haste module map. It cannot be resolved'
-              )) &&
-            err.output?.includes('jest-haste-map')
-
-          if (i < numRetries || isJestHasteError) {
+          if (i < numRetries) {
             try {
               let testDir = path.dirname(path.join(__dirname, test))
 


### PR DESCRIPTION
This pops up occasionally depending on order tests are run and `.next` being present and `jest` trying to process modules inside this folder. 

x-ref: https://github.com/vercel/next.js/actions/runs/5193671295/jobs/9364540542?pr=50869 