### PR TITLE
add turbopack integration tests to CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,5 +5,5 @@ filter = "package(next-dev-tests)"
 leak-timeout = "500ms"
 retries = 2
 slow-timeout = "60s"
-threads-required = 2
+threads-required = 4
 failure-output = "immediate-final"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -63,6 +63,27 @@ jobs:
       afterBuild: turbo run test-cargo-unit
     secrets: inherit
 
+  test-cargo-integration:
+    name: test cargo integration
+    needs: ['build']
+
+    uses: ./.github/workflows/build_reusable.yml
+    with:
+      skipForDocsOnly: 'yes'
+      skipInstallBuild: 'yes'
+      needsNextest: 'yes'
+      afterBuild: turbo run test-cargo-integration
+
+  test-cargo-bench:
+    name: test cargo benchmarks
+    needs: ['build']
+
+    uses: ./.github/workflows/build_reusable.yml
+    with:
+      skipForDocsOnly: 'yes'
+      skipInstallBuild: 'yes'
+      afterBuild: turbo run test-cargo-bench
+
   rust-check:
     name: rust check
     needs: ['build']

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,7 +71,6 @@ jobs:
     with:
       skipForDocsOnly: 'yes'
       needsNextest: 'yes'
-      needsChromium: 'yes'
       afterBuild: turbo run test-cargo-integration
 
   test-cargo-bench:
@@ -81,7 +80,6 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
-      needsChromium: 'yes'
       afterBuild: turbo run test-cargo-bench
 
   rust-check:
@@ -107,7 +105,6 @@ jobs:
   test-next-swc-wasm:
     name: test next-swc wasm
     needs: ['build']
-
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -177,6 +177,8 @@ jobs:
         'test-prod',
         'test-integration',
         'test-cargo-unit',
+        'test-cargo-integration',
+        'test-cargo-bench',
         'rust-check',
         'test-next-swc-wasm',
         'test-turbopack-dev',

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,6 +68,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
+      needsRust: 'yes'
       skipInstallBuild: 'yes'
       skipNativeBuild: 'yes'
       afterBuild: turbo run test-cargo-unit
@@ -81,6 +82,7 @@ jobs:
     with:
       skipForDocsOnly: 'yes'
       needsNextest: 'yes'
+      needsRust: 'yes'
       skipNativeBuild: 'yes'
       afterBuild: xvfb-run turbo run test-cargo-integration
 
@@ -91,6 +93,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
+      needsRust: 'yes'
       skipNativeBuild: 'yes'
       afterBuild: xvfb-run turbo run test-cargo-bench
 
@@ -101,6 +104,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
+      needsRust: 'yes'
       skipInstallBuild: 'yes'
       skipNativeBuild: 'yes'
       afterBuild: turbo run rust-check

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,7 +71,7 @@ jobs:
     with:
       skipForDocsOnly: 'yes'
       needsNextest: 'yes'
-      afterBuild: turbo run test-cargo-integration
+      afterBuild: xvfb-run turbo run test-cargo-integration
 
   test-cargo-bench:
     name: test cargo benchmarks
@@ -80,7 +80,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
-      afterBuild: turbo run test-cargo-bench
+      afterBuild: xvfb-run turbo run test-cargo-bench
 
   rust-check:
     name: rust check

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,6 +71,7 @@ jobs:
     with:
       skipForDocsOnly: 'yes'
       needsNextest: 'yes'
+      needsChromium: 'yes'
       afterBuild: turbo run test-cargo-integration
 
   test-cargo-bench:
@@ -80,6 +81,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
+      needsChromium: 'yes'
       afterBuild: turbo run test-cargo-bench
 
   rust-check:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,14 +28,23 @@ env:
   NEXT_TEST_JOB: 1
 
 jobs:
-  build:
+  build-native:
+    name: build-native
+    uses: ./.github/workflows/build_reusable.yml
+    with:
+      skipInstallBuild: 'yes'
+    secrets: inherit
+
+  build-next:
     name: build
     uses: ./.github/workflows/build_reusable.yml
+    with:
+      skipNativeBuild: 'yes'
     secrets: inherit
 
   lint:
     name: lint
-    needs: ['build']
+    needs: ['build-native', 'build-next']
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -44,7 +53,7 @@ jobs:
 
   check-types-precompiled:
     name: types and precompiled
-    needs: ['build']
+    needs: ['build-native', 'build-next']
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -54,48 +63,52 @@ jobs:
 
   test-cargo-unit:
     name: test cargo unit
-    needs: ['build']
+    needs: ['build-next']
 
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
       skipInstallBuild: 'yes'
+      skipNativeBuild: 'yes'
       afterBuild: turbo run test-cargo-unit
     secrets: inherit
 
   test-cargo-integration:
     name: test cargo integration
-    needs: ['build']
+    needs: ['build-next']
 
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
       needsNextest: 'yes'
+      skipNativeBuild: 'yes'
       afterBuild: xvfb-run turbo run test-cargo-integration
 
   test-cargo-bench:
     name: test cargo benchmarks
-    needs: ['build']
+    needs: ['build-next']
 
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
+      skipNativeBuild: 'yes'
       afterBuild: xvfb-run turbo run test-cargo-bench
 
   rust-check:
     name: rust check
-    needs: ['build']
+    needs: ['build-next']
 
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
       skipInstallBuild: 'yes'
+      skipNativeBuild: 'yes'
       afterBuild: turbo run rust-check
     secrets: inherit
 
   test-turbopack-dev:
     name: test turbopack dev
-    needs: ['build']
+    needs: ['build-native', 'build-next']
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
@@ -104,7 +117,7 @@ jobs:
 
   test-next-swc-wasm:
     name: test next-swc wasm
-    needs: ['build']
+    needs: ['build-native', 'build-next']
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
@@ -113,7 +126,7 @@ jobs:
 
   test-dev:
     name: test dev
-    needs: ['build']
+    needs: ['build-native', 'build-next']
     strategy:
       fail-fast: false
       matrix:
@@ -127,7 +140,7 @@ jobs:
 
   test-prod:
     name: test prod
-    needs: ['build']
+    needs: ['build-native', 'build-next']
     strategy:
       fail-fast: false
       matrix:
@@ -141,7 +154,7 @@ jobs:
 
   test-integration:
     name: test integration
-    needs: ['build']
+    needs: ['build-native', 'build-next']
     strategy:
       fail-fast: false
       matrix:
@@ -156,7 +169,7 @@ jobs:
 
   test-firefox-safari:
     name: test firefox and safari
-    needs: ['build']
+    needs: ['build-native', 'build-next']
 
     uses: ./.github/workflows/build_reusable.yml
     with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,7 +70,6 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
-      skipInstallBuild: 'yes'
       needsNextest: 'yes'
       afterBuild: turbo run test-cargo-integration
 
@@ -81,7 +80,6 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
-      skipInstallBuild: 'yes'
       afterBuild: turbo run test-cargo-bench
 
   rust-check:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
     secrets: inherit
 
   build-next:
