### PR TITLE
Change the Server Actions feature flag to be validated at compile time

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -22,6 +22,7 @@ use turbopack_binding::swc::core::{
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Config {
     pub is_server: bool,
+    pub enabled: bool
 }
 
 pub fn server_actions<C: Comments>(
@@ -101,6 +102,7 @@ impl<C: Comments> ServerActions<C> {
                     &mut body.stmts,
                     remove_directive,
                     &mut is_action_fn,
+                    self.config.enabled,
                 );
 
                 if is_action_fn && !self.config.is_server {
@@ -721,6 +723,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             stmts,
             &mut self.in_action_file,
             &mut self.has_action,
+            self.config.enabled,
         );
 
         let old_annotations = self.annotations.take();
@@ -1231,6 +1234,7 @@ fn remove_server_directive_index_in_module(
     stmts: &mut Vec<ModuleItem>,
     in_action_file: &mut bool,
     has_action: &mut bool,
+    enabled: bool,
 ) {
     let mut is_directive = true;
 
@@ -1244,6 +1248,16 @@ fn remove_server_directive_index_in_module(
                     if is_directive {
                         *in_action_file = true;
                         *has_action = true;
+                        if !enabled {
+                            HANDLER.with(|handler| {
+                                handler
+                                    .struct_span_err(
+                                        *span,
+                                        "To use Server Actions, please enable the feature flag in your Next.js config. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions#convention",
+                                    )
+                                    .emit()
+                            });
+                        }
                         return false;
                     } else {
                         HANDLER.with(|handler| {
@@ -1320,6 +1334,7 @@ fn remove_server_directive_index_in_fn(
     stmts: &mut Vec<Stmt>,
     remove_directive: bool,
     is_action_fn: &mut bool,
+    enabled: bool,
 ) {
     let mut is_directive = true;
 
@@ -1332,6 +1347,16 @@ fn remove_server_directive_index_in_fn(
             if value == "use server" {
                 if is_directive {
                     *is_action_fn = true;
+                    if !enabled {
+                        HANDLER.with(|handler| {
+                            handler
+                                .struct_span_err(
+                                    *span,
+                                    "To use Server Actions, please enable the feature flag in your Next.js config. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions#convention",
+                                )
+                                .emit()
+                        });
+                    }
                     if remove_directive {
                         return false;
                     }

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -43,6 +43,7 @@ function getBaseSWCOptions({
   swcCacheDir,
   isServerLayer,
   hasServerComponents,
+  isServerActionsEnabled,
 }: {
   filename: string
   jest?: boolean
@@ -57,6 +58,7 @@ function getBaseSWCOptions({
   swcCacheDir?: string
   isServerLayer?: boolean
   hasServerComponents?: boolean
+  isServerActionsEnabled?: boolean
 }) {
   const parserConfig = getParserOptions({ filename, jsConfig })
   const paths = jsConfig?.compilerOptions?.paths
@@ -157,6 +159,8 @@ function getBaseSWCOptions({
       : undefined,
     serverActions: hasServerComponents
       ? {
+          // TODO-APP: When Server Actions is stable, we need to remove this flag.
+          enabled: !!isServerActionsEnabled,
           isServer: !!isServerLayer,
         }
       : undefined,
@@ -285,6 +289,7 @@ export function getLoaderSWCOptions({
   relativeFilePathFromRoot,
   hasServerComponents,
   isServerLayer,
+  isServerActionsEnabled,
 }: // This is not passed yet as "paths" resolving is handled by webpack currently.
 // resolvedBaseUrl,
 {
@@ -304,6 +309,7 @@ export function getLoaderSWCOptions({
   relativeFilePathFromRoot: string
   hasServerComponents?: boolean
   isServerLayer: boolean
+  isServerActionsEnabled?: boolean
 }) {
   let baseOptions: any = getBaseSWCOptions({
     filename,
@@ -318,6 +324,7 @@ export function getLoaderSWCOptions({
     swcCacheDir,
     hasServerComponents,
     isServerLayer,
+    isServerActionsEnabled,
   })
   baseOptions.fontLoaders = {
     fontLoaders: [

--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -73,6 +73,7 @@ async function loaderTransform(
     swcCacheDir,
     relativeFilePathFromRoot,
     hasServerComponents,
+    isServerActionsEnabled: nextConfig?.experimental?.serverActions,
     isServerLayer,
   })
 

--- a/test/e2e/app-dir/actions/app-action-invalid.test.ts
+++ b/test/e2e/app-dir/actions/app-action-invalid.test.ts
@@ -34,7 +34,7 @@ createNextDescribe(
 
     it('should error if serverActions is not enabled', async () => {
       expect(next.cliOutput).toContain(
-        'Server Actions require `experimental.serverActions` option'
+        'To use Server Actions, please enable the feature flag in your Next.js config.'
       )
     })
   }


### PR DESCRIPTION
Currently we are validating the `experimental.serverActions` flag when creating the actual entries for Server Actions, this causes two problems. One is that syntax errors caught at compilation time are still shown, even if you don't have this flag enabled. Another problem is we still traverse the client graph to collect these action modules even if the flag isn't enabled.

This PR moves that check to be happening at compilation time, which addresses the two above but also brings the extra benefit of showing the exact span and module trace that errors:

<img width="974" alt="CleanShot 2023-07-03 at 20 26 34@2x" src="https://github.com/vercel/next.js/assets/3676859/1676b1f6-e205-4963-bce4-5b515a698e9c">
