### PR TITLE
Automatically modularizeImports for the popular @headlessui/react library

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -721,6 +721,11 @@ function assignDefaults(
         '*': 'modularize-import-loader?name={{ member }}&from=default&as=default&join=../esm/icons/{{ kebabCase member }}!lucide-react',
       },
     },
+    '@headlessui/react': {
+      transform:
+        'modularize-import-loader?name={{member}}&join=./components/{{lowerCase member}}/{{lowerCase member}}!@headlessui/react',
+      skipDefaultConversion: true,
+    },
     '@heroicons/react/20/solid': {
       transform: '@heroicons/react/20/solid/esm/{{member}}',
     },


### PR DESCRIPTION
`import { Listbox } from "@headlessui-float/react";` becomes
`import { Listbox } from "@headlessui/react/dist/components/listbox/listbox";`