-    name: build
+    name: build-next
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipNativeBuild: 'yes'
@@ -180,7 +180,8 @@ jobs:
   tests-pass:
     needs:
       [
-        'build',
+        'build-native',
+        'build-next',
         'lint',
         'check-types-precompiled',
         'test-dev',

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -84,11 +84,15 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - run: rustc --version
+        if: ${{ inputs.skipNativeBuild != 'yes' || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
 
       - run: npm i -g yarn "pnpm@${PNPM_VERSION}" "turbo@${TURBO_VERSION}" "@napi-rs/cli@${NAPI_CLI_VERSION}"
 
       # clean up any previous artifacts to avoid hitting disk space limits
-      - run: git clean -xdf && rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target && cargo clean
+      - run: git clean -xdf && rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
+
+      - run: cargo clean
+        if: ${{ inputs.skipNativeBuild != 'yes' || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
 
       - run: echo "DOCS_CHANGE<<EOF" >> $GITHUB_OUTPUT; echo "$(node scripts/run-for-change.js --not --type docs --exec echo 'nope')" >> $GITHUB_OUTPUT; echo 'EOF' >> $GITHUB_OUTPUT
         name: check docs only change

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -11,6 +11,10 @@ on:
         required: false
         description: 'whether to skip pnpm install && pnpm build'
         type: string
+      skipNativeBuild:
+        required: false
+        description: 'whether to skip building native modules'
+        type: string
       skipForDocsOnly:
         required: false
         description: 'skip for docs only changes'
@@ -18,6 +22,10 @@ on:
       nodeVersion:
         required: false
         description: 'version of Node.js to use'
+        type: string
+      needsRust:
+        required: false
+        description: 'if rust is needed'
         type: string
       needsNextest:
         required: false
@@ -67,6 +75,7 @@ jobs:
       # local action -> needs to run after checkout
       - name: Install Rust
         uses: ./.github/actions/setup-rust
+        if: ${{ inputs.skipNativeBuild != 'yes' || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
         with:
           components: rustfmt, clippy
 
@@ -90,6 +99,7 @@ jobs:
         name: normalize versions
 
       - run: turbo run build-native-release --summarize -- --target x86_64-unknown-linux-gnu
+        if: ${{ inputs.skipNativeBuild != 'yes' }}
 
       - name: Upload next-swc artifact
         if: ${{ inputs.uploadSwcArtifact == 'yes' }}
@@ -117,9 +127,6 @@ jobs:
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
       - run: turbo run get-test-timings -- --build ${{ github.sha }}
-
-      - run: df -h
-      - run: free -mh
 
       - run: /bin/bash -c "${{ inputs.afterBuild }}"
         if: ${{inputs.skipForDocsOnly != 'yes' || steps.docs-change.outputs.DOCS_CHANGE == 'nope'}}

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -59,8 +59,6 @@ jobs:
       - run: fnm use ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
       - run: node -v
       - run: pwd
-      - run: df -h
-      - run: free -mh
 
       - uses: actions/checkout@v3
         with:
@@ -119,6 +117,9 @@ jobs:
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
       - run: turbo run get-test-timings -- --build ${{ github.sha }}
+
+      - run: df -h
+      - run: free -mh
 
       - run: /bin/bash -c "${{ inputs.afterBuild }}"
         if: ${{inputs.skipForDocsOnly != 'yes' || steps.docs-change.outputs.DOCS_CHANGE == 'nope'}}

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -23,6 +23,10 @@ on:
         required: false
         description: 'if nextest rust dep is needed'
         type: string
+      needsChromium:
+        required: false
+        description: 'if chromium is needed'
+        type: string
       uploadSwcArtifact:
         required: false
         description: 'if swc artifact needs uploading'
@@ -73,6 +77,10 @@ jobs:
       - name: Install nextest
         if: ${{ inputs.needsNextest == 'yes' }}
         uses: taiki-e/install-action@nextest
+
+      - name: Install Chromium
+        if: ${{ inputs.needsChromium == 'yes' }}
+        run: sudo apt-get update && sudo apt-get -y install chromium
 
       - run: rustc --version
 

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -59,6 +59,8 @@ jobs:
       - run: fnm use ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
       - run: node -v
       - run: pwd
+      - run: df -h
+      - run: free -mh
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -23,10 +23,6 @@ on:
         required: false
         description: 'if nextest rust dep is needed'
         type: string
-      needsChromium:
-        required: false
-        description: 'if chromium is needed'
-        type: string
       uploadSwcArtifact:
         required: false
         description: 'if swc artifact needs uploading'
@@ -77,10 +73,6 @@ jobs:
       - name: Install nextest
         if: ${{ inputs.needsNextest == 'yes' }}
         uses: taiki-e/install-action@nextest
-
-      - name: Install Chromium
-        if: ${{ inputs.needsChromium == 'yes' }}
-        run: sudo apt-get update && sudo apt-get -y install chromium
 
       - run: rustc --version
 

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -59,8 +59,6 @@ jobs:
       - run: fnm use ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
       - run: node -v
       - run: pwd
-      - run: df -h
-      - run: free -mh
 
       - uses: actions/checkout@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6acf7e4a267eecbb127ed696bb2d50572c22ba7f586a646321e1798d8336a1"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tokio",
+ "tungstenite 0.18.0",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,11 +767,37 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5506e432f602b1747e8a0d60ac6607c6977af4ee9720237764170305323e62"
 dependencies = [
- "async-tungstenite",
+ "async-tungstenite 0.17.2",
  "base64 0.13.1",
  "cfg-if 1.0.0",
- "chromiumoxide_cdp",
- "chromiumoxide_types",
+ "chromiumoxide_cdp 0.4.0",
+ "chromiumoxide_types 0.4.0",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "which",
+ "winreg",
+]
+
+[[package]]
+name = "chromiumoxide"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbef58698a487c253c55c3d17bb1efbe268d2961a2c8278e3f86fff721355fc"
+dependencies = [
+ "async-tungstenite 0.19.0",
+ "base64 0.21.0",
+ "cfg-if 1.0.0",
+ "chromiumoxide_cdp 0.5.0",
+ "chromiumoxide_types 0.5.0",
+ "dunce",
  "fnv",
  "futures",
  "futures-timer",
@@ -778,8 +818,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b6988af5c6bbf097999e7db879729dd7b27a62010c482d4922fddeb4f220d4"
 dependencies = [
- "chromiumoxide_pdl",
- "chromiumoxide_types",
+ "chromiumoxide_pdl 0.4.0",
+ "chromiumoxide_types 0.4.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_cdp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902b90e019dff479bf5a36ed3961e955afa48c35fb2d4245d0b193e7746d50b9"
+dependencies = [
+ "chromiumoxide_pdl 0.5.0",
+ "chromiumoxide_types 0.5.0",
  "serde",
  "serde_json",
 ]
@@ -790,7 +842,24 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cdf6513e24d260548345a5ef13a04110f5915b7764c274933e10f9363a43e3b"
 dependencies = [
- "chromiumoxide_types",
+ "chromiumoxide_types 0.4.0",
+ "either",
+ "heck 0.4.1",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_pdl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9319fb29ecce08ac90dd5a798c391f6a8ae1d7c90aff71f3fa27cb3cdfc3ec"
+dependencies = [
+ "chromiumoxide_types 0.5.0",
  "either",
  "heck 0.4.1",
  "once_cell",
@@ -806,6 +875,16 @@ name = "chromiumoxide_types"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1af9c183b5aac7f09639cc7b4ddde8a8551850d2c9bf36530830cb10e28e676f"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9187058637b8e555690935a6d25a1f7af1d71b377fc45b4257712efb34551f"
 dependencies = [
  "serde",
  "serde_json",
@@ -3308,7 +3387,7 @@ name = "next-dev"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chromiumoxide",
+ "chromiumoxide 0.5.0",
  "clap 4.1.11",
  "console-subscriber",
  "criterion",
@@ -3343,7 +3422,7 @@ name = "next-dev-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chromiumoxide",
+ "chromiumoxide 0.5.0",
  "console-subscriber",
  "dunce",
  "futures",
@@ -7311,7 +7390,7 @@ version = "0.1.0"
 source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
 dependencies = [
  "anyhow",
- "chromiumoxide",
+ "chromiumoxide 0.4.0",
  "criterion",
  "dunce",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "serde",
 ]
@@ -3464,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "serde",
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7093,7 +7093,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7105,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7134,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7151,7 +7151,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7181,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "base16",
  "hex",
@@ -7193,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7207,7 +7207,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7217,7 +7217,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "mimalloc",
 ]
@@ -7225,7 +7225,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7248,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7260,7 +7260,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7290,7 +7290,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7320,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7361,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7385,7 +7385,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7426,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7507,7 +7507,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7540,7 +7540,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7563,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7580,7 +7580,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7596,7 +7596,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "serde",
@@ -7631,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7646,7 +7646,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7681,7 +7681,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "serde",
@@ -7697,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7708,7 +7708,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,20 +359,6 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b71b31561643aa8e7df3effe284fa83ab1a840e52294c5f4bd7bfd8b2becbb"
-dependencies = [
- "futures-io",
- "futures-util",
- "log",
- "pin-project-lite",
- "tokio",
- "tungstenite 0.17.3",
-]
-
-[[package]]
-name = "async-tungstenite"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6acf7e4a267eecbb127ed696bb2d50572c22ba7f586a646321e1798d8336a1"
@@ -382,7 +368,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
- "tungstenite 0.18.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -414,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "serde",
 ]
@@ -541,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.50.35"
+version = "0.50.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31f397ada59fbcd6cb7f0a9d5bab4a53bb7cfc3ee2277b9f93d0ea2c88704d6"
+checksum = "ef3a809ca2ce465f8c44acb578f9730234a0faf9199590cd5e00e537bb2affa2"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -763,40 +749,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chromiumoxide"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5506e432f602b1747e8a0d60ac6607c6977af4ee9720237764170305323e62"
-dependencies = [
- "async-tungstenite 0.17.2",
- "base64 0.13.1",
- "cfg-if 1.0.0",
- "chromiumoxide_cdp 0.4.0",
- "chromiumoxide_types 0.4.0",
- "fnv",
- "futures",
- "futures-timer",
- "pin-project-lite",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "url",
- "which",
- "winreg",
-]
-
-[[package]]
-name = "chromiumoxide"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbef58698a487c253c55c3d17bb1efbe268d2961a2c8278e3f86fff721355fc"
 dependencies = [
- "async-tungstenite 0.19.0",
+ "async-tungstenite",
  "base64 0.21.0",
  "cfg-if 1.0.0",
- "chromiumoxide_cdp 0.5.0",
- "chromiumoxide_types 0.5.0",
+ "chromiumoxide_cdp",
+ "chromiumoxide_types",
  "dunce",
  "fnv",
  "futures",
@@ -814,41 +775,12 @@ dependencies = [
 
 [[package]]
 name = "chromiumoxide_cdp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b6988af5c6bbf097999e7db879729dd7b27a62010c482d4922fddeb4f220d4"
-dependencies = [
- "chromiumoxide_pdl 0.4.0",
- "chromiumoxide_types 0.4.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "chromiumoxide_cdp"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "902b90e019dff479bf5a36ed3961e955afa48c35fb2d4245d0b193e7746d50b9"
 dependencies = [
- "chromiumoxide_pdl 0.5.0",
- "chromiumoxide_types 0.5.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "chromiumoxide_pdl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdf6513e24d260548345a5ef13a04110f5915b7764c274933e10f9363a43e3b"
-dependencies = [
- "chromiumoxide_types 0.4.0",
- "either",
- "heck 0.4.1",
- "once_cell",
- "proc-macro2",
- "quote",
- "regex",
+ "chromiumoxide_pdl",
+ "chromiumoxide_types",
  "serde",
  "serde_json",
 ]
@@ -859,23 +791,13 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9319fb29ecce08ac90dd5a798c391f6a8ae1d7c90aff71f3fa27cb3cdfc3ec"
 dependencies = [
- "chromiumoxide_types 0.5.0",
+ "chromiumoxide_types",
  "either",
  "heck 0.4.1",
  "once_cell",
  "proc-macro2",
  "quote",
  "regex",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "chromiumoxide_types"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1af9c183b5aac7f09639cc7b4ddde8a8551850d2c9bf36530830cb10e28e676f"
-dependencies = [
  "serde",
  "serde_json",
 ]
@@ -2445,7 +2367,7 @@ dependencies = [
  "pin-project",
  "tokio",
  "tokio-tungstenite",
- "tungstenite 0.18.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -3387,7 +3309,7 @@ name = "next-dev"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chromiumoxide 0.5.0",
+ "chromiumoxide",
  "clap 4.1.11",
  "console-subscriber",
  "criterion",
@@ -3409,7 +3331,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "tungstenite 0.17.3",
+ "tungstenite",
  "turbo-tasks",
  "turbopack-binding",
  "url",
@@ -3422,7 +3344,7 @@ name = "next-dev-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chromiumoxide 0.5.0",
+ "chromiumoxide",
  "console-subscriber",
  "dunce",
  "futures",
@@ -3439,7 +3361,7 @@ dependencies = [
  "serde_json",
  "testing",
  "tokio",
- "tungstenite 0.17.3",
+ "tungstenite",
  "turbo-tasks",
  "turbopack-binding",
  "url",
@@ -3542,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "serde",
@@ -5463,9 +5385,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.261.35"
+version = "0.261.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56428a57e7898982bee4530923a85ba17ad2b555a1502bcdccf6dc7ae483621f"
+checksum = "1b59f4e1f5ebb10037de0a3a5c25d2fe7691f8811f42d3549fb81f2b9047205b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5531,9 +5453,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.214.26"
+version = "0.214.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a20b862690e5c6c5e70fc0d56c156175514520c98e89220d408fc0e0d62759a"
+checksum = "1a22f0573fef09dffc3db7094d29ef9445b4f09b76da650bc870060ca0b8c8a4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5637,9 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.76.41"
+version = "0.76.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cd48cee857b467c1a7f3ff14ec26bfcdbe6a08f3218577e15d8157701da958"
+checksum = "82b4ef70c1c82e3392058c2a497e2fc787ed0df3b92dddbbef2e864d866cfa7f"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5771,9 +5693,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.149.14"
+version = "0.149.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada0aafa05a52012e4409976dd3352f1986701b7b7756946700543b4b2ebec9c"
+checksum = "13d84e4959647c275a6eaf3c40c2f830b2dd3c169149a5d5c03734cfad7f839c"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -5835,9 +5757,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.139.15"
+version = "0.139.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c6af8e6d6714ecd7ef5cfba322aa1b436f78d9a82b0c3ff16aeaf97b65cd6d"
+checksum = "c66d1ea16bb9b7ea6f87f17325742ff256fcbd65b188af57c2bf415fe4afc945"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -5881,9 +5803,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.82.16"
+version = "0.82.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3ea8c34004c75da37b7c4f70d1f043f4de455e6a6e78440bfa4d24a3bd201d"
+checksum = "48d5b6aadff572b212ceadba56da45a6bb9af7d67ce1c234a27073d4ec4e6361"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -5924,9 +5846,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.181.26"
+version = "0.181.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4006ddfdcdcf8eb3a83f077ae03b6ee5a94bd9d55d52198bbed2228a6acafcbe"
+checksum = "0f85eb56b6c5a8ba4e91141602511b9c5a390bad4c8e454bff77d80c2033c265"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -5980,9 +5902,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.195.23"
+version = "0.195.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa9f2862180c733b633572be7d42b690cf2d878280a199a9b5f7cfba2cfd89e"
+checksum = "384802032a00bc0e67993e7c3c9a28b82af19c5685eb9d8f93655376f3f823c2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6035,9 +5957,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.218.21"
+version = "0.218.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef09fbed21e8bcdf22bbfd88e5ec83c2acc2c831c39ca2fde01e1f040a85167"
+checksum = "dbe5ca1c16b4ea9ece9f43a24554edce402641c46b2cc4e418be6c40897572b0"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6055,9 +5977,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.127.16"
+version = "0.127.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6232e641bef05c462bc7da34a3771f9b3f1f3352349ae0cd72b8eee8b0f5d5e0"
+checksum = "f9c33ec5369178f3a0580ab86cfe89ffb9c3fbd122aed379cfb71d469d9d61c1"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.2.1",
@@ -6079,9 +6001,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.116.16"
+version = "0.116.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f086829a3e645382f5609c9c6dce1d29e5204b3c81f82fe8d65d3bf17bcca68b"
+checksum = "6e3b0d5f362f0da97be1f1b06d7b0d8667ea70b4adeabff0dcaecb6259c09525"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6093,9 +6015,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.153.18"
+version = "0.153.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1ce5cb1e660b972799a3f28587e01d665981661753cb8f3eb7db89e77dae28"
+checksum = "851739faeec27389fbfe5b170534df7868bbcc5c78f229f22fce43f004858eca"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -6133,9 +6055,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.170.18"
+version = "0.170.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0dfc1f9d2dfa4a95cb10dea599ddf61506e35f5eafbac25cd14bc33f413a7c"
+checksum = "b1595b0522333346488ad7354ad55d4ed337d4e5d7ded5e4d468c523ecb9a495"
 dependencies = [
  "Inflector",
  "ahash",
@@ -6161,9 +6083,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.187.21"
+version = "0.187.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d27c12926427f235d149e60f9a9e67a2181fe1eb418c12b53b8e0778c5052a2"
+checksum = "3fff2641ba155b3aaa8ef15c1888d75b73e9f10431ec1cb58e66598266199322"
 dependencies = [
  "ahash",
  "dashmap",
@@ -6187,9 +6109,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.161.20"
+version = "0.161.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416fbb84f84644ef0e81df80bf44fd575bbb297a78887e359e16a61f6dc5af86"
+checksum = "593d2c321aa9b29b289d144832d985031ddc453ab1fdf59170d810e2283944f2"
 dependencies = [
  "either",
  "rustc-hash",
@@ -6207,9 +6129,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.173.18"
+version = "0.173.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39a0de45fa34ee797a1c80497c8b9dcb6cf6e56b455c163453399894c58a812"
+checksum = "5fb9481ad4e2acba34c6fbb6d4ccc64efe9f1821675e883dcfa732d7220f4b1e"
 dependencies = [
  "ahash",
  "base64 0.13.1",
@@ -6233,9 +6155,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.130.16"
+version = "0.130.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2f974e4f1d78309ea24cce2631a664eb367347c9d2e6677f96c7b8b6b176d"
+checksum = "01e7727573d1ea0a9d3f24c11fe4cb5038ce904bf3e67a13c0ee4a07d3ae4a1d"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -6259,9 +6181,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.177.21"
+version = "0.177.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd32915040ed6ffdfeafb7a63276529df9ed83d8b6e7a6ce22d95ce98d137a21"
+checksum = "64f65165a1ef99b7638503fcf6ead4f58b7cfbf3a37c75dfd6f541b491323041"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6275,9 +6197,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.13.15"
+version = "0.13.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aacc5022f52ae332c6545b9248b70285be1847cf85d48b0640d05f68ff971f"
+checksum = "b7da59ebce19380671e76cfe7e9b0cdd6f430b3090c65c24aefcc07ed63739f2"
 dependencies = [
  "ahash",
  "indexmap",
@@ -6446,9 +6368,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.95.16"
+version = "0.95.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d8dc9624bfd27ec09d4dcf56d9e0ed5faaef056629f5d190fc69fde46ec489"
+checksum = "32cea3fce3d59a0962dc427019c469cd44a68c52224af1c7cc2a93f0d41d5890"
 dependencies = [
  "anyhow",
  "enumset",
@@ -6898,7 +6820,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.18.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -7120,25 +7042,6 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
-dependencies = [
- "base64 0.13.1",
- "byteorder",
- "bytes",
- "http",
- "httparse",
- "log",
- "rand",
- "sha-1",
- "thiserror",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
@@ -7159,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7190,7 +7093,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7202,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7217,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7231,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7248,7 +7151,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7278,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "base16",
  "hex",
@@ -7290,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7304,7 +7207,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7314,7 +7217,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "mimalloc",
 ]
@@ -7322,7 +7225,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7345,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7357,7 +7260,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7387,10 +7290,10 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
- "chromiumoxide 0.4.0",
+ "chromiumoxide",
  "criterion",
  "dunce",
  "futures",
@@ -7406,7 +7309,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "tungstenite 0.17.3",
+ "tungstenite",
  "turbo-tasks",
  "turbo-tasks-testing",
  "turbopack-create-test-app",
@@ -7417,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7458,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7482,7 +7385,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7510,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7523,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7545,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7569,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7604,7 +7507,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7637,7 +7540,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7660,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7677,7 +7580,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7693,7 +7596,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7713,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "serde",
@@ -7728,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7743,7 +7646,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7778,7 +7681,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "serde",
@@ -7794,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7805,7 +7708,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230608.1#a00ba87b486db48038e1d6e74775a29b920ef03b"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#01541c4ac4333a6e196b8e5e3bbffcbcb86d0161"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,6 +1848,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,7 +3329,7 @@ dependencies = [
  "owo-colors",
  "parking_lot",
  "portpicker",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
@@ -3355,10 +3361,11 @@ dependencies = [
  "next-dev",
  "owo-colors",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
+ "tempdir",
  "testing",
  "tokio",
  "tungstenite",
@@ -3892,7 +3899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4030,7 +4037,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4249,13 +4256,26 @@ checksum = "ce082a9940a7ace2ad4a8b7d0b1eac6aa378895f18be598230c5f2284ac05426"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4265,8 +4285,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -4303,6 +4338,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4401,6 +4445,15 @@ name = "relative-path"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "rend"
@@ -4775,7 +4828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a4591a2d128af73b1b819ab95f143bc6a2fbe48cd23a4c45e1ee32177e66ae6"
 dependencies = [
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "sentry-types",
  "serde",
  "serde_json",
@@ -6498,6 +6551,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6906,7 +6969,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -7052,7 +7115,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1 0.10.5",
  "thiserror",
  "url",
@@ -7303,7 +7366,7 @@ dependencies = [
  "owo-colors",
  "parking_lot",
  "portpicker",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
@@ -7727,7 +7790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -8386,7 +8449,7 @@ dependencies = [
  "linked_hash_set",
  "once_cell",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -8514,7 +8577,7 @@ dependencies = [
  "memmap2",
  "once_cell",
  "path-clean",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_cbor",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "serde",
 ]
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "serde",
@@ -7125,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7168,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7183,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7197,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "base16",
  "hex",
@@ -7256,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7280,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "mimalloc",
 ]
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7476,7 +7476,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7535,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7570,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7626,7 +7626,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "serde",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "serde",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230612.1#6c55f3ddc263cd30e6f776611147d487323271b0"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "serde",
 ]
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "serde",
@@ -7125,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7168,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7183,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -7197,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "base16",
  "hex",
@@ -7256,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7280,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "mimalloc",
 ]
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7476,7 +7476,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7535,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7570,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7626,7 +7626,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "serde",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "serde",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/update-chromiumoxide#e59e5697bfae0b2487c297f2f35fe923c7e0379f"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -7790,7 +7790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack
 # and some aren't buildable with rustls.
 reqwest = { version = "0.11.14", default-features = false }
 
-chromiumoxide = { version = "0.4.0", features = [
+chromiumoxide = { version = "0.5.0", features = [
   "tokio-runtime",
 ], default-features = false }
 # For matching on errors from chromiumoxide. Keep in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ swc_core = { version = "0.76.46" }
 testing = { version = "0.33.13" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "sokra/update-chromiumoxide" } # last tag: "turbopack-230608.1"
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230612.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "sokra/update-chromiumoxide" } # last tag: "turbopack-230608.1"
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230612.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "sokra/update-chromiumoxide" } # last tag: "turbopack-230608.1"
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230612.1" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ swc_core = { version = "0.76.46" }
 testing = { version = "0.33.13" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230608.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "sokra/update-chromiumoxide" } # last tag: "turbopack-230608.1"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230608.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "sokra/update-chromiumoxide" } # last tag: "turbopack-230608.1"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230608.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "sokra/update-chromiumoxide" } # last tag: "turbopack-230608.1"
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ next-transform-strip-page-exports = { path = "packages/next-swc/crates/next-tran
 
 # SWC crates
 # Keep consistent with preset_env_base through swc_core
-swc_core = { version = "0.76.41" }
+swc_core = { version = "0.76.46" }
 testing = { version = "0.33.13" }
 
 # Turbo crates
@@ -61,7 +61,7 @@ chromiumoxide = { version = "0.5.0", features = [
 ], default-features = false }
 # For matching on errors from chromiumoxide. Keep in
 # sync with chromiumoxide's tungstenite requirement.
-tungstenite = "0.17.3"
+tungstenite = "0.18.0"
 
 # flate2_zlib requires zlib, use flate2_rust
 allsorts = { version = "0.14.0", default_features = false, features = [

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/18/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/18/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ $$ACTION_1,$$ACTION_3 */ import __create_action_proxy__ from "private-next-rsc-action-proxy";
 import deleteFromDb from 'db';
 const v1 = 'v1';
-export function Item({ id1 , id2  }) {
+export function Item({ id1, id2 }) {
     const v2 = id2;
     return <>
 

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/19/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/19/output.js
@@ -1,5 +1,5 @@
 /* __next_internal_action_entry_do_not_use__ $$ACTION_1 */ import __create_action_proxy__ from "private-next-rsc-action-proxy";
-export function Item({ value  }) {
+export function Item({ value }) {
     return <>
 
       <Button action={$$ACTION_0 = async (...args)=>$$ACTION_1.apply(null, ($$ACTION_0.$$bound || []).concat(args)), __create_action_proxy__("188d5d945750dc32e2c842b93c75a65763d4a922", [

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230608.1",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230608.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230612.1",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161",
-    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845",
+    "@vercel/turbopack-node": "https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-dev-tests/Cargo.toml
+++ b/packages/next-swc/crates/next-dev-tests/Cargo.toml
@@ -37,6 +37,7 @@ rand = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempdir = "0.3.7"
 testing = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 # For matching on errors from chromiumoxide. Keep in

--- a/packages/next-swc/crates/next-dev-tests/tests/integration.rs
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration.rs
@@ -554,8 +554,8 @@ async fn run_browser(addr: SocketAddr, project_dir: &Path) -> Result<JsResult> {
 }
 
 fn get_free_local_addr() -> Result<SocketAddr, std::io::Error> {
-    let socket = TcpSocket::new_v6()?;
-    socket.bind("[::]:0".parse().unwrap())?;
+    let socket = TcpSocket::new_v4()?;
+    socket.bind("0.0.0.0:0".parse().unwrap())?;
     socket.local_addr()
 }
 

--- a/packages/next-swc/crates/next-dev-tests/tests/integration.rs
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration.rs
@@ -358,9 +358,7 @@ async fn create_browser(is_debugging: bool) -> Result<(Browser, JoinSet<()>)> {
             .with_head()
             .args(vec!["--auto-open-devtools-for-tabs", "--no-sandbox"]);
     } else {
-        config_builder = config_builder
-            .with_head()
-            .args(vec!["--no-sandbox"]);
+        config_builder = config_builder.with_head().args(vec!["--no-sandbox"]);
     }
 
     let (browser, mut handler) = retry_async(

--- a/packages/next-swc/crates/next-dev-tests/tests/integration.rs
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration.rs
@@ -358,7 +358,9 @@ async fn create_browser(is_debugging: bool) -> Result<(Browser, TempDir, JoinSet
     let tmp = TempDir::new("chromiumoxid").unwrap();
     config_builder = config_builder.user_data_dir(&tmp);
     if is_debugging {
-        config_builder = config_builder.with_head().args(vec!["--auto-open-devtools-for-tabs"]);
+        config_builder = config_builder
+            .with_head()
+            .args(vec!["--auto-open-devtools-for-tabs"]);
     }
 
     let (browser, mut handler) = retry_async(

--- a/packages/next-swc/crates/next-dev-tests/tests/integration.rs
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration.rs
@@ -357,9 +357,8 @@ async fn create_browser(is_debugging: bool) -> Result<(Browser, TempDir, JoinSet
     config_builder = config_builder.no_sandbox();
     let tmp = TempDir::new("chromiumoxid").unwrap();
     config_builder = config_builder.user_data_dir(&tmp);
-    config_builder = config_builder.with_head();
     if is_debugging {
-        config_builder = config_builder.args(vec!["--auto-open-devtools-for-tabs"]);
+        config_builder = config_builder.with_head().args(vec!["--auto-open-devtools-for-tabs"]);
     }
 
     let (browser, mut handler) = retry_async(

--- a/packages/next-swc/crates/next-dev-tests/tests/integration.rs
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration.rs
@@ -357,10 +357,9 @@ async fn create_browser(is_debugging: bool) -> Result<(Browser, TempDir, JoinSet
     config_builder = config_builder.no_sandbox();
     let tmp = TempDir::new("chromiumoxid").unwrap();
     config_builder = config_builder.user_data_dir(&tmp);
+    config_builder = config_builder.with_head();
     if is_debugging {
-        config_builder = config_builder
-            .with_head()
-            .args(vec!["--auto-open-devtools-for-tabs"]);
+        config_builder = config_builder.args(vec!["--auto-open-devtools-for-tabs"]);
     }
 
     let (browser, mut handler) = retry_async(

--- a/packages/next-swc/crates/next-dev-tests/tests/integration.rs
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration.rs
@@ -404,8 +404,10 @@ const BINDINGS: [&str; 3] = [
 
 async fn run_browser(addr: SocketAddr, project_dir: &Path) -> Result<JsResult> {
     let is_debugging = *DEBUG_BROWSER;
+    println!("starting browser...");
     let (browser, _tmp, mut handle) = create_browser(is_debugging).await?;
 
+    println!("open about:blank...");
     // `browser.new_page()` opens a tab, navigates to the destination, and waits for
     // the page to load. chromiumoxide/Chrome DevTools Protocol has been flakey,
     // returning `ChannelSendError`s (WEB-259). Retry if necessary.
@@ -439,10 +441,12 @@ async fn run_browser(addr: SocketAddr, project_dir: &Path) -> Result<JsResult> {
         .await
         .context("Unable to listen to response received events")?;
 
+    println!("start navigating to http://{addr}...");
     page.evaluate_expression(format!("window.location='http://{addr}'"))
         .await
         .context("Unable to evaluate javascript to naviagate to target page")?;
 
+    println!("waiting for navigation...");
     // Wait for the next network response event
     // This is the HTML page that we're testing
     network_response_events.next().await.context(

--- a/packages/next-swc/crates/next-dev-tests/tests/integration.rs
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration.rs
@@ -459,6 +459,7 @@ async fn run_browser(addr: SocketAddr, project_dir: &Path) -> Result<JsResult> {
         .await;
     }
 
+    println!("finished navigation to http://{addr}");
     let mut errors_next = errors.next();
     let mut bindings_next = binding_events.next();
     let mut console_next = console_events.next();

--- a/packages/next-swc/crates/next-dev-tests/tests/integration.rs
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration.rs
@@ -554,8 +554,8 @@ async fn run_browser(addr: SocketAddr, project_dir: &Path) -> Result<JsResult> {
 }
 
 fn get_free_local_addr() -> Result<SocketAddr, std::io::Error> {
-    let socket = TcpSocket::new_v4()?;
-    socket.bind("0.0.0.0:0".parse().unwrap())?;
+    let socket = TcpSocket::new_v6()?;
+    socket.bind("[::]:0".parse().unwrap())?;
     socket.local_addr()
 }
 

--- a/packages/next-swc/crates/next-dev-tests/tests/integration.rs
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration.rs
@@ -356,7 +356,11 @@ async fn create_browser(is_debugging: bool) -> Result<(Browser, JoinSet<()>)> {
     if is_debugging {
         config_builder = config_builder
             .with_head()
-            .args(vec!["--auto-open-devtools-for-tabs"]);
+            .args(vec!["--auto-open-devtools-for-tabs", "--no-sandbox"]);
+    } else {
+        config_builder = config_builder
+            .with_head()
+            .args(vec!["--no-sandbox"]);
     }
 
     let (browser, mut handler) = retry_async(

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/font-google/at-next-font/input/pages/index.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/font-google/at-next-font/input/pages/index.js
@@ -14,7 +14,7 @@ function runTests() {
     expect(interNoArgs).toEqual({
       className: 'className__inter_34ab8b4d__7bdff866',
       style: {
-        fontFamily: "'__Inter_34ab8b'",
+        fontFamily: "'__Inter_34ab8b', '__Inter_Fallback_34ab8b'",
         fontStyle: 'normal',
       },
     })

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/font-google/basic/input/pages/index.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/font-google/basic/input/pages/index.js
@@ -26,7 +26,7 @@ function runTests() {
   it('includes a rule styling the exported className', async () => {
     const matchingRule = await getRuleMatchingClassName(interNoArgs.className)
     expect(matchingRule).toBeTruthy()
-    expect(matchingRule.style.fontFamily).toEqual('__Inter_34ab8b')
+    expect(matchingRule.style.fontFamily).toEqual('__Inter_34ab8b, __Inter_Fallback_34ab8b')
     expect(matchingRule.style.fontStyle).toEqual('normal')
   })
 
@@ -44,7 +44,7 @@ function runTests() {
       interWithVariableName.variable
     )
     expect(matchingRule.styleMap.get('--my-font').toString().trim()).toBe(
-      '"__Inter_c6e282"'
+      '"__Inter_c6e282", "__Inter_Fallback_c6e282"'
     )
   })
 }

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/font-google/basic/input/pages/index.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/font-google/basic/input/pages/index.js
@@ -26,7 +26,9 @@ function runTests() {
   it('includes a rule styling the exported className', async () => {
     const matchingRule = await getRuleMatchingClassName(interNoArgs.className)
     expect(matchingRule).toBeTruthy()
-    expect(matchingRule.style.fontFamily).toEqual('__Inter_34ab8b, __Inter_Fallback_34ab8b')
+    expect(matchingRule.style.fontFamily).toEqual(
+      '__Inter_34ab8b, __Inter_Fallback_34ab8b'
+    )
     expect(matchingRule.style.fontStyle).toEqual('normal')
   })
 

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/font-google/basic/input/pages/index.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/font-google/basic/input/pages/index.js
@@ -17,7 +17,7 @@ function runTests() {
     expect(interNoArgs).toEqual({
       className: 'className__inter_34ab8b4d__7bdff866',
       style: {
-        fontFamily: "'__Inter_34ab8b'",
+        fontFamily: "'__Inter_34ab8b', '__Inter_Fallback_34ab8b'",
         fontStyle: 'normal',
       },
     })
@@ -34,7 +34,7 @@ function runTests() {
     expect(interWithVariableName).toEqual({
       className: 'className__inter_c6e282f1__e152ac0c',
       style: {
-        fontFamily: "'__Inter_c6e282'",
+        fontFamily: "'__Inter_c6e282', '__Inter_Fallback_34ab8b'",
         fontStyle: 'normal',
       },
       variable: 'variable__inter_c6e282f1__e152ac0c',

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/font-google/basic/input/pages/index.js
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/font-google/basic/input/pages/index.js
@@ -34,7 +34,7 @@ function runTests() {
     expect(interWithVariableName).toEqual({
       className: 'className__inter_c6e282f1__e152ac0c',
       style: {
-        fontFamily: "'__Inter_c6e282', '__Inter_Fallback_34ab8b'",
+        fontFamily: "'__Inter_c6e282', '__Inter_Fallback_c6e282'",
         fontStyle: 'normal',
       },
       variable: 'variable__inter_c6e282f1__e152ac0c',

--- a/packages/next-swc/crates/next-transform-font/Cargo.toml
+++ b/packages/next-swc/crates/next-transform-font/Cargo.toml
@@ -11,5 +11,5 @@ bench = false
 [dependencies]
 rustc-hash = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
 swc_core = { workspace = true }

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -14,7 +14,7 @@
     "rust-check": "cd ../../; cargo fmt -- --check && cargo clippy --all -- -D warnings -A deprecated && cargo check -p next-dev --no-default-features --features cli,custom_allocator,rustls-tls,__internal_nextjs_integration_test && rm -rf target",
     "test-cargo-unit": "cargo test --workspace --exclude next-dev-tests",
     "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo nextest run -p next-dev-tests --release --no-fail-fast",
-    "test-cargo-bench": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo test --benches -p next-dev --release --no-fail-fast"
+    "test-cargo-bench": "cross-env CARGO_PROFILE_RELEASE_LTO=false TURBOPACK_BENCH_COUNTS=10 TURBOPACK_BENCH_CACHED=1 TURBOPACK_BENCH_PROGRESS=1 cargo test --benches -p next-dev --release --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -13,8 +13,8 @@
     "cache-build-native": "echo $(ls native)",
     "rust-check": "cd ../../; cargo fmt -- --check && cargo clippy --all -- -D warnings -A deprecated && cargo check -p next-dev --no-default-features --features cli,custom_allocator,rustls-tls,__internal_nextjs_integration_test && rm -rf target",
     "test-cargo-unit": "cargo test --workspace --exclude next-dev-tests",
-    "test-cargo-integration": "cargo nextest run -p next-dev-tests --release --no-fail-fast",
-    "test-cargo-bench": "cargo test --benches -p next-dev --release --no-fail-fast"
+    "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=0 cargo nextest run -p next-dev-tests --release --no-fail-fast",
+    "test-cargo-bench": "cross-env CARGO_PROFILE_RELEASE_LTO=0 cargo test --benches -p next-dev --release --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",
@@ -31,6 +31,7 @@
     }
   },
   "devDependencies": {
-    "@napi-rs/cli": "2.14.7"
+    "@napi-rs/cli": "2.14.7",
+    "cross-env": "6.0.3"
   }
 }

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -13,8 +13,8 @@
     "cache-build-native": "echo $(ls native)",
     "rust-check": "cd ../../; cargo fmt -- --check && cargo clippy --all -- -D warnings -A deprecated && cargo check -p next-dev --no-default-features --features cli,custom_allocator,rustls-tls,__internal_nextjs_integration_test && rm -rf target",
     "test-cargo-unit": "cargo test --workspace --exclude next-dev-tests",
-    "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo nextest run -p next-dev-tests --release --no-fail-fast",
-    "test-cargo-bench": "cross-env CARGO_PROFILE_RELEASE_LTO=false TURBOPACK_BENCH_COUNTS=10 TURBOPACK_BENCH_CACHED=1 TURBOPACK_BENCH_PROGRESS=1 cargo test --benches -p next-dev --release --no-fail-fast"
+    "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo nextest run -p next-dev-tests --release --features tracing/release_max_level_off --no-fail-fast",
+    "test-cargo-bench": "cross-env CARGO_PROFILE_RELEASE_LTO=false TURBOPACK_BENCH_COUNTS=10 TURBOPACK_BENCH_CACHED=1 TURBOPACK_BENCH_PROGRESS=1 cargo test --benches -p next-dev --release --features tracing/release_max_level_off --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -13,8 +13,8 @@
     "cache-build-native": "echo $(ls native)",
     "rust-check": "cd ../../; cargo fmt -- --check && cargo clippy --all -- -D warnings -A deprecated && cargo check -p next-dev --no-default-features --features cli,custom_allocator,rustls-tls,__internal_nextjs_integration_test && rm -rf target",
     "test-cargo-unit": "cargo test --workspace --exclude next-dev-tests",
-    "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=0 cargo nextest run -p next-dev-tests --release --no-fail-fast",
-    "test-cargo-bench": "cross-env CARGO_PROFILE_RELEASE_LTO=0 cargo test --benches -p next-dev --release --no-fail-fast"
+    "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo nextest run -p next-dev-tests --release --no-fail-fast",
+    "test-cargo-bench": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo test --benches -p next-dev --release --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -12,7 +12,9 @@
     "build-wasm": "wasm-pack build crates/wasm --scope=next",
     "cache-build-native": "echo $(ls native)",
     "rust-check": "cd ../../; cargo fmt -- --check && cargo clippy --all -- -D warnings -A deprecated && cargo check -p next-dev --no-default-features --features cli,custom_allocator,rustls-tls,__internal_nextjs_integration_test && rm -rf target",
-    "test-cargo-unit": "cargo test --workspace --exclude next-dev-tests"
+    "test-cargo-unit": "cargo test --workspace --exclude next-dev-tests",
+    "test-cargo-integration": "cargo nextest run -p next-dev-tests --release --no-fail-fast",
+    "test-cargo-bench": "cargo test --benches -p next-dev --release --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -13,8 +13,8 @@
     "cache-build-native": "echo $(ls native)",
     "rust-check": "cd ../../; cargo fmt -- --check && cargo clippy --all -- -D warnings -A deprecated && cargo check -p next-dev --no-default-features --features cli,custom_allocator,rustls-tls,__internal_nextjs_integration_test && rm -rf target",
     "test-cargo-unit": "cargo test --workspace --exclude next-dev-tests",
-    "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo nextest run -p next-dev-tests --release --features tracing/release_max_level_off --no-fail-fast",
-    "test-cargo-bench": "cross-env CARGO_PROFILE_RELEASE_LTO=false TURBOPACK_BENCH_COUNTS=10 TURBOPACK_BENCH_CACHED=1 TURBOPACK_BENCH_PROGRESS=1 cargo test --benches -p next-dev --release --features tracing/release_max_level_off --no-fail-fast"
+    "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo nextest run -p next-dev-tests --release --no-fail-fast",
+    "test-cargo-bench": "cross-env CARGO_PROFILE_RELEASE_LTO=false TURBOPACK_BENCH_COUNTS=10 TURBOPACK_BENCH_CACHED=1 TURBOPACK_BENCH_PROGRESS=1 cargo test --benches -p next-dev --release --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -13,7 +13,7 @@
     "cache-build-native": "echo $(ls native)",
     "rust-check": "cd ../../; cargo fmt -- --check && cargo clippy --all -- -D warnings -A deprecated && cargo check -p next-dev --no-default-features --features cli,custom_allocator,rustls-tls,__internal_nextjs_integration_test && rm -rf target",
     "test-cargo-unit": "cargo test --workspace --exclude next-dev-tests",
-    "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo nextest run -p next-dev-tests --release --no-fail-fast --no-capture",
+    "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo nextest run -p next-dev-tests --release --no-fail-fast",
     "test-cargo-bench": "cross-env CARGO_PROFILE_RELEASE_LTO=false TURBOPACK_BENCH_COUNTS=10 TURBOPACK_BENCH_CACHED=1 TURBOPACK_BENCH_PROGRESS=1 cargo test --benches -p next-dev --release --no-fail-fast"
   },
   "napi": {

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -13,7 +13,7 @@
     "cache-build-native": "echo $(ls native)",
     "rust-check": "cd ../../; cargo fmt -- --check && cargo clippy --all -- -D warnings -A deprecated && cargo check -p next-dev --no-default-features --features cli,custom_allocator,rustls-tls,__internal_nextjs_integration_test && rm -rf target",
     "test-cargo-unit": "cargo test --workspace --exclude next-dev-tests",
-    "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo nextest run -p next-dev-tests --release --no-fail-fast",
+    "test-cargo-integration": "cross-env CARGO_PROFILE_RELEASE_LTO=false cargo nextest run -p next-dev-tests --release --no-fail-fast --no-capture",
     "test-cargo-bench": "cross-env CARGO_PROFILE_RELEASE_LTO=false TURBOPACK_BENCH_COUNTS=10 TURBOPACK_BENCH_CACHED=1 TURBOPACK_BENCH_PROGRESS=1 cargo test --benches -p next-dev --release --no-fail-fast"
   },
   "napi": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,8 +980,8 @@ importers:
       '@types/react': 18.2.7
       '@types/react-dom': 18.2.4
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-ecmascript-runtime': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f
+      '@vercel/turbopack-ecmascript-runtime': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230612.1
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -993,8 +993,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-ecmascript-runtime': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f'
+      '@vercel/turbopack-ecmascript-runtime': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230612.1'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25531,9 +25531,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230612.1'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:
@@ -25544,8 +25544,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230612.1':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230612.1}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,8 +980,8 @@ importers:
       '@types/react': 18.2.7
       '@types/react-dom': 18.2.4
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-ecmascript-runtime': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845
+      '@vercel/turbopack-ecmascript-runtime': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -993,8 +993,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-ecmascript-runtime': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845'
+      '@vercel/turbopack-ecmascript-runtime': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25531,9 +25531,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:
@@ -25544,8 +25544,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?e59e5697bfae0b2487c297f2f35fe923c7e0379f}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -968,8 +968,10 @@ importers:
   packages/next-swc:
     specifiers:
       '@napi-rs/cli': 2.14.7
+      cross-env: 6.0.3
     devDependencies:
       '@napi-rs/cli': 2.14.7
+      cross-env: 6.0.3
 
   packages/next-swc/crates/next-core/js:
     specifiers:
@@ -6110,7 +6112,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.2.1
       source-map: 0.7.3
-      webpack: 5.86.0
+      webpack: 5.86.0_@swc+core@1.3.55
     transitivePeerDependencies:
       - supports-color
 
@@ -23768,7 +23770,6 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.17.7
       webpack: 5.86.0_@swc+core@1.3.55
-    dev: true
 
   /terser/5.10.0:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -968,10 +968,8 @@ importers:
   packages/next-swc:
     specifiers:
       '@napi-rs/cli': 2.14.7
-      cross-env: 6.0.3
     devDependencies:
       '@napi-rs/cli': 2.14.7
-      cross-env: 6.0.3
 
   packages/next-swc/crates/next-core/js:
     specifiers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,8 +980,8 @@ importers:
       '@types/react': 18.2.7
       '@types/react-dom': 18.2.4
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-ecmascript-runtime': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230608.1
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230608.1
+      '@vercel/turbopack-ecmascript-runtime': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -993,8 +993,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-ecmascript-runtime': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230608.1_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230608.1'
+      '@vercel/turbopack-ecmascript-runtime': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25531,9 +25531,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230608.1_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230608.1}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230608.1'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:
@@ -25544,8 +25544,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230608.1':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?turbopack-230608.1}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -968,8 +968,10 @@ importers:
   packages/next-swc:
     specifiers:
       '@napi-rs/cli': 2.14.7
+      cross-env: 6.0.3
     devDependencies:
       '@napi-rs/cli': 2.14.7
+      cross-env: 6.0.3
 
   packages/next-swc/crates/next-core/js:
     specifiers:
@@ -6784,7 +6786,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64/1.3.55:
@@ -6793,7 +6794,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.3.55:
@@ -6802,7 +6802,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.3.55:
@@ -6811,7 +6810,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl/1.3.55:
@@ -6820,7 +6818,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu/1.3.55:
@@ -6829,7 +6826,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl/1.3.55:
@@ -6838,7 +6834,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.3.55:
@@ -6847,7 +6842,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.3.55:
@@ -6856,7 +6850,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc/1.3.55:
@@ -6865,7 +6858,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core/1.3.55_@swc+helpers@0.5.1:
@@ -6890,7 +6882,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.55
       '@swc/core-win32-ia32-msvc': 1.3.55
       '@swc/core-win32-x64-msvc': 1.3.55
-    dev: true
 
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
@@ -25137,7 +25128,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /websocket-driver/0.7.3:
     resolution: {integrity: sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,8 +980,8 @@ importers:
       '@types/react': 18.2.7
       '@types/react-dom': 18.2.4
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-ecmascript-runtime': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161
-      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161
+      '@vercel/turbopack-ecmascript-runtime': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845
+      '@vercel/turbopack-node': https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -993,8 +993,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-ecmascript-runtime': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161'
+      '@vercel/turbopack-ecmascript-runtime': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25531,9 +25531,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161}
-    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161'
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845}
+    id: '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:
@@ -25544,8 +25544,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161':
-    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?01541c4ac4333a6e196b8e5e3bbffcbcb86d0161}
+  '@gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845':
+    resolution: {tarball: https://gitpkg.vercel.app/vercel/turbo/crates/turbopack-node/js?b3d99ef5ac0beceeef0be0dd8a2cad9fb51b3845}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -40,6 +40,8 @@
     "typescript": {},
     "rust-check": {},
     "test-cargo-unit": {},
+    "test-cargo-integration": {},
+    "test-cargo-bench": {},
     "//#get-test-timings": {
       "inputs": ["run-tests.js"],
       "outputs": ["test-timings.json"]


### PR DESCRIPTION
### What?

* enable turbopack tests in new CI
* split pre-build step into native and JS builds to allow to start native tests faster
* update swc_core to sync with turbo
* update turbopack

### Why?

Running our test suite is still important as long we don't have the full integration test suite enabled.

### Turbopack updates

* https://github.com/vercel/turbo/pull/5215 <!-- OJ Kwon - ci(workflow): upload benchmark results to datadog  -->
* https://github.com/vercel/turbo/pull/5239 <!-- OJ Kwon - fix(swc_plugin): use shared runtime  -->
* https://github.com/vercel/turbo/pull/3090 <!-- CHEN Yuan - Docs: prior to run testcases, add guides to install dependencies for testcases.  -->
* https://github.com/vercel/turbo/pull/5264 <!-- Tobias Koppers - update test runner  -->
