### PR TITLE
feat: add component stack to recoverable error

### DIFF
--- a/packages/next/src/client/on-recoverable-error.ts
+++ b/packages/next/src/client/on-recoverable-error.ts
@@ -12,7 +12,7 @@ export default function onRecoverableError(err: any, errorInfo: ErrorInfo) {
   // such as from custom `window.onerror` or `window` `error` event listeners in an app.
   // Similar is done in `@next/react-dev-overlay`, but this supports production use cases as well.
   // This is technically a mutation of an argument, which is generally inadvisable, but probably not problematic in this case.
-  // The alternative of constucting a new error could be more complicated.
+  // The alternative of constructing a new error could be more complicated.
   if (errorInfo.componentStack) {
     err._componentStack = errorInfo.componentStack
   }

--- a/packages/next/src/client/on-recoverable-error.ts
+++ b/packages/next/src/client/on-recoverable-error.ts
@@ -24,7 +24,7 @@ export default function onRecoverableError(err: any, errorInfo?: ErrorInfo) {
       ? // In modern browsers, reportError will dispatch an error event,
         // emulating an uncaught JavaScript error.
         reportError
-      : (error: any, errorInfo: ErrorInfo) => {
+      : (error: any, errorInfo?: ErrorInfo) => {
           window.console.error(error, errorInfo)
         }
 

--- a/packages/next/src/client/on-recoverable-error.ts
+++ b/packages/next/src/client/on-recoverable-error.ts
@@ -7,13 +7,13 @@ interface ErrorInfo {
   componentStack?: string
 }
 
-export default function onRecoverableError(err: any, errorInfo: ErrorInfo) {
+export default function onRecoverableError(err: any, errorInfo?: ErrorInfo) {
   // Attach any component stack to the error, so it's accessible when passed thru `reportError` below,
   // such as from custom `window.onerror` or `window` `error` event listeners in an app.
   // Similar is done in `@next/react-dev-overlay`, but this supports production use cases as well.
   // This is technically a mutation of an argument, which is generally inadvisable, but probably not problematic in this case.
   // The alternative of constructing a new error could be more complicated.
-  if (errorInfo.componentStack) {
+  if (errorInfo?.componentStack) {
     err._componentStack = errorInfo.componentStack
   }
 

--- a/packages/next/src/client/on-recoverable-error.ts
+++ b/packages/next/src/client/on-recoverable-error.ts
@@ -1,6 +1,22 @@
 import { NEXT_DYNAMIC_NO_SSR_CODE } from '../shared/lib/lazy-dynamic/no-ssr-error'
 
-export default function onRecoverableError(err: any) {
+/**
+ * @see [ReactInternalTypes]{@link https://github.com/facebook/react/blob/910045696bb5f693acb77890e6750c5e4659b420/packages/react-reconciler/src/ReactInternalTypes.js#L278-L281}
+ */
+interface ErrorInfo {
+  componentStack?: string
+}
+
+export default function onRecoverableError(err: any, errorInfo: ErrorInfo) {
+  // Attach any component stack to the error, so it's accessible when passed thru `reportError` below,
+  // such as from custom `window.onerror` or `window` `error` event listeners in an app.
+  // Similar is done in `@next/react-dev-overlay`, but this supports production use cases as well.
+  // This is technically a mutation of an argument, which is generally inadvisable, but probably not problematic in this case.
+  // The alternative of constucting a new error could be more complicated.
+  if (errorInfo.componentStack) {
+    err._componentStack = errorInfo.componentStack
+  }
+
   // Using default react onRecoverableError
   // x-ref: https://github.com/facebook/react/blob/d4bc16a7d69eb2ea38a88c8ac0b461d5f72cdcab/packages/react-dom/src/client/ReactDOMRoot.js#L83
   const defaultOnRecoverableError =
@@ -8,11 +24,12 @@ export default function onRecoverableError(err: any) {
       ? // In modern browsers, reportError will dispatch an error event,
         // emulating an uncaught JavaScript error.
         reportError
-      : (error: any) => {
-          window.console.error(error)
+      : (error: any, errorInfo: ErrorInfo) => {
+          window.console.error(error, errorInfo)
         }
 
   // Skip certain custom errors which are not expected to be reported on client
   if (err.digest === NEXT_DYNAMIC_NO_SSR_CODE) return
-  defaultOnRecoverableError(err)
+
+  defaultOnRecoverableError(err, errorInfo)
 }


### PR DESCRIPTION
### What?

Attaches any component stack from error info to the error object on a recoverable error.

### Why?

Hopefully this will help understanding hydration mismatch errors in production logs - not just in development, which we understand is already supported. I have confirmed that component stack is provided with error info in production builds. Apps can implement a custom `window.onerror` or `window` `error` event listener and grab the component stack from the error object to submit to their logging systems.

### How?

A simple code change to extend the error object with a `_componentStack` property, aligning with what is already done in development with `@next/react-dev-overlay`. Open to other property names if preferred.

Do we feel there is any risk in adding this property to the error object?

Is there a recommended way to unit test this, if needed?

Let me know if it would be necessary or useful to add documentation, and to where.

Related to https://github.com/vercel/next.js/discussions/47542 and https://github.com/vercel/next.js/discussions/36641#discussioncomment-5215494.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md
-->