### PR TITLE
Refactor: avoid import next/navigation inside Next.js internal

### DIFF
--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import React from 'react'
-import { usePathname } from './navigation'
+import React, { useContext } from 'react'
+import { PathnameContext } from '../../shared/lib/hooks-client-context'
 
 const styles = {
   error: {
@@ -134,7 +134,12 @@ export function ErrorBoundary({
   errorStyles,
   children,
 }: ErrorBoundaryProps & { children: React.ReactNode }): JSX.Element {
-  const pathname = usePathname()
+  // FIXME: Reading pathname from PathnameContext directly instead of `next/navigation`
+  // to prevent the entire navigation.ts from being introduced to the client bundle due
+  // to the inefficient tree-shaking. This is only a temporary workaround and we need to
+  // look into the tree-shaking issue in the future.
+  const pathname = useContext(PathnameContext) as string
+
   if (errorComponent) {
     return (
       <ErrorBoundaryHandler

--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -134,8 +134,8 @@ export function ErrorBoundary({
   errorStyles,
   children,
 }: ErrorBoundaryProps & { children: React.ReactNode }): JSX.Element {
-  // FIXME: Reading pathname from PathnameContext directly instead of `next/navigation`
-  // to prevent the entire navigation.ts from being introduced to the client bundle due
+  // FIXME: Reading pathname from PathnameContext directly instead of `usePathname` to
+  // prevent the entire `next/navigation` from being introduced to the client bundle due
   // to the inefficient tree-shaking. This is only a temporary workaround and we need to
   // look into the tree-shaking issue in the future.
   const pathname = useContext(PathnameContext) as string

--- a/packages/next/src/client/components/not-found-boundary.tsx
+++ b/packages/next/src/client/components/not-found-boundary.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { usePathname } from './navigation'
+import React, { useContext } from 'react'
+import { PathnameContext } from '../../shared/lib/hooks-client-context'
 
 interface NotFoundBoundaryProps {
   notFound?: React.ReactNode
@@ -80,7 +80,12 @@ export function NotFoundBoundary({
   asNotFound,
   children,
 }: NotFoundBoundaryProps) {
-  const pathname = usePathname()
+  // FIXME: Reading pathname from PathnameContext directly instead of `next/navigation`
+  // to prevent the entire navigation.ts from being introduced to the client bundle due
+  // to the inefficient tree-shaking. This is only a temporary workaround and we need to
+  // look into the tree-shaking issue in the future.
+  const pathname = useContext(PathnameContext) as string
+
   return notFound ? (
     <NotFoundErrorBoundary
       pathname={pathname}

--- a/packages/next/src/client/components/not-found-boundary.tsx
+++ b/packages/next/src/client/components/not-found-boundary.tsx
@@ -80,8 +80,8 @@ export function NotFoundBoundary({
   asNotFound,
   children,
 }: NotFoundBoundaryProps) {
-  // FIXME: Reading pathname from PathnameContext directly instead of `next/navigation`
-  // to prevent the entire navigation.ts from being introduced to the client bundle due
+  // FIXME: Reading pathname from PathnameContext directly instead of `usePathname` to
+  // prevent the entire `next/navigation` from being introduced to the client bundle due
   // to the inefficient tree-shaking. This is only a temporary workaround and we need to
   // look into the tree-shaking issue in the future.
   const pathname = useContext(PathnameContext) as string


### PR DESCRIPTION
Continues #51806.

I noticed that the entire `next/navigation` is introduced to my bundle (see the screenshot below) while I only use `import { notFound } from 'next/navigation'` in my app:

<details>
<summary>screenshot</summary>

<img width="793" alt="image" src="https://github.com/vercel/next.js/assets/40715044/afe00f3d-adba-429c-b5d8-fde0d86cd29e">

</details>

The PR ensures that if a Next.js app doesn't utilize `next/navigation`, the `next/navigation` will not be included in the final bundle. However, considering that most of the Next.js apps will indeed make use of the `next/navigation`, it seems that this optimization may only provide limited benefits.