### PR TITLE
Update app router revalidate handling on deploy

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -671,8 +671,14 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       }
       // in minimal mode we detect RSC revalidate if the .rsc
       // path is requested
-      if (this.minimalMode && req.url.endsWith('.rsc')) {
-        parsedUrl.query.__nextDataReq = '1'
+      if (this.minimalMode) {
+        if (req.url.endsWith('.rsc')) {
+          parsedUrl.query.__nextDataReq = '1'
+        } else if (req.headers['x-now-route-matches']) {
+          for (const param of FLIGHT_PARAMETERS) {
+            delete req.headers[param.toString().toLowerCase()]
+          }
+        }
       }
 
       req.url = normalizeRscPath(req.url, this.hasAppDir)

--- a/test/production/standalone-mode/response-cache/app/app/app-blog/page.js
+++ b/test/production/standalone-mode/response-cache/app/app/app-blog/page.js
@@ -1,0 +1,10 @@
+export const revalidate = 1
+
+export default function Page() {
+  return (
+    <>
+      <p>/app-blog</p>
+      <p>Date: {Date.now()}</p>
+    </>
+  )
+}

--- a/test/production/standalone-mode/response-cache/app/app/layout.js
+++ b/test/production/standalone-mode/response-cache/app/app/layout.js
@@ -1,0 +1,8 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/standalone-mode/response-cache/index.test.ts
+++ b/test/production/standalone-mode/response-cache/index.test.ts
@@ -9,6 +9,7 @@ import {
   findPort,
   renderViaHTTP,
   initNextServerScript,
+  fetchViaHTTP,
 } from 'next-test-utils'
 
 describe('minimal-mode-response-cache', () => {
@@ -78,6 +79,29 @@ describe('minimal-mode-response-cache', () => {
   afterAll(async () => {
     await next.destroy()
     if (server) await killApp(server)
+  })
+
+  it('app router revalidate should work with previous response cache', async () => {
+    const res1 = await fetchViaHTTP(appPort, '/app-blog', undefined, {
+      headers: {
+        'x-matched-path': '/app-blog.rsc',
+        rsc: '1',
+      },
+    })
+    const content1 = await res1.text()
+    expect(content1).not.toContain('<html')
+    expect(content1).toContain('app-blog')
+    expect(res1.headers.get('content-type')).toContain('text/x-component')
+
+    const res2 = await fetchViaHTTP(appPort, '/app-blog', undefined, {
+      headers: {
+        'x-matched-path': '/app-blog',
+      },
+    })
+    const content2 = await res2.text()
+    expect(content2).toContain('<html')
+    expect(content2).toContain('app-blog')
+    expect(res2.headers.get('content-type')).toContain('text/html')
   })
 
   it('should have correct "Listening on" log', async () => {


### PR DESCRIPTION
This ensures we clear the RSC headers during revalidate when deployed so that the HTML revalidation isn't treated as the RSC revalidation. 