### PR TITLE
fix: typo into 03-css-in-js.mdx page

### DIFF
--- a/docs/02-app/01-building-your-application/04-styling/03-css-in-js.mdx
+++ b/docs/02-app/01-building-your-application/04-styling/03-css-in-js.mdx
@@ -9,7 +9,7 @@ description: Use CSS-in-JS libraries with Next.js
 >
 > We're working with the React team on upstream APIs to handle CSS and JavaScript assets with support for React Server Components and streaming architecture.
 
-The following libraries are supported in Client Components in the `app` directory (alphbetical):
+The following libraries are supported in Client Components in the `app` directory (alphabetical):
 
 - [`pandacss`](https://panda-css.com)
 - [`styled-jsx`](#styled-jsx)


### PR DESCRIPTION
### Improving Documentation
Just fixing a typo into "alphabetical" word

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### What?
Misleading typo