### PR TITLE
Do not shorten URL if Verbose Logging is added

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1775,7 +1775,7 @@ export default class NextNodeServer extends BaseServer {
               }
               let url = metric.url
 
-              if (url.length > 48) {
+             if (url.length > 48 && this.nextConfig.experimental.logging !== 'verbose') {
                 const parsed = new URL(url)
                 const truncatedHost =
                   parsed.host.length > 16


### PR DESCRIPTION
### What?
Do not shorten the URL if verbose logging is added 
### Why?
Because the logging of the URL is pointless when you have longer URLs see below for example 
![image](https://github.com/vercel/next.js/assets/44407681/e7f174d7-9ab1-49f2-9ed0-4c35e6b79342)
