### PR TITLE
feature: Adding ESLint rule to prevent usage document or other browser APIs outside of useEffect

### DIFF
--- a/errors/no-browser-api-in-server-component.mdx
+++ b/errors/no-browser-api-in-server-component.mdx
@@ -1,0 +1,47 @@
+---
+title: No Browser API In Server Component
+---
+
+> Prevent the use of browser APIs in server components.
+
+#### Why This Error Occurred
+
+<!-- Explain why the error occurred. Ensure the description makes it clear why the warning/error exists -->
+
+The error occurs when a server-side component uses a browser-specific API that is not available in the server environment.
+
+#### Possible Ways to Fix It
+
+<!-- Explain how to fix the warning/error, potentially by providing alternative approaches. Ensure this section is actionable by users -->
+
+1. Put the browser API related code in a useEffect.
+
+```jsx filename="app/my-server-component.tsx"
+import { useEffect } from 'react'
+
+const MyComponent = () => {
+  useEffect(() => {
+    // Browser API related code
+  }, [])
+
+  return <div>My Component</div>
+}
+```
+
+2.Convert the component to a client component.
+
+```jsx filename="app/my-client-component.tsx"
+'use client'
+
+const MyComponent = () => {
+  // Browser API related code
+
+  return <div>My Component</div>
+}
+```
+
+### Useful Links
+
+<!-- Add links to relevant documentation -->
+
+- [When to use Server and Client Components?](/docs/getting-started/react-essentials#when-to-use-server-and-client-components)

--- a/errors/no-browser-api-in-server-component.mdx
+++ b/errors/no-browser-api-in-server-component.mdx
@@ -6,13 +6,9 @@ title: No Browser API In Server Component
 
 #### Why This Error Occurred
 
-<!-- Explain why the error occurred. Ensure the description makes it clear why the warning/error exists -->
-
 The error occurs when a server-side component uses a browser-specific API that is not available in the server environment.
 
 #### Possible Ways to Fix It
-
-<!-- Explain how to fix the warning/error, potentially by providing alternative approaches. Ensure this section is actionable by users -->
 
 1. Put the browser API related code in a useEffect.
 
@@ -41,7 +37,5 @@ const MyComponent = () => {
 ```
 
 ### Useful Links
-
-<!-- Add links to relevant documentation -->
 
 - [When to use Server and Client Components?](/docs/getting-started/react-essentials#when-to-use-server-and-client-components)

--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -21,6 +21,7 @@ module.exports = {
     'no-title-in-document-head': require('./rules/no-title-in-document-head'),
     'no-typos': require('./rules/no-typos'),
     'no-unwanted-polyfillio': require('./rules/no-unwanted-polyfillio'),
+    'no-browser-api-server-component': require('./rules/no-browser-api-server-component'),
   },
   configs: {
     recommended: {

--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -50,6 +50,7 @@ module.exports = {
         '@next/next/no-duplicate-head': 'error',
         '@next/next/no-head-import-in-document': 'error',
         '@next/next/no-script-component-in-head': 'error',
+        '@next/next/no-browser-api-server-component': 'error',
       },
     },
     'core-web-vitals': {

--- a/packages/eslint-plugin-next/src/rules/no-async-client-component.ts
+++ b/packages/eslint-plugin-next/src/rules/no-async-client-component.ts
@@ -1,12 +1,9 @@
 import { defineRule } from '../utils/define-rule'
+import { isCapitalized } from '../utils/regex'
 
 const url = 'https://nextjs.org/docs/messages/no-async-client-component'
 const description = 'Prevent client components from being async functions.'
 const message = `${description} See: ${url}`
-
-function isCapitalized(str: string): boolean {
-  return /[A-Z]/.test(str?.[0])
-}
 
 export = defineRule({
   meta: {

--- a/packages/eslint-plugin-next/src/rules/no-browser-api-server-component.ts
+++ b/packages/eslint-plugin-next/src/rules/no-browser-api-server-component.ts
@@ -5,6 +5,44 @@ const description = 'Prevent the use of browser APIs in server components.'
 const url =
   'https://nextjs.org/docs/messages/no-browser-api-in-server-component'
 
+const browserAPIs = [
+  'document',
+  'window',
+  'navigator',
+  'location',
+  'history',
+  'localStorage',
+  'sessionStorage',
+  'fetch',
+  'XMLHttpRequest',
+  'setTimeout',
+  'setInterval',
+  'requestAnimationFrame',
+  'addEventListener',
+  'removeEventListener',
+  'CustomEvent',
+  'Promise',
+  'Worker',
+  'navigator.geolocation',
+  'canvas',
+  'WebSocket',
+  'navigator.mediaDevices.getUserMedia',
+  'AudioContext',
+  'history',
+  'Notification',
+  'navigator.serviceWorker',
+  'IntersectionObserver',
+  'ondragstart',
+  'ondragover',
+  'Element.requestFullscreen',
+  'Storage',
+  'navigator.clipboard',
+  'Animation',
+  'alert',
+  'confirm',
+  'prompt',
+]
+
 export = defineRule({
   meta: {
     docs: {
@@ -49,44 +87,6 @@ export = defineRule({
         }
       },
       Identifier(node) {
-        const browserAPIs = [
-          'document',
-          'window',
-          'navigator',
-          'location',
-          'history',
-          'localStorage',
-          'sessionStorage',
-          'fetch',
-          'XMLHttpRequest',
-          'setTimeout',
-          'setInterval',
-          'requestAnimationFrame',
-          'addEventListener',
-          'removeEventListener',
-          'CustomEvent',
-          'Promise',
-          'Worker',
-          'navigator.geolocation',
-          'canvas',
-          'WebSocket',
-          'navigator.mediaDevices.getUserMedia',
-          'AudioContext',
-          'history',
-          'Notification',
-          'navigator.serviceWorker',
-          'IntersectionObserver',
-          'ondragstart',
-          'ondragover',
-          'Element.requestFullscreen',
-          'Storage',
-          'navigator.clipboard',
-          'Animation',
-          'alert',
-          'confirm',
-          'prompt',
-        ]
-
         if (
           !inUseEffectHook &&
           browserAPIs.includes(node.name) &&

--- a/packages/eslint-plugin-next/src/rules/no-browser-api-server-component.ts
+++ b/packages/eslint-plugin-next/src/rules/no-browser-api-server-component.ts
@@ -21,12 +21,12 @@ export = defineRule({
     const text = sourceCode.text
     const allComments = sourceCode.getAllComments()
 
-    const useClientInText = text.includes('use client')
-    const useClientInComments = allComments.some((comment) =>
+    const isClientSideComponent = text.includes('use client')
+    const isUseClientCommented = allComments.some((comment) =>
       comment.value.includes('use client')
     )
 
-    if (useClientInText && !useClientInComments) {
+    if (isClientSideComponent && !isUseClientCommented) {
       return {}
     }
 

--- a/packages/eslint-plugin-next/src/rules/no-browser-api-server-component.ts
+++ b/packages/eslint-plugin-next/src/rules/no-browser-api-server-component.ts
@@ -1,0 +1,103 @@
+import { defineRule } from '../utils/define-rule'
+
+const description = 'Prevent the use of browser APIs in server components.'
+
+const url =
+  'https://nextjs.org/docs/messages/no-browser-api-in-server-component'
+
+export = defineRule({
+  meta: {
+    docs: {
+      description,
+      recommended: true,
+      url,
+    },
+    type: 'problem',
+    schema: [],
+  },
+  create(context) {
+    let inUseEffectHook = false
+    const sourceCode = context.getSourceCode()
+    const text = sourceCode.text
+    const allComments = sourceCode.getAllComments()
+
+    const useClientInText = text.includes('use client')
+    const useClientInComments = allComments.some((comment) =>
+      comment.value.includes('use client')
+    )
+
+    if (useClientInText && !useClientInComments) {
+      return {}
+    }
+
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'useEffect'
+        ) {
+          inUseEffectHook = true
+        }
+      },
+      'CallExpression:exit'(node) {
+        // Check if we're leaving a useEffect hook
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'useEffect'
+        ) {
+          inUseEffectHook = false
+        }
+      },
+      Identifier(node) {
+        const browserAPIs = [
+          'document',
+          'window',
+          'navigator',
+          'location',
+          'history',
+          'localStorage',
+          'sessionStorage',
+          'fetch',
+          'XMLHttpRequest',
+          'setTimeout',
+          'setInterval',
+          'requestAnimationFrame',
+          'addEventListener',
+          'removeEventListener',
+          'CustomEvent',
+          'Promise',
+          'Worker',
+          'navigator.geolocation',
+          'canvas',
+          'WebSocket',
+          'navigator.mediaDevices.getUserMedia',
+          'AudioContext',
+          'history',
+          'Notification',
+          'navigator.serviceWorker',
+          'IntersectionObserver',
+          'ondragstart',
+          'ondragover',
+          'Element.requestFullscreen',
+          'Storage',
+          'navigator.clipboard',
+          'Animation',
+          'alert',
+          'confirm',
+          'prompt',
+        ]
+
+        if (
+          !inUseEffectHook &&
+          browserAPIs.includes(node.name) &&
+          node.name !== 'useEffect'
+        ) {
+          context.report({
+            node,
+            message: `Do not use ${node.name} outside of a useEffect hook in a server component.`,
+          })
+        }
+      },
+    }
+  },
+})

--- a/packages/eslint-plugin-next/src/rules/no-browser-api-server-component.ts
+++ b/packages/eslint-plugin-next/src/rules/no-browser-api-server-component.ts
@@ -94,7 +94,7 @@ export = defineRule({
         ) {
           context.report({
             node,
-            message: `Do not use ${node.name} outside of a useEffect hook in a server component.`,
+            message: `${description} Avoid using \`${node.name}\` in server components. See: ${url}`,
           })
         }
       },

