### PR TITLE
Fix typos in examples/with-redux

### DIFF
--- a/examples/with-redux/lib/redux/createAppAsyncThunk.ts
+++ b/examples/with-redux/lib/redux/createAppAsyncThunk.ts
@@ -5,7 +5,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit'
 import type { ReduxState, ReduxDispatch } from './store'
 
 /**
- * ? A utility function to create a typed Async Thnuk Actions.
+ * ? A utility function to create a typed Async Thunk Actions.
  */
 export const createAppAsyncThunk = createAsyncThunk.withTypes<{
   state: ReduxState

--- a/examples/with-redux/lib/redux/store.ts
+++ b/examples/with-redux/lib/redux/store.ts
@@ -15,10 +15,10 @@ import {
 import { reducer } from './rootReducer'
 import { middleware } from './middleware'
 
-const configreStoreDefaultOptions: ConfigureStoreOptions = { reducer }
+const configureStoreDefaultOptions: ConfigureStoreOptions = { reducer }
 
 export const makeReduxStore = (
-  options: ConfigureStoreOptions = configreStoreDefaultOptions
+  options: ConfigureStoreOptions = configureStoreDefaultOptions
 ) => {
   const store = configureStore(options)
 


### PR DESCRIPTION
Two minor typos fixed:

`Thnuk` >> `Thunk`
`configre` >> `configure`
