### PR TITLE
Update flakey rsc streaming test

### DIFF
--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -399,7 +399,7 @@ createNextDescribe(
           const result = await resolveStreamResponse(response)
           expect(result).toContain('component:index.server')
           expect(result).toMatch(
-            isNextDev ? /0:\["development",/ : /0:\["\w+",/
+            isNextDev ? /0:\["development",/ : /0:\[".*?",/
           )
         })
     })


### PR DESCRIPTION
This is checking for only alpha-numerical chars for the build_id value although they can also contain dashes

x-ref: https://github.com/vercel/next.js/actions/runs/5263773644/jobs/9514284188#step:25:454