### PR TITLE
[Docs] fix example function param and signature

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/05-dynamic-routes.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/05-dynamic-routes.mdx
@@ -22,14 +22,14 @@ Dynamic Segments are passed as the `params` prop to [`layout`](/docs/app/api-ref
 For example, a blog could include the following route `app/blog/[slug]/page.js` where `[slug]` is the Dynamic Segment for blog posts.
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
-export default function Page({ params: { slug: string } }) {
-  return <div>My Post: {slug}</div>
+export default function Page({ params }: { params: { slug: string } }) {
+  return <div>My Post: {params.slug}</div>
 }
 ```
 
 ```jsx filename="app/blog/[slug]/page.js" switcher
 export default function Page({ params }) {
-  return <div>My Post: {slug}</div>
+  return <div>My Post: {params.slug}</div>
 }
 ```
 


### PR DESCRIPTION
Apparently the object deconstruction in the example doesn't work. This PR proposes a working version:

```diff
- export default function Page({ params: { slug: string } }) {
-   return <div>My Post: {slug}</div>
- }
+ export default function Page({ params }: { params: { slug: string } }) {
+   return <div>My Post: {params.slug}</div>
+ }
```

According to the [page reference](https://nextjs.org/docs/app/api-reference/file-conventions/page), the page function parameter slugs needs to be retrieved by calling `params.slug`.

The TypeScript section below shows the correct function type signature, although not referencing to the parameter.