### PR TITLE
fix: env hot reload for RSC pages

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
@@ -428,7 +428,7 @@ function processMessage(
               router.fastRefresh()
               dispatcher.onRefresh()
             })
-          } else {
+          } else if (pageRes.status === 404) {
             // We are still on the page,
             // dispatch an error so it's caught by the NotFound handler
             dispatcher.onNotFound()

--- a/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
@@ -437,6 +437,9 @@ function processMessage(
       }
       return
     }
+    case 'devPagesManifestUpdate': {
+      return
+    }
     default: {
       throw new Error('Unexpected action ' + obj.action)
     }

--- a/packages/next/src/client/dev/amp-dev.ts
+++ b/packages/next/src/client/dev/amp-dev.ts
@@ -85,8 +85,12 @@ addMessageListener((event) => {
   try {
     const message = JSON.parse(event.data)
 
-    // action `serverError` is not for amp-dev
-    if (message.action === 'serverError') return
+    // actions which are not related to amp-dev
+    if (
+      message.action === 'serverError' ||
+      message.action === 'devPagesManifestUpdate'
+    )
+      return
     if (message.action === 'sync' || message.action === 'built') {
       if (!message.hash) {
         return

--- a/packages/next/src/client/dev/error-overlay/hot-dev-client.ts
+++ b/packages/next/src/client/dev/error-overlay/hot-dev-client.ts
@@ -276,9 +276,11 @@ function processMessage(obj: any) {
       return handleSuccess()
     }
     case 'serverComponentChanges': {
-      // Server component changes don't apply to `pages`.
-      // TODO-APP: Remove reload once the correct overlay is rendered on initial page load in app dir
-      window.location.reload()
+      if (!obj.appDirOnly) {
+        // Server component changes don't apply to `pages`.
+        // TODO-APP: Remove reload once the correct overlay is rendered on initial page load in app dir
+        window.location.reload()
+      }
       return
     }
     case 'serverError': {

--- a/packages/next/src/client/dev/error-overlay/hot-dev-client.ts
+++ b/packages/next/src/client/dev/error-overlay/hot-dev-client.ts
@@ -276,11 +276,7 @@ function processMessage(obj: any) {
       return handleSuccess()
     }
     case 'serverComponentChanges': {
-      if (!obj.appDirOnly) {
-        // Server component changes don't apply to `pages`.
-        // TODO-APP: Remove reload once the correct overlay is rendered on initial page load in app dir
-        window.location.reload()
-      }
+      window.location.reload()
       return
     }
     case 'serverError': {

--- a/packages/next/src/client/dev/webpack-hot-middleware-client.ts
+++ b/packages/next/src/client/dev/webpack-hot-middleware-client.ts
@@ -45,7 +45,10 @@ export default () => {
       }
       return
     }
-    if (obj.action === 'serverError') {
+    if (
+      obj.action === 'serverError' ||
+      obj.action === 'devPagesManifestUpdate'
+    ) {
       return
     }
     throw new Error('Unexpected action ' + obj.action)

--- a/packages/next/src/server/dev/hot-reloader.ts
+++ b/packages/next/src/server/dev/hot-reloader.ts
@@ -338,6 +338,17 @@ export default class HotReloader {
     }
   }
 
+  public async refreshServerComponents({
+    appDirOnly = false,
+  }: { appDirOnly?: boolean } = {}): Promise<void> {
+    this.send({
+      action: 'serverComponentChanges',
+      appDirOnly, // if it's soft refresh, we don't need to reload the page
+      // TODO: granular reloading of changes
+      // entrypoints: serverComponentChanges,
+    })
+  }
+
   public onHMR(req: IncomingMessage, _socket: Duplex, head: Buffer) {
     wsServer.handleUpgrade(req, req.socket, head, (client) => {
       this.webpackHotMiddleware?.onHMR(client)
@@ -1234,11 +1245,7 @@ export default class HotReloader {
       }
 
       if (changedServerComponentPages.size || changedCSSImportPages.size) {
-        this.send({
-          action: 'serverComponentChanges',
-          // TODO: granular reloading of changes
-          // entrypoints: serverComponentChanges,
-        })
+        this.refreshServerComponents()
       }
 
       changedClientPages.clear()

--- a/packages/next/src/server/dev/hot-reloader.ts
+++ b/packages/next/src/server/dev/hot-reloader.ts
@@ -201,7 +201,7 @@ export default class HotReloader {
     staleness: 'unknown',
     installed: '0.0.0',
   }
-  private reloadOnDone: boolean = false
+  private reloadAfterInvalidation: boolean = false
   public multiCompiler?: webpack.MultiCompiler
   public activeConfigs?: Array<
     UnwrapPromise<ReturnType<typeof getBaseWebpackConfig>>
@@ -1210,8 +1210,8 @@ export default class HotReloader {
     )
 
     this.multiCompiler.hooks.done.tap('NextjsHotReloaderForServer', () => {
-      const reloadOnDone = this.reloadOnDone
-      this.reloadOnDone = false
+      const reloadAfterInvalidation = this.reloadAfterInvalidation
+      this.reloadAfterInvalidation = false
 
       const serverOnlyChanges = difference<string>(
         changedServerPages,
@@ -1248,7 +1248,7 @@ export default class HotReloader {
       if (
         changedServerComponentPages.size ||
         changedCSSImportPages.size ||
-        reloadOnDone
+        reloadAfterInvalidation
       ) {
         this.refreshServerComponents()
       }
@@ -1349,9 +1349,12 @@ export default class HotReloader {
   }
 
   public invalidate(
-    { reloadOnDone }: { reloadOnDone: boolean } = { reloadOnDone: false }
+    { reloadAfterInvalidation }: { reloadAfterInvalidation: boolean } = {
+      reloadAfterInvalidation: false,
+    }
   ) {
-    this.reloadOnDone = reloadOnDone
+    // Cache the `reloadAfterInvalidation` flag, and use it to reload the page when compilation is done
+    this.reloadAfterInvalidation = reloadAfterInvalidation
     const outputPath = this.multiCompiler?.outputPath
     return outputPath && getInvalidator(outputPath)?.invalidate()
   }

--- a/packages/next/src/server/dev/hot-reloader.ts
+++ b/packages/next/src/server/dev/hot-reloader.ts
@@ -339,12 +339,9 @@ export default class HotReloader {
     }
   }
 
-  public async refreshServerComponents({
-    appDirOnly = false,
-  }: { appDirOnly?: boolean } = {}): Promise<void> {
+  public async refreshServerComponents(): Promise<void> {
     this.send({
       action: 'serverComponentChanges',
-      appDirOnly, // if it's soft refresh, we don't need to reload the page
       // TODO: granular reloading of changes
       // entrypoints: serverComponentChanges,
     })
@@ -1214,7 +1211,6 @@ export default class HotReloader {
 
     this.multiCompiler.hooks.done.tap('NextjsHotReloaderForServer', () => {
       const reloadOnDone = this.reloadOnDone
-
       this.reloadOnDone = false
 
       const serverOnlyChanges = difference<string>(

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -714,7 +714,7 @@ export default class DevServer extends Server {
               })
             }
 
-            if (envChange) {
+            if (envChange || clientRouterFilterChange) {
               config.plugins?.forEach((plugin: any) => {
                 // we look for the DefinePlugin definitions so we can
                 // update them on the active compilers

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -440,6 +440,7 @@ export default class DevServer extends Server {
         const pagesPageFilePaths = new Map<string, string>()
 
         let envChange = false
+        let clientRouterFilterChange = false
         let tsconfigChange = false
         let conflictingPageChange = 0
 
@@ -636,7 +637,7 @@ export default class DevServer extends Server {
             JSON.stringify(previousClientRouterFilters) !==
               JSON.stringify(clientRouterFilters)
           ) {
-            envChange = true
+            clientRouterFilterChange = true
             previousClientRouterFilters = clientRouterFilters
           }
         }
@@ -651,7 +652,7 @@ export default class DevServer extends Server {
             .catch(() => {})
         }
 
-        if (envChange || tsconfigChange) {
+        if (clientRouterFilterChange || envChange || tsconfigChange) {
           if (envChange) {
             this.loadEnvConfig({
               dev: true,

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -744,8 +744,10 @@ export default class DevServer extends Server {
             }
           })
           this.hotReloader?.invalidate()
-          // Update server components as well in case they're dependent on env
-          this.hotReloader?.refreshServerComponents({ appDirOnly: true })
+          if (envChange) {
+            // Update server components as well in case they're dependent on env
+            this.hotReloader?.refreshServerComponents({ appDirOnly: true })
+          }
         }
 
         if (nestedMiddleware.length > 0) {

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -745,7 +745,7 @@ export default class DevServer extends Server {
             }
           })
           this.hotReloader?.invalidate({
-            reloadOnDone: envChange,
+            reloadAfterInvalidation: envChange,
           })
         }
 

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -743,11 +743,9 @@ export default class DevServer extends Server {
               })
             }
           })
-          this.hotReloader?.invalidate()
-          if (envChange) {
-            // Update server components as well in case they're dependent on env
-            this.hotReloader?.refreshServerComponents({ appDirOnly: true })
-          }
+          this.hotReloader?.invalidate({
+            reloadOnDone: envChange,
+          })
         }
 
         if (nestedMiddleware.length > 0) {

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -744,6 +744,8 @@ export default class DevServer extends Server {
             }
           })
           this.hotReloader?.invalidate()
+          // Update server components as well in case they're dependent on env
+          this.hotReloader?.refreshServerComponents({ appDirOnly: true })
         }
 
         if (nestedMiddleware.length > 0) {

--- a/test/development/app-hmr/.env.development.local
+++ b/test/development/app-hmr/.env.development.local
@@ -1,0 +1,1 @@
+MY_DEVICE="mac"

--- a/test/development/app-hmr/app/env/edge/page.jsx
+++ b/test/development/app-hmr/app/env/edge/page.jsx
@@ -1,0 +1,5 @@
+export default function Page() {
+  return <p>{process.env.MY_DEVICE}</p>
+}
+
+export const runtime = 'edge'

--- a/test/development/app-hmr/app/env/node/page.jsx
+++ b/test/development/app-hmr/app/env/node/page.jsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>{process.env.MY_DEVICE}</p>
+}

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -1,6 +1,8 @@
 import { createNextDescribe } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+const envFile = '.env.development.local'
+
 createNextDescribe(
   `app-dir-hmr`,
   {
@@ -9,7 +11,6 @@ createNextDescribe(
   ({ next }) => {
     describe('filesystem changes', () => {
       it('should not break when renaming a folder', async () => {
-        console.log(next.url)
         const browser = await next.browser('/folder')
         const text = await browser.elementByCss('h1').text()
         expect(text).toBe('Hello')
@@ -32,6 +33,42 @@ createNextDescribe(
           // Rename it back
           await next.renameFolder('app/folder-renamed', 'app/folder')
         }
+      })
+
+      it('should update server components pages when env files is changed (nodejs)', async () => {
+        const envContent = await next.readFile(envFile)
+        const browser = await next.browser('/env/node')
+        expect(await browser.elementByCss('p').text()).toBe('mac')
+        await next.patchFile(envFile, 'MY_DEVICE="ipad"')
+
+        try {
+          await check(async () => {
+            expect(await browser.elementByCss('p').text()).toBe('ipad')
+            return 'success'
+          }, /success/)
+        } finally {
+          await next.patchFile(envFile, envContent)
+        }
+      })
+
+      it('should update server components pages when env files is changed (edge)', async () => {
+        const envContent = await next.readFile(envFile)
+        const browser = await next.browser('/env/edge')
+        expect(await browser.elementByCss('p').text()).toBe('mac')
+        await next.patchFile(envFile, 'MY_DEVICE="ipad"')
+
+        try {
+          await check(async () => {
+            expect(await browser.elementByCss('p').text()).toBe('ipad')
+            return 'success'
+          }, /success/)
+        } finally {
+          await next.patchFile(envFile, envContent)
+        }
+      })
+
+      it('should have no unexpected action error for hmr', async () => {
+        expect(next.cliOutput).not.toContain('Unexpected action')
       })
     })
   }

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -8,7 +8,7 @@ createNextDescribe(
   {
     files: __dirname,
   },
-  ({ next }) => {
+  ({ next, isTurbopack }) => {
     describe('filesystem changes', () => {
       it('should not break when renaming a folder', async () => {
         const browser = await next.browser('/folder')
@@ -35,37 +35,39 @@ createNextDescribe(
         }
       })
 
-      it('should update server components pages when env files is changed (nodejs)', async () => {
-        const envContent = await next.readFile(envFile)
-        const browser = await next.browser('/env/node')
-        expect(await browser.elementByCss('p').text()).toBe('mac')
-        await next.patchFile(envFile, 'MY_DEVICE="ipad"')
+      if (!isTurbopack) {
+        it('should update server components pages when env files is changed (nodejs)', async () => {
+          const envContent = await next.readFile(envFile)
+          const browser = await next.browser('/env/node')
+          expect(await browser.elementByCss('p').text()).toBe('mac')
+          await next.patchFile(envFile, 'MY_DEVICE="ipad"')
 
-        try {
-          await check(async () => {
-            expect(await browser.elementByCss('p').text()).toBe('ipad')
-            return 'success'
-          }, /success/)
-        } finally {
-          await next.patchFile(envFile, envContent)
-        }
-      })
+          try {
+            await check(async () => {
+              expect(await browser.elementByCss('p').text()).toBe('ipad')
+              return 'success'
+            }, /success/)
+          } finally {
+            await next.patchFile(envFile, envContent)
+          }
+        })
 
-      it('should update server components pages when env files is changed (edge)', async () => {
-        const envContent = await next.readFile(envFile)
-        const browser = await next.browser('/env/edge')
-        expect(await browser.elementByCss('p').text()).toBe('mac')
-        await next.patchFile(envFile, 'MY_DEVICE="ipad"')
+        it('should update server components pages when env files is changed (edge)', async () => {
+          const envContent = await next.readFile(envFile)
+          const browser = await next.browser('/env/edge')
+          expect(await browser.elementByCss('p').text()).toBe('mac')
+          await next.patchFile(envFile, 'MY_DEVICE="ipad"')
 
-        try {
-          await check(async () => {
-            expect(await browser.elementByCss('p').text()).toBe('ipad')
-            return 'success'
-          }, /success/)
-        } finally {
-          await next.patchFile(envFile, envContent)
-        }
-      })
+          try {
+            await check(async () => {
+              expect(await browser.elementByCss('p').text()).toBe('ipad')
+              return 'success'
+            }, /success/)
+          } finally {
+            await next.patchFile(envFile, envContent)
+          }
+        })
+      }
 
       it('should have no unexpected action error for hmr', async () => {
         expect(next.cliOutput).not.toContain('Unexpected action')


### PR DESCRIPTION
### Issue
When you edit .env* files, the pages under app dir that using env vars are not triggering hot reload

### Fix
Triggering serverComponentChanges hot reload action when we detect env or tsconfig related change. There's a time period that we need to wait before the compilation is finished. First we save a flag `reloadOnDone` if we need to reload when after compilation is done, by determining if `envChange` is `true` (we already know this in dev server). Then in the compilation hooks, we refresh RSC page once it's finished.

### Extra change 

since we're checking `event.action` in client hot reloader, and throwing error for unknown action, filter devPagesManifestUpdate out from unexpected action as it sometimes triggered as error in console. Introduced in #51516
Fixes NEXT-1261