### PR TITLE
chore(docs): note cache-control header for preview/draft mode

### DIFF
--- a/docs/03-pages/01-building-your-application/06-configuring/11-draft-mode.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/11-draft-mode.mdx
@@ -156,7 +156,9 @@ Then, send a request to `/api/disable-draft` to invoke the API Route. If calling
 
 ### Works with `getServerSideProps`
 
-Draft Mode works with `getServerSideProps` as well. It will also be available on the `context` object containing `draftMode`
+Draft Mode works with `getServerSideProps` as well. It will also be available on the `context` object containing `draftMode`.
+
+> **Good to know**: Avoid setting the `Cache-Control` header because it cannot be bypassed. Instead, use [ISR](/docs/pages/building-your-application/data-fetching/incremental-static-regeneration).
 
 ### Works with API Routes
 

--- a/docs/03-pages/01-building-your-application/06-configuring/11-draft-mode.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/11-draft-mode.mdx
@@ -156,9 +156,9 @@ Then, send a request to `/api/disable-draft` to invoke the API Route. If calling
 
 ### Works with `getServerSideProps`
 
-Draft Mode works with `getServerSideProps` as well. It will also be available on the `context` object containing `draftMode`.
+Draft Mode works with `getServerSideProps`, and is available as a `draftMode` key in the [`context`](/docs/pages/api-reference/functions/get-server-side-props#context-parameter) object.
 
-> **Good to know**: Avoid setting the `Cache-Control` header because it cannot be bypassed. Instead, use [ISR](/docs/pages/building-your-application/data-fetching/incremental-static-regeneration).
+> **Good to know**: You shouldn't set the `Cache-Control` header when using Draft Mode because it cannot be bypassed. Instead, we recommend using [ISR](/docs/pages/building-your-application/data-fetching/incremental-static-regeneration).
 
 ### Works with API Routes
 

--- a/docs/03-pages/01-building-your-application/06-configuring/14-preview-mode.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/14-preview-mode.mdx
@@ -219,6 +219,8 @@ You can pass an object to `setPreviewData` and have it be available in `getStati
 
 The preview mode works on `getServerSideProps` as well. It will also be available on the `context` object containing `preview` and `previewData`.
 
+> **Good to know**: Avoid setting the `Cache-Control` header because it cannot be bypassed. Instead, use [ISR](/docs/pages/building-your-application/data-fetching/incremental-static-regeneration).
+
 ### Works with API Routes
 
 API Routes will have access to `preview` and `previewData` under the request object. For example:

--- a/docs/03-pages/01-building-your-application/06-configuring/14-preview-mode.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/14-preview-mode.mdx
@@ -219,7 +219,7 @@ You can pass an object to `setPreviewData` and have it be available in `getStati
 
 The preview mode works on `getServerSideProps` as well. It will also be available on the `context` object containing `preview` and `previewData`.
 
-> **Good to know**: Avoid setting the `Cache-Control` header because it cannot be bypassed. Instead, use [ISR](/docs/pages/building-your-application/data-fetching/incremental-static-regeneration).
+> **Good to know**: You shouldn't set the `Cache-Control` header when using Preview Mode because it cannot be bypassed. Instead, we recommend using [ISR](/docs/pages/building-your-application/data-fetching/incremental-static-regeneration).
 
 ### Works with API Routes
 


### PR DESCRIPTION
You can technically get similar ISR behavior setting the `Cache-Control` in `getServerSideProps()`, but this won't be automatically bypassed when enabling Preview Mode or Draft Mode so this PR adds that to the documentation.

x-ref: [slack discussion](https://vercel.slack.com/archives/C03S8ED1DKM/p1691514209722429)