### PR TITLE
Decreased watchpack aggregate timeout

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev.ts
@@ -91,15 +91,8 @@ import type { RenderWorkers } from '../router-server'
  * This is the timeout for which the watchpack will emit the `aggregate` event
  * after file changes are made. This is to prevent unnecessary rebuilds when
  * multiple files are changed at once.
- *
- * This defaults to a value, but can be overridden by setting the
- * `NEXT_DEV_WATCHPACK_AGGREGATE_TIMEOUT` environment variable to a value in
- * milliseconds. For example, to set the timeout to 100 milliseconds: `100`.
  */
-const WATCHPACK_AGGREGATE_TIMEOUT = process.env
-  .NEXT_DEV_WATCHPACK_AGGREGATE_TIMEOUT
-  ? parseInt(process.env.NEXT_DEV_WATCHPACK_AGGREGATE_TIMEOUT, 10)
-  : 50
+const WATCHPACK_AGGREGATE_TIMEOUT = 5
 
 type SetupOpts = {
   renderWorkers: RenderWorkers

--- a/packages/next/src/server/lib/router-utils/setup-dev.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev.ts
@@ -87,6 +87,20 @@ import { MiddlewareManifest } from '../../../build/webpack/plugins/middleware-pl
 import { devPageFiles } from '../../../build/webpack/plugins/next-types-plugin/shared'
 import type { RenderWorkers } from '../router-server'
 
+/**
+ * This is the timeout for which the watchpack will emit the `aggregate` event
+ * after file changes are made. This is to prevent unnecessary rebuilds when
+ * multiple files are changed at once.
+ *
+ * This defaults to a value, but can be overridden by setting the
+ * `NEXT_DEV_WATCHPACK_AGGREGATE_TIMEOUT` environment variable to a value in
+ * milliseconds. For example, to set the timeout to 100 milliseconds: `100`.
+ */
+const WATCHPACK_AGGREGATE_TIMEOUT = process.env
+  .NEXT_DEV_WATCHPACK_AGGREGATE_TIMEOUT
+  ? parseInt(process.env.NEXT_DEV_WATCHPACK_AGGREGATE_TIMEOUT, 10)
+  : 50
+
 type SetupOpts = {
   renderWorkers: RenderWorkers
   dir: string
@@ -780,6 +794,7 @@ async function startWatcher(opts: SetupOpts) {
     files.push(...tsconfigPaths)
 
     const wp = new Watchpack({
+      aggregateTimeout: WATCHPACK_AGGREGATE_TIMEOUT,
       ignored: (pathname: string) => {
         return (
           !files.some((file) => file.startsWith(pathname)) &&


### PR DESCRIPTION
This decreases the aggregate event timeout for WatchPack in development to `5ms` which should improve the performance of reloading routes for users developing Next.js applications.