### PR TITLE
docs: Add Panda CSS to CSS-in-JS docs.

### DIFF
--- a/docs/02-app/01-building-your-application/04-styling/03-css-in-js.mdx
+++ b/docs/02-app/01-building-your-application/04-styling/03-css-in-js.mdx
@@ -9,19 +9,19 @@ description: Use CSS-in-JS libraries with Next.js
 >
 > We're working with the React team on upstream APIs to handle CSS and JavaScript assets with support for React Server Components and streaming architecture.
 
-The following libraries are supported in Client Components in the `app` directory:
+The following libraries are supported in Client Components in the `app` directory (alphbetical):
 
+- [`pandacss`](https://panda-css.com)
 - [`styled-jsx`](#styled-jsx)
 - [`styled-components`](#styled-components)
-- [`tamagui`](https://tamagui.dev/docs/guides/next-js#server-components)
 - [`style9`](https://github.com/johanholmerin/style9)
+- [`tamagui`](https://tamagui.dev/docs/guides/next-js#server-components)
 - [`vanilla-extract`](https://github.com/vercel/next.js/tree/canary/examples/with-vanilla-extract)
 
 The following are currently working on support:
 
 - [`emotion`](https://github.com/emotion-js/emotion/issues/2928)
 - [Material UI](https://github.com/mui/material-ui/issues/34905#issuecomment-1401306594)
-- [Chakra UI](https://github.com/chakra-ui/chakra-ui/issues/7180)
 
 > **Good to know**: We're testing out different CSS-in-JS libraries and we'll be adding more examples for libraries that support React 18 features and/or the `app` directory.
 


### PR DESCRIPTION
https://panda-css.com is a new solution that works with the Next.js App Router.