### PR TITLE
chore: fix next dev turbopack benchmark

### DIFF
--- a/packages/next-swc/crates/next-dev/benches/bundler.rs
+++ b/packages/next-swc/crates/next-dev/benches/bundler.rs
@@ -69,11 +69,6 @@ impl Bundler for TurboNext {
             return Err(anyhow!("pnpm build failed. See above."));
         }
 
-        fs::write(
-            install_dir.join("next.config.js"),
-            include_bytes!("next.config.js"),
-        )?;
-
         Ok(())
     }
 


### PR DESCRIPTION
This is a follow up to PR https://github.com/vercel/next.js/pull/52291 which removed the `next.config.js` which started causing an error during CI:

```
@next/swc:test-cargo-bench: error: couldn't read packages/next-swc/crates/next-dev/benches/next.config.js: No such file or directory (os error 2)
@next/swc:test-cargo-bench:   --> packages/next-swc/crates/next-dev/benches/bundler.rs:74:13
@next/swc:test-cargo-bench:    |
@next/swc:test-cargo-bench: 74 |             include_bytes!("next.config.js"),
@next/swc:test-cargo-bench:    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@next/swc:test-cargo-bench:    |
@next/swc:test-cargo-bench:    = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@next/swc:test-cargo-bench: 
@next/swc:test-cargo-bench: error: could not compile `next-dev` (bench "mod") due to previous error
@next/swc:test-cargo-bench: warning: build failed, waiting for other jobs to finish...
@next/swc:test-cargo-bench:  ELIFECYCLE  Command failed with exit code 101.
```
https://github.com/vercel/next.js/actions/runs/5476339074/jobs/9973767389#step:27:959