### PR TITLE
Fix missing locale info for middleware data request

### DIFF
--- a/test/e2e/skip-trailing-slash-redirect/app/middleware.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/middleware.js
@@ -18,6 +18,13 @@ export default function handler(req) {
   console.log(req.nextUrl)
   let { pathname } = req.nextUrl
 
+  if (pathname.startsWith('/_next/data') && pathname.includes('locale-test')) {
+    return NextResponse.json({
+      locale: req.nextUrl.locale,
+      pathname: req.nextUrl.pathname,
+    })
+  }
+
   if (pathname.includes('docs') || pathname.includes('chained-rewrite')) {
     if (pathname.startsWith('/en')) {
       pathname = pathname.replace(/^\/en/, '') || '/'

--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -16,6 +16,16 @@ describe('skip-trailing-slash-redirect', () => {
   })
   afterAll(() => next.destroy())
 
+  it('should parse locale info for data request correctly', async () => {
+    const pathname = `/_next/data/${next.buildId}/ja-jp/locale-test.json`
+    const res = await next.fetch(pathname)
+
+    expect(await res.json()).toEqual({
+      locale: 'ja-jp',
+      pathname,
+    })
+  })
+
   it.each(['EN', 'JA-JP'])(
     'should be able to redirect locale casing $1',
     async (locale) => {


### PR DESCRIPTION
This ensures we properly populate locale information with `skipMiddlewareUrlNormalize` enabled as we shouldn't provide incorrect values even if we are skipping normalizing. 

Fixes: https://github.com/vercel/next.js/issues/53646