### PR TITLE
fix: next/link does not acivate css :target selector

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -125,6 +125,18 @@ function HistoryUpdater({ tree, pushRef, canonicalUrl, sync }: any) {
       // This intentionally mutates React state, pushRef is overwritten to ensure additional push/replace calls do not trigger an additional history entry.
       pushRef.pendingPush = false
       window.history.pushState(historyState, '', canonicalUrl)
+      // navigate back and immidiatly navigate forward again to trigger css :target selector evaluation in the browser
+      window.history.back()
+      window.addEventListener(
+        'popstate',
+        () => {
+          window.history.forward()
+        },
+        {
+          once: true,
+          passive: true,
+        }
+      )
     } else {
       window.history.replaceState(historyState, '', canonicalUrl)
     }

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -1847,6 +1847,21 @@ export default class Router implements BaseRouter {
         '',
         as
       )
+
+      if (method === 'pushState') {
+        // go back and then come forward again immediately, to force :target to update.
+        history.back()
+        window.addEventListener(
+          'popstate',
+          () => {
+            history.forward()
+          },
+          {
+            once: true,
+            passive: true,
+          }
+        )
+      }
     }
   }
 

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -1850,11 +1850,11 @@ export default class Router implements BaseRouter {
 
       if (method === 'pushState') {
         // go back and then come forward again immediately, to force :target to update.
-        history.back()
+        window.history.back()
         window.addEventListener(
           'popstate',
           () => {
-            history.forward()
+            window.history.forward()
           },
           {
             once: true,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
### What? / Why?
Fixes #51346 

### How?
By performing a window.history.back() immediately followed by a window.history.forward() the browser will evaluate the `:target` selector as expected from a regular `<a>` link.

