### PR TITLE
Turbopack: fix hiding node_modules warnings in error overlay.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "serde",
 ]
@@ -3633,7 +3633,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "serde",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7350,7 +7350,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7362,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7377,7 +7377,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7391,7 +7391,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7408,7 +7408,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7438,7 +7438,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "base16",
  "hex",
@@ -7450,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7464,7 +7464,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7474,7 +7474,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "mimalloc",
 ]
@@ -7482,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7505,7 +7505,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7518,7 +7518,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7549,7 +7549,7 @@ dependencies = [
 [[package]]
 name = "turbopack-bench"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "chromiumoxide",
@@ -7579,7 +7579,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7622,7 +7622,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7644,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7668,7 +7668,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7697,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "turbopack-create-test-app"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "clap 4.1.11",
@@ -7710,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7732,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7756,7 +7756,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7793,7 +7793,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7827,7 +7827,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "serde",
  "serde_json",
@@ -7838,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7861,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7878,7 +7878,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7894,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -7914,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "serde",
@@ -7929,7 +7929,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7944,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7979,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "serde",
@@ -7995,7 +7995,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8006,7 +8006,7 @@ dependencies = [
 [[package]]
 name = "turbopack-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230811.2#a964d782cc17594a37d9ac5305c0b7e6aef1312d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230814.2#1295dbce87dc480b0eb1e19108950e1adce54573"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,11 @@ swc_core = { version = "0.79.55" }
 testing = { version = "0.33.21" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230811.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230814.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230811.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230814.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230811.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230814.2" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/js/package.json
+++ b/packages/next-swc/crates/next-core/js/package.json
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230811.2",
-    "@vercel/turbopack-node": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230811.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230814.2",
+    "@vercel/turbopack-node": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230814.2",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
     "next": "*",

--- a/packages/next-swc/crates/next-core/js/src/overlay/internal/container/Errors.tsx
+++ b/packages/next-swc/crates/next-core/js/src/overlay/internal/container/Errors.tsx
@@ -147,7 +147,7 @@ function isWarning(issue: Issue) {
 }
 
 function isUserCode(issue: Issue) {
-  return !issue.context || !issue.context.includes('node_modules')
+  return !issue.file_path || !issue.file_path.includes('node_modules')
 }
 
 function isRuntimeWarning(error: ReadyRuntimeError) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1428,11 +1428,11 @@ importers:
   packages/next-swc/crates/next-core/js:
     dependencies:
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230811.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230811.2(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230814.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230814.2(react-refresh@0.12.0)(webpack@5.86.0)'
       '@vercel/turbopack-node':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230811.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230811.2'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230814.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230814.2'
       anser:
         specifier: ^2.1.1
         version: 2.1.1
@@ -26388,9 +26388,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230811.2(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230811.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230811.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230814.2(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230814.2}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230814.2'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:
@@ -26401,8 +26401,8 @@ packages:
       - webpack
     dev: false
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230811.2':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230811.2}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230814.2':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230814.2}
     name: '@vercel/turbopack-node'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
This regressed in vercel/turbo#5661 when `context` was renamed `file_path`.
