### PR TITLE
Add failing test for #53792

### DIFF
--- a/test/development/app-dir/file-not-found-in-route/app/api/route.ts
+++ b/test/development/app-dir/file-not-found-in-route/app/api/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs'
+
+const data = fs.readFileSync('file-does-not-exist.txt', 'utf8')
+
+export function GET() {
+  return new NextResponse(data, {
+    status: 200,
+  })
+}

--- a/test/development/app-dir/file-not-found-in-route/file-not-found-in-route.test.ts
+++ b/test/development/app-dir/file-not-found-in-route/file-not-found-in-route.test.ts
@@ -1,0 +1,24 @@
+import stripAnsi from 'next/dist/compiled/strip-ansi'
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'file-not-found-in-route',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('responds with 500 (Internal Server Error) when file not found error was thrown', async () => {
+      const res = await next.fetch('/api')
+      expect(res.status).toBe(500)
+    })
+
+    it('logs error to console', async () => {
+      const outputIndex = next.cliOutput.length
+      await next.fetch('/api')
+      const output = stripAnsi(next.cliOutput.slice(outputIndex))
+      expect(output).toContain(
+        "- error Error: ENOENT: no such file or directory, open 'file-does-not-exist.txt'"
+      )
+    })
+  }
+)


### PR DESCRIPTION
I investigated the [issue](https://github.com/vercel/next.js/issues/53792) a bit and I'm pretty sure the problem is [this](https://github.com/vercel/next.js/blob/6f7ffadc86081c2da8e43fe541f086faa56a640e/packages/next/src/server/dev/next-dev-server.ts#L790) line. If the route happens to throw a "file not found" error then it gets ignored like a normal 404 would.

I'm lacking context so I don't think I can submit a fix, but I added a failing test if someone wants to pick this up.