### PR TITLE
Export `RedirectType` from `next/navigation`

### DIFF
--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -232,5 +232,5 @@ export function useSelectedLayoutSegment(
   return selectedLayoutSegments[0]
 }
 
-export { redirect } from './redirect'
+export { redirect, RedirectType } from './redirect'
 export { notFound } from './not-found'


### PR DESCRIPTION
This PR adds an export for `RedirectType` to `next/navigation`.
This allows you to import it together with `redirect`, instead of importing from `next/dist/client/components/redirect`

before:

```tsx
import { redirect } from 'next/navigation';
import { RedirectType } from 'next/dist/client/components/redirect';

redirect('/foo', RedirectType.push);
```

after:

```tsx
import { redirect, RedirectType } from 'next/navigation';

redirect('/foo', RedirectType.push);
```

