### PR TITLE
Lock down server IPC address

### DIFF
--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -137,6 +137,6 @@ export async function initialize(opts: {
         return reject(err)
       }
     })
-    server.listen(await getFreePort(), opts.hostname)
+    server.listen(await getFreePort(), '0.0.0.0')
   })
 }

--- a/packages/next/src/server/lib/server-ipc/index.ts
+++ b/packages/next/src/server/lib/server-ipc/index.ts
@@ -63,7 +63,7 @@ export async function createIpcServer(
   )
 
   const ipcPort = await new Promise<number>((resolveIpc) => {
-    ipcServer.listen(0, server.hostname, () => {
+    ipcServer.listen(0, '0.0.0.0', () => {
       const addr = ipcServer.address()
 
       if (addr && typeof addr === 'object') {

--- a/packages/next/src/server/lib/server-ipc/invoke-request.ts
+++ b/packages/next/src/server/lib/server-ipc/invoke-request.ts
@@ -18,8 +18,13 @@ export const invokeRequest = async (
       const http = require('http') as typeof import('http')
 
       try {
+        // force to 127.0.0.1 as IPC always runs on this hostname
+        // to avoid localhost issues
+        const parsedTargetUrl = new URL(targetUrl)
+        parsedTargetUrl.hostname = '0.0.0.0'
+
         const invokeReq = http.request(
-          targetUrl,
+          parsedTargetUrl.toString(),
           {
             headers: invokeHeaders,
             method: requestInit.method,

--- a/packages/next/src/server/lib/server-ipc/invoke-request.ts
+++ b/packages/next/src/server/lib/server-ipc/invoke-request.ts
@@ -21,7 +21,7 @@ export const invokeRequest = async (
         // force to 127.0.0.1 as IPC always runs on this hostname
         // to avoid localhost issues
         const parsedTargetUrl = new URL(targetUrl)
-        parsedTargetUrl.hostname = '0.0.0.0'
+        parsedTargetUrl.hostname = '127.0.0.1'
 
         const invokeReq = http.request(
           parsedTargetUrl.toString(),


### PR DESCRIPTION
This attempts to avoid IPv6 and IPv4 resolve issues across network setups by locking down our internal IPC requests to just one address for consistency. This way there aren't issues when `localhost` resolves to one or the other in different cases. 

x-ref: https://github.com/vercel/next.js/issues/49677