### PR TITLE
fix(create-next-app): fix CI defaults (default to typescript)

### DIFF
--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -255,10 +255,9 @@ async function run(): Promise<void> {
 
     if (!program.typescript && !program.javascript) {
       if (ciInfo.isCI) {
-        // default to JavaScript in CI as we can't prompt to
+        // default to TypeScript in CI as we can't prompt to
         // prevent breaking setup flows
-        program.typescript = false
-        program.javascript = true
+        program.typescript = getPrefOrDefault('typescript')
       } else {
         const styledTypeScript = blue('TypeScript')
         const { typescript } = await prompts(
@@ -295,7 +294,7 @@ async function run(): Promise<void> {
       !process.argv.includes('--no-eslint')
     ) {
       if (ciInfo.isCI) {
-        program.eslint = true
+        program.eslint = getPrefOrDefault('eslint')
       } else {
         const styledEslint = blue('ESLint')
         const { eslint } = await prompts({
@@ -317,7 +316,7 @@ async function run(): Promise<void> {
       !process.argv.includes('--no-tailwind')
     ) {
       if (ciInfo.isCI) {
-        program.tailwind = false
+        program.tailwind = getPrefOrDefault('tailwind')
       } else {
         const tw = blue('Tailwind CSS')
         const { tailwind } = await prompts({
@@ -339,7 +338,7 @@ async function run(): Promise<void> {
       !process.argv.includes('--no-src-dir')
     ) {
       if (ciInfo.isCI) {
-        program.srcDir = false
+        program.srcDir = getPrefOrDefault('srcDir')
       } else {
         const styledSrcDir = blue('`src/` directory')
         const { srcDir } = await prompts({


### PR DESCRIPTION
Since the default for `create-next-app` has been TypeScript for some time, we should make sure this is also the case for CI.

This PR also makes sure that CI will use the same value as if the question was asked. Therefore changing defaults in the future will automatically change the behavior of CI defaults.

- Related https://github.com/vercel/next.js/issues/42592