### PR TITLE
Fix build side-effects from third-parties package

### DIFF
--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -12,8 +12,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "rm -rf dist && tsc -d -p tsconfig.json && node scripts/update-third-parties",
-    "prepublishOnly": "cd ../../ && turbo run build",
+    "manual-build": "rm -rf dist && tsc -d -p tsconfig.json && node scripts/update-third-parties",
     "dev": "tsc -d -w -p tsconfig.json",
     "typescript": "tsec --noEmit -p tsconfig.json"
   },


### PR DESCRIPTION
We shouldn't be generating src files during the build script as these can break publishing. 