### PR TITLE
Remove `execSync`

### DIFF
--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -61,7 +61,7 @@ export class Telemetry {
   private conf: Conf<any> | null
   private distDir: string
   private sessionId: string
-  private rawProjectId: string
+  private loadProjectId: undefined | string | Promise<string>
   private NEXT_TELEMETRY_DISABLED: any
   private NEXT_TELEMETRY_DEBUG: any
 
@@ -84,8 +84,6 @@ export class Telemetry {
       this.conf = null
     }
     this.sessionId = randomBytes(32).toString('hex')
-    this.rawProjectId = getRawProjectId()
-
     this.queue = new Set()
 
     this.notify()
@@ -176,8 +174,9 @@ export class Telemetry {
     return hash.digest('hex')
   }
 
-  private get projectId(): string {
-    return this.oneWayHash(this.rawProjectId)
+  private async getProjectId(): Promise<string> {
+    this.loadProjectId = this.loadProjectId || getRawProjectId()
+    return this.oneWayHash(await this.loadProjectId)
   }
 
   record = (
@@ -270,7 +269,7 @@ export class Telemetry {
     })
   }
 
-  private submitRecord = (
+  private submitRecord = async (
     _events: TelemetryEvent | TelemetryEvent[]
   ): Promise<any> => {
     let events: TelemetryEvent[]
@@ -303,7 +302,7 @@ export class Telemetry {
 
     const context: EventContext = {
       anonymousId: this.anonymousId,
-      projectId: this.projectId,
+      projectId: await this.getProjectId(),
       sessionId: this.sessionId,
     }
     const meta: EventMeta = getAnonymousMeta()


### PR DESCRIPTION
Currently we have an `execSync` in the Telemetry class constructor which runs at startup even if it might not be needed. This PR changes it to be non-blocking and makes it lazily loaded.

Before:

<img width="907" alt="CleanShot 2023-06-25 at 16 33 57@2x" src="https://github.com/vercel/next.js/assets/3676859/b3b1acb6-9968-4a00-9da9-b4b7fa859be3">

Note that all 3 processes (main, app renderer, pages renderer) all have this.

After:

<img width="956" alt="CleanShot 2023-06-25 at 16 36 52@2x" src="https://github.com/vercel/next.js/assets/3676859/7ef1973b-bdb2-485d-9336-6f67e13bccff">
