### PR TITLE
Remove redundant condition

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -903,10 +903,7 @@ export default async function getBaseWebpackConfig(
       // for middleware to tree shake the unused default optimized imports like "next/server".
       // This will cause some performance overhead but
       // acceptable as Babel will not be recommended.
-      [
-        getSwcLoader({ hasServerComponents: false }),
-        getBabelLoader(),
-      ]
+      [getSwcLoader({ hasServerComponents: false }), getBabelLoader()]
 
   // Loader for API routes needs to be differently configured as it shouldn't
   // have RSC transpiler enabled, so syntax checks such as invalid imports won't

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -904,7 +904,7 @@ export default async function getBaseWebpackConfig(
       // This will cause some performance overhead but
       // acceptable as Babel will not be recommended.
       [
-        getSwcLoader({ hasServerComponents: false, isServerLayer: false }),
+        getSwcLoader({ hasServerComponents: false }),
         getBabelLoader(),
       ]
 


### PR DESCRIPTION
This review comment was sent after merging the PR: https://github.com/vercel/next.js/pull/51067#discussion_r1224745071

The layer condition doesn't do anything if `hasServerComponents` is disabled.