### PR TITLE
chore(script): improve markdown changelog output in sync-react.js

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -138,7 +138,7 @@ Or, run this command with no arguments to use the most recently published versio
         `GitHub reported no changes between ${baseSha} and ${newSha}.`
       )
     } else {
-      console.log('### React upstream changes:\n\n' + changelog)
+      console.log(`### React upstream changes\n\n${changelog}\n\n`)
     }
   } catch (error) {
     console.error(error)

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -138,7 +138,7 @@ Or, run this command with no arguments to use the most recently published versio
         `GitHub reported no changes between ${baseSha} and ${newSha}.`
       )
     } else {
-      console.log('Includes the following upstream changes:\n\n' + changelog)
+      console.log('### React upstream changes:\n\n' + changelog)
     }
   } catch (error) {
     console.error(error)
@@ -191,11 +191,19 @@ async function getChangelogFromGitHub(baseSha, newSha) {
 
     const { commits } = data
     for (const { commit, sha } of commits) {
-      changelog.push(
-        `-  ${sha.slice(0, 9)} ${commit.message.split('\n')[0]} (${
-          commit.author.name
-        })`
-      )
+      const title = commit.message.split('\n')[0] || ''
+      // The "title" looks like "[Fiber][Float] preinitialized stylesheets should support integrity option (#26881)"
+      const match = /\(#([0-9]+)\)$/.exec(title)
+      const prNum = match ? match[1] : ''
+      if (prNum) {
+        changelog.push(`- https://github.com/facebook/react/pulls/${prNum}`)
+      } else {
+        changelog.push(
+          `-  ${sha.slice(0, 9)} ${commit.message.split('\n')[0]} (${
+            commit.author.name
+          })`
+        )
+      }
     }
 
     if (commits.length !== pageSize) {


### PR DESCRIPTION
This makes it really easy to copy/paste the changelog into the PR description after running `sync-react.js`.

Previously, the output would link to incorrect PRs because it didn't know the PR number was from a different repo.

We know `facebook/react` uses squash so there should always be a PR number at the end of the commit title.

Example of the new format: https://github.com/vercel/next.js/pull/52005