### PR TITLE
node-polyfill-web-streams: require from stream/web instead of stream

### DIFF
--- a/packages/next/src/server/node-polyfill-web-streams.ts
+++ b/packages/next/src/server/node-polyfill-web-streams.ts
@@ -2,8 +2,8 @@
 if (!global.ReadableStream) {
   // In Node v16, ReadableStream is available natively but under the `stream` namespace.
   // In Node v18+, it's available under global.
-  if (require('stream').ReadableStream) {
-    global.ReadableStream = require('stream').ReadableStream
+  if (require('stream/web').ReadableStream) {
+    global.ReadableStream = require('stream/web').ReadableStream
   } else {
     const { ReadableStream } =
       require('next/dist/compiled/@edge-runtime/ponyfill') as typeof import('next/dist/compiled/@edge-runtime/ponyfill')
@@ -12,8 +12,8 @@ if (!global.ReadableStream) {
 }
 if (!global.TransformStream) {
   // Same as ReadableStream above.
-  if (require('stream').TransformStream) {
-    global.TransformStream = require('stream').TransformStream
+  if (require('stream/web').TransformStream) {
+    global.TransformStream = require('stream/web').TransformStream
   } else {
     const { TransformStream } =
       require('next/dist/compiled/@edge-runtime/ponyfill') as typeof import('next/dist/compiled/@edge-runtime/ponyfill')


### PR DESCRIPTION
Follow-up to #51901 