### PR TITLE
Named page chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "serde",
 ]
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "serde",
@@ -7213,7 +7213,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7256,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7271,7 +7271,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7285,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7332,7 +7332,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "base16",
  "hex",
@@ -7344,7 +7344,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7358,7 +7358,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7368,7 +7368,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "mimalloc",
 ]
@@ -7376,7 +7376,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7399,7 +7399,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7412,7 +7412,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7442,7 +7442,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7514,7 +7514,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7534,7 +7534,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7558,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7586,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7599,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7621,7 +7621,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7645,7 +7645,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7681,7 +7681,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7737,7 +7737,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7754,7 +7754,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7770,7 +7770,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7790,7 +7790,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "serde",
@@ -7805,7 +7805,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7820,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "serde",
@@ -7871,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7882,10 +7882,11 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230704.5#c9868f7310dfd1edc57e0e3d975394e8f7086c39"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
 dependencies = [
  "anyhow",
  "once_cell",
+ "serde",
  "similar",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -7901,7 +7902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.4.6",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "serde",
 ]
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "serde",
@@ -7213,7 +7213,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7256,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7271,7 +7271,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7285,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7332,7 +7332,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "base16",
  "hex",
@@ -7344,7 +7344,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7358,7 +7358,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7368,7 +7368,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "mimalloc",
 ]
