### PR TITLE
chore: pin to `npm@9.6.7`

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -374,7 +374,7 @@ jobs:
           name: wasm-binaries
           path: packages/next-swc/crates/wasm
 
-      - run: npm i -g npm@9 # need latest version for provenance
+      - run: npm i -g npm@9.6.7 # need latest version for provenance (pinning to avoid bugs)
       - run: npm i -g pnpm@${PNPM_VERSION}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: ./scripts/publish-native.js


### PR DESCRIPTION
This might fix the npm publish error

```
Error: Command failed with exit code 254 (Unknown system error -254): npm publish /home/runner/work/next.js/next.js/packages/next --access public --tag canary
```

https://github.com/vercel/next.js/actions/runs/5219901558/jobs/9422546478#step:11:9353