### PR TITLE
disable cache compression

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2697,7 +2697,9 @@ export default async function getBaseWebpackConfig(
     //  - next.config.js keys that affect compilation
     version: `${process.env.__NEXT_VERSION}|${configVars}`,
     cacheDirectory: path.join(distDir, 'cache', 'webpack'),
-    compression: 'gzip',
+    // It's more efficient to compress all cache files together instead of compression each one individually.
+    // So we disable compression here and allow the build runner to take care of compressing the cache as a whole.
+    compression: false,
   }
 
   // Adds `next.config.js` as a buildDependency when custom webpack config is provided


### PR DESCRIPTION
### What?

Disables webpacks cache compression

### Why?

CI already compresses the cache. No need for next.js to do that. In fact this actually causes worse experience in multiple ways:

* CI compresses the cache after the build has finished. So compressing inline slows down the build.
* gzip compression runs with BEST_SPEED optimization, which creates larger cache files. This leads to running into potential cache size limits easier.
* Two layers for compression are not efficient in size and speed.

Trade-off:

* The whole cache will be decompressed on every build, which is less efficient.

In a few tests the benefits are greater than the trade offs.
