### PR TITLE
Error handling when non-string value is passed as parameter to catch-all segments

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1003,6 +1003,9 @@ export async function buildStaticPaths({
         }
         if (
           (repeat && !Array.isArray(paramValue)) ||
+          (repeat &&
+            Array.isArray(paramValue) &&
+            paramValue.some((param) => typeof param !== 'string')) ||
           (!repeat && typeof paramValue !== 'string')
         ) {
           // If from appDir and not all params were provided from
@@ -1014,9 +1017,9 @@ export async function buildStaticPaths({
             return
           }
 
-          throw new Error(
+          throw new TypeError(
             `A required parameter (${validParamKey}) was not provided as ${
-              repeat ? 'an array' : 'a string'
+              repeat ? 'an array of string' : 'a string'
             } received ${typeof paramValue} in ${
               appDir ? 'generateStaticParams' : 'getStaticPaths'
             } for ${page}`

--- a/test/integration/conflicting-ssg-paths/test/index.test.js
+++ b/test/integration/conflicting-ssg-paths/test/index.test.js
@@ -199,38 +199,14 @@ describe('Conflicting SSG paths', () => {
       export const getStaticPaths = () => {
         return {
           paths: [
-            { params: { slug: [1] }}
+            { params: { slug: ['string', 4] }}
           ],
           fallback: false
         }
       }
 
       export default function Page() {
-        return '/hello/[...slug]'
-      }
-    `
-    )
-
-    await fs.writeFile(
-      join(pagesDir, '[...catchAll].js'),
-      `
-      export const getStaticProps = () => {
-        return {
-          props: {}
-        }
-      }
-
-      export const getStaticPaths = () => {
-        return {
-          paths: [
-            { params: { slug: [1] }}
-          ],
-          fallback: false
-        }
-      }
-
-      export default function Page() {
-        return '/[catchAll]'
+        return '/blog/[...slug]'
       }
     `
     )

--- a/test/integration/conflicting-ssg-paths/test/index.test.js
+++ b/test/integration/conflicting-ssg-paths/test/index.test.js
@@ -185,7 +185,7 @@ describe('Conflicting SSG paths', () => {
     )
   })
 
-  it('should show proper error when a non-string value is supplied as the parameter to a dynamic route', async () => {
+  it('should show proper error when a non-string value is supplied as the parameter to a catch-all segment', async () => {
     await fs.ensureDir(join(pagesDir, 'blog'))
     await fs.writeFile(
       join(pagesDir, 'blog/[...slug].js'),


### PR DESCRIPTION
### What?
Fix for bug #41281

### Why?
When catch-all segments are passed there is an unhandled error whereby non-string value(s) passed as a parameter to the array for catch all routes was not being checked. 

### How?
Added a check to see if the parameters passed to the array were of type string. If statement now throws a TypeError if the parameter passed is not an array, not a string or if the parameters passed to the array are not of type string.
 