### PR TITLE
Fix build-native turbo config

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,26 +2,62 @@
   "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build-native": {
+      "inputs": [
+        "../../.cargo/**",
+        "../../packages/next-swc/crates/**",
+        "../../**/Cargo.toml",
+        "../../**/Cargo.lock"
+      ],
       "dependsOn": ["^build-native"],
       "outputs": ["native/*.node"]
     },
     "build-native-release": {
+      "inputs": [
+        "../../.cargo/**",
+        "../../packages/next-swc/crates/**",
+        "../../**/Cargo.toml",
+        "../../**/Cargo.lock"
+      ],
       "dependsOn": ["^build-native-release"],
       "outputs": ["native/*.node"]
     },
     "build-native-no-plugin": {
+      "inputs": [
+        "../../.cargo/**",
+        "../../packages/next-swc/crates/**",
+        "../../**/Cargo.toml",
+        "../../**/Cargo.lock"
+      ],
       "dependsOn": ["^build-native-no-plugin"],
       "outputs": ["native/*.node"]
     },
     "build-native-no-plugin-woa": {
+      "inputs": [
+        "../../.cargo/**",
+        "../../packages/next-swc/crates/**",
+        "../../**/Cargo.toml",
+        "../../**/Cargo.lock"
+      ],
       "dependsOn": ["^build-native-no-plugin-woa"],
       "outputs": ["native/*.node"]
     },
     "build-native-no-plugin-woa-release": {
+      "inputs": [
+        "../../.cargo/**",
+        "../../packages/next-swc/crates/**",
+        "../../**/Cargo.toml",
+        "../../**/Cargo.lock"
+      ],
       "dependsOn": ["^build-native-no-plugin-woa-release"],
       "outputs": ["native/*.node"]
     },
     "build-wasm": {
+      "inputs": [
+        "../../.cargo/**",
+        "../../packages/next-swc/crates/**",
+        "../../**/Cargo.toml",
+        "../../**/Cargo.lock"
+      ],
       "dependsOn": ["^build-wasm"],
       "outputs": ["crates/wasm/pkg/*"]
     },


### PR DESCRIPTION
The turbo cache is currently not being invalidated for our `build-native` jobs when the root `Cargo.lock` is changed so https://github.com/vercel/next.js/pull/53308 never actually got re-built/applied in CI and tests are unexpectedly passing. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1690808468319679)

- Related to https://github.com/vercel/next.js/pull/52414