### PR TITLE
router: apply server actions in a similar way to router.refresh()

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -132,11 +132,7 @@ const createEmptyCacheNode = () => ({
   parallelRoutes: new Map(),
 })
 
-function useServerActionDispatcher(
-  changeByServerResponse: RouterChangeByServerResponse,
-  dispatch: React.Dispatch<ReducerActions>,
-  navigate: RouterNavigate
-) {
+function useServerActionDispatcher(dispatch: React.Dispatch<ReducerActions>) {
   const serverActionDispatcher: ServerActionDispatcher = useCallback(
     (actionPayload) => {
       startTransition(() => {
@@ -144,12 +140,11 @@ function useServerActionDispatcher(
           ...actionPayload,
           type: ACTION_SERVER_ACTION,
           mutable: {},
-          navigate,
-          changeByServerResponse,
+          cache: createEmptyCacheNode(),
         })
       })
     },
-    [changeByServerResponse, dispatch, navigate]
+    [dispatch]
   )
   globalServerActionDispatcher = serverActionDispatcher
 }
@@ -262,7 +257,7 @@ function Router({
 
   const changeByServerResponse = useChangeByServerResponse(dispatch)
   const navigate = useNavigate(dispatch)
-  useServerActionDispatcher(changeByServerResponse, dispatch, navigate)
+  useServerActionDispatcher(dispatch)
 
   /**
    * The app router that is exposed through `useRouter`. It's only concerned with dispatching actions to the reducer, does not hold state.

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -25,6 +25,12 @@ import {
 import { addBasePath } from '../../../add-base-path'
 import { createHrefFromUrl } from '../create-href-from-url'
 import { RedirectType, getRedirectError } from '../../redirect'
+import { handleExternalUrl } from './navigate-reducer'
+import { applyRouterStatePatchToTree } from '../apply-router-state-patch-to-tree'
+import { isNavigatingToNewRootLayout } from '../is-navigating-to-new-root-layout'
+import { CacheStates } from '../../../../shared/lib/app-router-context'
+import { handleMutable } from '../handle-mutable'
+import { fillLazyItemsTillLeafWithHead } from '../fill-lazy-items-till-leaf-with-head'
 
 type FetchServerActionResult = {
   redirectLocation: URL | undefined
@@ -98,23 +104,23 @@ async function fetchServerAction(
       }
     )
 
-    // if it was a redirection, then result is just a regular RSC payload
     if (location) {
-      const [, payload] = response
+      // if it was a redirection, then result is just a regular RSC payload
+      const [, actionFlightData] = (response as any) ?? []
       return {
-        actionFlightData: payload?.[1],
+        actionFlightData: actionFlightData,
         redirectLocation,
         revalidatedParts,
       }
-      // otherwise it's a tuple of [actionResult, actionFlightData]
-    } else {
-      const [actionResult, [, actionFlightData]] = response ?? []
-      return {
-        actionResult,
-        actionFlightData,
-        redirectLocation,
-        revalidatedParts,
-      }
+    }
+
+    // otherwise it's a tuple of [actionResult, actionFlightData]
+    const [actionResult, [, actionFlightData]] = (response as any) ?? []
+    return {
+      actionResult,
+      actionFlightData,
+      redirectLocation,
+      revalidatedParts,
     }
   }
   return {
@@ -131,113 +137,117 @@ export function serverActionReducer(
   state: ReadonlyReducerState,
   action: ServerActionAction
 ): ReducerState {
-  // the action could be called twice so we need to check if we already have applied it
-  if (action.mutable.serverActionApplied) {
-    return state
+  const { mutable, cache, resolve } = action
+  const href = state.canonicalUrl
+
+  let currentTree = state.tree
+
+  const isForCurrentTree =
+    JSON.stringify(mutable.previousTree) === JSON.stringify(currentTree)
+
+  if (isForCurrentTree) {
+    return handleMutable(state, mutable)
   }
 
   if (!action.mutable.inFlightServerAction) {
-    action.mutable.previousTree = state.tree
-    action.mutable.previousUrl = state.canonicalUrl
+    // action.mutable.previousTree = state.tree
+    // action.mutable.previousUrl = state.canonicalUrl
     action.mutable.inFlightServerAction = createRecordFromThenable(
       fetchServerAction(state, action)
     )
   }
-  try {
-    // suspends until the server action is resolved.
-    const {
-      actionResult,
-      actionFlightData,
-      redirectLocation,
-      revalidatedParts,
-    } = readRecordValue(
-      action.mutable.inFlightServerAction!
-    ) as Awaited<FetchServerActionResult>
 
-    // Invalidate the cache for the revalidated parts. This has to be done before the
-    // cache is updated with the action's flight data again.
-    if (revalidatedParts.tag || revalidatedParts.cookie) {
-      // Invalidate everything if the tag is set.
-      state.prefetchCache.clear()
-    } else if (revalidatedParts.paths.length > 0) {
-      // Invalidate all subtrees that are below the revalidated paths, and invalidate
-      // all the prefetch cache.
-      // TODO-APP: Currently the prefetch cache doesn't have subtree information,
-      // so we need to invalidate the entire cache if a path was revalidated.
-      state.prefetchCache.clear()
+  // suspends until the server action is resolved.
+  const {
+    actionResult,
+    actionFlightData: flightData,
+    redirectLocation,
+    revalidatedParts,
+  } = readRecordValue(
+    action.mutable.inFlightServerAction!
+  ) as Awaited<FetchServerActionResult>
+
+  mutable.previousTree = state.tree
+
+  if (!flightData) {
+    if (!mutable.actionResultResolved) {
+      resolve(actionResult)
+      mutable.actionResultResolved = true
     }
-
-    if (redirectLocation) {
-      // the redirection might have a flight data associated with it, so we'll populate the cache with it
-      if (actionFlightData) {
-        const href = createHrefFromUrl(redirectLocation, false)
-        const previousCacheEntry = state.prefetchCache.get(href)
-        state.prefetchCache.set(href, {
-          data: createRecordFromThenable(
-            Promise.resolve([
-              actionFlightData,
-              // TODO-APP: verify the logic around canonical URL overrides
-              undefined,
-            ])
-          ),
-          kind: previousCacheEntry?.kind ?? PrefetchKind.TEMPORARY,
-          prefetchTime: Date.now(),
-          treeAtTimeOfPrefetch: action.mutable.previousTree!,
-          lastUsedTime: null,
-        })
-      }
-
-      // we throw the redirection in the action handler so that it is caught during render
-      action.reject(
-        getRedirectError(redirectLocation.toString(), RedirectType.push)
-      )
-    } else {
-      if (actionFlightData) {
-        const href = createHrefFromUrl(
-          new URL(action.mutable.previousUrl!, window.location.origin),
-          false
-        )
-        const previousCacheEntry = state.prefetchCache.get(href)
-        state.prefetchCache.set(
-          createHrefFromUrl(
-            new URL(action.mutable.previousUrl!, window.location.origin),
-            false
-          ),
-          {
-            data: createRecordFromThenable(
-              Promise.resolve([
-                actionFlightData,
-                // TODO-APP: verify the logic around canonical URL overrides
-                undefined,
-              ])
-            ),
-            kind: previousCacheEntry?.kind ?? PrefetchKind.TEMPORARY,
-            prefetchTime: Date.now(),
-            treeAtTimeOfPrefetch: action.mutable.previousTree!,
-            lastUsedTime: null,
-          }
-        )
-        // this is an intentional hack around React: we want to update the tree in a new render
-        setTimeout(() => {
-          action.changeByServerResponse(
-            action.mutable.previousTree!,
-            actionFlightData,
-            // TODO-APP: verify the logic around canonical URL overrides
-            undefined
-          )
-        })
-      }
-
-      action.resolve(actionResult)
-    }
-  } catch (e: any) {
-    if (e.status === 'rejected') {
-      action.reject(e.value)
-    } else {
-      throw e
-    }
+    return state
   }
 
-  action.mutable.serverActionApplied = true
-  return state
+  if (typeof flightData === 'string') {
+    // Handle case when navigating to page in `pages` from `app`
+    return handleExternalUrl(
+      state,
+      mutable,
+      flightData,
+      state.pushRef.pendingPush
+    )
+  }
+
+  // Remove cache.data as it has been resolved at this point.
+  mutable.inFlightServerAction = null
+
+  for (const flightDataPath of flightData) {
+    // FlightDataPath with more than two items means unexpected Flight data was returned
+    if (flightDataPath.length !== 3) {
+      // TODO-APP: handle this case better
+      console.log('SERVER ACTION APPLY FAILED')
+      return state
+    }
+
+    // Given the path can only have two items the items are only the router state and subTreeData for the root.
+    const [treePatch] = flightDataPath
+    const newTree = applyRouterStatePatchToTree(
+      // TODO-APP: remove ''
+      [''],
+      currentTree,
+      treePatch
+    )
+
+    if (newTree === null) {
+      throw new Error('SEGMENT MISMATCH')
+    }
+
+    if (isNavigatingToNewRootLayout(currentTree, newTree)) {
+      return handleExternalUrl(state, mutable, href, state.pushRef.pendingPush)
+    }
+
+    // The one before last item is the router state tree patch
+    const [subTreeData, head] = flightDataPath.slice(-2)
+
+    // Handles case where prefetch only returns the router tree patch without rendered components.
+    if (subTreeData !== null) {
+      cache.status = CacheStates.READY
+      cache.subTreeData = subTreeData
+      fillLazyItemsTillLeafWithHead(
+        cache,
+        // Existing cache is not passed in as `router.refresh()` has to invalidate the entire cache.
+        undefined,
+        treePatch,
+        head
+      )
+      mutable.cache = cache
+      mutable.prefetchCache = new Map()
+    }
+
+    mutable.previousTree = currentTree
+    mutable.patchedTree = newTree
+    mutable.canonicalUrl = href
+
+    currentTree = newTree
+  }
+
+  if (redirectLocation) {
+    const newHref = createHrefFromUrl(redirectLocation, false)
+    mutable.canonicalUrl = newHref
+  }
+
+  if (!mutable.actionResultResolved) {
+    resolve(actionResult)
+    mutable.actionResultResolved = true
+  }
+  return handleMutable(state, mutable)
 }

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -150,8 +150,6 @@ export function serverActionReducer(
   }
 
   if (!action.mutable.inFlightServerAction) {
-    // action.mutable.previousTree = state.tree
-    // action.mutable.previousUrl = state.canonicalUrl
     action.mutable.inFlightServerAction = createRecordFromThenable(
       fetchServerAction(state, action)
     )
@@ -162,7 +160,7 @@ export function serverActionReducer(
     actionResult,
     actionFlightData: flightData,
     redirectLocation,
-    revalidatedParts,
+    // revalidatedParts,
   } = readRecordValue(
     action.mutable.inFlightServerAction!
   ) as Awaited<FetchServerActionResult>

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -153,8 +153,9 @@ export function serverActionReducer(
     )
   }
 
-  // suspends until the server action is resolved.
+  // TODO-APP: Make try/catch wrap only readRecordValue so that other errors bubble up through the reducer instead.
   try {
+    // suspends until the server action is resolved.
     const {
       actionResult,
       actionFlightData: flightData,

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -170,6 +170,16 @@ export function serverActionReducer(
       resolve(actionResult)
       mutable.actionResultResolved = true
     }
+
+    // If there is a redirect but no flight data we need to do a mpaNavigation.
+    if (redirectLocation) {
+      return handleExternalUrl(
+        state,
+        mutable,
+        redirectLocation.href,
+        state.pushRef.pendingPush
+      )
+    }
     return state
   }
 

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -17,14 +17,12 @@ import { createFromFetch } from 'react-server-dom-webpack/client'
 import { encodeReply } from 'react-server-dom-webpack/client'
 
 import {
-  PrefetchKind,
   ReadonlyReducerState,
   ReducerState,
   ServerActionAction,
 } from '../router-reducer-types'
 import { addBasePath } from '../../../add-base-path'
 import { createHrefFromUrl } from '../create-href-from-url'
-import { RedirectType, getRedirectError } from '../../redirect'
 import { handleExternalUrl } from './navigate-reducer'
 import { applyRouterStatePatchToTree } from '../apply-router-state-patch-to-tree'
 import { isNavigatingToNewRootLayout } from '../is-navigating-to-new-root-layout'

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -79,8 +79,6 @@ export interface ServerActionAction {
   reject: (reason?: any) => void
   cache: CacheNode
   mutable: ServerActionMutable
-  // navigate: RouterNavigate
-  // changeByServerResponse: RouterChangeByServerResponse
 }
 
 /**

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -40,12 +40,9 @@ export interface Mutable {
   shouldScroll?: boolean
 }
 
-export interface ServerActionMutable {
+export interface ServerActionMutable extends Mutable {
   inFlightServerAction?: Promise<any> | null
-  serverActionApplied?: boolean
-  previousTree?: FlightRouterState
-  previousUrl?: string
-  prefetchCache?: AppRouterState['prefetchCache']
+  actionResultResolved?: boolean
 }
 
 /**
@@ -70,7 +67,7 @@ export interface FastRefreshAction {
 export type ServerActionDispatcher = (
   args: Omit<
     ServerActionAction,
-    'type' | 'mutable' | 'navigate' | 'changeByServerResponse'
+    'type' | 'mutable' | 'navigate' | 'changeByServerResponse' | 'cache'
   >
 ) => void
 
@@ -80,9 +77,10 @@ export interface ServerActionAction {
   actionArgs: any[]
   resolve: (value: any) => void
   reject: (reason?: any) => void
+  cache: CacheNode
   mutable: ServerActionMutable
-  navigate: RouterNavigate
-  changeByServerResponse: RouterChangeByServerResponse
+  // navigate: RouterNavigate
+  // changeByServerResponse: RouterChangeByServerResponse
 }
 
 /**

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -206,8 +206,10 @@ async function createRedirectRenderResult(
       )
     }
 
-    // TODO-APP: Only do this when revalidatePath / revalidateTag was called.
-    forwardedHeaders.delete('next-router-state-tree')
+    // Ensures that when the path was revalidated we don't return a partial response on redirects
+    if (staticGenerationStore.pathWasRevalidated) {
+      forwardedHeaders.delete('next-router-state-tree')
+    }
 
     try {
       const headResponse = await fetchIPv4v6(fetchUrl, {

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -206,6 +206,9 @@ async function createRedirectRenderResult(
       )
     }
 
+    // TODO-APP: Only do this when revalidatePath / revalidateTag was called.
+    forwardedHeaders.delete('next-router-state-tree')
+
     try {
       const headResponse = await fetchIPv4v6(fetchUrl, {
         method: 'HEAD',

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -207,9 +207,9 @@ async function createRedirectRenderResult(
     }
 
     // Ensures that when the path was revalidated we don't return a partial response on redirects
-    if (staticGenerationStore.pathWasRevalidated) {
-      forwardedHeaders.delete('next-router-state-tree')
-    }
+    // if (staticGenerationStore.pathWasRevalidated) {
+    forwardedHeaders.delete('next-router-state-tree')
+    // }
 
     try {
       const headResponse = await fetchIPv4v6(fetchUrl, {

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -104,10 +104,10 @@ export type ActionResult = Promise<any>
 export type NextFlightResponse = [buildId: string, flightData: FlightData]
 
 // Response from `createFromFetch` for server actions. Action's flight data can be null
-export type ActionFlightResponse = [
-  ActionResult,
-  [buildId: NextFlightResponse[0], flightData: NextFlightResponse[1] | null]
-]
+export type ActionFlightResponse =
+  | [ActionResult, [buildId: string, flightData: FlightData | null]]
+  // This case happens when `redirect()` is called in a server action.
+  | NextFlightResponse
 
 /**
  * Property holding the current subTreeData.

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -374,7 +374,7 @@ createNextDescribe(
 
         await check(async () => {
           return browser.eval('window.location.toString()')
-        }, 'https://example.com/')
+        }, 'https://next-data-api-endpoint.vercel.app/api/random?page')
       })
 
       it('should allow cookie and header async storages', async () => {
@@ -422,7 +422,7 @@ createNextDescribe(
 
         await check(async () => {
           return browser.eval('window.location.toString()')
-        }, 'https://example.com/')
+        }, 'https://next-data-api-endpoint.vercel.app/api/random?page')
       })
 
       // TODO: investigate flakey behavior with revalidate

--- a/test/e2e/app-dir/actions/app/client/edge/page.js
+++ b/test/e2e/app-dir/actions/app/client/edge/page.js
@@ -47,7 +47,11 @@ export default function Counter() {
       <form>
         <button
           id="redirect-external"
-          formAction={() => redirectAction('https://example.com')}
+          formAction={() =>
+            redirectAction(
+              'https://next-data-api-endpoint.vercel.app/api/random?page'
+            )
+          }
         >
           redirect external
         </button>

--- a/test/e2e/app-dir/actions/app/client/page.js
+++ b/test/e2e/app-dir/actions/app/client/page.js
@@ -49,7 +49,11 @@ export default function Counter() {
       <form>
         <button
           id="redirect-external"
-          formAction={() => redirectAction('https://example.com')}
+          formAction={() =>
+            redirectAction(
+              'https://next-data-api-endpoint.vercel.app/api/random?page'
+            )
+          }
         >
           redirect external
         </button>


### PR DESCRIPTION
## What?

I was investigating reports of server actions with `revalidatePath` / `revalidateTag` not invalidating the client-side router cache. Managed to reproduce the issue here: https://github.com/timneutkens/server-actions-test (requires Vercel KV to run).

While looking at the reducer I noticed a few things that seemed off:

- setTimeout to trigger another `dispatch` on the same reducer with the fetched data. This means that it would not be part of the same React Transition.
- redirects weren't applying the data that comes back from the server (that allows for single hop navigation)
- prefetchCache was invalidated, but the router cache which is used for back/forward navigation was not invalidated, causing back/forward to not get the new data.
- all changes in the action-reducer mutate. The part that shouldn't mutate was part of that setTimeout dispatch.

This PR aims to solve all of these by reworking the actions reducer to be handled similarly to `router.refresh()`. Since `router.refresh()` was already modeled to be similar to `revalidatePath('/')`.

The flow is now more like the other reducers:
- Fetch data
- Wait for the data to come back
- Apply the data to the cache and keep it in a mutable variable
- Return the new cache and otherwise values like the url

In particular the actions reducer handles a few extra specifics:
- Resolving the server action promise, so that the value is passed to the application code waiting for the result.
- Applying redirects from `redirect()` calls.
- Invalidating the router cache

## Followup changes

- Currently when calling `revalidatePath('/dashboard')` the entire router cache is invalidated instead of only `/dashboard` and further down, this is not in scope for this PR but still has to be added.
- `notFound()`, I'm not sure how this is supposed to work exactly, it doesn't really make sense to me to allow it in server actions.
- Return partial render for redirect() without revalidate

Kudos @feedthejim for helping investigate for this PR 😌 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
