### PR TITLE
feat(i18n-routing): Hide sub-path routing locale prefix when use NEXT_LOCALE cookie

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -61,6 +61,7 @@ import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
 import * as Log from '../build/output/log'
 import escapePathDelimiters from '../shared/lib/router/utils/escape-path-delimiters'
+import { detectLocaleCookie } from '../shared/lib/i18n/detect-locale-cookie'
 import { getUtils } from './server-utils'
 import isError, { getProperError } from '../lib/is-error'
 import {
@@ -698,6 +699,13 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       const defaultLocale =
         domainLocale?.defaultLocale || this.nextConfig.i18n?.defaultLocale
       parsedUrl.query.__nextDefaultLocale = defaultLocale
+
+      const locales = this.nextConfig.i18n?.locales || []
+      const cookieLocale = detectLocaleCookie(req, locales)
+
+      if (!Boolean(domainLocale)) {
+        this.i18nProvider && (this.i18nProvider.cookieLocale = cookieLocale);
+      }
 
       const url = parseUrlUtil(req.url.replace(/^\/+/, '/'))
       const pathnameInfo = getNextPathnameInfo(url.pathname, {

--- a/packages/next/src/server/future/helpers/i18n-provider.ts
+++ b/packages/next/src/server/future/helpers/i18n-provider.ts
@@ -44,6 +44,7 @@ export class I18NProvider {
       hostname: string
     }
   >
+  private lowerCaseCookieLocale: string
 
   constructor(public readonly config: Readonly<I18NConfig>) {
     if (!config.locales.length) {
@@ -61,6 +62,7 @@ export class I18NProvider {
         http: domainLocale.http,
       }
     })
+    this.lowerCaseCookieLocale = '';
   }
 
   /**
@@ -152,6 +154,12 @@ export class I18NProvider {
     // no detected locale.
     let inferredFromDefault = typeof detectedLocale === 'string'
 
+    // See if the cookie matches one of the locales.
+    let index = this.lowerCaseLocales.indexOf(this.lowerCaseCookieLocale)
+    if (index > -1) {
+      detectedLocale = this.lowerCaseCookieLocale
+    }
+
     // The first segment will be empty, because it has a leading `/`. If
     // there is no further segment, there is no locale (or it's the default).
     const segments = pathname.split('/')
@@ -167,7 +175,7 @@ export class I18NProvider {
 
     // See if the segment matches one of the locales. If it doesn't, there is
     // no locale (or it's the default).
-    const index = this.lowerCaseLocales.indexOf(segment)
+    index = this.lowerCaseLocales.indexOf(segment)
     if (index < 0)
       return {
         detectedLocale,
@@ -186,6 +194,16 @@ export class I18NProvider {
       detectedLocale,
       pathname,
       inferredFromDefault,
+    }
+  }
+
+  public get cookieLocale(): string {
+    return this.lowerCaseCookieLocale;
+  }
+
+  public set cookieLocale(value: string | undefined) {
+    if (typeof value === 'string' && value) {
+      this.lowerCaseCookieLocale = value.toLowerCase();
     }
   }
 }

--- a/packages/next/src/shared/lib/i18n/detect-locale-cookie.ts
+++ b/packages/next/src/shared/lib/i18n/detect-locale-cookie.ts
@@ -1,6 +1,8 @@
 import { IncomingMessage } from 'http'
 
-export function detectLocaleCookie(req: IncomingMessage, locales: string[]) {
+import type { BaseNextRequest } from '../../../server/base-http'
+
+export function detectLocaleCookie(req: BaseNextRequest | IncomingMessage, locales: string[]) {
   const { NEXT_LOCALE } = (req as any).cookies || {}
   return NEXT_LOCALE
     ? locales.find(


### PR DESCRIPTION
### Adding a feature

While using NEXT_LOCALE cookie, sub-path routing removes locale prefix and remains the same across all locales

Related issue and discussions

- https://github.com/vercel/next.js/issues/22375
- https://github.com/vercel/next.js/discussions/39746