### PR TITLE
Use base36 for the RSC query

### DIFF
--- a/packages/next/src/shared/lib/hash.ts
+++ b/packages/next/src/shared/lib/hash.ts
@@ -9,5 +9,5 @@ export function djb2Hash(str: string) {
 }
 
 export function hexHash(str: string) {
-  return djb2Hash(str).toString(16).slice(0, 7)
+  return djb2Hash(str).toString(36).slice(0, 5)
 }


### PR DESCRIPTION
By using a larger base we can have a shorter parameter with almost the same result space.