### PR TITLE
[docs] Replace the term "hole" with "slot"

### DIFF
--- a/docs/01-getting-started/03-react-essentials.mdx
+++ b/docs/01-getting-started/03-react-essentials.mdx
@@ -242,11 +242,11 @@ export default function ExampleClientComponent({ children }) {
 
 #### Recommended Pattern: Passing Server Components to Client Components as Props
 
-Instead, when designing Client Components you can use React props to mark _"holes"_ for Server Components.
+Instead, when designing Client Components you can use React props to mark _"slots"_ for Server Components.
 
-The Server Component will be rendered on the server, and when the Client Component is rendered on the client, the _"hole"_ will be filled in with the rendered result of the Server Component.
+The Server Component will be rendered on the server, and when the Client Component is rendered on the client, the _"slot"_ will be filled in with the rendered result of the Server Component.
 
-A common pattern is to use the React `children` prop to create the _"hole"_. We can refactor `<ExampleClientComponent>` to accept a generic `children` prop and move the import and explicit nesting of `<ExampleClientComponent>` up to a parent component.
+A common pattern is to use the React `children` prop to create the _"slot"_. We can refactor `<ExampleClientComponent>` to accept a generic `children` prop and move the import and explicit nesting of `<ExampleClientComponent>` up to a parent component.
 
 ```tsx filename="app/example-client-component.tsx" switcher highlight={6,16}
 'use client'


### PR DESCRIPTION
It feels more natural to use the actual term "slot" when describing how to interweave server and client components since it's used in other frameworks as well.