### PR TITLE
Fix runtime edge not-found handling

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2457,7 +2457,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     })
   }
 
-  private async renderErrorToResponseImpl(
+  protected async renderErrorToResponseImpl(
     ctx: RequestContext,
     err: Error | null
   ): Promise<ResponsePayload | null> {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1901,10 +1901,12 @@ export default class NextNodeServer extends BaseServer {
         : '/_not-found'
 
       if (this.renderOpts.dev) {
-        await (this as any).ensurePage({
-          page: notFoundPathname,
-          clientOnly: false,
-        })
+        await (this as any)
+          .ensurePage({
+            page: notFoundPathname,
+            clientOnly: false,
+          })
+          .catch(() => {})
       }
 
       if (this.getEdgeFunctionsPages().includes(notFoundPathname)) {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1888,6 +1888,40 @@ export default class NextNodeServer extends BaseServer {
     )
   }
 
+  protected async renderErrorToResponseImpl(
+    ctx: RequestContext,
+    err: Error | null
+  ) {
+    const { req, res, query } = ctx
+    const is404 = res.statusCode === 404
+
+    if (is404 && this.hasAppDir && this.isRenderWorker) {
+      const notFoundPathname = this.renderOpts.dev
+        ? '/not-found'
+        : '/_not-found'
+
+      if (this.renderOpts.dev) {
+        await (this as any).ensurePage({
+          page: notFoundPathname,
+          clientOnly: false,
+        })
+      }
+
+      if (this.getEdgeFunctionsPages().includes(notFoundPathname)) {
+        await this.runEdgeFunction({
+          req: req as BaseNextRequest,
+          res: res as BaseNextResponse,
+          query: query || {},
+          params: {},
+          page: notFoundPathname,
+          appPaths: null,
+        })
+        return null
+      }
+    }
+    return super.renderErrorToResponseImpl(ctx, err)
+  }
+
   public async renderError(
     err: Error | null,
     req: BaseNextRequest | IncomingMessage,


### PR DESCRIPTION
This ensures we properly detect `not-found` as `runtime = 'edge'` and treat it as such instead of attempting to render it like normal. 

x-ref: https://github.com/vercel/next.js/issues/52648