### PR TITLE
Clean up promises after resolving

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1014,14 +1014,20 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     this.renderOpts.assetPrefix = prefix ? prefix.replace(/\/$/, '') : ''
   }
 
+  protected prepared: boolean = false
   protected preparedPromise: Promise<void> | null = null
   /**
    * Runs async initialization of server.
    * It is idempotent, won't fire underlying initialization more than once.
    */
   public async prepare(): Promise<void> {
+    if (this.prepared) return
+
     if (this.preparedPromise === null) {
-      this.preparedPromise = this.prepareImpl()
+      this.preparedPromise = this.prepareImpl().then(() => {
+        this.prepared = true
+        this.preparedPromise = null
+      })
     }
     return this.preparedPromise
   }

--- a/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.ts
+++ b/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.ts
@@ -35,8 +35,11 @@ export class DefaultRouteMatcherManager implements RouteMatcherManager {
   }
 
   private waitTillReadyPromise?: Promise<void>
-  public waitTillReady(): Promise<void> {
-    return this.waitTillReadyPromise ?? Promise.resolve()
+  public async waitTillReady(): Promise<void> {
+    if (this.waitTillReadyPromise) {
+      await this.waitTillReadyPromise
+      delete this.waitTillReadyPromise
+    }
   }
 
   private previousMatchers: ReadonlyArray<RouteMatcher> = []


### PR DESCRIPTION
Long-hanging promises are retaining the closure context where it's being `await`'ed even it's resolved already. You can tell it from this screenshot:

<img width="1822" alt="CleanShot 2023-07-13 at 18 09 11@2x" src="https://github.com/vercel/next.js/assets/3676859/1d6210b0-16ba-440e-a8b6-c8c4343f4850">

In some cases, the entire `req` object is retained because of that. This increases the memory usage a bit.

So this PR changes these promises to be cleaned up after they got resolved.