### PR TITLE
Remove unused startedDevelopmentServer function

### DIFF
--- a/packages/next/src/build/output/index.ts
+++ b/packages/next/src/build/output/index.ts
@@ -107,13 +107,10 @@ let edgeServerWasLoading = false
 buildStore.subscribe((state) => {
   const { amp, client, server, edgeServer, trigger } = state
 
-  const { appUrl } = consoleStore.getState()
-
   if (client.loading || server.loading || edgeServer?.loading) {
     consoleStore.setState(
       {
         bootstrap: false,
-        appUrl: appUrl!,
         loading: true,
         trigger,
       } as OutputState,
@@ -131,7 +128,6 @@ buildStore.subscribe((state) => {
 
   const partialState: Partial<OutputState> = {
     bootstrap: false,
-    appUrl: appUrl!,
     loading: false,
     typeChecking: false,
     partial:

--- a/packages/next/src/build/output/index.ts
+++ b/packages/next/src/build/output/index.ts
@@ -129,7 +129,7 @@ buildStore.subscribe((state) => {
 
   buildWasDone = true
 
-  let partialState: Partial<OutputState> = {
+  const partialState: Partial<OutputState> = {
     bootstrap: false,
     appUrl: appUrl!,
     loading: false,

--- a/packages/next/src/build/output/index.ts
+++ b/packages/next/src/build/output/index.ts
@@ -7,10 +7,6 @@ import { OutputState, store as consoleStore } from './store'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { CompilerNameValues, COMPILER_NAMES } from '../../shared/lib/constants'
 
-export function startedDevelopmentServer(appUrl: string, bindAddr: string) {
-  consoleStore.setState({ appUrl, bindAddr })
-}
-
 type CompilerDiagnostics = {
   modules: number
   errors: string[] | null

--- a/packages/next/src/build/output/store.ts
+++ b/packages/next/src/build/output/store.ts
@@ -9,8 +9,8 @@ import {
 import * as Log from './log'
 
 export type OutputState =
-  | { bootstrap: true; appUrl: string | null; bindAddr: string | null }
-  | ({ bootstrap: false; appUrl: string | null; bindAddr: string | null } & (
+  | { bootstrap: true; appUrl: string | null }
+  | ({ bootstrap: false; appUrl: string | null } & (
       | {
           loading: true
           trigger: string | undefined
@@ -28,11 +28,10 @@ export type OutputState =
 
 export const store = createStore<OutputState>({
   appUrl: null,
-  bindAddr: null,
   bootstrap: true,
 })
 
-let lastStore: OutputState = { appUrl: null, bindAddr: null, bootstrap: true }
+let lastStore: OutputState = { appUrl: null, bootstrap: true }
 function hasStoreChanged(nextStore: OutputState) {
   if (
     (

--- a/packages/next/src/build/output/store.ts
+++ b/packages/next/src/build/output/store.ts
@@ -9,8 +9,8 @@ import {
 import * as Log from './log'
 
 export type OutputState =
-  | { bootstrap: true; appUrl: string | null }
-  | ({ bootstrap: false; appUrl: string | null } & (
+  | { bootstrap: true }
+  | ({ bootstrap: false } & (
       | {
           loading: true
           trigger: string | undefined
@@ -27,11 +27,10 @@ export type OutputState =
     ))
 
 export const store = createStore<OutputState>({
-  appUrl: null,
   bootstrap: true,
 })
 
-let lastStore: OutputState = { appUrl: null, bootstrap: true }
+let lastStore: OutputState = { bootstrap: true }
 function hasStoreChanged(nextStore: OutputState) {
   if (
     (

--- a/packages/next/src/build/output/store.ts
+++ b/packages/next/src/build/output/store.ts
@@ -55,10 +55,12 @@ store.subscribe((state) => {
     return
   }
 
+  // This condition is always false because
+  // 1. `.subscribe()` listener is only fired when `.setState()` happens, not on `createStore()` initialization
+  // 2. `.setState()` is always called with `bootstrap: false` explicitly.
+  //
+  // This `if` block only acts as a type guard
   if (state.bootstrap) {
-    if (state.appUrl) {
-      Log.ready(`started server on ${state.bindAddr}, url: ${state.appUrl}`)
-    }
     return
   }
 


### PR DESCRIPTION
## Why

I was trying to add another edit #54294 and searching for where the message "started server on ..., url: ..." is printed and I found two places. But one of them seem to be unreachable.

## What's changed?

These changes are added in sequence (mapped to each commits of this PR):

1. The `startedDevelopmentServer` function declared in [`packages/next/src/build/output/index.ts`](https://github.com/vercel/next.js/pull/54272/files#diff-ecb0329373eaa18c7242af1866659194a88311ee0829775a98fafc51b557eeef) is never called anywhere, per search results and "Go to references" results, so it's removed.
2. It turns out that `consoleStore.setState` is always called with `bootstrap: false` (the only place where it's called with `bootstrap` omitted was in `startDevelopmentServer` which is removed now), so the unreachable statements in `if (state.bootstrap)` block are removed
3. It also turns out that `OutputState.bindAddr` is never read or set (the only place where it used to be set was in `startDevelopmentServer` which is removed now, and the only place it used to be read was in that unreachable `if` branch), so it's removed from `OutputState` declaration and every `OutputState` instances.
4. `OutputState.appUrl` is never used either (the only place where it used to be read and set was setting it to be the same value), so it's removed from `OutputState` declaration and every `OutputState` instances.