### PR TITLE
Fix bundle path normalization for /index routes

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -16,6 +16,7 @@ import { getProxiedPluginState } from '../../build-context'
 
 import { nonNullable } from '../../../lib/non-nullable'
 import { WEBPACK_LAYERS } from '../../../lib/constants'
+import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
 
 interface Options {
   dev: boolean
@@ -394,12 +395,18 @@ export class ClientReferenceManifestPlugin {
         const json = JSON.stringify(mergedManifest)
 
         const pagePath = groupName.replace(/%5F/g, '_')
-        assets['server/' + pagePath + '_' + CLIENT_REFERENCE_MANIFEST + '.js'] =
-          new sources.RawSource(
-            `globalThis.__RSC_MANIFEST=(globalThis.__RSC_MANIFEST||{});globalThis.__RSC_MANIFEST[${JSON.stringify(
-              pagePath.slice('app'.length)
-            )}]=${JSON.stringify(json)}`
-          ) as unknown as webpack.sources.RawSource
+        const pageBundlePath = normalizePagePath(pagePath.slice('app'.length))
+        assets[
+          'server/app' +
+            pageBundlePath +
+            '_' +
+            CLIENT_REFERENCE_MANIFEST +
+            '.js'
+        ] = new sources.RawSource(
+          `globalThis.__RSC_MANIFEST=(globalThis.__RSC_MANIFEST||{});globalThis.__RSC_MANIFEST[${JSON.stringify(
+            pagePath.slice('app'.length)
+          )}]=${JSON.stringify(json)}`
+        ) as unknown as webpack.sources.RawSource
 
         if (pagePath === 'app/not-found') {
           // Create a separate special manifest for the root not-found page.

--- a/packages/next/src/server/future/normalizers/built/app/app-bundle-path-normalizer.ts
+++ b/packages/next/src/server/future/normalizers/built/app/app-bundle-path-normalizer.ts
@@ -1,6 +1,7 @@
 import { Normalizers } from '../../normalizers'
 import { Normalizer } from '../../normalizer'
 import { PrefixingNormalizer } from '../../prefixing-normalizer'
+import { normalizePagePath } from '../../../../../shared/lib/page-path/normalize-page-path'
 
 export class AppBundlePathNormalizer extends PrefixingNormalizer {
   constructor() {
@@ -8,7 +9,7 @@ export class AppBundlePathNormalizer extends PrefixingNormalizer {
   }
 
   public normalize(page: string): string {
-    return super.normalize(page)
+    return super.normalize(normalizePagePath(page))
   }
 }
 

--- a/test/e2e/app-dir/app-edge/app-edge.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge.test.ts
@@ -21,6 +21,11 @@ createNextDescribe(
       expect(await res.text()).toInclude('Hello')
     })
 
+    it('should handle /index routes correctly', async () => {
+      const appHtml = await next.render('/index')
+      expect(appHtml).toContain('the /index route')
+    })
+
     if ((globalThis as any).isNextDev) {
       it('should resolve module without error in edge runtime', async () => {
         const logs = []

--- a/test/e2e/app-dir/app-edge/app/index/page.js
+++ b/test/e2e/app-dir/app-edge/app/index/page.js
@@ -1,0 +1,5 @@
+export default function Page() {
+  return <p>the /index route</p>
+}
+
+export const runtime = 'edge'


### PR DESCRIPTION
We have some special bundle path handling logic for `/index` routes in `normalizePagePath`, which is missing in the new `AppBundlePathNormalizer`. This already broke `/index/page.js` in dev in the past, and now become noticeable in prod as well because of the manifest change.

https://github.com/vercel/next.js/blob/b98469c86b74b06b55fc4c59bcf87d034e1919f1/packages/next/src/shared/lib/page-path/normalize-page-path.ts#L5-L14