### PR TITLE
docs: Bump minimum Node.js version to 16.14

### DIFF
--- a/docs/02-app/01-building-your-application/09-upgrading/02-app-router-migration.mdx
+++ b/docs/02-app/01-building-your-application/09-upgrading/02-app-router-migration.mdx
@@ -14,7 +14,7 @@ This guide will help you:
 
 ### Node.js Version
 
-The minimum Node.js version is now **v16.8**. See the [Node.js documentation](https://nodejs.org/docs/latest-v16.x/api/) for more information.
+The minimum Node.js version is now **v16.14**. See the [Node.js documentation](https://nodejs.org/docs/latest-v16.x/api/) for more information.
 
 ### Next.js Version
 


### PR DESCRIPTION
### What?

Docs change.

### Why?

- https://github.com/vercel/next.js/issues/54269

### How?

Bump the Node.js version shown at: https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#nodejs-version 

Fixes #54269
