### PR TITLE
Testmode: intercept rewrite fetches

### DIFF
--- a/packages/next/src/experimental/testmode/playwright/msw.ts
+++ b/packages/next/src/experimental/testmode/playwright/msw.ts
@@ -61,12 +61,17 @@ export const test = base.extend<{
           referrer,
           referrerPolicy,
         })
+        let isUnhandled = false
         let isPassthrough = false
         let mockedResponse: MockedResponse | undefined
         await handleRequest(
           mockedRequest,
           handlers.slice(0),
-          { onUnhandledRequest: 'error' },
+          {
+            onUnhandledRequest: () => {
+              isUnhandled = true
+            },
+          },
           emitter as any,
           {
             onPassthroughResponse: () => {
@@ -78,6 +83,9 @@ export const test = base.extend<{
           }
         )
 
+        if (isUnhandled) {
+          return undefined
+        }
         if (isPassthrough) {
           return 'continue'
         }

--- a/packages/next/src/experimental/testmode/server.ts
+++ b/packages/next/src/experimental/testmode/server.ts
@@ -175,6 +175,6 @@ export function wrapRequestHandlerNode(
       proxyPort,
       testData,
     }
-    await testStorage.run(testReqInfo, () => handler(req, res))
+    await testStorage.run(testReqInfo, () => handler(req, res, parsedUrl))
   }
 }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1073,8 +1073,10 @@ export default class NextNodeServer extends BaseServer {
   public getRequestHandler(): NodeRequestHandler {
     const handler = this.makeRequestHandler()
     if (this.serverOptions.experimentalTestProxy) {
-      const { wrapRequestHandler } = require('../experimental/testmode/server')
-      return wrapRequestHandler(handler)
+      const {
+        wrapRequestHandlerNode,
+      } = require('../experimental/testmode/server')
+      return wrapRequestHandlerNode(handler)
     }
     return handler
   }


### PR DESCRIPTION
The test mode should allow interception of all fetches made by the server, including rewrites.