### PR TITLE
next/node-polyfill-web-streams: fix web stream polyfill for Node v16

### DIFF
--- a/packages/next/src/server/node-polyfill-web-streams.ts
+++ b/packages/next/src/server/node-polyfill-web-streams.ts
@@ -1,8 +1,14 @@
 // Polyfill Web Streams for the Node.js runtime.
 if (!global.ReadableStream) {
-  const { ReadableStream } =
-    require('next/dist/compiled/@edge-runtime/ponyfill') as typeof import('next/dist/compiled/@edge-runtime/ponyfill')
-  global.ReadableStream = ReadableStream
+  // In Node v16, ReadableStream is available natively but under the `stream` namespace.
+  // In Node v18+, it's available under global.
+  if (require('stream').ReadableStream) {
+    global.ReadableStream = require('stream').ReadableStream
+  } else {
+    const { ReadableStream } =
+      require('next/dist/compiled/@edge-runtime/ponyfill') as typeof import('next/dist/compiled/@edge-runtime/ponyfill')
+    global.ReadableStream = ReadableStream
+  }
 }
 if (!global.TransformStream) {
   const { TransformStream } =

--- a/packages/next/src/server/node-polyfill-web-streams.ts
+++ b/packages/next/src/server/node-polyfill-web-streams.ts
@@ -11,7 +11,12 @@ if (!global.ReadableStream) {
   }
 }
 if (!global.TransformStream) {
-  const { TransformStream } =
-    require('next/dist/compiled/@edge-runtime/ponyfill') as typeof import('next/dist/compiled/@edge-runtime/ponyfill')
-  global.TransformStream = TransformStream
+  // Same as ReadableStream above.
+  if (require('stream').TransformStream) {
+    global.TransformStream = require('stream').TransformStream
+  } else {
+    const { TransformStream } =
+      require('next/dist/compiled/@edge-runtime/ponyfill') as typeof import('next/dist/compiled/@edge-runtime/ponyfill')
+    global.TransformStream = TransformStream
+  }
 }


### PR DESCRIPTION
### What?
Slack thread: https://vercel.slack.com/archives/C050WU03V3N/p1687889719318819

In Node 16, the ReadableStream is not on the global but instead under the `stream` package. We should polyfill the global with that implementation, if available

### Why?
Fixes passing ReadableStream from the Node.js runtime to the vercel/ai SDK.

