### PR TITLE
Add `webpack.Configuration` type to `next.config.js`

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -131,7 +131,7 @@ export interface WebpackConfigContext {
   /** Number of total Next.js pages */
   totalPages: number
   /** The webpack configuration */
-  webpack: any
+  webpack: webpack.Configuration
   /** The current server runtime */
   nextRuntime?: 'nodejs' | 'edge'
 }
@@ -139,7 +139,7 @@ export interface WebpackConfigContext {
 export interface NextJsWebpackConfig {
   (
     /** Existing Webpack config */
-    config: any,
+    config: webpack.Configuration,
     context: WebpackConfigContext
   ): any
 }


### PR DESCRIPTION
I noticed the type for the Webpack configuration was missing.
I opened this PR in case this wasn't intentional.
It probably is intentional but with the codebase being so huge there's no way I could ever find the reason, if there's a reason for this missing type and there's anything I can do to help, please let me know!
Thanks :)