### PR TITLE
fix(eslint-config-next): add missing peer dependency `next`

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -22,6 +22,7 @@
   },
   "peerDependencies": {
     "eslint": "^7.23.0 || ^8.0.0",
+    "next": "*",
     "typescript": ">=3.3.1"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
`eslint-config-next` tries to require from `next` but doesn't declare it as a dependency.
https://github.com/vercel/next.js/blob/b98469c86b74b06b55fc4c59bcf87d034e1919f1/packages/eslint-config-next/parser.js#L4

This PR fixes that by declaring `next` as a peer dependency of `eslint-config-next`.