### PR TITLE
Update example of Server Actions HoC

### DIFF
--- a/docs/02-app/01-building-your-application/03-data-fetching/04-server-actions.mdx
+++ b/docs/02-app/01-building-your-application/03-data-fetching/04-server-actions.mdx
@@ -480,7 +480,7 @@ export const action = withValidate((data) => {
 
 ```js filename="lib/form-validation.js"
 export function withValidate(action) {
-  return (formData: FormData) => {
+  return async (formData: FormData) => {
     'use server'
 
     const isValidData = verifyData(formData)


### PR DESCRIPTION
Currently the Server Action function with `"use server"` must be an async function as it's required by the compiler, even if it returns a promise already.