### PR TITLE
fix: webpack target should match node engines

### DIFF
--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -15,7 +15,7 @@ export const base = curry(function base(
     : COMPILER_NAMES.client
 
   config.target = !ctx.targetWeb
-    ? 'node16.8.0' // Same version defined in packages/next/package.json#engine
+    ? 'node16.8' // Same version defined in packages/next/package.json#engine
     : ctx.isEdgeRuntime
     ? ['web', 'es6']
     : ['web', 'es5']

--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -14,9 +14,8 @@ export const base = curry(function base(
       : COMPILER_NAMES.server
     : COMPILER_NAMES.client
 
-  // @ts-ignore TODO webpack 5 typings
   config.target = !ctx.targetWeb
-    ? 'node12.22'
+    ? 'node16.8.0' // Same version defined in packages/next/package.json#engine
     : ctx.isEdgeRuntime
     ? ['web', 'es6']
     : ['web', 'es5']

--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -15,7 +15,7 @@ export const base = curry(function base(
     : COMPILER_NAMES.client
 
   config.target = !ctx.targetWeb
-    ? 'node16.8' // Same version defined in packages/next/package.json#engine
+    ? 'node16.8' // Same version defined in packages/next/package.json#engines
     : ctx.isEdgeRuntime
     ? ['web', 'es6']
     : ['web', 'es5']

--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -70,7 +70,7 @@ module.exports = function (task) {
         },
         env: {
           targets: {
-            // Follows version defined in packages/next/package.json#engines
+            // Same version defined in packages/next/package.json#engines
             // Currently a few minors behind due to babel class transpiling
             node: '16.8.0',
           },

--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -70,7 +70,7 @@ module.exports = function (task) {
         },
         env: {
           targets: {
-            // Follows version defined in packages/next/package.json#engine
+            // Follows version defined in packages/next/package.json#engines
             // Currently a few minors behind due to babel class transpiling
             node: '16.8.0',
           },


### PR DESCRIPTION
The webpack `target` was outdated so I updated to match `engines`. See related https://github.com/vercel/next.js/pull/48941