### PR TITLE
Fix tracing in require-hook

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -126,7 +126,7 @@ if (!process.env.NEXT_MANUAL_SIG_HANDLE && command !== 'dev') {
 commands[command]()
   .then((exec) => exec(forwardedArgs))
   .then(() => {
-    if (command === 'build') {
+    if (command === 'build' || command === 'experimental-compile') {
       // ensure process exits after build completes so open handles/connections
       // don't cause process to hang
       process.exit(0)

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -141,11 +141,7 @@ import { createValidFileMatcher } from '../server/lib/find-page-file'
 import { startTypeChecking } from './type-check'
 import { generateInterceptionRoutesRewrites } from '../lib/generate-interception-routes-rewrites'
 import { buildDataRoute } from '../server/lib/router-utils/build-data-route'
-import {
-  baseOverrides,
-  defaultOverrides,
-  experimentalOverrides,
-} from '../server/require-hook'
+import { baseOverrides, experimentalOverrides } from '../server/require-hook'
 import { initialize } from '../server/lib/incremental-cache-server'
 import { nodeFs } from '../server/lib/node-fs-methods'
 
@@ -2041,11 +2037,6 @@ export default async function build(
               ...Object.values(experimentalOverrides).map((override) =>
                 require.resolve(override)
               ),
-              ...(config.experimental.turbotrace
-                ? []
-                : Object.values(defaultOverrides).map((value) =>
-                    require.resolve(value)
-                  )),
             ]
 
             // ensure we trace any dependencies needed for custom

--- a/packages/next/src/server/require-hook.ts
+++ b/packages/next/src/server/require-hook.ts
@@ -19,9 +19,10 @@ const resolve = process.env.NEXT_MINIMAL
 const toResolveMap = (map: Record<string, string>): [string, string][] =>
   Object.entries(map).map(([key, value]) => [key, resolve(value)])
 
+// these must use require.resolve to be statically analyzable
 export const defaultOverrides = {
-  'styled-jsx': dirname(resolve('styled-jsx/package.json')),
-  'styled-jsx/style': resolve('styled-jsx/style'),
+  'styled-jsx': dirname(require.resolve('styled-jsx/package.json')),
+  'styled-jsx/style': require.resolve('styled-jsx/style'),
 }
 
 export const baseOverrides = {


### PR DESCRIPTION
This ensures the resolve calls for `styled-jsx` are done in the correct context so that tracing can include the correct symlinks/package.json files. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1691217652833079)