### PR TITLE
OpenTel: remove the internal (ipc) fetched from traces in a non-verbose mode

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -1,7 +1,7 @@
 import type { StaticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage'
 import type * as ServerHooks from '../../client/components/hooks-server-context'
 
-import { AppRenderSpan } from './trace/constants'
+import { AppRenderSpan, NextNodeServerSpan } from './trace/constants'
 import { getTracer, SpanKind } from './trace/tracer'
 import { CACHE_ONE_YEAR } from '../../lib/constants'
 
@@ -103,12 +103,9 @@ export function patchFetch({
     // Do create a new span trace for internal fetches in the
     // non-verbose mode.
     const isInternal = (init?.next as any)?.internal === true
-    if (isInternal && process.env.NEXT_OTEL_VERBOSE !== '1') {
-      return originFetch(input, init)
-    }
 
     return await getTracer().trace(
-      AppRenderSpan.fetch,
+      isInternal ? NextNodeServerSpan.internalFetch : AppRenderSpan.fetch,
       {
         kind: SpanKind.CLIENT,
         spanName: ['fetch', method, fetchUrl].filter(Boolean).join(' '),

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -64,6 +64,7 @@ enum NextNodeServerSpan {
   route = 'route',
   onProxyReq = 'onProxyReq',
   apiResolver = 'apiResolver',
+  internalFetch = 'internalFetch',
 }
 
 enum StartServerSpan {


### PR DESCRIPTION
The internal IPC fetches are an internal framework detail and they shouldn't pollute the tracing in a non-verbose mode.

Examples of internal fetch output:

<img width="600" alt="image" src="https://github.com/vercel/next.js/assets/726049/64a25c02-bf39-4f54-8fe3-86018c7720dc">


<img width="1369" alt="image" src="https://github.com/vercel/next.js/assets/726049/f8f1d65c-5444-42c7-9e7d-6cdf9865eace">
