### PR TITLE
docs(with-stripe-typescript): Update README demo link

### DIFF
--- a/examples/with-stripe-typescript/README.md
+++ b/examples/with-stripe-typescript/README.md
@@ -11,7 +11,7 @@ This is a full-stack TypeScript example using:
 
 ## Demo
 
-- [Live demo](https://nextjs-typescript-react-stripe-js.vercel.app)
+- [Live demo](https://nextjs-with-stripe-typescript-demo.vercel.app)
 - [Guide](https://vercel.com/guides/getting-started-with-nextjs-typescript-stripe)
 
 The demo is running in test mode -- use `4242424242424242` as a test card number with any CVC + future expiration date.

--- a/examples/with-stripe-typescript/lib/stripe.ts
+++ b/examples/with-stripe-typescript/lib/stripe.ts
@@ -7,6 +7,6 @@ export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   apiVersion: '2022-11-15',
   appInfo: {
     name: 'nextjs-with-stripe-typescript-demo',
-    url: 'https://nextjs-with-stripe-typescript-demo.vercel.app'
-  }
+    url: 'https://nextjs-with-stripe-typescript-demo.vercel.app',
+  },
 })

--- a/examples/with-stripe-typescript/lib/stripe.ts
+++ b/examples/with-stripe-typescript/lib/stripe.ts
@@ -5,4 +5,8 @@ import Stripe from 'stripe'
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   // https://github.com/stripe/stripe-node#configuration
   apiVersion: '2022-11-15',
+  appInfo: {
+    name: 'nextjs-with-stripe-typescript-demo',
+    url: 'https://nextjs-with-stripe-typescript-demo.vercel.app'
+  }
 })


### PR DESCRIPTION
### What?
* Updates [demo link](https://nextjs-with-stripe-typescript-demo.vercel.app/) for the `with-stripe-typescript` example. Follow-up to #53255.
