### PR TITLE
performance: don't compile on hover on dev

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -211,13 +211,24 @@ export function navigateReducer(
   // If we don't have a prefetch value, we need to create one
   if (!prefetchValues) {
     const data = createRecordFromThenable(
-      fetchServerResponse(url, state.tree, state.nextUrl, state.buildId)
+      fetchServerResponse(
+        url,
+        state.tree,
+        state.nextUrl,
+        state.buildId,
+        // in dev, there's never gonna be a prefetch entry so we want to prefetch here
+        // in order to simulate the behavior of the prefetch cache
+        process.env.NODE_ENV === 'development' ? PrefetchKind.AUTO : undefined
+      )
     )
 
     const newPrefetchValue = {
       data: Promise.resolve(data),
       // this will make sure that the entry will be discarded after 30s
-      kind: PrefetchKind.TEMPORARY,
+      kind:
+        process.env.NODE_ENV === 'development'
+          ? PrefetchKind.AUTO
+          : PrefetchKind.TEMPORARY,
       prefetchTime: Date.now(),
       treeAtTimeOfPrefetch: state.tree,
       lastUsedTime: null,

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -284,7 +284,17 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       children = <a>{children}</a>
     }
 
-    const prefetchEnabled = prefetchProp !== false
+    const pagesRouter = React.useContext(RouterContext)
+    const appRouter = React.useContext(AppRouterContext)
+    const router = pagesRouter ?? appRouter
+
+    // We're in the app directory if there is no pages router.
+    const isAppRouter = !pagesRouter
+
+    const prefetchEnabled =
+      prefetchProp !== false &&
+      // no prefetch for app router in development
+      !(process.env.NODE_ENV === 'development' && isAppRouter)
     /**
      * The possible states for prefetch are:
      * - null: this is the default "auto" mode, where we will prefetch partially if the link is in the viewport
@@ -294,12 +304,6 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     const appPrefetchKind =
       prefetchProp === null ? PrefetchKind.AUTO : PrefetchKind.FULL
 
-    const pagesRouter = React.useContext(RouterContext)
-    const appRouter = React.useContext(AppRouterContext)
-    const router = pagesRouter ?? appRouter
-
-    // We're in the app directory if there is no pages router.
-    const isAppRouter = !pagesRouter
     if (process.env.NODE_ENV !== 'production') {
       function createPropError(args: {
         key: string

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -291,10 +291,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     // We're in the app directory if there is no pages router.
     const isAppRouter = !pagesRouter
 
-    const prefetchEnabled =
-      prefetchProp !== false &&
-      // no prefetch for app router in development
-      !(process.env.NODE_ENV === 'development' && isAppRouter)
+    const prefetchEnabled = prefetchProp !== false
     /**
      * The possible states for prefetch are:
      * - null: this is the default "auto" mode, where we will prefetch partially if the link is in the viewport
@@ -653,7 +650,10 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
           return
         }
 
-        if (!prefetchEnabled && isAppRouter) {
+        if (
+          (!prefetchEnabled || process.env.NODE_ENV === 'development') &&
+          isAppRouter
+        ) {
           return
         }
 


### PR DESCRIPTION
An annoying issue that slows down compilation times in dev for Next is that we might trigger compilation of a page via hover on app.

We do this because we want the same experience in production and dev and the prefetching is important for instantaneous loading states.

The alternative in this PR is that we don't prefetch at all anymore in dev but instead, when we handle navigation, we can force a prefetch navigation.

The slight compromise with this approach is that you can't test prefetching anymore in dev.


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

link NEXT-1317