### PR TITLE
Add test for catching metadata error in error boundaries

### DIFF
--- a/test/e2e/app-dir/global-error/basic/app/metadata-error-with-boundary/error.js
+++ b/test/e2e/app-dir/global-error/basic/app/metadata-error-with-boundary/error.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Error() {
+  return <p id="error">Local error boundary</p>
+}

--- a/test/e2e/app-dir/global-error/basic/app/metadata-error-with-boundary/page.js
+++ b/test/e2e/app-dir/global-error/basic/app/metadata-error-with-boundary/page.js
@@ -1,0 +1,9 @@
+export const dynamic = 'force-dynamic'
+
+export function generateMetadata() {
+  throw new Error('Metadata error')
+}
+
+export default function Page() {
+  return <p>Metadata error</p>
+}

--- a/test/e2e/app-dir/global-error/basic/app/metadata-error-without-boundary/page.js
+++ b/test/e2e/app-dir/global-error/basic/app/metadata-error-without-boundary/page.js
@@ -1,0 +1,9 @@
+export const dynamic = 'force-dynamic'
+
+export function generateMetadata() {
+  throw new Error('Metadata error')
+}
+
+export default function Page() {
+  return <p>Metadata error</p>
+}

--- a/test/e2e/app-dir/global-error/basic/index.test.ts
+++ b/test/e2e/app-dir/global-error/basic/index.test.ts
@@ -64,6 +64,7 @@ createNextDescribe(
       expect(await browser.elementByCss('#error').text()).toBe(
         'Local error boundary'
       )
+      expect(await browser.hasElementByCssSelector('#digest')).toBeFalsy()
     })
 
     it('should catch metadata error in global-error if no error boundary is presented', async () => {
@@ -76,7 +77,6 @@ createNextDescribe(
         expect(await browser.elementByCss('#error').text()).toBe(
           'Global error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
         )
-        expect(await browser.hasElementByCssSelector('#digest')).toBeFalsy()
       }
     })
   }

--- a/test/e2e/app-dir/global-error/basic/index.test.ts
+++ b/test/e2e/app-dir/global-error/basic/index.test.ts
@@ -57,5 +57,27 @@ createNextDescribe(
         expect(await browser.hasElementByCssSelector('#digest')).toBeFalsy()
       }
     })
+
+    it('should catch metadata error in error boundary if presented', async () => {
+      const browser = await next.browser('/metadata-error-with-boundary')
+
+      expect(await browser.elementByCss('#error').text()).toBe(
+        'Local error boundary'
+      )
+    })
+
+    it('should catch metadata error in global-error if no error boundary is presented', async () => {
+      const browser = await next.browser('/metadata-error-without-boundary')
+
+      if (isNextDev) {
+        await testDev(browser, /Error: Metadata error/)
+      } else {
+        expect(await browser.elementByCss('h1').text()).toBe('Global Error')
+        expect(await browser.elementByCss('#error').text()).toBe(
+          'Global error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
+        )
+        expect(await browser.hasElementByCssSelector('#digest')).toBeFalsy()
+      }
+    })
   }
 )


### PR DESCRIPTION
After landing #53551 we can catch metadata error in error boundaries now, this PR adds tests for catching metadata error with `error.js` and `global-error.js`

Fixes #50863 
Closes #53546