### PR TITLE
Fix HMR for missing dependencies in next-app-loader

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -522,11 +522,11 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
         !result &&
         (await fileExists(absolutePathWithExtension, FileType.File))
       ) {
-        // Ensures we call `addMissingDependency` for all files that didn't match
         result = absolutePathWithExtension
-      } else {
-        this.addMissingDependency(absolutePathWithExtension)
       }
+      // Call `addMissingDependency` for all files even if they didn't match,
+      // because they might be added or removed during development.
+      this.addMissingDependency(absolutePathWithExtension)
     }
 
     return result
@@ -545,9 +545,10 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
         (await fileExists(absolutePathWithExtension, FileType.File))
       ) {
         result = absolutePathWithExtension
-      } else {
-        this.addMissingDependency(absolutePathWithExtension)
       }
+      // Call `addMissingDependency` for all files even if they didn't match,
+      // because they might be added or removed during development.
+      this.addMissingDependency(absolutePathWithExtension)
     }
 
     return result

--- a/test/e2e/app-dir/app-compilation/app/layout.js
+++ b/test/e2e/app-dir/app-compilation/app/layout.js
@@ -1,0 +1,7 @@
+export default function Root({ children }) {
+  return (
+    <html className="this-is-the-document-html">
+      <body className="this-is-the-document-body">{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-compilation/app/page-with-loading/loading.js
+++ b/test/e2e/app-dir/app-compilation/app/page-with-loading/loading.js
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="loading">Loading...</p>
+}

--- a/test/e2e/app-dir/app-compilation/app/page-with-loading/page.js
+++ b/test/e2e/app-dir/app-compilation/app/page-with-loading/page.js
@@ -1,7 +1,7 @@
 import { use } from 'react'
 
 async function getData() {
-  await new Promise((resolve) => setTimeout(resolve, 2000))
+  await new Promise((resolve) => setTimeout(resolve, 4000))
   return {
     message: 'hello from slow page',
   }

--- a/test/e2e/app-dir/app-compilation/app/page-with-loading/page.js
+++ b/test/e2e/app-dir/app-compilation/app/page-with-loading/page.js
@@ -1,7 +1,7 @@
 import { use } from 'react'
 
 async function getData() {
-  await new Promise((resolve) => setTimeout(resolve, 4000))
+  await new Promise((resolve) => setTimeout(resolve, 1000))
   return {
     message: 'hello from slow page',
   }
@@ -12,3 +12,5 @@ export default function SlowPage() {
 
   return <h1 id="slow-page-message">{data.message}</h1>
 }
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/app-compilation/app/page-with-loading/page.js
+++ b/test/e2e/app-dir/app-compilation/app/page-with-loading/page.js
@@ -1,0 +1,14 @@
+import { use } from 'react'
+
+async function getData() {
+  await new Promise((resolve) => setTimeout(resolve, 2000))
+  return {
+    message: 'hello from slow page',
+  }
+}
+
+export default function SlowPage() {
+  const data = use(getData())
+
+  return <h1 id="slow-page-message">{data.message}</h1>
+}

--- a/test/e2e/app-dir/app-compilation/index.test.ts
+++ b/test/e2e/app-dir/app-compilation/index.test.ts
@@ -1,0 +1,52 @@
+import { createNextDescribe } from 'e2e-utils'
+import { check, hasRedbox, waitFor } from 'next-test-utils'
+
+createNextDescribe(
+  'app dir',
+  {
+    files: __dirname,
+  },
+  ({ next, isNextDev: isDev, isNextStart }) => {
+    if (isNextStart) {
+      describe('Loading', () => {
+        it('should render loading.js in initial html for slow page', async () => {
+          const $ = await next.render$('/page-with-loading')
+          expect($('#loading').text()).toBe('Loading...')
+        })
+      })
+    }
+
+    if (isDev) {
+      describe('HMR', () => {
+        it('should not cause error when removing loading.js', async () => {
+          const browser = await next.browser('/page-with-loading')
+          await check(
+            () => browser.elementByCss('h1').text(),
+            'hello from slow page'
+          )
+
+          await next.renameFile(
+            'app/page-with-loading/loading.js',
+            'app/page-with-loading/_loading.js'
+          )
+
+          await waitFor(1000)
+
+          // It should not have an error
+          expect(await hasRedbox(browser, false)).toBe(false)
+
+          // HMR should still work
+          const code = await next.readFile('app/page-with-loading/page.js')
+          await next.patchFile(
+            'app/page-with-loading/page.js',
+            code.replace('hello from slow page', 'hello from new page')
+          )
+          await check(
+            () => browser.elementByCss('h1').text(),
+            'hello from new page'
+          )
+        })
+      })
+    }
+  }
+)

--- a/test/e2e/app-dir/app-compilation/next.config.js
+++ b/test/e2e/app-dir/app-compilation/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -37,9 +37,9 @@ createNextDescribe(
         )
 
         // Inherits from the root layout.
-        expect(
-          middlewareManifest.functions['/slow-page-with-loading/page'].regions
-        ).toEqual(['sfo1'])
+        expect(middlewareManifest.functions['/script/page'].regions).toEqual([
+          'sfo1',
+        ])
       })
     }
 
@@ -933,77 +933,6 @@ createNextDescribe(
           // After hydration count should be 1
           expect(await browser.elementByCss('p').text()).toBe(
             'hello from app/client-nested'
-          )
-        })
-      })
-
-      describe('Loading', () => {
-        it('should render loading.js in initial html for slow page', async () => {
-          const $ = await next.render$('/slow-page-with-loading')
-
-          expect($('#loading').text()).toBe('Loading...')
-        })
-
-        it('should render loading.js in browser for slow page', async () => {
-          const browser = await next.browser('/slow-page-with-loading', {
-            waitHydration: false,
-          })
-          // TODO-APP: `await next.browser()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
-          // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
-
-          expect(await browser.elementByCss('#slow-page-message').text()).toBe(
-            'hello from slow page'
-          )
-        })
-
-        it('should render loading.js in initial html for slow layout', async () => {
-          const $ = await next.render$('/slow-layout-with-loading/slow')
-
-          expect($('#loading').text()).toBe('Loading...')
-        })
-
-        it('should render loading.js in browser for slow layout', async () => {
-          const browser = await next.browser('/slow-layout-with-loading/slow', {
-            waitHydration: false,
-          })
-          // TODO-APP: `await next.browser()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
-          // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
-
-          expect(
-            await browser.elementByCss('#slow-layout-message').text()
-          ).toBe('hello from slow layout')
-
-          expect(await browser.elementByCss('#page-message').text()).toBe(
-            'Hello World'
-          )
-        })
-
-        it('should render loading.js in initial html for slow layout and page', async () => {
-          const $ = await next.render$(
-            '/slow-layout-and-page-with-loading/slow'
-          )
-
-          expect($('#loading-layout').text()).toBe('Loading layout...')
-          expect($('#loading-page').text()).toBe('Loading page...')
-        })
-
-        it('should render loading.js in browser for slow layout and page', async () => {
-          const browser = await next.browser(
-            '/slow-layout-and-page-with-loading/slow',
-            {
-              waitHydration: false,
-            }
-          )
-          // TODO-APP: `await next.browser()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
-          // expect(await browser.elementByCss('#loading-layout').text()).toBe('Loading...')
-          // expect(await browser.elementByCss('#loading-page').text()).toBe('Loading...')
-
-          expect(
-            await browser.elementByCss('#slow-layout-message').text()
-          ).toBe('hello from slow layout')
-
-          expect(await browser.elementByCss('#slow-page-message').text()).toBe(
-            'hello from slow page'
           )
         })
       })

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -37,9 +37,9 @@ createNextDescribe(
         )
 
         // Inherits from the root layout.
