### PR TITLE
Docs: Add documentation for `next/third-parties`

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/10-third-parties.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/10-third-parties.mdx
@@ -1,0 +1,120 @@
+---
+title: Third Parties
+nav_title: Third Parties
+description: Optimize the performance of third-party libraries in your application with the `@next/third-parties` package.
+---
+
+{/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+[**`@next/third-parties`**](/docs/app/api-reference/components/font) is a library that provides a
+collection of components and utilities that improve the performance and developer experience of
+loading popular third-party libraries in your Next.js application.
+
+> **Good to know**: `@next/third-parties` is a new **experimental** library that is still under
+> active development. We're currently working on adding more third-party integrations.
+
+All third-party integrations provided by `@next/third-parties` have been optimized for performance
+and ease of use.
+
+## Getting Started
+
+To get started, you must install the `@next/third-parties` library:
+
+```bash filename="Terminal"
+npm install @next/third-parties
+```
+
+## Google Third-Parties
+
+All supported third-party libraries from Google can be imported from `@next/third-parties/google`.
+
+### Google Maps Embed
+
+The `GoogleMapsEmbed` component can be used to add a Google Maps Embed to your page. By default, it
+uses the `loading` attribute to lazy-load the embed below the fold.
+
+<AppOnly>
+
+```jsx filename="app/page.js"
+import { GoogleMapsEmbed } from '@next/third-parties/google'
+
+export default function Page() {
+  return (
+    <GoogleMapsEmbed
+      apiKey="XYZ"
+      height={200}
+      width="100%"
+      mapMode="place"
+      parameters="q=Brooklyn+Bridge,New+York,NY"
+    />
+  )
+}
+```
+
+</AppOnly>
+
+<PagesOnly>
+
+```jsx filename="pages/index.js"
+import { GoogleMapsEmbed } from '@next/third-parties/google'
+
+export default function Page() {
+  return (
+    <GoogleMapsEmbed
+      apiKey="XYZ"
+      height={200}
+      width="100%"
+      mapMode="place"
+      parameters="q=Brooklyn+Bridge,New+York,NY"
+    />
+  )
+}
+```
+
+</PagesOnly>
+
+### YouTube Embed
+
+The `YoutubeEmbed` component can be used to load and display a YouTube embed. This component loads
+faster by using [`lite-youtube-embed`](https://github.com/paulirish/lite-youtube-embed) under the
+hood.
+
+<AppOnly>
+
+```jsx filename="app/page.js"
+import { GoogleMapsEmbed } from '@next/third-parties/google'
+
+export default function Page() {
+  return (
+    <GoogleMapsEmbed
+      apiKey="XYZ"
+      height={200}
+      width="100%"
+      mapMode="place"
+      parameters="q=Brooklyn+Bridge,New+York,NY"
+    />
+  )
+}
+```
+
+</AppOnly>
+
+<PagesOnly>
+
+```jsx filename="pages/index.js"
+import { GoogleMapsEmbed } from '@next/third-parties/google'
+
+export default function Page() {
+  return (
+    <YoutubeEmbed
+      videoid="ogfYd705cRs"
+      height={400}
+      width="100%"
+      mapMode="place"
+      parameters="q=Brooklyn+Bridge,New+York,NY"
+    />
+  )
+}
+```
+
+</PagesOnly>

--- a/docs/03-pages/01-building-your-application/05-optimizing/11-third-parties.mdx
+++ b/docs/03-pages/01-building-your-application/05-optimizing/11-third-parties.mdx
@@ -1,0 +1,8 @@
+---
+title: Third Parties
+nav_title: Third Parties
+description: Optimize the performance of third-party libraries in your application with the `@next/third-parties` package.
+source: app/building-your-application/optimizing/third-parties
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}


### PR DESCRIPTION
This PR adds documentation for `next/third-parties`.

- [X] Add a page to the Optimizing section of the docs
- [ ] Add a page to the API reference section of the docs that shows all required and supported props for each third-party
- [ ] Test changes locally 