### PR TITLE
Remove extra label from runner

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -119,7 +119,6 @@ jobs:
               - 'linux'
               - 'x64'
               - 'metal'
-              - 'docker'
 
             target: 'x86_64-unknown-linux-gnu'
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
@@ -140,7 +139,6 @@ jobs:
               - 'linux'
               - 'x64'
               - 'metal'
-              - 'docker'
 
             target: 'x86_64-unknown-linux-musl'
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
@@ -174,7 +172,6 @@ jobs:
               - 'linux'
               - 'x64'
               - 'metal'
-              - 'docker'
 
             target: 'aarch64-unknown-linux-gnu'
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
@@ -196,7 +193,6 @@ jobs:
               - 'linux'
               - 'x64'
               - 'metal'
-              - 'docker'
 
             target: 'aarch64-unknown-linux-musl'
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine


### PR DESCRIPTION
All have docker available now so don't need this label to distinguish anymore. 