### PR TITLE
Fix rsc payload fetch failures due to state tree encoding

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -37,7 +37,9 @@ export async function fetchServerResponse(
     // Enable flight response
     [RSC]: '1',
     // Provide the current router state
-    [NEXT_ROUTER_STATE_TREE]: JSON.stringify(flightRouterState),
+    [NEXT_ROUTER_STATE_TREE]: encodeURIComponent(
+      JSON.stringify(flightRouterState)
+    ),
   }
 
   /**

--- a/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
@@ -23,7 +23,9 @@ export function parseAndValidateFlightRouterState(
   }
 
   try {
-    return flightRouterStateSchema.parse(JSON.parse(stateHeader))
+    return flightRouterStateSchema.parse(
+      JSON.parse(decodeURIComponent(stateHeader))
+    )
   } catch {
     throw new Error('The router state header was sent but could not be parsed.')
   }

--- a/test/e2e/app-dir/navigation/app/search-params/page.js
+++ b/test/e2e/app-dir/navigation/app/search-params/page.js
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function page({ searchParams }) {
+  return (
+    <div>
+      <p id="name">{searchParams.name ?? ''}</p>
+      <Link id="link" href="/">
+        home
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
Encode the state tree where the content could contain unicode when request the RSC payload, to avoid the fetch failure due to bad encoding for headers

Fixes #48728
fix NEXT-1258