### PR TITLE
chore(docs): add Typescript statically typed links mention in link doc

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/03-linking-and-navigating.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/03-linking-and-navigating.mdx
@@ -1,6 +1,10 @@
 ---
 title: Linking and Navigating
 description: Learn how navigation works in Next.js, and how to use the Link Component and `useRouter` hook.
+related:
+  description: Learn more about statically typed links with TypeScript.
+  links:
+    - app/building-your-application/configuring/typescript#statically-typed-links
 ---
 
 The Next.js router uses [server-centric routing](/docs/app/building-your-application/routing#server-centric-routing-with-client-side-navigation) with [client-side navigation](#how-navigation-works). It supports [instant loading states](/docs/app/building-your-application/routing/loading-ui-and-streaming) and [concurrent rendering](https://react.dev/reference/react/startTransition). This means navigation maintains client-side state, avoids expensive re-renders, is interruptible, and doesn't cause race conditions.


### PR DESCRIPTION
### What?

Update Link documentation to mention `Statically typed links` feature with Typescript.

### Why?

- Linking documentation doesn't talk about this Typescript feature.
- [Typescript](https://nextjs.org/docs/app/building-your-application/configuring/typescript#statically-typed-links) documentation talk about statically typed links for `next/link` but not the section itself.

### How?

- Check documentation
