### PR TITLE
Update needs for build and deploy

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -163,7 +163,6 @@ jobs:
             build: |
               npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" "turbo@${TURBO_VERSION}" "pnpm@${PNPM_VERSION}"
               turbo run build-native-no-plugin-woa-release --remote-cache-timeout 90 --summarize -- --target aarch64-pc-windows-msvc
-    needs: build
     name: stable - ${{ matrix.settings.target }} - node@16
     runs-on: ${{ matrix.settings.host }}
     env:
@@ -282,7 +281,6 @@ jobs:
           path: turbopack-bin-size/*
 
       - name: Upload swc artifact
-        if: ${{ needs.build.outputs.isRelease == 'true' }}
         uses: actions/upload-artifact@v3
         with:
           name: next-swc-binaries
@@ -295,7 +293,6 @@ jobs:
           path: .turbo/runs
 
   build-wasm:
-    needs: build
     strategy:
       matrix:
         target: [web, nodejs]


### PR DESCRIPTION
These don't need to wait for the build step so we can remove the "needs" step from them to allow them to start earlier. 