### PR TITLE
Fixed wrong link

### DIFF
--- a/examples/cms-enterspeed/README.md
+++ b/examples/cms-enterspeed/README.md
@@ -4,7 +4,7 @@ This example showcases Next.js's [Static Generation](https://nextjs.org/docs/bas
 
 ## Demo
 
-### [https://next-blog-wordpress.vercel.app](https://next-blog-wordpress.vercel.app)
+### [https://next-blog-demo.enterspeed.com/](https://next-blog-demo.enterspeed.com/)
 
 ## Deploy your own
 


### PR DESCRIPTION
### What?
The link to the demo in README.md for `example/cms-enterspeed`.

### Why?
The link was pointing to the wrong demo.

### How?
Updated the README.md.