### PR TITLE
make sure serverResponse is ended

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1976,6 +1976,12 @@ createServerHandler({
       console.error(err);
       res.statusCode = 500
       res.end('Internal Server Error')
+    } finally {
+      if (!res.outgoingMessage.writableEnded()){
+        console.error("next handler didn't call end()");
+        res.statusCode = 500
+        res.end('Internal Server Error')
+      }
     }
   })
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

- When we deploy next.js 13.4.1 to production, the server has a lot of socket hang up, connection reset and eventually server restart and kernel log showing TCP: Out of memory"
- 
### Why?
- Somehow the handler didn't call the "end" method so the socket cannot be closed

### How?
- Check if the response is closed, if not yet close, close the response with 500 errors

Closes NEXT-
Fixes #

-->
