### PR TITLE
Make next as dependency of `@next/third-parties` package

### DIFF
--- a/examples/with-supertokens/config/backendConfig.ts
+++ b/examples/with-supertokens/config/backendConfig.ts
@@ -22,7 +22,7 @@ export let backendConfig = (): AuthConfig => {
           // IMPORTANT: Please replace them with your own OAuth keys for production use.
           {
             config: {
-              thirdPartyId: "google",
+              thirdPartyId: 'google',
               clients: [
                 {
                   clientId: process.env.GOOGLE_CLIENT_ID,
@@ -33,7 +33,7 @@ export let backendConfig = (): AuthConfig => {
           },
           {
             config: {
-              thirdPartyId: "github",
+              thirdPartyId: 'github',
               clients: [
                 {
                   clientId: process.env.GITHUB_CLIENT_ID,
@@ -44,13 +44,16 @@ export let backendConfig = (): AuthConfig => {
           },
           {
             config: {
-              thirdPartyId: "apple",
+              thirdPartyId: 'apple',
               clients: [
                 {
                   clientId: process.env.APPLE_CLIENT_ID,
                   additionalConfig: {
                     keyId: process.env.APPLE_KEY_ID,
-                    privateKey: process.env.APPLE_PRIVATE_KEY.replace(/\\n/g, "\n"),
+                    privateKey: process.env.APPLE_PRIVATE_KEY.replace(
+                      /\\n/g,
+                      '\n'
+                    ),
                     teamId: process.env.APPLE_TEAM_ID,
                   },
                 },

--- a/examples/with-supertokens/pages/auth/[[...path]].tsx
+++ b/examples/with-supertokens/pages/auth/[[...path]].tsx
@@ -1,17 +1,32 @@
 import Head from 'next/head'
-import React, { ComponentType, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import styles from '../../styles/Home.module.css'
 import dynamic from 'next/dynamic'
 import { canHandleRoute, getRoutingComponent } from 'supertokens-auth-react/ui'
 import { redirectToAuth } from 'supertokens-auth-react'
-import { ThirdPartyEmailPasswordPreBuiltUI } from "supertokens-auth-react/recipe/thirdpartyemailpassword/prebuiltui";
-import { EmailVerificationPreBuiltUI } from "supertokens-auth-react/recipe/emailverification/prebuiltui";
+import { ThirdPartyEmailPasswordPreBuiltUI } from 'supertokens-auth-react/recipe/thirdpartyemailpassword/prebuiltui'
+import { EmailVerificationPreBuiltUI } from 'supertokens-auth-react/recipe/emailverification/prebuiltui'
 
-const SuperTokensComponentNoSSR = dynamic<{}>(new Promise((res) => res(() => getRoutingComponent([ThirdPartyEmailPasswordPreBuiltUI, EmailVerificationPreBuiltUI]))), { ssr: false })
+const SuperTokensComponentNoSSR = dynamic<{}>(
+  new Promise((res) =>
+    res(() =>
+      getRoutingComponent([
+        ThirdPartyEmailPasswordPreBuiltUI,
+        EmailVerificationPreBuiltUI,
+      ])
+    )
+  ),
+  { ssr: false }
+)
 
 export default function Auth(): JSX.Element {
   useEffect(() => {
-    if (canHandleRoute([ThirdPartyEmailPasswordPreBuiltUI, EmailVerificationPreBuiltUI]) === false) {
+    if (
+      canHandleRoute([
+        ThirdPartyEmailPasswordPreBuiltUI,
+        EmailVerificationPreBuiltUI,
+      ]) === false
+    ) {
       redirectToAuth({
         redirectBack: false,
       })

--- a/examples/with-supertokens/pages/index.tsx
+++ b/examples/with-supertokens/pages/index.tsx
@@ -136,7 +136,7 @@ function ProtectedPage({ userId }) {
             {JSON.stringify(session.accessTokenPayload, null, 2)}
           </pre>
         </p>
-        
+
         <div className={styles.grid}>
           <a href="https://nextjs.org/docs" className={styles.card}>
             <h3>Documentation &rarr;</h3>

--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -11,14 +11,14 @@
   ],
   "license": "MIT",
   "scripts": {
-    "release": "rm -rf dist && tsc -d -p tsconfig.json",
-    "build": "pnpm release",
+    "build": "rm -rf dist && tsc -d -p tsconfig.json",
     "prepublishOnly": "cd ../../ && turbo run build",
     "update-third-parties": "rm -rf src/**/index.tsx && node scripts/update-third-parties",
     "dev": "tsc -d -w -p tsconfig.json",
     "typescript": "tsec --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "next": "^13.0.0",
     "third-party-capital": "1.0.17"
   },
   "devDependencies": {
@@ -26,7 +26,6 @@
     "prettier": "2.5.1"
   },
   "peerDependencies": {
-    "next": "^13.0.0",
     "react": "^18.2.0"
   }
 }

--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -21,14 +21,15 @@
     "typescript": "tsec --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "next": "^13.0.0",
     "third-party-capital": "1.0.17"
   },
   "devDependencies": {
+    "next": "13.4.14",
     "outdent": "0.8.0",
     "prettier": "2.5.1"
   },
   "peerDependencies": {
+    "next": "^13.0.0",
     "react": "^18.2.0"
   }
 }

--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -6,9 +6,6 @@
     "url": "vercel/next.js",
     "directory": "packages/third-parties"
   },
-  "exports": {
-    "./google": "./dist/google/index.js"
-  },
   "files": [
     "dist"
   ],

--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -14,9 +14,10 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "rm -rf dist && tsc -d -p tsconfig.json",
+    "release": "rm -rf dist && tsc -d -p tsconfig.json",
+    "build": "pnpm release",
     "prepublishOnly": "cd ../../ && turbo run build",
-    "updateThirdParties": "rm -rf src/**/index.tsx && node scripts/update-third-parties",
+    "update-third-parties": "rm -rf src/**/index.tsx && node scripts/update-third-parties",
     "dev": "tsc -d -w -p tsconfig.json",
     "typescript": "tsec --noEmit -p tsconfig.json"
   },

--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -6,6 +6,9 @@
     "url": "vercel/next.js",
     "directory": "packages/third-parties"
   },
+  "exports": {
+    "./google": "./dist/google/index.js"
+  },
   "files": [
     "dist"
   ],

--- a/packages/third-parties/tsconfig.json
+++ b/packages/third-parties/tsconfig.json
@@ -10,5 +10,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "src/**/index.tsx"]
+  "exclude": ["node_modules"]
 }

--- a/packages/third-parties/tsconfig.json
+++ b/packages/third-parties/tsconfig.json
@@ -9,6 +9,6 @@
     "module": "commonjs",
     "rootDir": "src"
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/packages/third-parties/tsconfig.json
+++ b/packages/third-parties/tsconfig.json
@@ -9,6 +9,6 @@
     "module": "commonjs",
     "rootDir": "src"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "src/**/index.tsx"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1572,9 +1572,6 @@ importers:
 
   packages/third-parties:
     dependencies:
-      next:
-        specifier: ^13.0.0
-        version: link:../next
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -1582,6 +1579,9 @@ importers:
         specifier: 1.0.17
         version: 1.0.17
     devDependencies:
+      next:
+        specifier: 13.4.14
+        version: link:../next
       outdent:
         specifier: 0.8.0
         version: 0.8.0


### PR DESCRIPTION
ensure `next` is the dependency of third-parties package so turbo will build next first then `@next/third-parties` to avoid type failing