### PR TITLE
fix: add missed / at useSelectedLayoutSegment at App routing/Pages and Layout

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/02-pages-and-layouts.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/02-pages-and-layouts.mdx
@@ -112,7 +112,7 @@ export default function DashboardLayout({
 > - Layouts are [Server Components](/docs/getting-started/react-essentials) by default but can be set to a [Client Component](/docs/getting-started/react-essentials#client-components).
 > - Layouts can fetch data. View the [Data Fetching](/docs/app/building-your-application/data-fetching) section for more information.
 > - Passing data between a parent layout and its children is not possible. However, you can fetch the same data in a route more than once, and React will [automatically dedupe the requests](/docs/app/building-your-application/data-fetching#automatic-fetch-request-deduping) without affecting performance.
-> - Layouts do not have access to the current route segment(s). To access route segments, you can use [`useSelectedLayoutSegment`](docs/app/api-reference/functions/use-selected-layout-segment) or [`useSelectedLayoutSegments`](/docs/app/api-reference/functions/use-selected-layout-segments) in a Client Component.
+> - Layouts do not have access to the current route segment(s). To access route segments, you can use [`useSelectedLayoutSegment`](/docs/app/api-reference/functions/use-selected-layout-segment) or [`useSelectedLayoutSegments`](/docs/app/api-reference/functions/use-selected-layout-segments) in a Client Component.
 > - `.js`, `.jsx`, or `.tsx` file extensions can be used for Layouts.
 > - A `layout.js` and `page.js` file can be defined in the same folder. The layout will wrap the page.
 


### PR DESCRIPTION
## Why?
- When i click `red box` in following image, page returns 404 page.
<img width="1728" alt="스크린샷 2023-06-08 오후 7 31 37" src="https://github.com/vercel/next.js/assets/63336958/903b11e3-17af-426e-8787-b6e033c14a24">

## How?
- I found that `/` is missed at `docs/02-app/01-building-your-application/01-routing/02-pages-and-layouts.mdx`.
- So I added `/`.
