### PR TITLE
fix: interception rewrites should support catch-all segments

### DIFF
--- a/packages/next/src/lib/generate-interception-routes-rewrites.ts
+++ b/packages/next/src/lib/generate-interception-routes-rewrites.ts
@@ -9,7 +9,13 @@ import { Rewrite } from './load-custom-routes'
 
 // a function that converts normalised paths (e.g. /foo/[bar]/[baz]) to the format expected by pathToRegexp (e.g. /foo/:bar/:baz)
 function toPathToRegexpPath(path: string): string {
-  return path.replace(/\[([^\]]+)\]/g, ':$1')
+  return path.replace(/\[\[?([^\]]+)\]\]?/g, (_, capture) => {
+    // handle catch-all segments (e.g. /foo/bar/[...baz] or /foo/bar/[[...baz]])
+    if (capture.startsWith('...')) {
+      return `:${capture.slice(3)}*`
+    }
+    return ':' + capture
+  })
 }
 
 // for interception routes we don't have access to the dynamic segments from the

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)catchall/[...id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)catchall/[...id]/page.tsx
@@ -1,0 +1,3 @@
+export default function InterceptedAuthorIdPage() {
+  return <div id="user-intercept-page">Intercepted Page</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)catchall/[...id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)catchall/[...id]/page.tsx
@@ -1,3 +1,3 @@
-export default function InterceptedAuthorIdPage() {
-  return <div id="user-intercept-page">Intercepted Page</div>
+export default function InterceptPage() {
+  return <div id="catchall-intercept-page">Intercepted Page</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)optional-catchall/[[...id]]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)optional-catchall/[[...id]]/page.tsx
@@ -1,0 +1,3 @@
+export default function InterceptedAuthorIdPage() {
+  return <div id="user-intercept-page">Intercepted Page</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)optional-catchall/[[...id]]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)optional-catchall/[[...id]]/page.tsx
@@ -1,3 +1,3 @@
-export default function InterceptedAuthorIdPage() {
-  return <div id="user-intercept-page">Intercepted Page</div>
+export default function InterceptedPage() {
+  return <div id="optional-catchall-intercept-page">Intercepted Page</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/catchall/[id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/catchall/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function AuthorIdPage() {
+  return <div id="user-regular-page">Regular Page</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/catchall/[id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/catchall/[id]/page.tsx
@@ -1,3 +1,3 @@
-export default function AuthorIdPage() {
-  return <div id="user-regular-page">Regular Page</div>
+export default function RegularPage() {
+  return <div id="catchall-regular-page">Regular Page</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/optional-catchall/[[...id]]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/optional-catchall/[[...id]]/page.tsx
@@ -1,0 +1,3 @@
+export default function RegularPage() {
+  return <div id="optional-catchall-regular-page">Regular Page</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/optional-catchall/[id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/optional-catchall/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function AuthorIdPage() {
+  return <div id="user-regular-page">Regular Page</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/optional-catchall/[id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/optional-catchall/[id]/page.tsx
@@ -1,3 +1,0 @@
-export default function AuthorIdPage() {
-  return <div id="user-regular-page">Regular Page</div>
-}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <>
+      <Link href="/intercepting-routes-dynamic-catchall/photos/catchall/123">
+        Visit Catch-all
+      </Link>
+
+      <Link href="/intercepting-routes-dynamic-catchall/photos/optional-catchall/123">
+        Visit Optional Catch-all
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -394,7 +394,7 @@ createNextDescribe(
                 '[href="/intercepting-routes-dynamic-catchall/photos/optional-catchall/123"]'
               )
               .click()
-              .waitForElementByCss('#user-intercept-page')
+              .waitForElementByCss('#optional-catchall-intercept-page')
               .text(),
           'Intercepted Page'
         )
@@ -409,7 +409,10 @@ createNextDescribe(
         // Trigger a refresh, this should load the normal page, not the modal.
         await check(
           () =>
-            browser.refresh().waitForElementByCss('#user-regular-page').text(),
+            browser
+              .refresh()
+              .waitForElementByCss('#optional-catchall-regular-page')
+              .text(),
           'Regular Page'
         )
 
@@ -436,7 +439,7 @@ createNextDescribe(
                 '[href="/intercepting-routes-dynamic-catchall/photos/catchall/123"]'
               )
               .click()
-              .waitForElementByCss('#user-intercept-page')
+              .waitForElementByCss('#catchall-intercept-page')
               .text(),
           'Intercepted Page'
         )
@@ -450,7 +453,10 @@ createNextDescribe(
         // Trigger a refresh, this should load the normal page, not the modal.
         await check(
           () =>
-            browser.refresh().waitForElementByCss('#user-regular-page').text(),
+            browser
+              .refresh()
+              .waitForElementByCss('#catchall-regular-page')
+              .text(),
           'Regular Page'
         )
 

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -380,6 +380,88 @@ createNextDescribe(
       })
     })
 
+    describe('route intercepting with dynamic optional catch-all routes', () => {
+      it('should render intercepted route', async () => {
+        const browser = await next.browser(
+          '/intercepting-routes-dynamic-catchall/photos'
+        )
+
+        // Check if navigation to modal route works
+        await check(
+          () =>
+            browser
+              .elementByCss(
+                '[href="/intercepting-routes-dynamic-catchall/photos/optional-catchall/123"]'
+              )
+              .click()
+              .waitForElementByCss('#user-intercept-page')
+              .text(),
+          'Intercepted Page'
+        )
+
+        // Check if url matches even though it was intercepted.
+        await check(
+          () => browser.url(),
+          next.url +
+            '/intercepting-routes-dynamic-catchall/photos/optional-catchall/123'
+        )
+
+        // Trigger a refresh, this should load the normal page, not the modal.
+        await check(
+          () =>
+            browser.refresh().waitForElementByCss('#user-regular-page').text(),
+          'Regular Page'
+        )
+
+        // Check if the url matches still.
+        await check(
+          () => browser.url(),
+          next.url +
+            '/intercepting-routes-dynamic-catchall/photos/optional-catchall/123'
+        )
+      })
+    })
+
+    describe('route intercepting with dynamic catch-all routes', () => {
+      it('should render intercepted route', async () => {
+        const browser = await next.browser(
+          '/intercepting-routes-dynamic-catchall/photos'
+        )
+
+        // Check if navigation to modal route works
+        await check(
+          () =>
+            browser
+              .elementByCss(
+                '[href="/intercepting-routes-dynamic-catchall/photos/catchall/123"]'
+              )
+              .click()
+              .waitForElementByCss('#user-intercept-page')
+              .text(),
+          'Intercepted Page'
+        )
+
+        // Check if url matches even though it was intercepted.
+        await check(
+          () => browser.url(),
+          next.url + '/intercepting-routes-dynamic-catchall/photos/catchall/123'
+        )
+
+        // Trigger a refresh, this should load the normal page, not the modal.
+        await check(
+          () =>
+            browser.refresh().waitForElementByCss('#user-regular-page').text(),
+          'Regular Page'
+        )
+
+        // Check if the url matches still.
+        await check(
+          () => browser.url(),
+          next.url + '/intercepting-routes-dynamic-catchall/photos/catchall/123'
+        )
+      })
+    })
+
     describe('route intercepting', () => {
       it('should render intercepted route', async () => {
         const browser = await next.browser('/intercepting-routes/feed')


### PR DESCRIPTION
### What?
Interception route rewrites are not properly parsing catch-all segments, which leads to "missing parameter name" errors when passed to `pathToRegexp`.

### Why?
The existing `toPathToRegexpPath` function ignores `...` and keeps it as part of the regexp path. This means `pathToRegexp` will attempt to handle `/foo/bar/:...baz` and `/foo/bar/:[...baz]` rather than `/foo/bar/:baz*`

### How?
The regex used for matching the path was updated to support the dynamic optional segment, and then we special case catch-all segments

Fixes #51784
