### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,4 @@
 
 /**/*image*                                   @timneutkens @ijjk @shuding @styfle @huozhi @vercel/devex
 /**/*image*/**                                @timneutkens @ijjk @shuding @styfle @huozhi @vercel/devex
-/packages/next/client/use-intersection.tsx    @timneutkens @ijjk @shuding @styfle
-/packages/next/server/lib/squoosh/            @timneutkens @ijjk @shuding @styfle
-/packages/next/server/serve-static.ts         @timneutkens @ijjk @shuding @styfle @huozhi
-/packages/next/server/config.ts               @timneutkens @ijjk @shuding @styfle @huozhi
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,13 @@
 # Learn how to add code owners here:
 # https://help.github.com/en/articles/about-code-owners
 
-# Part of code owners now use Vercel Spaces
+# Codeowners now use Vercel Spaces
 # Search .vercel.approvers for all files
-          
-/.git*                                        @vercel/next-js
-/.alex*                                       @vercel/next-js @leerob
-/.eslint*                                     @vercel/next-js @leerob
-/.prettier*                                   @vercel/next-js @leerob
 
 # Image Component (@styfle)
 
-/**/*image*                                   @timneutkens @ijjk @shuding @styfle @huozhi
-/**/*image*/**                                @timneutkens @ijjk @shuding @styfle @huozhi
+/**/*image*                                   @styfle @vercel/devex
+/**/*image*/**                                @styfle @vercel/devex
 /packages/next/client/use-intersection.tsx    @timneutkens @ijjk @shuding @styfle
 /packages/next/server/lib/squoosh/            @timneutkens @ijjk @shuding @styfle
 /packages/next/server/serve-static.ts         @timneutkens @ijjk @shuding @styfle @huozhi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,8 +6,8 @@
 
 # Image Component (@styfle)
 
-/**/*image*                                   @styfle @vercel/devex
-/**/*image*/**                                @styfle @vercel/devex
+/**/*image*                                   @timneutkens @ijjk @shuding @styfle @huozhi @vercel/devex
+/**/*image*/**                                @timneutkens @ijjk @shuding @styfle @huozhi @vercel/devex
 /packages/next/client/use-intersection.tsx    @timneutkens @ijjk @shuding @styfle
 /packages/next/server/lib/squoosh/            @timneutkens @ijjk @shuding @styfle
 /packages/next/server/serve-static.ts         @timneutkens @ijjk @shuding @styfle @huozhi

--- a/.vercel.approvers
+++ b/.vercel.approvers
@@ -4,6 +4,7 @@
 @shuding
 @huozhi
 @feedthejim
+@vercel/next.js:optional
 
 # Tooling & Telemetry
 pnpm-lock.yaml                                @vercel/web-tooling

--- a/contributing/.vercel.approvers
+++ b/contributing/.vercel.approvers
@@ -1,2 +1,1 @@
 @vercel/devex
-@vercel/next-js:optional

--- a/docs/.vercel.approvers
+++ b/docs/.vercel.approvers
@@ -1,2 +1,1 @@
 @vercel/devex
-@vercel/next-js:optional

--- a/errors/.vercel.approvers
+++ b/errors/.vercel.approvers
@@ -1,2 +1,1 @@
 @vercel/devex
-@vercel/next-js:optional

--- a/examples/.vercel.approvers
+++ b/examples/.vercel.approvers
@@ -1,2 +1,1 @@
 @vercel/devrel
-@vercel/next-js:optional

--- a/packages/create-next-app/.vercel.approvers
+++ b/packages/create-next-app/.vercel.approvers
@@ -1,1 +1,0 @@
-@vercel/next-js

--- a/packages/next/src/client/.vercel.approvers
+++ b/packages/next/src/client/.vercel.approvers
@@ -1,0 +1,1 @@
+**/use-intersection.tsx @timneutkens @ijjk @shuding @styfle

--- a/packages/next/src/server/.vercel.approvers
+++ b/packages/next/src/server/.vercel.approvers
@@ -1,0 +1,2 @@
+**/serve-static.ts         @timneutkens @ijjk @shuding @styfle @huozhi
+**/config.ts               @timneutkens @ijjk @shuding @styfle @huozhi

--- a/packages/next/src/server/lib/squoosh/.vercel.approvers
+++ b/packages/next/src/server/lib/squoosh/.vercel.approvers
@@ -1,0 +1,4 @@
+@timneutkens
+@ijjk
+@shuding
+@styfle

--- a/scripts/.vercel.approvers
+++ b/scripts/.vercel.approvers
@@ -1,1 +1,0 @@
-@vercel/next-js


### PR DESCRIPTION
Tweak code owners after some testing and feedback. 

- Move the Next.js team up to be optional global code owners (so that everyone can review but are not tagged for review). Global individuals should still be tagged if there are no specific `.vercel.approvers` files in subdirectories.
- Adds @vercel/devex to image files so there's coverage on those files for the docs
- Target specific folder and files for Styfle to get notified
- Deletes some rules in the old GitHub codeowners