### PR TITLE
Optimize external resolution

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1432,9 +1432,9 @@ export default async function getBaseWebpackConfig(
       }
     }
 
-    // Don't bundle @vercel/og nodejs bundle for nodejs runtime.
-    // TODO-APP: bundle route.js with different layer that externals common node_module deps.
     if (isWebpackServerLayer(layer)) {
+      // Don't bundle @vercel/og nodejs bundle for nodejs runtime.
+      // TODO-APP: bundle route.js with different layer that externals common node_module deps.
       if (request === 'next/dist/compiled/@vercel/og/index.node.js') {
         return `module ${request}`
       }

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1277,10 +1277,17 @@ export default async function getBaseWebpackConfig(
       .map((p) => p.replace(/\//g, '[/\\\\]'))
       .join('|')})[/\\\\]`
   )
+  /**
+   * Similar to `optOutBundlingPackageRegex`, but for quickly filter out requests
+   * that haven't been resolved yet.
+   * For example, if `optOutBundlingPackages` is `["foo", "bar"]`, then
+   * `require('baz')` can be directly filtered out using this regex without
+   * having to resolve to `node_modules/baz/...`.
+   */
   const optOutBundlingPackageFastPathRegex = new RegExp(
-    `[/\\\\](${optOutBundlingPackages
+    `(${optOutBundlingPackages
       .map((p) => p.replace(/\//g, '[/\\\\]'))
-      .join('|')})[/\\\\]`
+      .join('|')})`
   )
 
   let resolvedTranspilePackageDirsRegex: RegExp


### PR DESCRIPTION
There're 2 major changes in this PR:
1. Change for-loops to regexp in a hot path
2. Add a fast path to avoid custom resolution calls for requests that must be bundled

On a large application's page, this change reduced the number of resolve calls from 730 to 24.