### PR TITLE
chore(docs): explain `NODE_ENV` environment variable

### DIFF
--- a/docs/02-app/01-building-your-application/06-configuring/03-environment-variables.mdx
+++ b/docs/02-app/01-building-your-application/06-configuring/03-environment-variables.mdx
@@ -168,4 +168,4 @@ For example, if `NODE_ENV` is `development` and you define a variable in both `.
 ## Good to know
 
 - If you are using a [`/src` directory](/docs/app/building-your-application/configuring/src-directory), `.env.*` files should remain in the root of your project.
-- The environment variable `NODE_ENV` is automatically assigned to `development` when running `next dev`. All other commands automatically assign `NODE_ENV` to `production`.
+- If the environment variable `NODE_ENV` is unassigned, Next.js automatically assigns `development` when running the `next dev` command, or `production` for all other commands.

--- a/docs/02-app/01-building-your-application/06-configuring/03-environment-variables.mdx
+++ b/docs/02-app/01-building-your-application/06-configuring/03-environment-variables.mdx
@@ -168,3 +168,4 @@ For example, if `NODE_ENV` is `development` and you define a variable in both `.
 ## Good to know
 
 - If you are using a [`/src` directory](/docs/app/building-your-application/configuring/src-directory), `.env.*` files should remain in the root of your project.
+- The environment variable `NODE_ENV` is automatically assigned to `development` when running `next dev`. All other commands automatically assign `NODE_ENV` to `production`.


### PR DESCRIPTION
This PR documents the `NODE_ENV` environment variable behavior.

This feature was originally added in 152c2c2af3e61e18833fae104ee3af8ddac3d63c which was released in `next@5`.

See the current source code here:

https://github.com/vercel/next.js/blob/e3e76a45ee2b10e91b4e285fea536e42cf8e60e2/packages/next/src/bin/next.ts#L82
