### PR TITLE
Fix a typo

### DIFF
--- a/docs/02-app/01-building-your-application/03-data-fetching/04-server-actions.mdx
+++ b/docs/02-app/01-building-your-application/03-data-fetching/04-server-actions.mdx
@@ -104,7 +104,7 @@ export async function myAction() {
 ```
 
 ```jsx filename="app/client-component.jsx" highlight={1}
-|"use client"
+"use client"
 
 import { myAction } from './actions';
 


### PR DESCRIPTION
Remove `|` before 'use client'
