### PR TITLE
Support metadata exports for server components not-found

### DIFF
--- a/packages/next/src/client/on-recoverable-error.ts
+++ b/packages/next/src/client/on-recoverable-error.ts
@@ -14,5 +14,7 @@ export default function onRecoverableError(err: any) {
 
   // Skip certain custom errors which are not expected to be reported on client
   if (err.digest === NEXT_DYNAMIC_NO_SSR_CODE) return
+
+  console.log('err', err)
   defaultOnRecoverableError(err)
 }

--- a/packages/next/src/client/on-recoverable-error.ts
+++ b/packages/next/src/client/on-recoverable-error.ts
@@ -15,6 +15,5 @@ export default function onRecoverableError(err: any) {
   // Skip certain custom errors which are not expected to be reported on client
   if (err.digest === NEXT_DYNAMIC_NO_SSR_CODE) return
 
-  console.log('err', err)
   defaultOnRecoverableError(err)
 }

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -35,7 +35,7 @@ export async function MetadataTree({
   searchParams: { [key: string]: any }
   getDynamicParamFromSegment: GetDynamicParamFromSegment
   appUsingSizeAdjust: boolean
-  errorType?: 'not-found'
+  errorType?: 'not-found' | 'redirect'
 }) {
   const metadataContext = {
     pathname,
@@ -47,20 +47,16 @@ export async function MetadataTree({
     metadataItems: [],
     searchParams,
     getDynamicParamFromSegment,
-    errorType,
+    errorConvention: errorType === 'redirect' ? undefined : errorType,
   })
   let metadata: ResolvedMetadata | undefined = undefined
-  try {
+
+  const defaultMetadata = createDefaultMetadata()
+  // Skip for redirect case as for the temporary redirect case we don't need the metadata on client
+  if (errorType === 'redirect') {
+    metadata = defaultMetadata
+  } else {
     metadata = await accumulateMetadata(resolvedMetadata, metadataContext)
-  } catch (err) {
-    // If there's error thrown from metadata resolving for error convention,
-    // hide the error and use default metadata instead.
-    // Otherwise if it's resolving metadata for normal page, throw the error.
-    if (errorType) {
-      metadata = createDefaultMetadata()
-    } else {
-      throw err
-    }
   }
 
   const elements = MetaFilter([

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -26,21 +26,18 @@ export async function MetadataTree({
   searchParams,
   getDynamicParamFromSegment,
   appUsingSizeAdjust,
-  statusCode = 200,
+  errorType,
 }: {
   tree: LoaderTree
   pathname: string
   searchParams: { [key: string]: any }
   getDynamicParamFromSegment: GetDynamicParamFromSegment
   appUsingSizeAdjust: boolean
-  statusCode?: number
+  errorType?: 'not-found' | 'error'
 }) {
   const metadataContext = {
     pathname,
   }
-
-  const errorType =
-    statusCode === 404 ? 'not-found' : statusCode > 400 ? 'error' : undefined
 
   const resolvedMetadata = await resolveMetadata({
     tree,

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -26,22 +26,29 @@ export async function MetadataTree({
   searchParams,
   getDynamicParamFromSegment,
   appUsingSizeAdjust,
+  statusCode = 200,
 }: {
   tree: LoaderTree
   pathname: string
   searchParams: { [key: string]: any }
   getDynamicParamFromSegment: GetDynamicParamFromSegment
   appUsingSizeAdjust: boolean
+  statusCode?: number
 }) {
   const metadataContext = {
     pathname,
   }
+
+  const errorType =
+    statusCode === 404 ? 'not-found' : statusCode > 400 ? 'error' : undefined
+
   const resolvedMetadata = await resolveMetadata({
     tree,
     parentParams: {},
     metadataItems: [],
     searchParams,
     getDynamicParamFromSegment,
+    errorType,
   })
   const metadata = await accumulateMetadata(resolvedMetadata, metadataContext)
 

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -15,7 +15,7 @@ import { resolveTitle } from './resolvers/resolve-title'
 import { resolveAsArrayOrUndefined } from './generate/utils'
 import { isClientReference } from '../client-reference'
 import {
-  getErrorModule,
+  getErrorOrLayoutModule,
   getLayoutOrPageModule,
   LoaderTree,
 } from '../../server/lib/app-dir-module'
@@ -329,7 +329,7 @@ export async function collectMetadata({
   let mod
   let modType
   if (errorType) {
-    mod = await getErrorModule(tree, errorType)
+    mod = await getErrorOrLayoutModule(tree, errorType)
     modType = errorType
   } else {
     ;[mod, modType] = await getLayoutOrPageModule(tree)
@@ -389,26 +389,27 @@ export async function resolveMetadata({
     ...(isPage && { searchParams }),
   }
 
-  const isLeaf =
-    !parallelRoutes.children ||
-    Object.keys(parallelRoutes.children[1]).length === 0
-  if (isLeaf && notFound && errorType) {
-    await collectMetadata({
-      tree,
-      errorType,
-      metadataItems,
-      props: layerProps,
-      route: currentTreePrefix
-        // __PAGE__ shouldn't be shown in a route
-        .filter((s) => s !== PAGE_SEGMENT_KEY)
-        .join('/'),
-    })
-    return metadataItems
-  }
+  // const isLeaf =
+  //   !parallelRoutes.children ||
+  //   Object.keys(parallelRoutes.children[1]).length === 0
+  // if (isLeaf && notFound && errorType) {
+  //   await collectMetadata({
+  //     tree,
+  //     errorType,
+  //     metadataItems,
+  //     props: layerProps,
+  //     route: currentTreePrefix
+  //       // __PAGE__ shouldn't be shown in a route
+  //       .filter((s) => s !== PAGE_SEGMENT_KEY)
+  //       .join('/'),
+  //   })
+  //   return metadataItems
+  // }
 
   await collectMetadata({
     tree,
     metadataItems,
+    errorType,
     props: layerProps,
     route: currentTreePrefix
       // __PAGE__ shouldn't be shown in a route

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -318,19 +318,19 @@ export async function collectMetadata({
   metadataItems: array,
   props,
   route,
-  errorType,
+  errorConvention,
 }: {
   tree: LoaderTree
   metadataItems: MetadataItems
   props: any
   route: string
-  errorType?: 'not-found'
+  errorConvention?: 'not-found'
 }) {
   let mod
   let modType
-  if (errorType) {
-    mod = await getErrorOrLayoutModule(tree, errorType)
-    modType = errorType
+  if (errorConvention) {
+    mod = await getErrorOrLayoutModule(tree, errorConvention)
+    modType = errorConvention
   } else {
     ;[mod, modType] = await getLayoutOrPageModule(tree)
   }
@@ -354,7 +354,7 @@ export async function resolveMetadata({
   treePrefix = [],
   getDynamicParamFromSegment,
   searchParams,
-  errorType,
+  errorConvention,
 }: {
   tree: LoaderTree
   parentParams: { [key: string]: any }
@@ -363,7 +363,7 @@ export async function resolveMetadata({
   treePrefix?: string[]
   getDynamicParamFromSegment: GetDynamicParamFromSegment
   searchParams: { [key: string]: any }
-  errorType: 'not-found' | undefined
+  errorConvention: 'not-found' | undefined
 }): Promise<MetadataItems> {
   const [segment, parallelRoutes, { page }] = tree
   const currentTreePrefix = [...treePrefix, segment]
@@ -392,7 +392,7 @@ export async function resolveMetadata({
   await collectMetadata({
     tree,
     metadataItems,
-    errorType,
+    errorConvention,
     props: layerProps,
     route: currentTreePrefix
       // __PAGE__ shouldn't be shown in a route
@@ -409,7 +409,7 @@ export async function resolveMetadata({
       treePrefix: currentTreePrefix,
       searchParams,
       getDynamicParamFromSegment,
-      errorType,
+      errorConvention,
     })
   }
 

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -389,23 +389,6 @@ export async function resolveMetadata({
     ...(isPage && { searchParams }),
   }
 
-  // const isLeaf =
-  //   !parallelRoutes.children ||
-  //   Object.keys(parallelRoutes.children[1]).length === 0
-  // if (isLeaf && notFound && errorType) {
-  //   await collectMetadata({
-  //     tree,
-  //     errorType,
-  //     metadataItems,
-  //     props: layerProps,
-  //     route: currentTreePrefix
-  //       // __PAGE__ shouldn't be shown in a route
-  //       .filter((s) => s !== PAGE_SEGMENT_KEY)
-  //       .join('/'),
-  //   })
-  //   return metadataItems
-  // }
-
   await collectMetadata({
     tree,
     metadataItems,

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -15,6 +15,7 @@ import { resolveTitle } from './resolvers/resolve-title'
 import { resolveAsArrayOrUndefined } from './generate/utils'
 import { isClientReference } from '../client-reference'
 import {
+  getErrorModule,
   getLayoutOrPageModule,
   LoaderTree,
 } from '../../server/lib/app-dir-module'
@@ -248,28 +249,28 @@ function merge({
 async function getDefinedMetadata(
   mod: any,
   props: any,
-  route: string
+  tracingProps: { route: string }
 ): Promise<Metadata | MetadataResolver | null> {
   // Layer is a client component, we just skip it. It can't have metadata exported.
   // Return early to avoid accessing properties error for client references.
   if (isClientReference(mod)) {
     return null
   }
-  return (
-    (mod.generateMetadata
-      ? (parent: ResolvingMetadata) =>
-          getTracer().trace(
-            ResolveMetadataSpan.generateMetadata,
-            {
-              spanName: `generateMetadata ${route}`,
-              attributes: {
-                'next.page': route,
-              },
-            },
-            () => mod.generateMetadata(props, parent)
-          )
-      : mod.metadata) || null
-  )
+  if (typeof mod.generateMetadata === 'function') {
+    const { route } = tracingProps
+    return (parent: ResolvingMetadata) =>
+      getTracer().trace(
+        ResolveMetadataSpan.generateMetadata,
+        {
+          spanName: `generateMetadata ${route}`,
+          attributes: {
+            'next.page': route,
+          },
+        },
+        () => mod.generateMetadata(props, parent)
+      )
+  }
+  return mod.metadata || null
 }
 
 async function collectStaticImagesFiles(
@@ -317,13 +318,22 @@ export async function collectMetadata({
   metadataItems: array,
   props,
   route,
+  errorType,
 }: {
   tree: LoaderTree
   metadataItems: MetadataItems
   props: any
   route: string
+  errorType?: 'not-found' | 'error'
 }) {
-  const [mod, modType] = await getLayoutOrPageModule(tree)
+  let mod
+  let modType
+  if (errorType) {
+    mod = await getErrorModule(tree, errorType)
+    modType = errorType
+  } else {
+    ;[mod, modType] = await getLayoutOrPageModule(tree)
+  }
 
   if (modType) {
     route += `/${modType}`
@@ -331,7 +341,7 @@ export async function collectMetadata({
 
   const staticFilesMetadata = await resolveStaticMetadata(tree[2], props)
   const metadataExport = mod
-    ? await getDefinedMetadata(mod, props, route)
+    ? await getDefinedMetadata(mod, props, { route })
     : null
 
   array.push([metadataExport, staticFilesMetadata])
@@ -344,6 +354,7 @@ export async function resolveMetadata({
   treePrefix = [],
   getDynamicParamFromSegment,
   searchParams,
+  errorType,
 }: {
   tree: LoaderTree
   parentParams: { [key: string]: any }
@@ -352,10 +363,12 @@ export async function resolveMetadata({
   treePrefix?: string[]
   getDynamicParamFromSegment: GetDynamicParamFromSegment
   searchParams: { [key: string]: any }
+  errorType: 'not-found' | 'error' | undefined
 }): Promise<MetadataItems> {
-  const [segment, parallelRoutes, { page }] = tree
+  const [segment, parallelRoutes, { page, 'not-found': notFound }] = tree
   const currentTreePrefix = [...treePrefix, segment]
   const isPage = typeof page !== 'undefined'
+
   // Handle dynamic segment params.
   const segmentParam = getDynamicParamFromSegment(segment)
   /**
@@ -374,6 +387,23 @@ export async function resolveMetadata({
   const layerProps = {
     params: currentParams,
     ...(isPage && { searchParams }),
+  }
+
+  const isLeaf =
+    !parallelRoutes.children ||
+    Object.keys(parallelRoutes.children[1]).length === 0
+  if (isLeaf && notFound && errorType) {
+    await collectMetadata({
+      tree,
+      errorType,
+      metadataItems,
+      props: layerProps,
+      route: currentTreePrefix
+        // __PAGE__ shouldn't be shown in a route
+        .filter((s) => s !== PAGE_SEGMENT_KEY)
+        .join('/'),
+    })
+    return metadataItems
   }
 
   await collectMetadata({
@@ -395,6 +425,7 @@ export async function resolveMetadata({
       treePrefix: currentTreePrefix,
       searchParams,
       getDynamicParamFromSegment,
+      errorType,
     })
   }
 

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -324,7 +324,7 @@ export async function collectMetadata({
   metadataItems: MetadataItems
   props: any
   route: string
-  errorType?: 'not-found' | 'error'
+  errorType?: 'not-found'
 }) {
   let mod
   let modType
@@ -363,9 +363,9 @@ export async function resolveMetadata({
   treePrefix?: string[]
   getDynamicParamFromSegment: GetDynamicParamFromSegment
   searchParams: { [key: string]: any }
-  errorType: 'not-found' | 'error' | undefined
+  errorType: 'not-found' | undefined
 }): Promise<MetadataItems> {
-  const [segment, parallelRoutes, { page, 'not-found': notFound }] = tree
+  const [segment, parallelRoutes, { page }] = tree
   const currentTreePrefix = [...treePrefix, segment]
   const isPage = typeof page !== 'undefined'
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1625,19 +1625,22 @@ export async function renderToHTMLOrFlight(
             ? interopDefault(await rootLayoutModule())
             : null
 
+          console.log('res.statusCode', res.statusCode)
           const serverErrorElement = (
             <ErrorHtml
               head={
-                // @ts-expect-error allow to use async server component
-                <MetadataTree
-                  key={requestId}
-                  tree={emptyLoaderTree}
-                  pathname={pathname}
-                  statusCode={res.statusCode}
-                  searchParams={providedSearchParams}
-                  getDynamicParamFromSegment={getDynamicParamFromSegment}
-                  appUsingSizeAdjust={appUsingSizeAdjust}
-                />
+                useDefaultError ? (
+                  // @ts-expect-error allow to use async server component
+                  <MetadataTree
+                    key={requestId}
+                    tree={loaderTree}
+                    pathname={pathname}
+                    statusCode={res.statusCode}
+                    searchParams={providedSearchParams}
+                    getDynamicParamFromSegment={getDynamicParamFromSegment}
+                    appUsingSizeAdjust={appUsingSizeAdjust}
+                  />
+                ) : null
               }
             >
               {useDefaultError
@@ -1647,6 +1650,24 @@ export async function renderToHTMLOrFlight(
                       async () => {
                         return (
                           <>
+                            {/* @ts-expect-error allow to use async server component */}
+                            <MetadataTree
+                              key={requestId}
+                              tree={loaderTree}
+                              pathname={pathname}
+                              errorType={
+                                use404Error
+                                  ? 'not-found'
+                                  : res.statusCode === 307
+                                  ? undefined
+                                  : 'error'
+                              }
+                              searchParams={providedSearchParams}
+                              getDynamicParamFromSegment={
+                                getDynamicParamFromSegment
+                              }
+                              appUsingSizeAdjust={appUsingSizeAdjust}
+                            />
                             {use404Error ? (
                               <RootLayout params={{}}>
                                 {notFoundStyles}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1361,13 +1361,13 @@ export async function renderToHTMLOrFlight(
           query
         )
 
-        const createMetadata = (tree: LoaderTree) => (
+        const createMetadata = (tree: LoaderTree, statusCode: number) => (
           // Adding key={requestId} to make metadata remount for each render
           // @ts-expect-error allow to use async server component
           <MetadataTree
             key={requestId}
             tree={tree}
-            statusCode={res.statusCode}
+            statusCode={statusCode}
             pathname={pathname}
             searchParams={providedSearchParams}
             getDynamicParamFromSegment={getDynamicParamFromSegment}
@@ -1389,12 +1389,12 @@ export async function renderToHTMLOrFlight(
               assetPrefix={assetPrefix}
               initialCanonicalUrl={pathname}
               initialTree={initialTree}
-              initialHead={<>{createMetadata(loaderTree)}</>}
+              initialHead={<>{createMetadata(loaderTree, 200)}</>}
               globalErrorComponent={GlobalError}
               notFound={
                 NotFound ? (
                   <ErrorHtml>
-                    {createMetadata(loaderTree)}
+                    {createMetadata(loaderTree, 200)}
                     {notFoundStyles}
                     <NotFound />
                   </ErrorHtml>

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1214,7 +1214,6 @@ export async function renderToHTMLOrFlight(
                   <MetadataTree
                     key={requestId}
                     tree={loaderTree}
-                    statusCode={res.statusCode}
                     pathname={pathname}
                     searchParams={providedSearchParams}
                     getDynamicParamFromSegment={getDynamicParamFromSegment}
@@ -1594,7 +1593,9 @@ export async function renderToHTMLOrFlight(
           if (isNotFoundError(err)) {
             res.statusCode = 404
           }
+          let hasRedirectError = false
           if (isRedirectError(err)) {
+            hasRedirectError = true
             res.statusCode = 307
             if (err.mutableCookies) {
               const headers = new Headers()
@@ -1609,7 +1610,7 @@ export async function renderToHTMLOrFlight(
           }
 
           const use404Error = res.statusCode === 404
-          const useDefaultError = res.statusCode < 400 || res.statusCode === 307
+          const useDefaultError = res.statusCode < 400 || hasRedirectError
 
           const { layout } = loaderTree[2]
           const injectedCSS = new Set<string>()
@@ -1630,7 +1631,13 @@ export async function renderToHTMLOrFlight(
               key={requestId}
               tree={loaderTree}
               pathname={pathname}
-              errorType={use404Error ? 'not-found' : undefined}
+              errorType={
+                use404Error
+                  ? 'not-found'
+                  : hasRedirectError
+                  ? 'redirect'
+                  : undefined
+              }
               searchParams={providedSearchParams}
               getDynamicParamFromSegment={getDynamicParamFromSegment}
               appUsingSizeAdjust={appUsingSizeAdjust}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -82,7 +82,6 @@ import { ComponentsType } from '../../build/webpack/loaders/next-app-loader'
 import { ModuleReference } from '../../build/webpack/loaders/metadata/types'
 
 export const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
-
 const emptyLoaderTree: LoaderTree = ['', {}, {}]
 
 export type GetDynamicParamFromSegment = (
@@ -1216,6 +1215,7 @@ export async function renderToHTMLOrFlight(
                   <MetadataTree
                     key={requestId}
                     tree={loaderTree}
+                    statusCode={res.statusCode}
                     pathname={pathname}
                     searchParams={providedSearchParams}
                     getDynamicParamFromSegment={getDynamicParamFromSegment}
@@ -1367,6 +1367,7 @@ export async function renderToHTMLOrFlight(
           <MetadataTree
             key={requestId}
             tree={tree}
+            statusCode={res.statusCode}
             pathname={pathname}
             searchParams={providedSearchParams}
             getDynamicParamFromSegment={getDynamicParamFromSegment}
@@ -1632,6 +1633,7 @@ export async function renderToHTMLOrFlight(
                   key={requestId}
                   tree={emptyLoaderTree}
                   pathname={pathname}
+                  statusCode={res.statusCode}
                   searchParams={providedSearchParams}
                   getDynamicParamFromSegment={getDynamicParamFromSegment}
                   appUsingSizeAdjust={appUsingSizeAdjust}

--- a/packages/next/src/server/lib/app-dir-module.ts
+++ b/packages/next/src/server/lib/app-dir-module.ts
@@ -32,3 +32,14 @@ export async function getLayoutOrPageModule(loaderTree: LoaderTree) {
 
   return [value, modType] as const
 }
+
+export async function getErrorModule(
+  loaderTree: LoaderTree,
+  errorType: 'error' | 'not-found'
+) {
+  const error = loaderTree[2][errorType]
+  if (typeof error !== 'undefined') {
+    return await error[0]()
+  }
+  return undefined
+}

--- a/packages/next/src/server/lib/app-dir-module.ts
+++ b/packages/next/src/server/lib/app-dir-module.ts
@@ -33,13 +33,16 @@ export async function getLayoutOrPageModule(loaderTree: LoaderTree) {
   return [value, modType] as const
 }
 
-export async function getErrorModule(
+// First check not-found, if it doesn't exist then pick layout
+export async function getErrorOrLayoutModule(
   loaderTree: LoaderTree,
   errorType: 'error' | 'not-found'
 ) {
-  const error = loaderTree[2][errorType]
+  const { [errorType]: error, layout } = loaderTree[2]
   if (typeof error !== 'undefined') {
     return await error[0]()
+  } else if (typeof layout !== 'undefined') {
+    return await layout[0]()
   }
   return undefined
 }

--- a/test/e2e/app-dir/metadata/app/async/not-found/not-found.tsx
+++ b/test/e2e/app-dir/metadata/app/async/not-found/not-found.tsx
@@ -1,0 +1,8 @@
+export default function notFound() {
+  return <h2>local found boundary</h2>
+}
+
+export const metadata = {
+  title: 'Local not found',
+  description: 'Local not found description',
+}

--- a/test/e2e/app-dir/metadata/app/layout.tsx
+++ b/test/e2e/app-dir/metadata/app/layout.tsx
@@ -10,4 +10,5 @@ export default function Layout({ children }) {
 export const metadata = {
   title: 'this is the layout title',
   description: 'this is the layout description',
+  keywords: ['nextjs', 'react'],
 }

--- a/test/e2e/app-dir/metadata/app/not-found.tsx
+++ b/test/e2e/app-dir/metadata/app/not-found.tsx
@@ -1,3 +1,8 @@
 export default function notFound() {
   return <h2>root not found page</h2>
 }
+
+export const metadata = {
+  title: 'Not found',
+  description: 'Not found description',
+}

--- a/test/e2e/app-dir/metadata/app/not-found.tsx
+++ b/test/e2e/app-dir/metadata/app/not-found.tsx
@@ -3,6 +3,6 @@ export default function notFound() {
 }
 
 export const metadata = {
-  title: 'Not found',
-  description: 'Not found description',
+  title: 'Root not found',
+  description: 'Root not found description',
 }

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -416,69 +416,6 @@ createNextDescribe(
         )
       })
 
-      it('should render root not-found with default metadata', async () => {
-        const $ = await next.render$('/does-not-exist')
-
-        // Should contain default metadata and noindex tag
-        const matchHtml = createMultiHtmlMatcher($)
-        expect($('meta[charset="utf-8"]').length).toBe(1)
-        await matchHtml('meta', 'name', 'content', {
-          viewport: 'width=device-width, initial-scale=1',
-          robots: 'noindex',
-          // not found metadata
-          description: 'Root not found description',
-        })
-        expect(await $('title').text()).toBe('Root not found')
-      })
-
-      it('should support notFound in generateMetadata', async () => {
-        const res = await next.fetch('/async/not-found')
-        expect(res.status).toBe(404)
-        const html = await res.text()
-        const $ = cheerio.load(html)
-
-        // TODO-APP: support render custom not-found in SSR for generateMetadata.
-        // Check contains root not-found payload in flight response for now.
-        let hasRootNotFoundFlight = false
-        for (const el of $('script').toArray()) {
-          const text = $(el).text()
-          if (text.includes('root not found page')) {
-            hasRootNotFoundFlight = true
-          }
-        }
-        expect(hasRootNotFoundFlight).toBe(true)
-
-        // Should contain default metadata and noindex tag
-        const matchHtml = createMultiHtmlMatcher($)
-        expect($('meta[charset="utf-8"]').length).toBe(1)
-        await matchHtml('meta', 'name', 'content', {
-          viewport: 'width=device-width, initial-scale=1',
-          robots: 'noindex',
-        })
-
-        const browser = await next.browser('/async/not-found')
-        expect(await browser.elementByCss('h2').text()).toBe(
-          'root not found page'
-        )
-
-        const matchMultiDom = createMultiDomMatcher(browser)
-        await matchMultiDom('meta', 'name', 'content', {
-          viewport: 'width=device-width, initial-scale=1',
-          keywords: 'parent',
-          robots: 'noindex',
-          // not found metadata
-          description: 'Local not found description',
-        })
-        expect(await getTitle(browser)).toBe('Local not found')
-      })
-
-      it('should support redirect in generateMetadata', async () => {
-        const res = await next.fetch('/async/redirect', {
-          redirect: 'manual',
-        })
-        expect(res.status).toBe(307)
-      })
-
       it('should handle metadataBase for urls resolved as only URL type', async () => {
         // including few urls in opengraph and alternates
         const url$ = await next.render$('/metadata-base/url')
@@ -603,6 +540,71 @@ createNextDescribe(
         expect($('link[rel="icon"]').attr('href')).toBe(
           'https://custom-icon-1.png'
         )
+      })
+    })
+
+    describe('navigation', () => {
+      it('should render root not-found with default metadata', async () => {
+        const $ = await next.render$('/does-not-exist')
+
+        // Should contain default metadata and noindex tag
+        const matchHtml = createMultiHtmlMatcher($)
+        expect($('meta[charset="utf-8"]').length).toBe(1)
+        await matchHtml('meta', 'name', 'content', {
+          viewport: 'width=device-width, initial-scale=1',
+          robots: 'noindex',
+          // not found metadata
+          description: 'Root not found description',
+        })
+        expect(await $('title').text()).toBe('Root not found')
+      })
+
+      it('should support notFound in generateMetadata', async () => {
+        const res = await next.fetch('/async/not-found')
+        expect(res.status).toBe(404)
+        const html = await res.text()
+        const $ = cheerio.load(html)
+
+        // TODO-APP: support render custom not-found in SSR for generateMetadata.
+        // Check contains root not-found payload in flight response for now.
+        let hasRootNotFoundFlight = false
+        for (const el of $('script').toArray()) {
+          const text = $(el).text()
+          if (text.includes('root not found page')) {
+            hasRootNotFoundFlight = true
+          }
+        }
+        expect(hasRootNotFoundFlight).toBe(true)
+
+        // Should contain default metadata and noindex tag
+        const matchHtml = createMultiHtmlMatcher($)
+        expect($('meta[charset="utf-8"]').length).toBe(1)
+        await matchHtml('meta', 'name', 'content', {
+          viewport: 'width=device-width, initial-scale=1',
+          robots: 'noindex',
+        })
+
+        const browser = await next.browser('/async/not-found')
+        expect(await browser.elementByCss('h2').text()).toBe(
+          'root not found page'
+        )
+
+        const matchMultiDom = createMultiDomMatcher(browser)
+        await matchMultiDom('meta', 'name', 'content', {
+          viewport: 'width=device-width, initial-scale=1',
+          keywords: 'parent',
+          robots: 'noindex',
+          // not found metadata
+          description: 'Local not found description',
+        })
+        expect(await getTitle(browser)).toBe('Local not found')
+      })
+
+      it('should support redirect in generateMetadata', async () => {
+        const res = await next.fetch('/async/redirect', {
+          redirect: 'manual',
+        })
+        expect(res.status).toBe(307)
       })
     })
 

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -425,7 +425,10 @@ createNextDescribe(
         await matchHtml('meta', 'name', 'content', {
           viewport: 'width=device-width, initial-scale=1',
           robots: 'noindex',
+          // not found metadata
+          description: 'Root not found description',
         })
+        expect(await $('title').text()).toBe('Root not found')
       })
 
       it('should support notFound in generateMetadata', async () => {
@@ -457,6 +460,16 @@ createNextDescribe(
         expect(await browser.elementByCss('h2').text()).toBe(
           'root not found page'
         )
+
+        const matchMultiDom = createMultiDomMatcher(browser)
+        await matchMultiDom('meta', 'name', 'content', {
+          viewport: 'width=device-width, initial-scale=1',
+          keywords: 'parent',
+          robots: 'noindex',
+          // not found metadata
+          description: 'Local not found description',
+        })
+        expect(await getTitle(browser)).toBe('Local not found')
       })
 
       it('should support redirect in generateMetadata', async () => {


### PR DESCRIPTION
### What?

Support metadata exports for `not-found.js` conventions

### Why?

We want to define metadata such as title or description basic properties for error pages, including 404 and 500 which referrs to `error.js` and `not-found.js` convention. See more requests in #45620 

Did some research around metadata support for not-found and error convention. It's possible to support in `not-found.js` when it's server components as currently metadata is only available but for `error.js` it has to be client components for now so it's hard to support it for now as it's a boundary.

### How?

We determine the convention if we're going to render is page or `not-found` boundary then we traverse the loader tree based on the convention type. One special case is for redirection the temporary metadata is not generated yet, we leave it as default now.

Fixes #52636

