### PR TITLE
Update 02-edge-and-nodejs-runtimes.mdx

### DIFF
--- a/docs/02-app/01-building-your-application/02-rendering/02-edge-and-nodejs-runtimes.mdx
+++ b/docs/02-app/01-building-your-application/02-rendering/02-edge-and-nodejs-runtimes.mdx
@@ -68,7 +68,7 @@ export const runtime = 'edge' // 'nodejs' (default) | 'edge'
 export const runtime = 'edge' // 'nodejs' (default) | 'edge'
 ```
 
-You can also define `runtime` on a layout level, which will make all pages under the layout run on the edge runtime:
+You can also define `runtime` on a layout level, which will make all routes under the layout run on the edge runtime:
 
 
 ```tsx filename="app/layout.tsx" switcher

--- a/docs/02-app/01-building-your-application/02-rendering/02-edge-and-nodejs-runtimes.mdx
+++ b/docs/02-app/01-building-your-application/02-rendering/02-edge-and-nodejs-runtimes.mdx
@@ -70,7 +70,6 @@ export const runtime = 'edge' // 'nodejs' (default) | 'edge'
 
 You can also define `runtime` on a layout level, which will make all routes under the layout run on the edge runtime:
 
-
 ```tsx filename="app/layout.tsx" switcher
 export const runtime = 'edge' // 'nodejs' (default) | 'edge'
 ```

--- a/docs/02-app/01-building-your-application/02-rendering/02-edge-and-nodejs-runtimes.mdx
+++ b/docs/02-app/01-building-your-application/02-rendering/02-edge-and-nodejs-runtimes.mdx
@@ -68,6 +68,17 @@ export const runtime = 'edge' // 'nodejs' (default) | 'edge'
 export const runtime = 'edge' // 'nodejs' (default) | 'edge'
 ```
 
+You can also define `runtime` on a layout level, which will make all pages under the layout run on the edge runtime:
+
+
+```tsx filename="app/layout.tsx" switcher
+export const runtime = 'edge' // 'nodejs' (default) | 'edge'
+```
+
+```jsx filename="app/layout.js" switcher
+export const runtime = 'edge' // 'nodejs' (default) | 'edge'
+```
+
 If the segment runtime is _not_ set, the default `nodejs` runtime will be used. You do not need to use the `runtime` option if you do not plan to change from the Node.js runtime.
 
 </AppOnly>


### PR DESCRIPTION
Added clarification that runtime edge can be defined on Layout level too.