### PR TITLE
docs: fix import type code blocks

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/10-router-handlers.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/10-router-handlers.mdx
@@ -278,7 +278,7 @@ export async function GET(request) {
 Alternatively, you can use abstractions on top of the underlying Web APIs to read cookies ([`NextRequest`](/docs/app/api-reference/functions/next-request)):
 
 ```ts filename="app/api/route.ts" switcher
-import { type NextRequest } from 'next/server'
+import type { NextRequest } from 'next/server'
 
 export async function GET(request: NextRequest) {
   const token = request.cookies.get('token')
@@ -328,7 +328,7 @@ export async function GET(request) {
 Alternatively, you can use abstractions on top of the underlying Web APIs to read headers ([`NextRequest`](/docs/app/api-reference/functions/next-request)):
 
 ```ts filename="app/api/route.ts" switcher
-import { type NextRequest } from 'next/server'
+import type { NextRequest } from 'next/server'
 
 export async function GET(request: NextRequest) {
   const requestHeaders = new Headers(request.headers)


### PR DESCRIPTION
### What

should be `import type { ... }` instead of `import { type ... }`

