### PR TITLE
Delete errorneous empty content length header

### DIFF
--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -17,13 +17,12 @@ export const filterReqHeaders = (
   headers: Record<string, undefined | string | number | string[]>,
   forbiddenHeaders: string[]
 ) => {
-
   // Some browsers are not matching spec and sending Content-Length: 0. This causes issues in undici
   // https://github.com/nodejs/undici/issues/2046
   if (headers['content-length'] && headers['content-length'] === '0') {
     delete headers['content-length']
   }
-  
+
   for (const [key, value] of Object.entries(headers)) {
     if (
       forbiddenHeaders.includes(key) ||

--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -18,6 +18,8 @@ export const filterReqHeaders = (
   forbiddenHeaders: string[]
 ) => {
 
+  // Some browsers are not matching spec and sending Content-Length: 0. This causes issues in undici
+  // https://github.com/nodejs/undici/issues/2046
   if (headers['content-length'] && headers['content-length'] === '0') {
     delete headers['content-length']
   }

--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -17,6 +17,11 @@ export const filterReqHeaders = (
   headers: Record<string, undefined | string | number | string[]>,
   forbiddenHeaders: string[]
 ) => {
+
+  if (headers['content-length'] && headers['content-length'] === '0') {
+    delete headers['content-length']
+  }
+  
   for (const [key, value] of Object.entries(headers)) {
     if (
       forbiddenHeaders.includes(key) ||


### PR DESCRIPTION
fixes https://github.com/vercel/next.js/issues/53822

PR https://github.com/vercel/next.js/pull/53368 introduced a regression causing fetch with custom headers to fail in safari.
There are known issues with uncidi when a content-length: 0 header exists.

When performing a custom fetch in safari, this header is present.
When performing a custom fetch in chrome, this header is not present.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
