### PR TITLE
Ensure we run cargo-integration on next change

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -59,6 +59,7 @@
       "inputs": [
         ".cargo/**",
         "packages/next-swc/crates/**",
+        "packages/next/**",
         "**/Cargo.toml",
         "**/Cargo.lock"
       ]


### PR DESCRIPTION
This is currently only running for `next-swc` change but we want this running on `next` change as well as they both impact these tests. 

x-ref: https://github.com/vercel/next.js/actions/runs/5362063391/jobs/9728782834