### PR TITLE
correct typo deriving base filename for variable b in sortByPageExts

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -68,7 +68,7 @@ export function sortByPageExts(pageExtensions: string[]) {
     const bExt = extname(b)
 
     const aNoExt = a.substring(0, a.length - aExt.length)
-    const bNoExt = a.substring(0, b.length - bExt.length)
+    const bNoExt = b.substring(0, b.length - bExt.length)
 
     if (aNoExt !== bNoExt) return 0
 


### PR DESCRIPTION
fixes a typo from https://github.com/vercel/next.js/commit/7d67f00f8fabb9044ec445d8aebed88c5f6d0f19
