### PR TITLE
Add leerob as an optional global codeowner

### DIFF
--- a/.vercel.approvers
+++ b/.vercel.approvers
@@ -4,6 +4,7 @@
 @shuding
 @huozhi
 @feedthejim
+@leerob:optional
 @vercel/next.js:optional
 
 # Tooling & Telemetry


### PR DESCRIPTION
Add @leerob as an optional global code owner. This means he won't be tagged for reviews on every PR, but he can approve PRs. This allows the @vercel/devex to make changes more quickly, without having to distract the Next.js team. 