### PR TITLE
Fix file tracing issues for not-found pages

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2505,6 +2505,16 @@ export default async function build(
               appConfig.revalidate === 0 ||
               exportConfig.initialPageRevalidationMap[page] === 0
 
+            if (hasDynamicData && pageInfos.get(page)?.static) {
+              // if the page was marked as being static, but it contains dynamic data
+              // (ie, in the case of a static generation bailout), then it should be marked dynamic
+              pageInfos.set(page, {
+                ...(pageInfos.get(page) as PageInfo),
+                static: false,
+                isSsg: false,
+              })
+            }
+
             const isRouteHandler = isAppRouteRoute(originalAppPath)
 
             routes.forEach((route) => {

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -292,8 +292,8 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
           // include the client reference manifest
           const clientManifestsForPage =
             entrypoint.name.endsWith('/page') ||
-            entrypoint.name === '/not-found' ||
-            entrypoint.name === '/_not-found'
+            entrypoint.name === 'app/not-found' ||
+            entrypoint.name === 'app/_not-found'
               ? nodePath.join(
                   outputPath,
                   '..',

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2641,7 +2641,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
       if (is404) {
         // Rendering app routes only in render worker to make sure the require-hook is setup
-        if (this.hasAppDir && this.isRenderWorker) {
+        if (this.hasAppDir && (this.isRenderWorker || this.minimalMode)) {
           // Use the not-found entry in app directory
           result = await this.findPageComponents({
             pathname: this.renderOpts.dev ? '/not-found' : '/_not-found',

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2640,8 +2640,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       let using404Page = false
 
       if (is404) {
-        // Rendering app routes only in render worker to make sure the require-hook is setup
-        if (this.hasAppDir && (this.isRenderWorker || this.minimalMode)) {
+        if (this.hasAppDir) {
           // Use the not-found entry in app directory
           result = await this.findPageComponents({
             pathname: this.renderOpts.dev ? '/not-found' : '/_not-found',

--- a/test/e2e/app-dir/not-found/not-found.test.ts
+++ b/test/e2e/app-dir/not-found/not-found.test.ts
@@ -9,7 +9,7 @@ createNextDescribe(
   },
   ({ next, isNextDev, isNextStart }) => {
     if (isNextStart) {
-      it('should include not found page in the file trace', async () => {
+      it('should include not found client reference manifest in the file trace', async () => {
         const fileTrace = JSON.parse(
           await next.readFile('.next/server/app/_not-found.js.nft.json')
         )

--- a/test/e2e/app-dir/not-found/not-found.test.ts
+++ b/test/e2e/app-dir/not-found/not-found.test.ts
@@ -7,7 +7,21 @@ createNextDescribe(
     files: __dirname,
     skipDeployment: true,
   },
-  ({ next, isNextDev }) => {
+  ({ next, isNextDev, isNextStart }) => {
+    if (isNextStart) {
+      it('should include not found page in the file trace', async () => {
+        const fileTrace = JSON.parse(
+          await next.readFile('.next/server/app/_not-found.js.nft.json')
+        )
+
+        const isTraced = fileTrace.files.some((filePath) =>
+          filePath.includes('_not-found_client-reference-manifest.js')
+        )
+
+        expect(isTraced).toBe(true)
+      })
+    }
+
     const runTests = ({ isEdge }: { isEdge: boolean }) => {
       it('should use the not-found page for non-matching routes', async () => {
         const browser = await next.browser('/random-content')


### PR DESCRIPTION
This fixes the `.nft.json` output for not-found pages to correctly grab the client reference manifest. We were checking for `entryPoint.name.startsWith('app/')` but then asserting on `entryPoint.name === '/_not-found'` when determining the manifest path.

This also fixes the build output to mark pages with `λ` if the corresponding page has dynamic data. This revealed a separate issue that de-opts all pages into dynamic rendering if the root `NotFound` page bails, tracked in [NEXT-1474](https://linear.app/vercel/issue/NEXT-1474/if-the-root-notfound-page-opts-into-dynamic-rendering-all-pages-do-too)

[slack x-ref](https://vercel.slack.com/archives/C03S8ED1DKM/p1683763412272429)