### PR TITLE
Avoid verifying TS setup in render workers

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -882,7 +882,10 @@ export default class DevServer extends Server {
     setGlobal('distDir', this.distDir)
     setGlobal('phase', PHASE_DEVELOPMENT_SERVER)
 
-    await this.verifyTypeScript()
+    if (!this.isRenderWorker) {
+      await this.verifyTypeScript()
+    }
+
     this.customRoutes = await loadCustomRoutes(this.nextConfig)
 
     // reload router

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -641,7 +641,11 @@ export default class DevServer extends Server {
           }
         }
 
-        if (!this.usingTypeScript && enabledTypeScript) {
+        if (
+          !this.usingTypeScript &&
+          enabledTypeScript &&
+          !this.isRenderWorker
+        ) {
           // we tolerate the error here as this is best effort
           // and the manual install command will be shown
           await this.verifyTypeScript()


### PR DESCRIPTION
The router worker already verified TS setup, and there's no need to do it again in the other processes.

This saves ~110 ms dev startup time and 16.7 MB memory (59.9 MB → 43.2 MB) for the render worker when the project is using TS.