### PR TITLE
Fix minimal basePath handling

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -930,9 +930,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           for (const key of routeParamKeys) {
             delete parsedUrl.query[key]
           }
-          parsedUrl.pathname = `${this.nextConfig.basePath || ''}${
-            matchedPath === '/' && this.nextConfig.basePath ? '' : matchedPath
-          }`
+          parsedUrl.pathname = matchedPath
           url.pathname = parsedUrl.pathname
         } catch (err) {
           if (err instanceof DecodeError || err instanceof NormalizeError) {


### PR DESCRIPTION
We no longer handle basePath stripping further down in minimal mode so this prevents the re-adding we used to do. 

Manually tested with https://33-base-path-gsp-404-m8w6hhs1m-vtest314-ijjk-testing.vercel.app/docs/api/hello

Fixes: [slack thread](https://vercel.slack.com/archives/C03F2CMNGKG/p1690309135573409)