### PR TITLE
Fix tracking of client reference manifest

### DIFF
--- a/packages/next/src/build/webpack/plugins/app-build-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/app-build-manifest-plugin.ts
@@ -1,7 +1,6 @@
 import { webpack, sources } from 'next/dist/compiled/webpack/webpack'
 import {
   APP_BUILD_MANIFEST,
-  CLIENT_REFERENCE_MANIFEST,
   CLIENT_STATIC_FILES_RUNTIME_MAIN_APP,
   SYSTEM_ENTRYPOINTS,
 } from '../../../shared/lib/constants'
@@ -77,22 +76,7 @@ export class AppBuildManifestPlugin {
       }
 
       const filesForPage = getEntrypointFiles(entrypoint)
-      const manifestsForPage =
-        pagePath.endsWith('/page') ||
-        pagePath === '/not-found' ||
-        pagePath === '/_not-found'
-          ? [
-              'server/app' +
-                pagePath.replace(/%5F/g, '_') +
-                '_' +
-                CLIENT_REFERENCE_MANIFEST +
-                '.js',
-            ]
-          : []
-
-      manifest.pages[pagePath] = [
-        ...new Set([...mainFiles, ...manifestsForPage, ...filesForPage]),
-      ]
+      manifest.pages[pagePath] = [...new Set([...mainFiles, ...filesForPage])]
     }
 
     const json = JSON.stringify(manifest, null, 2)

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -6,7 +6,10 @@ import {
   nodeFileTrace,
   NodeFileTraceReasons,
 } from 'next/dist/compiled/@vercel/nft'
-import { TRACE_OUTPUT_VERSION } from '../../../shared/lib/constants'
+import {
+  CLIENT_REFERENCE_MANIFEST,
+  TRACE_OUTPUT_VERSION,
+} from '../../../shared/lib/constants'
 import { webpack, sources } from 'next/dist/compiled/webpack/webpack'
 import {
   NODE_ESM_RESOLVE_OPTIONS,
@@ -284,6 +287,27 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
         })
         // don't include the entry itself in the trace
         entryFiles.delete(nodePath.join(outputPath, `../${entrypoint.name}.js`))
+
+        if (entrypoint.name.startsWith('app/')) {
+          // include the client reference manifest
+          const clientManifestsForPage =
+            entrypoint.name.endsWith('/page') ||
+            entrypoint.name === '/not-found' ||
+            entrypoint.name === '/_not-found'
+              ? nodePath.join(
+                  outputPath,
+                  '..',
+                  entrypoint.name.replace(/%5F/g, '_') +
+                    '_' +
+                    CLIENT_REFERENCE_MANIFEST +
+                    '.js'
+                )
+              : null
+
+          if (clientManifestsForPage !== null) {
+            entryFiles.add(clientManifestsForPage)
+          }
+        }
 
         const finalFiles: string[] = []
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -293,7 +293,6 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }): Promise<FindComponentsResult | null>
   protected abstract getFontManifest(): FontManifest | undefined
   protected abstract getPrerenderManifest(): PrerenderManifest
-  // protected abstract getServerComponentManifest(): any
   protected abstract getNextFontManifest(): NextFontManifest | undefined
   protected abstract attachRequestMeta(
     req: BaseNextRequest,

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -564,16 +564,6 @@ createNextDescribe(
         })
         await Promise.all(promises)
       })
-
-      it('should generate client reference manifest for edge SSR pages', async () => {
-        const buildManifest = JSON.parse(
-          await next.readFile('.next/app-build-manifest.json')
-        )
-
-        expect(buildManifest.pages['/edge/dynamic/page']).toInclude(
-          'server/app/edge/dynamic/page_client-reference-manifest.js'
-        )
-      })
     }
   }
 )


### PR DESCRIPTION
The problem was introduced in #52450, that the client reference manifest isn't being tracked and included in the function.

Verified that this fixes the issue.