### PR TITLE
fix: invalid module transform for `@headlessui/react`

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -722,8 +722,12 @@ function assignDefaults(
       },
     },
     '@headlessui/react': {
-      transform:
-        'modularize-import-loader?name={{member}}&join=./components/{{lowerCase member}}/{{lowerCase member}}!@headlessui/react',
+      transform: {
+        Transition:
+          'modularize-import-loader?name={{member}}&join=./components/transitions/transition!@headlessui/react',
+        Tab: 'modularize-import-loader?name={{member}}&join=./components/tabs/tabs!@headlessui/react',
+        '*': 'modularize-import-loader?name={{member}}&join=./components/{{ kebabCase member }}/{{ kebabCase member }}!@headlessui/react',
+      },
       skipDefaultConversion: true,
     },
     '@heroicons/react/20/solid': {

--- a/test/development/basic/modularize-imports.test.ts
+++ b/test/development/basic/modularize-imports.test.ts
@@ -12,6 +12,7 @@ describe('modularize-imports', () => {
       },
       dependencies: {
         'lucide-react': '0.264.0',
+        '@headlessui/react': '1.7.17',
       },
     })
   })

--- a/test/development/basic/modularize-imports/app/page.js
+++ b/test/development/basic/modularize-imports/app/page.js
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   IceCream,
   BackpackIcon,
@@ -20,6 +22,8 @@ import {
   LucideEdit3,
   TextSelection,
 } from 'lucide-react'
+
+import { Tab, RadioGroup, Transition } from '@headlessui/react'
 
 export default function Page() {
   return (
@@ -44,6 +48,28 @@ export default function Page() {
       <Edit2 />
       <LucideEdit3 />
       <TextSelection />
+      <Tab.Group>
+        <Tab.List>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+          <Tab>Tab 3</Tab>
+        </Tab.List>
+        <Tab.Panels>
+          <Tab.Panel>Content 1</Tab.Panel>
+          <Tab.Panel>Content 2</Tab.Panel>
+          <Tab.Panel>Content 3</Tab.Panel>
+        </Tab.Panels>
+      </Tab.Group>
+      <RadioGroup>
+        <RadioGroup.Label>Plan</RadioGroup.Label>
+        <RadioGroup.Option value="startup">
+          {({ checked }) => <span>{checked ? 'checked' : ''} Startup</span>}
+        </RadioGroup.Option>
+        <RadioGroup.Option value="business">
+          {({ checked }) => <span>{checked ? 'checked' : ''} Business</span>}
+        </RadioGroup.Option>
+      </RadioGroup>
+      <Transition show>I will fade in and out</Transition>
     </>
   )
 }


### PR DESCRIPTION
occured since #54188

- `*`: use kebabcase instead of lowercase
- Transition: `components/transitions/transition`
- Tab: `components/tabs/tabs`

```plain
- wait compiling /not-found (client and server)...
- error ./node_modules/.pnpm/@headlessui+react@1.7.17_react-dom@18.2.0_react@18.2.0/node_modules/@headlessui/react/dist/headlessui.esm.js:2:0
Module not found: Can't resolve '/Projects/node_modules/.pnpm/@headlessui+react@1.7.17_react-dom@18.2.0_react@18.2.0/node_modules/@headlessui/react/dist/components/tab/tab'
```

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
