### PR TITLE
Revert "perf: improve URL validation performance"

### DIFF
--- a/packages/next/src/server/app-render/validate-url.tsx
+++ b/packages/next/src/server/app-render/validate-url.tsx
@@ -1,25 +1,10 @@
 const DUMMY_ORIGIN = 'http://n'
 const INVALID_URL_MESSAGE = 'Invalid request URL'
 
-// URL.canParse is supported on Node 19 and 20.
-// Node 18 backport is pending.
-// Reference: https://github.com/nodejs/node/pull/48345
-const supportsCanParse = URL.hasOwnProperty('canParse')
-
 export function validateURL(url: string | undefined): string {
-  if (url == null) {
+  if (!url) {
     throw new Error(INVALID_URL_MESSAGE)
   }
-
-  if (supportsCanParse) {
-    // @ts-ignore
-    if (!URL.canParse(url, DUMMY_ORIGIN)) {
-      throw new Error(INVALID_URL_MESSAGE)
-    }
-
-    return url
-  }
-
   try {
     const parsed = new URL(url, DUMMY_ORIGIN)
     // Avoid origin change by extra slashes in pathname


### PR DESCRIPTION
> https://github.com/nodejs/node/issues/48816

This was an unsafe change that caused errors to the user due to a bug in Node and a fix will get upstreamed soon but in the meantime we should reverse this.

Reverts vercel/next.js#52353