### PR TITLE
Update 05-mdx.mdx because of wrong info

### DIFF
--- a/docs/02-app/01-building-your-application/06-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/06-configuring/05-mdx.mdx
@@ -224,7 +224,7 @@ To add a layout to your MDX page, create a new component and import it into the 
 import { MyLayoutComponent } from 'my-components';
 import HelloWorld from './hello.mdx';
 
-export const meta = {
+export const metadata = {
   author: 'Rich Haines',
 };
 


### PR DESCRIPTION
Fix wrong info on app/building-your-application/configuring/mdx#frontmatter

export const meta does not work, as it's supposed to be:

```
export const metadata
```

Reference [repo](https://codesandbox.io/p/sandbox/crazy-marco-kg8xjk) about this change.
