### PR TITLE
code fixed that redefines the response.end as async at with-passport-and-next-connect #51628

### DIFF
--- a/errors/fixes-for-with-passport-and-next-connect.md
+++ b/errors/fixes-for-with-passport-and-next-connect.md
@@ -1,0 +1,21 @@
+---
+title: middleware keeps redefining response.end as async
+---
+
+## ``
+
+#### Why This Error Occurred
+
+<!-- Explain why the error occurred. Ensure the description makes it clear why the warning/error exists -->
+
+asynchronous handling of res.end using async/await keyword
+
+#### Possible Ways to Fix It
+
+<!-- Explain how to fix the warning/error, potentially by providing alternative approaches. Ensure this section is actionable by users -->
+
+remove the async keyword from the function definition
+
+### Useful Links
+
+<!-- Add links to relevant documentation -->

--- a/examples/with-passport-and-next-connect/lib/session.js
+++ b/examples/with-passport-and-next-connect/lib/session.js
@@ -29,13 +29,13 @@ export default function session({ name, secret, cookie: cookieOpts }) {
 
     // We are proxying res.end to commit the session cookie
     const oldEnd = res.end
-    res.end = async function resEndProxy(...args) {
+    res.end = function resEndProxy(...args) {
       if (res.finished || res.writableEnded || res.headersSent) return
       if (cookieOpts.maxAge) {
         req.session.maxAge = cookieOpts.maxAge
       }
 
-      const token = await createLoginSession(req.session, secret)
+      const token = createLoginSession(req.session, secret)
 
       res.setHeader('Set-Cookie', serialize(name, token, cookieOpts))
       oldEnd.apply(this, args)


### PR DESCRIPTION
- Fixes #51628 