@@ -7376,7 +7376,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7399,7 +7399,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7412,7 +7412,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7442,7 +7442,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7514,7 +7514,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7534,7 +7534,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7558,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7586,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7599,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7621,7 +7621,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7645,7 +7645,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7681,7 +7681,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7737,7 +7737,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7754,7 +7754,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7770,7 +7770,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7790,7 +7790,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "serde",
@@ -7805,7 +7805,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7820,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "serde",
@@ -7871,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7882,7 +7882,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.2#006b5b13cb976edf288829158f8530eaf60ab2da"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230706.3#ab723987de55dfa4694cac11b6d0bbabc7ed330b"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ swc_core = { version = "0.78.24" }
 testing = { version = "0.33.19" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230706.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230706.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230706.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230706.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230706.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230706.3" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ swc_core = { version = "0.78.24" }
 testing = { version = "0.33.19" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230704.5" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230706.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230704.5" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230706.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230704.5" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230706.2" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-build/src/next_build.rs
+++ b/packages/next-swc/crates/next-build/src/next_build.rs
@@ -115,6 +115,7 @@ pub(crate) async fn next_build(options: TransientInstance<BuildOptions>) -> Resu
 
     let page_chunks = get_page_chunks(
         pages_structure,
+        next_router_root,
         project_root,
         execution_context,
         node_root,

--- a/packages/next-swc/crates/next-build/src/next_build.rs
+++ b/packages/next-swc/crates/next-build/src/next_build.rs
@@ -412,9 +412,10 @@ pub(crate) async fn next_build(options: TransientInstance<BuildOptions>) -> Resu
                     continue;
                 }
 
-                let dependencies = pages_manifest
+                let dependencies = build_manifest
                     .pages
                     .get(page)
+                    .unwrap()
                     .iter()
                     .map(|dep| dep.as_str())
                     .filter(|dep| !app_dependencies.contains(*dep))

--- a/packages/next-swc/crates/next-build/src/next_pages/node_context.rs
+++ b/packages/next-swc/crates/next-build/src/next_pages/node_context.rs
@@ -97,6 +97,10 @@ impl PagesBuildNodeContextVc {
         };
 
         let pathname = pathname.await?;
+        let pathname = match pathname.as_str() {
+            "/" => "/index",
+            pathname => pathname,
+        };
 
         let chunking_context = self.node_chunking_context();
         Ok(chunking_context.generate_entry_chunk(

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230704.5",
-    "@vercel/turbopack-node": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230704.5",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2",
+    "@vercel/turbopack-node": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.2",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2",
-    "@vercel/turbopack-node": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.3",
+    "@vercel/turbopack-node": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.3",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/src/build/client/bootstrap.ts
+++ b/packages/next-swc/crates/next-core/js/src/build/client/bootstrap.ts
@@ -1,5 +1,5 @@
 /**
- * This is the runtime entry point for Next.js client-side bundles.
+ * This is the runtime entry point for Next.js Page Router client-side bundles.
  */
 
 import './shims'

--- a/packages/next-swc/crates/next-core/src/next_image/module.rs
+++ b/packages/next-swc/crates/next-core/src/next_image/module.rs
@@ -5,7 +5,7 @@ use turbopack_binding::{
     turbopack::{
         core::{
             asset::AssetVc,
-            context::{AssetContext, AssetContextVc},
+            context::AssetContext,
             reference_type::{InnerAssetsVc, ReferenceType},
             resolve::ModulePartVc,
         },
@@ -46,9 +46,9 @@ impl StructuredImageModuleType {
     pub(crate) fn create_module(
         source: AssetVc,
         blur_placeholder_mode: BlurPlaceholderMode,
-        context: AssetContextVc,
+        context: ModuleAssetContextVc,
     ) -> AssetVc {
-        let static_asset = StaticModuleAssetVc::new(source, context);
+        let static_asset = StaticModuleAssetVc::new(source, context.into());
         context.process(
             StructuredImageSourceAsset {
                 image: source,

--- a/packages/next-swc/crates/next-core/src/page_source.rs
+++ b/packages/next-swc/crates/next-core/src/page_source.rs
@@ -74,8 +74,8 @@ use crate::{
     },
     page_loader::create_page_loader,
     pages_structure::{
-        OptionPagesStructureVc, PagesDirectoryStructure, PagesDirectoryStructureVc, PagesStructure,
-        PagesStructureItem, PagesStructureVc,
+        PagesDirectoryStructure, PagesDirectoryStructureVc, PagesStructure, PagesStructureItem,
+        PagesStructureVc,
     },
     util::{parse_config_from_source, pathname_for_path, render_data, NextRuntime, PathType},
 };
@@ -84,7 +84,7 @@ use crate::{
 /// Next.js pages folder.
 #[turbo_tasks::function]
 pub async fn create_page_source(
-    pages_structure: OptionPagesStructureVc,
+    pages_structure: PagesStructureVc,
     project_root: FileSystemPathVc,
     execution_context: ExecutionContextVc,
     node_root: FileSystemPathVc,
@@ -94,13 +94,10 @@ pub async fn create_page_source(
     next_config: NextConfigVc,
     server_addr: ServerAddrVc,
 ) -> Result<ContentSourceVc> {
-    let (pages_dir, pages_structure) = if let Some(pages_structure) = *pages_structure.await? {
-        (
-            pages_structure.project_path().resolve().await?,
-            Some(pages_structure),
-        )
+    let pages_dir = if let Some(pages) = pages_structure.await?.pages {
+        pages.project_path().resolve().await?
     } else {
-        (project_root.join("pages"), None)
+        project_root.join("pages")
     };
 
     let mode = NextMode::Development;
@@ -295,22 +292,20 @@ pub async fn create_page_source(
         .issue_context(pages_dir, "Next.js pages directory not found"),
     );
 
-    if let Some(pages_structure) = pages_structure {
-        sources.push(create_page_source_for_root_directory(
-            pages_structure,
-            project_root,
-            env,
-            server_context,
-            server_data_context,
-            client_context,
-            pages_dir,
-            server_runtime_entries,
-            fallback_page,
-            client_root,
-            node_root,
-            render_data,
-        ));
-    }
+    sources.push(create_page_source_for_root_directory(
+        pages_structure,
+        project_root,
+        env,
+        server_context,
+        server_data_context,
+        client_context,
+        pages_dir,
+        server_runtime_entries,
+        fallback_page,
+        client_root,
+        node_root,
+        render_data,
+    ));
 
     sources.push(
         AssetGraphContentSourceVc::new_eager(client_root, fallback_page.as_asset())
@@ -637,21 +632,23 @@ async fn create_page_source_for_root_directory(
     } = *pages_structure.await?;
     let mut sources = vec![];
 
-    sources.push(create_page_source_for_directory(
-        *pages,
-        project_root,
-        env,
-        server_context,
-        server_data_context,
-        client_context,
-        pages_dir,
-        runtime_entries,
-        fallback_page,
-        client_root,
-        false,
-        node_root,
-        render_data,
-    ));
+    if let Some(pages) = pages {
+        sources.push(create_page_source_for_directory(
+            *pages,
+            project_root,
+            env,
+            server_context,
+            server_data_context,
+            client_context,
+            pages_dir,
+            runtime_entries,
+            fallback_page,
+            client_root,
+            false,
+            node_root,
+            render_data,
+        ));
+    }
 
     if let Some(api) = api {
         sources.push(create_page_source_for_directory(

--- a/packages/next-swc/crates/next-core/src/page_source.rs
+++ b/packages/next-swc/crates/next-core/src/page_source.rs
@@ -701,6 +701,7 @@ async fn create_page_source_for_directory(
         let PagesStructureItem {
             project_path,
             next_router_path,
+            original_path: _,
         } = *item.await?;
         let source = create_page_source_for_file(
             project_root,

--- a/packages/next-swc/crates/next-core/src/pages_structure.rs
+++ b/packages/next-swc/crates/next-core/src/pages_structure.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use turbo_tasks::{primitives::StringsVc, CompletionVc};
+use turbo_tasks_fs::FileSystemPathOptionVc;
 use turbopack_binding::turbo::tasks_fs::{
     DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPathVc,
 };
@@ -45,18 +46,11 @@ pub struct PagesStructure {
     pub document: PagesStructureItemVc,
     pub error: PagesStructureItemVc,
     pub api: Option<PagesDirectoryStructureVc>,
-    pub pages: PagesDirectoryStructureVc,
+    pub pages: Option<PagesDirectoryStructureVc>,
 }
 
 #[turbo_tasks::value_impl]
 impl PagesStructureVc {
-    /// Returns the path to the directory of this structure in the project file
-    /// system.
-    #[turbo_tasks::function]
-    pub async fn project_path(self) -> Result<FileSystemPathVc> {
-        Ok(self.await?.pages.project_path())
-    }
-
     /// Returns a completion that changes when any route in the whole tree
     /// changes.
     #[turbo_tasks::function]
@@ -74,20 +68,8 @@ impl PagesStructureVc {
         if let Some(api) = api {
             api.routes_changed().await?;
         }
-        pages.routes_changed().await?;
-        Ok(CompletionVc::new())
-    }
-}
-
-#[turbo_tasks::value(transparent)]
-pub struct OptionPagesStructure(Option<PagesStructureVc>);
-
-#[turbo_tasks::value_impl]
-impl OptionPagesStructureVc {
-    #[turbo_tasks::function]
-    pub async fn routes_changed(self) -> Result<CompletionVc> {
-        if let Some(pages_structure) = *self.await? {
-            pages_structure.routes_changed().await?;
+        if let Some(pages) = pages {
+            pages.routes_changed().await?;
         }
         Ok(CompletionVc::new())
     }
@@ -136,111 +118,130 @@ pub async fn find_pages_structure(
     project_root: FileSystemPathVc,
     next_router_root: FileSystemPathVc,
     next_config: NextConfigVc,
-) -> Result<OptionPagesStructureVc> {
+) -> Result<PagesStructureVc> {
     let pages_root = project_root.join("pages");
-    let pages_root = if *pages_root.get_type().await? == FileSystemEntryType::Directory {
-        pages_root
-    } else {
-        let src_pages_root = project_root.join("src/pages");
-        if *src_pages_root.get_type().await? == FileSystemEntryType::Directory {
-            src_pages_root
+    let pages_root: FileSystemPathOptionVc = FileSystemPathOptionVc::cell(
+        if *pages_root.get_type().await? == FileSystemEntryType::Directory {
+            Some(pages_root)
         } else {
-            return Ok(OptionPagesStructureVc::cell(None));
-        }
-    }
+            let src_pages_root = project_root.join("src/pages");
+            if *src_pages_root.get_type().await? == FileSystemEntryType::Directory {
+                Some(src_pages_root)
+            } else {
+                // If neither pages nor src/pages exists, we still want to generate
+                // the pages structure, but with no pages and default values for
+                // _app, _document and _error.
+                None
+            }
+        },
+    )
     .resolve()
     .await?;
 
-    Ok(OptionPagesStructureVc::cell(Some(
-        get_pages_structure_for_root_directory(
-            pages_root,
-            next_router_root,
-            next_config.page_extensions(),
-        ),
-    )))
+    Ok(get_pages_structure_for_root_directory(
+        pages_root,
+        next_router_root,
+        next_config.page_extensions(),
+    ))
 }
 
 /// Handles the root pages directory.
 #[turbo_tasks::function]
 async fn get_pages_structure_for_root_directory(
-    project_path: FileSystemPathVc,
+    project_path: FileSystemPathOptionVc,
     next_router_path: FileSystemPathVc,
     page_extensions: StringsVc,
 ) -> Result<PagesStructureVc> {
     let page_extensions_raw = &*page_extensions.await?;
 
-    let mut children = vec![];
-    let mut items = vec![];
     let mut app_item = None;
     let mut document_item = None;
     let mut error_item = None;
     let mut api_directory = None;
-    let dir_content = project_path.read_dir().await?;
-    if let DirectoryContent::Entries(entries) = &*dir_content {
-        for (name, entry) in entries.iter() {
-            match entry {
-                DirectoryEntry::File(file_project_path) => {
-                    let Some(basename) = page_basename(name, page_extensions_raw) else {
-                        continue;
-                    };
-                    match basename {
-                        "_app" => {
-                            let _ = app_item.insert(PagesStructureItemVc::new(
-                                *file_project_path,
-                                next_router_path.join("_app"),
-                            ));
-                        }
-                        "_document" => {
-                            let _ = document_item.insert(PagesStructureItemVc::new(
-                                *file_project_path,
-                                next_router_path.join("_document"),
-                            ));
-                        }
-                        "_error" => {
-                            let _ = error_item.insert(PagesStructureItemVc::new(
-                                *file_project_path,
-                                next_router_path.join("_error"),
-                            ));
-                        }
-                        basename => {
-                            let next_router_path =
-                                next_router_path_for_basename(next_router_path, basename);
-                            items.push((
-                                basename,
-                                PagesStructureItemVc::new(*file_project_path, next_router_path),
-                            ));
+
+    let pages_directory = if let Some(project_path) = &*project_path.await? {
+        let mut children = vec![];
+        let mut items = vec![];
+
+        let dir_content = project_path.read_dir().await?;
+        if let DirectoryContent::Entries(entries) = &*dir_content {
+            for (name, entry) in entries.iter() {
+                match entry {
+                    DirectoryEntry::File(file_project_path) => {
+                        let Some(basename) = page_basename(name, page_extensions_raw) else {
+                            continue;
+                        };
+                        match basename {
+                            "_app" => {
+                                let _ = app_item.insert(PagesStructureItemVc::new(
+                                    *file_project_path,
+                                    next_router_path.join("_app"),
+                                ));
+                            }
+                            "_document" => {
+                                let _ = document_item.insert(PagesStructureItemVc::new(
+                                    *file_project_path,
+                                    next_router_path.join("_document"),
+                                ));
+                            }
+                            "_error" => {
+                                let _ = error_item.insert(PagesStructureItemVc::new(
+                                    *file_project_path,
+                                    next_router_path.join("_error"),
+                                ));
+                            }
+                            basename => {
+                                let next_router_path =
+                                    next_router_path_for_basename(next_router_path, basename);
+                                items.push((
+                                    basename,
+                                    PagesStructureItemVc::new(*file_project_path, next_router_path),
+                                ));
+                            }
                         }
                     }
-                }
-                DirectoryEntry::Directory(dir_project_path) => match name.as_ref() {
-                    "api" => {
-                        let _ = api_directory.insert(get_pages_structure_for_directory(
-                            *dir_project_path,
-                            next_router_path.join(name),
-                            1,
-                            page_extensions,
-                        ));
-                    }
-                    _ => {
-                        children.push((
-                            name,
-                            get_pages_structure_for_directory(
+                    DirectoryEntry::Directory(dir_project_path) => match name.as_ref() {
+                        "api" => {
+                            let _ = api_directory.insert(get_pages_structure_for_directory(
                                 *dir_project_path,
                                 next_router_path.join(name),
                                 1,
                                 page_extensions,
-                            ),
-                        ));
-                    }
-                },
-                _ => {}
+                            ));
+                        }
+                        _ => {
+                            children.push((
+                                name,
+                                get_pages_structure_for_directory(
+                                    *dir_project_path,
+                                    next_router_path.join(name),
+                                    1,
+                                    page_extensions,
+                                ),
+                            ));
+                        }
+                    },
+                    _ => {}
+                }
             }
         }
-    }
 
-    // Ensure deterministic order since read_dir is not deterministic
-    items.sort_by_key(|(k, _)| *k);
-    children.sort_by_key(|(k, _)| *k);
+        // Ensure deterministic order since read_dir is not deterministic
+        items.sort_by_key(|(k, _)| *k);
+        children.sort_by_key(|(k, _)| *k);
+
+        Some(
+            PagesDirectoryStructure {
+                project_path: *project_path,
+                next_router_path,
+                items: items.into_iter().map(|(_, v)| v).collect(),
+                children: children.into_iter().map(|(_, v)| v).collect(),
+            }
+            .cell(),
+        )
+    } else {
+        None
+    };
 
     let app_item = if let Some(app_item) = app_item {
         app_item
@@ -274,13 +275,7 @@ async fn get_pages_structure_for_root_directory(
         document: document_item,
         error: error_item,
         api: api_directory,
-        pages: PagesDirectoryStructure {
-            project_path,
-            next_router_path,
-            items: items.into_iter().map(|(_, v)| v).collect(),
-            children: children.into_iter().map(|(_, v)| v).collect(),
-        }
-        .cell(),
+        pages: pages_directory,
     }
     .cell())
 }

--- a/packages/next-swc/crates/next-core/src/router_source.rs
+++ b/packages/next-swc/crates/next-core/src/router_source.rs
@@ -19,7 +19,7 @@ use turbopack_binding::turbopack::{
 use crate::{
     app_structure::OptionAppDirVc,
     next_config::NextConfigVc,
-    pages_structure::OptionPagesStructureVc,
+    pages_structure::PagesStructureVc,
     router::{route, RouterRequest, RouterResult},
 };
 
@@ -31,7 +31,7 @@ pub struct NextRouterContentSource {
     next_config: NextConfigVc,
     server_addr: ServerAddrVc,
     app_dir: OptionAppDirVc,
-    pages_structure: OptionPagesStructureVc,
+    pages_structure: PagesStructureVc,
 }
 
 #[turbo_tasks::value_impl]
@@ -43,7 +43,7 @@ impl NextRouterContentSourceVc {
         next_config: NextConfigVc,
         server_addr: ServerAddrVc,
         app_dir: OptionAppDirVc,
-        pages_structure: OptionPagesStructureVc,
+        pages_structure: PagesStructureVc,
     ) -> NextRouterContentSourceVc {
         NextRouterContentSource {
             inner,
@@ -60,7 +60,7 @@ impl NextRouterContentSourceVc {
 #[turbo_tasks::function]
 fn routes_changed(
     app_dir: OptionAppDirVc,
-    pages_structure: OptionPagesStructureVc,
+    pages_structure: PagesStructureVc,
     next_config: NextConfigVc,
 ) -> CompletionVc {
     CompletionsVc::all(vec![
@@ -77,7 +77,7 @@ impl ContentSource for NextRouterContentSource {
         // The next-dev server can currently run against projects as simple as
         // `index.js`. If this isn't a Next.js project, don't try to use the Next.js
         // router.
-        if this.app_dir.await?.is_none() && this.pages_structure.await?.is_none() {
+        if this.app_dir.await?.is_none() && this.pages_structure.await?.pages.is_none() {
             return Ok(this.inner.get_routes());
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -992,8 +992,8 @@ importers:
       '@types/react': 18.2.7
       '@types/react-dom': 18.2.4
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-ecmascript-runtime': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230704.5
-      '@vercel/turbopack-node': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230704.5
+      '@vercel/turbopack-ecmascript-runtime': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2
+      '@vercel/turbopack-node': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.2
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1005,8 +1005,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-ecmascript-runtime': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230704.5_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230704.5'
+      '@vercel/turbopack-ecmascript-runtime': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.2'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -6120,7 +6120,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.2.1
       source-map: 0.7.3
-      webpack: 5.86.0
+      webpack: 5.86.0_@swc+core@1.3.55
     transitivePeerDependencies:
       - supports-color
 
@@ -6794,7 +6794,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64/1.3.55:
@@ -6803,7 +6802,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.3.55:
@@ -6812,7 +6810,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.3.55:
@@ -6821,7 +6818,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl/1.3.55:
@@ -6830,7 +6826,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu/1.3.55:
@@ -6839,7 +6834,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl/1.3.55:
@@ -6848,7 +6842,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.3.55:
@@ -6857,7 +6850,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.3.55:
@@ -6866,7 +6858,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc/1.3.55:
@@ -6875,7 +6866,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core/1.3.55_@swc+helpers@0.5.1:
@@ -6900,7 +6890,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.55
       '@swc/core-win32-ia32-msvc': 1.3.55
       '@swc/core-win32-x64-msvc': 1.3.55
-    dev: true
 
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
@@ -23815,7 +23804,6 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.17.7
       webpack: 5.86.0_@swc+core@1.3.55
-    dev: true
 
   /terser/5.10.0:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
@@ -25173,7 +25161,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /websocket-driver/0.7.3:
     resolution: {integrity: sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==}
@@ -25582,9 +25569,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230704.5_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230704.5}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230704.5'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:
@@ -25595,8 +25582,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230704.5':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230704.5}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.2':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.2}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -992,8 +992,8 @@ importers:
       '@types/react': 18.2.7
       '@types/react-dom': 18.2.4
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-ecmascript-runtime': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2
-      '@vercel/turbopack-node': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.2
+      '@vercel/turbopack-ecmascript-runtime': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.3
+      '@vercel/turbopack-node': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.3
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1005,8 +1005,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-ecmascript-runtime': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.2'
+      '@vercel/turbopack-ecmascript-runtime': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.3_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.3'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25569,9 +25569,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.3_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.3}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230706.3'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:
@@ -25582,8 +25582,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.2':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.2}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.3':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230706.3}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
Depends on https://github.com/vercel/turbo/pull/5398 (and downstack) on the Turbo side.

This PR makes it so the output path of Node.js entry chunks for pages is determined solely from the pathname. This isn't actually necessary for pages, but it makes for easier debugging anyway. See the Turbo PR for more details.

This also changes the page structure so it also works if there is no `pages` directory. In this case, we still want to use pages' default _app, _document, and _error pages, even with existing app routes. So an empty page structure should still have an effect.

## Turbopack updates

* https://github.com/vercel/turbo/pull/5415 <!-- Will Binns-Smith - Turbopack: Execution tests in node.js  -->
* https://github.com/vercel/turbo/pull/5461 <!-- Tobias Koppers - use a lock to ensure atomic invalidation from file changes  -->
* https://github.com/vercel/turbo/pull/5398 <!-- Alex Kirszenberg - Configure the path of the Node.js entry chunk  -->
* https://github.com/vercel/turbo/pull/5469 <!-- Tobias Koppers - allow hmr tests to correctly detect hmr event  -->