### PR TITLE
Update opengraph-image.mdx: Fix typo

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/opengraph-image.mdx
@@ -68,7 +68,7 @@ About Acme
 ```
 
 ```html filename="<head> output"
-<meta property="og:image:alt" content="About Acme" />
+<meta property="twitter:image:alt" content="About Acme" />
 ```
 
 ## Generate images using code (.js, .ts, .tsx)


### PR DESCRIPTION
This commit fixes a typo in the `<head> output` (twitter-image.alt.txt) code block