### PR TITLE
Make tests result check more accurate

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -238,4 +238,4 @@ jobs:
     name: thank you, next
     steps:
       - run: exit 1
-        if: ${{ always() && !contains(needs.*.result, 'success') }}
+        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')) }}


### PR DESCRIPTION
This ensures we check all statuses properly as previously only one success was required. 

x-ref: https://github.com/vercel/next.js/pull/52272
x-ref: [slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1688573457803739)