### PR TITLE
Add `@heroicons/react` to `modularizeImports`

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -721,6 +721,15 @@ function assignDefaults(
         '*': 'modularize-import-loader?name={{ member }}&from=default&as=default&join=../esm/icons/{{ kebabCase member }}!lucide-react',
       },
     },
+    '@heroicons/react/20/solid': {
+      transform: '@heroicons/react/20/solid/esm/{{member}}',
+    },
+    '@heroicons/react/24/solid': {
+      transform: '@heroicons/react/24/solid/esm/{{member}}',
+    },
+    '@heroicons/react/24/outline': {
+      transform: '@heroicons/react/24/outline/esm/{{member}}',
+    },
     ramda: {
       transform: 'ramda/es/{{member}}',
     },


### PR DESCRIPTION
As discussed [here](https://vercel.slack.com/archives/C0591D8EN4C/p1691752316347649?thread_ts=1691743605.677919&cid=C0591D8EN4C), there're other popular icon and component libraries to be added until we have a better solution.