### PR TITLE
Avoid bundling `react-dev-overlay` for dev

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1412,7 +1412,7 @@ export default async function getBaseWebpackConfig(
         /next[/\\]dist[/\\](esm[\\/])?(shared|server)[/\\](?!lib[/\\](router[/\\]router|dynamic|app-dynamic|image-external|lazy-dynamic|head[^-]))/.test(
           localRes
         ) ||
-        // No need to bundle so many things during dev
+        // There's no need to bundle the dev overlay
         (process.env.NODE_ENV === 'development' &&
           /next[/\\]dist[/\\](esm[/\\])?client[/\\]components[/\\]react-dev-overlay[/\\]/.test(
             localRes

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1411,7 +1411,12 @@ export default async function getBaseWebpackConfig(
       const isNextExternal =
         /next[/\\]dist[/\\](esm[\\/])?(shared|server)[/\\](?!lib[/\\](router[/\\]router|dynamic|app-dynamic|image-external|lazy-dynamic|head[^-]))/.test(
           localRes
-        )
+        ) ||
+        // No need to bundle so many things during dev
+        (process.env.NODE_ENV === 'development' &&
+          /next[/\\]dist[/\\](esm[/\\])?client[/\\]components[/\\]react-dev-overlay[/\\]/.test(
+            localRes
+          ))
 
       if (isNextExternal) {
         // Generate Next.js external import


### PR DESCRIPTION
Mark `react-dev-overlay` as an external for the client layer. This reduces the server bundle by 1 MB (2.5 MB → 1.5 MB) during dev with fewer resolve calls. Note that it applies to all pages, so this will have a non-trivial memory improvement potentially.