### PR TITLE
add "expect" to list of forbidden IPC headers

### DIFF
--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -6,6 +6,8 @@ export const ipcForbiddenHeaders = [
   'transfer-encoding',
   // https://github.com/nodejs/undici/issues/1470
   'connection',
+  // marked as unsupported by undici: https://github.com/nodejs/undici/blob/c83b084879fa0bb8e0469d31ec61428ac68160d5/lib/core/request.js#L354
+  'expect',
 ]
 
 export const actionsForbiddenHeaders = [

--- a/test/production/ipc-forbidden-headers/app/api/app-api/route.ts
+++ b/test/production/ipc-forbidden-headers/app/api/app-api/route.ts
@@ -1,0 +1,7 @@
+export async function POST(req: Request) {
+  return new Response('Hello, Next.js!')
+}
+
+export async function DELETE(req: Request) {
+  return new Response('Hello, Next.js!')
+}

--- a/test/production/ipc-forbidden-headers/ipc-forbidden-headers.test.ts
+++ b/test/production/ipc-forbidden-headers/ipc-forbidden-headers.test.ts
@@ -1,0 +1,49 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'ipc-forbidden-headers',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should not error if expect header is included', async () => {
+      let res = await next.fetch('/api/pages-api', {
+        method: 'POST',
+        headers: { expect: '100-continue' },
+      })
+      let text = await res.text()
+
+      expect(text).toEqual('Hello, Next.js!')
+
+      res = await next.fetch('/api/app-api', {
+        method: 'POST',
+        headers: {
+          expect: '100-continue',
+        },
+      })
+      text = await res.text()
+
+      expect(text).toEqual('Hello, Next.js!')
+      expect(next.cliOutput).not.toContain('UND_ERR_NOT_SUPPORTED')
+    })
+
+    it("should not error on content-length: 0 if request shouldn't contain a payload", async () => {
+      let res = await next.fetch('/api/pages-api', {
+        method: 'DELETE',
+        headers: { 'content-length': '0' },
+      })
+
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/api/app-api', {
+        method: 'DELETE',
+        headers: { 'content-length': '0' },
+      })
+
+      expect(res.status).toBe(200)
+      expect(next.cliOutput).not.toContain(
+        'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH'
+      )
+    })
+  }
+)

--- a/test/production/ipc-forbidden-headers/pages/api/pages-api.js
+++ b/test/production/ipc-forbidden-headers/pages/api/pages-api.js
@@ -1,0 +1,3 @@
+export default async function handler(req, res) {
+  return res.status(200).send('Hello, Next.js!')
+}


### PR DESCRIPTION
`expect` is an unsupported header for undici: https://github.com/nodejs/undici/blob/c83b084879fa0bb8e0469d31ec61428ac68160d5/lib/core/request.js#L354 -- this filters it out so that the API routes don't throw an internal server error if that header is included. 

Also added a test case for the previously submitted PR that was added for `content-length: 0`

- x-ref: #53843

Fixes #53822 (erroneously closed by a content-length issue being fixed)

