### PR TITLE
test(next-dev): hard fail if next-dev runs with turbopack intenral flag

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -295,6 +295,12 @@ const nextDev: CliCommand = async (argv) => {
   } else {
     let cleanupFns: (() => Promise<void> | void)[] = []
     const runDevServer = async () => {
+      if (process.env.__INTERNAL_NEXT_DEV_TEST_TURBO_DEV) {
+        require('console').error(
+          `[ERROR]: Incorrect mode: turbopack test mode is force enabled, shouldn't run dev server`
+        )
+        process.exit(1)
+      }
       const oldCleanupFns = cleanupFns
       cleanupFns = []
       await Promise.allSettled(oldCleanupFns.map((fn) => fn()))


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

WEB-1183

Context: https://vercel.slack.com/archives/C04KC8A53T7/p1686768648161459?thread_ts=1686763527.218549&cid=C04KC8A53T7

We'd like to avoid false positives to the test cases if test supposed to run turbopack (having __INTERNAL_ flags) but somehow test fixture does not run turbopack correctly.