### PR TITLE
fix(node): pnpm 8.6 needs node 16.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     "@types/react-dom": "18.2.4"
   },
   "engines": {
-    "node": ">=16.8.0",
+    "node": ">=16.14.0",
     "pnpm": "8.6.11"
   },
   "packageManager": "pnpm@8.6.11"


### PR DESCRIPTION
The `pnpm` version was recently updated to `8.6`, however the node version was left at `16.8`. `pnpm@8.6` requires at least `node@16.14` ([source](https://github.com/pnpm/pnpm/blob/main/pnpm/package.json#L145)).

This fixes the engines spec to avoid conflicting versions. 
