### PR TITLE
Ensure Webpack isn't loaded in render workers

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.test.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.test.ts
@@ -1,4 +1,4 @@
-import { NextTypesPlugin } from './next-types-plugin'
+import { NextTypesPlugin } from '.'
 
 describe('next-types-plugin', () => {
   it('should generate correct base import path', () => {

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -1,4 +1,4 @@
-import type { Rewrite, Redirect } from '../../../lib/load-custom-routes'
+import type { Rewrite, Redirect } from '../../../../lib/load-custom-routes'
 import type { Token } from 'next/dist/compiled/path-to-regexp'
 
 import fs from 'fs/promises'
@@ -6,14 +6,15 @@ import { webpack, sources } from 'next/dist/compiled/webpack/webpack'
 import { parse } from 'next/dist/compiled/path-to-regexp'
 import path from 'path'
 
-import { WEBPACK_LAYERS } from '../../../lib/constants'
-import { denormalizePagePath } from '../../../shared/lib/page-path/denormalize-page-path'
-import { ensureLeadingSlash } from '../../../shared/lib/page-path/ensure-leading-slash'
-import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
-import { HTTP_METHODS } from '../../../server/web/http'
-import { isDynamicRoute } from '../../../shared/lib/router/utils'
-import { normalizeAppPath } from '../../../shared/lib/router/utils/app-paths'
-import { getPageFromPath } from '../../entries'
+import { WEBPACK_LAYERS } from '../../../../lib/constants'
+import { denormalizePagePath } from '../../../../shared/lib/page-path/denormalize-page-path'
+import { ensureLeadingSlash } from '../../../../shared/lib/page-path/ensure-leading-slash'
+import { normalizePathSep } from '../../../../shared/lib/page-path/normalize-path-sep'
+import { HTTP_METHODS } from '../../../../server/web/http'
+import { isDynamicRoute } from '../../../../shared/lib/router/utils'
+import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
+import { getPageFromPath } from '../../../entries'
+import { devPageFiles } from './shared'
 
 const PLUGIN_NAME = 'NextTypesPlugin'
 
@@ -187,8 +188,6 @@ async function collectNamedSlots(layoutPath: string) {
   }
   return slots
 }
-
-export const devPageFiles = new Set<string>()
 
 // By exposing the static route types separately as string literals,
 // editors can provide autocompletion for them. However it's currently not

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/shared.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/shared.ts
@@ -1,0 +1,2 @@
+// TODO: Eliminate this singleton in the future.
+export const devPageFiles = new Set<string>()

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -747,7 +747,10 @@ export default async function loadConfig(
     : Log
 
   await loadEnvConfig(dir, phase === PHASE_DEVELOPMENT_SERVER, curLog)
-  loadWebpackHook()
+
+  if (!process.env.__NEXT_PRIVATE_RENDER_WORKER) {
+    loadWebpackHook()
+  }
 
   let configFileName = 'next.config.js'
 


### PR DESCRIPTION
There's no need to require the HotLoader module as well as Webpack in render workers, as we are not running compilation there. This reduces 10 MB memory in total and some time from `require`ing Webpack.

Before:

<img width="1639" alt="CleanShot 2023-07-05 at 11 33 39@2x" src="https://github.com/vercel/next.js/assets/3676859/48f31051-7a27-4cf6-94aa-1b2ddf313f20">

After:

<img width="1639" alt="CleanShot 2023-07-05 at 12 02 04@2x" src="https://github.com/vercel/next.js/assets/3676859/4c717d75-c0cd-458f-a6c9-6f967ae6df90">
