### PR TITLE
Automatically detect and configure Tailwind CSS as a PostCSS plugin

### DIFF
--- a/packages/next/src/build/webpack/config/blocks/css/plugins.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/plugins.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import chalk from 'next/dist/compiled/chalk'
 import { findConfig } from '../../../../../lib/find-config'
 
@@ -90,6 +91,16 @@ function getDefaultPlugins(
   supportedBrowsers: string[] | undefined,
   disablePostcssPresetEnv: boolean
 ): any[] {
+  let rootDir = process.cwd()
+  let pkg = require(path.resolve(rootDir, 'package.json'))
+
+  if (
+    'tailwindcss' in pkg.dependencies ||
+    'tailwindcss' in pkg.devDependencies
+  ) {
+    return [require.resolve('tailwindcss', { paths: [rootDir] })]
+  }
+
   return [
     require.resolve('next/dist/compiled/postcss-flexbugs-fixes'),
     disablePostcssPresetEnv


### PR DESCRIPTION
This PR adds support for automatically detecting and configuring Tailwind CSS as a PostCSS plugin

This tries to detect if Tailwind is installed, if it is then we can set it up as the default PostCSS plugin in case you don't have a `postcss.config.js` file already.

More information can be found in the discussion: https://github.com/vercel/next.js/discussions/50972

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
