### PR TITLE
align not-found between dev and prod

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -292,7 +292,6 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
           // include the client reference manifest
           const clientManifestsForPage =
             entrypoint.name.endsWith('/page') ||
-            entrypoint.name === '/not-found' ||
             entrypoint.name === '/_not-found'
               ? nodePath.join(
                   outputPath,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2631,7 +2631,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         if (this.hasAppDir && this.isRenderWorker) {
           // Use the not-found entry in app directory
           result = await this.findPageComponents({
-            pathname: this.renderOpts.dev ? '/not-found' : '/_not-found',
+            pathname: '/_not-found',
             query,
             params: {},
             isAppPath: true,

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -134,10 +134,7 @@ async function loadComponentsImpl({
 
   // Make sure to avoid loading the manifest for Route Handlers
   const hasClientManifest =
-    isAppPath &&
-    (pathname.endsWith('/page') ||
-      pathname === '/not-found' ||
-      pathname === '/_not-found')
+    isAppPath && (pathname.endsWith('/page') || pathname === '/_not-found')
 
   const [
     buildManifest,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1253,9 +1253,7 @@ export default class NextNodeServer extends BaseServer {
     const is404 = res.statusCode === 404
 
     if (is404 && this.hasAppDir && this.isRenderWorker) {
-      const notFoundPathname = this.renderOpts.dev
-        ? '/not-found'
-        : '/_not-found'
+      const notFoundPathname = '/_not-found'
 
       if (this.renderOpts.dev) {
         await (this as any)


### PR DESCRIPTION
### What?

* make it consistent between dev and prod: `_not-found`

### Why?

Why should it be different?


Closes PACK-4393