### PR TITLE
[WIP] refactor: replace ajv with zod

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -108,6 +108,97 @@ export const configSchemaZod: zod.ZodType<NextConfig> = z.lazy(() =>
       dirs: z.array(z.string()).optional(),
       ignoreDuringBuilds: z.boolean().optional(),
     }),
+    excludeDefaultMomentLocales: z.boolean().optional(),
+    exprimental: z.object({
+      appDocumentPreloading: z.boolean().optional(),
+      adjustFontFallbacks: z.boolean().optional(),
+      adjustFontFallbacksWithSizeAdjust: z.boolean().optional(),
+      allowedRevalidateHeaderKeys: z.array(z.string()).optional(),
+      amp: z
+        .object({
+          optimizer: z.any(),
+          validator: z.string().optional(),
+          skipValidation: z.boolean().optional(),
+        })
+        .optional(),
+      clientRouterFilter: z.boolean().optional(),
+      clientRouterFilterRedirects: z.boolean().optional(),
+      clientRouterFilterAllowedRate: z.number().optional(),
+      cpus: z.number().optional(),
+      memoryBasedWorkersCount: z.boolean().optional(),
+      craCompat: z.boolean().optional(),
+      caseSensitiveRoutes: z.boolean().optional(),
+      useDeploymenId: z.boolean().optional(),
+      deploymentId: z.string().optional(),
+      disableOptimizedLoading: z.boolean().optional(),
+      disablePostCssPresetEnv: z.boolean().optional(),
+      esmExternals: z.union([z.boolean(), z.literal('loose')]).optional(),
+      appDir: z.boolean().optional(),
+      serverActions: z.boolean().optional(),
+      serverActionsBodySizeLimit: z.union([z.number(), z.string()]).optional(),
+      extensionAlias: z.record(z.string()).optional(),
+      externalDir: z.boolean().optional(),
+      externalMiddlewareRewritesResolve: z.boolean().optional(),
+      fallbackNodePolyfills: z.boolean().optional(),
+      fetchCacheKeyPrefix: z.string().optional(),
+      forceSwcTransforms: z.boolean().optional(),
+      fullySpecified: z.boolean().optional(),
+      gzipSize: z.boolean().optional(),
+      incrementalCacheHandlerPath: z.string().optional(),
+      isrFlushToDisk: z.boolean().optional(),
+      isrMemoryCacheSize: z.number().optional(),
+      largePageDataBytes: z.number().optional(),
+      legacyBrowsers: z.boolean().optional(),
+      manualClientBasePath: z.boolean().optional(),
+      middleware: z
+        .union([z.literal('strict'), z.literal('flexible')])
+        .optional(),
+      newNextLinkBehavior: z.boolean().optional(),
+      nextScriptWorkers: z.boolean().optional(),
+      optimizeCss: z.union([z.boolean(), z.any()]).optional(),
+      optimisticClientCache: z.boolean().optional(),
+      outputFileTracingRoot: z.string().optional(),
+      outputFileTracingExcludes: z
+        .record(z.string(), z.array(z.string()))
+        .optional(),
+      outputFileTracingIgnores: z.array(z.string()).optional(),
+      outputFileTracingIncludes: z
+        .record(z.string(), z.array(z.string()))
+        .optional(),
+      swcTraceProfiling: z.boolean().optional(),
+      pageEnv: z.boolean().optional(),
+      proxyTimeout: z.number().min(0).optional(),
+      serverComponentsExternalPackages: z.array(z.string()).optional(),
+      scrollRestoration: z.boolean().optional(),
+      sharedPool: z.boolean().optional(),
+      srt: z.object({
+        algorithm: z
+          .union([
+            z.literal('sha256'),
+            z.literal('sha384'),
+            z.literal('sha512'),
+          ])
+          .optional(),
+      }),
+      strictNextHead: z.boolean().optional(),
+      swcFileReading: z.boolean().optional(),
+      swcMinify: z.boolean().optional(),
+      swcPlugins: z
+        .array(z.tuple([z.string(), z.record(z.string(), z.any()).optional()]))
+        .optional(),
+      urlImports: z.any(),
+      workerThreads: z.boolean().optional(),
+      webVitalsAttribution: z.array(
+        z.union([
+          z.literal('CLS'),
+          z.literal('FCP'),
+          z.literal('FID'),
+          z.literal('INP'),
+          z.literal('LCP'),
+          z.literal('TTFB'),
+        ])
+      ),
+    }),
   })
 )
 
