### PR TITLE
Fixes the link from components/fonts to api/fonts

### DIFF
--- a/docs/02-app/01-building-your-application/05-optimizing/02-fonts.mdx
+++ b/docs/02-app/01-building-your-application/05-optimizing/02-fonts.mdx
@@ -502,7 +502,7 @@ const roboto = localFont({
 })
 ```
 
-View the [Font API Reference](#local-fonts) for more information.
+View the [Font API Reference](/docs/app/api-reference/components/font) for more information.
 
 ## With Tailwind CSS
 


### PR DESCRIPTION
### What?

Fixes a link in [Components: Font](https://nextjs.org/docs/pages/api-reference/components/font) where the link mentions the fonts API page, but links to the current page anchor.
