### PR TITLE
performance: enable minification for the server bundles

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1766,7 +1766,7 @@ export default async function getBaseWebpackConfig(
       runtimeChunk: isClient
         ? { name: CLIENT_STATIC_FILES_RUNTIME_WEBPACK }
         : undefined,
-      minimize: !dev && !config.disableServerMinification,
+      minimize: !dev && !(isNodeServer && config.disableServerMinification),
       minimizer: [
         // Minify JavaScript
         (compiler: webpack.Compiler) => {

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1766,7 +1766,7 @@ export default async function getBaseWebpackConfig(
       runtimeChunk: isClient
         ? { name: CLIENT_STATIC_FILES_RUNTIME_WEBPACK }
         : undefined,
-      minimize: !dev && (isClient || isEdgeServer),
+      minimize: !dev && !config.disableServerMinification,
       minimizer: [
         // Minify JavaScript
         (compiler: webpack.Compiler) => {

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2724,6 +2724,7 @@ export default async function getBaseWebpackConfig(
     experimental: config.experimental,
     disableStaticImages: config.images.disableStaticImages,
     transpilePackages: config.transpilePackages,
+    enableSourceMapsForServer: config.enableSourceMapsForServer,
   })
 
   // @ts-ignore Cache exists

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1767,8 +1767,10 @@ export default async function getBaseWebpackConfig(
         ? { name: CLIENT_STATIC_FILES_RUNTIME_WEBPACK }
         : undefined,
       minimize:
-        !dev ||
-        (!dev && isNodeServer && config.experimental.enableServerMinification),
+        !dev &&
+        (isClient ||
+          isEdgeServer ||
+          (isNodeServer && config.experimental.enableServerMinification)),
       minimizer: [
         // Minify JavaScript
         (compiler: webpack.Compiler) => {

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1766,7 +1766,9 @@ export default async function getBaseWebpackConfig(
       runtimeChunk: isClient
         ? { name: CLIENT_STATIC_FILES_RUNTIME_WEBPACK }
         : undefined,
-      minimize: !dev && !(isNodeServer && config.disableServerMinification),
+      minimize:
+        !dev ||
+        (!dev && isNodeServer && config.experimental.enableServerMinification),
       minimizer: [
         // Minify JavaScript
         (compiler: webpack.Compiler) => {
@@ -2724,7 +2726,7 @@ export default async function getBaseWebpackConfig(
     experimental: config.experimental,
     disableStaticImages: config.images.disableStaticImages,
     transpilePackages: config.transpilePackages,
-    enableSourceMapsForServer: config.enableSourceMapsForServer,
+    enableSourceMapsForServer: config.experimental.enableSourceMapsForServer,
   })
 
   // @ts-ignore Cache exists

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1770,7 +1770,7 @@ export default async function getBaseWebpackConfig(
         !dev &&
         (isClient ||
           isEdgeServer ||
-          (isNodeServer && config.experimental.enableServerMinification)),
+          (isNodeServer && config.experimental.serverMinification)),
       minimizer: [
         // Minify JavaScript
         (compiler: webpack.Compiler) => {
@@ -2728,7 +2728,7 @@ export default async function getBaseWebpackConfig(
     experimental: config.experimental,
     disableStaticImages: config.images.disableStaticImages,
     transpilePackages: config.transpilePackages,
-    enableSourceMapsForServer: config.experimental.enableSourceMapsForServer,
+    serverSourceMaps: config.experimental.serverSourceMaps,
   })
 
   // @ts-ignore Cache exists

--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -34,6 +34,7 @@ export const base = curry(function base(
   } else {
     if (
       ctx.isEdgeRuntime ||
+      ctx.isServer ||
       // Enable browser sourcemaps:
       (ctx.productionBrowserSourceMaps && ctx.isClient)
     ) {

--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -34,7 +34,7 @@ export const base = curry(function base(
   } else {
     if (
       ctx.isEdgeRuntime ||
-      ctx.isServer ||
+      (ctx.isServer && ctx.enableSourceMapsForServer) ||
       // Enable browser sourcemaps:
       (ctx.productionBrowserSourceMaps && ctx.isClient)
     ) {

--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -34,7 +34,7 @@ export const base = curry(function base(
   } else {
     if (
       ctx.isEdgeRuntime ||
-      (ctx.isServer && ctx.enableSourceMapsForServer) ||
+      (ctx.isServer && ctx.serverSourceMaps) ||
       // Enable browser sourcemaps:
       (ctx.productionBrowserSourceMaps && ctx.isClient)
     ) {

--- a/packages/next/src/build/webpack/config/index.ts
+++ b/packages/next/src/build/webpack/config/index.ts
@@ -25,6 +25,7 @@ export async function buildConfiguration(
     transpilePackages,
     experimental,
     disableStaticImages,
+    enableSourceMapsForServer,
   }: {
     hasAppDir: boolean
     supportedBrowsers: string[] | undefined
@@ -41,6 +42,7 @@ export async function buildConfiguration(
     future: NextConfigComplete['future']
     experimental: NextConfigComplete['experimental']
     disableStaticImages: NextConfigComplete['disableStaticImages']
+    enableSourceMapsForServer: NextConfigComplete['enableSourceMapsForServer']
   }
 ): Promise<webpack.Configuration> {
   const ctx: ConfigurationContext = {
@@ -64,6 +66,7 @@ export async function buildConfiguration(
     transpilePackages,
     future,
     experimental,
+    enableSourceMapsForServer,
   }
 
   let fns = [base(ctx), css(ctx)]

--- a/packages/next/src/build/webpack/config/index.ts
+++ b/packages/next/src/build/webpack/config/index.ts
@@ -25,7 +25,7 @@ export async function buildConfiguration(
     transpilePackages,
     experimental,
     disableStaticImages,
-    enableSourceMapsForServer,
+    serverSourceMaps,
   }: {
     hasAppDir: boolean
     supportedBrowsers: string[] | undefined
@@ -42,7 +42,7 @@ export async function buildConfiguration(
     future: NextConfigComplete['future']
     experimental: NextConfigComplete['experimental']
     disableStaticImages: NextConfigComplete['disableStaticImages']
-    enableSourceMapsForServer: NextConfigComplete['experimental']['enableSourceMapsForServer']
+    serverSourceMaps: NextConfigComplete['experimental']['serverSourceMaps']
   }
 ): Promise<webpack.Configuration> {
   const ctx: ConfigurationContext = {
@@ -66,7 +66,7 @@ export async function buildConfiguration(
     transpilePackages,
     future,
     experimental,
-    enableSourceMapsForServer: enableSourceMapsForServer ?? false,
+    serverSourceMaps: serverSourceMaps ?? false,
   }
 
   let fns = [base(ctx), css(ctx)]

--- a/packages/next/src/build/webpack/config/index.ts
+++ b/packages/next/src/build/webpack/config/index.ts
@@ -42,7 +42,7 @@ export async function buildConfiguration(
     future: NextConfigComplete['future']
     experimental: NextConfigComplete['experimental']
     disableStaticImages: NextConfigComplete['disableStaticImages']
-    enableSourceMapsForServer: NextConfigComplete['enableSourceMapsForServer']
+    enableSourceMapsForServer: NextConfigComplete['experimental']['enableSourceMapsForServer']
   }
 ): Promise<webpack.Configuration> {
   const ctx: ConfigurationContext = {
@@ -66,7 +66,7 @@ export async function buildConfiguration(
     transpilePackages,
     future,
     experimental,
-    enableSourceMapsForServer,
+    enableSourceMapsForServer: enableSourceMapsForServer ?? false,
   }
 
   let fns = [base(ctx), css(ctx)]

--- a/packages/next/src/build/webpack/config/utils.ts
+++ b/packages/next/src/build/webpack/config/utils.ts
@@ -22,6 +22,7 @@ export type ConfigurationContext = {
 
   sassOptions: any
   productionBrowserSourceMaps: boolean
+  enableSourceMapsForServer: boolean
 
   transpilePackages: NextConfigComplete['transpilePackages']
 

--- a/packages/next/src/build/webpack/config/utils.ts
+++ b/packages/next/src/build/webpack/config/utils.ts
@@ -22,7 +22,7 @@ export type ConfigurationContext = {
 
   sassOptions: any
   productionBrowserSourceMaps: boolean
-  enableSourceMapsForServer: boolean
+  serverSourceMaps: boolean
 
   transpilePackages: NextConfigComplete['transpilePackages']
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -203,6 +203,9 @@ const configSchema = {
     disableServerMinification: {
       type: 'boolean',
     },
+    enableSourceMapsForServer: {
+      type: 'boolean',
+    },
     env: {
       type: 'object',
     },

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -200,6 +200,9 @@ const configSchema = {
       type: 'string',
       nullable: true,
     },
+    disableServerMinification: {
+      type: 'boolean',
+    },
     env: {
       type: 'object',
     },

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -200,12 +200,6 @@ const configSchema = {
       type: 'string',
       nullable: true,
     },
-    disableServerMinification: {
-      type: 'boolean',
-    },
-    enableSourceMapsForServer: {
-      type: 'boolean',
-    },
     env: {
       type: 'object',
     },
@@ -517,6 +511,12 @@ const configSchema = {
         },
         logging: {
           type: 'string',
+        },
+        enableServerMinification: {
+          type: 'boolean',
+        },
+        enableSourceMapsForServer: {
+          type: 'boolean',
         },
       },
       type: 'object',

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -512,10 +512,10 @@ const configSchema = {
         logging: {
           type: 'string',
         },
-        enableServerMinification: {
+        serverMinification: {
           type: 'boolean',
         },
-        enableSourceMapsForServer: {
+        serverSourceMaps: {
           type: 'boolean',
         },
       },

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -460,6 +460,11 @@ export interface NextConfig extends Record<string, any> {
   disableServerMinification?: boolean
 
   /**
+   * Enables source maps generation for the server production bundle.
+   */
+  enableSourceMapsForServer?: boolean
+
+  /**
    * Next.js exposes some options that give you some control over how the server will dispose or keep in memory built pages in development.
    *
    * @see [Configuring `onDemandEntries`](https://nextjs.org/docs/api-reference/next.config.js/configuring-onDemandEntries)
@@ -646,6 +651,7 @@ export const defaultConfig: NextConfig = {
   analyticsId: process.env.VERCEL_ANALYTICS_ID || '',
   images: imageConfigDefault,
   disableServerMinification: false,
+  enableSourceMapsForServer: false,
   devIndicators: {
     buildActivity: true,
     buildActivityPosition: 'bottom-right',

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -455,6 +455,11 @@ export interface NextConfig extends Record<string, any> {
   }
 
   /**
+   * Disables the automatic minification of server code.
+   */
+  disableServerMinification?: boolean
+
+  /**
    * Next.js exposes some options that give you some control over how the server will dispose or keep in memory built pages in development.
    *
    * @see [Configuring `onDemandEntries`](https://nextjs.org/docs/api-reference/next.config.js/configuring-onDemandEntries)
@@ -640,6 +645,7 @@ export const defaultConfig: NextConfig = {
   compress: true,
   analyticsId: process.env.VERCEL_ANALYTICS_ID || '',
   images: imageConfigDefault,
+  disableServerMinification: false,
   devIndicators: {
     buildActivity: true,
     buildActivityPosition: 'bottom-right',

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -291,12 +291,12 @@ export interface ExperimentalConfig {
   /**
    * enables the minification of server code.
    */
-  enableServerMinification?: boolean
+  serverMinification?: boolean
 
   /**
    * Enables source maps generation for the server production bundle.
    */
-  enableSourceMapsForServer?: boolean
+  serverSourceMaps?: boolean
 }
 
 export type ExportPathMap = {
@@ -680,8 +680,8 @@ export const defaultConfig: NextConfig = {
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,
   experimental: {
-    enableServerMinification: false,
-    enableSourceMapsForServer: false,
+    serverMinification: false,
+    serverSourceMaps: false,
     caseSensitiveRoutes: false,
     useDeploymentId: false,
     deploymentId: undefined,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -287,6 +287,16 @@ export interface ExperimentalConfig {
    * Allows adjusting body parser size limit for server actions.
    */
   serverActionsBodySizeLimit?: SizeLimit
+
+  /**
+   * enables the minification of server code.
+   */
+  enableServerMinification?: boolean
+
+  /**
+   * Enables source maps generation for the server production bundle.
+   */
+  enableSourceMapsForServer?: boolean
 }
 
 export type ExportPathMap = {
@@ -453,16 +463,6 @@ export interface NextConfig extends Record<string, any> {
       | 'top-right'
       | 'top-left'
   }
-
-  /**
-   * Disables the automatic minification of server code.
-   */
-  disableServerMinification?: boolean
-
-  /**
-   * Enables source maps generation for the server production bundle.
-   */
-  enableSourceMapsForServer?: boolean
 
   /**
    * Next.js exposes some options that give you some control over how the server will dispose or keep in memory built pages in development.
@@ -650,8 +650,6 @@ export const defaultConfig: NextConfig = {
   compress: true,
   analyticsId: process.env.VERCEL_ANALYTICS_ID || '',
   images: imageConfigDefault,
-  disableServerMinification: false,
-  enableSourceMapsForServer: false,
   devIndicators: {
     buildActivity: true,
     buildActivityPosition: 'bottom-right',
@@ -682,6 +680,8 @@ export const defaultConfig: NextConfig = {
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,
   experimental: {
+    enableServerMinification: false,
+    enableSourceMapsForServer: false,
     caseSensitiveRoutes: false,
     useDeploymentId: false,
     deploymentId: undefined,

--- a/test/integration/externalize-next-server/app/next.config.js
+++ b/test/integration/externalize-next-server/app/next.config.js
@@ -1,6 +1,0 @@
-/**
- * @type {import('next').NextConfig}
- */
-module.exports = {
-  disableServerMinification: true,
-}

--- a/test/integration/externalize-next-server/app/next.config.js
+++ b/test/integration/externalize-next-server/app/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+module.exports = {
+  disableServerMinification: true,
+}


### PR DESCRIPTION
This PR makes the server code be minified.

## Why

This will improve performance of the server code because of the lesser size, lesser time to parse and lesser code via tree sharking.

Cons: this should lead to increased build times, so a `disableServerMinification` config was added


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

link NEXT-1319