### PR TITLE
actions: fix revalidate after redirect

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -23,7 +23,10 @@ import { StaticGenerationStore } from '../../client/components/static-generation
 import { FlightRenderResult } from './flight-render-result'
 import { ActionResult } from './types'
 import { ActionAsyncStorage } from '../../client/components/action-async-storage'
-import { filterReqHeaders, forbiddenHeaders } from '../lib/server-ipc/utils'
+import {
+  filterReqHeaders,
+  actionsForbiddenHeaders,
+} from '../lib/server-ipc/utils'
 import {
   appendMutableCookies,
   getModifiedCookieValues,
@@ -98,10 +101,13 @@ function getForwardedHeaders(
   })
 
   // Merge request and response headers
-  const mergedHeaders = filterReqHeaders({
-    ...nodeHeadersToRecord(requestHeaders),
-    ...nodeHeadersToRecord(responseHeaders),
-  }) as Record<string, string>
+  const mergedHeaders = filterReqHeaders(
+    {
+      ...nodeHeadersToRecord(requestHeaders),
+      ...nodeHeadersToRecord(responseHeaders),
+    },
+    actionsForbiddenHeaders
+  ) as Record<string, string>
 
   // Merge cookies
   const mergedCookies = requestCookies.split('; ').concat(setCookies).join('; ')
