### PR TITLE
Support relative url for openGraph.url and itunes.appArgument

### DIFF
--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -59,6 +59,27 @@ describe('accumulateMetadata', () => {
     })
   })
 
+  describe('itunes', () => {
+    it('should resolve relative url starting with ./ with pathname for itunes.appArgument', async () => {
+      const metadataItems: MetadataItems = [
+        [
+          {
+            metadataBase: new URL('http://test.com/base'),
+            itunes: { appId: 'id', appArgument: './native/app' },
+          },
+          null,
+        ],
+      ]
+      const metadata = await accumulateMetadata(metadataItems)
+      expect(metadata).toMatchObject({
+        metadataBase: new URL('http://test.com/base'),
+        itunes: {
+          appArgument: new URL('http://test.com/base/test/native/app'),
+        },
+      })
+    })
+  })
+
   describe('openGraph', () => {
     it('should convert string or URL images field to array, not only for basic og type', async () => {
       const items: [Metadata[], Metadata][] = [
@@ -152,6 +173,27 @@ describe('accumulateMetadata', () => {
           },
           description: 'description',
           images: [{ url: new URL('https://test.com') }],
+        },
+      })
+    })
+
+    it('should resolve relative url starting with ./ with pathname for openGraph.url', async () => {
+      const metadataItems: MetadataItems = [
+        [
+          {
+            metadataBase: new URL('http://test.com/base'),
+            openGraph: {
+              url: './abc',
+            },
+          },
+          null,
+        ],
+      ]
+      const metadata = await accumulateMetadata(metadataItems)
+      expect(metadata).toMatchObject({
+        metadataBase: new URL('http://test.com/base'),
+        openGraph: {
+          url: new URL('http://test.com/base/test/abc'),
         },
       })
     })

--- a/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
@@ -11,8 +11,21 @@ import type {
 } from '../types/resolvers'
 import type { Viewport } from '../types/extra-types'
 import { resolveAsArrayOrUndefined } from '../generate/utils'
-import { resolveUrlWithMetadata } from './resolve-url'
+import { resolveAbsoluteUrlWithPathname } from './resolve-url'
 import { ViewPortKeys } from '../constants'
+
+function resolveAlternateUrl(
+  url: string | URL,
+  metadataBase: URL | null,
+  pathname: string
+) {
+  // If alter native url is an URL instance,
+  // we treat it as a URL base and resolve with current pathname
+  if (url instanceof URL) {
+    url = new URL(pathname, url)
+  }
+  return resolveAbsoluteUrlWithPathname(url, metadataBase, pathname)
+}
 
 export const resolveThemeColor: FieldResolver<'themeColor'> = (themeColor) => {
   if (!themeColor) return null
@@ -66,13 +79,13 @@ function resolveUrlValuesOfObject(
     if (typeof value === 'string' || value instanceof URL) {
       result[key] = [
         {
-          url: resolveUrlWithMetadata(value, metadataBase, pathname),
+          url: resolveAlternateUrl(value, metadataBase, pathname),
         },
       ]
     } else {
       result[key] = []
       value?.forEach((item, index) => {
-        const url = resolveUrlWithMetadata(item.url, metadataBase, pathname)
+        const url = resolveAlternateUrl(item.url, metadataBase, pathname)
         result[key][index] = {
           url,
           title: item.title,
@@ -97,7 +110,7 @@ function resolveCanonicalUrl(
 
   // Return string url because structureClone can't handle URL instance
   return {
-    url: resolveUrlWithMetadata(url, metadataBase, pathname),
+    url: resolveAlternateUrl(url, metadataBase, pathname),
   }
 }
 
@@ -247,7 +260,7 @@ export const resolveItunes: FieldResolverWithMetadataBase<
   return {
     appId: itunes.appId,
     appArgument: itunes.appArgument
-      ? resolveUrlWithMetadata(itunes.appArgument, metadataBase, pathname)
+      ? resolveAlternateUrl(itunes.appArgument, metadataBase, pathname)
       : undefined,
   }
 }

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
@@ -14,7 +14,7 @@ import {
   getSocialImageFallbackMetadataBase,
   isStringOrURL,
   resolveUrl,
-  resolveUrlWithMetadata,
+  resolveAbsoluteUrlWithPathname,
 } from './resolve-url'
 
 const OgTypeFields = {
@@ -116,7 +116,7 @@ export const resolveOpenGraph: FieldResolverWithMetadataBase<
   assignProps(openGraph)
 
   resolved.url = openGraph.url
-    ? resolveUrlWithMetadata(openGraph.url, metadataBase, pathname)
+    ? resolveAbsoluteUrlWithPathname(openGraph.url, metadataBase, pathname)
     : null
 
   return resolved

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
@@ -4,13 +4,17 @@ import type {
   OpenGraph,
   ResolvedOpenGraph,
 } from '../types/opengraph-types'
-import type { FieldResolverWithMetadataBase } from '../types/resolvers'
+import type {
+  FieldResolverWithMetadataBase,
+  MetadataAccumulationOptions,
+} from '../types/resolvers'
 import type { ResolvedTwitterMetadata, Twitter } from '../types/twitter-types'
 import { resolveAsArrayOrUndefined } from '../generate/utils'
 import {
   getSocialImageFallbackMetadataBase,
   isStringOrURL,
   resolveUrl,
+  resolveUrlWithMetadata,
 } from './resolve-url'
 
 const OgTypeFields = {
@@ -78,13 +82,16 @@ function getFieldsByOgType(ogType: OpenGraphType | undefined) {
   }
 }
 
-export const resolveOpenGraph: FieldResolverWithMetadataBase<'openGraph'> = (
+export const resolveOpenGraph: FieldResolverWithMetadataBase<
+  'openGraph',
+  MetadataAccumulationOptions
+> = (
   openGraph: Metadata['openGraph'],
-  metadataBase: ResolvedMetadata['metadataBase']
+  metadataBase: ResolvedMetadata['metadataBase'],
+  { pathname }
 ) => {
   if (!openGraph) return null
 
-  const url = resolveUrl(openGraph.url, metadataBase)
   const resolved = { ...openGraph } as ResolvedOpenGraph
 
   function assignProps(og: OpenGraph) {
@@ -108,7 +115,9 @@ export const resolveOpenGraph: FieldResolverWithMetadataBase<'openGraph'> = (
 
   assignProps(openGraph)
 
-  resolved.url = url
+  resolved.url = openGraph.url
+    ? resolveUrlWithMetadata(openGraph.url, metadataBase, pathname)
+    : null
 
   return resolved
 }

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -73,15 +73,13 @@ function resolveUrl(
 // Resolve with `pathname` if `url` is a relative path.
 function resolveRelativeUrl(url: string | URL, pathname: string): string | URL {
   if (typeof url === 'string' && url.startsWith('./')) {
-    url = path.resolve(pathname, url)
-  } else if (url instanceof URL) {
-    url = new URL(pathname, url)
+    return path.resolve(pathname, url)
   }
   return url
 }
 
-// Resolve with `metadataBase` if it's present, otherwise resolve with `pathname`.
-function resolveUrlWithMetadata(
+// Resolve `pathname` if `url` is a relative path the compose with `metadataBase`.
+function resolveAbsoluteUrlWithPathname(
   url: string | URL,
   metadataBase: URL | null,
   pathname: string
@@ -92,4 +90,9 @@ function resolveUrlWithMetadata(
   return result.toString()
 }
 
-export { isStringOrURL, resolveUrl, resolveUrlWithMetadata }
+export {
+  isStringOrURL,
+  resolveUrl,
+  resolveRelativeUrl,
+  resolveAbsoluteUrlWithPathname,
+}

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -70,4 +70,26 @@ function resolveUrl(
   return new URL(joinedPath, metadataBase)
 }
 
-export { isStringOrURL, resolveUrl }
+// Resolve with `pathname` if `url` is a relative path.
+function resolveRelativeUrl(url: string | URL, pathname: string): string | URL {
+  if (typeof url === 'string' && url.startsWith('./')) {
+    url = path.resolve(pathname, url)
+  } else if (url instanceof URL) {
+    url = new URL(pathname, url)
+  }
+  return url
+}
+
+// Resolve with `metadataBase` if it's present, otherwise resolve with `pathname`.
+function resolveUrlWithMetadata(
+  url: string | URL,
+  metadataBase: URL | null,
+  pathname: string
+) {
+  url = resolveRelativeUrl(url, pathname)
+
+  const result = metadataBase ? resolveUrl(url, metadataBase) : url
+  return result.toString()
+}
+
+export { isStringOrURL, resolveUrl, resolveUrlWithMetadata }

--- a/packages/next/src/lib/metadata/types/resolvers.ts
+++ b/packages/next/src/lib/metadata/types/resolvers.ts
@@ -16,3 +16,7 @@ export type FieldResolverWithMetadataBase<
       metadataBase: ResolvedMetadata['metadataBase'],
       options: Options
     ) => ResolvedMetadata[Key]
+
+export type MetadataAccumulationOptions = {
+  pathname: string
+}

--- a/test/e2e/app-dir/metadata/app/metadata-base/url-instance/page.tsx
+++ b/test/e2e/app-dir/metadata/app/metadata-base/url-instance/page.tsx
@@ -5,6 +5,6 @@ export default function page() {
 export const metadata = {
   metadataBase: new URL('https://example.com/foo'),
   openGraph: {
-    url: new URL('http://https://outerspace.com/huozhi.png'),
+    url: new URL('https://outerspace.com/huozhi.png'),
   },
 }

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -476,7 +476,7 @@ createNextDescribe(
         // override metadataBase
         const urlInstance$ = await next.render$('/metadata-base/url-instance')
         expect(urlInstance$('meta[property="og:url"]').attr('content')).toBe(
-          'http://https//outerspace.com/huozhi.png'
+          'https://outerspace.com/huozhi.png'
         )
       })
     })


### PR DESCRIPTION
To enable the ability of leveraging current `pathname` and configured `metadataBase` for other canonical like urls, we support those urls with auto resolving with `pathename` and `metadataBase` like canonical url, then you could just configure relative paths like below

```js
openGraph: {
    url: './abc', // will be resolved based on pathname and metadata base
},
itunes: {
   appId: 'my-app-id'
   appArgument: './native-app'
}
```


Fixes #51829
Closes NEXT-1302