### PR TITLE
Turbopack: Emit whether server or client assets changed

### DIFF
--- a/packages/next-swc/crates/napi/src/next_api/endpoint.rs
+++ b/packages/next-swc/crates/napi/src/next_api/endpoint.rs
@@ -93,7 +93,7 @@ pub async fn endpoint_write_to_disk(
 }
 
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
-pub fn endpoint_changed_subscribe(
+pub fn endpoint_server_changed_subscribe(
     #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: External<ExternalEndpoint>,
     func: JsFunction,
 ) -> napi::Result<External<RootTask>> {
@@ -103,7 +103,35 @@ pub fn endpoint_changed_subscribe(
         turbo_tasks,
         func,
         move || async move {
-            let changed = endpoint.changed();
+            let changed = endpoint.server_changed();
+            let issues = get_issues(changed).await?;
+            let diags = get_diagnostics(changed).await?;
+            changed.strongly_consistent().await?;
+            Ok((issues, diags))
+        },
+        |ctx| {
+            let (issues, diags) = ctx.value;
+            Ok(vec![TurbopackResult {
+                result: (),
+                issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+                diagnostics: diags.iter().map(|d| NapiDiagnostic::from(d)).collect(),
+            }])
+        },
+    )
+}
+
+#[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
+pub fn endpoint_client_changed_subscribe(
+    #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: External<ExternalEndpoint>,
+    func: JsFunction,
+) -> napi::Result<External<RootTask>> {
+    let turbo_tasks = endpoint.turbo_tasks().clone();
+    let endpoint = ***endpoint;
+    subscribe(
+        turbo_tasks,
+        func,
+        move || async move {
+            let changed = endpoint.client_changed();
             let issues = get_issues(changed).await?;
             let diags = get_diagnostics(changed).await?;
             changed.strongly_consistent().await?;

--- a/packages/next-swc/crates/next-api/src/pages.rs
+++ b/packages/next-swc/crates/next-api/src/pages.rs
@@ -771,13 +771,15 @@ impl PageEndpoint {
     async fn output(self: Vc<Self>) -> Result<Vc<PageEndpointOutput>> {
         let this = self.await?;
 
-        let mut output_assets = vec![];
+        let mut server_assets = vec![];
+        let mut client_assets = vec![];
+
         let ssr_chunk = match this.ty {
             PageEndpointType::Html => {
                 let client_chunks = self.client_chunks();
-                output_assets.extend(client_chunks.await?.iter().copied());
+                client_assets.extend(client_chunks.await?.iter().copied());
                 let build_manifest = self.build_manifest(client_chunks);
-                output_assets.push(build_manifest);
+                server_assets.push(build_manifest);
                 self.ssr_chunk()
             }
             PageEndpointType::Data => self.ssr_data_chunk(),
@@ -788,19 +790,21 @@ impl PageEndpoint {
         let page_output = match *ssr_chunk.await? {
             SsrChunk::NodeJs { entry } => {
                 let pages_manifest = self.pages_manifest(entry);
-                output_assets.push(pages_manifest);
-                output_assets.push(entry);
+                server_assets.push(pages_manifest);
+                server_assets.push(entry);
 
                 PageEndpointOutput::NodeJs {
                     entry_chunk: entry,
-                    output_assets: Vc::cell(output_assets),
+                    server_assets: Vc::cell(server_assets),
+                    client_assets: Vc::cell(client_assets),
                 }
             }
             SsrChunk::Edge { files } => {
-                output_assets.extend(files.await?.iter().copied());
+                server_assets.extend(files.await?.iter().copied());
                 PageEndpointOutput::Edge {
                     files,
-                    output_assets: Vc::cell(output_assets),
+                    server_assets: Vc::cell(server_assets),
+                    client_assets: Vc::cell(client_assets),
                 }
             }
         };
@@ -832,20 +836,14 @@ impl Endpoint for PageEndpoint {
 
         let node_root = &node_root.await?;
         let written_endpoint = match *output.await? {
-            PageEndpointOutput::NodeJs {
-                entry_chunk,
-                output_assets: _,
-            } => WrittenEndpoint::NodeJs {
+            PageEndpointOutput::NodeJs { entry_chunk, .. } => WrittenEndpoint::NodeJs {
                 server_entry_path: node_root
                     .get_path_to(&*entry_chunk.ident().path().await?)
                     .context("ssr chunk entry path must be inside the node root")?
                     .to_string(),
                 server_paths,
             },
-            PageEndpointOutput::Edge {
-                files,
-                output_assets: _,
-            } => WrittenEndpoint::Edge {
+            PageEndpointOutput::Edge { files, .. } => WrittenEndpoint::Edge {
                 files: files
                     .await?
                     .iter()
@@ -866,11 +864,13 @@ impl Endpoint for PageEndpoint {
     }
 
     #[turbo_tasks::function]
-    async fn changed(self: Vc<Self>) -> Result<Vc<Completion>> {
-        let output = self.output();
-        let output_assets = output.output_assets();
+    fn server_changed(self: Vc<Self>) -> Vc<Completion> {
+        any_content_changed_of_output_assets(self.output().server_assets())
+    }
 
-        Ok(any_content_changed_of_output_assets(output_assets))
+    #[turbo_tasks::function]
+    fn client_changed(self: Vc<Self>) -> Vc<Completion> {
+        any_content_changed_of_output_assets(self.output().client_assets())
     }
 }
 
@@ -878,27 +878,44 @@ impl Endpoint for PageEndpoint {
 enum PageEndpointOutput {
     NodeJs {
         entry_chunk: Vc<Box<dyn OutputAsset>>,
-        output_assets: Vc<OutputAssets>,
+        server_assets: Vc<OutputAssets>,
+        client_assets: Vc<OutputAssets>,
     },
     Edge {
         files: Vc<OutputAssets>,
-        output_assets: Vc<OutputAssets>,
+        server_assets: Vc<OutputAssets>,
+        client_assets: Vc<OutputAssets>,
     },
 }
 
 #[turbo_tasks::value_impl]
 impl PageEndpointOutput {
     #[turbo_tasks::function]
-    pub fn output_assets(&self) -> Vc<OutputAssets> {
+    pub async fn output_assets(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
+        let server_assets = self.server_assets().await?;
+        let client_assets = self.client_assets().await?;
+        Ok(Vc::cell(
+            server_assets
+                .iter()
+                .cloned()
+                .chain(client_assets.iter().cloned())
+                .collect(),
+        ))
+    }
+
+    #[turbo_tasks::function]
+    pub fn server_assets(&self) -> Vc<OutputAssets> {
         match *self {
-            PageEndpointOutput::NodeJs {
-                entry_chunk: _,
-                output_assets,
-            } => output_assets,
-            PageEndpointOutput::Edge {
-                files: _,
-                output_assets,
-            } => output_assets,
+            PageEndpointOutput::NodeJs { server_assets, .. }
+            | PageEndpointOutput::Edge { server_assets, .. } => server_assets,
+        }
+    }
+
+    #[turbo_tasks::function]
+    pub fn client_assets(&self) -> Vc<OutputAssets> {
+        match *self {
+            PageEndpointOutput::NodeJs { client_assets, .. }
+            | PageEndpointOutput::Edge { client_assets, .. } => client_assets,
         }
     }
 }

--- a/packages/next-swc/crates/next-api/src/route.rs
+++ b/packages/next-swc/crates/next-api/src/route.rs
@@ -24,7 +24,8 @@ pub enum Route {
 #[turbo_tasks::value_trait]
 pub trait Endpoint {
     fn write_to_disk(self: Vc<Self>) -> Vc<WrittenEndpoint>;
-    fn changed(self: Vc<Self>) -> Vc<Completion>;
+    fn server_changed(self: Vc<Self>) -> Vc<Completion>;
+    fn client_changed(self: Vc<Self>) -> Vc<Completion>;
 }
 
 #[turbo_tasks::value(shared)]


### PR DESCRIPTION
### What?

Updates the new `entrypoint.changed()` method to signal whether the server or client assets changed. Now, a `{ changed: 'server' | 'client' | 'both' }` will value will be yielded by the subscription.

### Why?

So that client-only changes can be handled differently than server-only changes.

### How?

We just needed to track the server and client output assets separately, so that we can detect changes to either individually. It's difficult to tell what `Vc` change triggered a recomputation on the Rust side (I'd have to involve mutable `State` into the Vc), and it's also hard to re-emit a duplicate value (eg, if a client change follows a client change, we need 2 emits). Instead, I tie the two different `server_changed()` and `client_changed()` functions into a single enum on the TS side.

Depends on https://github.com/vercel/next.js/pull/53809, since I don't want to introduce merge conflicts while Tobias is on vacation.