### PR TITLE
Avoid disposing middleware and instrumentation hook during development

### DIFF
--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -308,10 +308,19 @@ function disposeInactiveEntries(
 ) {
   Object.keys(entries).forEach((entryKey) => {
     const entryData = entries[entryKey]
-    const { lastActiveTime, status, dispose } = entryData
+    const { lastActiveTime, status, dispose, bundlePath } = entryData
 
     // TODO-APP: implement disposing of CHILD_ENTRY
     if (entryData.type === EntryTypes.CHILD_ENTRY) {
+      return
+    }
+
+    // For the root middleware and the instrumentation hook files,
+    // we don't dispose them periodically as it's needed for every request.
+    if (
+      isMiddlewareFilename(bundlePath) ||
+      isInstrumentationHookFilename(bundlePath)
+    ) {
       return
     }
 


### PR DESCRIPTION
Unlike other routes, these two entries are needed for every request so there is no reason to have them disposed. This avoids wasting extra dev server resource to get them re-compiled.