### PR TITLE
chore: make next/src/build files indexable on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 packages/next/bundles/** -text
 packages/next/compiled/** -text
+
+# Make next/src/build folder indexable for github search
+packages/next/src/build/** linguist-generated=false


### PR DESCRIPTION
`build/` folder is by default ignored by github, need to make them indexable for file searching

x-ref: https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files