### PR TITLE
chore: remove skip to renable tsconfig tests

### DIFF
--- a/test/integration/tsconfig-verifier/test/index.test.js
+++ b/test/integration/tsconfig-verifier/test/index.test.js
@@ -298,10 +298,7 @@ describe('tsconfig.json verifier', () => {
     `)
   })
 
-  // TODO-APP: Re-enable this test. Currently fails with the following message:
-  // Type error: Layout "app/layout.jsx" does not match the required types of a Next.js Layout.
-  // Invalid configuration "default":
-  it.skip('allows you to set node16 moduleResolution mode', async () => {
+  it('allows you to set node16 moduleResolution mode', async () => {
     expect(await exists(tsConfig)).toBe(false)
 
     await writeFile(
@@ -411,10 +408,7 @@ describe('tsconfig.json verifier', () => {
     `)
   })
 
-  // TODO-APP: Re-enable this test. Currently fails with the following message:
-  // Type error: Layout "app/layout.jsx" does not match the required types of a Next.js Layout.
-  // Invalid configuration "default":
-  it.skip('allows you to set node16 module mode', async () => {
+  it('allows you to set node16 module mode', async () => {
     expect(await exists(tsConfig)).toBe(false)
 
     await writeFile(


### PR DESCRIPTION
These tests were disabled temporarily in PR #49088 so we can enable once again now.