### PR TITLE
chore: remove unnecessary type cast in dev-build-watcher

### DIFF
--- a/packages/next/src/client/dev/dev-build-watcher.ts
+++ b/packages/next/src/client/dev/dev-build-watcher.ts
@@ -8,8 +8,7 @@ export default function initializeBuildWatcher(
   toggleCallback: (cb: (event: string | { data: string }) => void) => void,
   position = 'bottom-right'
 ) {
-  const type = 'div' as string
-  const shadowHost = document.createElement(type)
+  const shadowHost = document.createElement('div')
   const [verticalProperty, horizontalProperty] = position.split('-') as [
     VerticalPosition,
     HorizonalPosition


### PR DESCRIPTION
I accidentally left this type cast in from previous PR https://github.com/vercel/next.js/pull/54074 but it is unnecessary.