### PR TITLE
Revert "Prefer module fields for RSC server layer"

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1941,10 +1941,6 @@ export default async function getBaseWebpackConfig(
                   ],
                 },
                 resolve: {
-                  mainFields: isEdgeServer
-                    ? mainFieldsPerCompiler[COMPILER_NAMES.edgeServer]
-                    : // Prefer module fields over main fields for isomorphic packages on server layer
-                      ['module', 'main'],
                   conditionNames: reactServerCondition,
                   alias: {
                     // If missing the alias override here, the default alias will be used which aliases

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -88,23 +88,24 @@ createNextDescribe(
     })
 
     it('should resolve 3rd party package exports based on the react-server condition', async () => {
-      const $ = await next.render$('/react-server/3rd-party-package')
+      await next
+        .fetch('/react-server/3rd-party-package')
+        .then(async (response) => {
+          const result = await resolveStreamResponse(response)
 
-      const result = $('body').text()
+          // Package should be resolved based on the react-server condition,
+          // as well as package's internal & external dependencies.
+          expect(result).toContain(
+            'Server: index.react-server:react.subset:dep.server'
+          )
+          expect(result).toContain(
+            'Client: index.default:react.full:dep.default'
+          )
 
-      // Package should be resolved based on the react-server condition,
-      // as well as package's internal & external dependencies.
-      expect(result).toContain(
-        'Server: index.react-server:react.subset:dep.server'
-      )
-      expect(result).toContain('Client: index.default:react.full:dep.default')
-
-      // Subpath exports should be resolved based on the condition too.
-      expect(result).toContain('Server subpath: subpath.react-server')
-      expect(result).toContain('Client subpath: subpath.default')
-
-      // Prefer `module` field for isomorphic packages.
-      expect($('#main-field').text()).toContain('server-module-field:module')
+          // Subpath exports should be resolved based on the condition too.
+          expect(result).toContain('Server subpath: subpath.react-server')
+          expect(result).toContain('Client subpath: subpath.default')
+        })
     })
 
     it('should correctly collect global css imports and mark them as side effects', async () => {

--- a/test/e2e/app-dir/app-external/app/react-server/3rd-party-package/page.js
+++ b/test/e2e/app-dir/app-external/app/react-server/3rd-party-package/page.js
@@ -1,6 +1,5 @@
 import v from 'conditional-exports'
 import v1 from 'conditional-exports/subpath'
-import { name as serverFieldName } from 'server-module-field'
 
 import Client from './client'
 
@@ -12,8 +11,6 @@ export default function Page() {
       {`Server subpath: ${v1}`}
       <br />
       <Client />
-      <br />
-      <div id="main-field">{`Server module field: ${serverFieldName}`}</div>
     </div>
   )
 }

--- a/test/e2e/app-dir/app-external/node_modules_bak/server-module-field/index.cjs
+++ b/test/e2e/app-dir/app-external/node_modules_bak/server-module-field/index.cjs
@@ -1,1 +1,0 @@
-exports.name = 'server-module-field:main'

--- a/test/e2e/app-dir/app-external/node_modules_bak/server-module-field/index.esm.js
+++ b/test/e2e/app-dir/app-external/node_modules_bak/server-module-field/index.esm.js
@@ -1,1 +1,0 @@
-export const name = 'server-module-field:module'

--- a/test/e2e/app-dir/app-external/node_modules_bak/server-module-field/package.json
+++ b/test/e2e/app-dir/app-external/node_modules_bak/server-module-field/package.json
@@ -1,4 +1,0 @@
-{
-  "main": "./index.cjs",
-  "module": "./index.esm.js"
-}


### PR DESCRIPTION
Closes: https://github.com/vercel/next.js/issues/51309

Reverts vercel/next.js#51179