### PR TITLE
feat(next-dev): add a new experimental flag

### DIFF
--- a/packages/next-swc/crates/napi/src/turbopack.rs
+++ b/packages/next-swc/crates/napi/src/turbopack.rs
@@ -181,3 +181,8 @@ impl From<NapiRouteHas> for RouteHas {
 pub async fn next_build(ctx: NextBuildContext) -> napi::Result<()> {
     turbo_next_build(ctx.try_into()?).await.convert_err()
 }
+
+#[napi]
+pub async fn experimental_turbo(_unused: Buffer) -> napi::Result<()> {
+    unimplemented!("__experimental_turbo is not yet implemented");
+}

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -296,6 +296,9 @@ async function loadWasm(importPath = '', isCustomTurbopack: boolean) {
           startTrace: () => {
             Log.error('Wasm binding does not support trace yet')
           },
+          experimentalTurbo: () => {
+            Log.error('Wasm binding does not support this interface')
+          },
           entrypoints: {
             stream: (
               turboTasks: any,
@@ -553,6 +556,12 @@ function loadNative(isCustomTurbopack = false) {
             toBuffer({ exact: true, ...options }),
             turboTasks
           )
+          return ret
+        },
+        experimentalTurbo: () => {
+          initHeapProfiler()
+
+          const ret = bindings.experimentalTurbo()
           return ret
         },
         createTurboTasks: (memoryLimit?: number): unknown =>

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -119,6 +119,7 @@ const nextDev: CliCommand = async (argv) => {
     '--port': Number,
     '--hostname': String,
     '--turbo': Boolean,
+    '--experimental-turbo': Boolean,
 
     // To align current messages with native binary.
     // Will need to adjust subcommand later.
@@ -209,6 +210,7 @@ const nextDev: CliCommand = async (argv) => {
   // We do not set a default host value here to prevent breaking
   // some set-ups that rely on listening on other interfaces
   const host = args['--hostname']
+  const experimentalTurbo = args['--experimental-turbo']
 
   const devServerOptions: StartServerOptions = {
     dir,
@@ -218,6 +220,7 @@ const nextDev: CliCommand = async (argv) => {
     hostname: host,
     // This is required especially for app dir.
     useWorkers: true,
+    isExperimentalTurbo: experimentalTurbo,
   }
 
   if (args['--turbo']) {
@@ -311,6 +314,11 @@ const nextDev: CliCommand = async (argv) => {
 
     return server
   } else {
+    if (experimentalTurbo) {
+      Log.error('Not supported yet')
+      process.exit(1)
+    }
+
     let cleanupFns: (() => Promise<void> | void)[] = []
     const runDevServer = async () => {
       const oldCleanupFns = cleanupFns

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -22,6 +22,7 @@ export interface StartServerOptions {
   useWorkers: boolean
   allowRetry?: boolean
   isTurbopack?: boolean
+  isExperimentalTurbo?: boolean
   keepAliveTimeout?: number
   onStdout?: (data: any) => void
   onStderr?: (data: any) => void


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change



### Why?

### How?

Closes NEXT-
Fixes #

-->
### What?

WEB-1239. This is mainly for the code paths to not to cause regressions to existing turbopack.

