### PR TITLE
fix(#52216): add default export interop to `image-external`

### DIFF
--- a/packages/next/image.js
+++ b/packages/next/image.js
@@ -1,1 +1,5 @@
-module.exports = require('./dist/shared/lib/image-external')
+const imageExternalExports = require('./dist/shared/lib/image-external')
+
+module.exports = imageExternalExports.default || imageExternalExports
+module.exports.unstable_getImgProps = imageExternalExports.unstable_getImgProps
+module.exports.default = module.exports


### PR DESCRIPTION
Fixes #52216.

`src/shared/image-external` is mixed with both default export and named export, which requires the `interopClientDefaultExport` build flag to be enabled (as swc can't transpile mixed default/named exports properly).