-        expect(middlewareManifest.functions['/script/page'].regions).toEqual([
-          'sfo1',
-        ])
+        expect(
+          middlewareManifest.functions['/slow-page-with-loading/page'].regions
+        ).toEqual(['sfo1'])
       })
     }
 
@@ -933,6 +933,77 @@ createNextDescribe(
           // After hydration count should be 1
           expect(await browser.elementByCss('p').text()).toBe(
             'hello from app/client-nested'
+          )
+        })
+      })
+
+      describe('Loading', () => {
+        it('should render loading.js in initial html for slow page', async () => {
+          const $ = await next.render$('/slow-page-with-loading')
+
+          expect($('#loading').text()).toBe('Loading...')
+        })
+
+        it('should render loading.js in browser for slow page', async () => {
+          const browser = await next.browser('/slow-page-with-loading', {
+            waitHydration: false,
+          })
+          // TODO-APP: `await next.browser()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+          // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
+
+          expect(await browser.elementByCss('#slow-page-message').text()).toBe(
+            'hello from slow page'
+          )
+        })
+
+        it('should render loading.js in initial html for slow layout', async () => {
+          const $ = await next.render$('/slow-layout-with-loading/slow')
+
+          expect($('#loading').text()).toBe('Loading...')
+        })
+
+        it('should render loading.js in browser for slow layout', async () => {
+          const browser = await next.browser('/slow-layout-with-loading/slow', {
+            waitHydration: false,
+          })
+          // TODO-APP: `await next.browser()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+          // expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
+
+          expect(
+            await browser.elementByCss('#slow-layout-message').text()
+          ).toBe('hello from slow layout')
+
+          expect(await browser.elementByCss('#page-message').text()).toBe(
+            'Hello World'
+          )
+        })
+
+        it('should render loading.js in initial html for slow layout and page', async () => {
+          const $ = await next.render$(
+            '/slow-layout-and-page-with-loading/slow'
+          )
+
+          expect($('#loading-layout').text()).toBe('Loading layout...')
+          expect($('#loading-page').text()).toBe('Loading page...')
+        })
+
+        it('should render loading.js in browser for slow layout and page', async () => {
+          const browser = await next.browser(
+            '/slow-layout-and-page-with-loading/slow',
+            {
+              waitHydration: false,
+            }
+          )
+          // TODO-APP: `await next.browser()` causes waiting for the full page to complete streaming. At that point "Loading..." is replaced by the actual content
+          // expect(await browser.elementByCss('#loading-layout').text()).toBe('Loading...')
+          // expect(await browser.elementByCss('#loading-page').text()).toBe('Loading...')
+
+          expect(
+            await browser.elementByCss('#slow-layout-message').text()
+          ).toBe('hello from slow layout')
+
+          expect(await browser.elementByCss('#slow-page-message').text()).toBe(
+            'hello from slow page'
           )
         })
       })


### PR DESCRIPTION
As noted in the comments, it's necessary to always add optional dependencies as missing dependencies even if they exist because they might be deleted and re-added.

Closes #51763.