### PR TITLE
Fix confusing object declaration

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/10-route-handlers.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/10-route-handlers.mdx
@@ -552,7 +552,7 @@ You can read the `Request` body using the standard Web API methods:
 import { NextResponse } from 'next/server'
 
 export async function POST(request: Request) {
-  const res = await request.json()
+  const req = await request.json()
   return NextResponse.json({ res })
 }
 ```
@@ -561,7 +561,7 @@ export async function POST(request: Request) {
 import { NextResponse } from 'next/server'
 
 export async function POST(request) {
-  const res = await request.json()
+  const req = await request.json()
   return NextResponse.json({ res })
 }
 ```


### PR DESCRIPTION
### What?
Fixes confusing app declaration `res` referring to a request object

### Why?
`req` is the standard
