### PR TITLE
adds payload to server-external-packages.json

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
@@ -35,6 +35,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `mongodb`
 - `next-mdx-remote`
 - `next-seo`
+- `payload`
 - `postcss`
 - `prettier`
 - `prisma`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -25,6 +25,7 @@
   "mongoose",
   "next-mdx-remote",
   "next-seo",
+  "payload",
   "pg",
   "playwright",
   "postcss",


### PR DESCRIPTION
### What?
Adds `payload` to the external package list

### Why?

To prevent developers using [Payload](https://github.com/payloadcms/payload) modules within Next.js from having to add this in their next config.