### PR TITLE
refactor(codemod): replace chalk with picocolors

### DIFF
--- a/packages/next-codemod/bin/cli.ts
+++ b/packages/next-codemod/bin/cli.ts
@@ -13,7 +13,7 @@ import inquirer from 'inquirer'
 import meow from 'meow'
 import path from 'path'
 import execa from 'execa'
-import chalk from 'chalk'
+import { yellow } from 'picocolors'
 import isGitClean from 'is-git-clean'
 import { uninstallPackage } from '../lib/uninstall-package'
 
@@ -38,7 +38,7 @@ export function checkGitStatus(force) {
     } else {
       console.log('Thank you for using @next/codemod!')
       console.log(
-        chalk.yellow(
+        yellow(
           '\nBut before we continue, please stash or commit your git changes.'
         )
       )

--- a/packages/next-codemod/lib/install.ts
+++ b/packages/next-codemod/lib/install.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import chalk from 'chalk'
+import { yellow } from 'picocolors'
 import spawn from 'cross-spawn'
 
 interface InstallArgs {
@@ -70,9 +70,9 @@ export function install(
        */
       args = ['install']
       if (!isOnline) {
-        console.log(chalk.yellow('You appear to be offline.'))
+        console.log(yellow('You appear to be offline.'))
         if (useYarn) {
-          console.log(chalk.yellow('Falling back to the local Yarn cache.'))
+          console.log(yellow('Falling back to the local Yarn cache.'))
           console.log()
           args.push('--offline')
         } else {

--- a/packages/next-codemod/package.json
+++ b/packages/next-codemod/package.json
@@ -8,14 +8,14 @@
     "directory": "packages/next-codemod"
   },
   "dependencies": {
-    "chalk": "4.1.0",
     "cheerio": "1.0.0-rc.9",
     "execa": "4.0.3",
     "globby": "11.0.1",
     "inquirer": "7.3.3",
     "is-git-clean": "1.1.0",
     "jscodeshift": "0.13.1",
-    "meow": "7.0.1"
+    "meow": "7.0.1",
+    "picocolors": "1.0.0"
   },
   "files": [
     "transforms/*.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -915,7 +915,6 @@ importers:
   packages/next-codemod:
     specifiers:
       '@types/jscodeshift': 0.11.0
-      chalk: 4.1.0
       cheerio: 1.0.0-rc.9
       execa: 4.0.3
       globby: 11.0.1
@@ -923,8 +922,8 @@ importers:
       is-git-clean: 1.1.0
       jscodeshift: 0.13.1
       meow: 7.0.1
+      picocolors: 1.0.0
     dependencies:
-      chalk: 4.1.0
       cheerio: 1.0.0-rc.9
       execa: 4.0.3
       globby: 11.0.1
@@ -932,6 +931,7 @@ importers:
       is-git-clean: 1.1.0
       jscodeshift: 0.13.1_@babel+preset-env@7.22.2
       meow: 7.0.1
+      picocolors: 1.0.0
     devDependencies:
       '@types/jscodeshift': 0.11.0
 


### PR DESCRIPTION
The PR replaces `chalk` inside `@next/codemod` with `picocolors`.

Generally, `@next/codemod` is used through `npx`/`pnpx` as it serves as a sort of "one-time fix". By replacing `chalk` with the `picocolors` (which is 14 times smaller and 2 times faster), we can speed up the installation process of `npx @next/codemod`.

Currently, `@next/codemod` has about 10k downloads per week, so I guess this PR is worth it:

<img width="441" alt="image" src="https://github.com/vercel/next.js/assets/40715044/a32fd6e0-bbe6-48e8-985d-83393c141b23">

In my next PR, I will replace `chalk` inside `create-next-app` with `picocolors` as well.