### PR TITLE
fix process.env not being available in standalone mode

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -198,13 +198,16 @@ export async function initialize(opts: {
     },
   } as any)
 
+  const { initialEnv } = require('@next/env') as typeof import('@next/env')
+
   if (!!config.experimental.appDir) {
     renderWorkers.app = await createWorker(
       ipcPort,
       ipcValidationKey,
       opts.isNodeDebugging,
       'app',
-      config
+      config,
+      initialEnv
     )
   }
   renderWorkers.pages = await createWorker(
@@ -212,7 +215,8 @@ export async function initialize(opts: {
     ipcValidationKey,
     opts.isNodeDebugging,
     'pages',
-    config
+    config,
+    initialEnv
   )
 
   // pre-initialize workers

--- a/packages/next/src/server/lib/server-ipc/index.ts
+++ b/packages/next/src/server/lib/server-ipc/index.ts
@@ -8,6 +8,7 @@ import isError from '../../../lib/is-error'
 import { genRenderExecArgv } from '../worker-utils'
 import { deserializeErr } from './request-utils'
 import { RenderWorker } from '../router-server'
+import type { Env } from '@next/env'
 
 // we can't use process.send as jest-worker relies on
 // it already and can cause unexpected message errors
@@ -87,9 +88,9 @@ export const createWorker = async (
   ipcValidationKey: string,
   isNodeDebugging: boolean | 'brk' | undefined,
   type: 'pages' | 'app',
-  nextConfig: NextConfigComplete
+  nextConfig: NextConfigComplete,
+  initialEnv: NodeJS.ProcessEnv | Env = process.env
 ): Promise<RenderWorker> => {
-  const { initialEnv } = require('@next/env') as typeof import('@next/env')
   const useServerActions = !!nextConfig.experimental.serverActions
   const { Worker } =
     require('next/dist/compiled/jest-worker') as typeof import('next/dist/compiled/jest-worker')

--- a/test/production/standalone-mode/required-server-files/pages/api/env.js
+++ b/test/production/standalone-mode/required-server-files/pages/api/env.js
@@ -3,5 +3,6 @@ export default function handler(_, res) {
     env: process.env.FOO,
     envLocal: process.env.LOCAL_SECRET,
     envProd: process.env.PROD_SECRET,
+    envFromHost: process.env.ENV_FROM_HOST,
   })
 }

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -122,6 +122,7 @@ describe('should set-up next', () => {
       /ready started server on/,
       {
         ...process.env,
+        ENV_FROM_HOST: 'FOOBAR',
         PORT: appPort,
       },
       undefined,
@@ -1266,7 +1267,7 @@ describe('should set-up next', () => {
     }
   })
 
-  it('should copy and read .env file', async () => {
+  it('should read .env files and process.env', async () => {
     const res = await fetchViaHTTP(appPort, '/api/env')
 
     const envVariables = await res.json()
@@ -1274,6 +1275,7 @@ describe('should set-up next', () => {
     expect(envVariables.env).not.toBeUndefined()
     expect(envVariables.envProd).not.toBeUndefined()
     expect(envVariables.envLocal).toBeUndefined()
+    expect(envVariables.envFromHost).toBe('FOOBAR')
   })
 
   it('should run middleware correctly (without minimalMode, with wasm)', async () => {


### PR DESCRIPTION
### What?
When running Next in standalone mode, `process.env` is not made available to the render workers, making it impossible to access environment variables that aren't provided in `.env` files.

### Why?
`initialEnv` is undefined in `createWorkers` when the server is started in standalone mode.

### How?
This initializes the workers with `process.env` in case `initialEnv` is unavailable, similar to the behavior of `loadEnvConfig()`

Closes NEXT-1508
Fixes #53367
