### PR TITLE
chore(ci): update logging for release

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -72,7 +72,7 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
       let mainRef = statsConfig.mainBranch
 
       if (actionInfo.isRelease) {
-        logger(`Release detected, using last stable tag: ${actionInfo.prRef}`)
+        logger(`Release detected, using last stable tag: "${actionInfo.prRef}"`)
         const lastStableTag = await getLastStable(diffRepoDir, actionInfo.prRef)
         mainRef = lastStableTag
         mainNextSwcVersion = lastStableTag

--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -72,12 +72,12 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
       let mainRef = statsConfig.mainBranch
 
       if (actionInfo.isRelease) {
-        logger('Release detected, using last stable tag')
+        logger(`Release detected, using last stable tag: ${actionInfo.prRef}`)
         const lastStableTag = await getLastStable(diffRepoDir, actionInfo.prRef)
         mainRef = lastStableTag
         mainNextSwcVersion = lastStableTag
         if (!lastStableTag) throw new Error('failed to get last stable tag')
-        console.log('using latestStable', lastStableTag)
+        logger(`using latestStable: "${lastStableTag}"`)
 
         /* eslint-disable-next-line */
         actionInfo.lastStableTag = lastStableTag

--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -18,11 +18,16 @@ module.exports = (actionInfo) => {
       const tag = stdout.trim()
 
       if (!tag || !tag.startsWith('v')) {
-        throw new Error(`Failed to get tag info ${stdout}`)
+        throw new Error(`Failed to get tag info "${stdout}"`)
       }
-      const tagParts = tag.split('-canary')[0].split('.')
+      const [major, minor, patch] = tag.split('-canary')[0].split('.')
+      if (!major || !minor || !patch) {
+        throw new Error(
+          `Failed to split tag into major/minor/patch "${stdout}"`
+        )
+      }
       // last stable tag will always be 1 patch less than canary
-      return `${tagParts[0]}.${tagParts[1]}.${Number(tagParts[2]) - 1}`
+      return `${major}.${minor}.${Number(patch) - 1}`
     },
     async getCommitId(repoDir = '') {
       const { stdout } = await exec(`cd ${repoDir} && git rev-parse HEAD`)

--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -18,12 +18,12 @@ module.exports = (actionInfo) => {
       const tag = stdout.trim()
 
       if (!tag || !tag.startsWith('v')) {
-        throw new Error(`Failed to get tag info "${stdout}"`)
+        throw new Error(`Failed to get tag info: "${stdout}"`)
       }
       const [major, minor, patch] = tag.split('-canary')[0].split('.')
       if (!major || !minor || !patch) {
         throw new Error(
-          `Failed to split tag into major/minor/patch "${stdout}"`
+          `Failed to split tag into major/minor/patch: "${stdout}"`
         )
       }
       // last stable tag will always be 1 patch less than canary


### PR DESCRIPTION
```
Error: Command failed: git clone https://github.com/vercel/next.js --single-branch --branch v13.4.NaN --depth=20 /tmp/next-statsmIAdTr/main-repo
Cloning into '/tmp/next-statsmIAdTr/main-repo'...
warning: Could not find remote branch v13.4.NaN to clone.
fatal: Remote branch v13.4.NaN not found in upstream origin
```

https://github.com/vercel/next.js/actions/runs/5480032198/jobs/9982817862#step:7:1658