### PR TITLE
docs: Correct `useFormStatus` to be a client component

### DIFF
--- a/docs/02-app/01-building-your-application/03-data-fetching/04-server-actions.mdx
+++ b/docs/02-app/01-building-your-application/03-data-fetching/04-server-actions.mdx
@@ -329,6 +329,8 @@ export function Thread({ messages }) {
 The **experimental** `useFormStatus` hook can be used within Form Actions, and provides the `pending` property.
 
 ```jsx filename="app/form.js"
+'use client'
+
 import { experimental_useFormStatus as useFormStatus } from 'react-dom'
 
 function Submit() {


### PR DESCRIPTION
### What?

The `useFormStatus` needs to be used in a client component. That component should be used within a `form` for the `pending` property to reflect the form status.

### Why?

The docs are currently not accurate.

### Notes

I could also update the name of the file to not be `form.js`, which implies this is the entire form instead of just the submit button being used as a component within the form.