### PR TITLE
docs: Add updated `next/image` video.

### DIFF
--- a/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
+++ b/docs/02-app/01-building-your-application/05-optimizing/01-images.mdx
@@ -25,6 +25,8 @@ The Next.js Image component extends the HTML `<img>` element with features for a
 - **Faster Page Loads:** Images are only loaded when they enter the viewport using native browser lazy loading, with optional blur-up placeholders.
 - **Asset Flexibility:** On-demand image resizing, even for images stored on remote servers
 
+> **🎥 Watch:** Learn more about how to use `next/image` → [YouTube (9 minutes)](https://youtu.be/IU_qq_c_lKA).
+
 ## Usage
 
 ```js


### PR DESCRIPTION
I made a video two years ago that was teaching old patterns of the Next.js image component. Since then, we have simplified the API, made improvements to the component that no longer require wrapping DOM elements, and more. This updated video explains these concepts, as well as walks through some of the practical examples in the `examples/` fold here.