### PR TITLE
chore: extract common get-validated-args

### DIFF
--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -7,6 +7,7 @@ import build from '../build'
 import { printAndExit } from '../server/lib/utils'
 import isError from '../lib/is-error'
 import { getProjectDir } from '../lib/get-project-dir'
+import { getValidatedArgs } from '../lib/get-validated-args'
 
 const nextBuild: CliCommand = (argv) => {
   const validArgs: arg.Spec = {
@@ -25,15 +26,8 @@ const nextBuild: CliCommand = (argv) => {
     '-d': '--debug',
   }
 
-  let args: arg.Result<arg.Spec>
-  try {
-    args = arg(validArgs, { argv })
-  } catch (error) {
-    if (isError(error) && error.code === 'ARG_UNKNOWN_OPTION') {
-      return printAndExit(error.message, 1)
-    }
-    throw error
-  }
+  const args = getValidatedArgs(validArgs, argv)
+
   if (args['--help']) {
     printAndExit(
       `

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -4,7 +4,6 @@ import { startServer, StartServerOptions } from '../server/lib/start-server'
 import { getPort, printAndExit } from '../server/lib/utils'
 import * as Log from '../build/output/log'
 import { CliCommand } from '../lib/commands'
-import isError from '../lib/is-error'
 import { getProjectDir } from '../lib/get-project-dir'
 import { CONFIG_FILES, PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
 import path from 'path'
@@ -20,6 +19,7 @@ import Watchpack from 'watchpack'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { getPossibleInstrumentationHookFilenames } from '../build/worker'
 import { resetEnv } from '@next/env'
+import { getValidatedArgs } from '../lib/get-validated-args'
 
 let dir: string
 let config: NextConfigComplete
@@ -131,15 +131,7 @@ const nextDev: CliCommand = async (argv) => {
     '-p': '--port',
     '-H': '--hostname',
   }
-  let args: arg.Result<arg.Spec>
-  try {
-    args = arg(validArgs, { argv })
-  } catch (error) {
-    if (isError(error) && error.code === 'ARG_UNKNOWN_OPTION') {
-      return printAndExit(error.message, 1)
-    }
-    throw error
-  }
+  const args = getValidatedArgs(validArgs, argv)
   if (args['--help']) {
     console.log(`
       Description

--- a/packages/next/src/cli/next-export.ts
+++ b/packages/next/src/cli/next-export.ts
@@ -8,8 +8,8 @@ import * as Log from '../build/output/log'
 import { printAndExit } from '../server/lib/utils'
 import { CliCommand } from '../lib/commands'
 import { trace } from '../trace'
-import isError from '../lib/is-error'
 import { getProjectDir } from '../lib/get-project-dir'
+import { getValidatedArgs } from '../lib/get-validated-args'
 
 const nextExport: CliCommand = (argv) => {
   const nextExportCliSpan = trace('next-export-cli')
@@ -25,15 +25,7 @@ const nextExport: CliCommand = (argv) => {
     '-o': '--outdir',
     '-s': '--silent',
   }
-  let args: arg.Result<arg.Spec>
-  try {
-    args = arg(validArgs, { argv })
-  } catch (error) {
-    if (isError(error) && error.code === 'ARG_UNKNOWN_OPTION') {
-      return printAndExit(error.message, 1)
-    }
-    throw error
-  }
+  const args = getValidatedArgs(validArgs, argv)
   if (args['--help']) {
     console.log(`
       Description

--- a/packages/next/src/cli/next-info.ts
+++ b/packages/next/src/cli/next-info.ts
@@ -8,11 +8,10 @@ import arg from 'next/dist/compiled/arg/index.js'
 const { fetch } = require('next/dist/compiled/undici') as {
   fetch: typeof global.fetch
 }
-import { printAndExit } from '../server/lib/utils'
 import { CliCommand } from '../lib/commands'
-import isError from '../lib/is-error'
 import { PHASE_INFO } from '../shared/lib/constants'
 import loadConfig from '../server/config'
+import { getValidatedArgs } from '../lib/get-validated-args'
 
 const dir = process.cwd()
 
@@ -50,15 +49,7 @@ const nextInfo: CliCommand = async (argv) => {
     // Aliases
     '-h': '--help',
   }
-  let args: arg.Result<arg.Spec>
-  try {
-    args = arg(validArgs, { argv })
-  } catch (error) {
-    if (isError(error) && error.code === 'ARG_UNKNOWN_OPTION') {
-      return printAndExit(error.message, 1)
-    }
-    throw error
-  }
+  const args = getValidatedArgs(validArgs, argv)
 
   if (args['--help']) {
     console.log(

--- a/packages/next/src/cli/next-lint.ts
+++ b/packages/next/src/cli/next-lint.ts
@@ -16,10 +16,10 @@ import loadConfig from '../server/config'
 import { PHASE_PRODUCTION_BUILD } from '../shared/lib/constants'
 import { eventLintCheckCompleted } from '../telemetry/events'
 import { CompileError } from '../lib/compile-error'
-import isError from '../lib/is-error'
 import { getProjectDir } from '../lib/get-project-dir'
 import { findPagesDir } from '../lib/find-pages-dir'
 import { verifyTypeScriptSetup } from '../lib/verifyTypeScriptSetup'
+import { getValidatedArgs } from '../lib/get-validated-args'
 
 const eslintOptions = (args: arg.Spec, defaultCacheLocation: string) => ({
   overrideConfigFile: args['--config'] || null,
@@ -93,15 +93,8 @@ const nextLint: CliCommand = async (argv) => {
     '-o': '--output-file',
   }
 
-  let args: arg.Result<arg.Spec>
-  try {
-    args = arg({ ...validArgs, ...validEslintArgs }, { argv })
-  } catch (error) {
-    if (isError(error) && error.code === 'ARG_UNKNOWN_OPTION') {
-      return printAndExit(error.message, 1)
-    }
-    throw error
-  }
+  const args = getValidatedArgs({ ...validArgs, ...validEslintArgs }, argv)
+
   if (args['--help']) {
     printAndExit(
       `

--- a/packages/next/src/cli/next-start.ts
+++ b/packages/next/src/cli/next-start.ts
@@ -3,12 +3,12 @@
 import arg from 'next/dist/compiled/arg/index.js'
 import { startServer } from '../server/lib/start-server'
 import { getPort, printAndExit } from '../server/lib/utils'
-import isError from '../lib/is-error'
 import { getProjectDir } from '../lib/get-project-dir'
 import { CliCommand } from '../lib/commands'
 import { resolve } from 'path'
 import { PHASE_PRODUCTION_SERVER } from '../shared/lib/constants'
 import loadConfig from '../server/config'
+import { getValidatedArgs } from '../lib/get-validated-args'
 
 const nextStart: CliCommand = async (argv) => {
   const validArgs: arg.Spec = {
@@ -23,15 +23,7 @@ const nextStart: CliCommand = async (argv) => {
     '-p': '--port',
     '-H': '--hostname',
   }
-  let args: arg.Result<arg.Spec>
-  try {
-    args = arg(validArgs, { argv })
-  } catch (error) {
-    if (isError(error) && error.code === 'ARG_UNKNOWN_OPTION') {
-      return printAndExit(error.message, 1)
-    }
-    throw error
-  }
+  const args = getValidatedArgs(validArgs, argv)
   if (args['--help']) {
     console.log(`
       Description

--- a/packages/next/src/cli/next-telemetry.ts
+++ b/packages/next/src/cli/next-telemetry.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 import chalk from 'next/dist/compiled/chalk'
 import arg from 'next/dist/compiled/arg/index.js'
-import { printAndExit } from '../server/lib/utils'
 import { CliCommand } from '../lib/commands'
 import { Telemetry } from '../telemetry/storage'
-import isError from '../lib/is-error'
+import { getValidatedArgs } from '../lib/get-validated-args'
 
 const nextTelemetry: CliCommand = (argv) => {
   const validArgs: arg.Spec = {
@@ -15,15 +14,7 @@ const nextTelemetry: CliCommand = (argv) => {
     // Aliases
     '-h': '--help',
   }
-  let args: arg.Result<arg.Spec>
-  try {
-    args = arg(validArgs, { argv })
-  } catch (error) {
-    if (isError(error) && error.code === 'ARG_UNKNOWN_OPTION') {
-      return printAndExit(error.message, 1)
-    }
-    throw error
-  }
+  const args = getValidatedArgs(validArgs, argv)
 
   if (args['--help']) {
     console.log(

--- a/packages/next/src/lib/get-validated-args.ts
+++ b/packages/next/src/lib/get-validated-args.ts
@@ -1,0 +1,16 @@
+import arg from 'next/dist/compiled/arg/index.js'
+import { printAndExit } from '../server/lib/utils'
+import isError from './is-error'
+
+export function getValidatedArgs(validArgs: arg.Spec, argv?: string[]) {
+  let args: arg.Result<arg.Spec>
+  try {
+    args = arg(validArgs, { argv })
+  } catch (error) {
+    if (isError(error) && error.code === 'ARG_UNKNOWN_OPTION') {
+      printAndExit(error.message, 1)
+    }
+    throw error
+  }
+  return args
+}


### PR DESCRIPTION
Since every file under  the`packages/next/src/cli` directory has the same validation argument logic, extract it to `get-validated-args.ts` for reuse.


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
