### PR TITLE
Update eslint-plugin-react-hooks to 5.0.0-canary-7118f5dd7-20230705

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.31.7",
-    "eslint-plugin-react-hooks": "^4.5.0"
+    "eslint-plugin-react-hooks": "5.0.0-canary-7118f5dd7-20230705"
   },
   "peerDependencies": {
     "eslint": "^7.23.0 || ^8.0.0",


### PR DESCRIPTION
5.0.0-canary-7118f5dd7-20230705 includes a new [lint error for hook calls inside an async component](https://github.com/facebook/react/commit/7118f5dd7bf5f1c44d0d2944ef8ad58e423909ad), a common mistake when refactoring Server Components to Client Components, or vice versa.

This updates the dependency in eslint-config-next.