### PR TITLE
fix parallel route tests & improve error for conflicting pages

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -462,6 +462,14 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
           continue
         }
 
+        // avoid clobbering existing page segments
+        // if it's a valid parallel segment, the `children` property will be set appropriately
+        if (matched.children && matched.children !== rest[0]) {
+          throw new Error(
+            `/You cannot have two parallel pages that resolve to the same path. Please check ${appPath}.`
+          )
+        }
+
         matched.children = rest[0]
       }
     }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/(new)/@baz/default.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/(new)/@baz/default.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>parallel/@bar/nested/default</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/@bar/default.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/@bar/default.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>parallel/@bar/default</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/@bar/nested/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/@bar/nested/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>parallel/@bar/nested/page</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/@bar/nested/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/@bar/nested/page.js
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <div>parallel/@bar/nested/page</div>
+  return <div>parallel/@foo/nested/page</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/@foo/default.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/@foo/default.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>parallel/@foo/default</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/@foo/nested/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/@foo/nested/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>parallel/@foo/nested/page</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/layout.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel/layout.js
@@ -2,7 +2,7 @@ import './style.css'
 
 export default function Parallel({ foo, bar, children }) {
   return (
-    <div>
+    <div id="parallel-layout">
       parallel/layout:
       <div className="parallel" title="@foo">
         {foo}

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -1,5 +1,6 @@
 import { createNextDescribe } from 'e2e-utils'
 import { check } from 'next-test-utils'
+import { outdent } from 'outdent'
 
 createNextDescribe(
   'parallel-routes-and-interception',
@@ -165,27 +166,57 @@ createNextDescribe(
         await step5()
       })
 
-      // FIXME: this parallel route test is broken, shouldn't only check if html containing those strings
-      // previous they're erroring so the html is empty but those strings are still in flight response.
-      it.skip('should match parallel routes', async () => {
-        const html = await next.render('/parallel/nested')
-        expect(html).toContain('parallel/layout')
-        expect(html).toContain('parallel/@foo/nested/layout')
-        expect(html).toContain('parallel/@foo/nested/@a/page')
-        expect(html).toContain('parallel/@foo/nested/@b/page')
-        expect(html).toContain('parallel/@bar/nested/layout')
-        expect(html).toContain('parallel/@bar/nested/@a/page')
-        expect(html).toContain('parallel/@bar/nested/@b/page')
-        expect(html).toContain('parallel/nested/page')
+      it('should match parallel routes', async () => {
+        const $ = await next.render$('/parallel/nested')
+        const pageText = $('#parallel-layout').text()
+        expect(pageText).toContain('parallel/layout')
+        expect(pageText).toContain('parallel/@foo/nested/layout')
+        expect(pageText).toContain('parallel/@foo/nested/@a/page')
+        expect(pageText).toContain('parallel/@foo/nested/@b/page')
+        expect(pageText).toContain('parallel/@bar/nested/layout')
+        expect(pageText).toContain('parallel/@bar/nested/@a/page')
+        expect(pageText).toContain('parallel/@bar/nested/@b/page')
+        expect(pageText).toContain('parallel/nested/page')
       })
 
-      // FIXME: this parallel route test is broken, shouldn't only check if html containing those strings
-      // previous they're erroring so the html is empty but those strings are still in flight response.
-      it.skip('should match parallel routes in route groups', async () => {
-        const html = await next.render('/parallel/nested-2')
-        expect(html).toContain('parallel/layout')
-        expect(html).toContain('parallel/(new)/layout')
-        expect(html).toContain('parallel/(new)/@baz/nested/page')
+      it('should match parallel routes in route groups', async () => {
+        const $ = await next.render$('/parallel/nested-2')
+        const pageText = $('#parallel-layout').text()
+        expect(pageText).toContain('parallel/layout')
+        expect(pageText).toContain('parallel/(new)/layout')
+        expect(pageText).toContain('parallel/(new)/@baz/nested/page')
+      })
+
+      it('should throw an error when a route groups causes a conflict with a parallel segment', async () => {
+        await next.stop()
+        await next.patchFile(
+          'app/parallel/nested-2/page.js',
+          outdent`
+              export default function Page() {
+                return 'hello world'
+              }
+            `
+        )
+
+        if (isNextDev) {
+          await next.start()
+
+          const html = await next.render('/parallel/nested-2')
+
+          expect(html).toContain(
+            'You cannot have two parallel pages that resolve to the same path.'
+          )
+        } else {
+          await expect(next.start()).rejects.toThrow('next build failed')
+
+          await check(
+            () => next.cliOutput,
+            /You cannot have two parallel pages that resolve to the same path./i
+          )
+        }
+        await next.stop()
+        await next.deleteFile('app/parallel/nested-2/page.js')
+        await next.start()
       })
 
       it('should throw a 404 when no matching parallel route is found', async () => {


### PR DESCRIPTION
This fixes some tests that were disabled due to a missing `page` segment for the corresponding slots in `/parallel/nested`. 

While fixing, I also noticed if you accidentally create two pages that resolve to the same URL segment (which is fairly easy to do accidentally do with route groups), we were throwing an unhelpful error of "Cannot find module: '<snip>/page_client-reference-manifest.js'" when building (and fail silently in dev). For example, this scenario was throwing a manifest error:

```
app
  (groupa)
    page.tsx
  (groupb)
    page.tsx
```

This will now throw with a more helpful error when resolving parallel segments if the page segment was already resolved. This also re-enables the disabled tests.

Closes NEXT-1440
Fixes #53569 (by virtue of throwing a more helpful error)