### PR TITLE
docs: 📝 Propose a work around for Router Cache opting out

### DIFF
--- a/docs/02-app/01-building-your-application/04-caching/index.mdx
+++ b/docs/02-app/01-building-your-application/04-caching/index.mdx
@@ -378,7 +378,41 @@ There are two ways you can invalidate the Router Cache:
 
 ### Opting out
 
-It's not possible to opt out of the Router Cache.
+It's not possible to opt out of the Router Cache inside a Server Component. A possible work around is to wrap your route inside a Client Component using the ['use client' directive](/docs/getting-started/react-essentials#the-use-client-directive):
+
+```tsx filename="app/page.tsx" highlight={1} switcher
+'use client'
+
+import Link from 'next/link'
+
+// Shows a new random number every time the user navigates to this page
+export default function Page() {
+  
+  return (
+    <div>
+      <p>{Math.random()}</p> 
+      <Link href='/another-page'>To another page</Link>
+    </div>
+  )
+}
+```  
+
+```jsx filename="app/page.js" highlight={1} switcher
+'use client'
+
+import Link from 'next/link'
+
+// Shows a new random number every time the user navigates to this page
+export default function Page() {
+  
+  return (
+    <div>
+      <p>{Math.random()}</p> 
+      <Link href='/another-page'>To another page</Link>
+    </div>
+  )
+}
+```
 
 You can opt out of **prefetching** by setting the `prefetch` prop of the `<Link>` component to `false`. However, this will still temporarily store the route segments for 30s to allow instant navigation between nested segments, such as tab bars, or back and forward navigation. Visited routes will still be cached.
 


### PR DESCRIPTION
My attempt to contribute to [this specific section](https://nextjs.org/docs/app/building-your-application/caching#opting-out-3
) of the docs.
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
