### PR TITLE
Turbopack: Use @mdx-js/loader in e2e test when not using mdx-rs

### DIFF
--- a/packages/next-swc/crates/next-core/src/fallback.rs
+++ b/packages/next-swc/crates/next-core/src/fallback.rs
@@ -61,13 +61,7 @@ pub async fn get_fallback_page(
         get_client_runtime_entries(project_path, env, ty, mode, next_config, execution_context);
 
     let mut import_map = ImportMap::empty();
-    insert_next_shared_aliases(
-        &mut import_map,
-        project_path,
-        execution_context,
-        next_config,
-    )
-    .await?;
+    insert_next_shared_aliases(&mut import_map, project_path, execution_context).await?;
 
     let context: AssetContextVc = ModuleAssetContextVc::new(
         TransitionsByNameVc::cell(HashMap::new()),

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -43,13 +43,7 @@ pub async fn get_next_client_import_map(
 ) -> Result<ImportMapVc> {
     let mut import_map = ImportMap::empty();
 
-    insert_next_shared_aliases(
-        &mut import_map,
-        project_path,
-        execution_context,
-        next_config,
-    )
-    .await?;
+    insert_next_shared_aliases(&mut import_map, project_path, execution_context).await?;
 
     insert_alias_option(
         &mut import_map,
@@ -193,13 +187,7 @@ pub async fn get_next_server_import_map(
 ) -> Result<ImportMapVc> {
     let mut import_map = ImportMap::empty();
 
-    insert_next_shared_aliases(
-        &mut import_map,
-        project_path,
-        execution_context,
-        next_config,
-    )
-    .await?;
+    insert_next_shared_aliases(&mut import_map, project_path, execution_context).await?;
 
     insert_alias_option(
         &mut import_map,
@@ -263,13 +251,7 @@ pub async fn get_next_edge_import_map(
 ) -> Result<ImportMapVc> {
     let mut import_map = ImportMap::empty();
 
-    insert_next_shared_aliases(
-        &mut import_map,
-        project_path,
-        execution_context,
-        next_config,
-    )
-    .await?;
+    insert_next_shared_aliases(&mut import_map, project_path, execution_context).await?;
 
     insert_alias_option(
         &mut import_map,
@@ -424,21 +406,18 @@ pub async fn insert_next_shared_aliases(
     import_map: &mut ImportMap,
     project_path: FileSystemPathVc,
     execution_context: ExecutionContextVc,
-    next_config: NextConfigVc,
 ) -> Result<()> {
     let package_root = next_js_fs().root();
 
-    if *next_config.mdx_rs().await? {
-        insert_alias_to_alternatives(
-            import_map,
-            mdx_import_source_file(),
-            vec![
-                request_to_import_mapping(project_path, "./mdx-components"),
-                request_to_import_mapping(project_path, "./src/mdx-components"),
-                external_request_to_import_mapping("@mdx-js/react"),
-            ],
-        );
-    }
+    insert_alias_to_alternatives(
+        import_map,
+        mdx_import_source_file(),
+        vec![
+            request_to_import_mapping(project_path, "./mdx-components"),
+            request_to_import_mapping(project_path, "./src/mdx-components"),
+            external_request_to_import_mapping("@mdx-js/react"),
+        ],
+    );
 
     // we use the next.js hydration code, so we replace the error overlay with our
     // own

--- a/test/e2e/app-dir/mdx/next.config.js
+++ b/test/e2e/app-dir/mdx/next.config.js
@@ -1,3 +1,5 @@
+const shouldUseMdxRs = process.env.WITH_MDX_RS === 'true'
+
 const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
 })
@@ -8,8 +10,23 @@ const withMDX = require('@next/mdx')({
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
   experimental: {
-    mdxRs: process.env.WITH_MDX_RS === 'true',
+    mdxRs: shouldUseMdxRs,
   },
+}
+
+if (shouldUseMdxRs) {
+  nextConfig.experimental.turbo = {
+    rules: {
+      '*.mdx': [
+        {
+          loader: '@mdx-js/loader',
+          options: {
+            providerImportSource: '@vercel/turbopack-next/mdx-import-source',
+          },
+        },
+      ],
+    },
+  }
 }
 
 module.exports = withMDX(nextConfig)

--- a/test/e2e/app-dir/mdx/next.config.js
+++ b/test/e2e/app-dir/mdx/next.config.js
@@ -14,7 +14,7 @@ const nextConfig = {
   },
 }
 
-if (shouldUseMdxRs) {
+if (!shouldUseMdxRs) {
   nextConfig.experimental.turbo = {
     rules: {
       '*.mdx': [


### PR DESCRIPTION
This has the mdx e2e test use the js `@mdx-js/loader` when it's not configured to use mdx-rs.

This required exposing the mdx import source for components unconditionally, so that it can be referenced from the loader options.

Test Plan: `test/e2e/app-dir/mdx/mdx.test.ts`


Closes PACK-3957