### PR TITLE
fix(flight-manifest-plugin): passthrough intercepting routes in manifest

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -351,7 +351,7 @@ export class ClientReferenceManifestPlugin {
       // - app/(group)/@named/foo/page -> app/foo
       // - app/(group)/@named/(.)foo/page -> app/(.)foo
       const groupName = normalizePagePath(entryName).replace(
-        /\/(page|loading|layout|route|default|error|not-found)(\.tsx?)?/g,
+        /\/(page|loading|layout|route|default|error|not-found)(\.tsx?|\.jsx?)?/g,
         ''
       )
 

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -349,10 +349,11 @@ export class ClientReferenceManifestPlugin {
       // - app/foo/loading -> app/foo
       // - app/foo/page -> app/foo
       // - app/(group)/@named/foo/page -> app/foo
-      const groupName = entryName
-        .slice(0, entryName.lastIndexOf('/'))
-        .replace(/\/@[^/]+/g, '')
-        .replace(/\/\([^/]+\)/g, '')
+      // - app/(group)/@named/(.)foo/page -> app/(.)foo
+      const groupName = normalizePagePath(entryName).replace(
+        /\/(page|loading|layout|route)(\.tsx?)?/g,
+        ''
+      )
 
       if (!manifestsPerGroup.has(groupName)) {
         manifestsPerGroup.set(groupName, [])

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -351,7 +351,7 @@ export class ClientReferenceManifestPlugin {
       // - app/(group)/@named/foo/page -> app/foo
       // - app/(group)/@named/(.)foo/page -> app/(.)foo
       const groupName = normalizePagePath(entryName).replace(
-        /\/(page|loading|layout|route)(\.tsx?)?/g,
+        /\/(page|loading|layout|route|default|error|not-found)(\.tsx?)?/g,
         ''
       )
 

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -17,6 +17,7 @@ import { getProxiedPluginState } from '../../build-context'
 import { nonNullable } from '../../../lib/non-nullable'
 import { WEBPACK_LAYERS } from '../../../lib/constants'
 import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
+import { normalizeAppPath } from '../../../shared/lib/router/utils/app-paths'
 
 interface Options {
   dev: boolean
@@ -350,7 +351,7 @@ export class ClientReferenceManifestPlugin {
       // - app/foo/page -> app/foo
       // - app/(group)/@named/foo/page -> app/foo
       // - app/(group)/@named/(.)foo/page -> app/(.)foo
-      const groupName = normalizePagePath(entryName).replace(
+      const groupName = normalizeAppPath(entryName).replace(
         /\/(page|loading|layout|route|default|error|not-found)(\.tsx?|\.jsx?)?/g,
         ''
       )

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -351,16 +351,10 @@ export class ClientReferenceManifestPlugin {
       // - app/foo/page -> app/foo
       // - app/(group)/@named/foo/page -> app/foo
       // - app/(group)/@named/(.)foo/page -> app/(.)foo
-      const preGroupName = entryName
-        .slice(0, entryName.lastIndexOf('/'))
-        .replace(/\/@[^/]+/g, '')
-        .replace(/\/\([^/]+\)/g, '')
-
       const groupName = normalizeAppPath(entryName, [
         'loading',
         'layout',
       ]).slice(1)
-      console.log({ preGroupName, groupName })
 
       if (!manifestsPerGroup.has(groupName)) {
         manifestsPerGroup.set(groupName, [])

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -351,10 +351,16 @@ export class ClientReferenceManifestPlugin {
       // - app/foo/page -> app/foo
       // - app/(group)/@named/foo/page -> app/foo
       // - app/(group)/@named/(.)foo/page -> app/(.)foo
-      const groupName = normalizeAppPath(entryName).replace(
-        /\/(page|loading|layout|route|default|error|not-found)(\.tsx?|\.jsx?)?/g,
-        ''
-      )
+      const preGroupName = entryName
+        .slice(0, entryName.lastIndexOf('/'))
+        .replace(/\/@[^/]+/g, '')
+        .replace(/\/\([^/]+\)/g, '')
+
+      const groupName = normalizeAppPath(entryName, [
+        'loading',
+        'layout',
+      ]).slice(1)
+      console.log({ preGroupName, groupName })
 
       if (!manifestsPerGroup.has(groupName)) {
         manifestsPerGroup.set(groupName, [])

--- a/packages/next/src/shared/lib/router/utils/app-paths.ts
+++ b/packages/next/src/shared/lib/router/utils/app-paths.ts
@@ -19,7 +19,10 @@ import { ensureLeadingSlash } from '../../page-path/ensure-leading-slash'
  * @param route the app route to normalize
  * @returns the normalized pathname
  */
-export function normalizeAppPath(route: string) {
+export function normalizeAppPath(route: string, extraLeafs?: string[]) {
+  const DEFAULT_LEAFS = ['page', 'route']
+  const mergedLeafs = [...(extraLeafs ?? []), ...DEFAULT_LEAFS]
+
   return ensureLeadingSlash(
     route.split('/').reduce((pathname, segment, index, segments) => {
       // Empty segments are ignored.
@@ -38,10 +41,7 @@ export function normalizeAppPath(route: string) {
       }
 
       // The last segment (if it's a leaf) should be ignored.
-      if (
-        (segment === 'page' || segment === 'route') &&
-        index === segments.length - 1
-      ) {
+      if (mergedLeafs.includes(segment) && index === segments.length - 1) {
         return pathname
       }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change



-->

### What?

Use `normalizeAppPath` so it only parses groups, etc. It will passthrough the intercepting routes

### Why?

This feature wasn't working previously 

Fixes #52862