### PR TITLE
Revert "Changed package manager for install-native.mjs to pnpm (#52971)"

### DIFF
--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -56,9 +56,7 @@ import fs from 'fs-extra'
       path.join(tmpdir, 'package.json'),
       JSON.stringify(pkgJson)
     )
-    let { stdout } = await execa('pnpm', ['install', '--force'], {
-      cwd: tmpdir,
-    })
+    let { stdout } = await execa('yarn', ['--force'], { cwd: tmpdir })
     console.log(stdout)
     let pkgs = await fs.readdir(path.join(tmpdir, 'node_modules/@next'))
     await fs.ensureDir(path.join(cwd, 'node_modules/@next'))


### PR DESCRIPTION
This was causing issues with installing swc binaries (appears to be creating corrupt aliases in `node_modules/@next` rather than the actual resolved swc package)

Since pnpm creates hard links on disk, the files being moved aren't the actual binaries, they're just aliases. And when tmpdir gets removed, the aliases point to nothing