@@ -223,7 +229,7 @@ async function createRedirectRenderResult(
         })
         // copy the headers from the redirect response to the response we're sending
         for (const [key, value] of response.headers) {
-          if (!forbiddenHeaders.includes(key)) {
+          if (!actionsForbiddenHeaders.includes(key)) {
             res.setHeader(key, value)
           }
         }

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -11,7 +11,7 @@ import setupDebug from 'next/dist/compiled/debug'
 import { splitCookiesString, toNodeOutgoingHttpHeaders } from '../web/utils'
 import { Telemetry } from '../../telemetry/storage'
 import { DecodeError } from '../../shared/lib/utils'
-import { filterReqHeaders } from './server-ipc/utils'
+import { filterReqHeaders, ipcForbiddenHeaders } from './server-ipc/utils'
 import { findPagesDir } from '../../lib/find-pages-dir'
 import { setupFsCheck } from './router-utils/filesystem'
 import { proxyRequest } from './router-utils/proxy-request'
@@ -365,7 +365,10 @@ export async function initialize(opts: {
       }
 
       for (const [key, value] of Object.entries(
-        filterReqHeaders(toNodeOutgoingHttpHeaders(invokeRes.headers))
+        filterReqHeaders(
+          toNodeOutgoingHttpHeaders(invokeRes.headers),
+          ipcForbiddenHeaders
+        )
       )) {
         if (value !== undefined) {
           if (key === 'set-cookie') {

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -8,7 +8,7 @@ import { Redirect } from '../../../../types'
 import { RenderWorker } from '../router-server'
 import setupDebug from 'next/dist/compiled/debug'
 import { getCloneableBody } from '../../body-streams'
-import { filterReqHeaders } from '../server-ipc/utils'
+import { filterReqHeaders, ipcForbiddenHeaders } from '../server-ipc/utils'
 import { Header } from '../../../lib/load-custom-routes'
 import { stringifyQuery } from '../../server-route-utils'
 import { toNodeOutgoingHttpHeaders } from '../../web/utils'
@@ -530,7 +530,7 @@ export function getResolveRoutes(
             delete middlewareHeaders['x-middleware-next']
 
             for (const [key, value] of Object.entries({
-              ...filterReqHeaders(middlewareHeaders),
+              ...filterReqHeaders(middlewareHeaders, ipcForbiddenHeaders),
             })) {
               if (
                 [

--- a/packages/next/src/server/lib/server-ipc/invoke-request.ts
+++ b/packages/next/src/server/lib/server-ipc/invoke-request.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from 'http'
 import type { Readable } from 'stream'
-import { filterReqHeaders } from './utils'
+import { filterReqHeaders, ipcForbiddenHeaders } from './utils'
 
 export const invokeRequest = async (
   targetUrl: string,
@@ -16,10 +16,13 @@ export const invokeRequest = async (
   const parsedTargetUrl = new URL(targetUrl)
   parsedTargetUrl.hostname = '127.0.0.1'
 
-  const invokeHeaders = filterReqHeaders({
-    'cache-control': '',
-    ...requestInit.headers,
-  }) as IncomingMessage['headers']
+  const invokeHeaders = filterReqHeaders(
+    {
+      'cache-control': '',
+      ...requestInit.headers,
+    },
+    ipcForbiddenHeaders
+  ) as IncomingMessage['headers']
 
   return await fetch(parsedTargetUrl.toString(), {
     headers: invokeHeaders as any as Headers,

--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -1,4 +1,4 @@
-export const forbiddenHeaders = [
+export const ipcForbiddenHeaders = [
   'accept-encoding',
   'keepalive',
   'keep-alive',
@@ -8,8 +8,14 @@ export const forbiddenHeaders = [
   'connection',
 ]
 
+export const actionsForbiddenHeaders = [
+  ...ipcForbiddenHeaders,
+  'content-length',
+]
+
 export const filterReqHeaders = (
-  headers: Record<string, undefined | string | number | string[]>
+  headers: Record<string, undefined | string | number | string[]>,
+  forbiddenHeaders: string[]
 ) => {
   for (const [key, value] of Object.entries(headers)) {
     if (

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -12,7 +12,7 @@ import * as Log from '../../build/output/log'
 import setupDebug from 'next/dist/compiled/debug'
 import { splitCookiesString, toNodeOutgoingHttpHeaders } from '../web/utils'
 import { getCloneableBody } from '../body-streams'
-import { filterReqHeaders } from './server-ipc/utils'
+import { filterReqHeaders, ipcForbiddenHeaders } from './server-ipc/utils'
 import setupCompression from 'next/dist/compiled/compression'
 import { normalizeRepeatedSlashes } from '../../shared/lib/utils'
 import { invokeRequest } from './server-ipc/invoke-request'
@@ -418,7 +418,10 @@ export async function startServer({
         res.statusMessage = invokeRes.statusText
 
         for (const [key, value] of Object.entries(
-          filterReqHeaders(toNodeOutgoingHttpHeaders(invokeRes.headers))
+          filterReqHeaders(
+            toNodeOutgoingHttpHeaders(invokeRes.headers),
+            ipcForbiddenHeaders
+          )
         )) {
           if (value !== undefined) {
             if (key === 'set-cookie') {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -93,7 +93,7 @@ import { nodeFs } from './lib/node-fs-methods'
 import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { invokeRequest } from './lib/server-ipc/invoke-request'
 import { pipeReadable } from './pipe-readable'
-import { filterReqHeaders } from './lib/server-ipc/utils'
+import { filterReqHeaders, ipcForbiddenHeaders } from './lib/server-ipc/utils'
 import { createRequestResponseMocks } from './lib/mock-request'
 import chalk from 'next/dist/compiled/chalk'
 import { NEXT_RSC_UNION_QUERY } from '../client/components/app-router-headers'
@@ -525,7 +525,8 @@ export default class NextNodeServer extends BaseServer {
             }
           )
           const filteredResHeaders = filterReqHeaders(
-            toNodeOutgoingHttpHeaders(invokeRes.headers)
+            toNodeOutgoingHttpHeaders(invokeRes.headers),
+            ipcForbiddenHeaders
           )
 
           for (const key of Object.keys(filteredResHeaders)) {

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -426,7 +426,7 @@ createNextDescribe(
       })
 
       // TODO: investigate flakey behavior with revalidate
-      it.skip('should handle revalidatePath', async () => {
+      it('should handle revalidatePath', async () => {
         const browser = await next.browser('/revalidate')
         const randomNumber = await browser.elementByCss('#random-number').text()
         const justPutIt = await browser.elementByCss('#justputit').text()
@@ -452,7 +452,7 @@ createNextDescribe(
       })
 
       // TODO: investigate flakey behavior with revalidate
-      it.skip('should handle revalidateTag', async () => {
+      it('should handle revalidateTag', async () => {
         const browser = await next.browser('/revalidate')
         const randomNumber = await browser.elementByCss('#random-number').text()
         const justPutIt = await browser.elementByCss('#justputit').text()
@@ -478,7 +478,7 @@ createNextDescribe(
       })
 
       // TODO: investigate flakey behavior with revalidate
-      it.skip('should handle revalidateTag + redirect', async () => {
+      it('should handle revalidateTag + redirect', async () => {
         const browser = await next.browser('/revalidate')
         const randomNumber = await browser.elementByCss('#random-number').text()
         const justPutIt = await browser.elementByCss('#justputit').text()
@@ -503,7 +503,7 @@ createNextDescribe(
         }, 'success')
       })
 
-      it.skip('should store revalidation data in the prefetch cache', async () => {
+      it('should store revalidation data in the prefetch cache', async () => {
         const browser = await next.browser('/revalidate')
         const justPutIt = await browser.elementByCss('#justputit').text()
         await browser.elementByCss('#revalidate-justputit').click()
@@ -534,7 +534,7 @@ createNextDescribe(
       })
 
       // TODO: investigate flakey behavior with revalidate
-      it.skip('should revalidate when cookies.set is called', async () => {
+      it('should revalidate when cookies.set is called', async () => {
         const browser = await next.browser('/revalidate')
         const randomNumber = await browser.elementByCss('#random-cookie').text()
 
@@ -550,7 +550,7 @@ createNextDescribe(
       })
 
       // TODO: investigate flakey behavior with revalidate
-      it.skip('should revalidate when cookies.set is called in a client action', async () => {
+      it('should revalidate when cookies.set is called in a client action', async () => {
         const browser = await next.browser('/revalidate')
         await browser.refresh()
 
@@ -607,7 +607,7 @@ createNextDescribe(
         }, 'success')
       })
 
-      it.skip.each(['tag', 'path'])(
+      it.each(['tag', 'path'])(
         'should invalidate client cache when %s is revalidated',
         async (type) => {
           const browser = await next.browser('/revalidate')

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -478,7 +478,7 @@ createNextDescribe(
       })
 
       // TODO: investigate flakey behavior with revalidate
-      it('should handle revalidateTag + redirect', async () => {
+      it.skip('should handle revalidateTag + redirect', async () => {
         const browser = await next.browser('/revalidate')
         const randomNumber = await browser.elementByCss('#random-number').text()
         const justPutIt = await browser.elementByCss('#justputit').text()


### PR DESCRIPTION
This PR reverts a change that removed the `content-length` header filtering from the req made by the actions when redirecting. This change made some tests flaky and presumably also broke server actions in subtle ways.

There's still one other bug when redirecting after revalidating that will happen in you revalidate a page that was already rendered before where we will still show stale content. @timneutkens is fixing that one.

NEXT-1483

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
