### PR TITLE
feat(route-announcer): add inline cors css fix for route announcement…

### DIFF
--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -740,7 +740,7 @@ function doRender(input: RenderRouteInfo): Promise<any> {
       <AppContainer>
         {renderApp(App, appProps)}
         <Portal type="next-route-announcer">
-          <RouteAnnouncer />
+          <RouteAnnouncer srOnly={Component.tailwindcss ?? props?.tailwindcss} />
         </Portal>
       </AppContainer>
     </>

--- a/packages/next/src/client/route-announcer.tsx
+++ b/packages/next/src/client/route-announcer.tsx
@@ -1,23 +1,7 @@
 import React from 'react'
 import { useRouter } from './router'
 
-const nextjsRouteAnnouncerStyles: React.CSSProperties = {
-  border: 0,
-  clip: 'rect(0 0 0 0)',
-  height: '1px',
-  margin: '-1px',
-  overflow: 'hidden',
-  padding: 0,
-  position: 'absolute',
-  top: 0,
-  width: '1px',
-
-  // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
-  whiteSpace: 'nowrap',
-  wordWrap: 'normal',
-}
-
-export const RouteAnnouncer = () => {
+export const RouteAnnouncer = ({ srOnly }: { srOnly?: boolean }) => {
   const { asPath } = useRouter()
   const [routeAnnouncement, setRouteAnnouncement] = React.useState('')
 
@@ -50,12 +34,36 @@ export const RouteAnnouncer = () => {
     [asPath]
   )
 
+  const [style, className]: React.CSSProperties = React.useMemo(() => {
+    // re-use tailwindcss screen-reader class. This also fixes inline-cors security issues.
+    if (srOnly) {
+      return [undefined, "sr-only"]
+    }
+    return [{
+      border: 0,
+      clip: 'rect(0 0 0 0)',
+      height: '1px',
+      margin: '-1px',
+      overflow: 'hidden',
+      padding: 0,
+      position: 'absolute',
+      top: 0,
+      width: '1px',
+    
+      // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
+      whiteSpace: 'nowrap',
+      wordWrap: 'normal',
+    }, undefined]
+  }, [srOnly])
+
+  
   return (
     <p
       aria-live="assertive" // Make the announcement immediately.
       id="__next-route-announcer__"
       role="alert"
-      style={nextjsRouteAnnouncerStyles}
+      className={className}
+      style={style}
     >
       {routeAnnouncement}
     </p>

--- a/packages/next/src/client/route-announcer.tsx
+++ b/packages/next/src/client/route-announcer.tsx
@@ -34,7 +34,7 @@ export const RouteAnnouncer = ({ srOnly }: { srOnly?: boolean }) => {
     [asPath]
   )
 
-  const [style, className]: React.CSSProperties = React.useMemo(() => {
+  const [style, className]: [React.CSSProperties?, string?] = React.useMemo(() => {
     // re-use tailwindcss screen-reader class. This also fixes inline-cors security issues.
     if (srOnly) {
       return [undefined, "sr-only"]


### PR DESCRIPTION
# Fix RouteAnnouncer inline css cors security issue

* Add the ability to use tailwindcss `sr-only` class for `<RouteAnnouncer />` .

This PR exposes a `tailwindcss` key on the Component to give the ability to apply pre-built css across components. This fixes inline style cors issues that comes when security is strict on a website.

### Improving Documentation

TODO: Need to add this to docs

### Adding or Updating Examples

### Fixing a bug

Fixes security issues from cors.

### Adding a feature

Adds a small feature dedicated to using `tailwindcss` key to apply pre-built styles on custom components.

## For Maintainers

Mainly need a way to remove inline styles with a valid css version.

### What?

Allow tailwind classes for the RouteAnnouncer inline css.

### Why?

To improve security and prevent duplicate styling.

### How?

Through page props or Component props.