### PR TITLE
chore: mark build folder indexable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@ packages/next/bundles/** -text
 packages/next/compiled/** -text
 
 # Make next/src/build folder indexable for github search
-packages/next/src/build/** linguist-generated=false
+build/** linguist-generated=false


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/pull/51647
follow up for the code indexing issue for "build/**" folder, previous solution seem not working, trying just "build/**" without prefix