### PR TITLE
Add `WATCHPACK_WATCHER_LIMIT=20`

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -210,6 +210,7 @@ export async function startServer({
             ...(process.env.NEXT_CPU_PROF
               ? { __NEXT_PRIVATE_CPU_PROFILE: `CPU.router` }
               : {}),
+            WATCHPACK_WATCHER_LIMIT: '20',
           },
         },
         exposedMethods: ['initialize'],


### PR DESCRIPTION
Limit the number of Watchpack's watchers to 20 for the routing worker which runs Watchpack. By default this value is 2000 on macOS and 10000 on Windows, which can hold too much resource.