### PR TITLE
fix(output): do not slice pathname unless ends with `.txt`

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -73,22 +73,20 @@ export function getServerActionDispatcher() {
 }
 
 export function urlToUrlWithoutFlightMarker(url: string): URL {
-  const urlWithoutFlightParameters = new URL(url, location.origin)
-  urlWithoutFlightParameters.searchParams.delete(NEXT_RSC_UNION_QUERY)
+  const urlWithoutFlightParams = new URL(url, location.origin)
+  urlWithoutFlightParams.searchParams.delete(NEXT_RSC_UNION_QUERY)
   if (process.env.NODE_ENV === 'production') {
-    if (process.env.__NEXT_CONFIG_OUTPUT === 'export') {
-      if (urlWithoutFlightParameters.pathname.endsWith('/index.txt')) {
-        // Slice off `/index.txt` from the end of the pathname
-        urlWithoutFlightParameters.pathname =
-          urlWithoutFlightParameters.pathname.slice(0, -`/index.txt`.length)
-      } else {
-        // Slice off `.txt` from the end of the pathname
-        urlWithoutFlightParameters.pathname =
-          urlWithoutFlightParameters.pathname.slice(0, -`.txt`.length)
-      }
+    if (
+      process.env.__NEXT_CONFIG_OUTPUT === 'export' &&
+      urlWithoutFlightParams.pathname.endsWith('.txt')
+    ) {
+      // Slice off `/index.txt` or `.txt` from the end of the pathname
+      const { pathname } = urlWithoutFlightParams
+      const length = pathname.endsWith('/index.txt') ? 10 : 4
+      urlWithoutFlightParams.pathname = pathname.slice(0, -length)
     }
   }
-  return urlWithoutFlightParameters
+  return urlWithoutFlightParams
 }
 
 const HotReloader:

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -73,20 +73,20 @@ export function getServerActionDispatcher() {
 }
 
 export function urlToUrlWithoutFlightMarker(url: string): URL {
-  const urlWithoutFlightParams = new URL(url, location.origin)
-  urlWithoutFlightParams.searchParams.delete(NEXT_RSC_UNION_QUERY)
+  const urlWithoutFlightParameters = new URL(url, location.origin)
+  urlWithoutFlightParameters.searchParams.delete(NEXT_RSC_UNION_QUERY)
   if (process.env.NODE_ENV === 'production') {
     if (
       process.env.__NEXT_CONFIG_OUTPUT === 'export' &&
-      urlWithoutFlightParams.pathname.endsWith('.txt')
+      urlWithoutFlightParameters.pathname.endsWith('.txt')
     ) {
       // Slice off `/index.txt` or `.txt` from the end of the pathname
-      const { pathname } = urlWithoutFlightParams
+      const { pathname } = urlWithoutFlightParameters
       const length = pathname.endsWith('/index.txt') ? 10 : 4
-      urlWithoutFlightParams.pathname = pathname.slice(0, -length)
+      urlWithoutFlightParameters.pathname = pathname.slice(0, -length)
     }
   }
-  return urlWithoutFlightParams
+  return urlWithoutFlightParameters
 }
 
 const HotReloader:

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -80,9 +80,9 @@ export function urlToUrlWithoutFlightMarker(url: string): URL {
       process.env.__NEXT_CONFIG_OUTPUT === 'export' &&
       urlWithoutFlightParameters.pathname.endsWith('.txt')
     ) {
-      // Slice off `/index.txt` or `.txt` from the end of the pathname
       const { pathname } = urlWithoutFlightParameters
       const length = pathname.endsWith('/index.txt') ? 10 : 4
+      // Slice off `/index.txt` or `.txt` from the end of the pathname
       urlWithoutFlightParameters.pathname = pathname.slice(0, -length)
     }
   }


### PR DESCRIPTION
### What?

When using `output: "export"`, all URL pathnames are sliced.

### Why?

A regression was introduced at https://github.com/vercel/next.js/pull/50974/files#diff-7b6239af735eba0c401e1a0db1a04dd4575c19a031934f02d128cf3ac813757bR76-R80

### How?

Check if a pathname ends with `.txt` before slicing the end.

Fixes #52381