### PR TITLE
Update flakey build output test

### DIFF
--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -171,11 +171,6 @@ describe('Build Output', () => {
           expect.stringMatching(/\/2000\/10 \(\d+ ms\)$/),
           expect.stringMatching(/\/10\/1000 \(\d+ ms\)$/),
           expect.stringMatching(/\/300\/10 \(\d+ ms\)$/),
-          // kept in original order
-          expect.stringMatching(/\/5\/5/),
-          expect.stringMatching(/\/25\/25/),
-          expect.stringMatching(/\/20\/20/),
-          expect.stringMatching(/\/10\/10/),
           // max of 7 preview paths
           ' [+2 more paths]',
         ]) {


### PR DESCRIPTION
These are sorted by duration which can be arbitrary and aren't guaranteed to not be collapsed so this updates to only check for the ones we know will always be visible. 

x-ref: https://github.com/vercel/next.js/actions/runs/5289693006/jobs/9573031740?pr=51406#step:26:275