### PR TITLE
Skip getStaticPaths check for non-dynamic app routes

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1443,6 +1443,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     let staticPaths: string[] | undefined
 
     let fallbackMode: FallbackMode
+    let hasFallback = false
     const isDynamic = isDynamicRoute(components.pathname)
 
     if (isAppPath && isDynamic) {
@@ -1454,8 +1455,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
       staticPaths = pathsResult.staticPaths
       fallbackMode = pathsResult.fallbackMode
-
-      const hasFallback = typeof fallbackMode !== 'undefined'
+      hasFallback = typeof fallbackMode !== 'undefined'
 
       if (this.nextConfig.output === 'export') {
         const page = components.pathname

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1443,8 +1443,9 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     let staticPaths: string[] | undefined
 
     let fallbackMode: FallbackMode
+    const isDynamic = isDynamicRoute(components.pathname)
 
-    if (isAppPath && isDynamicRoute(pathname)) {
+    if (isAppPath && isDynamic) {
       const pathsResult = await this.getStaticPaths({
         pathname,
         originalAppPath: components.pathname,
@@ -1458,39 +1459,36 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
       if (this.nextConfig.output === 'export') {
         const page = components.pathname
-        const isDynamic = isDynamicRoute(page)
-        if (isDynamic) {
-          if (fallbackMode !== 'static') {
-            throw new Error(
-              `Page "${page}" is missing exported function "generateStaticParams()", which is required with "output: export" config.`
-            )
-          }
-          const resolvedWithoutSlash = removeTrailingSlash(resolvedUrlPathname)
-          if (!staticPaths?.includes(resolvedWithoutSlash)) {
-            throw new Error(
-              `Page "${page}" is missing param "${resolvedWithoutSlash}" in "generateStaticParams()", which is required with "output: export" config.`
-            )
-          }
+
+        if (fallbackMode !== 'static') {
+          throw new Error(
+            `Page "${page}" is missing exported function "generateStaticParams()", which is required with "output: export" config.`
+          )
+        }
+        const resolvedWithoutSlash = removeTrailingSlash(resolvedUrlPathname)
+        if (!staticPaths?.includes(resolvedWithoutSlash)) {
+          throw new Error(
+            `Page "${page}" is missing param "${resolvedWithoutSlash}" in "generateStaticParams()", which is required with "output: export" config.`
+          )
         }
       }
 
       if (hasFallback) {
         hasStaticPaths = true
       }
+    }
 
-      if (
-        hasFallback ||
-        staticPaths?.includes(resolvedUrlPathname) ||
-        // this signals revalidation in deploy environments
-        // TODO: make this more generic
-        req.headers['x-now-route-matches']
-      ) {
-        isSSG = true
-      } else if (!this.renderOpts.dev) {
-        const manifest = this.getPrerenderManifest()
-        isSSG =
-          isSSG || !!manifest.routes[pathname === '/index' ? '/' : pathname]
-      }
+    if (
+      typeof fallbackMode !== 'undefined' ||
+      staticPaths?.includes(resolvedUrlPathname) ||
+      // this signals revalidation in deploy environments
+      // TODO: make this more generic
+      req.headers['x-now-route-matches']
+    ) {
+      isSSG = true
+    } else if (!this.renderOpts.dev) {
+      const manifest = this.getPrerenderManifest()
+      isSSG = isSSG || !!manifest.routes[pathname === '/index' ? '/' : pathname]
     }
 
     // Toggle whether or not this is a Data request

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1444,7 +1444,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
     let fallbackMode: FallbackMode
 
-    if (isAppPath) {
+    if (isAppPath && isDynamicRoute(pathname)) {
       const pathsResult = await this.getStaticPaths({
         pathname,
         originalAppPath: components.pathname,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1479,7 +1479,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     }
 
     if (
-      typeof fallbackMode !== 'undefined' ||
+      hasFallback ||
       staticPaths?.includes(resolvedUrlPathname) ||
       // this signals revalidation in deploy environments
       // TODO: make this more generic


### PR DESCRIPTION
We don't need to apply this check for non-dynamic app routes so this adds a check to skip it when not necessary. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1692366432958709)