### PR TITLE
Enhancing Next.js: Updating Third-Party Scripts in Concurrent Fashion

### DIFF
--- a/packages/third-parties/scripts/update-third-parties.js
+++ b/packages/third-parties/scripts/update-third-parties.js
@@ -85,7 +85,7 @@ function generateComponent(thirdParty) {
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name)
 
-  for (let dir of dirs) {
+  await Promise.all(dirs.map(async(dir) => {
     // Fetch the list of third-parties from tpc-config.json
     // Then retrieve its loading instructions from Third Party Capital
     const dirPath = path.join(SRC, dir)
@@ -111,11 +111,11 @@ function generateComponent(thirdParty) {
       thirdPartyFunctions += generateComponent(thirdParty)
     }
 
-    await Promise.all([
+    return Promise.all([
       fs.writeFile(
         path.join(dirPath, 'index.tsx'),
         prettier.format(thirdPartyFunctions, { semi: false, parser: 'babel' })
       ),
     ])
-  }
+  }))
 })()


### PR DESCRIPTION
Running the `update-scripts.js` function concurrently, as advised by @leerob in this comment (https://github.com/vercel/next.js/pull/53617#issuecomment-1666610953), I have decided not to modify the core Next.js code. Instead, I will be updating the scripts from third-party sources. I apologize if I have made any mistakes, and I am sorry if I have repeated the same mistakes again :) 