### PR TITLE
Update manual basePath with trailingSlash

### DIFF
--- a/packages/next/src/client/add-base-path.ts
+++ b/packages/next/src/client/add-base-path.ts
@@ -4,11 +4,9 @@ import { normalizePathTrailingSlash } from './normalize-trailing-slash'
 const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
 
 export function addBasePath(path: string, required?: boolean): string {
-  if (process.env.__NEXT_MANUAL_CLIENT_BASE_PATH) {
-    if (!required) {
-      return path
-    }
-  }
-
-  return normalizePathTrailingSlash(addPathPrefix(path, basePath))
+  return normalizePathTrailingSlash(
+    process.env.__NEXT_MANUAL_CLIENT_BASE_PATH && !required
+      ? path
+      : addPathPrefix(path, basePath)
+  )
 }

--- a/test/e2e/manual-client-base-path/app/pages/index.js
+++ b/test/e2e/manual-client-base-path/app/pages/index.js
@@ -32,6 +32,11 @@ export default function Page(props) {
       </Link>
       <br />
 
+      <Link href="/another/" id="to-another-slash">
+        to /another
+      </Link>
+      <br />
+
       <Link href="/dynamic/first" id="to-dynamic">
         to /dynamic/first
       </Link>

--- a/test/e2e/manual-client-base-path/index.test.ts
+++ b/test/e2e/manual-client-base-path/index.test.ts
@@ -159,6 +159,14 @@ describe('manual-client-base-path', () => {
     await check(() => browser.elementByCss('#page').text(), 'index page')
     expect(await browser.eval('window.location.pathname')).toBe('/')
 
+    await browser.elementByCss('#to-another-slash').click()
+    await check(() => browser.elementByCss('#page').text(), 'another page')
+    expect(await browser.eval('window.location.pathname')).toBe('/another')
+
+    await browser.back()
+    await check(() => browser.elementByCss('#page').text(), 'index page')
+    expect(await browser.eval('window.location.pathname')).toBe('/')
+
     await browser.elementByCss('#to-dynamic').click()
     await check(() => browser.elementByCss('#page').text(), 'dynamic page')
     expect(await browser.eval('window.location.pathname')).toBe(


### PR DESCRIPTION
With the manualBasePath config we still need to normalize the trailing slash per that config. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1687543336964799?thread_ts=1687487533.019499&cid=C03S8ED1DKM)