### PR TITLE
Fix Server Actions compiler

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -261,7 +261,7 @@ impl<C: Comments> ServerActions<C> {
                     span: DUMMY_SP,
                     decl: Decl::Var(Box::new(VarDecl {
                         span: DUMMY_SP,
-                        kind: VarDeclKind::Const,
+                        kind: VarDeclKind::Var,
                         declare: Default::default(),
                         decls: vec![VarDeclarator {
                             span: DUMMY_SP,
@@ -942,7 +942,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                 span: DUMMY_SP,
                                 decl: Decl::Var(Box::new(VarDecl {
                                     span: DUMMY_SP,
-                                    kind: VarDeclKind::Const,
+                                    kind: VarDeclKind::Var,
                                     declare: false,
                                     decls: vec![VarDeclarator {
                                         span: DUMMY_SP,

--- a/packages/next-swc/crates/core/tests/errors/server-actions/server-graph/7/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/server-graph/7/output.js
@@ -1,4 +1,4 @@
 /* __next_internal_action_entry_do_not_use__ $$ACTION_1 */ import __create_action_proxy__ from "private-next-rsc-action-proxy";
 const foo = ($$ACTION_0 = async (...args)=>$$ACTION_1.apply(null, ($$ACTION_0.$$bound || []).concat(args)), __create_action_proxy__("188d5d945750dc32e2c842b93c75a65763d4a922", null, $$ACTION_0, $$ACTION_1), $$ACTION_0);
-export const $$ACTION_1 = ()=>{};
+export var $$ACTION_1 = ()=>{};
 var $$ACTION_0;

--- a/packages/next-swc/crates/core/tests/errors/server-actions/server-graph/8/output.js
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/server-graph/8/output.js
@@ -1,6 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ $$ACTION_1 */ import __create_action_proxy__ from "private-next-rsc-action-proxy";
 const foo = ($$ACTION_0 = async (...args)=>$$ACTION_1.apply(null, ($$ACTION_0.$$bound || []).concat(args)), __create_action_proxy__("188d5d945750dc32e2c842b93c75a65763d4a922", null, $$ACTION_0, $$ACTION_1), $$ACTION_0);
-export const $$ACTION_1 = async ()=>{
+export var $$ACTION_1 = async ()=>{
     'use strict';
 };
 var $$ACTION_0;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/client/1/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/client/1/output.js
@@ -1,5 +1,5 @@
 // app/send.ts
 /* __next_internal_action_entry_do_not_use__ myAction,default */ import __create_action_proxy__ from "private-next-rsc-action-proxy";
 import createServerReference from "private-next-rsc-action-client-wrapper";
-export const myAction = createServerReference("e10665baac148856374b2789aceb970f66fec33e");
+export var myAction = createServerReference("e10665baac148856374b2789aceb970f66fec33e");
 export default createServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d");

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/client/2/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/client/2/output.js
@@ -1,4 +1,4 @@
 // app/send.ts
 /* __next_internal_action_entry_do_not_use__ foo */ import __create_action_proxy__ from "private-next-rsc-action-proxy";
 import createServerReference from "private-next-rsc-action-client-wrapper";
-export const foo = createServerReference("ab21efdafbe611287bc25c0462b1e0510d13e48b");
+export var foo = createServerReference("ab21efdafbe611287bc25c0462b1e0510d13e48b");

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/client/3/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/client/3/output.js
@@ -1,6 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ sampleFunction,sampleFunction2,sampleFunction3,sampleFunction4 */ import __create_action_proxy__ from "private-next-rsc-action-proxy";
 import createServerReference from "private-next-rsc-action-client-wrapper";
-export const sampleFunction = createServerReference("bd336abe00c3c59da66acb696fc8e151d8e54ea4");
-export const sampleFunction2 = createServerReference("a0c73dd6f5af839e3335c6b19262ecb86cca6af4");
-export const sampleFunction3 = createServerReference("d4f2e95bc745b6500b439c0847003511748c8ece");
-export const sampleFunction4 = createServerReference("f03b256ee88a51700367acee3082894e25e6e7d9");
+export var sampleFunction = createServerReference("bd336abe00c3c59da66acb696fc8e151d8e54ea4");
+export var sampleFunction2 = createServerReference("a0c73dd6f5af839e3335c6b19262ecb86cca6af4");
+export var sampleFunction3 = createServerReference("d4f2e95bc745b6500b439c0847003511748c8ece");
+export var sampleFunction4 = createServerReference("f03b256ee88a51700367acee3082894e25e6e7d9");

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/1/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/1/output.js
@@ -25,7 +25,7 @@ export default function Home() {
     ], $$ACTION_1, $$ACTION_2), $$ACTION_1);
     return null;
 }
-export const $$ACTION_2 = async ($$ACTION_ARG_0, $$ACTION_ARG_1)=>{
+export var $$ACTION_2 = async ($$ACTION_ARG_0, $$ACTION_ARG_1)=>{
     console.log($$ACTION_ARG_0);
     console.log($$ACTION_ARG_1);
 };

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/16/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/16/output.js
@@ -9,7 +9,7 @@ export function Item({ id1 , id2  }) {
     ], $$ACTION_0, $$ACTION_1), $$ACTION_0);
     return <Button action={deleteItem}>Delete</Button>;
 }
-export const $$ACTION_1 = async ($$ACTION_ARG_0, $$ACTION_ARG_1)=>{
+export var $$ACTION_1 = async ($$ACTION_ARG_0, $$ACTION_ARG_1)=>{
     await deleteFromDb($$ACTION_ARG_0);
     await deleteFromDb(v1);
     await deleteFromDb($$ACTION_ARG_1);
@@ -31,7 +31,7 @@ const g = (x)=>{
         x
     ], $$ACTION_3, $$ACTION_4), $$ACTION_3);
 };
-export const $$ACTION_4 = async ($$ACTION_ARG_0, y, ...z)=>{
+export var $$ACTION_4 = async ($$ACTION_ARG_0, y, ...z)=>{
     return $$ACTION_ARG_0 + y + z[0];
 };
 var $$ACTION_3;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/18/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/18/output.js
@@ -27,7 +27,7 @@ export function Item({ id1, id2 }) {
 
     </>;
 }
-export const $$ACTION_1 = async ($$ACTION_ARG_0, $$ACTION_ARG_1)=>{
+export var $$ACTION_1 = async ($$ACTION_ARG_0, $$ACTION_ARG_1)=>{
     await deleteFromDb($$ACTION_ARG_0);
     await deleteFromDb(v1);
     await deleteFromDb($$ACTION_ARG_1);

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/19/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/19/output.js
@@ -12,7 +12,7 @@ export function Item({ value }) {
 
     </>;
 }
-export const $$ACTION_1 = async ($$ACTION_ARG_0, value2)=>{
+export var $$ACTION_1 = async ($$ACTION_ARG_0, value2)=>{
     return $$ACTION_ARG_0 * value2;
 };
 var $$ACTION_0;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/2/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/2/input.js
@@ -6,3 +6,7 @@ async function myAction(a, b, c) {
 export default function Page() {
   return <Button action={myAction}>Delete</Button>
 }
+
+export const action = withValidate(async () => {
+  'use server'
+})

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/2/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/2/output.js
@@ -10,5 +10,5 @@ export default function Page() {
     return <Button action={myAction}>Delete</Button>;
 }
 export const action = withValidate(($$ACTION_1 = async (...args)=>$$ACTION_2.apply(null, ($$ACTION_1.$$bound || []).concat(args)), __create_action_proxy__("9878bfa39811ca7650992850a8751f9591b6a557", null, $$ACTION_1, $$ACTION_2), $$ACTION_1));
-export const $$ACTION_2 = async ()=>{};
+export var $$ACTION_2 = async ()=>{};
 var $$ACTION_1;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/2/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/2/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ $$ACTION_0 */ import __create_action_proxy__ from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ $$ACTION_0,$$ACTION_2 */ import __create_action_proxy__ from "private-next-rsc-action-proxy";
 async function myAction(...args) {
     return $$ACTION_0.apply(null, (myAction.$$bound || []).concat(args));
 }
@@ -9,3 +9,6 @@ export async function $$ACTION_0(a, b, c) {
 export default function Page() {
     return <Button action={myAction}>Delete</Button>;
 }
+export const action = withValidate(($$ACTION_1 = async (...args)=>$$ACTION_2.apply(null, ($$ACTION_1.$$bound || []).concat(args)), __create_action_proxy__("9878bfa39811ca7650992850a8751f9591b6a557", null, $$ACTION_1, $$ACTION_2), $$ACTION_1));
+export const $$ACTION_2 = async ()=>{};
+var $$ACTION_1;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/21/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/21/output.js
@@ -14,8 +14,8 @@ export async function $$ACTION_1($$ACTION_ARG_0, z) {
 }
 var $$ACTION_0;
 validator(($$ACTION_2 = async (...args)=>$$ACTION_3.apply(null, ($$ACTION_2.$$bound || []).concat(args)), __create_action_proxy__("56a859f462d35a297c46a1bbd1e6a9058c104ab8", null, $$ACTION_2, $$ACTION_3), $$ACTION_2));
-export const $$ACTION_3 = async ()=>{};
+export var $$ACTION_3 = async ()=>{};
 var $$ACTION_2;
 another(validator(($$ACTION_4 = async (...args)=>$$ACTION_5.apply(null, ($$ACTION_4.$$bound || []).concat(args)), __create_action_proxy__("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", null, $$ACTION_4, $$ACTION_5), $$ACTION_4)));
-export const $$ACTION_5 = async ()=>{};
+export var $$ACTION_5 = async ()=>{};
 var $$ACTION_4;

--- a/packages/next-swc/crates/core/tests/fixture/server-actions/server/23/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/server-actions/server/23/output.js
@@ -1,5 +1,5 @@
 /* __next_internal_action_entry_do_not_use__ $$ACTION_0,$$ACTION_2 */ import __create_action_proxy__ from "private-next-rsc-action-proxy";
-export default function Page({ foo , x , y  }) {
+export default function Page({ foo, x, y }) {
     async function action(...args) {
         return $$ACTION_0.apply(null, (action.$$bound || []).concat(args));
     }
@@ -15,7 +15,7 @@ export default function Page({ foo , x , y  }) {
 export async function $$ACTION_0($$ACTION_ARG_0, a, b, c, d) {
     console.log(a, b, $$ACTION_ARG_0, c, d);
 }
-export const $$ACTION_2 = async ($$ACTION_ARG_0, a, b, c, d)=>{
+export var $$ACTION_2 = async ($$ACTION_ARG_0, a, b, c, d)=>{
     console.log(a, b, $$ACTION_ARG_0, c, d);
 };
 var $$ACTION_1;

--- a/test/e2e/app-dir/actions/app/server/actions-2.js
+++ b/test/e2e/app-dir/actions/app/server/actions-2.js
@@ -1,0 +1,6 @@
+const noop = (action) => action
+
+export const log = noop(async (data) => {
+  'use server'
+  console.log(data)
+})

--- a/test/e2e/app-dir/actions/app/server/page.js
+++ b/test/e2e/app-dir/actions/app/server/page.js
@@ -2,6 +2,7 @@ import Counter from './counter'
 import Form from './form'
 
 import dec, { inc } from './actions'
+import { log } from './actions-2'
 
 export default function Page() {
   const two = { value: 2 }
@@ -16,6 +17,11 @@ export default function Page() {
         }}
       />
       <Form />
+      <form>
+        <button id="log" formAction={log}>
+          log
+        </button>
+      </form>
     </>
   )
 }


### PR DESCRIPTION
Make sure we are using `var` instead of `const` as we always put the new appended statements to the end of the module body, but they can still be referenced before in the HOC case in the runtime. This causes a runtime error.

Tl;dr: `a = 1; var a` is fine, but `a; const a = ...` will result in a compilation error.

Closes #49344.