### PR TITLE
fix: wait `__NEXT_DATA__` script tag evaluatable when initialize

### DIFF
--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -191,8 +191,13 @@ export async function initialize(opts: { webpackHMR?: any } = {}): Promise<{
     webpackHMR = opts.webpackHMR
   }
 
+  // This block prevents cannot get `script#__NEXT_DATA__` some use cases.
+  while (document.readyState === 'loading') {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
   initialData = JSON.parse(
-    document.getElementById('__NEXT_DATA__')!.textContent!
+    document.getElementById('__NEXT_DATA__')?.textContent || '{}'
   )
   window.__NEXT_DATA__ = initialData
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


### Related issues

- https://github.com/vercel/next.js/discussions/41299
- https://github.com/vercel/next.js/issues/47377
- https://github.com/nibtime/next-safe-middleware/issues/83

### Why

When Next.js is initializing in client side, Next.js don't wait for dom loaded. Thus, some use case could not load `__NEXT_DATA__` textContent. Please check related issues.

Notice that these issues may not be fully reproduced because of a specific browser, browser memory usage, caching, using an extension or something else.

Although, It can prevent by check document.readyState is not `loading`.

I was afraid this approach has the possibility of degrading first loaded rendering performance, so I checked Lighthouse and it didn't in `create-next-app` default page.

If I have forget some consideration, please tell and comment this PR.
