### PR TITLE
[Docs][CSS-in-JS]: Update Vanilla Extract link

### DIFF
--- a/docs/02-app/01-building-your-application/04-styling/03-css-in-js.mdx
+++ b/docs/02-app/01-building-your-application/04-styling/03-css-in-js.mdx
@@ -15,7 +15,7 @@ The following libraries are supported in Client Components in the `app` director
 - [`styled-components`](#styled-components)
 - [`tamagui`](https://tamagui.dev/docs/guides/next-js#server-components)
 - [`style9`](https://github.com/johanholmerin/style9)
-- [`vanilla-extract`](https://github.com/SuttonJack/vanilla-extract-app-dir)
+- [`vanilla-extract`](https://github.com/vercel/next.js/tree/canary/examples/with-vanilla-extract)
 
 The following are currently working on support:
 


### PR DESCRIPTION
- Updates the Vanilla Extract example link to the [one](https://github.com/vercel/next.js/pull/50394) in the next.js repo