@@ -115,239 +206,9 @@ const configSchema = {
   type: 'object',
   additionalProperties: false,
   properties: {
-    excludeDefaultMomentLocales: {
-      type: 'boolean',
-    },
     experimental: {
       additionalProperties: false,
       properties: {
-        appDocumentPreloading: {
-          type: 'boolean',
-        },
-        adjustFontFallbacks: {
-          type: 'boolean',
-        },
-        adjustFontFallbacksWithSizeAdjust: {
-          type: 'boolean',
-        },
-        allowedRevalidateHeaderKeys: {
-          type: 'array',
-        },
-        amp: {
-          additionalProperties: false,
-          properties: {
-            optimizer: {
-              type: 'object',
-            },
-            skipValidation: {
-              type: 'boolean',
-            },
-            validator: {
-              type: 'string',
-            },
-          },
-          type: 'object',
-        },
-        clientRouterFilter: {
-          type: 'boolean',
-        },
-        clientRouterFilterRedirects: {
-          type: 'boolean',
-        },
-        clientRouterFilterAllowedRate: {
-          type: 'number',
-        },
-        cpus: {
-          type: 'number',
-        },
-        memoryBasedWorkersCount: {
-          type: 'boolean',
-        },
-        craCompat: {
-          type: 'boolean',
-        },
-        caseSensitiveRoutes: {
-          type: 'boolean',
-        },
-        useDeploymentId: {
-          type: 'boolean',
-        },
-        useDeploymentIdServerActions: {
-          type: 'boolean',
-        },
-        deploymentId: {
-          type: 'string',
-        },
-        disableOptimizedLoading: {
-          type: 'boolean',
-        },
-        disablePostcssPresetEnv: {
-          type: 'boolean',
-        },
-        esmExternals: {
-          oneOf: [
-            {
-              type: 'boolean',
-            },
-            {
-              const: 'loose',
-            },
-          ] as any,
-        },
-        appDir: {
-          type: 'boolean',
-        },
-        serverActions: {
-          type: 'boolean',
-        },
-        serverActionsBodySizeLimit: {
-          oneOf: [
-            {
-              type: 'number',
-            },
-            {
-              type: 'string',
-            },
-          ] as any,
-        },
-        extensionAlias: {
-          type: 'object',
-        },
-        externalDir: {
-          type: 'boolean',
-        },
-        externalMiddlewareRewritesResolve: {
-          type: 'boolean',
-        },
-        fallbackNodePolyfills: {
-          type: 'boolean',
-        },
-        fetchCacheKeyPrefix: {
-          type: 'string',
-        },
-        forceSwcTransforms: {
-          type: 'boolean',
-        },
-        fullySpecified: {
-          type: 'boolean',
-        },
-        gzipSize: {
-          type: 'boolean',
-        },
-        incrementalCacheHandlerPath: {
-          type: 'string',
-        },
-        isrFlushToDisk: {
-          type: 'boolean',
-        },
-        isrMemoryCacheSize: {
-          type: 'number',
-        },
-        largePageDataBytes: {
-          type: 'number',
-        },
-        legacyBrowsers: {
-          type: 'boolean',
-        },
-        manualClientBasePath: {
-          type: 'boolean',
-        },
-        middlewarePrefetch: {
-          // automatic typing doesn't like enum
-          enum: ['strict', 'flexible'] as any,
-          type: 'string',
-        },
-        newNextLinkBehavior: {
-          type: 'boolean',
-        },
-        nextScriptWorkers: {
-          type: 'boolean',
-        },
-        optimizeCss: {
-          oneOf: [
-            {
-              type: 'boolean',
-            },
-            {
-              type: 'object',
-            },
-          ] as any,
-        },
-        optimisticClientCache: {
-          type: 'boolean',
-        },
-        outputFileTracingRoot: {
-          nullable: true,
-          type: 'string',
-        },
-        outputFileTracingExcludes: {
-          type: 'object',
-        },
-        outputFileTracingIgnores: {
-          type: 'array',
-        },
-        outputFileTracingIncludes: {
-          type: 'object',
-        },
-        pageEnv: {
-          type: 'boolean',
-        },
-        proxyTimeout: {
-          minimum: 0,
-          type: 'number',
-        },
-        serverComponentsExternalPackages: {
-          items: {
-            type: 'string',
-          },
-          type: 'array',
-        },
-        scrollRestoration: {
-          type: 'boolean',
-        },
-        sharedPool: {
-          type: 'boolean',
-        },
-        sri: {
-          properties: {
-            algorithm: {
-              enum: ['sha256', 'sha384', 'sha512'] as any,
-              type: 'string',
-            },
-          },
-          type: 'object',
-        },
-        strictNextHead: {
-          type: 'boolean',
-        },
-        swcFileReading: {
-          type: 'boolean',
-        },
-        swcMinify: {
-          type: 'boolean',
-        },
-        swcPlugins: {
-          type: 'array',
-        },
-        swcTraceProfiling: {
-          type: 'boolean',
-        },
-        urlImports: {
-          items: {
-            type: 'string',
-          },
-          type: 'array',
-        },
-        workerThreads: {
-          type: 'boolean',
-        },
-        webVitalsAttribution: {
-          type: 'array',
-          items: {
-            type: 'string',
-            enum: ['CLS', 'FCP', 'FID', 'INP', 'LCP', 'TTFB'],
-          } as any,
-        },
         mdxRs: {
           type: 'boolean',
         },

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -2,223 +2,119 @@ import { NextConfig } from './config'
 import type { JSONSchemaType } from 'ajv'
 import { VALID_LOADERS } from '../shared/lib/image-config'
 
+import { z } from 'zod'
+import type zod from 'zod'
+
+export const configSchemaZod: zod.ZodType<NextConfig> = z.lazy(() =>
+  z.object({
+    amp: z.object({
+      canonicalBase: z.string().optional(),
+    }),
+    analyticsId: z.string().optional(),
+    assetPrefix: z.string().optional(),
+    basePath: z.string().optional(),
+    cleanDistDir: z.boolean().optional(),
+    compiler: z.object({
+      emotion: z
+        .union([
+          z.boolean(),
+          z.object({
+            sourceMap: z.boolean().optional(),
+            autoLabel: z
+              .union([
+                z.literal('always'),
+                z.literal('dev-only'),
+                z.literal('never'),
+              ])
+              .optional(),
+            labelFormat: z.string().min(1).optional(),
+            importMap: z
+              .record(
+                z.string(),
+                z.record(
+                  z.string(),
+                  z.object({
+                    canonicalImport: z
+                      .tuple([z.string(), z.string()])
+                      .optional(),
+                    styledBaseImport: z
+                      .tuple([z.string(), z.string()])
+                      .optional(),
+                  })
+                )
+              )
+              .optional(),
+          }),
+        ])
+        .optional(),
+      reactRemoveProperties: z
+        .union([
+          z.boolean().optional(),
+          z.object({
+            properties: z.array(z.string()).optional(),
+          }),
+        ])
+        .optional(),
+      relay: z.any().optional(),
+      removeConsole: z
+        .union([
+          z.boolean().optional(),
+          z.object({
+            exclude: z.array(z.string()).min(1).optional(),
+          }),
+        ])
+        .optional(),
+      styledComponents: z.union([
+        z.boolean().optional(),
+        z.object({
+          displayName: z.boolean().optional(),
+          topLevelImportPaths: z.array(z.string()).min(1).optional(),
+          ssr: z.boolean().optional(),
+          fileName: z.boolean().optional(),
+          meaninglessFileNames: z.array(z.string()).min(1).optional(),
+          minify: z.boolean().optional(),
+          transpileTemplateLiterals: z.boolean().optional(),
+          namespace: z.string().min(1).optional(),
+          pure: z.boolean().optional(),
+          cssProp: z.boolean().optional(),
+        }),
+      ]),
+    }),
+    compress: z.boolean().optional(),
+    configOrigin: z.string().optional(),
+    crossOrigin: z
+      .union([
+        z.literal(false),
+        z.literal('anonymous'),
+        z.literal('use-credentials'),
+      ])
+      .optional(),
+    devIndicators: z
+      .object({
+        buildActivity: z.boolean().optional(),
+        buildActivityPosition: z
+          .union([
+            z.literal('bottom-left'),
+            z.literal('bottom-right'),
+            z.literal('top-left'),
+            z.literal('top-right'),
+          ])
+          .optional(),
+      })
+      .optional(),
+    distDir: z.string().optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    eslint: z.object({
+      dirs: z.array(z.string()).optional(),
+      ignoreDuringBuilds: z.boolean().optional(),
+    }),
+  })
+)
+
 const configSchema = {
   type: 'object',
   additionalProperties: false,
   properties: {
-    amp: {
-      additionalProperties: false,
-      properties: {
-        canonicalBase: {
-          nullable: true,
-          type: 'string',
-        },
-      },
-      type: 'object',
-    },
-    analyticsId: {
-      type: 'string',
-    },
-    assetPrefix: {
-      nullable: true,
-      type: 'string',
-    },
-    basePath: {
-      type: 'string',
-    },
-    cleanDistDir: {
-      type: 'boolean',
-    },
-    compiler: {
-      additionalProperties: false,
-      properties: {
-        emotion: {
-          oneOf: [
-            {
-              type: 'boolean',
-            },
-            {
-              type: 'object',
-              additionalProperties: false,
-              properties: {
-                sourceMap: {
-                  type: 'boolean',
-                },
-                autoLabel: {
-                  type: 'string',
-                  enum: ['always', 'dev-only', 'never'],
-                },
-                labelFormat: {
-                  type: 'string',
-                  minLength: 1,
-                },
-                importMap: {
-                  type: 'object',
-                },
-              },
-            },
-          ] as any,
-        },
-        reactRemoveProperties: {
-          oneOf: [
-            {
-              type: 'boolean',
-            },
-            {
-              type: 'object',
-              additionalProperties: false,
-              properties: {
-                properties: {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              },
-            },
-          ] as any,
-        },
-        relay: {
-          type: 'object',
-        },
-        removeConsole: {
-          oneOf: [
-            {
-              type: 'boolean',
-            },
-            {
-              type: 'object',
-              additionalProperties: false,
-              properties: {
-                exclude: {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                    minLength: 1,
-                  },
-                },
-              },
-            },
-          ] as any,
-        },
-        styledComponents: {
-          oneOf: [
-            {
-              type: 'boolean',
-            },
-            {
-              type: 'object',
-              additionalProperties: false,
-              properties: {
-                displayName: {
-                  type: 'boolean',
-                },
-                topLevelImportPaths: {
-                  oneOf: [
-                    { type: 'boolean' },
-                    {
-                      type: 'array',
-                      items: {
-                        type: 'string',
-                        minLength: 1,
-                      },
-                    },
-                  ],
-                },
-                ssr: {
-                  type: 'boolean',
-                },
-                fileName: {
-                  type: 'boolean',
-                },
-                meaninglessFileNames: {
-                  oneOf: [
-                    { type: 'boolean' },
-                    {
-                      type: 'array',
-                      items: {
-                        type: 'string',
-                        minLength: 1,
-                      },
-                    },
-                  ],
-                },
-                minify: {
-                  type: 'boolean',
-                },
-                transpileTemplateLiterals: {
-                  type: 'boolean',
-                },
-                namespace: {
-                  type: 'string',
-                  minLength: 1,
-                },
-                pure: {
-                  type: 'boolean',
-                },
-                cssProp: {
-                  type: 'boolean',
-                },
-              },
-            },
-          ] as any,
-        },
-      },
-      type: 'object',
-    },
-    compress: {
-      type: 'boolean',
-    },
-    configOrigin: {
-      type: 'string',
-    },
-    crossOrigin: {
-      oneOf: [
-        false,
-        {
-          enum: ['anonymous', 'use-credentials'],
-          type: 'string',
-        },
-      ], // automatic typing does not like enum
-    } as any,
-    devIndicators: {
-      additionalProperties: false,
-      properties: {
-        buildActivity: {
-          type: 'boolean',
-        },
-        buildActivityPosition: {
-          // automatic typing does not like enum
-          enum: ['bottom-left', 'bottom-right', 'top-left', 'top-right'] as any,
-          type: 'string',
-        },
-      },
-      type: 'object',
-    },
-    distDir: {
-      minLength: 1,
-      type: 'string',
-      nullable: true,
-    },
-    env: {
-      type: 'object',
-    },
-    eslint: {
-      additionalProperties: false,
-      properties: {
-        dirs: {
-          items: {
-            minLength: 1,
-            type: 'string',
-          },
-          type: 'array',
-        },
-        ignoreDuringBuilds: {
-          type: 'boolean',
-        },
-      },
-      type: 'object',
-    },
     excludeDefaultMomentLocales: {
       type: 'boolean',
     },


### PR DESCRIPTION
This is an **ongoing** PR that replaces Next.js' `ajv` based config validation with the Zod (which is already a dependency of Next.js).