### PR TITLE
Docs: fix parent argument in generateMetadata demo code

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/04-metadata.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/04-metadata.mdx
@@ -57,7 +57,7 @@ type Props = {
 
 export async function generateMetadata(
   { params, searchParams }: Props,
-  parent?: ResolvingMetadata
+  parent: ResolvingMetadata
 ): Promise<Metadata> {
   // read route params
   const id = params.id


### PR DESCRIPTION
This PR fixes `parent` argument that was marked as optional in `generateMetadata` function within 04-metadata.mdx