### PR TITLE
test(ci): refine test suite name unique

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -30,9 +30,7 @@ const customJestConfig = {
 // This won't count for the retry to avoid duplicated test being reported twice
 // - which means our test trace will report test results for the flaky test as failed without retry.
 const shouldEnableTestTrace =
-  process.env.DATADOG_API_KEY &&
-  process.env.DATADOG_TRACE_NEXTJS_TEST &&
-  !process.env.IS_RETRY
+  process.env.DATADOG_API_KEY && process.env.DATADOG_TRACE_NEXTJS_TEST
 
 if (shouldEnableTestTrace) {
   if (!customJestConfig.reporters) {
@@ -48,11 +46,6 @@ if (shouldEnableTestTrace) {
     'jest-junit',
     {
       outputDirectory,
-      // note: {filename} is not a full path, since putting full path
-      // makes suite name too long and truncates and not able to read the suite name
-      suiteNameTemplate: `{title} [${process.env.NEXT_TEST_MODE ?? 'default'}${
-        process.env.TURBOPACK ? '/t' : ''
-      }${process.env.EXPERIMENTAL_TURBOPACK ? '/et' : ''}/{filename}]`,
       reportTestSuiteErrors: 'true',
       uniqueOutputName: 'true',
       outputName: 'nextjs-test-junit',

--- a/run-tests.js
+++ b/run-tests.js
@@ -278,6 +278,7 @@ async function main() {
   console.log(`${GROUP}Running tests:
 ${testNames.join('\n')}
 ${ENDGROUP}`)
+  console.log(`total: ${testNames.length}`)
 
   const hasIsolatedTests = testNames.some((test) => {
     return configuredTestTypes.some(
@@ -365,6 +366,22 @@ ${ENDGROUP}`)
             CONTINUOUS_INTEGRATION: '',
             RUN_ID: '',
             BUILD_NUMBER: '',
+            // Format the output of junit report to include the test name
+            // For the debugging purpose to compare actual run list to the generated reports
+            // [NOTE]: This won't affect if junit reporter is not enabled
+            JEST_JUNIT_OUTPUT_NAME:
+              test && test.length > 0 ? test.replaceAll('/', '_') : undefined,
+            // Specify suite name for the test to avoid unexpected merging across different env / grouped tests
+            // This is not individual suites name (corresponding 'describe'), top level suite name which have redundant names by default
+            // [NOTE]: This won't affect if junit reporter is not enabled
+            JEST_SUITE_NAME: [
+              `${process.env.NEXT_TEST_MODE ?? 'default'}`,
+              groupArg,
+              testType,
+              test,
+            ]
+              .filter(Boolean)
+              .join(':'),
             ...(isFinalRun
               ? {
                   // Events can be finicky in CI. This switches to a more


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What

Pairing PR to https://github.com/vercel/turbo/pull/5714, which I believe last piece to reenable correct datadog test reports for daily next.js integration + turbopack.

1. Creates a unique suite name to avoid collision / merging across different env / grouped test run
2. revert suitename template (which is for _suites_, not _suite_ for top level) as 1 resolves uniqueness
