### PR TITLE
feat(devserver): accept experimental turbo flags

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -120,6 +120,7 @@ export interface Options extends ServerOptions {
    * Tells of Next.js is running from the `next dev` command
    */
   isNextDevCommand?: boolean
+  isExperimentalTurbo?: boolean
 }
 
 export default class DevServer extends Server {
@@ -128,6 +129,7 @@ export default class DevServer extends Server {
   private webpackWatcher?: any | null
   private hotReloader?: HotReloader
   private isCustomServer: boolean
+  private isExperimentalTurbo: boolean
   protected sortedRoutes?: string[]
   private addedUpgradeListener = false
   private pagesDir?: string
@@ -182,6 +184,7 @@ export default class DevServer extends Server {
       Error.stackTraceLimit = 50
     } catch {}
     super({ ...options, dev: true })
+    this.isExperimentalTurbo = options.isExperimentalTurbo ?? false
     this.originalFetch = global.fetch
     this.renderOpts.dev = true
     this.renderOpts.appDirDevErrorLogger = (err: any) =>
@@ -354,6 +357,12 @@ export default class DevServer extends Server {
   }
 
   async startWatcher(): Promise<void> {
+    if (this.isExperimentalTurbo) {
+      const bindings = await require('../../build/swc').loadBindings()
+
+      bindings.experimentalTurbo()
+    }
+
     if (this.webpackWatcher) {
       return
     }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -41,6 +41,7 @@ export async function startServer({
   keepAliveTimeout,
   onStdout,
   onStderr,
+  isExperimentalTurbo,
 }: StartServerOptions): Promise<TeardownServer> {
   const sockets = new Set<ServerResponse | Duplex>()
   let worker: import('next/dist/compiled/jest-worker').Worker | undefined
@@ -333,6 +334,7 @@ export async function startServer({
         httpServer: server,
         customServer: false,
         port: addr && typeof addr === 'object' ? addr.port : port,
+        isExperimentalTurbo,
       })
       // handle in process
       requestHandler = app.getRequestHandler()


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change



### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

closes WEB-1239.

exposes initial config entrypoint to the new flag to the devserver as first step. production --build may comes later.
