### PR TITLE
Update install-native script to avoid pnpm cache

### DIFF
--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -59,7 +59,7 @@ import fs from 'fs-extra'
       JSON.stringify(pkgJson)
     )
     await fs.writeFile(path.join(tmpdir, '.npmrc'), 'node-linker=hoisted')
-    let { stdout } = await execa('pnpm', ['install'], {
+    let { stdout } = await execa('pnpm', ['add', 'next@canary'], {
       cwd: tmpdir,
     })
     console.log(stdout)


### PR DESCRIPTION
Seems this sometimes pulls from pnpm cache instead of checking for newer canary version so this updates to use `pnpm add` instead which should help here.