### PR TITLE
docs(deploy): fix GitHub Actions cache key

### DIFF
--- a/docs/03-pages/01-building-your-application/07-deploying/04-ci-build-caching.mdx
+++ b/docs/03-pages/01-building-your-application/07-deploying/04-ci-build-caching.mdx
@@ -81,7 +81,7 @@ with:
     ~/.npm
     ${{ github.workspace }}/.next/cache
   # Generate a new cache whenever packages or source files change.
-  key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+  key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.[jt]s', '**/*.[jt]sx') }}
   # If source files changed but packages didn't, rebuild from a prior cache.
   restore-keys: |
     ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-


### PR DESCRIPTION
The specified default cache key `**.[jt]s` does not consider any files in
folders, while `**/*.[jt]s` recursively includes all files.
The same goes for jsx/tsx.