### PR TITLE
Docs: Change to official strapi git repo

### DIFF
--- a/docs/03-pages/01-building-your-application/03-data-fetching/index.mdx
+++ b/docs/03-pages/01-building-your-application/03-data-fetching/index.mdx
@@ -14,7 +14,7 @@ Data fetching in Next.js allows you to render your content in different ways, de
 - [Sanity Example](https://github.com/vercel/next.js/tree/canary/examples/cms-sanity) ([Demo](https://next-blog-sanity.vercel.app/))
 - [Prismic Example](https://github.com/vercel/next.js/tree/canary/examples/cms-prismic) ([Demo](https://next-blog-prismic.vercel.app/))
 - [Contentful Example](https://github.com/vercel/next.js/tree/canary/examples/cms-contentful) ([Demo](https://next-blog-contentful.vercel.app/))
-- [Strapi Example](https://github.com/vercel/next.js/tree/canary/examples/cms-strapi) ([Demo](https://next-blog-strapi.vercel.app/))
+- [Strapi Example](https://github.com/strapi/nextjs-corporate-starter)
 - [Prepr Example](https://github.com/vercel/next.js/tree/canary/examples/cms-prepr) ([Demo](https://next-blog-prepr.vercel.app/))
 - [Agility CMS Example](https://github.com/vercel/next.js/tree/canary/examples/cms-agilitycms) ([Demo](https://next-blog-agilitycms.vercel.app/))
 - [Cosmic Example](https://github.com/vercel/next.js/tree/canary/examples/cms-cosmic) ([Demo](https://next-blog-cosmic.vercel.app/))


### PR DESCRIPTION
### What?
Change strapi example url
### Why?
Old repo is deprecated

It's just a simple url change.