### PR TITLE
Temporarily skip flakey action revalidate

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -422,10 +422,8 @@ createNextDescribe(
         }, 'https://example.com/')
       })
 
-      // TODO: investigate flakey behavior on deploy
-      const skipDeploy = (global as any).isNextDeploy ? it.skip : it
-
-      skipDeploy('should handle revalidatePath', async () => {
+      // TODO: investigate flakey behavior with revalidate
+      it.skip('should handle revalidatePath', async () => {
         const browser = await next.browser('/revalidate')
         const randomNumber = await browser.elementByCss('#random-number').text()
         const justPutIt = await browser.elementByCss('#justputit').text()
@@ -450,7 +448,8 @@ createNextDescribe(
         }, 'success')
       })
 
-      skipDeploy('should handle revalidateTag', async () => {
+      // TODO: investigate flakey behavior with revalidate
+      it.skip('should handle revalidateTag', async () => {
         const browser = await next.browser('/revalidate')
         const randomNumber = await browser.elementByCss('#random-number').text()
         const justPutIt = await browser.elementByCss('#justputit').text()
@@ -475,7 +474,7 @@ createNextDescribe(
         }, 'success')
       })
 
-      // TODO: investigate flakey behavior
+      // TODO: investigate flakey behavior with revalidate
       it.skip('should handle revalidateTag + redirect', async () => {
         const browser = await next.browser('/revalidate')
         const randomNumber = await browser.elementByCss('#random-number').text()
@@ -501,42 +500,38 @@ createNextDescribe(
         }, 'success')
       })
 
-      skipDeploy(
-        'should store revalidation data in the prefetch cache',
-        async () => {
-          const browser = await next.browser('/revalidate')
-          const justPutIt = await browser.elementByCss('#justputit').text()
-          await browser.elementByCss('#revalidate-justputit').click()
+      it.skip('should store revalidation data in the prefetch cache', async () => {
+        const browser = await next.browser('/revalidate')
+        const justPutIt = await browser.elementByCss('#justputit').text()
+        await browser.elementByCss('#revalidate-justputit').click()
 
-          // TODO: investigate flakiness when deployed
-          if (!isNextDeploy) {
-            await check(async () => {
-              const newJustPutIt = await browser
-                .elementByCss('#justputit')
-                .text()
-              expect(newJustPutIt).not.toBe(justPutIt)
-              return 'success'
-            }, 'success')
-          }
-
-          const newJustPutIt = await browser.elementByCss('#justputit').text()
-
-          await browser
-            .elementByCss('#navigate-client')
-            .click()
-            .waitForElementByCss('#inc')
-          await browser
-            .elementByCss('#navigate-revalidate')
-            .click()
-            .waitForElementByCss('#revalidate-justputit')
-
-          const newJustPutIt2 = await browser.elementByCss('#justputit').text()
-
-          expect(newJustPutIt).toEqual(newJustPutIt2)
+        // TODO: investigate flakiness when deployed
+        if (!isNextDeploy) {
+          await check(async () => {
+            const newJustPutIt = await browser.elementByCss('#justputit').text()
+            expect(newJustPutIt).not.toBe(justPutIt)
+            return 'success'
+          }, 'success')
         }
-      )
 
-      skipDeploy('should revalidate when cookies.set is called', async () => {
+        const newJustPutIt = await browser.elementByCss('#justputit').text()
+
+        await browser
+          .elementByCss('#navigate-client')
+          .click()
+          .waitForElementByCss('#inc')
+        await browser
+          .elementByCss('#navigate-revalidate')
+          .click()
+          .waitForElementByCss('#revalidate-justputit')
+
+        const newJustPutIt2 = await browser.elementByCss('#justputit').text()
+
+        expect(newJustPutIt).toEqual(newJustPutIt2)
+      })
+
+      // TODO: investigate flakey behavior with revalidate
+      it.skip('should revalidate when cookies.set is called', async () => {
         const browser = await next.browser('/revalidate')
         const randomNumber = await browser.elementByCss('#random-cookie').text()
 
@@ -551,67 +546,65 @@ createNextDescribe(
         }, 'success')
       })
 
-      skipDeploy(
-        'should revalidate when cookies.set is called in a client action',
-        async () => {
-          const browser = await next.browser('/revalidate')
-          await browser.refresh()
+      // TODO: investigate flakey behavior with revalidate
+      it.skip('should revalidate when cookies.set is called in a client action', async () => {
+        const browser = await next.browser('/revalidate')
+        await browser.refresh()
 
-          let randomCookie
-          await check(async () => {
-            randomCookie = JSON.parse(
-              await browser.elementByCss('#random-cookie').text()
-            ).value
-            return randomCookie ? 'success' : 'failure'
-          }, 'success')
-
-          console.log(123, await browser.elementByCss('body').text())
-
-          await browser.elementByCss('#another').click()
-          await check(async () => {
-            return browser.elementByCss('#title').text()
-          }, 'another route')
-
-          const newRandomCookie = JSON.parse(
+        let randomCookie
+        await check(async () => {
+          randomCookie = JSON.parse(
             await browser.elementByCss('#random-cookie').text()
           ).value
+          return randomCookie ? 'success' : 'failure'
+        }, 'success')
 
-          console.log(456, await browser.elementByCss('body').text())
+        console.log(123, await browser.elementByCss('body').text())
 
-          // Should be the same value
-          expect(randomCookie).toEqual(newRandomCookie)
+        await browser.elementByCss('#another').click()
+        await check(async () => {
+          return browser.elementByCss('#title').text()
+        }, 'another route')
 
-          await browser.elementByCss('#back').click()
+        const newRandomCookie = JSON.parse(
+          await browser.elementByCss('#random-cookie').text()
+        ).value
 
-          // Modify the cookie
-          await browser.elementByCss('#set-cookie').click()
+        console.log(456, await browser.elementByCss('body').text())
 
-          // Should be different
-          let revalidatedRandomCookie
-          await check(async () => {
-            revalidatedRandomCookie = JSON.parse(
-              await browser.elementByCss('#random-cookie').text()
-            ).value
-            return randomCookie !== revalidatedRandomCookie
-              ? 'success'
-              : 'failure'
-          }, 'success')
+        // Should be the same value
+        expect(randomCookie).toEqual(newRandomCookie)
 
-          await browser.elementByCss('#another').click()
+        await browser.elementByCss('#back').click()
 
-          // The other page should be revalidated too
-          await check(async () => {
-            const newRandomCookie = await JSON.parse(
-              await browser.elementByCss('#random-cookie').text()
-            ).value
-            return revalidatedRandomCookie === newRandomCookie
-              ? 'success'
-              : 'failure'
-          }, 'success')
-        }
-      )
+        // Modify the cookie
+        await browser.elementByCss('#set-cookie').click()
 
-      skipDeploy.each(['tag', 'path'])(
+        // Should be different
+        let revalidatedRandomCookie
+        await check(async () => {
+          revalidatedRandomCookie = JSON.parse(
+            await browser.elementByCss('#random-cookie').text()
+          ).value
+          return randomCookie !== revalidatedRandomCookie
+            ? 'success'
+            : 'failure'
+        }, 'success')
+
+        await browser.elementByCss('#another').click()
+
+        // The other page should be revalidated too
+        await check(async () => {
+          const newRandomCookie = await JSON.parse(
+            await browser.elementByCss('#random-cookie').text()
+          ).value
+          return revalidatedRandomCookie === newRandomCookie
+            ? 'success'
+            : 'failure'
+        }, 'success')
+      })
+
+      it.skip.each(['tag', 'path'])(
         'should invalidate client cache when %s is revalidated',
         async (type) => {
           const browser = await next.browser('/revalidate')


### PR DESCRIPTION
These have been flaking for quite a while so skips them more consistently until they are investigated. 

x-ref: https://github.com/vercel/next.js/actions/runs/5650048471/job/15305721826#step:27:590