### PR TITLE
fix(typedRoutes): added missing anchor props to LinkRestProps

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -413,7 +413,7 @@ declare module 'next' {
 
 declare module 'next/link' {
   import type { LinkProps as OriginalLinkProps } from 'next/dist/client/link'
-  import type { AnchorHTMLAttributes, DetailedHTMLAttributes } from 'react'
+  import type { AnchorHTMLAttributes, DetailedHTMLProps } from 'react'
   import type { UrlObject } from 'url'
   
   type LinkRestProps = Omit<

--- a/packages/next/src/build/webpack/plugins/next-types-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin.ts
@@ -413,11 +413,17 @@ declare module 'next' {
 
 declare module 'next/link' {
   import type { LinkProps as OriginalLinkProps } from 'next/dist/client/link'
-  import type { AnchorHTMLAttributes } from 'react'
+  import type { AnchorHTMLAttributes, DetailedHTMLAttributes } from 'react'
   import type { UrlObject } from 'url'
   
   type LinkRestProps = Omit<
-    Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof OriginalLinkProps> &
+    Omit<
+      DetailedHTMLProps<
+        AnchorHTMLAttributes<HTMLAnchorElement>,
+        HTMLAnchorElement
+      >,
+      keyof OriginalLinkProps
+    > &
       OriginalLinkProps,
     'href'
   >


### PR DESCRIPTION
### What?
This PR fixes `next/link`'s `<Link />` missing many `<a />` props when `experimental.typedRoutes` is enabled.

### How?
It does that by changing `AnchorHTMLAttributes<HTMLAnchorElement>` in LinkRestProps to `DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>`, which contains all `<a />` props.

Fixes #51907

