### PR TITLE
feat(next-swc): support env var for --experimental-turbo

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -832,6 +832,9 @@ function loadNative(isCustomTurbopack = false, importPath?: string) {
     return nativeBindings
   }
 
+  const customBindings = !!__INTERNAL_CUSTOM_TURBOPACK_BINDINGS
+    ? require(__INTERNAL_CUSTOM_TURBOPACK_BINDINGS)
+    : null
   let bindings: any
   let attempts: any[] = []
 
@@ -1027,13 +1030,13 @@ function loadNative(isCustomTurbopack = false, importPath?: string) {
         },
         nextBuild: (options: unknown) => {
           initHeapProfiler()
-          const ret = bindings.nextBuild(options)
+          const ret = (customBindings ?? bindings).nextBuild(options)
 
           return ret
         },
         startTrace: (options = {}, turboTasks: unknown) => {
           initHeapProfiler()
-          const ret = bindings.runTurboTracing(
+          const ret = (customBindings ?? bindings).runTurboTracing(
             toBuffer({ exact: true, ...options }),
             turboTasks
           )
@@ -1049,7 +1052,7 @@ function loadNative(isCustomTurbopack = false, importPath?: string) {
             pageExtensions: string[],
             fn: (entrypoints: any) => void
           ) => {
-            return bindings.streamEntrypoints(
+            return (customBindings ?? bindings).streamEntrypoints(
               turboTasks,
               rootDir,
               applicationDir,
@@ -1063,7 +1066,7 @@ function loadNative(isCustomTurbopack = false, importPath?: string) {
             applicationDir: string,
             pageExtensions: string[]
           ) => {
-            return bindings.getEntrypoints(
+            return (customBindings ?? bindings).getEntrypoints(
               turboTasks,
               rootDir,
               applicationDir,
@@ -1071,7 +1074,7 @@ function loadNative(isCustomTurbopack = false, importPath?: string) {
             )
           },
         },
-        createProject: bindingToApi(bindings, false),
+        createProject: bindingToApi(customBindings ?? bindings, false),
       },
       mdx: {
         compile: (src: string, options: any) =>


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change



### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Minor update to next-swc to support `__INTERNAL_CUSTOM_TURBOPACK_BINDINGS` for the --experimental-turbo entrypoint as same as current --turbo.
