### PR TITLE
add test case for CSP with bootstrap scripts and preinit modules

### DIFF
--- a/test/e2e/app-dir/app/app/bootstrap/[[...*]]/ClientComponent.js
+++ b/test/e2e/app-dir/app/app/bootstrap/[[...*]]/ClientComponent.js
@@ -1,0 +1,11 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export function ClientComponent() {
+  const [val, setVal] = useState('initial')
+  useEffect(() => {
+    setVal('[[updated]]')
+  }, [])
+  return <span id="val">{val}</span>
+}

--- a/test/e2e/app-dir/app/app/bootstrap/[[...*]]/page.js
+++ b/test/e2e/app-dir/app/app/bootstrap/[[...*]]/page.js
@@ -1,0 +1,15 @@
+import { ClientComponent } from './ClientComponent'
+
+export default async function Page() {
+  return (
+    <>
+      <div>
+        This fixture is to assert where the bootstrap scripts and other required
+        scripts emit during SSR
+      </div>
+      <div>
+        <ClientComponent />
+      </div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/bootstrap/page.js
+++ b/test/e2e/app-dir/app/app/bootstrap/page.js
@@ -1,8 +1,0 @@
-export default async function Page() {
-  return (
-    <div>
-      This fixture is to assert where the bootstrap scripts and other required
-      scripts emit during SSR
-    </div>
-  )
-}

--- a/test/e2e/app-dir/app/middleware.js
+++ b/test/e2e/app-dir/app/middleware.js
@@ -3,9 +3,9 @@ import { NextResponse } from 'next/server'
 
 /**
  * @param {import('next/server').NextRequest} request
- * @returns {NextResponse | undefined}
+ * @returns {Promise<NextResponse | undefined>}
  */
-export function middleware(request) {
+export async function middleware(request) {
   if (request.nextUrl.pathname === '/searchparams-normalization-bug') {
     const headers = new Headers(request.headers)
     headers.set('test', request.nextUrl.searchParams.get('val') || '')
@@ -23,6 +23,17 @@ export function middleware(request) {
 
   if (request.nextUrl.pathname === '/middleware-to-dashboard') {
     return NextResponse.rewrite(new URL('/dashboard', request.url))
+  }
+
+  // In dev this route will fail to bootstrap because webpack uses eval which is dissallowed by
+  // this policy. In production this route will work
+  if (request.nextUrl.pathname === '/bootstrap/with-nonce') {
+    const nonce = crypto.randomUUID()
+    return NextResponse.next({
+      headers: {
+        'Content-Security-Policy': `script-src 'nonce-${nonce}' 'strict-dynamic';`,
+      },
+    })
   }
 
   if (request.nextUrl.pathname.startsWith('/internal/test')) {


### PR DESCRIPTION
in #54059 the nonce attribute was added to preinitialized scripts to when using this CSP directive. The test added asserts there is at least one script that has the nonce attribute. I've changed this to 2 because currently our builds produce at least two "main" scripts, the main chunk and the webpack runtime. The way we bootstrap there is always exactly one bootstrap script which means if we only assert that there is one script with a nonce we might not be asserting anything about the preinit script path. If we ever update our webpack config to produce a single main script this test will fail but we should never do that (it's bad for caching) and so it shouldn't happen and if it does it will hopefully force us to consider if we're making a mistake

Additionally I've added another test that is more e2e. it asserts that the page bootstraps even when using CSP (in prod). In Dev it asserts the CSP attributes but it expects the bootstrap to fail because our dev mode violates the CSP directive with eval.