### PR TITLE
Update e2e deploy tests to continue

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -418,6 +418,9 @@ jobs:
       NEXT_TELEMETRY_DISABLED: 1
       VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
       VERCEL_TEST_TEAM: vtest314-next-e2e-tests
+      # run all tests so we can see all failures even if
+      # some flake or aren't patched yet
+      NEXT_TEST_CONTINUE_ON_ERROR: 1
     steps:
       - uses: actions/cache@v3
         timeout-minutes: 5


### PR DESCRIPTION
Instead of temporarily disabling flakey or unpatched tests in deploy mode this continues to run all tests and see all failures at once. 

x-ref: https://github.com/vercel/next.js/actions/runs/5272454654/jobs/9536161644