### PR TITLE
Remove arbitrary timeout in pr/release stats

### DIFF
--- a/.github/actions/next-stats-action/src/util/exec.js
+++ b/.github/actions/next-stats-action/src/util/exec.js
@@ -12,7 +12,6 @@ const env = {
 function exec(command, noLog = false, opts = {}) {
   if (!noLog) logger(`exec: ${command}`)
   return execP(command, {
-    timeout: 180 * 1000,
     ...opts,
     env: { ...env, ...opts.env },
   })


### PR DESCRIPTION
Removes our arbitrary 3 minute timeout on commands in next-stats-action which may be contributing to the recent failures for release stats to run 

x-ref: https://github.com/vercel/next.js/actions/runs/5664570067/job/15348170497
x-ref: https://github.com/vercel/next.js/actions/runs/5650726841/job/15307909184
x-ref: https://github.com/vercel/next.js/actions/runs/5658309370/job/15329650002