### PR TITLE
Simplify module context invalidation

### DIFF
--- a/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
+++ b/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
@@ -80,18 +80,16 @@ export class NextJsRequireCacheHotReloader implements WebpackPluginInstance {
   }
 
   apply(compiler: Compiler) {
-    compiler.hooks.assetEmitted.tap(
-      PLUGIN_NAME,
-      (_file, { targetPath, content }) => {
-        deleteCache(targetPath)
-        const contentStr = content.toString('utf-8')
+    compiler.hooks.assetEmitted.tap(PLUGIN_NAME, (_file, { targetPath }) => {
+      deleteCache(targetPath)
 
-        if ((global as any)._nextClearModuleContext) {
-          ;(global as any)._nextClearModuleContext(targetPath, contentStr)
-        }
-        clearModuleContext(targetPath, contentStr)
+      // Clear module context in other processes
+      if ((global as any)._nextClearModuleContext) {
+        ;(global as any)._nextClearModuleContext(targetPath)
       }
-    )
+      // Clear module context in this process
+      clearModuleContext(targetPath)
+    })
 
     compiler.hooks.afterEmit.tap(PLUGIN_NAME, (compilation) => {
       RUNTIME_NAMES.forEach((name) => {

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -34,8 +34,8 @@ if (process.env.NODE_ENV !== 'production') {
   requireCacheHotReloader = require('../../build/webpack/plugins/nextjs-require-cache-hot-reloader')
 }
 
-export function clearModuleContext(target: string, content: string) {
-  sandboxContext?.clearModuleContext(target, content)
+export function clearModuleContext(target: string) {
+  sandboxContext?.clearModuleContext(target)
 }
 
 export function deleteAppClientCache() {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -326,13 +326,10 @@ export default class NextNodeServer extends BaseServer {
           console.error(err)
         }
       }
-      ;(global as any)._nextClearModuleContext = (
-        targetPath: any,
-        content: any
-      ) => {
+      ;(global as any)._nextClearModuleContext = (targetPath: string) => {
         try {
-          this.renderWorkers?.pages?.clearModuleContext(targetPath, content)
-          this.renderWorkers?.app?.clearModuleContext(targetPath, content)
+          this.renderWorkers?.pages?.clearModuleContext(targetPath)
+          this.renderWorkers?.app?.clearModuleContext(targetPath)
         } catch (err) {
           console.error(err)
         }

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -25,9 +25,6 @@ import AssertImplementation from 'node:assert'
 import UtilImplementation from 'node:util'
 import AsyncHooksImplementation from 'node:async_hooks'
 
-const WEBPACK_HASH_REGEX =
-  /__webpack_require__\.h = function\(\) \{ return "[0-9a-f]+"; \}/g
-
 interface ModuleContext {
   runtime: EdgeRuntime
   paths: Map<string, string>
@@ -48,20 +45,13 @@ const pendingModuleCaches = new Map<string, Promise<ModuleContext>>()
  * context that contains the path with an older content and, if that's the
  * case, removes the context from the cache.
  */
-export async function clearModuleContext(
-  path: string,
-  content: Buffer | string
-) {
+export async function clearModuleContext(path: string) {
   const handleContext = (
     key: string,
     cache: ReturnType<(typeof moduleContexts)['get']>,
     context: typeof moduleContexts | typeof pendingModuleCaches
   ) => {
-    const prev = cache?.paths.get(path)?.replace(WEBPACK_HASH_REGEX, '')
-    if (
-      typeof prev !== 'undefined' &&
-      prev !== content.toString().replace(WEBPACK_HASH_REGEX, '')
-    ) {
+    if (cache?.paths.has(path)) {
       context.delete(key)
     }
   }
@@ -463,7 +453,7 @@ export async function getModuleContext(options: ModuleContextOptions): Promise<{
         moduleContext.paths.set(filepath, content)
       } catch (error) {
         if (options.useCache) {
-          moduleContext?.paths.delete(options.moduleName)
+          moduleContext?.paths.delete(filepath)
         }
         throw error
       }


### PR DESCRIPTION
It _might_ be an overhead to send over a large amount of data over `postMessage` just for diff. HMR and module compilation is way less frequent than evaluation in the sandbox, so maybe we should always invalidate the cache eagerly without any comparison and defer the workload to `evaluateInContext`.

Some observations and numbers below.

#### Time spent on serialization when compiling a route:

<img width="662" src="https://github.com/vercel/next.js/assets/3676859/12136002-8857-4e10-ba9a-bf420d098dc8">

#### Large payload sent over the workers:

<img width="662" alt="CleanShot 2023-06-28 at 08 26 23@2x" src="https://github.com/vercel/next.js/assets/3676859/db054948-a0ea-4d98-bf4f-aa125e0eb1b5">

#### `postMessage` blocking other tasks:

![CleanShot 2023-06-28 at 08 02 24@2x](https://github.com/vercel/next.js/assets/3676859/b674beb1-d53c-4a1d-a9bf-ca3672e089c8)
