### PR TITLE
docs: Remove duplicate backtick in next/font

### DIFF
--- a/docs/02-app/02-api-reference/01-components/font.mdx
+++ b/docs/02-app/02-api-reference/01-components/font.mdx
@@ -147,7 +147,7 @@ Used in `next/font/google` and `next/font/local`
 
 Examples:
 
-- `adjustFontFallback: false`: for ``next/font/google`
+- `adjustFontFallback: false`: for `next/font/google`
 - `adjustFontFallback: 'Times New Roman'`: for `next/font/local`
 
 ### `variable`


### PR DESCRIPTION
Fixed duplicate backtick in [adjustFontFallback](https://nextjs.org/docs/pages/api-reference/components/font#adjustfontfallback:~:text=false%3A%20for-,%60%60next/font/google%60,-adjustFontFallback%3A%20%27Times%20New) API docs.