### PR TITLE
Turbopack: Fix debugging in napi for next-api

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -342,20 +342,6 @@ const nextDev: CliCommand = async (argv) => {
       )
     }
 
-    if (process.platform === 'darwin') {
-      // rust needs stdout to be blocking, otherwise it will throw an error (on macOS at least) when writing a lot of data (logs) to it
-      // see https://github.com/napi-rs/napi-rs/issues/1630
-      // and https://github.com/nodejs/node/blob/main/doc/api/process.md#a-note-on-process-io
-      if (process.stdout._handle != null) {
-        // @ts-ignore
-        process.stdout._handle.setBlocking(true)
-      }
-      if (process.stderr._handle != null) {
-        // @ts-ignore
-        process.stderr._handle.setBlocking(true)
-      }
-    }
-
     // Turbopack need to be in control over reading the .env files and watching them.
     // So we need to start with a initial env to know which env vars are coming from the user.
     resetEnv()


### PR DESCRIPTION
### What?

#51883:

> Node.js sets stdout to non-blocking by default, rust expects it to be blocking
> 
> so when logging a lot of data, it can happen that rust receives an error while writing causing it to panic, the error is just that the resource is temporarily unavailable, but rust doesn't handle this case
> 
> See https://github.com/napi-rs/napi-rs/issues/1630

### Why?

### How?

This moves the work done in #51883 into the `loadBindings` function used by both next-api and next-dev.