### PR TITLE
Add more retries to font fetching

### DIFF
--- a/packages/font/src/google/fetch-css-from-google-fonts.ts
+++ b/packages/font/src/google/fetch-css-from-google-fonts.ts
@@ -12,7 +12,7 @@ async function retry<T>(fn: () => Promise<T>, attempts: number): Promise<T> {
       cnt--
       if (cnt <= 0) throw err
       console.error(
-        (err as Error).message + `\n\nRetrying ${attempts - cnt}/3...`
+        (err as Error).message + `\n\nRetrying ${attempts - cnt}/${attempts}...`
       )
       await new Promise((resolve) => setTimeout(resolve, 100))
     }
@@ -79,7 +79,7 @@ export async function fetchCSSFromGoogleFonts(
       }
 
       return res.text()
-    }, 3)
+    }, 5)
   }
 
   return cssResponse


### PR DESCRIPTION
### What?

Increase the number of attempts from 3 to 5.

### Why?

Our team had introduced our own mechanism for retries even before this mechanism was introduced by https://github.com/vercel/next.js/pull/51890, and we had the sensation that 5 attempts would eliminate the potential for CI failure. But now it's 3 attempts, and in this case it's much better than nothing but still seems to fail sometimes. Too many retries may not be a good idea, but I feel that kicking CI over and over results in more computational resources being wasted.

### How?

Just as the code says!