### PR TITLE
test(turbopack): support new env to set --experimental-turbo

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -39,9 +39,10 @@ if (shouldEnableTestTrace) {
     customJestConfig.reporters = ['default']
   }
 
-  const outputDirectory = process.env.TURBOPACK
-    ? '<rootDir>/turbopack-test-junit-report'
-    : '<rootDir>/test-junit-report'
+  const outputDirectory =
+    process.env.TURBOPACK || process.env.__EXPERIMENTAL_TURBO
+      ? '<rootDir>/turbopack-test-junit-report'
+      : '<rootDir>/test-junit-report'
   customJestConfig.reporters.push([
     'jest-junit',
     {

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -211,7 +211,14 @@ const nextDev: CliCommand = async (argv) => {
   // We do not set a default host value here to prevent breaking
   // some set-ups that rely on listening on other interfaces
   const host = args['--hostname']
-  const experimentalTurbo = args['--experimental-turbo']
+
+  if (args['--turbo']) {
+    process.env.TURBOPACK = '1'
+  } else if (args['--experimental-turbo']) {
+    process.env.__EXPERIMENTAL_TURBO = '1'
+  }
+
+  const experimentalTurbo = !!process.env.__EXPERIMENTAL_TURBO
 
   const devServerOptions: StartServerOptions = {
     dir,
@@ -222,10 +229,6 @@ const nextDev: CliCommand = async (argv) => {
     // This is required especially for app dir.
     useWorkers: true,
     isExperimentalTurbo: experimentalTurbo,
-  }
-
-  if (args['--turbo']) {
-    process.env.TURBOPACK = '1'
   }
 
   if (process.env.TURBOPACK) {

--- a/test/development/basic/emotion-swc.test.ts
+++ b/test/development/basic/emotion-swc.test.ts
@@ -8,7 +8,9 @@ describe('emotion SWC option', () => {
   let next: NextInstance
 
   beforeAll(async () => {
-    const useTurbo = !!process.env.TEST_WASM ? false : shouldRunTurboDevTest()
+    const useTurbo = !!process.env.TEST_WASM
+      ? false
+      : shouldRunTurboDevTest().turbo
     next = await createNext({
       files: {
         'jsconfig.json': new FileRef(

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -11,7 +11,7 @@ const mockedGoogleFontResponses = require.resolve(
 
 function getClassNameRegex(className: string): RegExp {
   // Turbopack uses a different format for its css modules than webpack-based Next.js
-  return shouldRunTurboDevTest()
+  return shouldRunTurboDevTest().turbo
     ? new RegExp(`^${className}__.*__.{8}$`) // e.g. `className__inter_c6e282f1__a8cc5613`
     : new RegExp(`^__${className}_.{6}$`) // e.g. `__className_a8cc56`
 }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -33,6 +33,7 @@ export interface NextInstanceOpts {
   env?: Record<string, string>
   dirSuffix?: string
   turbo?: boolean
+  turboExperimental?: boolean
   forcedPort?: string
 }
 

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -24,10 +24,16 @@ export class NextDevInstance extends NextInstance {
 
     const useTurbo = !process.env.TEST_WASM && (this as any).turbo
 
+    const turboArgs = useTurbo
+      ? '--turbo'
+      : (this as any).turboExperimental
+      ? '--experimental-turbo'
+      : undefined
+
     let startArgs = [
       'yarn',
       'next',
-      useTurbo ? '--turbo' : undefined,
+      turboArgs,
       useDirArg && this.testDir,
     ].filter(Boolean) as string[]
 

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -433,12 +433,15 @@ export function launchApp(
   opts?: NextDevOptions
 ) {
   const options = opts ?? {}
-  const useTurbo = shouldRunTurboDevTest()
+  const { turbo: useTurbo, experimental } = shouldRunTurboDevTest()
+  const turboArgs = useTurbo
+    ? '--turbo'
+    : experimental
+    ? '--experimental-turbo'
+    : undefined
 
   return runNextCommandDev(
-    [useTurbo ? '--turbo' : undefined, dir, '-p', port as string].filter(
-      Boolean
-    ),
+    [turboArgs, dir, '-p', port as string].filter(Boolean),
     undefined,
     {
       ...options,
@@ -763,7 +766,7 @@ export async function hasRedbox(browser: BrowserInterface, expected = true) {
 export async function getRedboxHeader(browser: BrowserInterface) {
   return retry(
     () => {
-      if (shouldRunTurboDevTest()) {
+      if (shouldRunTurboDevTest().turbo) {
         return evaluate(browser, () => {
           const portal = [].slice
             .call(document.querySelectorAll('nextjs-portal'))
@@ -1021,7 +1024,8 @@ export function getSnapshotTestDescribe(variant: TestVariants) {
     )
   }
 
-  const shouldRunTurboDev = shouldRunTurboDevTest()
+  const { turbo, experimental } = shouldRunTurboDevTest()
+  const shouldRunTurboDev = turbo || experimental
   const shouldSkip =
     (runningEnv === 'turbo' && !shouldRunTurboDev) ||
     (runningEnv === 'default' && shouldRunTurboDev)

--- a/test/lib/turbo.ts
+++ b/test/lib/turbo.ts
@@ -9,9 +9,15 @@ let loggedTurbopack = false
  * it makes hard to conform with existing lint rules. Instead, starting off from manual fixture setup and
  * update test cases accordingly as turbopack changes enable more test cases.
  */
-export function shouldRunTurboDevTest(): boolean {
+export function shouldRunTurboDevTest(): {
+  turbo: boolean
+  experimental: boolean
+} {
   if (!!process.env.TEST_WASM) {
-    return false
+    return {
+      turbo: false,
+      experimental: false,
+    }
   }
 
   const shouldRunTurboDev = !!process.env.TURBOPACK
@@ -21,6 +27,17 @@ export function shouldRunTurboDevTest(): boolean {
     )
     loggedTurbopack = true
   }
+  const shouldRunExperimental = !!process.env.__EXPERIMENTAL_TURBO
 
-  return shouldRunTurboDev
+  if (shouldRunExperimental && !loggedTurbopack) {
+    require('console').log(
+      `Running tests with experimental turbopack because environment variable is set`
+    )
+    loggedTurbopack = true
+  }
+
+  return {
+    turbo: shouldRunTurboDev,
+    experimental: shouldRunExperimental,
+  }
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change



### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Closes WEB-1267. Same as current `--turbo` setup for the test runner, PR enables an additional path to support new `--experimental-turbo` flag. Mainly, this extends existing `shouldRunTurboDevTest` to return the values of existing env and new env both. Eventually we'll consolidate, or either deprecating one per progress but for now have to keep both.


