### PR TITLE
Fix/match resource

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -186,7 +186,9 @@ export class FlightClientEntryPlugin {
 
     compiler.hooks.afterCompile.tap(PLUGIN_NAME, (compilation) => {
       const recordModule = (modId: string, mod: any) => {
-        const modResource = mod.resourceResolveData?.path || mod.resource
+        const modResource =
+          mod.resourceResolveData?.path + mod.resourceResolveData?.query ||
+          mod.resource
 
         if (mod.layer !== WEBPACK_LAYERS.serverSideRendering) {
           return

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -186,9 +186,13 @@ export class FlightClientEntryPlugin {
 
     compiler.hooks.afterCompile.tap(PLUGIN_NAME, (compilation) => {
       const recordModule = (modId: string, mod: any) => {
-        const modResource =
-          mod.resourceResolveData?.path + mod.resourceResolveData?.query ||
-          mod.resource
+        // Match Resource is undefined unless an import is using the inline match resource syntax
+        // https://webpack.js.org/api/loaders/#inline-matchresource
+        const modPath = mod.matchResource || mod.resourceResolveData?.path
+        const modQuery = mod.resourceResolveData?.query || ''
+        // query is already part of mod.resource
+        // so it's only neccessary to add it for matchResource or mod.resourceResolveData
+        const modResource = modPath ? modPath + modQuery : mod.resource
 
         if (mod.layer !== WEBPACK_LAYERS.serverSideRendering) {
           return

--- a/test/e2e/app-dir/rsc-basic/app/loader-rule/a.txt
+++ b/test/e2e/app-dir/rsc-basic/app/loader-rule/a.txt
@@ -1,0 +1,3 @@
+.red {
+  color: red;
+}

--- a/test/e2e/app-dir/rsc-basic/app/loader-rule/page.js
+++ b/test/e2e/app-dir/rsc-basic/app/loader-rule/page.js
@@ -1,0 +1,11 @@
+'use client'
+
+import styles from './a.module.css!=!./a.txt'
+
+export default function Home() {
+  return (
+    <div id="red" className={styles.red}>
+      Red
+    </div>
+  )
+}

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -553,6 +553,16 @@ createNextDescribe(
       ).toBe('count: 1')
     })
 
+    it('should support webpack loader rules', async () => {
+      const browser = await next.browser('/loader-rule')
+
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.querySelector('#red')).color`
+        )
+      ).toBe('rgb(255, 0, 0)')
+    })
+
     if (isNextStart) {
       it('should generate edge SSR manifests for Node.js', async () => {
         const requiredServerFiles = JSON.parse(


### PR DESCRIPTION
### Bug Fix
fixes #53366



### Change

Add `query` and [`matchResource`](https://webpack.js.org/api/loaders/#inline-matchresource) to the module mapping. 



### Why

`mod.resource` and all other paths inside `packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts` are already using the query:

https://github.com/vercel/next.js/blob/e127c51327ee9191098fb7b73c681db934505dcc/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts#L506-L507

https://github.com/vercel/next.js/blob/e127c51327ee9191098fb7b73c681db934505dcc/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts#L584-L585



### Motivation

We are using a static extraction css-in-js solution which uses the [inline match resource feature](https://webpack.js.org/api/loaders/#inline-matchresource) (see more in #53366)

As a css-in-js file contains the TSX and the CSS code we have to split the file into two modules which share the same `resource.path`.  

This works well however there is a problem in the mapping inside `.next/server/app/page_client-reference-manifest.js`.
The `ssrModuleMapping` from `addSSRIDMapping` in 
https://github.com/vercel/next.js/blob/e127c51327ee9191098fb7b73c681db934505dcc/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts#L270 links to the latest module (the css part) and not the the initial one (the js part).

Therefore the css module is rendered [react-server-dom-webpack](https://www.npmjs.com/package/react-server-dom-webpack/v/0.0.1?activeTab=versions) and breaks.

The SSR/SSG fails with the error `Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined.`