### PR TITLE
Turbopack: ensure output assets reference only output assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "serde",
 ]
@@ -3602,7 +3602,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "serde",
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7306,7 +7306,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7321,7 +7321,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7335,7 +7335,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7352,7 +7352,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7382,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "base16",
  "hex",
@@ -7394,7 +7394,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7408,7 +7408,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7418,7 +7418,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "mimalloc",
 ]
@@ -7426,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7449,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7462,7 +7462,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7492,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7522,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7564,7 +7564,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7584,7 +7584,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7608,7 +7608,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7636,7 +7636,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7649,7 +7649,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7671,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7695,7 +7695,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7731,7 +7731,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7764,7 +7764,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7787,7 +7787,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7820,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7840,7 +7840,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "serde",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7870,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "serde",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7932,7 +7932,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.2#46bb9b755ec1661d3dea5986572576f7db9280c8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230718.3#3eb3a5f86fee9b19589d3620acaedcd7eb4a5a93"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,11 @@ swc_core = { version = "0.79.13" }
 testing = { version = "0.33.20" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230718.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230718.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230718.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230718.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230718.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230718.3" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-build/src/next_build.rs
+++ b/packages/next-swc/crates/next-build/src/next_build.rs
@@ -38,7 +38,6 @@ use turbopack_binding::{
             environment::ServerAddr,
             issue::{IssueContextExt, IssueReporter, IssueSeverity},
             output::{OutputAsset, OutputAssets},
-            reference::AssetReference,
             virtual_fs::VirtualFileSystem,
         },
         dev::DevChunkingContext,
@@ -560,27 +559,13 @@ async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<OutputA
 async fn get_referenced_assets(
     asset: Vc<Box<dyn OutputAsset>>,
 ) -> Result<impl Iterator<Item = Vc<Box<dyn OutputAsset>>> + Send> {
-    Ok(
-        asset
-            .references()
-            .await?
-            .iter()
-            .map(|reference| async move {
-                let primary_assets = reference.resolve_reference().primary_assets().await?;
-                Ok(primary_assets.clone_value())
-            })
-            .try_join()
-            .await?
-            .into_iter()
-            .flatten()
-            .map(|asset| async move {
-                Ok(Vc::try_resolve_downcast::<Box<dyn OutputAsset>>(asset).await?)
-            })
-            .try_join()
-            .await?
-            .into_iter()
-            .flatten(),
-    )
+    Ok(asset
+        .references()
+        .await?
+        .iter()
+        .copied()
+        .collect::<Vec<_>>()
+        .into_iter())
 }
 
 /// Writes a manifest to disk. This consumes the manifest to ensure we don't

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.2",
-    "@vercel/turbopack-node": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230718.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.3",
+    "@vercel/turbopack-node": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230718.3",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/src/emit.rs
+++ b/packages/next-swc/crates/next-core/src/emit.rs
@@ -7,7 +7,6 @@ use turbo_tasks_fs::{rebase, FileSystemPath};
 use turbopack_binding::turbopack::core::{
     asset::Asset,
     output::{OutputAsset, OutputAssets},
-    reference::AssetReference,
 };
 
 /// Emits all assets transitively reachable from the given chunks, that are
@@ -89,25 +88,11 @@ async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<OutputA
 async fn get_referenced_assets(
     asset: Vc<Box<dyn OutputAsset>>,
 ) -> Result<impl Iterator<Item = Vc<Box<dyn OutputAsset>>> + Send> {
-    Ok(
-        asset
-            .references()
-            .await?
-            .iter()
-            .map(|reference| async move {
-                let primary_assets = reference.resolve_reference().primary_assets().await?;
-                Ok(primary_assets.clone_value())
-            })
-            .try_join()
-            .await?
-            .into_iter()
-            .flatten()
-            .map(|asset| async move {
-                Ok(Vc::try_resolve_sidecast::<Box<dyn OutputAsset>>(asset).await?)
-            })
-            .try_join()
-            .await?
-            .into_iter()
-            .flatten(),
-    )
+    Ok(asset
+        .references()
+        .await?
+        .iter()
+        .copied()
+        .collect::<Vec<_>>()
+        .into_iter())
 }

--- a/packages/next-swc/crates/next-core/src/next_client_chunks/with_chunks.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_chunks/with_chunks.rs
@@ -18,7 +18,7 @@ use turbopack_binding::{
             ident::AssetIdent,
             module::Module,
             output::OutputAssets,
-            reference::AssetReferences,
+            reference::{AssetReferences, SingleAssetReference},
         },
         ecmascript::{
             chunk::{
@@ -218,8 +218,14 @@ impl ChunkItem for WithChunksChunkItem {
     async fn references(self: Vc<Self>) -> Result<Vc<AssetReferences>> {
         let mut references = self.await?.inner.references().await?.clone_value();
 
+        let chunk_data_key = Vc::cell("chunk data".to_string());
         for chunk_data in &*self.chunks_data().await? {
-            references.extend(chunk_data.references().await?.iter().copied());
+            references.extend(chunk_data.references().await?.iter().map(|&output_asset| {
+                Vc::upcast(SingleAssetReference::new(
+                    Vc::upcast(output_asset),
+                    chunk_data_key,
+                ))
+            }));
         }
 
         Ok(Vc::cell(references))

--- a/packages/next-swc/crates/next-core/src/next_client_component/with_client_chunks.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_component/with_client_chunks.rs
@@ -232,8 +232,14 @@ impl ChunkItem for WithClientChunksChunkItem {
                 client_chunk,
             )));
         }
+        let chunk_data_key = Vc::cell("chunk data".to_string());
         for chunk_data in &*self.chunks_data().await? {
-            references.extend(chunk_data.references().await?.iter().copied());
+            references.extend(chunk_data.references().await?.iter().map(|&output_asset| {
+                Vc::upcast(SingleAssetReference::new(
+                    Vc::upcast(output_asset),
+                    chunk_data_key,
+                ))
+            }));
         }
         Ok(Vc::cell(references))
     }

--- a/packages/next-swc/crates/next-core/src/page_loader.rs
+++ b/packages/next-swc/crates/next-core/src/page_loader.rs
@@ -16,7 +16,6 @@ use turbopack_binding::{
             ident::AssetIdent,
             module::Module,
             output::{OutputAsset, OutputAssets},
-            reference::{AssetReferences, SingleAssetReference},
             reference_type::{EntryReferenceSubType, ReferenceType},
             source::Source,
             virtual_source::VirtualSource,
@@ -146,15 +145,12 @@ impl OutputAsset for PageLoaderAsset {
     }
 
     #[turbo_tasks::function]
-    async fn references(self: Vc<Self>) -> Result<Vc<AssetReferences>> {
+    async fn references(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
         let chunks = self.get_page_chunks().await?;
 
         let mut references = Vec::with_capacity(chunks.len());
         for &chunk in chunks.iter() {
-            references.push(Vc::upcast(SingleAssetReference::new(
-                Vc::upcast(chunk),
-                page_loader_chunk_reference_description(),
-            )));
+            references.push(chunk);
         }
 
         for chunk_data in &*self.chunks_data().await? {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -994,8 +994,8 @@ importers:
       '@types/react': 18.2.7
       '@types/react-dom': 18.2.4
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-ecmascript-runtime': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.2
-      '@vercel/turbopack-node': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230718.2
+      '@vercel/turbopack-ecmascript-runtime': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.3
+      '@vercel/turbopack-node': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230718.3
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1007,8 +1007,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-ecmascript-runtime': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.2_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230718.2'
+      '@vercel/turbopack-ecmascript-runtime': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.3_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230718.3'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -6153,7 +6153,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.2.1
       source-map: 0.7.3
-      webpack: 5.86.0
+      webpack: 5.86.0_@swc+core@1.3.55
     transitivePeerDependencies:
       - supports-color
 
@@ -6912,7 +6912,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64/1.3.55:
@@ -6921,7 +6920,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.3.55:
@@ -6930,7 +6928,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.3.55:
@@ -6939,7 +6936,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl/1.3.55:
@@ -6948,7 +6944,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu/1.3.55:
@@ -6957,7 +6952,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl/1.3.55:
@@ -6966,7 +6960,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.3.55:
@@ -6975,7 +6968,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.3.55:
@@ -6984,7 +6976,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc/1.3.55:
@@ -6993,7 +6984,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core/1.3.55_@swc+helpers@0.5.1:
@@ -7018,7 +7008,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.55
       '@swc/core-win32-ia32-msvc': 1.3.55
       '@swc/core-win32-x64-msvc': 1.3.55
-    dev: true
 
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
@@ -23917,7 +23906,6 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.17.7
       webpack: 5.86.0_@swc+core@1.3.55
-    dev: true
 
   /terser/5.10.0:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
@@ -25274,7 +25262,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /websocket-driver/0.7.3:
     resolution: {integrity: sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==}
@@ -25683,9 +25670,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.2_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.3_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.3}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230718.3'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:
@@ -25696,8 +25683,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230718.2':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230718.2}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230718.3':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230718.3}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

refactoring see https://github.com/vercel/turbo/pull/5557

### Turbopack Changes

* https://github.com/vercel/turbo/pull/5506 <!-- Leah - feat(turbopack-ecmascript): implement acyclic SCC graph for ESM imports  -->
* https://github.com/vercel/turbo/pull/5557 <!-- Tobias Koppers - Ensure output assets reference only output assets  -->