### PR TITLE
App Router Preinitialize all required scripts except one for bootstrap

### DIFF
--- a/packages/next/src/server/app-render/required-scripts.tsx
+++ b/packages/next/src/server/app-render/required-scripts.tsx
@@ -1,0 +1,56 @@
+import type { BuildManifest } from '../get-page-files'
+
+import ReactDOM from 'react-dom'
+
+export function getRequiredScripts(
+  buildManifest: BuildManifest,
+  assetPrefix: string,
+  SRIManifest: undefined | Record<string, string>,
+  qs: string
+): [() => void, string | { src: string; integrity: string }] {
+  let preinitScripts: () => void
+  let preinitScriptCommands: string[] = []
+  let bootstrapScript: string | { src: string; integrity: string } = ''
+  const files = buildManifest.rootMainFiles
+  if (files.length === 0) {
+    throw new Error(
+      'Invariant: missing bootstrap script. This is a bug in Next.js'
+    )
+  }
+  if (SRIManifest) {
+    bootstrapScript = {
+      src: `${assetPrefix}/_next/` + files[0] + qs,
+      integrity: SRIManifest[files[0]],
+    }
+    for (let i = 1; i < files.length; i++) {
+      const src = `${assetPrefix}/_next/` + files[i] + qs
+      const integrity = SRIManifest[files[i]]
+      preinitScriptCommands.push(src, integrity)
+    }
+    preinitScripts = () => {
+      // preinitScriptCommands is a double indexed array of src/integrity pairs
+      for (let i = 0; i < preinitScriptCommands.length; i += 2) {
+        ReactDOM.preinit(preinitScriptCommands[i], {
+          as: 'script',
+          integrity: preinitScriptCommands[i + 1],
+        })
+      }
+    }
+  } else {
+    bootstrapScript = `${assetPrefix}/_next/` + files[0] + qs
+    for (let i = 1; i < files.length; i++) {
+      const src = `${assetPrefix}/_next/` + files[i] + qs
+      preinitScriptCommands.push(src)
+    }
+    preinitScripts = () => {
+      // preinitScriptCommands is a singled indexed array of src values
+      for (let i = 0; i < preinitScriptCommands.length; i++) {
+        ReactDOM.preinit(preinitScriptCommands[i], {
+          as: 'script',
+        })
+      }
+    }
+  }
+
+  return [preinitScripts, bootstrapScript]
+}

--- a/test/e2e/app-dir/app/app/bootstrap/page.js
+++ b/test/e2e/app-dir/app/app/bootstrap/page.js
@@ -1,0 +1,8 @@
+export default async function Page() {
+  return (
+    <div>
+      This fixture is to assert where the bootstrap scripts and other required
+      scripts emit during SSR
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -1859,5 +1859,16 @@ createNextDescribe(
         expect(await browser.elementByCss('p').text()).toBe('item count 128000')
       })
     })
+
+    describe('bootstrap scripts', () => {
+      it('should only bootstrap with one script, prinitializing the rest', async () => {
+        const html = await next.render('/bootstrap')
+        const $ = cheerio.load(html)
+
+        // We assume a minimum of 2 scripts, webpack runtime + main-app
+        expect($('script[async]').length).toBeGreaterThan(1)
+        expect($('body').find('script[async]').length).toBe(1)
+      })
+    })
   }
 )


### PR DESCRIPTION
Currently all scripts that are required for every page are loaded as part of the bootstrap scripts API in React. Unfortunately this loads them all as sync scripts and thus requires preloading which increases their priority higher than they might otherwise be causing things like images to load later than desired, blocking paint. We can improve this by only using one script for bootstrapping and having the rest pre-initialized. This only works because all of these scripts are webpack runtime or chunks and can be loaded in any order asynchronously.

With this change we should see improvements in LCP and other metrics as preloads for images are favored over loading scripts