### PR TITLE
Fix race condition with publish

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/action-info.js
+++ b/.github/actions/next-stats-action/src/prepare/action-info.js
@@ -61,6 +61,10 @@ module.exports = function actionInfo() {
       (GITHUB_REF || '').includes('canary'),
   }
 
+  if (info.isRelease) {
+    info.prRef = 'canary'
+  }
+
   // get comment
   if (GITHUB_EVENT_PATH) {
     const event = require(GITHUB_EVENT_PATH)

--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -3,7 +3,6 @@ const fs = require('fs-extra')
 const exec = require('../util/exec')
 const { remove } = require('fs-extra')
 const logger = require('../util/logger')
-const semver = require('semver')
 const execa = require('execa')
 
 module.exports = (actionInfo) => {
@@ -14,21 +13,16 @@ module.exports = (actionInfo) => {
         `git clone ${actionInfo.gitRoot}${repoPath} --single-branch --branch ${branch} --depth=${depth} ${dest}`
       )
     },
-    async getLastStable(repoDir = '', ref) {
-      const { stdout } = await exec(`cd ${repoDir} && git tag -l`)
-      const tags = stdout.trim().split('\n')
-      let lastStableTag
+    async getLastStable(repoDir = '') {
+      const { stdout } = await exec(`cd ${repoDir} && git describe`)
+      const tag = stdout.trim()
 
-      for (let i = tags.length - 1; i >= 0; i--) {
-        const curTag = tags[i]
-        // stable doesn't include `-canary` or `-beta`
-        if (!curTag.includes('-') && !ref.includes(curTag)) {
-          if (!lastStableTag || semver.gt(curTag, lastStableTag)) {
-            lastStableTag = curTag
-          }
-        }
+      if (!tag || !tag.startsWith('v')) {
+        throw new Error(`Failed to get tag info ${stdout}`)
       }
-      return lastStableTag
+      const tagParts = tag.split('-canary')[0].split('.')
+      // last stable tag will always be 1 patch less than canary
+      return `${tagParts[0]}.${tagParts[1]}.${Number(tagParts[2]) - 1}`
     },
     async getCommitId(repoDir = '') {
       const { stdout } = await exec(`cd ${repoDir} && git rev-parse HEAD`)

--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -70,16 +70,6 @@ const cwd = process.cwd()
         } finally {
           publishSema.release()
         }
-        // lerna publish in next step will fail if git status is not clean
-        await execa(
-          `git`,
-          [
-            'update-index',
-            '--skip-worktree',
-            `${path.join(nativePackagesDir, platform, 'package.json')}`,
-          ],
-          { stdio: 'inherit' }
-        )
       })
     )
 
@@ -151,14 +141,6 @@ const cwd = process.cwd()
     await writeFile(
       path.join(path.join(cwd, 'packages/next/package.json')),
       JSON.stringify(nextPkg, null, 2)
-    )
-    // lerna publish in next step will fail if git status is not clean
-    await execa(
-      'git',
-      ['update-index', '--skip-worktree', 'packages/next/package.json'],
-      {
-        stdio: 'inherit',
-      }
     )
   } catch (err) {
     console.error(err)

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -51,6 +51,7 @@ const cwd = process.cwd()
           `${path.join(packagesDir, pkg)}`,
           '--access',
           'public',
+          '--ignore-scripts',
           ...(isCanary ? ['--tag', 'canary'] : []),
         ],
         { stdio: 'inherit' }


### PR DESCRIPTION
We publish multiple packages in parallel which can cause issues with the prepublish only script running as turbo clearing/restoring dist caches can causing files to be missing if a publish is in progress. We also don't need to run these as all packages are already built prior to publishing. This also includes fixes for release stats. 
