### PR TITLE
Ensure metadata test is not affected by other tests

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -115,7 +115,7 @@ export async function GET(_, ctx) {
     id = imageMetadata.find((item) => {
       if (process.env.NODE_ENV !== 'production') {
         if (item?.id == null) {
-          throw new Error('id is required for every item returned from generateImageMetadata')
+          throw new Error('id property is required for every item returned from generateImageMetadata')
         }
       }
       return item.id.toString() === targetId

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -380,12 +380,18 @@ createNextDescribe(
           return new ImageResponse(<div>icon</div>)
         }
         `
+
+        const outputBeforeFetch = next.cliOutput + ''
+
         await next.patchFile(iconFilePath, contentMissingIdProperty)
         await next.fetch('/metadata-base/unset/icon/100')
         await next.deleteFile(iconFilePath) // revert
 
+        const outputAfterFetch = next.cliOutput + ''
+        const output = outputAfterFetch.replace(outputBeforeFetch, '')
+
         await check(async () => {
-          expect(next.cliOutput).toContain(
+          expect(output).toContain(
             `id is required for every item returned from generateImageMetadata`
           )
           return 'success'
@@ -411,12 +417,19 @@ createNextDescribe(
             },
           ]
         }`
+
+        const outputBeforeFetch = next.cliOutput + ''
+
         await next.patchFile(sitemapFilePath, contentMissingIdProperty)
         await next.fetch('/metadata-base/unset/sitemap.xml/0')
         await next.deleteFile(sitemapFilePath) // revert
 
+        const outputAfterFetch = next.cliOutput + ''
+
+        const output = outputAfterFetch.replace(outputBeforeFetch, '')
+
         await check(async () => {
-          expect(next.cliOutput).toContain(
+          expect(output).toContain(
             `id is required for every item returned from generateImageMetadata`
           )
           return 'success'

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -385,17 +385,21 @@ createNextDescribe(
 
         await next.patchFile(iconFilePath, contentMissingIdProperty)
         await next.fetch('/metadata-base/unset/icon/100')
-        await next.deleteFile(iconFilePath) // revert
 
         const outputAfterFetch = next.cliOutput + ''
         const output = outputAfterFetch.replace(outputBeforeFetch, '')
 
-        await check(async () => {
-          expect(output).toContain(
-            `id is required for every item returned from generateImageMetadata`
-          )
-          return 'success'
-        }, /success/)
+        try {
+          await check(async () => {
+            expect(output).toContain(
+              `id property is required for every item returned from generateImageMetadata`
+            )
+            return 'success'
+          }, /success/)
+        } finally {
+          await next.deleteFile(iconFilePath)
+          await next.fetch('/metadata-base/unset/icon/100')
+        }
       })
 
       it('should error when id is missing in generateSitemaps', async () => {
@@ -405,7 +409,7 @@ createNextDescribe(
 
         export async function generateSitemaps() {
           return [
-            { id: 0 },
+            { },
           ]
         }
 
@@ -422,18 +426,21 @@ createNextDescribe(
 
         await next.patchFile(sitemapFilePath, contentMissingIdProperty)
         await next.fetch('/metadata-base/unset/sitemap.xml/0')
-        await next.deleteFile(sitemapFilePath) // revert
 
         const outputAfterFetch = next.cliOutput + ''
-
         const output = outputAfterFetch.replace(outputBeforeFetch, '')
 
-        await check(async () => {
-          expect(output).toContain(
-            `id is required for every item returned from generateImageMetadata`
-          )
-          return 'success'
-        }, /success/)
+        try {
+          await check(async () => {
+            expect(output).toContain(
+              `id property is required for every item returned from generateSitemaps`
+            )
+            return 'success'
+          }, /success/)
+        } finally {
+          await next.deleteFile(sitemapFilePath)
+          await next.fetch('/metadata-base/unset/sitemap.xml/0')
+        }
       })
     }
 


### PR DESCRIPTION
Turn out the `should error when id is missing in generateSitemaps` test was passing because of this test passing: `should error when id is missing in generateImageMetadata`

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
