### PR TITLE
Do not merge chunkGroups' CSS files

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -219,13 +219,6 @@ export class ClientReferenceManifestPlugin {
               name: 'default',
               chunks: chunkCSS,
             }
-          } else {
-            // It is possible that there are multiple modules with the same resource,
-            // e.g. extracted by mini-css-extract-plugin. In that case we need to
-            // merge the chunks.
-            moduleReferences[exportName].chunks = [
-              ...new Set([...moduleReferences[exportName].chunks, ...chunkCSS]),
-            ]
           }
 
           return


### PR DESCRIPTION
This is a temporary fix before we can ship #51018 (more details there). If there're multiple chunk groups holding the same CSS module, we use files from the first one. This has some flaws but still better than our current status.