### PR TITLE
fix: prevent infinite dev refresh on nested parallel routes

### DIFF
--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -98,9 +98,9 @@ export function getEntryKey(
   pageBundleType: 'app' | 'pages' | 'root',
   page: string
 ) {
-  // TODO: handle the /@children slot better
-  // this is a quick hack to handle when children is provided as @children/page instead of /page
-  return `${compilerType}@${pageBundleType}@${page.replace(/\/@children/g, '')}`
+  // TODO: handle the /children slot better
+  // this is a quick hack to handle when children is provided as children/page instead of /page
+  return `${compilerType}@${pageBundleType}@${page.replace(/\/children/g, '')}`
 }
 
 function getPageBundleType(pageBundlePath: string) {

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-nested/home/@parallelB/nested/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-nested/home/@parallelB/nested/page.tsx
@@ -1,0 +1,8 @@
+export default function ParallelPage() {
+  return (
+    <>
+      <p>Hello from nested parallel page!</p>
+      <div id="timestamp">{Date.now()}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-nested/home/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-nested/home/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ parallelB }: { parallelB: React.ReactNode }) {
+  return (
+    <main>
+      <h3>{`(parallelB)`}</h3>
+      <div>{parallelB}</div>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-nested/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-nested/layout.tsx
@@ -1,0 +1,10 @@
+export default function Parallel({ children }) {
+  return (
+    <div>
+      parallel/layout:
+      <div className="parallel" title="children">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -354,6 +354,21 @@ createNextDescribe(
             return newTimestamp !== timestamp ? 'failure' : 'success'
           }, 'success')
         })
+
+        it('should support nested parallel routes', async () => {
+          const browser = await next.browser('parallel-nested/home/nested')
+          const timestamp = await browser.elementByCss('#timestamp').text()
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 3000)
+          })
+
+          await check(async () => {
+            // an invalid response triggers a fast refresh, so if the timestamp doesn't update, this behaved correctly
+            const newTimestamp = await browser.elementByCss('#timestamp').text()
+            return newTimestamp !== timestamp ? 'failure' : 'success'
+          }, 'success')
+        })
       }
     })
 


### PR DESCRIPTION
### What?
HMR causes infinite reloads for parallel routes when the corresponding page component is nested

### Why?
In 4900fa21b078fd1ec1adc5d570fcfb560be8aeb6, code was added to remove `/@children` from the page path (if present) but in 59b36349eb86427ac7b679ac62fa6628c9fc4886, `normalizeParallelKey` removes the @ prefix from children, so this doesn't seem to be catching the scenario it was intended to prevent

### How?
This updates the existing replace logic to consider `/children/page` rather than `/@children/page` -- it doesn't seem like `/@children` is a valid scenario given the `normalizeParallelKey` behavior

Fixes #52342 and addresses the concerns in https://github.com/vercel/next.js/pull/52061#issuecomment-1619145129 
