### PR TITLE
Temporarily revert change to pages render

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -155,7 +155,11 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
           ? `import * as userland500Page from ${stringified500Path}`
           : ''
       }
-      const renderToHTML = undefined
+
+      // TODO: re-enable this once we've refactored to use implicit matches
+      // const renderToHTML = undefined
+
+      import { renderToHTML as pagesRenderToHTML } from 'next/dist/esm/server/render'
       import RouteModule from "next/dist/esm/server/future/route-modules/pages/module"
 
       const pageMod = {

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -159,7 +159,7 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
       // TODO: re-enable this once we've refactored to use implicit matches
       // const renderToHTML = undefined
 
-      import { renderToHTML as pagesRenderToHTML } from 'next/dist/esm/server/render'
+      import { renderToHTML } from 'next/dist/esm/server/render'
       import RouteModule from "next/dist/esm/server/future/route-modules/pages/module"
 
       const pageMod = {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -28,7 +28,7 @@ import {
 } from '../shared/lib/router/utils/route-matcher'
 import type { MiddlewareRouteMatch } from '../shared/lib/router/utils/middleware-route-matcher'
 import type { RouteMatch } from './future/route-matches/route-match'
-import type { RenderOpts } from './render'
+import { renderToHTML, type RenderOpts } from './render'
 
 import fs from 'fs'
 import { join, relative, resolve, sep, isAbsolute } from 'path'
@@ -985,7 +985,16 @@ export default class NextNodeServer extends BaseServer {
       )
     }
 
-    throw new Error('Invariant: render should have used routeModule')
+    // TODO: re-enable this once we've refactored to use implicit matches
+    // throw new Error('Invariant: render should have used routeModule')
+
+    return renderToHTML(
+      req.originalRequest,
+      res.originalResponse,
+      pathname,
+      query,
+      renderOpts
+    )
   }
 
   private streamResponseChunk(res: ServerResponse, chunk: any) {

--- a/test/e2e/custom-app-render/components/page-identifier.jsx
+++ b/test/e2e/custom-app-render/components/page-identifier.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export function PageIdentifier({ page }) {
+  return (
+    <div id="page" data-page={page}>
+      Page: {page}
+    </div>
+  )
+}

--- a/test/e2e/custom-app-render/custom-app-render.test.ts
+++ b/test/e2e/custom-app-render/custom-app-render.test.ts
@@ -1,0 +1,16 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'custom-app-render',
+  {
+    files: __dirname,
+    skipDeployment: true,
+    startCommand: 'node server.js',
+  },
+  ({ next }) => {
+    it.each(['/', '/render'])('should render %s', async (page) => {
+      const $ = await next.render$(page)
+      expect($('#page').data('page')).toBe(page)
+    })
+  }
+)

--- a/test/e2e/custom-app-render/pages/_app.jsx
+++ b/test/e2e/custom-app-render/pages/_app.jsx
@@ -1,0 +1,7 @@
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}
+
+App.getInitialProps = async () => {
+  return {}
+}

--- a/test/e2e/custom-app-render/pages/index.jsx
+++ b/test/e2e/custom-app-render/pages/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+import { PageIdentifier } from '../components/page-identifier'
+
+export default function IndexPage() {
+  return <PageIdentifier page="/" />
+}

--- a/test/e2e/custom-app-render/pages/render.jsx
+++ b/test/e2e/custom-app-render/pages/render.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+import { PageIdentifier } from '../components/page-identifier'
+
+export default function RenderNodePage() {
+  return <PageIdentifier page="/render" />
+}

--- a/test/e2e/custom-app-render/server.js
+++ b/test/e2e/custom-app-render/server.js
@@ -1,0 +1,49 @@
+const http = require('http')
+const { parse } = require('url')
+const next = require('next')
+
+async function main() {
+  const dev = global.isNextDev || false
+  process.env.NODE_ENV = dev ? 'development' : 'production'
+
+  const port = parseInt(process.env.PORT, 10) || 3000
+
+  const app = next({ dev, port })
+  const handle = app.getRequestHandler()
+
+  await app.prepare()
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const parsedUrl = parse(req.url, true)
+      const { pathname, query } = parsedUrl
+
+      if (pathname.startsWith('/render')) {
+        await app.render(req, res, pathname, query)
+      } else {
+        await handle(req, res, parsedUrl)
+      }
+    } catch (err) {
+      res.statusCode = 500
+      res.end('Internal Server Error')
+    }
+  })
+
+  server.once('error', (err) => {
+    console.error(err)
+    process.exit(1)
+  })
+
+  server.listen(port, () => {
+    console.log(
+      `> started server on url: http://localhost:${port} as ${
+        dev ? 'development' : process.env.NODE_ENV
+      }`
+    )
+  })
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/test/e2e/custom-app-render/server.js
+++ b/test/e2e/custom-app-render/server.js
@@ -3,7 +3,7 @@ const { parse } = require('url')
 const next = require('next')
 
 async function main() {
-  const dev = global.isNextDev || false
+  const dev = process.env.NEXT_TEST_MODE === 'dev'
   process.env.NODE_ENV = dev ? 'development' : 'production'
 
   const port = parseInt(process.env.PORT, 10) || 3000


### PR DESCRIPTION
This reverts the change to the pages render until a more substantial refactor can ensure that using the custom `app.render` method will attach a match to the request metadata.

- Fixes #52384