### PR TITLE
Ensure non-implicit unstable_cache tags are propagated

### DIFF
--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -64,6 +64,17 @@ export function unstable_cache<T extends Callback>(
           (await incrementalCache?.get(cacheKey, true, options.revalidate))
 
         const tags = options.tags || []
+
+        if (Array.isArray(tags) && store) {
+          if (!store.tags) {
+            store.tags = []
+          }
+          for (const tag of tags) {
+            if (!store.tags.includes(tag)) {
+              store.tags.push(tag)
+            }
+          }
+        }
         const implicitTags = addImplicitTags(store)
 
         for (const tag of implicitTags) {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -34,6 +34,19 @@ createNextDescribe(
       }
     })
 
+    if (isNextStart) {
+      it('should propagate unstable_cache tags correctly', async () => {
+        const meta = JSON.parse(
+          await next.readFile(
+            '.next/server/app/variable-revalidate/revalidate-360-isr.meta'
+          )
+        )
+        expect(meta.headers['x-next-cache-tags']).toContain(
+          'unstable_cache_tag1'
+        )
+      })
+    }
+
     it('should correctly include headers instance in cache key', async () => {
       const res = await next.fetch('/variable-revalidate/headers-instance')
       expect(res.status).toBe(200)

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/revalidate-360-isr/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/revalidate-360-isr/page.js
@@ -28,7 +28,7 @@ export default async function Page() {
     },
     ['random'],
     {
-      tags: ['thankyounext'],
+      tags: ['thankyounext', 'unstable_cache_tag1'],
       revalidate: 10,
     }
   )()


### PR DESCRIPTION
This ensures we correctly pass up the non-implicit tags for `unstable_cache` so that `revalidateTag` can be triggered for ISR paths properly. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1687900021175649)