### PR TITLE
error recovery during turbopack hydration

### DIFF
--- a/packages/next-swc/crates/next-core/js/src/entry/next-hydrate.tsx
+++ b/packages/next-swc/crates/next-core/js/src/entry/next-hydrate.tsx
@@ -10,9 +10,6 @@ import { formatWithValidation } from 'next/dist/shared/lib/router/utils/format-u
 import { initializeHMR } from '../dev/client'
 import { subscribeToUpdate } from '@vercel/turbopack-ecmascript-runtime/dev/client/hmr-client'
 
-import * as _app from '@vercel/turbopack-next/pages/_app'
-import * as page from 'PAGE'
-
 async function loadPageChunk(assetPrefix: string, chunkData: ChunkData) {
   if (typeof chunkData === 'string') {
     const fullPath = assetPrefix + chunkData
@@ -60,8 +57,11 @@ async function loadPageChunk(assetPrefix: string, chunkData: ChunkData) {
   }
 
   const pagePath = window.__NEXT_DATA__.page
-  window.__NEXT_P.push(['/_app', () => _app])
-  window.__NEXT_P.push([pagePath, () => page])
+  window.__NEXT_P.push([
+    '/_app',
+    () => require('@vercel/turbopack-next/pages/_app'),
+  ])
+  window.__NEXT_P.push([pagePath, () => require('PAGE')])
 
   console.debug('Hydrating the page')
 

--- a/packages/next-swc/crates/next-core/js/src/entry/page-loader.ts
+++ b/packages/next-swc/crates/next-core/js/src/entry/page-loader.ts
@@ -1,5 +1,3 @@
-import * as page from 'PAGE'
-
 // inserted by rust code
 declare const PAGE_PATH: string
 
@@ -7,7 +5,7 @@ declare const PAGE_PATH: string
 ;(window.__NEXT_P = window.__NEXT_P || []).push([
   PAGE_PATH,
   () => {
-    return page
+    return require('PAGE')
   },
 ])
 if (module.hot) {


### PR DESCRIPTION
### What?

Makes sure the next.js hydration code can run and that we can open the error overlay when there's an error in the entry page

Fixes WEB-1168