### PR TITLE
Print dev server url with basePath

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -305,6 +305,7 @@ const nextDev: CliCommand = async (argv) => {
     allowRetry,
     isDev: true,
     hostname: host,
+    basePath: config.basePath,
     isExperimentalTestProxy,
   }
 

--- a/packages/next/src/cli/next-start.ts
+++ b/packages/next/src/cli/next-start.ts
@@ -6,6 +6,8 @@ import { getPort, printAndExit } from '../server/lib/utils'
 import { getProjectDir } from '../lib/get-project-dir'
 import { CliCommand } from '../lib/commands'
 import { getValidatedArgs } from '../lib/get-validated-args'
+import loadConfig from '../server/config'
+import { PHASE_PRODUCTION_SERVER } from '../shared/lib/constants'
 
 const nextStart: CliCommand = async (argv) => {
   const validArgs: arg.Spec = {
@@ -66,12 +68,15 @@ const nextStart: CliCommand = async (argv) => {
     ? Math.ceil(keepAliveTimeoutArg)
     : undefined
 
+  const config = await loadConfig(PHASE_PRODUCTION_SERVER, dir)
+
   await startServer({
     dir,
     isDev: false,
     isExperimentalTestProxy,
     hostname: host,
     port,
+    basePath: config.basePath,
     keepAliveTimeout,
   })
 }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -15,6 +15,8 @@ import {
   WorkerUpgradeHandler,
 } from './setup-server-worker'
 import { checkIsNodeDebugging } from './is-node-debugging'
+import type { NextConfigComplete } from '../config-shared'
+
 const debug = setupDebug('next:start-server')
 
 export interface StartServerOptions {
@@ -23,6 +25,7 @@ export interface StartServerOptions {
   logReady?: boolean
   isDev: boolean
   hostname: string
+  basePath: NextConfigComplete['basePath']
   allowRetry?: boolean
   customServer?: boolean
   minimalMode?: boolean
@@ -72,6 +75,7 @@ export async function startServer({
   port,
   isDev,
   hostname,
+  basePath,
   minimalMode,
   allowRetry,
   keepAliveTimeout,
@@ -197,7 +201,7 @@ export async function startServer({
       port = typeof addr === 'object' ? addr?.port || port : port
       const appUrl = `${
         selfSignedCertificate ? 'https' : 'http'
-      }://${formattedHostname}:${port}`
+      }://${formattedHostname}:${port}${basePath}`
 
       if (isNodeDebugging) {
         const debugPort = getDebugPort()


### PR DESCRIPTION
Append `basePath` to the dev server url printed in the console, so that user doesn't get 404 page 
when clicking the link to open browser.
