### PR TITLE
docs: Fix demo code generate-static-params.mdx

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-static-params.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-static-params.mdx
@@ -11,7 +11,9 @@ export async function generateStaticParams() {
   const posts = await fetch('https://.../posts').then((res) => res.json())
 
   return posts.map((post) => ({
-    slug: post.slug,
+    params: {
+      slug: post.slug,
+    },
   }))
 }
 


### PR DESCRIPTION
Fixes a wrong demo code on generate-static-params.

The old code gives error:

```
A required parameter (slug) was not provided as an array received string in generateStaticParams for /[...slug]
```

With the new code the `generateStaticParams` works properly