### PR TITLE
fix(doc): Broken link formatting in draft-mode doc (app router)

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/11-draft-mode.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/11-draft-mode.mdx
@@ -3,7 +3,7 @@ title: Draft Mode
 description: Next.js has draft mode to toggle between static and dynamic pages. You can learn how it works with App Router here.
 ---
 
-Static rendering is useful when your pages fetch data from a headless CMS. However, it’s not ideal when you’re writing a draft on your headless CMS and want to view the draft immediately on your page. You’d want Next.js to render these pages at **request time** instead of build time and fetch the draft content instead of the published content. You’d want Next.js to switch to [dynamic rendering](/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering only for this specific case.
+Static rendering is useful when your pages fetch data from a headless CMS. However, it’s not ideal when you’re writing a draft on your headless CMS and want to view the draft immediately on your page. You’d want Next.js to render these pages at **request time** instead of build time and fetch the draft content instead of the published content. You’d want Next.js to switch to [dynamic rendering](/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering) only for this specific case.
 
 Next.js has a feature called **Draft Mode** which solves this problem. Here are instructions on how to use it.
 


### PR DESCRIPTION
### What?
Link to dynamic rendering is not appearing as such in the App router's draft-mode docs.

### Why?
The formatting is wrong, it misses a parenthesis

### How?
Added the missing parenthesis