### PR TITLE
Fix getting last stable release stats

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -73,7 +73,7 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
 
       if (actionInfo.isRelease) {
         logger('Release detected, using last stable tag')
-        const lastStableTag = await getLastStable(mainRepoDir, actionInfo.prRef)
+        const lastStableTag = await getLastStable(diffRepoDir, actionInfo.prRef)
         mainRef = lastStableTag
         mainNextSwcVersion = lastStableTag
         if (!lastStableTag) throw new Error('failed to get last stable tag')


### PR DESCRIPTION
Small fix ensuring we use the correct repo for getting the last stable tag