### PR TITLE
chore(docs): fix typo in generate metadata docs

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -109,8 +109,7 @@ export async function generateMetadata(
 export default function Page({ params, searchParams }: Props) {}
 ```
 
-```
-jsx filename="app/products/[id]/page.js" switcher
+```jsx filename="app/products/[id]/page.js" switcher
 export async function generateMetadata({ params, searchParams }, parent) {
   // read route params
   const id = params.id


### PR DESCRIPTION
- See current bug: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#generatemetadata-function
- Closes #52903 