### PR TITLE
Update id handling for fonts

### DIFF
--- a/packages/next/src/pages/_document.tsx
+++ b/packages/next/src/pages/_document.tsx
@@ -354,8 +354,7 @@ function getAmpPath(ampPath: string, asPath: string): string {
 function getNextFontLinkTags(
   nextFontManifest: NextFontManifest | undefined,
   dangerousAsPath: string,
-  assetPrefix: string = '',
-  assetQueryString: string = ''
+  assetPrefix: string = ''
 ) {
   if (!nextFontManifest) {
     return {
@@ -378,11 +377,6 @@ function getNextFontLinkTags(
     (appFontsEntry || pageFontsEntry)
   )
 
-  // we only add if the dpl query is present for fonts
-  if (!assetQueryString.includes('dpl=')) {
-    assetQueryString = ''
-  }
-
   return {
     preconnect: preconnectToSelf ? (
       <link
@@ -401,9 +395,7 @@ function getNextFontLinkTags(
             <link
               key={fontFile}
               rel="preload"
-              href={`${assetPrefix}/_next/${encodeURI(
-                fontFile
-              )}${assetQueryString}`}
+              href={`${assetPrefix}/_next/${encodeURI(fontFile)}`}
               as="font"
               type={`font/${ext}`}
               crossOrigin="anonymous"
@@ -800,8 +792,7 @@ export class Head extends React.Component<HeadProps> {
     const nextFontLinkTags = getNextFontLinkTags(
       nextFontManifest,
       dangerousAsPath,
-      assetPrefix,
-      this.context.assetQueryString
+      assetPrefix
     )
 
     return (

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -466,9 +466,7 @@ export async function renderToHTMLOrFlight(
             const fontFilename = preloadedFontFiles[i]
             const ext = /\.(woff|woff2|eot|ttf|otf)$/.exec(fontFilename)![1]
             const type = `font/${ext}`
-            const href = `${assetPrefix}/_next/${fontFilename}${getAssetQueryString(
-              false
-            )}`
+            const href = `${assetPrefix}/_next/${fontFilename}`
             ComponentMod.preloadFont(href, type)
           }
         } else {

--- a/test/production/deployment-id-handling/deployment-id-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-handling.test.ts
@@ -39,7 +39,11 @@ createNextDescribe(
 
         for (const link of links) {
           if (link.attribs.href) {
-            expect(link.attribs.href).toContain('dpl=' + deploymentId)
+            if (link.attribs.as === 'font') {
+              expect(link.attribs.href).not.toContain('dpl=' + deploymentId)
+            } else {
+              expect(link.attribs.href).toContain('dpl=' + deploymentId)
+            }
           }
         }
 


### PR DESCRIPTION
We don't need to apply the ID here as these assets should always be available across deploys. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1689035592272659)