### PR TITLE
Reduce flakiness of app-fetch-logging test

### DIFF
--- a/test/e2e/app-dir/app-static/app-fetch-logging.test.ts
+++ b/test/e2e/app-dir/app-static/app-fetch-logging.test.ts
@@ -1,7 +1,7 @@
 import path from 'path'
-import { createNextDescribe, FileRef } from '../../../lib/e2e-utils'
 import stripAnsi from 'strip-ansi'
-import { check } from '../../../lib/next-test-utils'
+import { check } from 'next-test-utils'
+import { createNextDescribe, FileRef } from 'e2e-utils'
 
 function parseLogsFromCli(cliOutput: string) {
   return stripAnsi(cliOutput)


### PR DESCRIPTION
Updates `app-fetch-logging` tests to not start/stop the server each run and instead slice the relevant log output. Also moves log parsing inside of `check` since logs get appended asynchronously.

ref: https://github.com/vercel/next.js/actions/runs/5767647854/job/15637691191#step:28:662