### PR TITLE
perf: simplify getShortDynamicParamType on app-render

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -56,7 +56,10 @@ import { interopDefault } from './interop-default'
 import { preloadComponent } from './preload-component'
 import { FlightRenderResult } from './flight-render-result'
 import { createErrorHandler } from './create-error-handler'
-import { getShortDynamicParamType } from './get-short-dynamic-param-type'
+import {
+  getShortDynamicParamType,
+  dynamicParamTypes,
+} from './get-short-dynamic-param-type'
 import { getSegmentParam } from './get-segment-param'
 import { getCssInlinedLinkTags } from './get-css-inlined-link-tags'
 import { getPreloadableFonts } from './get-preloadable-fonts'
@@ -324,7 +327,7 @@ export async function renderToHTMLOrFlight(
       if (!value) {
         // Handle case where optional catchall does not have a value, e.g. `/dashboard/[...slug]` when requesting `/dashboard`
         if (segmentParam.type === 'optional-catchall') {
-          const type = getShortDynamicParamType(segmentParam.type)
+          const type = dynamicParamTypes[segmentParam.type]
           return {
             param: key,
             value: null,

--- a/packages/next/src/server/app-render/get-short-dynamic-param-type.tsx
+++ b/packages/next/src/server/app-render/get-short-dynamic-param-type.tsx
@@ -1,19 +1,23 @@
 import { DynamicParamTypes, DynamicParamTypesShort } from './types'
 
+export const dynamicParamTypes: Record<
+  DynamicParamTypes,
+  DynamicParamTypesShort
+> = {
+  catchall: 'c',
+  'optional-catchall': 'oc',
+  dynamic: 'd',
+}
+
 /**
  * Shorten the dynamic param in order to make it smaller when transmitted to the browser.
  */
 export function getShortDynamicParamType(
   type: DynamicParamTypes
 ): DynamicParamTypesShort {
-  switch (type) {
-    case 'catchall':
-      return 'c'
-    case 'optional-catchall':
-      return 'oc'
-    case 'dynamic':
-      return 'd'
-    default:
-      throw new Error('Unknown dynamic param type')
+  const short = dynamicParamTypes[type]
+  if (!short) {
+    throw new Error('Unknown dynamic param type')
   }
+  return short
 }


### PR DESCRIPTION
Removes the unnecessary switch case statement and provide a fast path for `optional-catchall` edge case.