### PR TITLE
chore: update lock bot wording

### DIFF
--- a/.github/workflows/issue_lock.yml
+++ b/.github/workflows/issue_lock.yml
@@ -24,6 +24,6 @@ jobs:
           add-issue-labels: 'locked'
           add-pr-labels: 'locked'
           issue-inactive-days: 14
-          issue-comment: 'This closed issue has been automatically locked because it had no new activity for a month. If you are running into a similar issue, please create a new issue with the steps to reproduce. Thank you.'
+          issue-comment: 'This closed issue has been automatically locked because it had no new activity for 2 weeks. If you are running into a similar issue, please create a new issue with the steps to reproduce. Thank you.'
           pr-inactive-days: 14
           log-output: true


### PR DESCRIPTION
Follow-up of #54048. We changed the lock action from waiting 1 month to 2 weeks, but the wording was not reflecting it.