### PR TITLE
remove --force from install-native postinstall

### DIFF
--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -57,7 +57,7 @@ import fs from 'fs-extra'
       JSON.stringify(pkgJson)
     )
     await fs.writeFile(path.join(tmpdir, '.npmrc'), 'node-linker=hoisted')
-    let { stdout } = await execa('pnpm', ['install', '--force'], {
+    let { stdout } = await execa('pnpm', ['install'], {
       cwd: tmpdir,
     })
     console.log(stdout)


### PR DESCRIPTION
This was leftover from when we were using yarn but `--force` has different behavior in pnpm (it will install all optionalDependencies regardless of the current environment), which was causing tests to slowdown