### PR TITLE
Fix missing new line for certain logs

### DIFF
--- a/packages/next/src/build/output/log.ts
+++ b/packages/next/src/build/output/log.ts
@@ -8,40 +8,66 @@ export const prefixes = {
   info: '- ' + chalk.cyan('info'),
   event: '- ' + chalk.magenta('event'),
   trace: '- ' + chalk.magenta('trace'),
+} as const
+
+const LOGGING_METHOD = {
+  log: 'log',
+  warn: 'warn',
+  error: 'error',
+} as const
+
+function prefixedLog(prefixType: keyof typeof prefixes, ...message: any[]) {
+  if ((message[0] === '' || message[0] === undefined) && message.length === 1) {
+    message.shift()
+  }
+
+  const consoleMethod: keyof typeof LOGGING_METHOD =
+    prefixType in LOGGING_METHOD
+      ? LOGGING_METHOD[prefixType as keyof typeof LOGGING_METHOD]
+      : 'log'
+
+  const prefix = prefixes[prefixType]
+  // If there's no message, don't print the prefix but a new line
+  if (message.length === 0) {
+    console[consoleMethod]('')
+  } else {
+    console[consoleMethod](prefix, ...message)
+  }
 }
 
 export function wait(...message: any[]) {
-  console.log(prefixes.wait, ...message)
+  prefixedLog('wait', ...message)
 }
 
 export function error(...message: any[]) {
-  console.error(prefixes.error, ...message)
+  prefixedLog('error', ...message)
 }
 
 export function warn(...message: any[]) {
-  console.warn(prefixes.warn, ...message)
+  prefixedLog('warn', ...message)
 }
 
 export function ready(...message: any[]) {
-  console.log(prefixes.ready, ...message)
+  prefixedLog('ready', ...message)
 }
 
 export function info(...message: any[]) {
-  console.log(prefixes.info, ...message)
+  prefixedLog('info', ...message)
 }
 
 export function event(...message: any[]) {
-  console.log(prefixes.event, ...message)
+  prefixedLog('event', ...message)
 }
 
 export function trace(...message: any[]) {
-  console.log(prefixes.trace, ...message)
+  prefixedLog('trace', ...message)
 }
 
 const warnOnceMessages = new Set()
 export function warnOnce(...message: any[]) {
   if (!warnOnceMessages.has(message[0])) {
     warnOnceMessages.add(message.join(' '))
+
     warn(...message)
   }
 }

--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -210,6 +210,7 @@ async function lint(
         eslint = new ESLint(options)
       }
     } else {
+      Log.warn('')
       Log.warn(
         'The Next.js plugin was not detected in your ESLint configuration. See https://nextjs.org/docs/basic-features/eslint#migrating-existing-config'
       )

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -32,8 +32,9 @@ export function getSocialImageFallbackMetadataBase(
   }
 
   if (isMetadataBaseMissing) {
+    Log.warnOnce('')
     Log.warnOnce(
-      `\nmetadata.metadataBase is not set for resolving social open graph or twitter images, using "${fallbackMetadata.origin}". See https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase`
+      `metadata.metadataBase is not set for resolving social open graph or twitter images, using "${fallbackMetadata.origin}". See https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase`
     )
   }
 


### PR DESCRIPTION
When logging are sending from worker they're missing new line, that could be directly added after to spinner

#### After
![image](https://github.com/vercel/next.js/assets/4800338/c4494ff8-0335-49e3-8cce-2f9dc1fe7975)

#### Before
![image](https://github.com/vercel/next.js/assets/4800338/bcf3e27d-de39-4e27-ac57-09c922c09ecc)

