### PR TITLE
Skip ensurePage in render workers

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -1719,7 +1719,8 @@ export default class DevServer extends Server {
     match?: RouteMatch
   }) {
     if (this.isRenderWorker) {
-      await this.invokeIpcMethod('ensurePage', [opts])
+      // There's no need to ensurePage again in the render worker, as the router
+      // worker should have the entry built already.
       return
     }
     return this.hotReloader?.ensurePage(opts)


### PR DESCRIPTION
`ensurePage` doesn't seem to be needed in the render worker. This saves about 30~50 ms.