### PR TITLE
refactor: change unnecessary else to continue

### DIFF
--- a/packages/eslint-config-next/index.js
+++ b/packages/eslint-config-next/index.js
@@ -20,9 +20,9 @@ for (let i = originalPaths.length - 1; i >= 0; i--) {
 
   if (currentPath.replace(/\\/g, '/').startsWith(cwd)) {
     sortedPaths.push(currentPath)
-  } else {
-    keptPaths.unshift(currentPath)
+    continue
   }
+  keptPaths.unshift(currentPath)
 }
 
 // maintain order of node_modules outside of cwd


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### Description
In the eslint-plugin-next folder, if you look at various files, you'll notice that they make an effort to utilize return as much as possible to avoid using else statements.
In eslint-config-next/index.js, unnecessary else directives and curly braces have been removed and replaced with continue, enhancing overall code style consistency and readability.

### Changes
- remove `else`
- add `continue`

File: `next.js/packages/eslint-config-next/index.js`


