### PR TITLE
Change "publically" to "publicly" in the routing docs

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/12-colocation.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/12-colocation.mdx
@@ -24,20 +24,20 @@ In the `app` directory, [nested folder hierarchy](/docs/app/building-your-applic
 
 Each folder represents a route segment that is mapped to a corresponding segment in a URL path.
 
-However, even though route structure is defined through folders, a route is **not publically accessible** until a `page.js` or `route.js` file is added to a route segment.
+However, even though route structure is defined through folders, a route is **not publicly accessible** until a `page.js` or `route.js` file is added to a route segment.
 
 <Image
-  alt="A diagram showing how a route is not publically accessible until a page.js or route.js file is added to a route segment."
+  alt="A diagram showing how a route is not publicly accessible until a page.js or route.js file is added to a route segment."
   srcLight="/docs/light/project-organization-not-routable.png"
   srcDark="/docs/dark/project-organization-not-routable.png"
   width="1600"
   height="444"
 />
 
-And, even when a route is made publically accessible, only the **content returned** by `page.js` or `route.js` is sent to the client.
+And, even when a route is made publicly accessible, only the **content returned** by `page.js` or `route.js` is sent to the client.
 
 <Image
-  alt="A diagram showing how page.js and route.js files make routes publically accessible."
+  alt="A diagram showing how page.js and route.js files make routes publicly accessible."
   srcLight="/docs/light/project-organization-routable.png"
   srcDark="/docs/dark/project-organization-routable.png"
   width="1600"

--- a/docs/02-app/01-building-your-application/01-routing/index.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/index.mdx
@@ -134,7 +134,7 @@ In a nested route, the components of a segment will be nested **inside** the com
 
 In addition to special files, you have the option to colocate your own files (e.g. components, styles, tests, etc) inside folders in the `app` directory.
 
-This is because while folders define routes, only the contents returned by `page.js` or `route.js` are publically addressable.
+This is because while folders define routes, only the contents returned by `page.js` or `route.js` are publicly addressable.
 
 <Image
   alt="An example folder structure with colocated files"


### PR DESCRIPTION
### What and why?

The word "publicly" should be spelled consistently across the documentation. It is spelled currently as "publically" in a few places.

### How?

Fixed the spelling!

