### PR TITLE
app router: fix double fetch on prefetch={false}

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -157,9 +157,16 @@ export function navigateReducer(
     temporaryCacheNode.subTreeData = state.cache.subTreeData
     temporaryCacheNode.parallelRoutes = new Map(state.cache.parallelRoutes)
 
-    const data = createRecordFromThenable(
-      fetchServerResponse(url, optimisticTree, state.nextUrl, state.buildId)
-    )
+    let data: ReturnType<typeof createRecordFromThenable> | undefined
+
+    const fetchResponse = () => {
+      if (!data) {
+        data = createRecordFromThenable(
+          fetchServerResponse(url, optimisticTree, state.nextUrl, state.buildId)
+        )
+      }
+      return data
+    }
 
     // TODO-APP: segments.slice(1) strips '', we can get rid of '' altogether.
     // TODO-APP: re-evaluate if we need to strip the last segment
@@ -174,7 +181,7 @@ export function navigateReducer(
       temporaryCacheNode,
       state.cache,
       optimisticFlightSegmentPath,
-      () => data,
+      fetchResponse,
       true
     )
 

--- a/test/e2e/app-dir/app-prefetch-false/app-prefetch-false.test.ts
+++ b/test/e2e/app-dir/app-prefetch-false/app-prefetch-false.test.ts
@@ -1,0 +1,51 @@
+import { createNextDescribe } from 'e2e-utils'
+
+const getPathname = (url: string) => {
+  const urlObj = new URL(url)
+  return urlObj.pathname
+}
+
+const createRequestsListener = async (browser: BrowserInterface) => {
+  // wait for network idle
+  await browser.waitForIdleNetwork()
+
+  let requests = []
+
+  browser.on('request', (req: Request) => {
+    requests.push([req.url(), !!req.headers()['next-router-prefetch']])
+  })
+
+  await browser.refresh()
+
+  return {
+    getRequests: () => requests,
+    clearRequests: () => {
+      requests = []
+    },
+  }
+}
+
+createNextDescribe(
+  'app-prefetch-false',
+  {
+    files: __dirname,
+  },
+  ({ next, isNextDev }) => {
+    if (isNextDev) {
+      it.skip('should skip test in dev mode', () => {})
+    } else {
+      it('should avoid double-fetching when optimistic navigation fails', async () => {
+        const browser = await next.browser('/foo')
+        const { getRequests } = await createRequestsListener(browser)
+
+        await browser.elementByCss('[href="/foo"]').click()
+        await browser.elementByCss('[href="/foo/bar"]').click()
+        console.log('getRequests()', getRequests())
+        expect(
+          getRequests().filter(([req]) => getPathname(req) === '/foo/bar')
+            .length
+        ).toBe(1)
+      })
+    }
+  }
+)

--- a/test/e2e/app-dir/app-prefetch-false/app/[slugA]/[slugB]/page.tsx
+++ b/test/e2e/app-dir/app-prefetch-false/app/[slugA]/[slugB]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/app-prefetch-false/app/[slugA]/layout.tsx
+++ b/test/e2e/app-dir/app-prefetch-false/app/[slugA]/layout.tsx
@@ -1,0 +1,3 @@
+export default function Layout({ children }) {
+  return children
+}

--- a/test/e2e/app-dir/app-prefetch-false/app/[slugA]/page.tsx
+++ b/test/e2e/app-dir/app-prefetch-false/app/[slugA]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/app-prefetch-false/app/layout.tsx
+++ b/test/e2e/app-dir/app-prefetch-false/app/layout.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+import React from 'react'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <div>
+          <Link prefetch={false} href="/foo">
+            foo
+          </Link>
+        </div>
+        <div>
+          <Link prefetch={false} href="/foo/bar">
+            foo/bar
+          </Link>
+        </div>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-prefetch-false/app/page.tsx
+++ b/test/e2e/app-dir/app-prefetch-false/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/app-prefetch-false/next.config.js
+++ b/test/e2e/app-dir/app-prefetch-false/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
This PR fixes a few reports that we were double fetching when navigating via a link that had prefetch false.

## Context

The bug was happening because we were inadvertently eagerly fetching even if we potentially bailed out of the optimistic navigation, which would then trigger another fetch from going through the regular navigation path.

There's potentially another bug here where we should potentially not bail out of optimistic navigation in the cases reported but we can fix that later.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

fix #49844
link NEXT-1287