### PR TITLE
Removes `PORT` from `.env` concatenation example

### DIFF
--- a/docs/02-app/01-building-your-application/06-configuring/03-environment-variables.mdx
+++ b/docs/02-app/01-building-your-application/06-configuring/03-environment-variables.mdx
@@ -57,12 +57,11 @@ This loads `process.env.DB_HOST`, `process.env.DB_USER`, and `process.env.DB_PAS
 Next.js will automatically expand variables that use `$` to reference other variables e.g. `$VARIABLE` inside of your `.env*` files. This allows you to reference other secrets. For example:
 
 ```txt filename=".env"
-TWITTER_URL=https://twitter.com
 TWITTER_USER=vercel
-VERCEL_TWITTER_URL=$TWITTER_URL/$TWITTER_USER
+TWITTER_URL=https://twitter.com/$TWITTER_USER
 ```
 
-In the above example, `process.env.VERCEL_TWITTER_URL` would be set to `http://twitter.com/vercel`.
+In the above example, `process.env.TWITTER_URL` would be set to `http://twitter.com/vercel`.
 
 > **Note**: If you need to use variable with a `$` in the actual value, it needs to be escaped e.g. `\$`.
 

--- a/docs/02-app/01-building-your-application/06-configuring/03-environment-variables.mdx
+++ b/docs/02-app/01-building-your-application/06-configuring/03-environment-variables.mdx
@@ -57,12 +57,12 @@ This loads `process.env.DB_HOST`, `process.env.DB_USER`, and `process.env.DB_PAS
 Next.js will automatically expand variables that use `$` to reference other variables e.g. `$VARIABLE` inside of your `.env*` files. This allows you to reference other secrets. For example:
 
 ```txt filename=".env"
-HOSTNAME=localhost
-PORT=8080
-HOST=http://$HOSTNAME:$PORT
+TWITTER_URL=https://twitter.com
+TWITTER_USER=vercel
+VERCEL_TWITTER_URL=$TWITTER_URL/$TWITTER_USER
 ```
 
-In the above example, `process.env.HOST` would be set to `http://localhost:8080`.
+In the above example, `process.env.VERCEL_TWITTER_URL` would be set to `http://twitter.com/vercel`.
 
 > **Note**: If you need to use variable with a `$` in the actual value, it needs to be escaped e.g. `\$`.
 


### PR DESCRIPTION
This is to [avoid confusion](https://github.com/vercel/next.js/issues/32603#issuecomment-996751692) about being able to set Next.js's port via `.env`, which is currently not allowed.