### PR TITLE
chore(docs): codemod docs should mention `.` for cwd

### DIFF
--- a/docs/02-app/01-building-your-application/08-upgrading/01-codemods.mdx
+++ b/docs/02-app/01-building-your-application/08-upgrading/01-codemods.mdx
@@ -31,7 +31,7 @@ Replacing `<transform>` and `<path>` with appropriate values.
 ##### `built-in-next-font`
 
 ```bash filename="Terminal"
-npx @next/codemod@latest built-in-next-font
+npx @next/codemod@latest built-in-next-font .
 ```
 
 This codemod uninstalls the `@next/font` package and transforms `@next/font` imports into the built-in `next/font`.
@@ -55,7 +55,7 @@ import { Inter } from 'next/font/google'
 ##### `next-image-to-legacy-image`
 
 ```bash filename="Terminal"
-npx @next/codemod@latest next-image-to-legacy-image ./pages
+npx @next/codemod@latest next-image-to-legacy-image .
 ```
 
 Safely renames `next/image` imports in existing Next.js 10, 11, or 12 applications to `next/legacy/image` in Next.js 13. Also renames `next/future/image` to `next/image`.
@@ -99,7 +99,7 @@ export default function Home() {
 ##### `next-image-experimental`
 
 ```bash filename="Terminal"
-npx @next/codemod@latest next-image-experimental ./pages
+npx @next/codemod@latest next-image-experimental .
 ```
 
 Dangerously migrates from `next/legacy/image` to the new `next/image` by adding inline styles and removing unused props.
@@ -115,7 +115,7 @@ Dangerously migrates from `next/legacy/image` to the new `next/image` by adding 
 ##### `new-link`
 
 ```bash filename="Terminal"
-npx @next/codemod@latest new-link ./pages
+npx @next/codemod@latest new-link .
 ```
 
 Remove `<a>` tags inside [Link Components](/docs/app/api-reference/components/link), or add a `legacyBehavior` prop to Links that cannot be auto-fixed.


### PR DESCRIPTION
These docs were wrong because `./pages` is not sufficient to run a codemod. 

Imagine a project that has `./components` and `./pages` and many directories for example.

Also its important to run at the root of the Next.js project so that the path has a `next.config.js` because some codemods modify that config.