### PR TITLE
Fixied:#52898 LangCode Missing zh-Hans and zh-Hant

### DIFF
--- a/packages/next/src/lib/metadata/types/alternative-urls-types.ts
+++ b/packages/next/src/lib/metadata/types/alternative-urls-types.ts
@@ -413,6 +413,7 @@ type LangCode =
   | 'zh-SG'
   | 'zh-TW'
   | 'zu-ZA'
+  |  string
 
 type UnmatchedLang = 'x-default'
 


### PR DESCRIPTION
#52898

  | 'yo-NG'
  | 'zh-CN'
  | 'zh-HK'
  | 'zh-MO'
  | 'zh-SG'
  | 'zh-TW'
  | 'zu-ZA'
  |  string    // here added string 

https://github.com/vercel/next.js/blob/f5272acbe5628164257ef8e584c8a469a4af5cb8/packages/next/src/lib/metadata/types/alternative-urls-types.ts#L419
