### PR TITLE
Fix esm module import warning for middleware loader

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-middleware-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-middleware-loader.ts
@@ -42,8 +42,9 @@ export default function middlewareLoader(this: any) {
   return `
         import 'next/dist/esm/server/web/globals'
         import { adapter } from 'next/dist/esm/server/web/adapter'
-        import * as mod from ${stringifiedPagePath}
+        import * as _mod from ${stringifiedPagePath}
 
+        const mod = { ..._mod }
         const handler = mod.middleware || mod.default
 
         if (typeof handler !== 'function') {


### PR DESCRIPTION
We need to spread the module into an object instead of access the module exports that could not exist, to avoid triggering the warning. Fix the bad loader change introduced in #50548 

```
Attempted import error: './middleware.js' does not contain a default export (imported as '
mod').
- info Using locally built binary of @next/swc
- warn You are using an experimental edge runtime, the API might change.
- wait compiling...
- warn ../../../../packages/next/dist/build/webpack/loaders/next-middleware-loader.js?abso
lutePagePath=%2FUsers%2Fhuozhi%2Fworkspace%2Fnext.js%2Ftest%2Fe2e%2Fapp-dir%2Fapp%2Fmiddle
ware.js&page=%2Fmiddleware&rootDir=%2FUsers%2Fhuozhi%2Fworkspace%2Fnext.js%2Ftest%2Fe2e%2F
app-dir%2Fapp&matchers=!
Attempted import error: './middleware.js' does not contain a default export (imported as '
mod').
- wait compiling...
```
