### PR TITLE
Fix missing request body in DELETE and OPTIONS Route Handlers

### DIFF
--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -1,6 +1,5 @@
 export const forbiddenHeaders = [
   'accept-encoding',
-  'content-length',
   'keepalive',
   'content-encoding',
   'transfer-encoding',

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -257,6 +257,28 @@ createNextDescribe(
         expect(meta.body).toEqual(body)
       })
 
+      it('can read a JSON encoded body for DELETE requests', async () => {
+        const body = { name: 'foo' }
+        const res = await next.fetch('/advanced/body/json', {
+          method: 'DELETE',
+          body: JSON.stringify(body),
+        })
+
+        expect(res.status).toEqual(200)
+        expect(await res.text()).toEqual('delete foo')
+      })
+
+      it('can read a JSON encoded body for OPTIONS requests', async () => {
+        const body = { name: 'bar' }
+        const res = await next.fetch('/advanced/body/json', {
+          method: 'OPTIONS',
+          body: JSON.stringify(body),
+        })
+
+        expect(res.status).toEqual(200)
+        expect(await res.text()).toEqual('options bar')
+      })
+
       // we can't stream a body to a function currently only stream response
       if (!isNextDeploy) {
         it('can read a streamed JSON encoded body', async () => {

--- a/test/e2e/app-dir/app-routes/app/advanced/body/json/route.ts
+++ b/test/e2e/app-dir/app-routes/app/advanced/body/json/route.ts
@@ -8,3 +8,17 @@ export async function POST(request: NextRequest) {
     headers: withRequestMeta({ body }),
   })
 }
+
+export async function DELETE(request: NextRequest) {
+  const body = await request.json()
+  return new Response('delete ' + body.name, {
+    status: 200,
+  })
+}
+
+export async function OPTIONS(request: NextRequest) {
+  const body = await request.json()
+  return new Response('options ' + body.name, {
+    status: 200,
+  })
+}


### PR DESCRIPTION
It looks like the `content-length` header can't be ignored for the request forwarded to the render worker. See https://github.com/nodejs/node/issues/27880.

Closes #48096, closes #49310. Fix NEXT-1194
fix NEXT-1114