### PR TITLE
chore(docs): remove "Legacy" from Preview Mode

### DIFF
--- a/docs/03-pages/01-building-your-application/06-configuring/14-preview-mode.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/14-preview-mode.mdx
@@ -1,9 +1,9 @@
 ---
-title: Preview Mode (Legacy)
+title: Preview Mode
 description: Next.js has the preview mode for statically generated pages. You can learn how it works here.
 ---
 
-> **Warning**: This feature is **legacy** and is superseded by [Draft Mode](/docs/pages/building-your-application/configuring/draft-mode).
+> **Note**: This feature is superseded by [Draft Mode](/docs/pages/building-your-application/configuring/draft-mode).
 
 <details>
   <summary>Examples</summary>


### PR DESCRIPTION
[Some readers](https://twitter.com/madebymutual/status/1676515579362942976 ) are confused about the docs using the term [Legacy](https://en.wikipedia.org/wiki/Legacy_system) thinking it means [Deprecated](https://en.wikipedia.org/wiki/Deprecation).

Preview Mode only exists in Pages Router so technically both are legacy, but we don't need to call out Preview Mode specifically as legacy since we don't do that for any other Pages Router feature.

This PR removes the term "Legacy" to avoid confusion.