### PR TITLE
generate `next-env` in `.next/types` in app dir

### DIFF
--- a/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
@@ -4,17 +4,21 @@ import { promises as fs } from 'fs'
 
 export async function writeAppTypeDeclarations({
   baseDir,
+  distDir,
   imageImportsEnabled,
   hasPagesDir,
   isAppDirEnabled,
 }: {
   baseDir: string
+  distDir: string
   imageImportsEnabled: boolean
   hasPagesDir: boolean
   isAppDirEnabled: boolean
 }): Promise<void> {
   // Reference `next` types
-  const appTypeDeclarations = path.join(baseDir, 'next-env.d.ts')
+  const appTypeDeclarations = isAppDirEnabled
+    ? path.join(baseDir, distDir, 'types/next-env.d.ts')
+    : path.join(baseDir, 'next-env.d.ts')
 
   // Defaults EOL to system default
   let eol = os.EOL

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -182,14 +182,14 @@ export async function writeConfigurationDefaults(
 
   if (!('include' in rawConfig)) {
     userTsConfig.include = isAppDirEnabled
-      ? ['next-env.d.ts', nextAppTypes, '**/*.ts', '**/*.tsx']
+      ? [nextAppTypes, '**/*.ts', '**/*.tsx']
       : ['next-env.d.ts', '**/*.ts', '**/*.tsx']
     suggestedActions.push(
       chalk.cyan('include') +
         ' was set to ' +
         chalk.bold(
           isAppDirEnabled
-            ? `['next-env.d.ts', '${nextAppTypes}', '**/*.ts', '**/*.tsx']`
+            ? `['${nextAppTypes}', '**/*.ts', '**/*.tsx']`
             : `['next-env.d.ts', '**/*.ts', '**/*.tsx']`
         )
     )

--- a/packages/next/src/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/src/lib/verifyTypeScriptSetup.ts
@@ -130,6 +130,7 @@ export async function verifyTypeScriptSetup({
     // Next.js' types:
     await writeAppTypeDeclarations({
       baseDir: dir,
+      distDir,
       imageImportsEnabled: !disableStaticImages,
       hasPagesDir,
       isAppDirEnabled: hasAppDir,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md
- 
-->

I suggest we generate the `next-env.d.ts` file in the `.next/types` directory. This will help a few setups:

- less 'config' files in root - we already have way to many config files in a javascript project 🤷🏼 
- less things to include in `tsconfig.includes`, we can match everything with `.next/types/**/*.ts`
- less things to include in `turbo.outputs`, we can match everything with `.next/types/**`. Got bit by this since I tend to run typechecking as a separate step in CI and missed to include this file in the build outputs so it wasnt restored

For pages router, there is no `.next/types` so we can keep the `next-env.d.ts` in root there.

What do you think? I made some initial changes but haven't touched either tests or docs