--- a/packages/eslint-plugin-next/src/utils/regex.ts
+++ b/packages/eslint-plugin-next/src/utils/regex.ts
@@ -1,0 +1,3 @@
+export function isCapitalized(str: string): boolean {
+  return /[A-Z]/.test(str?.[0])
+}

--- a/test/unit/eslint-plugin-next/no-browser-api-server-component.test.ts
+++ b/test/unit/eslint-plugin-next/no-browser-api-server-component.test.ts
@@ -46,6 +46,14 @@ ruleTester.run('no-browser-api-in-server-component', rule, {
         );
       }
     `,
+    `
+      const functionWithWindow = () => {
+        const myWindow = window;
+      }
+    `,
+    `
+      const myWindow = window;
+    `,
   ],
   invalid: [
     {

--- a/test/unit/eslint-plugin-next/no-browser-api-server-component.test.ts
+++ b/test/unit/eslint-plugin-next/no-browser-api-server-component.test.ts
@@ -1,0 +1,88 @@
+import rule from '@next/eslint-plugin-next/dist/rules/no-browser-api-server-component'
+import { RuleTester } from 'eslint'
+;(RuleTester as any).setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      modules: true,
+      jsx: true,
+    },
+  },
+})
+const ruleTester = new RuleTester()
+
+const message = 'Prevent the use of browser APIs in server components.'
+
+const url =
+  'https://nextjs.org/docs/messages/no-browser-api-in-server-component'
+
+ruleTester.run('no-browser-api-in-server-component', rule, {
+  valid: [
+    `
+    export default function MyComponent() {
+      return <></>
+    }
+    `,
+    `
+    export default function MyComponent() {
+      useEffect(() => {
+        const myWindow = window;
+      }, []);
+
+      return <></>
+    }
+    `,
+    `
+     'use client';
+
+      export default function MyComponent() {
+        const myWindow = window;
+
+        return (
+          <div>
+            My Client Component
+          </div>
+        );
+      }
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+      export default function MyComponent() {
+        const myWindow = window;
+
+        return (
+          <div>
+            My Component
+          </div>
+        );
+      }
+      `,
+      errors: [
+        {
+          message: `${message} Avoid using \`window\` in server components. See: ${url}`,
+        },
+      ],
+    },
+    {
+      code: `
+      export default function MyComponent() {
+        const myDocument = document;
+
+        return (
+          <>
+            My Component
+          </>
+        );
+      }
+      `,
+      errors: [
+        {
+          message: `${message} Avoid using \`document\` in server components. See: ${url}`,
+        },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
### Related issues
https://github.com/vercel/next.js/issues/27051

### What?
I have created a new eslint rule which will check if the developer is using the browser API in a server component.

### Why?
The reason for doing this is to prevent the developer to cause a potential crash in his server component when using any of the browser API outside of a `useEffect`.

This also takes into consideration client components, where I explicitly check for the `use client` keyword, in that case it is allowed to use the browser API since we have access to that API in a client component.

### How?

Firstly, I check if there is `use client` in the file content, if so, the rule is ignored since it is a client component.

Secondly, I have a while loop which finds the top most parent function / arrow function and check if it's a React component.

Last but not least, I check if the current identifier is part of the browser API's array, if so, it should show an error.