### PR TITLE
Delegate static analyzation task to the router worker

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -498,14 +498,10 @@ export default class DevServer extends Server {
           })
 
           if (isMiddlewareFile(rootFile)) {
-            const staticInfo = await getStaticInfoIncludingLayouts({
-              pageFilePath: fileName,
-              config: this.nextConfig,
-              appDir: this.appDir,
-              page: rootFile,
-              isDev: true,
-              isInsideAppDir: isAppPath,
-              pageExtensions: this.nextConfig.pageExtensions,
+            const staticInfo = await this.getStaticInfo({
+              fileName,
+              rootFile,
+              isAppPath,
             })
             if (this.nextConfig.output === 'export') {
               Log.error(
@@ -1839,6 +1835,30 @@ export default class DevServer extends Server {
 
     // Return the very first error we found.
     return errors[0]
+  }
+
+  async getStaticInfo({
+    fileName,
+    rootFile,
+    isAppPath,
+  }: {
+    fileName: string
+    rootFile: string
+    isAppPath: boolean
+  }) {
+    if (this.isRenderWorker) {
+      return this.invokeIpcMethod('getStaticInfo', [fileName])
+    } else {
+      return getStaticInfoIncludingLayouts({
+        pageFilePath: fileName,
+        config: this.nextConfig,
+        appDir: this.appDir,
+        page: rootFile,
+        isDev: true,
+        isInsideAppDir: isAppPath,
+        pageExtensions: this.nextConfig.pageExtensions,
+      })
+    }
   }
 
   protected isServableUrl(untrustedFileUrl: string): boolean {


### PR DESCRIPTION
In the dev server, we need to call `getStaticInfoIncludingLayouts` for the middleware file to extract its `matchers` field. However, that's currently executed in both app and pages workers. This method is expensive as it depends on the SWC binary to be loaded.

This PR changes it to invoke it as an IPC method, so only the router worker (which runs the compilation) loads SWC, instead of all 3 of them.

This also fixes duplicated console messages of:

```
Using locally built binary of @next/swc
```

For our test app, I'm seeing a 150~250ms improvement:

![CleanShot 2023-07-02 at 18 29 22@2x](https://github.com/vercel/next.js/assets/3676859/be78b79b-2eb4-4f04-92dc-3640e12cde23)

Haven't measured about the memory impact yet, but it should be a lot.