### PR TITLE
docs: remove copy mentioning appDir as an experimental feature

### DIFF
--- a/docs/02-app/01-building-your-application/06-configuring/02-eslint.mdx
+++ b/docs/02-app/01-building-your-application/06-configuring/02-eslint.mdx
@@ -127,7 +127,7 @@ If you're using `eslint-plugin-next` in a project where Next.js isn't installed 
 
 ## Linting Custom Directories and Files
 
-By default, Next.js will run ESLint for all files in the `pages/`, `app` (only if the experimental `appDir` feature is enabled), `components/`, `lib/`, and `src/` directories. However, you can specify which directories using the `dirs` option in the `eslint` config in `next.config.js` for production builds:
+By default, Next.js will run ESLint for all files in the `pages/`, `app/`, `components/`, `lib/`, and `src/` directories. However, you can specify which directories using the `dirs` option in the `eslint` config in `next.config.js` for production builds:
 
 ```js filename="next.config.js"
 module.exports = {


### PR DESCRIPTION
The documentation for `(App or Pages) / Building your Application / Configuring / Eslint` [here](https://nextjs.org/docs/app/building-your-application/configuring/eslint#linting-custom-directories-and-files) is mentioning the appDir as an experimental feature that needs to be enabled.

This PR update it's content removing this mention