### PR TITLE
Add option to bypass error serialization

### DIFF
--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
@@ -1907,6 +1907,10 @@ function logRecoverableError(request, error) {
 }
 
 function getErrorMessageAndStackDev(error) {
+  if (error?._bypassSerialization === true) {
+    return error;
+  }
+
   {
     var message;
     var stack = '';


### PR DESCRIPTION
### What?
A field you can pass on an error-by-error basis to bypass serialization of errors on server components to the error boundary.

### Why?
I recently spent hours trying to find a solution to this problem. I understand serialization happens to protect important data from being leaked but I also believe Next.js should give the opportunity for the developer to decide when this should be bypassed.

Simply because messages changes and the digest seems to also be based on the stack so it's not a reliable way of identifying types of error for proper handling.

The only solution I found was to create a client component that redirects the error to be thrown on the client side, but this is a terrible solution as it adds so much boilerplate, you have to basically add this component to every single component, and if you forget to, your error handling might break.

### How?
I'm going to be totally honest, I'm sure this is a relatively simple task for those who have a strong knowledge of the codebase, but I'm way in over my head here, I tried to make some changes but I don't understand if what I changed is the actual source code or compiled code for distribution, either way I'm probably way off so that's why I'm allowing edits and asking for help on this one.