### PR TITLE
make stdout blocking on macos

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -276,6 +276,20 @@ const nextDev: CliCommand = async (argv) => {
       )
     }
 
+    if (process.platform === 'darwin') {
+      // rust needs stdout to be blocking, otherwise it will throw an error (on macOS at least) when writing a lot of data (logs) to it
+      // see https://github.com/napi-rs/napi-rs/issues/1630
+      // and https://github.com/nodejs/node/blob/main/doc/api/process.md#a-note-on-process-io
+      if (process.stdout._handle != null) {
+        // @ts-ignore
+        process.stdout._handle.setBlocking(true)
+      }
+      if (process.stderr._handle != null) {
+        // @ts-ignore
+        process.stderr._handle.setBlocking(true)
+      }
+    }
+
     let bindings: any = await loadBindings()
     let server = bindings.turbo.startDev({
       ...devServerOptions,

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -2,6 +2,15 @@
 
 // Extend the NodeJS namespace with Next.js-defined properties
 declare namespace NodeJS {
+  // only for rust, see https://github.com/napi-rs/napi-rs/issues/1630
+  interface TTY {
+    setBlocking(blocking: boolean): void
+  }
+
+  interface WriteStream {
+    _handle?: TTY
+  }
+
   interface Process {
     /**
      * @deprecated Use `typeof window` instead


### PR DESCRIPTION
### What?

Node.js sets stdout to non-blocking by default, rust expects it to be blocking

so when logging a lot of data, it can happen that rust receives an error while writing causing it to panic, the error is just that the resource is temporarily unavailable, but rust doesn't handle this case

See https://github.com/napi-rs/napi-rs/issues/1630