### PR TITLE
fix(font): expose loading error for debugging

### DIFF
--- a/packages/font/src/google/loader.ts
+++ b/packages/font/src/google/loader.ts
@@ -164,7 +164,9 @@ const nextFontGoogleFontLoader: FontLoader = async ({
     if (isDev) {
       if (isServer) {
         Log.error(
-          `Failed to download \`${fontFamily}\` from Google Fonts. Using fallback font instead.`
+          `Failed to download \`${fontFamily}\` from Google Fonts. Using fallback font instead.\n\n${
+            (err as Error).message
+          }}`
         )
       }
 


### PR DESCRIPTION
### What?

Exposing the original error message.

### Why?

While looking at #53279, I noticed that we don't show the original error message, which makes it hard to guess why the error was thrown in the first place.

### How?

Related #53279