### PR TITLE
Remove react-bootstrap from default modularizeImports

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -687,9 +687,11 @@ function assignDefaults(
     ramda: {
       transform: 'ramda/es/{{member}}',
     },
-    'react-bootstrap': {
-      transform: 'react-bootstrap/{{member}}',
-    },
+    // This will cause an error when import any hooks.
+    // Related issue: https://github.com/vercel/next.js/issues/52518
+    // 'react-bootstrap': {
+    //   transform: 'react-bootstrap/{{member}}',
+    // },
     antd: {
       transform: 'antd/lib/{{kebabCase member}}',
     },


### PR DESCRIPTION
### Fixing a bug

Fixes #52518


### What?
Error when import hooks from `react-bootstrap` 
`Module not found: Can't resolve 'react-bootstrap/useAccordionButton'`
![image](https://github.com/vercel/next.js/assets/14261588/69e23242-accd-4e13-b9fb-0b4aa67dcb39)

### Why?
After https://github.com/vercel/next.js/pull/50900 added default modularize imports config,
so we are unable to import any hooks (like `useAccordionButton`) from `react-bootstrap`,


### How?
Just remove `react-bootstrap` from default modularize imports config 


