### PR TITLE
Fix another case with app router revalidation

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1326,7 +1326,13 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         hasStaticPaths = true
       }
 
-      if (hasFallback || staticPaths?.includes(resolvedUrlPathname)) {
+      if (
+        hasFallback ||
+        staticPaths?.includes(resolvedUrlPathname) ||
+        // this signals revalidation in deploy environments
+        // TODO: make this more generic
+        req.headers['x-now-route-matches']
+      ) {
         isSSG = true
       } else if (!this.renderOpts.dev) {
         const manifest = this.getPrerenderManifest()

--- a/test/production/standalone-mode/response-cache/app/app/app-another/page.js
+++ b/test/production/standalone-mode/response-cache/app/app/app-another/page.js
@@ -1,9 +1,10 @@
 export const revalidate = 1
 
 export default function Page() {
+  console.log('rendering app-another')
   return (
     <>
-      <p>/app-blog</p>
+      <p>/app-another</p>
       <p>Date: {Date.now()}</p>
     </>
   )

--- a/test/production/standalone-mode/response-cache/app/app/app-blog/[...slug]/page.js
+++ b/test/production/standalone-mode/response-cache/app/app/app-blog/[...slug]/page.js
@@ -1,0 +1,20 @@
+export const revalidate = 1
+
+export function generateStaticParams() {
+  return [
+    {
+      slug: ['compare'],
+    },
+  ]
+}
+
+export default function Page({ params: { slug } }) {
+  console.log('rendering app-blog')
+  return (
+    <>
+      <p>/app-blog</p>
+      <p>slug {JSON.stringify(slug)}</p>
+      <p>Date: {Date.now()}</p>
+    </>
+  )
+}

--- a/test/production/standalone-mode/response-cache/index.test.ts
+++ b/test/production/standalone-mode/response-cache/index.test.ts
@@ -38,13 +38,18 @@ describe('minimal-mode-response-cache', () => {
       }
     }
     const files = glob.sync('**/*', {
-      cwd: join(next.testDir, 'standalone/.next/server/pages'),
+      cwd: join(next.testDir, 'standalone/.next/server'),
+      nodir: true,
       dot: true,
     })
 
     for (const file of files) {
-      if (file.endsWith('.json') || file.endsWith('.html')) {
-        await fs.remove(join(next.testDir, '.next/server', file))
+      if (file.match(/(pages|app)[/\\]/) && !file.endsWith('.js')) {
+        await fs.remove(join(next.testDir, 'standalone/.next/server', file))
+        console.log(
+          'removing',
+          join(next.testDir, 'standalone/.next/server', file)
+        )
       }
     }
 
@@ -81,27 +86,58 @@ describe('minimal-mode-response-cache', () => {
     if (server) await killApp(server)
   })
 
-  it('app router revalidate should work with previous response cache', async () => {
-    const res1 = await fetchViaHTTP(appPort, '/app-blog.rsc', undefined, {
-      headers: {
-        'x-matched-path': '/app-blog.rsc',
-        RSC: '1',
-      },
-    })
+  it('app router revalidate should work with previous response cache dynamic', async () => {
+    const headers = {
+      vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+      'x-now-route-matches': '1=compare&rsc=1',
+      'x-matched-path': '/app-blog/compare.rsc',
+      'x-vercel-id': '1',
+      rsc: '1',
+    }
+    const res1 = await fetchViaHTTP(
+      appPort,
+      '/app-blog/compare.rsc',
+      undefined,
+      {
+        headers,
+      }
+    )
     const content1 = await res1.text()
     expect(content1).not.toContain('<html')
     expect(content1).toContain('app-blog')
     expect(res1.headers.get('content-type')).toContain('text/x-component')
 
-    const res2 = await fetchViaHTTP(appPort, '/app-blog', undefined, {
-      headers: {
-        'x-matched-path': '/app-blog.rsc',
-        RSC: '1',
-      },
+    const res2 = await fetchViaHTTP(appPort, '/app-blog/compare', undefined, {
+      headers,
     })
     const content2 = await res2.text()
     expect(content2).toContain('<html')
     expect(content2).toContain('app-blog')
+    expect(res2.headers.get('content-type')).toContain('text/html')
+  })
+
+  it('app router revalidate should work with previous response cache', async () => {
+    const headers = {
+      vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+      'x-now-route-matches': '1=app-another&rsc=1',
+      'x-matched-path': '/app-another.rsc',
+      'x-vercel-id': '1',
+      rsc: '1',
+    }
+    const res1 = await fetchViaHTTP(appPort, '/app-another.rsc', undefined, {
+      headers,
+    })
+    const content1 = await res1.text()
+    expect(content1).not.toContain('<html')
+    expect(content1).toContain('app-another')
+    expect(res1.headers.get('content-type')).toContain('text/x-component')
+
+    const res2 = await fetchViaHTTP(appPort, '/app-another', undefined, {
+      headers,
+    })
+    const content2 = await res2.text()
+    expect(content2).toContain('<html')
+    expect(content2).toContain('app-another')
     expect(res2.headers.get('content-type')).toContain('text/html')
   })
 


### PR DESCRIPTION
This ensures we don't attempt streaming a response during revalidation in deployed environments. 

x-ref: https://github.com/vercel/next.js/pull/51062
x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1686216024812579)
