### PR TITLE
chore(test): fix flaky tsconfig.json test

### DIFF
--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -28,13 +28,14 @@ describe('correct tsconfig.json defaults', () => {
 
       await next.start()
 
+      let content: string
       // wait for tsconfig to be written
       await check(async () => {
-        await next.readFile('tsconfig.json')
-        return 'success'
-      }, 'success')
+        content = await next.readFile('tsconfig.json')
+        return content && content !== '{}' ? 'ready' : 'retry'
+      }, 'ready')
 
-      const tsconfig = JSON.parse(await next.readFile('tsconfig.json'))
+      const tsconfig = JSON.parse(content)
       expect(next.cliOutput).not.toContain('moduleResolution')
 
       expect(tsconfig.compilerOptions).toEqual(


### PR DESCRIPTION
This test was [sometimes failing](
https://github.com/vercel/next.js/actions/runs/5649220907/job/15303327768?pr=53130#step:27:230) because the `tsconfig.json` is [written as an empty object](https://github.com/vercel/next.js/blob/a26bac96048c7231271b5947eaf80241e94ca2fc/packages/next/src/lib/typescript/writeConfigurationDefaults.ts#L123-L125).

This PR makes sure the test waits until the tsconfig.json file is written with the complete contents.
