### PR TITLE
chore(docs): update static exports documentation with missing info

### DIFF
--- a/docs/02-app/01-building-your-application/08-deploying/01-static-exports.mdx
+++ b/docs/02-app/01-building-your-application/08-deploying/01-static-exports.mdx
@@ -27,8 +27,13 @@ To enable a static export, change the output mode inside `next.config.js`:
  */
 const nextConfig = {
   output: 'export',
-  // Optional: Add a trailing slash to all paths `/about` -> `/about/`
+
+  // Optional: Change links `/me` -> `/me/` and emit `/me.html` -> `/me/index.html`
   // trailingSlash: true,
+
+  // Optional: Prevent automatic `/me` -> `/me/`, instead preserve `href`
+  // skipTrailingSlashRedirect: true,
+
   // Optional: Change the output directory `out` -> `dist`
   // distDir: 'dist',
 }
@@ -175,7 +180,7 @@ const nextConfig = {
   output: 'export',
   images: {
     loader: 'custom',
-    loaderFile: './app/image.ts',
+    loaderFile: './my-loader.ts',
   },
 }
 
@@ -184,7 +189,7 @@ module.exports = nextConfig
 
 This custom loader will define how to fetch images from a remote source. For example, the following loader will construct the URL for Cloudinary:
 
-```ts filename="app/image.ts" switcher
+```ts filename="my-loader.ts" switcher
 export default function cloudinaryLoader({
   src,
   width,
@@ -201,7 +206,7 @@ export default function cloudinaryLoader({
 }
 ```
 
-```js filename="app/image.js" switcher
+```js filename="my-loader.js" switcher
 export default function cloudinaryLoader({ src, width, quality }) {
   const params = ['f_auto', 'c_limit', `w_${width}`, `q_${quality || 'auto'}`]
   return `https://res.cloudinary.com/demo/image/upload/${params.join(
@@ -277,30 +282,31 @@ export default function ClientComponent() {
 
 ## Unsupported Features
 
+Features that require a Node.js server, or dynamic logic that cannot be computed during the build process, are **not** supported:
+
 <AppOnly>
 
-After enabling the static export `output` mode, all routes inside `app` are opted-into the following [Route Segment Config](/docs/app/api-reference/file-conventions/route-segment-config):
+- [Dynamic Routes](/docs/app/building-your-application/routing/dynamic-routes) with `dynamicParams: true`
+- [Dynamic Routes](/docs/app/building-your-application/routing/dynamic-routes) without `generateStaticParams()`
+- [Route Handlers](/app/building-your-application/routing/route-handlers) that rely on Request
+- [Cookies](/docs/app/api-reference/functions/cookies)
+- [Rewrites](/docs/app/api-reference/next-config-js/rewrites)
+- [Redirects](/docs/app/api-reference/next-config-js/redirects)
+- [Headers](/docs/app/api-reference/next-config-js/headers)
+- [Middleware](/docs/app/building-your-application/routing/middleware)
+- [Incremental Static Regeneration](/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating)
+- [Image Optimization](/docs/app/building-your-application/optimizing/images) with the default `loader`
+- [Draft Mode](/docs/app/building-your-application/configuring/draft-mode)
+
+Attempting to use any of these features with `next dev` will result in an error, similar to setting the [`dynamic`](/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option to `error` in the root layout.
 
 ```jsx
 export const dynamic = 'error'
 ```
 
-With this configuration, your application **will produce an error** if you try to use server functions like [`headers`](/docs/app/api-reference/functions/headers) or [`cookies`](/docs/app/api-reference/functions/cookies), since there is no runtime server. This ensures local development matches the same behavior as a static export. If you need to use server functions, you cannot use a static export.
-
-The following additional dynamic features are not supported with a static export:
-
-- [Dynamic Routes](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes) without `generateStaticParams()`
-- `rewrites` in `next.config.js`
-- `redirects` in `next.config.js`
-- `headers` in `next.config.js`
-- Middleware
-- [Incremental Static Regeneration](/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating)
-
 </AppOnly>
 
 <PagesOnly>
-
-Features that require a Node.js server, or dynamic logic that cannot be computed during the build process, are not supported:
 
 - [Internationalized Routing](/docs/pages/building-your-application/routing/internationalization)
 - [API Routes](/docs/pages/building-your-application/routing/api-routes)
@@ -309,10 +315,11 @@ Features that require a Node.js server, or dynamic logic that cannot be computed
 - [Headers](/docs/pages/api-reference/next-config-js/headers)
 - [Middleware](/docs/pages/building-your-application/routing/middleware)
 - [Incremental Static Regeneration](/docs/pages/building-your-application/data-fetching/incremental-static-regeneration)
+- [Image Optimization](/docs/pages/building-your-application/optimizing/images) with the default `loader`
+- [Draft Mode](/docs/pages/building-your-application/configuring/draft-mode)
 - [`getStaticPaths` with `fallback: true`](/docs/pages/api-reference/functions/get-static-paths#fallback-true)
 - [`getStaticPaths` with `fallback: 'blocking'`](/docs/pages/api-reference/functions/get-static-paths#fallback-blocking)
 - [`getServerSideProps`](/docs/pages/building-your-application/data-fetching/get-server-side-props)
-- [Image Optimization](/docs/pages/building-your-application/optimizing/images) (default loader)
 
 </PagesOnly>
 
@@ -345,6 +352,8 @@ server {
       try_files $uri $uri.html $uri/ =404;
   }
 
+  # This is necessary when `trailingSlash: false`.
+  # You can omit this when `trailingSlash: true`.
   location /blog/ {
       rewrite ^/blog/(.*)$ /blog/$1.html break;
   }


### PR DESCRIPTION
- Related to https://github.com/vercel/next.js/issues/48022