### PR TITLE
perf: batch `realpath` call in `nextjs-require-cache-hot-reloader`

### DIFF
--- a/packages/next/src/lib/realpath.ts
+++ b/packages/next/src/lib/realpath.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import { promisify } from 'util'
 
 const isWindows = process.platform === 'win32'
 
@@ -7,3 +8,10 @@ const isWindows = process.platform === 'win32'
 // https://github.com/nodejs/node/issues/2680
 // However, we can't use fs.realpathSync.native on Windows due to behavior differences.
 export const realpathSync = isWindows ? fs.realpathSync : fs.realpathSync.native
+
+// fs.promises.realpath behaves like fs.realpath.native, because it is 70x faster and is preferred
+// by the Node.js team: https://github.com/nodejs/node/issues/37737
+// Use promisify(fs.realpath) to adapt behavior differences (namely Windows Network Drive behavior).
+export const realpath = isWindows
+  ? promisify(fs.realpath)
+  : fs.promises.realpath


### PR DESCRIPTION
Another PR to battle against slow compilation during dev:

- Add asynchronous version of `realpath(3)` API to `next/src/lib/realpath`.
  - The fallback for Windows is also added, just like `replaceSync`.
- Replace `nextjs-require-cache-hot-reloader`'s `tap` with `tapPromise`, which allows `realpath` fs call to be batched with `Promise.all`.