### PR TITLE
fixed error #52486  fetchUsers to fetchUser

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/not-found.mdx
+++ b/docs/02-app/02-api-reference/04-functions/not-found.mdx
@@ -12,7 +12,7 @@ Invoking the `notFound()` function throws a `NEXT_NOT_FOUND` error and terminate
 ```jsx filename="app/user/[id]/page.js"
 import { notFound } from 'next/navigation'
 
-async function fetchUsers(id) {
+async function fetchUser(id) {
   const res = await fetch('https://...')
   if (!res.ok) return undefined
   return res.json()


### PR DESCRIPTION
#52486 

Here I fixed the typo error of fetchUsers to fetchUser in   docs/api-reference/04-functions/not-found.mdx

async function fetchUser(id) { // Here instead of fetchUsers i changed it to  fetchUser
const res = await fetch('https://...')
if (!res.ok) return undefined
return res.json()
}

export default async function Profile({ params }) {
const user = await fetchUser(params.id)

if (!user) {
notFound()
}

// ...
}

https://nextjs.org/docs/app/api-reference/functions/not-found