### PR TITLE
ci(workflow): consolidate bytesize upload workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -166,7 +166,6 @@ jobs:
       TURBO_TEAM: 'vercel'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_REMOTE_ONLY: 'true'
-      DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
     steps:
       # https://github.com/actions/virtual-environments/issues/1187
       - name: tune linux network
@@ -253,12 +252,13 @@ jobs:
         run: if [[ ! -z $(ls .turbo/runs) ]]; then echo "DID_BUILD=yup" >> $GITHUB_OUTPUT; fi
 
       # Trying to upload metrics for the Turbopack to datadog's CI pipeline execution
-      - name: 'Upload turbopack build metrics'
+      - name: 'Collect turbopack build metrics'
+        id: check-turbopack-bytesize
         shell: bash
         if: ${{ steps.check-did-build.outputs.DID_BUILD == 'yup' }}
         continue-on-error: true
         run: |
-          npm install -g @datadog/datadog-ci
+          mkdir -p ./turbopack-bin-size
           shopt -s nullglob
           for filename in packages/next-swc/native/next-swc.*.node; do
             # Strip out filename to extract target triple
@@ -267,8 +267,15 @@ jobs:
             export FILENAME=${FILENAME%.node}
             export BYTESIZE=$(wc -c < $filename | xargs)
             echo "Reporting $FILENAME:$BYTESIZE for Turbopack bytesize"
-            datadog-ci metric --no-fail --level pipeline --metrics "turbopack.bytesize.$FILENAME:$BYTESIZE"
+            echo "turbopack.bytesize.$FILENAME:$BYTESIZE" > ./turbopack-bin-size/${{ matrix.settings.target }}
           done
+
+      - name: Upload turbopack bytesize artifact
+        if: ${{ steps.check-did-build.outputs.DID_BUILD == 'yup' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: turbopack-bytesize
+          path: turbopack-bin-size/*
 
       - name: Upload swc artifact
         if: ${{ needs.build.outputs.isRelease == 'true' }}
@@ -469,3 +476,25 @@ jobs:
       - uses: ./.github/actions/next-stats-action
         env:
           PR_STATS_COMMENT_TOKEN: ${{ secrets.PR_STATS_COMMENT_TOKEN }}
+
+  upload_turbopack_bytesize:
+    name: Upload Turbopack Bytesize trace to Datadog
+    runs-on: ubuntu-latest
+    needs: [build-native]
+    env:
+      DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
+    steps:
+      - name: Collect bytesize traces
+        uses: actions/download-artifact@v3
+        with:
+          name: turbopack-bytesize
+          path: turbopack-bin-size
+      - name: Upload to Datadog
+        run: |
+          ls -al turbopack-bin-size
+          npm install -g @datadog/datadog-ci
+          for filename in turbopack-bin-size/*; do
+            export BYTESIZE+=" --metrics $(cat $filename)"
+          done
+          echo "Reporting $BYTESIZE"
+          datadog-ci metric --no-fail --level pipeline $BYTESIZE


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

context: https://github.com/vercel/next.js/actions/runs/5231928600/jobs/9446394605#step:16:33

For some reason, installing datadog cli on some action runner (Windows) is unexpectedly slow: while other platform takes ~30s, windows only takes more than > 7m.

PR updates workflow logic to consolidate artifacts, and then send metrics at once on a separate ubuntu workflow.