### PR TITLE
chore(image): remove apple silicon workaround for versions older than `node@16.5.0`

### DIFF
--- a/packages/next/src/server/lib/squoosh/impl.ts
+++ b/packages/next/src/server/lib/squoosh/impl.ts
@@ -59,7 +59,6 @@ export async function encodeJpeg(
 
   const e = supportedFormats['mozjpeg']
   const m = await e.enc()
-  await maybeDelay()
   const r = await m.encode(image.data, image.width, image.height, {
     ...e.defaultEncoderOptions,
     quality,
@@ -75,7 +74,6 @@ export async function encodeWebp(
 
   const e = supportedFormats['webp']
   const m = await e.enc()
-  await maybeDelay()
   const r = await m.encode(image.data, image.width, image.height, {
     ...e.defaultEncoderOptions,
     quality,
@@ -91,7 +89,6 @@ export async function encodeAvif(
 
   const e = supportedFormats['avif']
   const m = await e.enc()
-  await maybeDelay()
   const val = e.autoOptimize.min || 62
   const r = await m.encode(image.data, image.width, image.height, {
     ...e.defaultEncoderOptions,
@@ -109,7 +106,6 @@ export async function encodePng(
 
   const e = supportedFormats['oxipng']
   const m = await e.enc()
-  await maybeDelay()
   const r = await m.encode(image.data, image.width, image.height, {
     ...e.defaultEncoderOptions,
   })

--- a/packages/next/src/server/lib/squoosh/impl.ts
+++ b/packages/next/src/server/lib/squoosh/impl.ts
@@ -1,4 +1,3 @@
-import semver from 'next/dist/compiled/semver'
 import { codecs as supportedFormats, preprocessors } from './codecs'
 import ImageData from './image_data'
 

--- a/packages/next/src/server/lib/squoosh/impl.ts
+++ b/packages/next/src/server/lib/squoosh/impl.ts
@@ -4,31 +4,6 @@ import ImageData from './image_data'
 
 type EncoderKey = keyof typeof supportedFormats
 
-// Fixed in Node.js 16.5.0 and newer.
-// See https://github.com/nodejs/node/pull/39337
-// Eventually, remove this delay when engines is updated.
-// See https://github.com/vercel/next.js/blob/1bcc923439f495a1717421e06af7e64c6003072c/packages/next/package.json#L249-L251
-const FIXED_VERSION = '16.5.0'
-const DELAY_MS = 1000
-let _promise: Promise<void> | undefined
-
-function delayOnce(ms: number): Promise<void> {
-  if (!_promise) {
-    _promise = new Promise((resolve) => {
-      setTimeout(resolve, ms)
-    })
-  }
-  return _promise
-}
-
-function maybeDelay(): Promise<void> {
-  const isAppleM1 = process.arch === 'arm64' && process.platform === 'darwin'
-  if (isAppleM1 && semver.lt(process.version, FIXED_VERSION)) {
-    return delayOnce(DELAY_MS)
-  }
-  return Promise.resolve()
-}
-
 export async function decodeBuffer(
   _buffer: Buffer | Uint8Array
 ): Promise<ImageData> {
@@ -70,7 +45,6 @@ export async function resize({ image, width, height }: ResizeOpts) {
 
   const p = preprocessors['resize']
   const m = await p.instantiate()
-  await maybeDelay()
   return await m(image.data, image.width, image.height, {
     ...p.defaultOptions,
     width,


### PR DESCRIPTION
Since Next.js already requires [`node@16.8.0`](https://github.com/vercel/next.js/blob/88b8d15f41f894011cf33af0b1f4a3fb24aed46b/packages/next/package.json#L319) or newer, we can drop this workaround for squoosh/wasm on apple silicon.

- x-ref: https://github.com/vercel/next.js/pull/27031