### PR TITLE
Turbopack: Update Turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "serde",
 ]
@@ -3610,7 +3610,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "serde",
@@ -7293,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7325,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7337,7 +7337,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7352,7 +7352,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7366,7 +7366,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "base16",
  "hex",
@@ -7425,7 +7425,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7439,7 +7439,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7449,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "mimalloc",
 ]
@@ -7457,7 +7457,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7480,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7493,7 +7493,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7523,7 +7523,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7553,7 +7553,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7595,7 +7595,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7615,7 +7615,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7667,7 +7667,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7702,7 +7702,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7726,7 +7726,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7763,7 +7763,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "serde",
  "serde_json",
@@ -7808,7 +7808,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7831,7 +7831,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -7864,7 +7864,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7884,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "serde",
@@ -7899,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7914,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7949,7 +7949,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "serde",
@@ -7965,7 +7965,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7976,7 +7976,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230726.2#c7e797ada6f66c9ab5949857232190278f289036"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230727.2#cf5e667bce8bc61111ed7561a1cf3d7901b66cce"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,11 @@ swc_core = { version = "0.79.22" }
 testing = { version = "0.33.21" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230726.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230727.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230726.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230727.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230726.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230727.2" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230726.2",
-    "@vercel/turbopack-node": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230726.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230727.2",
+    "@vercel/turbopack-node": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230727.2",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -994,8 +994,8 @@ importers:
       '@types/react': 18.2.7
       '@types/react-dom': 18.2.4
       '@vercel/ncc': ^0.36.0
-      '@vercel/turbopack-ecmascript-runtime': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230726.2
-      '@vercel/turbopack-node': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230726.2
+      '@vercel/turbopack-ecmascript-runtime': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230727.2
+      '@vercel/turbopack-node': https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230727.2
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
@@ -1007,8 +1007,8 @@ importers:
       stacktrace-parser: ^0.1.10
       strip-ansi: ^7.0.1
     dependencies:
-      '@vercel/turbopack-ecmascript-runtime': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230726.2_react-refresh@0.12.0'
-      '@vercel/turbopack-node': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230726.2'
+      '@vercel/turbopack-ecmascript-runtime': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230727.2_react-refresh@0.12.0'
+      '@vercel/turbopack-node': '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230727.2'
       anser: 2.1.1
       css.escape: 1.5.1
       next: link:../../../../next
@@ -25647,9 +25647,9 @@ packages:
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230726.2_react-refresh@0.12.0':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230726.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230726.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230727.2_react-refresh@0.12.0':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230727.2}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230727.2'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:
@@ -25660,8 +25660,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230726.2':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230726.2}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230727.2':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230727.2}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
* https://github.com/vercel/turbo/pull/5621 <!-- Tobias Koppers - fix esm export in build runtime  -->
* https://github.com/vercel/turbo/pull/5620 <!-- Tobias Koppers - Revert "export namespace object instead commonjs interop object"  -->