### PR TITLE
Open Graph Image font declaration moved to correct place

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/opengraph-image.mdx
@@ -104,13 +104,13 @@ export const size = {
 
 export const contentType = 'image/png'
 
-// Font
-const interSemiBold = fetch(
-  new URL('./Inter-SemiBold.ttf', import.meta.url)
-).then((res) => res.arrayBuffer())
-
 // Image generation
 export default async function Image() {
+  // Font
+  const interSemiBold = fetch(
+    new URL('./Inter-SemiBold.ttf', import.meta.url)
+  ).then((res) => res.arrayBuffer())
+
   return new ImageResponse(
     (
       // ImageResponse JSX element
@@ -159,15 +159,15 @@ export const size = {
   height: 630,
 }
 
-// Font
-const interSemiBold = fetch(
-  new URL('./Inter-SemiBold.ttf', import.meta.url)
-).then((res) => res.arrayBuffer())
-
 export const contentType = 'image/png'
 
 // Image generation
 export default function Image() {
+  // Font
+  const interSemiBold = fetch(
+    new URL('./Inter-SemiBold.ttf', import.meta.url)
+  ).then((res) => res.arrayBuffer())
+
   return new ImageResponse(
     (
       // ImageResponse JSX element


### PR DESCRIPTION
When implementing `opengraph-image` in my [personal-site-project](https://github.com/kylemcd/personal-site). I was consistently running into issues where custom fonts would either only work locally or only work on vercel. To me it seemed like differences in pathing in `edge` vs `nodejs` runtimes. After digging around I found issue #48081, more specifically [this comment](https://github.com/vercel/next.js/issues/48081#issuecomment-1565842740) where moving the `fetch` for the font into the `Image` function solved the issue.

I'm not sure if this is 100% the correct fix, or if this is an issue that needs to be solved in another way. If that's not the case this PR updates the documentation around `opengraph-image` to have the fetch for custom fonts inside of the `Image` function. 