### PR TITLE
fix: metadatabase warning message

### DIFF
--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -33,7 +33,7 @@ export function getSocialImageFallbackMetadataBase(
 
   if (isMetadataBaseMissing) {
     Log.warnOnce(
-      `\nmetadata.metadataBase is not set for resolving social open graph or twitter images, fallbacks to "${fallbackMetadata.origin}". See https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase`
+      `\nmetadata.metadataBase is not set for resolving social open graph or twitter images, using "${fallbackMetadata.origin}". See https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase`
     )
   }
 

--- a/test/e2e/app-dir/metadata-missing-metadata-base/index.test.ts
+++ b/test/e2e/app-dir/metadata-missing-metadata-base/index.test.ts
@@ -24,7 +24,7 @@ describe('app dir - metadata missing metadataBase', () => {
     await next.start()
     await fetchViaHTTP(next.url, '/')
     expect(next.cliOutput).toInclude(
-      'metadata.metadataBase is not set for resolving social open graph or twitter images, fallbacks to'
+      'metadata.metadataBase is not set for resolving social open graph or twitter images, using'
     )
     expect(next.cliOutput).toInclude(`"http://localhost:${port}`)
     expect(next.cliOutput).toInclude(


### PR DESCRIPTION
This PR is a small grammar change to the warning message since "fallbacks to" is not grammatically correct.