### PR TITLE
Add warnings for static generation bail outs

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1572,7 +1572,7 @@ export default async function build(
                           isSsg = false
 
                           Log.warnOnce(
-                            `using edge runtime on a page causes static generation to be disabled for that page currently`
+                            `Using edge runtime on a page currently disables static generation for that page`
                           )
                         } else {
                           // If a page has action and it is static, we need to
@@ -1603,7 +1603,7 @@ export default async function build(
                           if (appConfig.revalidate !== 0) {
                             if (hasAction) {
                               Log.warnOnce(
-                                `using server actions on a page causes static generation to be disabled for that page currently`
+                                `Using server actions on a page currently disables static generation for that page`
                               )
                             } else {
                               const isDynamic = isDynamicRoute(page)

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -23,7 +23,7 @@ createNextDescribe(
     if (isNextStart) {
       it('should warn for server actions + ISR incompat', async () => {
         expect(next.cliOutput).toContain(
-          'using server actions on a page causes static generation to be disabled for that page currently'
+          'Using server actions on a page currently disables static generation for that page'
         )
       })
     }

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -20,6 +20,14 @@ createNextDescribe(
     },
   },
   ({ next, isNextDev, isNextStart, isNextDeploy }) => {
+    if (isNextStart) {
+      it('should warn for server actions + ISR incompat', async () => {
+        expect(next.cliOutput).toContain(
+          'using server actions on a page causes static generation to be disabled for that page currently'
+        )
+      })
+    }
+
     it('should handle basic actions correctly', async () => {
       const browser = await next.browser('/server')
 


### PR DESCRIPTION
Currently using server actions on a page or using edge runtime causes that page to bail out of ISR or static generation so this adds warnings to make users aware of this. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1690816539472449)