### PR TITLE
Initial HMR Nexturbo API implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7608,6 +7608,7 @@ dependencies = [
  "turbopack-dev",
  "turbopack-dev-server",
  "turbopack-ecmascript",
+ "turbopack-ecmascript-hmr-protocol",
  "turbopack-ecmascript-plugins",
  "turbopack-ecmascript-runtime",
  "turbopack-env",

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -62,7 +62,8 @@ turbopack-binding = { workspace = true, features = [
   "__turbo",
   "__turbo_tasks",
   "__turbo_tasks_memory",
-  "__turbopack"
+  "__turbopack",
+  "__turbopack_ecmascript_hmr_protocol",
 ] }
 
 [target.'cfg(not(all(target_os = "linux", target_env = "musl", target_arch = "aarch64")))'.dependencies]

--- a/packages/next-swc/crates/napi/src/next_api/utils.rs
+++ b/packages/next-swc/crates/napi/src/next_api/utils.rs
@@ -4,7 +4,6 @@ use anyhow::{anyhow, Context, Result};
 use napi::{
     bindgen_prelude::{External, ToNapiValue},
     threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode},
-    tokio::sync::mpsc::{channel, Sender},
     JsFunction, JsObject, JsUnknown, NapiRaw, NapiValue, Status,
 };
 use serde::Serialize;
@@ -274,51 +273,4 @@ pub fn subscribe<T: 'static + Send + Sync, F: Future<Output = Result<T>> + Send,
         turbo_tasks,
         task_id: Some(task_id),
     }))
-}
-
-pub fn stream_channel<
-    T: 'static + Send + Sync,
-    F: Future<Output = Result<()>> + Send,
-    V: ToNapiValue,
->(
-    turbo_tasks: Arc<TurboTasks<MemoryBackend>>,
-    func: JsFunction,
-    handler: impl 'static + Sync + Send + Clone + Fn(Sender<Result<T>>) -> F,
-    mapper: impl 'static + Sync + Send + FnMut(ThreadSafeCallContext<T>) -> napi::Result<Vec<V>>,
-) -> napi::Result<External<RootTask>> {
-    let func: ThreadsafeFunction<T> = func.create_threadsafe_function(0, mapper)?;
-    let task_id = turbo_tasks.spawn_root_task(move || {
-        let handler = handler.clone();
-        let func = func.clone();
-        Box::pin(async move {
-            let (sx, mut rx) = channel(32);
-
-            if let Err(err) = handler(sx).await {
-                call_with(&func, Err(err))?;
-            } else {
-                while let Some(value) = rx.recv().await {
-                    call_with(&func, value)?;
-                }
-            }
-
-            Ok(unit().node)
-        })
-    });
-    Ok(External::new(RootTask {
-        turbo_tasks,
-        task_id: Some(task_id),
-    }))
-}
-
-fn call_with<T>(func: &ThreadsafeFunction<T>, res: Result<T>) -> Result<()> {
-    let status = func.call(
-        res.map_err(|err| napi::Error::from_reason(PrettyPrintError(&err).to_string())),
-        ThreadsafeFunctionCallMode::NonBlocking,
-    );
-    if !matches!(status, Status::Ok) {
-        let error = anyhow!("Error calling JS function: {}", status);
-        eprintln!("{}", error);
-        return Err(error);
-    }
-    Ok(())
 }

--- a/packages/next-swc/crates/next-api/src/lib.rs
+++ b/packages/next-swc/crates/next-api/src/lib.rs
@@ -7,6 +7,7 @@ mod entrypoints;
 mod pages;
 pub mod project;
 pub mod route;
+mod versioned_content_map;
 
 // Declare build-time information variables generated in build.rs
 shadow_rs::shadow!(build);

