### PR TITLE
Improve error message when using per function "use server" in Client Components

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -110,7 +110,7 @@ impl<C: Comments> ServerActions<C> {
                         handler
                             .struct_span_err(
                                 body.span,
-                                "It is not allowed to define inline \"use server\" annotated Server Actions in Client Components.\nYou can either mark the entire file by putting \"use server\" at the top, or pass them down through props from a Server Component.\n\nRead more: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions#with-client-components\n",
+                                "It is not allowed to define inline \"use server\" annotated Server Actions in Client Components.\nTo use Server Actions in a Client Component, you can either export them from a separate file with \"use server\" at the top, or pass them down through props from a Server Component.\n\nRead more: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions#with-client-components\n",
                             )
                             .emit()
                     });

--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -22,7 +22,7 @@ use turbopack_binding::swc::core::{
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Config {
     pub is_server: bool,
-    pub enabled: bool
+    pub enabled: bool,
 }
 
 pub fn server_actions<C: Comments>(
@@ -110,8 +110,7 @@ impl<C: Comments> ServerActions<C> {
                         handler
                             .struct_span_err(
                                 body.span,
-                                "\"use server\" functions are not allowed in client components. \
-                                 You can import them from a \"use server\" file instead.",
+                                "It is not allowed to define inline \"use server\" annotated Server Actions in Client Components.\nYou can either mark the entire file by putting \"use server\" at the top, or pass them down through props from a Server Component.\n\nRead more: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions#with-client-components\n",
                             )
                             .emit()
                     });

--- a/packages/next-swc/crates/core/tests/errors.rs
+++ b/packages/next-swc/crates/core/tests/errors.rs
@@ -168,7 +168,10 @@ fn react_server_actions_server_errors(input: PathBuf) {
                 ),
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
-                    server_actions::Config { is_server: true },
+                    server_actions::Config {
+                        is_server: true,
+                        enabled: true
+                    },
                     tr.comments.as_ref().clone(),
                 )
             )
@@ -200,7 +203,10 @@ fn react_server_actions_client_errors(input: PathBuf) {
                 ),
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
-                    server_actions::Config { is_server: false },
+                    server_actions::Config {
+                        is_server: false,
+                        enabled: true
+                    },
                     tr.comments.as_ref().clone(),
                 )
             )

--- a/packages/next-swc/crates/core/tests/errors/server-actions/client-graph/1/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/client-graph/1/output.stderr
@@ -1,6 +1,6 @@
 
   x It is not allowed to define inline "use server" annotated Server Actions in Client Components.
-  | You can either mark the entire file by putting "use server" at the top, or pass them down through props from a Server Component.
+  | To use Server Actions in a Client Component, you can either export them from a separate file with "use server" at the top, or pass them down through props from a Server Component.
   | 
   | Read more: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions#with-client-components
   | 

--- a/packages/next-swc/crates/core/tests/errors/server-actions/client-graph/1/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/server-actions/client-graph/1/output.stderr
@@ -1,5 +1,9 @@
 
-  x "use server" functions are not allowed in client components. You can import them from a "use server" file instead.
+  x It is not allowed to define inline "use server" annotated Server Actions in Client Components.
+  | You can either mark the entire file by putting "use server" at the top, or pass them down through props from a Server Component.
+  | 
+  | Read more: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions#with-client-components
+  | 
    ,-[input.js:3:1]
  3 |     export default function App() {
  4 | ,->   async function fn() {

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -325,7 +325,10 @@ fn server_actions_server_fixture(input: PathBuf) {
                 resolver(Mark::new(), Mark::new(), false),
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
-                    server_actions::Config { is_server: true },
+                    server_actions::Config {
+                        is_server: true,
+                        enabled: true
+                    },
                     _tr.comments.as_ref().clone(),
                 )
             )
@@ -346,7 +349,10 @@ fn server_actions_client_fixture(input: PathBuf) {
                 resolver(Mark::new(), Mark::new(), false),
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
-                    server_actions::Config { is_server: false },
+                    server_actions::Config {
+                        is_server: false,
+                        enabled: true
+                    },
                     _tr.comments.as_ref().clone(),
                 )
             )


### PR DESCRIPTION
The current message isn't very clear about `"use server" function` and `"use server" file`, and there's no link to docs to explain it further:

```
"use server" functions are not allowed in client components. 
You can import them from a "use server" file instead.
```

This PR makes it a bit more verbose:

```
It is not allowed to define inline "use server" annotated Server Actions in Client Components.
You can either mark the entire file by putting "use server" at the top, or pass them down through props from a Server Component.

Read more: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions#with-client-components
```