### PR TITLE
Update ISR revalidateTag handling

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -255,8 +255,12 @@ export default class FileSystemCache implements CacheHandler {
             (data?.lastModified || Date.now())
         )
       })
+
+      // we trigger a blocking validation if an ISR page
+      // had a tag revalidated, if we want to be a background
+      // revalidation instead we return data.lastModified = -1 instead
       if (isStale) {
-        data.lastModified = -1
+        data = undefined
       }
     }
 

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -258,7 +258,7 @@ export default class FileSystemCache implements CacheHandler {
 
       // we trigger a blocking validation if an ISR page
       // had a tag revalidated, if we want to be a background
-      // revalidation instead we return data.lastModified = -1 instead
+      // revalidation instead we return data.lastModified = -1
       if (isStale) {
         data = undefined
       }

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -245,6 +245,11 @@ createNextDescribe(
             const newRes = await next.fetch(
               '/variable-revalidate/revalidate-360'
             )
+            const cacheHeader = newRes.headers.get('x-nextjs-cache')
+
+            if ((global as any).isNextStart && cacheHeader) {
+              expect(cacheHeader).toBe('MISS')
+            }
             const newHtml = await newRes.text()
             const new$ = cheerio.load(newHtml)
             const newLayoutData = new$('#layout-data').text()


### PR DESCRIPTION
This ensures `revalidateTag()` doesn't cause an async/background revalidation unexpectedly and instead does a blocking revalidate so fresh data is shown right away when a path is using ISR. 

Test deployment with patch can be seen here: https://next-revalidation-test-47rqf8q5s-vtest314-ijjk-testing.vercel.app/

Fixes: https://github.com/vercel/next.js/issues/53187