### PR TITLE
Skip cargo bench job on release

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -94,6 +94,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipForDocsOnly: 'yes'
+      skipForRelease: 'yes'
       needsRust: 'yes'
       skipNativeBuild: 'yes'
       afterBuild: xvfb-run turbo run test-cargo-bench

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -19,6 +19,10 @@ on:
         required: false
         description: 'skip for docs only changes'
         type: string
+      skipForRelease:
+        required: false
+        description: 'skip for release'
+        type: string
       nodeVersion:
         required: false
         description: 'version of Node.js to use'
@@ -103,6 +107,15 @@ jobs:
         name: check docs only change
         id: docs-change
 
+      - id: is-release
+        run: |
+          if [[ $(node ./scripts/check-is-release.js 2> /dev/null || :) = v* ]];
+            then
+              echo "IS_RELEASE=yes" >> $GITHUB_OUTPUT
+            else
+              echo "IS_RELEASE=nope" >> $GITHUB_OUTPUT
+          fi
+
       # normalize versions before build-native for better cache hits
       - run: node scripts/normalize-version-bump.js
         name: normalize versions
@@ -138,7 +151,7 @@ jobs:
       - run: turbo run get-test-timings -- --build ${{ github.sha }}
 
       - run: /bin/bash -c "${{ inputs.afterBuild }}"
-        if: ${{inputs.skipForDocsOnly != 'yes' || steps.docs-change.outputs.DOCS_CHANGE == 'nope'}}
+        if: ${{(inputs.skipForDocsOnly != 'yes' || steps.docs-change.outputs.DOCS_CHANGE == 'nope') && (inputs.skipForRelease != 'yes' || steps.is-release.outputs.IS_RELEASE == 'nope')}}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This fails when run during a release since the new version isn't published yet

x-ref: https://github.com/vercel/next.js/actions/runs/5266469610/jobs/9520466217