### PR TITLE
Fix `modularizeImports` transform of `antd`

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -714,7 +714,7 @@ function assignDefaults(
       transform: 'react-bootstrap/{{member}}',
     },
     antd: {
-      transform: 'antd/es/{{member}}',
+      transform: 'antd/es/{{kebabCase member}}',
     },
     ahooks: {
       transform: 'ahooks/es/{{member}}',


### PR DESCRIPTION
`antd` should be using `kebabCase`: https://unpkg.com/browse/antd@5.6.4/es/index.js

This addresses the problem below as I tested locally:

<img width="397" alt="CleanShot 2023-07-03 at 20 45 48@2x" src="https://github.com/vercel/next.js/assets/3676859/73ae99b9-0f3b-49ef-9675-9f45322b708d">
