### PR TITLE
Revert "docker examples: improve perf by using COPY --link"

### DIFF
--- a/examples/with-docker-compose/next-app/dev.Dockerfile
+++ b/examples/with-docker-compose/next-app/dev.Dockerfile
@@ -1,10 +1,9 @@
-#syntax=docker/dockerfile:1.4
 FROM node:18-alpine
 
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY --link package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
@@ -13,10 +12,10 @@ RUN \
   else echo "Warning: Lockfile not found. It is recommended to commit lockfiles to version control." && yarn install; \
   fi
 
-COPY --link src ./src
-COPY --link public ./public
-COPY --link next.config.js .
-COPY --link tsconfig.json .
+COPY src ./src
+COPY public ./public
+COPY next.config.js .
+COPY tsconfig.json .
 
 # Next.js collects completely anonymous telemetry data about general usage. Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line to disable telemetry at run time

--- a/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
@@ -1,10 +1,9 @@
-#syntax=docker/dockerfile:1.4
 FROM node:18-alpine
 
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY --link package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 # Omit --production flag for TypeScript devDependencies
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
@@ -14,10 +13,10 @@ RUN \
   else echo "Warning: Lockfile not found. It is recommended to commit lockfiles to version control." && yarn install; \
   fi
 
-COPY --link src ./src
-COPY --link public ./public
-COPY --link next.config.js .
-COPY --link tsconfig.json .
+COPY src ./src
+COPY public ./public
+COPY next.config.js .
+COPY tsconfig.json .
 
 # Environment variables must be present at build time
 # https://github.com/vercel/next.js/discussions/14030

--- a/examples/with-docker-compose/next-app/prod.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod.Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile:1.4
 FROM node:18-alpine AS base
 
 # Step 1. Rebuild the source code only when needed
@@ -7,7 +6,7 @@ FROM base AS builder
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY --link package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 # Omit --production flag for TypeScript devDependencies
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
@@ -17,10 +16,10 @@ RUN \
   else echo "Warning: Lockfile not found. It is recommended to commit lockfiles to version control." && yarn install; \
   fi
 
-COPY --link src ./src
-COPY --link public ./public
-COPY --link next.config.js .
-COPY --link tsconfig.json .
+COPY src ./src
+COPY public ./public
+COPY next.config.js .
+COPY tsconfig.json .
 
 # Environment variables must be present at build time
 # https://github.com/vercel/next.js/discussions/14030
@@ -49,17 +48,16 @@ FROM base AS runner
 WORKDIR /app
 
 # Don't run production as root
-RUN \
-  addgroup --system --gid 1001 nodejs; \
-  adduser --system --uid 1001 nextjs
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
 USER nextjs
 
-COPY --from=builder --link /app/public ./public
+COPY --from=builder /app/public ./public
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --link --chown=1001:1001 /app/.next/standalone ./
-COPY --from=builder --link --chown=1001:1001 /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 # Environment variables must be redefined at run time
 ARG ENV_VARIABLE

--- a/examples/with-docker-multi-env/docker/development/Dockerfile
+++ b/examples/with-docker-multi-env/docker/development/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile:1.4
 FROM node:18-alpine AS base
 
 # 1. Install dependencies only when needed
@@ -9,7 +8,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY --link package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
@@ -20,10 +19,10 @@ RUN \
 # 2. Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /app
-COPY --from=deps --link /app/node_modules ./node_modules
-COPY --link . .
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
 # This will do the trick, use the corresponding env file for each environment.
-COPY --link .env.development.sample .env.production
+COPY .env.development.sample .env.production
 RUN yarn build
 
 # 3. Production image, copy all the files and run next
@@ -32,16 +31,15 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-RUN \
-  addgroup -g 1001 -S nodejs; \
-  adduser -S nextjs -u 1001
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nextjs -u 1001
 
-COPY --from=builder --link /app/public ./public
+COPY --from=builder /app/public ./public
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --link --chown=1001:1001 /app/.next/standalone ./
-COPY --from=builder --link --chown=1001:1001 /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 
 USER nextjs

--- a/examples/with-docker-multi-env/docker/production/Dockerfile
+++ b/examples/with-docker-multi-env/docker/production/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile:1.4
 FROM node:18-alpine AS base
 
 # 1. Install dependencies only when needed
@@ -9,7 +8,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY --link package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
@@ -21,10 +20,10 @@ RUN \
 # 2. Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /app
-COPY --from=deps --link /app/node_modules ./node_modules
-COPY --link . .
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
 # This will do the trick, use the corresponding env file for each environment.
-COPY --link .env.production.sample .env.production
+COPY .env.production.sample .env.production
 RUN yarn build
 
 # 3. Production image, copy all the files and run next
@@ -33,16 +32,15 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-RUN \
-  addgroup -g 1001 -S nodejs; \
-  adduser -S nextjs -u 1001
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nextjs -u 1001
 
-COPY --from=builder --link /app/public ./public
+COPY --from=builder /app/public ./public
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --link --chown=1001:1001 /app/.next/standalone ./
-COPY --from=builder --link --chown=1001:1001 /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 
 USER nextjs

--- a/examples/with-docker-multi-env/docker/staging/Dockerfile
+++ b/examples/with-docker-multi-env/docker/staging/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile:1.4
 FROM node:18-alpine AS base
 
 # 1. Install dependencies only when needed
@@ -9,7 +8,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY --link package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
@@ -21,10 +20,10 @@ RUN \
 # 2. Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /app
-COPY --from=deps --link /app/node_modules ./node_modules
-COPY --link . .
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
 # This will do the trick, use the corresponding env file for each environment.
-COPY --link .env.staging.sample .env.production
+COPY .env.staging.sample .env.production
 RUN yarn build
 
 # 3. Production image, copy all the files and run next
@@ -33,16 +32,15 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-RUN \
-  addgroup -g 1001 -S nodejs; \
-  adduser -S nextjs -u 1001
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nextjs -u 1001
 
-COPY --from=builder --link /app/public ./public
+COPY --from=builder /app/public ./public
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --link --chown=1001:1001 /app/.next/standalone ./
-COPY --from=builder --link --chown=1001:1001 /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 
 USER nextjs

--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile:1.4
 FROM node:18-alpine AS base
 
 # Install dependencies only when needed
@@ -8,7 +7,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY --link package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
@@ -20,8 +19,8 @@ RUN \
 # Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /app
-COPY --from=deps --link /app/node_modules ./node_modules
-COPY --link  . .
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
@@ -41,16 +40,15 @@ ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 # ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN \
-  addgroup --system --gid 1001 nodejs; \
-  adduser --system --uid 1001 nextjs
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
 
-COPY --from=builder --link /app/public ./public
+COPY --from=builder /app/public ./public
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --link --chown=1001:1001 /app/.next/standalone ./
-COPY --from=builder --link --chown=1001:1001 /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 


### PR DESCRIPTION
Reverts vercel/next.js#52835 because it does not work on Google Cloud Run, which we mention in the README.md.

Closes #53425