### PR TITLE
router: support layout/special files as direct children of parallel routes

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -52,6 +52,7 @@ const FILE_TYPES = {
 
 const GLOBAL_ERROR_FILE_TYPE = 'global-error'
 const PAGE_SEGMENT = 'page$'
+const PARALLEL_CHILDREN_SEGMENT = 'children$'
 
 type DirResolver = (pathToResolve: string) => string
 type PathResolver = (
@@ -315,7 +316,8 @@ async function createTreeCodeFromPath(
 
       subSegmentPath.push(
         ...normalizedParallelSegments.filter(
-          (segment) => segment !== PAGE_SEGMENT
+          (segment) =>
+            segment !== PAGE_SEGMENT && segment !== PARALLEL_CHILDREN_SEGMENT
         )
       )
 
@@ -359,10 +361,17 @@ async function createTreeCodeFromPath(
         }
       }
 
+      let parallelSegmentKey = Array.isArray(parallelSegment)
+        ? parallelSegment[0]
+        : parallelSegment
+
+      parallelSegmentKey =
+        parallelSegmentKey === PARALLEL_CHILDREN_SEGMENT
+          ? 'children'
+          : parallelSegmentKey
+
       props[normalizeParallelKey(parallelKey)] = `[
-        '${
-          Array.isArray(parallelSegment) ? parallelSegment[0] : parallelSegment
-        }',
+        '${parallelSegmentKey}',
         ${subtreeCode},
         {
           ${definedFilePaths
@@ -483,7 +492,8 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
           continue
         }
         if (isParallelRoute) {
-          matched[rest[0]] = rest.slice(1)
+          // we insert a special marker in order to also process layout/etc files at the slot level
+          matched[rest[0]] = [PARALLEL_CHILDREN_SEGMENT, ...rest.slice(1)]
           continue
         }
 

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-layout/@groupslot/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-layout/@groupslot/default.tsx
@@ -1,0 +1,1 @@
+export default () => null

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-layout/@slot/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-layout/@slot/page.tsx
@@ -1,3 +1,10 @@
+import Link from 'next/link'
+
 export default function Page() {
-  return 'slot children'
+  return (
+    <>
+      <div>slot children</div>
+      <Link href="/parallel-layout/subroute">parallel subroute</Link>
+    </>
+  )
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-layout/@slot/subroute/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-layout/@slot/subroute/layout.tsx
@@ -1,0 +1,8 @@
+export default ({ children }) => {
+  return (
+    <div>
+      <h1 id="parallel-subroute">parallel subroute layout</h1>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-layout/@slot/subroute/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-layout/@slot/subroute/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'subroute children'
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-layout/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-layout/default.tsx
@@ -1,0 +1,1 @@
+export default () => null

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -248,6 +248,17 @@ createNextDescribe(
           () => browser.waitForElementByCss('#parallel-layout').text(),
           'parallel layout'
         )
+
+        // navigate to /parallel-layout/subroute
+        await browser.elementByCss('[href="/parallel-layout/subroute"]').click()
+        await check(
+          () => browser.waitForElementByCss('#parallel-layout').text(),
+          'parallel layout'
+        )
+        await check(
+          () => browser.waitForElementByCss('#parallel-subroute').text(),
+          'parallel subroute layout'
+        )
       })
 
       it('should only scroll to the parallel route that was navigated to', async () => {


### PR DESCRIPTION
follow up on #51413 where I kinda forgot to support parsing layout files in sub routes in a parallel segment.

This should fix it by making sure that we check at all level of the app loader tree and by creating an implicit inner `children` for all parallel slot

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

link NEXT-1301