### PR TITLE
[WIP]: fix: Update cache handling to not cache POST methods in server actions environments

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -211,12 +211,8 @@ export function patchFetch({
           getRequestMeta('method')?.toLowerCase() || 'get'
         )
 
-        // if there are authorized headers or a POST method and
-        // dynamic data usage was present above the tree we bail
-        // e.g. if cookies() is used before an authed/POST fetch
-        const autoNoCache =
-          (hasUnCacheableHeader || isUnCacheableMethod) &&
-          staticGenerationStore.revalidate === 0
+        // if there are authorized headers or a POST method we bail
+        const autoNoCache = hasUnCacheableHeader || isUnCacheableMethod
 
         if (isForceNoStore) {
           revalidate = 0

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -207,7 +207,7 @@ export function patchFetch({
         const hasUnCacheableHeader =
           initHeaders.get('authorization') || initHeaders.get('cookie')
 
-        const isUnCacheableMethod = !['get', 'head'].includes(
+        const isUnCacheableMethod = !['get', 'head', 'post'].includes(
           getRequestMeta('method')?.toLowerCase() || 'get'
         )
 

--- a/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/app/[method]/page.tsx
+++ b/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/app/[method]/page.tsx
@@ -1,0 +1,39 @@
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: {
+    method: string
+  }
+  searchParams?: {
+    auth?: string
+    forceCache?: string
+  }
+}) {
+  const { method } = params
+  const headers = new Headers()
+  let cache: RequestCache | undefined = undefined
+
+  if (searchParams?.auth === 'true') {
+    headers.set('authorization', 'Bearer token')
+  }
+
+  if (searchParams?.forceCache === 'true') {
+    cache = 'force-cache'
+  }
+
+  const result = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      headers,
+      method,
+      cache,
+    }
+  ).then((r) => r.text())
+
+  return (
+    <>
+      <span id="result">{result}</span>
+    </>
+  )
+}

--- a/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/app/[method]/page.tsx
+++ b/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/app/[method]/page.tsx
@@ -7,19 +7,13 @@ export default async function Page({
   }
   searchParams?: {
     auth?: string
-    forceCache?: string
   }
 }) {
   const { method } = params
   const headers = new Headers()
-  let cache: RequestCache | undefined = undefined
 
   if (searchParams?.auth === 'true') {
     headers.set('authorization', 'Bearer token')
-  }
-
-  if (searchParams?.forceCache === 'true') {
-    cache = 'force-cache'
   }
 
   const result = await fetch(
@@ -27,7 +21,6 @@ export default async function Page({
     {
       headers,
       method,
-      cache,
     }
   ).then((r) => r.text())
 

--- a/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/app/layout.tsx
+++ b/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/fetch-uncacheable-methods-and-headers.test.ts
+++ b/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/fetch-uncacheable-methods-and-headers.test.ts
@@ -1,0 +1,86 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'Do not cache uncacheable fetch methods and headers',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should cache GET methods', async () => {
+      const firstRun = await next
+        .render$('/GET')
+        .then(($) => $('#result').text())
+      const secondRun = await next
+        .render$('/GET')
+        .then(($) => $('#result').text())
+
+      expect(firstRun).toBe(secondRun)
+    })
+
+    it('should cache POST methods with force-cache', async () => {
+      const firstRun = await next
+        .render$('/POST?forceCache=true')
+        .then(($) => $('#result').text())
+      const secondRun = await next
+        .render$('/POST?forceCache=true')
+        .then(($) => $('#result').text())
+
+      expect(firstRun).toBe(secondRun)
+    })
+
+    it('should not cache POST methods without authorization header', async () => {
+      const firstRun = await next
+        .render$('/POST')
+        .then(($) => $('#result').text())
+      const secondRun = await next
+        .render$('/POST')
+        .then(($) => $('#result').text())
+
+      expect(firstRun).not.toBe(secondRun)
+    })
+
+    it('should not cache POST methods with authorization header', async () => {
+      const firstRun = await next
+        .render$('/POST?auth=true')
+        .then(($) => $('#result').text())
+      const secondRun = await next
+        .render$('/POST?auth=true')
+        .then(($) => $('#result').text())
+
+      expect(firstRun).not.toBe(secondRun)
+    })
+
+    it('should not cache GET methods with an authorization header', async () => {
+      const firstRun = await next
+        .render$('/GET?auth=true')
+        .then(($) => $('#result').text())
+      const secondRun = await next
+        .render$('/GET?auth=true')
+        .then(($) => $('#result').text())
+
+      expect(firstRun).not.toBe(secondRun)
+    })
+
+    it('should not cache PUT methods', async () => {
+      const firstRun = await next
+        .render$('/PUT')
+        .then(($) => $('#result').text())
+      const secondRun = await next
+        .render$('/PUT')
+        .then(($) => $('#result').text())
+
+      expect(firstRun).not.toBe(secondRun)
+    })
+
+    it('should not cache DELETE methods', async () => {
+      const firstRun = await next
+        .render$('/DELETE')
+        .then(($) => $('#result').text())
+      const secondRun = await next
+        .render$('/DELETE')
+        .then(($) => $('#result').text())
+
+      expect(firstRun).not.toBe(secondRun)
+    })
+  }
+)

