### PR TITLE
install-native.mjs: include `packageManager` field

### DIFF
--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -13,6 +13,7 @@ import fs from 'fs-extra'
   const { version: nextVersion } = await fs.readJSON(
     path.join(cwd, 'packages', 'next', 'package.json')
   )
+  const { packageManager } = await fs.readJSON(path.join(cwd, 'package.json'))
 
   try {
     // if installed swc package version matches monorepo version
@@ -51,6 +52,7 @@ import fs from 'fs-extra'
         '@next/swc-win32-ia32-msvc': 'canary',
         '@next/swc-win32-x64-msvc': 'canary',
       },
+      packageManager,
     }
     await fs.writeFile(
       path.join(tmpdir, 'package.json'),


### PR DESCRIPTION
This ensures that corepack uses the correct package manager and version for the tmpdir install as it does for the rest of the repo. It reads the value from the root `package.json`.


Closes WEB-1401