### PR TITLE
fix(next-swc): coerce mdxrs default options

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1135,9 +1135,9 @@ async function loadWasm(importPath = '', isCustomTurbopack: boolean) {
         },
         mdx: {
           compile: (src: string, options: any) =>
-            bindings.mdxCompile(src, options),
+            bindings.mdxCompile(src, getMdxOptions(options)),
           compileSync: (src: string, options: any) =>
-            bindings.mdxCompileSync(src, options),
+            bindings.mdxCompileSync(src, getMdxOptions(options)),
         },
       }
       return wasmBindings
@@ -1409,15 +1409,31 @@ function loadNative(isCustomTurbopack = false, importPath?: string) {
       },
       mdx: {
         compile: (src: string, options: any) =>
-          bindings.mdxCompile(src, toBuffer(options ?? {})),
+          bindings.mdxCompile(src, toBuffer(getMdxOptions(options))),
         compileSync: (src: string, options: any) =>
-          bindings.mdxCompileSync(src, toBuffer(options ?? {})),
+          bindings.mdxCompileSync(src, toBuffer(getMdxOptions(options))),
       },
     }
     return nativeBindings
   }
 
   throw attempts
+}
+
+/// Build a mdx options object contains default values that
+/// can be parsed with serde_wasm_bindgen.
+function getMdxOptions(options: any = {}) {
+  const ret = {
+    ...options,
+    development: options.development ?? false,
+    jsx: options.jsx ?? false,
+    parse: options.parse ?? {
+      gfmStrikethroughSingleTilde: true,
+      mathTextSingleDollar: true,
+    },
+  }
+
+  return ret
 }
 
 function toBuffer(t: any) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change



### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

wasm-bindgen's serde deserialization is more strict to not automatically coerce non-optionable default values for the mdx configurations. Since these are required options anyway, consolidate to construct default options.


Closes WEB-1384