### PR TITLE
[Docs] Remove extra line in summary dropdowns

### DIFF
--- a/docs/02-app/01-building-your-application/04-styling/01-css-modules.mdx
+++ b/docs/02-app/01-building-your-application/04-styling/01-css-modules.mdx
@@ -6,9 +6,7 @@ description: Style your Next.js Application with CSS Modules.
 <PagesOnly>
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Basic CSS Example](https://github.com/vercel/next.js/tree/canary/examples/basic-css)
 

--- a/docs/02-app/01-building-your-application/04-styling/02-tailwind-css.mdx
+++ b/docs/02-app/01-building-your-application/04-styling/02-tailwind-css.mdx
@@ -6,9 +6,7 @@ description: Style your Next.js Application using Tailwind CSS.
 <PagesOnly>
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [With Tailwind CSS](https://github.com/vercel/next.js/tree/canary/examples/with-tailwindcss)
 

--- a/docs/02-app/01-building-your-application/04-styling/03-css-in-js.mdx
+++ b/docs/02-app/01-building-your-application/04-styling/03-css-in-js.mdx
@@ -236,9 +236,7 @@ export default function RootLayout({ children }) {
 <PagesOnly>
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Styled JSX](https://github.com/vercel/next.js/tree/canary/examples/with-styled-jsx)
 - [Styled Components](https://github.com/vercel/next.js/tree/canary/examples/with-styled-components)

--- a/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
+++ b/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
@@ -10,9 +10,7 @@ related:
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Image Component](https://github.com/vercel/next.js/tree/canary/examples/image-component)
 

--- a/docs/02-app/01-building-your-application/06-configuring/03-environment-variables.mdx
+++ b/docs/02-app/01-building-your-application/06-configuring/03-environment-variables.mdx
@@ -4,9 +4,7 @@ description: Learn to add and access environment variables in your Next.js appli
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Environment Variables](https://github.com/vercel/next.js/tree/canary/examples/environment-variables)
 

--- a/docs/02-app/01-building-your-application/06-configuring/04-absolute-imports-and-module-aliases.mdx
+++ b/docs/02-app/01-building-your-application/06-configuring/04-absolute-imports-and-module-aliases.mdx
@@ -4,9 +4,7 @@ description: Configure module path aliases that allow you to remap certain impor
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Absolute Imports and Aliases](https://github.com/vercel/next.js/tree/canary/examples/with-absolute-imports)
 

--- a/docs/02-app/01-building-your-application/08-upgrading/02-app-router-migration.mdx
+++ b/docs/02-app/01-building-your-application/08-upgrading/02-app-router-migration.mdx
@@ -194,9 +194,7 @@ If you are using any React Context providers, they will need to be moved to a [C
 Next.js recommended adding a [property to Page components](/docs/pages/building-your-application/routing/pages-and-layouts#layout-pattern#per-page-layouts) to achieve per-page layouts in the `pages` directory. This pattern can be replaced with native support for [nested layouts](/docs/app/building-your-application/routing/pages-and-layouts#layouts) in the `app` directory.
 
 <details>
-  <summary>
-    See before and after example
-  </summary>
+  <summary>See before and after example</summary>
 
 **Before**
 

--- a/docs/02-app/02-api-reference/01-components/image.mdx
+++ b/docs/02-app/02-api-reference/01-components/image.mdx
@@ -4,9 +4,7 @@ description: Optimize Images in your Next.js Application using the built-in `nex
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Image Component](https://github.com/vercel/next.js/tree/canary/examples/image-component)
 

--- a/docs/02-app/02-api-reference/01-components/link.mdx
+++ b/docs/02-app/02-api-reference/01-components/link.mdx
@@ -4,14 +4,10 @@ description: Enable fast client-side navigation with the built-in `next/link` co
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
-- [Hello
-      World](https://github.com/vercel/next.js/tree/canary/examples/hello-world)
+  <summary>Examples</summary>
 
-- [Active className on
-  Link](https://github.com/vercel/next.js/tree/canary/examples/active-class-name)
+- [Hello World](https://github.com/vercel/next.js/tree/canary/examples/hello-world)
+- [Active className on Link](https://github.com/vercel/next.js/tree/canary/examples/active-class-name)
 
 </details>
 

--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/app-icons.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/app-icons.mdx
@@ -14,16 +14,16 @@ There are two ways to set app icons:
 
 ## Image files (.ico, .jpg, .png)
 
-Use an image file to set an app icon by placing a `favicon`, `icon`, or `apple-icon` image file within your `/app` directory. 
-The `favicon` image can only be located in the top level of `app/`. 
+Use an image file to set an app icon by placing a `favicon`, `icon`, or `apple-icon` image file within your `/app` directory.
+The `favicon` image can only be located in the top level of `app/`.
 
 Next.js will evaluate the file and automatically add the appropriate tags to your app's `<head>` element.
 
-| File convention             | Supported file types                    | Valid locations
-| --------------------------- | --------------------------------------- | ---------------------------
-| [`favicon`](#favicon)       | `.ico`                                  | `app/`
-| [`icon`](#icon)             | `.ico`, `.jpg`, `.jpeg`, `.png`, `.svg` | `app/**/*`
-| [`apple-icon`](#apple-icon) | `.jpg`, `.jpeg`, `.png`                 | `app/**/*`
+| File convention             | Supported file types                    | Valid locations |
+| --------------------------- | --------------------------------------- | --------------- |
+| [`favicon`](#favicon)       | `.ico`                                  | `app/`          |
+| [`icon`](#icon)             | `.ico`, `.jpg`, `.jpeg`, `.png`, `.svg` | `app/**/*`      |
+| [`apple-icon`](#apple-icon) | `.jpg`, `.jpeg`, `.png`                 | `app/**/*`      |
 
 ### `favicon`
 

--- a/docs/02-app/02-api-reference/05-next-config-js/env.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/env.mdx
@@ -6,9 +6,7 @@ description: Learn to add and access environment variables in your Next.js appli
 > Since the release of [Next.js 9.4](https://nextjs.org/blog/next-9-4) we now have a more intuitive and ergonomic experience for [adding environment variables](/docs/pages/building-your-application/configuring/environment-variables). Give it a try!
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [With env](https://github.com/vercel/next.js/tree/canary/examples/with-env-from-next-config-js)
 

--- a/docs/02-app/02-api-reference/05-next-config-js/exportPathMap.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/exportPathMap.mdx
@@ -7,9 +7,8 @@ description: Customize the pages that will be exported as HTML files when using 
 > This feature is exclusive to `next export` and currently **deprecated** in favor of `getStaticPaths` with `pages` or `generateStaticParams` with `app`.
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
+  
 - [Static Export](https://github.com/vercel/next.js/tree/canary/examples/with-static-export)
 
 </details>

--- a/docs/02-app/02-api-reference/05-next-config-js/rewrites.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/rewrites.mdx
@@ -292,9 +292,7 @@ module.exports = {
 ## Rewriting to an external URL
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Incremental adoption of Next.js](https://github.com/vercel/next.js/tree/canary/examples/custom-routes-proxying)
 - [Using Multiple Zones](https://github.com/vercel/next.js/tree/canary/examples/with-zones)

--- a/docs/03-pages/01-building-your-application/01-routing/03-linking-and-navigating.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/03-linking-and-navigating.mdx
@@ -98,9 +98,7 @@ Now, instead of using interpolation to create the path, we use a URL object in `
 ## Injecting the router
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Dynamic Routing](https://github.com/vercel/next.js/tree/canary/examples/dynamic-routing)
 
@@ -113,9 +111,7 @@ In general we recommend using [`useRouter`](/docs/pages/api-reference/functions/
 ## Imperative Routing
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Using Router](https://github.com/vercel/next.js/tree/canary/examples/using-router)
 
@@ -142,9 +138,7 @@ export default function ReadMore() {
 ## Shallow Routing
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Shallow Routing](https://github.com/vercel/next.js/tree/canary/examples/with-shallow-routing)
 

--- a/docs/03-pages/01-building-your-application/01-routing/07-api-routes.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/07-api-routes.mdx
@@ -4,9 +4,7 @@ description: Next.js supports API Routes, which allow you to build your API with
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Basic API Routes](https://github.com/vercel/next.js/tree/canary/examples/api-routes)
 - [API Routes Request Helpers](https://github.com/vercel/next.js/tree/canary/examples/api-routes-middleware)

--- a/docs/03-pages/01-building-your-application/01-routing/08-internationalization.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/08-internationalization.mdx
@@ -5,9 +5,7 @@ description: Next.js has built-in support for internationalized routing and lang
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [i18n routing](https://github.com/vercel/next.js/tree/canary/examples/i18n-routing)
 

--- a/docs/03-pages/01-building-your-application/01-routing/09-authenticating.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/09-authenticating.mdx
@@ -104,9 +104,7 @@ Now that we've discussed authentication patterns, let's look at specific provide
 ### Bring Your Own Database
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [with-iron-session](https://github.com/vercel/next.js/tree/canary/examples/with-iron-session)
 - [next-auth-example](https://github.com/nextauthjs/next-auth-example)
@@ -128,9 +126,7 @@ Both of these libraries support either authentication pattern. If you're interes
 To see examples with other authentication providers, check out the [examples folder](https://github.com/vercel/next.js/tree/canary/examples).
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Auth0](https://github.com/vercel/next.js/tree/canary/examples/auth0)
 - [Clerk](https://github.com/vercel/next.js/tree/canary/examples/with-clerk)

--- a/docs/03-pages/01-building-your-application/02-rendering/02-static-site-generation.mdx
+++ b/docs/03-pages/01-building-your-application/02-rendering/02-static-site-generation.mdx
@@ -4,9 +4,7 @@ description: Use Static Site Generation (SSG) to pre-render pages at build time.
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [WordPress Example](https://github.com/vercel/next.js/tree/canary/examples/cms-wordpress)([Demo](https://next-blog-wordpress.vercel.app))
 - [Blog Starter using markdown files](https://github.com/vercel/next.js/tree/canary/examples/blog-starter) ([Demo](https://next-blog-starter.vercel.app/))

--- a/docs/03-pages/01-building-your-application/03-data-fetching/04-incremental-static-regeneration.mdx
+++ b/docs/03-pages/01-building-your-application/03-data-fetching/04-incremental-static-regeneration.mdx
@@ -4,9 +4,7 @@ description: 'Learn how to create or update static pages at runtime with Increme
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Next.js Commerce](https://nextjs.org/commerce)
 - [GitHub Reactions Demo](https://reactions-demo.vercel.app/)

--- a/docs/03-pages/01-building-your-application/05-optimizing/10-testing.mdx
+++ b/docs/03-pages/01-building-your-application/05-optimizing/10-testing.mdx
@@ -4,9 +4,7 @@ description: Learn how to set up Next.js with three commonly used testing tools 
 ---
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Next.js with Cypress](https://github.com/vercel/next.js/tree/canary/examples/with-cypress)
 - [Next.js with Playwright](https://github.com/vercel/next.js/tree/canary/examples/with-playwright)

--- a/docs/03-pages/01-building-your-application/06-configuring/07-amp.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/07-amp.mdx
@@ -4,8 +4,10 @@ description: With minimal config, and without leaving React, you can start addin
 ---
 
 <details>
-  <summary>Examples</summary>-
-  [AMP](https://github.com/vercel/next.js/tree/canary/examples/amp)
+  <summary>Examples</summary>
+  
+- [AMP](https://github.com/vercel/next.js/tree/canary/examples/amp)
+
 </details>
 
 With Next.js you can turn any React page into an AMP page, with minimal config, and without leaving React.

--- a/docs/03-pages/01-building-your-application/06-configuring/08-babel.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/08-babel.mdx
@@ -4,9 +4,7 @@ description: Extend the babel preset added by Next.js with your own configs.
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Customizing babel configuration](https://github.com/vercel/next.js/tree/canary/examples/with-custom-babel-config)
 

--- a/docs/03-pages/01-building-your-application/06-configuring/09-post-css.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/09-post-css.mdx
@@ -4,9 +4,7 @@ description: Extend the PostCSS config and plugins added by Next.js with your ow
 ---
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Tailwind CSS Example](https://github.com/vercel/next.js/tree/canary/examples/with-tailwindcss)
 

--- a/docs/03-pages/01-building-your-application/06-configuring/10-custom-server.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/10-custom-server.mdx
@@ -4,9 +4,7 @@ description: Start a Next.js app programmatically using a custom server.
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Custom Server](https://github.com/vercel/next.js/tree/canary/examples/custom-server)
 - [SSR Caching](https://github.com/vercel/next.js/tree/canary/examples/ssr-caching)

--- a/docs/03-pages/01-building-your-application/06-configuring/14-preview-mode.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/14-preview-mode.mdx
@@ -6,9 +6,7 @@ description: Next.js has the preview mode for statically generated pages. You ca
 > **Warning**: This feature is **legacy** and is superseded by [Draft Mode](/docs/pages/building-your-application/configuring/draft-mode).
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [WordPress Example](https://github.com/vercel/next.js/tree/canary/examples/cms-wordpress) ([Demo](https://next-blog-wordpress.vercel.app))
 - [DatoCMS Example](https://github.com/vercel/next.js/tree/canary/examples/cms-datocms) ([Demo](https://next-blog-datocms.vercel.app/))

--- a/docs/03-pages/01-building-your-application/07-deploying/01-production-checklist.mdx
+++ b/docs/03-pages/01-building-your-application/07-deploying/01-production-checklist.mdx
@@ -26,9 +26,7 @@ Before taking your Next.js application to production, here are some recommendati
 ## Caching
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [ssr-caching](https://github.com/vercel/next.js/tree/canary/examples/ssr-caching)
 
@@ -80,9 +78,7 @@ By default, `Cache-Control` headers will be set differently depending on how you
 ## Reducing JavaScript Size
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [with-dynamic-import](https://github.com/vercel/next.js/tree/canary/examples/with-dynamic-import)
 
@@ -101,9 +97,7 @@ Each file inside your `pages/` directory will automatically be code split into i
 ## Logging
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Pino and Logflare Example](https://github.com/Logflare/next-pino-logflare-logging-example)
 
@@ -119,9 +113,7 @@ If you want a structured logging package, we recommend [Pino](https://www.npmjs.
 ## Error Handling
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [with-sentry](https://github.com/vercel/next.js/tree/canary/examples/with-sentry)
 

--- a/docs/03-pages/01-building-your-application/07-deploying/03-multi-zones.mdx
+++ b/docs/03-pages/01-building-your-application/07-deploying/03-multi-zones.mdx
@@ -4,9 +4,7 @@ description: Learn how to use multi zones to deploy multiple Next.js apps as a s
 ---
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [With Zones](https://github.com/vercel/next.js/tree/canary/examples/with-zones)
 

--- a/docs/03-pages/02-api-reference/01-components/head.mdx
+++ b/docs/03-pages/02-api-reference/01-components/head.mdx
@@ -4,9 +4,7 @@ description: Add custom elements to the `head` of your page with the built-in He
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Head Elements](https://github.com/vercel/next.js/tree/canary/examples/head-elements)
 - [Layout Component](https://github.com/vercel/next.js/tree/canary/examples/layout-component)

--- a/docs/03-pages/02-api-reference/01-components/image-legacy.mdx
+++ b/docs/03-pages/02-api-reference/01-components/image-legacy.mdx
@@ -4,9 +4,7 @@ description: Backwards compatible Image Optimization with the Legacy Image compo
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Legacy Image Component](https://github.com/vercel/next.js/tree/canary/examples/image-legacy-component)
 

--- a/docs/03-pages/02-api-reference/02-functions/get-static-paths.mdx
+++ b/docs/03-pages/02-api-reference/02-functions/get-static-paths.mdx
@@ -150,9 +150,7 @@ export default Post
 ### `fallback: true`
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Static generation of a large number of pages](https://static-tweet.vercel.app)
 

--- a/docs/03-pages/02-api-reference/02-functions/use-amp.mdx
+++ b/docs/03-pages/02-api-reference/02-functions/use-amp.mdx
@@ -4,9 +4,7 @@ description: Enable AMP in a page, and control the way Next.js adds AMP to the p
 ---
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [AMP](https://github.com/vercel/next.js/tree/canary/examples/amp)
 

--- a/docs/03-pages/02-api-reference/02-functions/use-router.mdx
+++ b/docs/03-pages/02-api-reference/02-functions/use-router.mdx
@@ -55,9 +55,7 @@ The following methods are included inside `router`:
 ### router.push
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Using Router](https://github.com/vercel/next.js/tree/canary/examples/using-router)
 
@@ -363,9 +361,7 @@ export default function Page() {
 ### router.events
 
 <details>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [With a page loading indicator](https://github.com/vercel/next.js/tree/canary/examples/with-loading)
 

--- a/docs/04-architecture/fast-refresh.mdx
+++ b/docs/04-architecture/fast-refresh.mdx
@@ -4,9 +4,7 @@ description: Fast Refresh is a hot module reloading experience that gives you in
 ---
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [Fast Refresh Demo](https://github.com/vercel/next.js/tree/canary/examples/fast-refresh-demo)
 

--- a/docs/04-architecture/nextjs-compiler.mdx
+++ b/docs/04-architecture/nextjs-compiler.mdx
@@ -255,9 +255,7 @@ module.exports = {
 ### Modularize Imports
 
 <details open>
-  <summary>
-    Examples
-  </summary>
+  <summary>Examples</summary>
 
 - [modularize-imports](https://github.com/vercel/next.js/blob/canary/examples/modularize-imports/)
 


### PR DESCRIPTION
They were causing markdown to render a `<p>` tag which has margins and broke the summary dropdowns