### PR TITLE
Adds missing `and` in `How to Use These Docs` section

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -33,7 +33,7 @@ Some of the main Next.js features include:
 
 The sections and pages of the docs are organized sequentially, from basic to advanced, so you can follow them step-by-step when building your Next.js application. However, you can read them in any order or skip to the pages that apply to your use case.
 
-At the top of the sidebar, you'll notice a dropdown menu that allows you to switch between the **App Router** the **Pages Router** features. Since there are features that are unique to each directory, it's important to keep track of which tab is selected.
+At the top of the sidebar, you'll notice a dropdown menu that allows you to switch between the **App Router** and the **Pages Router** features. Since there are features that are unique to each directory, it's important to keep track of which tab is selected.
 
 On the right side of the page, you'll see a table of contents that makes it easier to navigate between sections of a page. The breadcrumbs at the top of the page will also indicate whether you're viewing App Router docs or Pages Router docs.
 


### PR DESCRIPTION
Fixes #50227