### PR TITLE
chore(docs): add missing "try it out"

### DIFF
--- a/docs/02-app/02-api-reference/01-components/image.mdx
+++ b/docs/02-app/02-api-reference/01-components/image.mdx
@@ -783,6 +783,8 @@ const ThemeImage = (props) => {
 
 > **Good to know**: The default behavior of `loading="lazy"` ensures that only the correct image is loaded. You cannot use `priority` or `loading="eager"` because that would cause both images to load. Instead, you can use [`fetchPriority="high"`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority).
 
+Try it out:
+
 - [Demo light/dark mode theme detection](https://image-component.nextjs.gallery/theme)
 
 ## Known Browser Bugs


### PR DESCRIPTION
Follow up to https://github.com/vercel/next.js/pull/53760

This follows the same pattern as other demo links on this page.