### PR TITLE
fix: dot in page name when `output: export` and `trailingSlash: true`

### DIFF
--- a/packages/next/src/client/normalize-trailing-slash.ts
+++ b/packages/next/src/client/normalize-trailing-slash.ts
@@ -12,9 +12,7 @@ export const normalizePathTrailingSlash = (path: string) => {
 
   const { pathname, query, hash } = parsePath(path)
   if (process.env.__NEXT_TRAILING_SLASH) {
-    if (/\.[^/]+\/?$/.test(pathname)) {
-      return `${removeTrailingSlash(pathname)}${query}${hash}`
-    } else if (pathname.endsWith('/')) {
+    if (pathname.endsWith('/')) {
       return `${pathname}${query}${hash}`
     } else {
       return `${pathname}/${query}${hash}`

--- a/packages/next/src/lib/load-custom-routes.ts
+++ b/packages/next/src/lib/load-custom-routes.ts
@@ -674,29 +674,13 @@ export default async function loadCustomRoutes(
 
   if (!config.skipTrailingSlashRedirect) {
     if (config.trailingSlash) {
-      redirects.unshift(
-        {
-          source: '/:file((?!\\.well-known(?:/.*)?)(?:[^/]+/)*[^/]+\\.\\w+)/',
-          destination: '/:file',
-          permanent: true,
-          locale: config.i18n ? false : undefined,
-          internal: true,
-          // don't run this redirect for _next/data requests
-          missing: [
-            {
-              type: 'header',
-              key: 'x-nextjs-data',
-            },
-          ],
-        } as Redirect,
-        {
-          source: '/:notfile((?!\\.well-known(?:/.*)?)(?:[^/]+/)*[^/\\.]+)',
-          destination: '/:notfile/',
-          permanent: true,
-          locale: config.i18n ? false : undefined,
-          internal: true,
-        } as Redirect
-      )
+      redirects.unshift({
+        source: '/:notfile((?!\\.well-known(?:/.*)?)(?:[^/]+/)*[^/\\.]+)',
+        destination: '/:notfile/',
+        permanent: true,
+        locale: config.i18n ? false : undefined,
+        internal: true,
+      } as Redirect)
       if (config.basePath) {
         redirects.unshift({
           source: config.basePath,

--- a/test/integration/app-dir-export/app/another/page.js
+++ b/test/integration/app-dir-export/app/another/page.js
@@ -18,6 +18,12 @@ export default function Another() {
           <Link href="/another/second">another second page</Link>
         </li>
         <li>
+          <Link href="/path.with.dot">path with dot has no trailingSlash</Link>
+        </li>
+        <li>
+          <Link href="/path.with.dot/">path with dot has trailingSlash</Link>
+        </li>
+        <li>
           <Link href="/image-import">image import page</Link>
         </li>
       </ul>

--- a/test/integration/app-dir-export/app/page.js
+++ b/test/integration/app-dir-export/app/page.js
@@ -18,6 +18,12 @@ export default function Home() {
           <Link href="/another/second">another second page</Link>
         </li>
         <li>
+          <Link href="/path.with.dot">path with dot has no trailingSlash</Link>
+        </li>
+        <li>
+          <Link href="/path.with.dot/">path with dot has trailingSlash</Link>
+        </li>
+        <li>
           <Link href="/image-import">image import page</Link>
         </li>
       </ul>

--- a/test/integration/app-dir-export/app/path.with.dot/page.js
+++ b/test/integration/app-dir-export/app/path.with.dot/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function PathWithDot() {
+  return (
+    <main>
+      <h1>Path With Dot</h1>
+      <ul>
+        <li>
+          <Link href="/another">visit another page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/integration/app-dir-export/test/utils.ts
+++ b/test/integration/app-dir-export/test/utils.ts
@@ -46,6 +46,8 @@ export const expectedWhenTrailingSlashTrue = [
   'image-import/index.txt',
   'index.html',
   'index.txt',
+  'path.with.dot/index.html',
+  'path.with.dot/index.txt',
   'robots.txt',
 ]
 
@@ -67,6 +69,8 @@ const expectedWhenTrailingSlashFalse = [
   'image-import.txt',
   'index.html',
   'index.txt',
+  'path.with.dot.html',
+  'path.with.dot.txt',
   'robots.txt',
 ]
 
@@ -150,6 +154,29 @@ export async function runTests({
     } else {
       const a = (n: number) => `li:nth-child(${n}) a`
       const browser = await webdriver(port, '/')
+      if (trailingSlash) {
+        expect(await browser.elementByCss(a(1)).getAttribute('href')).toEndWith(
+          '/'
+        )
+        expect(await browser.elementByCss(a(2)).getAttribute('href')).toEndWith(
+          '/'
+        )
+        expect(await browser.elementByCss(a(3)).getAttribute('href')).toEndWith(
+          '/'
+        )
+        expect(await browser.elementByCss(a(4)).getAttribute('href')).toEndWith(
+          '/'
+        )
+        expect(await browser.elementByCss(a(5)).getAttribute('href')).toEndWith(
+          '/'
+        )
+        expect(await browser.elementByCss(a(6)).getAttribute('href')).toEndWith(
+          '/'
+        )
+        expect(await browser.elementByCss(a(7)).getAttribute('href')).toEndWith(
+          '/'
+        )
+      }
       await check(() => browser.elementByCss('h1').text(), 'Home')
       expect(await browser.elementByCss(a(1)).text()).toBe(
         'another no trailingslash'
@@ -192,8 +219,28 @@ export async function runTests({
       await browser.elementByCss(a(1)).click()
 
       await check(() => browser.elementByCss('h1').text(), 'Another')
-      expect(await browser.elementByCss(a(5)).text()).toBe('image import page')
+      expect(await browser.elementByCss(a(5)).text()).toBe(
+        'path with dot has no trailingSlash'
+      )
       await browser.elementByCss(a(5)).click()
+
+      await check(() => browser.elementByCss('h1').text(), 'Path With Dot')
+      expect(await browser.elementByCss(a(1)).text()).toBe('visit another page')
+      await browser.elementByCss(a(1)).click()
+
+      await check(() => browser.elementByCss('h1').text(), 'Another')
+      expect(await browser.elementByCss(a(6)).text()).toBe(
+        'path with dot has trailingSlash'
+      )
+      await browser.elementByCss(a(6)).click()
+
+      await check(() => browser.elementByCss('h1').text(), 'Path With Dot')
+      expect(await browser.elementByCss(a(1)).text()).toBe('visit another page')
+      await browser.elementByCss(a(1)).click()
+
+      await check(() => browser.elementByCss('h1').text(), 'Another')
+      expect(await browser.elementByCss(a(7)).text()).toBe('image import page')
+      await browser.elementByCss(a(7)).click()
 
       await check(() => browser.elementByCss('h1').text(), 'Image Import')
       expect(await browser.elementByCss(a(2)).text()).toBe('View the image')


### PR DESCRIPTION
This PR fixes a bug mentioned in this blog post: https://dagster.io/blog/dbt-docs-on-react

> When we opened the web inspector, we found that the client-side router was requesting files as if trailingSlash was not enabled. This led to a 404 error which forced the full page reload. 

The root cause was that `next/link` normally adds a trailing slash automatically, but it wasn't adding it when the page name contains a dot. 

Fixes NEXT-1487