--- a/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/fetch-uncacheable-methods-and-headers.test.ts
+++ b/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/fetch-uncacheable-methods-and-headers.test.ts
@@ -17,26 +17,15 @@ createNextDescribe(
       expect(firstRun).toBe(secondRun)
     })
 
-    it('should cache POST methods with force-cache', async () => {
+    it('should cache POST methods', async () => {
       const firstRun = await next
-        .render$('/POST?forceCache=true')
+        .render$('/POST')
         .then(($) => $('#result').text())
       const secondRun = await next
-        .render$('/POST?forceCache=true')
+        .render$('/POST')
         .then(($) => $('#result').text())
 
       expect(firstRun).toBe(secondRun)
-    })
-
-    it('should not cache POST methods without authorization header', async () => {
-      const firstRun = await next
-        .render$('/POST')
-        .then(($) => $('#result').text())
-      const secondRun = await next
-        .render$('/POST')
-        .then(($) => $('#result').text())
-
-      expect(firstRun).not.toBe(secondRun)
     })
 
     it('should not cache POST methods with authorization header', async () => {

--- a/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/next.config.js
+++ b/test/e2e/app-dir/fetch-uncacheable-methods-and-headers/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What?
This PR fixes the issue of next caching `POST` requests by default when request are made with `Authorization` or `Cookie` header, it also make sure to not skip the cache for other methods such as `PUT` or `DELETE` which should not be cached and mark default `POST` requests (without authorization headers) to be cached.
 
### Why?

This solves some difficult to spot bugs in wrapper librairies used for data fetching (ex: `appolo`) and database librairies (ex:  [`@libsql/client`](https://github.com/libsql/libsql-client-ts), [`database-js` from planetscale](https://github.com/planetscale/database-js) ) which use `POST` requests by default but with an `Authorization` header for requests. 

This can be fixed on the library end by adding a `cache: no-store` method to fetch, but this is not implemented by vendors such as `cloudfare` (wich is a big IMHO).

I myself stumbled on this issue in my application where a request to create a new record in the database was cached resulting in no entry created, and a request to update a record in the database would not update the entry in the  database because it was be cached.

this PR is in stark contradiction with a previous one : #46856 where it caches all fetches by default unless there is a call to a dynamic function (i.e `headers()` or `cookies()`). I am open to discussion as i have not the context of the slack discussion referenced in that PR. 

I think this is a better heuristic as when using database librairies we tipically expect each call to make a network request or a database request and if the user wants to cache the request, they can manually decide to cache the request using `unstable_cache` or adding a `cache: no-store` option to fetch. using dynamic functions should not be required as they are not needed when doing so, and feels more like an escape hatch.

### How?

I have removed the check for `staticGenerationStore.revalidate === 0` that verify that a dynamic method was called before the fetch and added `POST` to cacheable methods.

fixes #52405


