### PR TITLE
Only upload turbopack metrics on cache miss

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -22,16 +22,10 @@ jobs:
       NEXT_SKIP_NATIVE_POSTINSTALL: 1
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     outputs:
-      docsChange: ${{ steps.docs-change.outputs.DOCS_CHANGE }}
-      codemodChange: ${{ steps.codemod-change.outputs.CODEMOD_CHANGE }}
       isRelease: ${{ github.event_name != 'workflow_dispatch' && steps.check-release.outputs.IS_RELEASE }}
-      swcChange: ${{ steps.swc-change.outputs.SWC_CHANGE }}
-      turboToken: ${{ steps.turbo-token.outputs.TURBO_TOKEN }}
-      weekNum: ${{ steps.get-week.outputs.WEEK }}
     steps:
       - name: Setup node
         uses: actions/setup-node@v3
-        if: ${{ steps.docs-change.outputs.docsChange == 'nope' }}
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
@@ -253,9 +247,14 @@ jobs:
         if: ${{ !matrix.settings.docker }}
         shell: bash
 
+      - name: 'check build cache status'
+        id: check-did-build
+        run: if [[ ! -z $(ls .turbo/runs) ]]; then echo "DID_BUILD=true" >> $GITHUB_OUTPUT; fi
+
       # Trying to upload metrics for the Turbopack to datadog's CI pipeline execution
       - name: 'Upload turbopack build metrics'
         shell: bash
+        if: ${{ steps.check-did-build.outputs.DID_BUILD == "true" }}
         continue-on-error: true
         run: |
           npm install -g @datadog/datadog-ci
@@ -349,7 +348,6 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v3
-        if: ${{needs.build.outputs.docsChange == 'nope'}}
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true


### PR DESCRIPTION
Currently this is uploading every time the job is run even if it's a cache hit and this step can take over 3 minutes un-necessarily so this skips it if a cache hit occurred. 