--- a/packages/next-swc/crates/next-api/src/pages.rs
+++ b/packages/next-swc/crates/next-api/src/pages.rs
@@ -1,8 +1,8 @@
 use anyhow::{bail, Context, Result};
 use indexmap::IndexMap;
 use next_core::{
-    all_server_paths, create_page_loader_entry_module, emit_all_assets,
-    get_asset_path_from_pathname, get_edge_resolve_options_context,
+    all_server_paths, create_page_loader_entry_module, get_asset_path_from_pathname,
+    get_edge_resolve_options_context,
     mode::NextMode,
     next_client::{
         get_client_module_options_context, get_client_resolve_options_context,
@@ -813,20 +813,17 @@ impl Endpoint for PageEndpoint {
 
         let this = self.await?;
 
-        let node_root = this.pages_project.project().node_root();
-        emit_all_assets(
-            output_assets,
-            node_root,
-            this.pages_project.project().client_relative_path(),
-            this.pages_project.project().node_root(),
-        )
-        .await?;
+        this.pages_project
+            .project()
+            .emit_all_output_assets(output_assets)
+            .await?;
 
+        let node_root = this.pages_project.project().node_root();
         let server_paths = all_server_paths(output_assets, node_root)
             .await?
             .clone_value();
 
-        let node_root = &this.pages_project.project().node_root().await?;
+        let node_root = &node_root.await?;
         let written_endpoint = match *output.await? {
             PageEndpointOutput::NodeJs {
                 entry_chunk,

--- a/packages/next-swc/crates/next-api/src/project.rs
+++ b/packages/next-swc/crates/next-api/src/project.rs
@@ -543,7 +543,7 @@ impl Project {
         // INVALIDATION: This is intentionally untracked to avoid invalidating this
         // function completely. We want to initialize the VersionState with the
         // first seen version of the session.
-        Ok(VersionState::new(version.into_trait_ref_untracked().await?).await?)
+        VersionState::new(version.into_trait_ref_untracked().await?).await
     }
 
     /// Emits opaque HMR events whenever a change is detected in the chunk group

--- a/packages/next-swc/crates/next-api/src/versioned_content_map.rs
+++ b/packages/next-swc/crates/next-api/src/versioned_content_map.rs
@@ -11,9 +11,11 @@ use turbopack_binding::{
     },
 };
 
+type VersionedContentMapInner = HashMap<Vc<FileSystemPath>, Vc<Box<dyn VersionedContent>>>;
+
 #[turbo_tasks::value]
 pub struct VersionedContentMap {
-    map: State<HashMap<Vc<FileSystemPath>, Vc<Box<dyn VersionedContent>>>>,
+    map: State<VersionedContentMapInner>,
 }
 
 impl ValueDefault for VersionedContentMap {

--- a/packages/next-swc/crates/next-api/src/versioned_content_map.rs
+++ b/packages/next-swc/crates/next-api/src/versioned_content_map.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+
+use anyhow::{bail, Result};
+use turbo_tasks::{State, TryJoinIterExt, ValueDefault, ValueToString, Vc};
+use turbopack_binding::{
+    turbo::tasks_fs::FileSystemPath,
+    turbopack::core::{
+        asset::Asset,
+        output::{OutputAsset, OutputAssets},
+        version::VersionedContent,
+    },
+};
+
+#[turbo_tasks::value]
+pub struct VersionedContentMap {
+    map: State<HashMap<Vc<FileSystemPath>, Vc<Box<dyn VersionedContent>>>>,
+}
+
+impl ValueDefault for VersionedContentMap {
+    fn value_default() -> Vc<Self> {
+        VersionedContentMap {
+            map: State::new(HashMap::new()),
+        }
+        .cell()
+    }
+}
+
+impl VersionedContentMap {
+    // NOTE(alexkirsz) This must not be a `#[turbo_tasks::function]` because it
+    // should be a singleton for each project.
+    pub fn new() -> Vc<Self> {
+        Self::value_default()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl VersionedContentMap {
+    #[turbo_tasks::function]
+    pub async fn insert_output_assets(self: Vc<Self>, assets: Vc<OutputAssets>) -> Result<()> {
+        let assets = assets.await?;
+        let entries: Vec<_> = assets
+            .iter()
+            .map(|asset| async move {
+                // NOTE(alexkirsz) `.versioned_content()` should not be resolved, to ensure that
+                // it always points to the task that computes the versioned
+                // content.
+                Ok((
+                    asset.ident().path().resolve().await?,
+                    asset.versioned_content(),
+                ))
+            })
+            .try_join()
+            .await?;
+        self.await?.map.update_conditionally(move |map| {
+            map.extend(entries);
+            true
+        });
+        Ok(())
+    }
+
+    #[turbo_tasks::function]
+    pub async fn get(&self, path: Vc<FileSystemPath>) -> Result<Vc<Box<dyn VersionedContent>>> {
+        let content = {
+            // NOTE(alexkirsz) This is to avoid Rust marking this method as !Send because a
+            // StateRef to the map is captured across an await boundary below, even though
+            // it does not look like it would.
+            // I think this is a similar issue as https://fasterthanli.me/articles/a-rust-match-made-in-hell
+            let map = self.map.get();
+            map.get(&path).copied()
+        };
+        let Some(content) = content else {
+            let path = path.to_string().await?;
+            bail!("could not find versioned content for path {}", path);
+        };
+        // NOTE(alexkirsz) This is necessary to mark the task as active again.
+        content.node.connect();
+        Ok(content)
+    }
+}

--- a/packages/next-swc/crates/next-core/src/emit.rs
+++ b/packages/next-swc/crates/next-core/src/emit.rs
@@ -38,15 +38,35 @@ pub async fn all_server_paths(
 /// Assets inside the given client root are rebased to the given client output
 /// path.
 #[turbo_tasks::function]
-pub async fn emit_all_assets(
+pub fn emit_all_assets(
+    assets: Vc<OutputAssets>,
+    node_root: Vc<FileSystemPath>,
+    client_relative_path: Vc<FileSystemPath>,
+    client_output_path: Vc<FileSystemPath>,
+) -> Vc<Completion> {
+    emit_assets(
+        all_assets_from_entries(assets),
+        node_root,
+        client_relative_path,
+        client_output_path,
+    )
+}
+
+/// Emits all assets transitively reachable from the given chunks, that are
+/// inside the node root or the client root.
+///
+/// Assets inside the given client root are rebased to the given client output
+/// path.
+#[turbo_tasks::function]
+pub async fn emit_assets(
     assets: Vc<OutputAssets>,
     node_root: Vc<FileSystemPath>,
     client_relative_path: Vc<FileSystemPath>,
     client_output_path: Vc<FileSystemPath>,
 ) -> Result<Vc<Completion>> {
-    let all_assets = all_assets_from_entries(assets).await?;
     Ok(Completions::all(
-        all_assets
+        assets
+            .await?
             .iter()
             .copied()
             .map(|asset| async move {
@@ -94,7 +114,7 @@ fn emit_rebase(
 /// Walks the asset graph from multiple assets and collect all referenced
 /// assets.
 #[turbo_tasks::function]
-async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<OutputAssets>> {
+pub async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<OutputAssets>> {
     Ok(Vc::cell(
         AdjacencyMap::new()
             .skip_duplicates()

--- a/packages/next-swc/crates/next-core/src/lib.rs
+++ b/packages/next-swc/crates/next-core/src/lib.rs
@@ -55,7 +55,7 @@ pub use app_segment_config::{
     parse_segment_config_from_loader_tree, parse_segment_config_from_source,
 };
 pub use app_source::create_app_source;
-pub use emit::{all_server_paths, emit_all_assets};
+pub use emit::{all_assets_from_entries, all_server_paths, emit_all_assets, emit_assets};
 pub use next_edge::context::{
     get_edge_chunking_context, get_edge_compile_time_info, get_edge_resolve_options_context,
 };


### PR DESCRIPTION
This implements a MVP of HMR. HMR works similarly as in turbopack-dev-server, but instead of going through the router to retrieve output assets, output assets are eagerly stored into a global hash map, and retrieved directly from there (see `VersionedContentMap`).

This will require some more glue on the Next.js side in order to handle:
* RSC headers;
* handling Turbopack subscriptiob HMR events from the Next.js WS server, proxying them to `hmr_events`, and sending back the stream of updates.

There's currently no way to evict deleted output assets, nor to communicate these events to the client. @sokra mentioned the `VersionedContentMap` could store a list of assets per entrypoint, instead of having a top-level flat map.