### PR TITLE
Add package.json engine requirement for Node <20, to help contributors use compatible Node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,4 @@ tag-version-prefix=""
 strict-peer-dependencies = false
 auto-install-peers = true
 lockfile = true
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     "@types/react-dom": "18.2.4"
   },
   "engines": {
-    "node": ">=16.8.0"
+    "node": ">=16.8.0 <20"
   },
   "packageManager": "pnpm@7.24.3"
 }


### PR DESCRIPTION
Partially addresses #52943

There's a PNPM bug that stops PNPM 7.24.3 working on Node 20: https://github.com/pnpm/pnpm/issues/6424. We previously tried updating PNPM to fix this (#51406), but this was reverted due to issues (#51539).

While we wait on a longer term solution (discussing in #52943), this temporary solution will help new contributors figure out what's going wrong sooner. The current experience is to get a few warnings and then get stuck: this will change the behaviour so it clearly asks people to use a different Node version.