### PR TITLE
chore(docs): Extend the options for custom server init

### DIFF
--- a/docs/03-pages/01-building-your-application/06-configuring/10-custom-server.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/10-custom-server.mdx
@@ -88,17 +88,17 @@ const app = next({})
 
 The above `next` import is a function that receives an object with the following options:
 
-|Option|Type|Description|
-|------|----|-----------|
-|`conf`|`Object`|The same object you would use in [next.config.js](/docs/pages/api-reference/next-config-js). Defaults to `{}`|
-|`customServer`|`Boolean`|(_Optional_) Set to false when the server was created by Next.js|
-|`dev`|`Boolean`|(_Optional_) Whether or not to launch Next.js in dev mode. Defaults to `false`|
-|`dir`|`String`|(_Optional_) Location of the Next.js project. Defaults to `'.'`|
-|`minimalMode`|`Boolean`|(_Optional_) Tells if Next.js is running in a Serverless platform|
-|`quiet`|`Boolean`|(_Optional_) Hide error messages containing server information. Defaults to `false`|
-|`hostname`|`String`|(_Optional_) The hostname the server is running behind|
-|`port`|`Number`|(_Optional_) The port the server is running behind|
-|`httpServer`|`node:http#Server`|(_Optional_) The HTTP Server that Next.js is running behind|
+| Option         | Type               | Description                                                                                                   |
+| -------------- | ------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `conf`         | `Object`           | The same object you would use in [next.config.js](/docs/pages/api-reference/next-config-js). Defaults to `{}` |
+| `customServer` | `Boolean`          | (_Optional_) Set to false when the server was created by Next.js                                              |
+| `dev`          | `Boolean`          | (_Optional_) Whether or not to launch Next.js in dev mode. Defaults to `false`                                |
+| `dir`          | `String`           | (_Optional_) Location of the Next.js project. Defaults to `'.'`                                               |
+| `minimalMode`  | `Boolean`          | (_Optional_) Tells if Next.js is running in a Serverless platform                                             |
+| `quiet`        | `Boolean`          | (_Optional_) Hide error messages containing server information. Defaults to `false`                           |
+| `hostname`     | `String`           | (_Optional_) The hostname the server is running behind                                                        |
+| `port`         | `Number`           | (_Optional_) The port the server is running behind                                                            |
+| `httpServer`   | `node:http#Server` | (_Optional_) The HTTP Server that Next.js is running behind                                                   |
 
 The returned `app` can then be used to let Next.js handle requests as required.
 

--- a/docs/03-pages/01-building-your-application/06-configuring/10-custom-server.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/10-custom-server.mdx
@@ -88,10 +88,17 @@ const app = next({})
 
 The above `next` import is a function that receives an object with the following options:
 
-- `dev`: `Boolean` - Whether or not to launch Next.js in dev mode. Defaults to `false`
-- `dir`: `String` - Location of the Next.js project. Defaults to `'.'`
-- `quiet`: `Boolean` - Hide error messages containing server information. Defaults to `false`
-- `conf`: `object` - The same object you would use in [next.config.js](/docs/pages/api-reference/next-config-js). Defaults to `{}`
+|Option|Type|Description|
+|------|----|-----------|
+|`conf`|`Object`|The same object you would use in [next.config.js](/docs/pages/api-reference/next-config-js). Defaults to `{}`|
+|`customServer`|`Boolean`|(_Optional_) Set to false when the server was created by Next.js|
+|`dev`|`Boolean`|(_Optional_) Whether or not to launch Next.js in dev mode. Defaults to `false`|
+|`dir`|`String`|(_Optional_) Location of the Next.js project. Defaults to `'.'`|
+|`minimalMode`|`Boolean`|(_Optional_) Tells if Next.js is running in a Serverless platform|
+|`quiet`|`Boolean`|(_Optional_) Hide error messages containing server information. Defaults to `false`|
+|`hostname`|`String`|(_Optional_) The hostname the server is running behind|
+|`port`|`Number`|(_Optional_) The port the server is running behind|
+|`httpServer`|`node:http#Server`|(_Optional_) The HTTP Server that Next.js is running behind|
 
 The returned `app` can then be used to let Next.js handle requests as required.
 

--- a/docs/03-pages/01-building-your-application/06-configuring/10-custom-server.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/10-custom-server.mdx
@@ -94,7 +94,6 @@ The above `next` import is a function that receives an object with the following
 | `customServer` | `Boolean`          | (_Optional_) Set to false when the server was created by Next.js                                              |
 | `dev`          | `Boolean`          | (_Optional_) Whether or not to launch Next.js in dev mode. Defaults to `false`                                |
 | `dir`          | `String`           | (_Optional_) Location of the Next.js project. Defaults to `'.'`                                               |
-| `minimalMode`  | `Boolean`          | (_Optional_) Tells if Next.js is running in a Serverless platform                                             |
 | `quiet`        | `Boolean`          | (_Optional_) Hide error messages containing server information. Defaults to `false`                           |
 | `hostname`     | `String`           | (_Optional_) The hostname the server is running behind                                                        |
 | `port`         | `Number`           | (_Optional_) The port the server is running behind                                                            |


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
## For Contributors

### Improving Documentation

While working with a custom server, I noticed that [the list of available options within the codebase](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/base-server.ts#L138-L180) was much larger than [the options listed within the docs](https://nextjs.org/docs/pages/building-your-application/configuring/custom-server). This PR extends the `next` import function options to include all of ~the allowed~ documented options from the codebase. 

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide


