### PR TITLE
Fix next-lint dirs logic

### DIFF
--- a/packages/next/src/cli/next-lint.ts
+++ b/packages/next/src/cli/next-lint.ts
@@ -172,7 +172,7 @@ const nextLint: CliCommand = async (argv) => {
   const nextConfig = await loadConfig(PHASE_PRODUCTION_BUILD, baseDir)
 
   const files: string[] = args['--file'] ?? []
-  const dirs: string[] = args['--dir'] ?? nextConfig.eslint?.dirs
+  const dirs: string[] = args['--dir'] ?? args['--file'] ? [] : nextConfig.eslint?.dirs ?? [];
   const filesToLint = [...(dirs ?? []), ...files]
 
   // Remove that when the `appDir` will be stable.


### PR DESCRIPTION
### What?

When running `next lint --fix {FILE}`, it not only lints the specified `FILE`, but also lints all files in the directories specified by `nextConfig.eslint.dirs`.

### Why?

The issue is caused by the code at [next-lint.ts#L175](https://github.com/vercel/next.js/blob/canary/packages/next/src/cli/next-lint.ts#L175), which overrides the behavior of `next lint --fix {FILE}` command to include `--dir {DIR_IN_nextConfig.eslint.dirs}`.

### How?

To address this issue, we should ignore `nextConfig.eslint?.dirs` when the `--file` option is used.

Fixes https://github.com/vercel/next.js/issues/51800
