### PR TITLE
Performance improvements for dev

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2630,6 +2630,7 @@ export default async function getBaseWebpackConfig(
     //  - next.config.js keys that affect compilation
     version: `${process.env.__NEXT_VERSION}|${configVars}`,
     cacheDirectory: path.join(distDir, 'cache', 'webpack'),
+    compression: 'gzip',
   }
 
   // Adds `next.config.js` as a buildDependency when custom webpack config is provided

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2630,7 +2630,7 @@ export default async function getBaseWebpackConfig(
     //  - next.config.js keys that affect compilation
     version: `${process.env.__NEXT_VERSION}|${configVars}`,
     cacheDirectory: path.join(distDir, 'cache', 'webpack'),
-    compression: 'gzip',
+    // compression: 'gzip',
   }
 
   // Adds `next.config.js` as a buildDependency when custom webpack config is provided

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -199,7 +199,7 @@ export async function startServer({
         // TODO: do we want to allow more than 10 OOM restarts?
         maxRetries: 10,
         forkOptions: {
-          execArgv: await genRouterWorkerExecArgv(
+          execArgv: genRouterWorkerExecArgv(
             isNodeDebugging === undefined ? false : isNodeDebugging
           ),
           env: {

--- a/packages/next/src/server/lib/utils.ts
+++ b/packages/next/src/server/lib/utils.ts
@@ -24,9 +24,7 @@ export const getDebugPort = () => {
   return debugPortStr ? parseInt(debugPortStr, 10) : 9229
 }
 
-export const genRouterWorkerExecArgv = async (
-  isNodeDebugging: boolean | 'brk'
-) => {
+export const genRouterWorkerExecArgv = (isNodeDebugging: boolean | 'brk') => {
   const execArgv = process.execArgv.filter((localArg) => {
     return (
       !localArg.startsWith('--inspect') && !localArg.startsWith('--inspect-brk')

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -191,6 +191,10 @@ type RenderWorker = Worker & {
   deleteCache: typeof import('./lib/render-server').deleteCache
   deleteAppClientCache: typeof import('./lib/render-server').deleteAppClientCache
   clearModuleContext: typeof import('./lib/render-server').clearModuleContext
+  initialized?: {
+    port: number
+    hostname: string
+  }
 }
 
 export default class NextNodeServer extends BaseServer {
@@ -1428,9 +1432,11 @@ export default class NextNodeServer extends BaseServer {
 
           if (renderWorker) {
             const initUrl = getRequestMeta(req, '__NEXT_INIT_URL')!
-            const { port, hostname } = await renderWorker.initialize(
-              this.renderWorkerOpts!
-            )
+            const { port, hostname } =
+              renderWorker.initialized ||
+              (renderWorker.initialized = await renderWorker.initialize(
+                this.renderWorkerOpts!
+              ))
             const renderUrl = new URL(initUrl)
             renderUrl.hostname = hostname
             renderUrl.port = port + ''
@@ -2442,9 +2448,11 @@ export default class NextNodeServer extends BaseServer {
                 }
 
                 const { port, hostname } =
-                  await this.renderWorkers.middleware.initialize(
-                    this.renderWorkerOpts!
-                  )
+                  this.renderWorkers.middleware.initialized ||
+                  (this.renderWorkers.middleware.initialized =
+                    await this.renderWorkers.middleware.initialize(
+                      this.renderWorkerOpts!
+                    ))
                 const renderUrl = new URL(initUrl)
                 renderUrl.hostname = hostname
                 renderUrl.port = port + ''


### PR DESCRIPTION
Two major changes for this PR:
- Avoid initializing the render workers on every request
- Enable `compression: 'gzip'` for the Webpack cache