### PR TITLE
docs: Add description for pages tailwindcss setting

### DIFF
--- a/docs/02-app/01-building-your-application/04-styling/02-tailwind-css.mdx
+++ b/docs/02-app/01-building-your-application/04-styling/02-tailwind-css.mdx
@@ -107,8 +107,8 @@ export default function RootLayout({ children }) {
 }
 ```
 
-You should import globals.css on _app.js/ts file for activate tailwindcss on your route.
-Putting _app.js/ts under page folder.
+After creating the pages folder, you should add _app.js/ts into it.
+Then, You should import globals.css on _app.js/ts file to activate tailwindcss on your route.
 ```
 import '../app/globals.css'
  

--- a/docs/02-app/01-building-your-application/04-styling/02-tailwind-css.mdx
+++ b/docs/02-app/01-building-your-application/04-styling/02-tailwind-css.mdx
@@ -107,6 +107,21 @@ export default function RootLayout({ children }) {
 }
 ```
 
+You should import globals.css on _app.js/ts file for activate tailwindcss on your route.
+Putting _app.js/ts under page folder.
+```
+import '../app/globals.css'
+ 
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <>
+      <Component {...pageProps} />
+    </>
+  )
+}
+```
+
+
 ## Using Classes
 
 After installing Tailwind CSS and adding the global styles, you can use Tailwind's utility classes in your application.


### PR DESCRIPTION
What?
Update the document for beginner could use tailwindcss more easily. The current create-next-app with tailwindcss will not work for route in pages but only in app folder.
Why?
Many questions about it are asked on the internet:
https://stackoverflow.com/questions/76568477/issues-with-tailwind-css-in-nextjs-pages-directory
https://stackoverflow.com/questions/76010733/tailwindcss-not-working-on-next-js-13-with-app-folder
https://stackoverflow.com/questions/76555057/tailwind-doesnt-apply-styles-on-components-in-pages-folder