### PR TITLE
[turbopack]: Remove skipped integration tests

### DIFF
--- a/packages/next-swc/crates/next-dev-tests/tests/integration.rs
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration.rs
@@ -115,7 +115,7 @@ fn run_async_test<'a, T>(future: impl Future<Output = T> + Send + 'a) -> T {
 #[testing::fixture("tests/integration/*/*/*/input")]
 fn test(resource: PathBuf) {
     let resource = resource.parent().unwrap().to_path_buf();
-    if resource.ends_with("__skipped__") || resource.ends_with("__flakey__") {
+    if resource.ends_with("__flakey__") {
         // "Skip" directories named `__skipped__`, which include test directories to
         // skip. These tests are not considered truly skipped by `cargo test`, but they
         // are not run.
@@ -162,29 +162,6 @@ fn test(resource: PathBuf) {
             messages.join("\n\n--\n")
         )
     };
-}
-
-#[testing::fixture("tests/integration/*/*/__skipped__/*/input")]
-#[should_panic]
-fn test_skipped_fails(resource: PathBuf) {
-    let resource = resource.parent().unwrap().to_path_buf();
-    let JsResult {
-        // Ignore uncaught exceptions for skipped tests.
-        uncaught_exceptions: _,
-        run_result,
-    } = run_async_test(run_test(resource));
-
-    // Assert that this skipped test itself has at least one browser test which
-    // fails.
-    assert!(
-        // Skipped tests sometimes have errors (e.g. unsupported syntax) that prevent tests from
-        // running at all. Allow them to have empty results.
-        run_result.test_results.is_empty()
-            || run_result
-                .test_results
-                .into_iter()
-                .any(|r| !r.errors.is_empty()),
-    );
 }
 
 fn copy_recursive(from: &Path, to: &Path) -> std::io::Result<()> {


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/52413 removed all of our skipped tests, and the test suite that runs them will panic if none are found as a safety feature.