### PR TITLE
Fix swc compiling of client components when directive appears later than exports

### DIFF
--- a/packages/next-swc/crates/core/src/react_server_components.rs
+++ b/packages/next-swc/crates/core/src/react_server_components.rs
@@ -222,6 +222,7 @@ impl<C: Comments> ReactServerComponents<C> {
                             },
                         })
                     }
+                    finished_directives = true;
                 }
                 ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl { decl, .. })) => {
                     match decl {
@@ -240,18 +241,21 @@ impl<C: Comments> ReactServerComponents<C> {
                         }
                         _ => {}
                     }
+                    finished_directives = true;
                 }
                 ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(ExportDefaultDecl {
                     decl: _,
                     ..
                 })) => {
                     self.export_names.push("default".to_string());
+                    finished_directives = true;
                 }
                 ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(ExportDefaultExpr {
                     expr: _,
                     ..
                 })) => {
                     self.export_names.push("default".to_string());
+                    finished_directives = true;
                 }
                 ModuleItem::ModuleDecl(ModuleDecl::ExportAll(_)) => {
                     self.export_names.push("*".to_string());

--- a/packages/next-swc/crates/core/src/react_server_components.rs
+++ b/packages/next-swc/crates/core/src/react_server_components.rs
@@ -70,6 +70,7 @@ impl<C: Comments> VisitMut for ReactServerComponents<C> {
                 self.assert_server_graph(&imports, module);
             } else {
                 self.to_module_ref(module, is_cjs);
+                print!("");
                 return;
             }
         } else {

--- a/packages/next-swc/crates/core/src/react_server_components.rs
+++ b/packages/next-swc/crates/core/src/react_server_components.rs
@@ -70,7 +70,6 @@ impl<C: Comments> VisitMut for ReactServerComponents<C> {
                 self.assert_server_graph(&imports, module);
             } else {
                 self.to_module_ref(module, is_cjs);
-                print!("");
                 return;
             }
         } else {

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/input.js
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/input.js
@@ -3,4 +3,4 @@ export default function () {
 }
 
 // prettier-ignore
-;'use client'
+'use client'

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/input.js
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/input.js
@@ -2,4 +2,6 @@ export default function () {
   return null
 }
 
-;('use client')
+export const runtime = 'edge'
+
+;'use client'

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/input.js
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/input.js
@@ -1,0 +1,5 @@
+export default function () {
+  return null
+}
+
+'use client'

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/input.js
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/input.js
@@ -2,6 +2,5 @@ export default function () {
   return null
 }
 
-export const runtime = 'edge'
-
+// prettier-ignore
 ;'use client'

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/input.js
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/input.js
@@ -2,4 +2,4 @@ export default function () {
   return null
 }
 
-'use client'
+;('use client')

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.js
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.js
@@ -1,0 +1,3 @@
+export default function() {
+    return null;
+}

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.js
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.js
@@ -1,4 +1,5 @@
 export default function() {
     return null;
 }
-export const runtime = 'edge';
+// prettier-ignore
+;

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.js
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.js
@@ -1,3 +1,4 @@
 export default function() {
     return null;
 }
+export const runtime = 'edge';

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.js
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.js
@@ -1,5 +1,3 @@
 export default function() {
     return null;
 }
-// prettier-ignore
-;

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.stderr
@@ -1,0 +1,7 @@
+
+  x NEXT_RSC_ERR_CLIENT_DIRECTIVE
+   ,-[input.js:4:1]
+ 4 | 
+ 5 | 'use client'
+   : ^^^^^^^^^^^^
+   `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.stderr
@@ -2,6 +2,6 @@
   x NEXT_RSC_ERR_CLIENT_DIRECTIVE
    ,-[input.js:5:1]
  5 | // prettier-ignore
- 6 | ;'use client'
-   :  ^^^^^^^^^^^^
+ 6 | 'use client'
+   : ^^^^^^^^^^^^
    `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.stderr
@@ -1,7 +1,7 @@
 
   x NEXT_RSC_ERR_CLIENT_DIRECTIVE
-   ,-[input.js:4:1]
- 4 | 
- 5 | 'use client'
-   : ^^^^^^^^^^^^
+   ,-[input.js:6:1]
+ 6 | 
+ 7 | ;'use client'
+   :  ^^^^^^^^^^^^
    `----

--- a/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.stderr
+++ b/packages/next-swc/crates/core/tests/errors/react-server-components/server-graph/fake-client-entry/output.stderr
@@ -1,7 +1,7 @@
 
   x NEXT_RSC_ERR_CLIENT_DIRECTIVE
-   ,-[input.js:6:1]
- 6 | 
- 7 | ;'use client'
+   ,-[input.js:5:1]
+ 5 | // prettier-ignore
+ 6 | ;'use client'
    :  ^^^^^^^^^^^^
    `----


### PR DESCRIPTION
When `"use client"` directive appears after other statements, it should be ignored instead of treat as client components. There's a bug inside swc transform that we should mark the directives detection is "finished" after other non string literals directives AST nodes are detected before the first directive

x-ref: https://github.com/vercel/next.js/pull/54358#discussion_r1300740950