### PR TITLE
Fix Typo in Optimizing - Open Telemetry docs

### DIFF
--- a/docs/02-app/01-building-your-application/05-optimizing/08-open-telemetry.mdx
+++ b/docs/02-app/01-building-your-application/05-optimizing/08-open-telemetry.mdx
@@ -25,7 +25,7 @@ When you enable OpenTelemetry we will automatically wrap all your code like `get
 
 OpenTelemetry is extensible but setting it up properly can be quite verbose.
 That's why we prepared a package `@vercel/otel` that helps you get started quickly.
-It's not extensible and you should configure OpenTelemetry manually you need to customize your setup.
+It's not extensible and you should configure OpenTelemetry manually if you need to customize your setup.
 
 ### Using `@vercel/otel`
 


### PR DESCRIPTION
### What this PR does

This PR fixes a minor typo on the Vercel Open Telemetry Docs.
`It's not extensible and you should configure OpenTelemetry manually (if) you need to customize your setup.`

That is all :)