### PR TITLE
Polish error page styling

### DIFF
--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -15,14 +15,11 @@ const styles = {
     alignItems: 'center',
     justifyContent: 'center',
   },
-  desc: {
-    textAlign: 'left',
-  },
   text: {
     fontSize: '14px',
     fontWeight: 400,
-    lineHeight: '3em',
-    margin: 0,
+    lineHeight: '2em',
+    margin: '0 8px',
   },
 } as const
 
@@ -108,7 +105,7 @@ export default function GlobalError({ error }: { error: any }) {
       <head></head>
       <body>
         <div style={styles.error}>
-          <div style={styles.desc}>
+          <div>
             <h2 style={styles.text}>
               Application error: a client-side exception has occurred (see the
               browser console for more information).

--- a/packages/next/src/pages/_error.tsx
+++ b/packages/next/src/pages/_error.tsx
@@ -36,12 +36,6 @@ const styles: Record<string, React.CSSProperties> = {
     alignItems: 'center',
     justifyContent: 'center',
   },
-
-  desc: {
-    display: 'inline-block',
-    textAlign: 'left',
-  },
-
   h1: {
     display: 'inline-block',
     margin: '0 20px 0 0',
@@ -51,12 +45,11 @@ const styles: Record<string, React.CSSProperties> = {
     verticalAlign: 'top',
     lineHeight: '49px',
   },
-
   h2: {
     fontSize: 14,
     fontWeight: 400,
-    lineHeight: '49px',
-    margin: 0,
+    lineHeight: '2em',
+    margin: '0 8px',
   },
 }
 
@@ -118,7 +111,7 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
               {statusCode}
             </h1>
           ) : null}
-          <div style={styles.desc}>
+          <div>
             <h2 style={styles.h2}>
               {this.props.title || statusCode ? (
                 title


### PR DESCRIPTION
Polish default client error page styling:

* shrink the `line-height` to `2em` for better mobile display
* remove `text-align: left` to let the text center properly

#### After vs Before
(both **app router** and **pages** default client error page)
<p>
<img width="300" alt="image" src="https://github.com/vercel/next.js/assets/4800338/de7260af-7046-4783-8f82-8ac5f39f25b7">
<img width="300" alt="image" src="https://github.com/vercel/next.js/assets/4800338/f4207809-f11f-448d-95ec-0a32b54f3562">
</p>


#### After
(both **app router** and **pages** default client error page)


Closes NEXT-1263