### PR TITLE
Try to fix flakey `socket hang up` failures in stream cancel tests

### DIFF
--- a/test/e2e/cancel-request/app/edge-route/route.ts
+++ b/test/e2e/cancel-request/app/edge-route/route.ts
@@ -9,19 +9,19 @@ export async function GET(req: Request): Promise<Response> {
   // This is so we don't confuse the request close with the connection close.
   await req.text()
 
-  // The 2nd request should render the stats. We don't use a query param
-  // because edge rendering will create a different bundle for that.
-  if (streamable) {
-    const old = streamable
-    streamable = undefined
-    const i = await old.finished
-    return new Response(`${i}`)
+  const write = new URL(req.url!, 'http://localhost/').searchParams.get('write')
+  if (write) {
+    const s = (streamable = Streamable(+write!))
+    req.signal.onabort = () => {
+      s.abort()
+    }
+    return new Response(s.stream)
   }
 
-  const write = new URL(req.url!, 'http://localhost/').searchParams.get('write')
-  const s = (streamable = Streamable(+write!))
-  req.signal.onabort = () => {
-    s.abort()
-  }
-  return new Response(s.stream)
+  // The 2nd request should render the stats. We don't use a query param
+  // because edge rendering will create a different bundle for that.
+  const old = streamable!
+  streamable = undefined
+  const i = await old.finished
+  return new Response(`${i}`)
 }

--- a/test/e2e/cancel-request/app/node-route/route.ts
+++ b/test/e2e/cancel-request/app/node-route/route.ts
@@ -11,19 +11,19 @@ export async function GET(req: Request): Promise<Response> {
   // This is so we don't confuse the request close with the connection close.
   await req.text()
 
-  // The 2nd request should render the stats. We don't use a query param
-  // because edge rendering will create a different bundle for that.
-  if (streamable) {
-    const old = streamable
-    streamable = undefined
-    const i = await old.finished
-    return new Response(`${i}`)
+  const write = new URL(req.url!, 'http://localhost/').searchParams.get('write')
+  if (write) {
+    const s = (streamable = Streamable(+write!))
+    req.signal.onabort = () => {
+      s.abort()
+    }
+    return new Response(s.stream)
   }
 
-  const write = new URL(req.url!, 'http://localhost/').searchParams.get('write')
-  const s = (streamable = Streamable(+write!))
-  req.signal.onabort = () => {
-    s.abort()
-  }
-  return new Response(s.stream)
+  // The 2nd request should render the stats. We don't use a query param
+  // because edge rendering will create a different bundle for that.
+  const old = streamable!
+  streamable = undefined
+  const i = await old.finished
+  return new Response(`${i}`)
 }

--- a/test/e2e/cancel-request/middleware.ts
+++ b/test/e2e/cancel-request/middleware.ts
@@ -11,19 +11,20 @@ export default async function handler(req: Request): Promise<Response> {
   // This is so we don't confuse the request close with the connection close.
   await req.text()
 
-  // The 2nd request should render the stats. We don't use a query param
-  // because edge rendering will create a different bundle for that.
-  if (streamable) {
-    const old = streamable
-    streamable = undefined
-    const i = await old.finished
-    return new Response(`${i}`)
+  const write = new URL(req.url!, 'http://localhost/').searchParams.get('write')
+
+  if (write) {
+    const s = (streamable = Streamable(+write!))
+    req.signal.onabort = () => {
+      s.abort()
+    }
+    return new Response(s.stream)
   }
 
-  const write = new URL(req.url!, 'http://localhost/').searchParams.get('write')
-  const s = (streamable = Streamable(+write!))
-  req.signal.onabort = () => {
-    s.abort()
-  }
-  return new Response(s.stream)
+  // The 2nd request should render the stats. We don't use a query param
+  // because edge rendering will create a different bundle for that.
+  const old = streamable!
+  streamable = undefined
+  const i = await old.finished
+  return new Response(`${i}`)
 }

--- a/test/e2e/cancel-request/pages/api/edge-api.ts
+++ b/test/e2e/cancel-request/pages/api/edge-api.ts
@@ -11,19 +11,19 @@ export default async function handler(req: Request): Promise<Response> {
   // This is so we don't confuse the request close with the connection close.
   await req.text()
 
-  // The 2nd request should render the stats. We don't use a query param
-  // because edge rendering will create a different bundle for that.
-  if (streamable) {
-    const old = streamable
-    streamable = undefined
-    const i = await old.finished
-    return new Response(`${i}`)
+  const write = new URL(req.url!, 'http://localhost/').searchParams.get('write')
+  if (write) {
+    const s = (streamable = Streamable(+write!))
+    req.signal.onabort = () => {
+      s.abort()
+    }
+    return new Response(s.stream)
   }
 
-  const write = new URL(req.url!, 'http://localhost/').searchParams.get('write')
-  const s = (streamable = Streamable(+write!))
-  req.signal.onabort = () => {
-    s.abort()
-  }
-  return new Response(s.stream)
+  // The 2nd request should render the stats. We don't use a query param
+  // because edge rendering will create a different bundle for that.
+  const old = streamable!
+  streamable = undefined
+  const i = await old.finished
+  return new Response(`${i}`)
 }

--- a/test/e2e/cancel-request/pages/api/node-api.ts
+++ b/test/e2e/cancel-request/pages/api/node-api.ts
@@ -15,25 +15,25 @@ export default function handler(
   // Pages API requests have already consumed the body.
   // This is so we don't confuse the request close with the connection close.
 
+  const write = new URL(req.url!, 'http://localhost/').searchParams.get('write')
   // The 2nd request should render the stats. We don't use a query param
   // because edge rendering will create a different bundle for that.
-  if (readable) {
-    const old = readable
-    readable = undefined
-    return old.finished.then((i) => {
-      res.end(`${i}`)
+  if (write) {
+    const r = (readable = Readable(+write!))
+    res.on('close', () => {
+      r.abort()
+    })
+    return new Promise((resolve) => {
+      pipeline(r.stream, res, () => {
+        resolve()
+        res.end()
+      })
     })
   }
 
-  const write = new URL(req.url!, 'http://localhost/').searchParams.get('write')
-  const r = (readable = Readable(+write!))
-  res.on('close', () => {
-    r.abort()
-  })
-  return new Promise((resolve) => {
-    pipeline(r.stream, res, () => {
-      resolve()
-      res.end()
-    })
+  const old = readable!
+  readable = undefined
+  return old.finished.then((i) => {
+    res.end(`${i}`)
   })
 }


### PR DESCRIPTION
### What?

I think the flakiness from the new stream cancel tests is due to a uncaught error thrown from the priming. If it is during the priming, then we need to also explicitly check if we restart the test and reset the `streamable`.

### Why?

Flakey tests suck.

### How?

- Adds a `on('error', reject)` to catch the socket error and associate it with the test
- Explicitly checks for the `?write=` param to see if we're priming or getting results
