### PR TITLE
[Docs] remove x-xss-protection-header

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/headers.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/headers.mdx
@@ -437,17 +437,6 @@ If you're deploying to [Vercel](https://vercel.com/docs/concepts/edge-network/he
 }
 ```
 
-### X-XSS-Protection
-
-This header stops pages from loading when they detect reflected cross-site scripting (XSS) attacks. Although this protection is not necessary when sites implement a strong [`Content-Security-Policy`](#content-security-policy) disabling the use of inline JavaScript (`'unsafe-inline'`), it can still provide protection for older web browsers that don't support CSP.
-
-```js
-{
-  key: 'X-XSS-Protection',
-  value: '1; mode=block'
-}
-```
-
 ### X-Frame-Options
 
 This header indicates whether the site should be allowed to be displayed within an `iframe`. This can prevent against clickjacking attacks. This header has been superseded by CSP's `frame-ancestors` option, which has better support in modern browsers.


### PR DESCRIPTION
The x-xss-protection header is a non-standardized http header and low browser-capability.
If it is likely to be supported in the future, it can be treated as experimental, but since it is not, it is preferable to remove it.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
https://caniuse.com/mdn-http_headers_x-xss-protection