### PR TITLE
remove `content-encoding` from fetch res headers

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -106,7 +106,6 @@ import { removePathPrefix } from '../shared/lib/router/utils/remove-path-prefix'
 import { addPathPrefix } from '../shared/lib/router/utils/add-path-prefix'
 import { pathHasPrefix } from '../shared/lib/router/utils/path-has-prefix'
 import { invokeRequest } from './lib/server-ipc/invoke-request'
-import { filterReqHeaders } from './lib/server-ipc/utils'
 import { createRequestResponseMocks } from './lib/mock-request'
 import chalk from 'next/dist/compiled/chalk'
 import { NEXT_RSC_UNION_QUERY } from '../client/components/app-router-headers'
@@ -1509,10 +1508,15 @@ export default class NextNodeServer extends BaseServer {
               }
             }
 
-            for (const [key, value] of Object.entries(
-              filterReqHeaders({ ...invokeRes.headers })
-            )) {
-              if (value !== undefined) {
+            for (const [key, value] of Object.entries({
+              ...invokeRes.headers,
+            })) {
+              if (
+                !['transfer-encoding', 'keep-alive', 'connection'].includes(
+                  key
+                ) &&
+                value !== undefined
+              ) {
                 if (key === 'set-cookie') {
                   const curValue = res.getHeader(key)
                   const newValue: string[] = [] as string[]

--- a/test/development/app-dir/content-encoding-res-header/app/api/route.ts
+++ b/test/development/app-dir/content-encoding-res-header/app/api/route.ts
@@ -1,0 +1,20 @@
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  // This test ensures that the `content-encoding` header is removed correctly in the downstream response.
+  // vercel.com supports compression and returns a `content-encoding: br` header
+  // but it's removed in patch-fetch.js to address https://github.com/nodejs/undici/issues/1462
+  const res = await fetch('https://vercel.com/', {
+    headers: {
+      cache: 'no-cache',
+    },
+  })
+
+  return new Response(res.body, {
+    headers: {
+      // the value should always be 'null'
+      'x-original-content-encoding':
+        res.headers.get('content-encoding') ?? 'null',
+    },
+  })
+}

--- a/test/development/app-dir/content-encoding-res-header/app/static/route.ts
+++ b/test/development/app-dir/content-encoding-res-header/app/static/route.ts
@@ -1,0 +1,14 @@
+export async function GET() {
+  // This test ensures that the `content-encoding` header is removed correctly in the downstream response.
+  // vercel.com supports compression and returns a `content-encoding: br` header
+  // but it's removed in patch-fetch.js to address https://github.com/nodejs/undici/issues/1462
+  const res = await fetch('https://vercel.com/')
+
+  return new Response(res.body, {
+    headers: {
+      // the value should always be 'null'
+      'x-original-content-encoding':
+        res.headers.get('content-encoding') ?? 'null',
+    },
+  })
+}

--- a/test/development/app-dir/content-encoding-res-header/content-encoding-res-header.test.ts
+++ b/test/development/app-dir/content-encoding-res-header/content-encoding-res-header.test.ts
@@ -1,0 +1,35 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'content-encoding-res-header',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should not return content-encoding reponse header for decompressed resposne (api)', async () => {
+      const res = await next.fetch('/api', {
+        method: 'GET',
+        headers: {
+          'accept-encoding': 'identity',
+        },
+      })
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('x-original-content-encoding')).toBe('null')
+      expect(res.headers.has('content-encoding')).toBe(false)
+    })
+
+    it('should not return content-encoding reponse header for decompressed resposne (static)', async () => {
+      const res = await next.fetch('/static', {
+        method: 'GET',
+        headers: {
+          'accept-encoding': 'identity',
+        },
+      })
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('x-original-content-encoding')).toBe('null')
+      expect(res.headers.has('content-encoding')).toBe(false)
+    })
+  }
+)

--- a/test/development/app-dir/content-encoding-res-header/next.config.js
+++ b/test/development/app-dir/content-encoding-res-header/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
for internal: https://vercel.slack.com/archives/C0289CGVAR2/p1688570010400989