### PR TITLE
fix: Apply ReactDevOverlay after hydration to prevent useId breakage

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -247,6 +247,8 @@ function Root({ children }: React.PropsWithChildren<{}>): React.ReactElement {
   }
 
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [isServer, setServer] = React.useState(true)
     const ReactDevOverlay: typeof import('./components/react-dev-overlay/internal/ReactDevOverlay').default =
       require('./components/react-dev-overlay/internal/ReactDevOverlay')
         .default as typeof import('./components/react-dev-overlay/internal/ReactDevOverlay').default
@@ -291,6 +293,14 @@ function Root({ children }: React.PropsWithChildren<{}>): React.ReactElement {
         websocket && websocket.removeEventListener('message', handler)
     }, [webSocketRef, hadRuntimeError])
 
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
+      setServer(false)
+    }, [])
+
+    if (isServer) {
+      return <>{children}</>
+    }
     // if an error is thrown while rendering an RSC stream, this will catch it in dev
     // and show the error overlay
     return (


### PR DESCRIPTION
### What?

Fixes https://github.com/vercel/next.js/issues/53110 

### Why?

As far as I understand, when the server side tree differs from the client side hydration tree, https://github.com/facebook/react/issues/22733, the useId hook breaks.

This is happening for Next.js in dev mode only.

### How?

Defer wrapping the client children with ReactDevOverlay till after mount.

To be perfectly honest, this is a bit of a hacky solution. Perhaps someone with a better understanding of the SSR step, can make the tree's match, and that's probably a better fix.

Fixes #53110

## Edit

Also, while this stops the divergence on `useId`, it might defeat the original purpose established by https://github.com/vercel/next.js/commit/4994a428ae5beeeb5e0ece1d791458a5ab1c41b2
