### PR TITLE
Drop the `chunks` field in the client manifest for SSR

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -307,6 +307,10 @@ export class ClientReferenceManifestPlugin {
             moduleIdMapping[id] = moduleIdMapping[id] || {}
             moduleIdMapping[id][name] = {
               ...manifest.clientModules[exportName],
+              // During SSR, we don't have external chunks to load on the server
+              // side with our architecture of Webpack / Turbopack. We can keep
+              // this field empty to save some bytes.
+              chunks: [],
               id: pluginState.serverModuleIds[ssrNamedModuleId],
             }
           }
@@ -318,6 +322,10 @@ export class ClientReferenceManifestPlugin {
             edgeModuleIdMapping[id] = edgeModuleIdMapping[id] || {}
             edgeModuleIdMapping[id][name] = {
               ...manifest.clientModules[exportName],
+              // During SSR, we don't have external chunks to load on the server
+              // side with our architecture of Webpack / Turbopack. We can keep
+              // this field empty to save some bytes.
+              chunks: [],
               id: pluginState.edgeServerModuleIds[ssrNamedModuleId],
             }
           }


### PR DESCRIPTION
The `ssrModuleMapping`/`edgeSSRModuleMapping` fields store information for the Flight client that does SSR to resolve the correct modules in the SSR bundle. This works as a module ID mapping between the client bundle and the SSR bundle. During the mapping, we can drop the `chunks` field because we don't actually have external chunks to load during SSR as everything is locally `require`'d.

This reduces the client manifest size by at least 20%.