### PR TITLE
Adds the "why" for `next/image` optimization

### DIFF
--- a/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
+++ b/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
@@ -20,7 +20,7 @@ related:
 
 According to [Web Almanac](https://almanac.httparchive.org), images account for a huge portion of the typical website’s [page weight](https://almanac.httparchive.org/en/2022/media#images) and can have an sizable impact on your website's [LCP performance](https://almanac.httparchive.org/en/2022/performance#lcp-image-optimization).
 
-The Next.js Image component extends the HTML `<img>` element with features that make image optimization easier to achieve:
+The Next.js Image component extends the HTML `<img>` element with features for image optimization:
 
 - **Size Optimization:** Automatically serve correctly sized images for each device, using modern image formats like WebP and AVIF.
 - **Visual Stability:** Prevent [layout shift](/learn/seo/web-performance/cls) automatically when images are loading.

--- a/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
+++ b/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
@@ -18,7 +18,7 @@ related:
 
 </details>
 
-According to [Web Almanac](https://almanac.httparchive.org), images account for a huge portion of the typical website’s [page weight](https://almanac.httparchive.org/en/2022/media#images) and can have an sizable impact on your website's [LCP performance](https://almanac.httparchive.org/en/2022/performance#lcp-image-optimization).
+According to [Web Almanac](https://almanac.httparchive.org), images account for a huge portion of the typical website’s [page weight](https://almanac.httparchive.org/en/2022/page-weight#content-type-and-file-formats) and can have an sizable impact on your website's [LCP performance](https://almanac.httparchive.org/en/2022/performance#lcp-image-optimization).
 
 The Next.js Image component extends the HTML `<img>` element with features for automatic image optimization:
 

--- a/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
+++ b/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
@@ -18,7 +18,9 @@ related:
 
 </details>
 
-The Next.js Image component extends the HTML `<img>` element with:
+According to [Web Almanac](https://almanac.httparchive.org), images account for a huge portion of the typical website’s [page weight](https://almanac.httparchive.org/en/2022/media#images) and can have an sizable impact on your website's [LCP performance](https://almanac.httparchive.org/en/2022/performance#lcp-image-optimization).
+
+The Next.js Image component extends the HTML `<img>` element with features that make image optimization easier to achieve:
 
 - **Size Optimization:** Automatically serve correctly sized images for each device, using modern image formats like WebP and AVIF.
 - **Visual Stability:** Prevent [layout shift](/learn/seo/web-performance/cls) automatically when images are loading.

--- a/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
+++ b/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
@@ -20,7 +20,7 @@ related:
 
 According to [Web Almanac](https://almanac.httparchive.org), images account for a huge portion of the typical website’s [page weight](https://almanac.httparchive.org/en/2022/media#images) and can have an sizable impact on your website's [LCP performance](https://almanac.httparchive.org/en/2022/performance#lcp-image-optimization).
 
-The Next.js Image component extends the HTML `<img>` element with features for image optimization:
+The Next.js Image component extends the HTML `<img>` element with features for automatic image optimization:
 
 - **Size Optimization:** Automatically serve correctly sized images for each device, using modern image formats like WebP and AVIF.
 - **Visual Stability:** Prevent [layout shift](/learn/seo/web-performance/cls) automatically when images are loading.


### PR DESCRIPTION
Give a touch more context as to why one would want to use image optimization.

Fixes #30220