### PR TITLE
feat(eslint-plugin-next): add `pageExtensions` option

### DIFF
--- a/errors/no-html-link-for-pages.mdx
+++ b/errors/no-html-link-for-pages.mdx
@@ -44,6 +44,26 @@ export default Home
 
 ### Options
 
+The rule accepts the following options:
+
+```ts
+type NoHTMLLinkForPagesOptions =
+  | string
+  | string[]
+  | {
+      pagesDir?: string | string[]
+      pageExtensions?: string | string[]
+    }
+```
+
+The values can be:
+
+- `string` - It's equivalent to the `pagesDir` argument.
+- `string[]` - It's equivalent to the `pagesDir` argument.
+- An object with the following properties:
+  - `pagesDir` - a path to a directory or an array of paths to directories
+  - `pageExtensions` - a string or an array of strings representing the extensions of the page files
+
 #### `pagesDir`
 
 This rule can normally locate your `pages` directory automatically.
@@ -52,14 +72,39 @@ If you're working in a monorepo, we recommend configuring the [`rootDir`](/docs/
 
 In some cases, you may also need to configure this rule directly by providing a `pages` directory. This can be a path or an array of paths.
 
-```json filename="eslint.config.json"
-{
-  "rules": {
-    "@next/next/no-html-link-for-pages": ["error", "packages/my-app/pages/"]
-  }
+```js filename=".eslintrc.js" highlight={3}
+module.exports = {
+  rules: {
+    '@next/next/no-html-link-for-pages': ['error', 'packages/foo/pages/'],
+    // or
+    // "@next/next/no-html-link-for-pages": ["error", { pagesDir: "packages/foo/pages/" }],
+  },
+}
+```
+
+#### `pageExtensions`
+
+If you set the [`pageExtensions`](/docs/app/api-reference/next-config-js/pageExtensions) config, this rule will not work and the `pageExtensions` option must be set for it to work.
+
+```js filename="next.config.js" highlight={3}
+/** @type {import('next').NextConfig} */
+module.exports = {
+  pageExtensions: ['page.tsx', 'mdx'],
+}
+```
+
+```js filename=".eslintrc.js" highlight={5}
+module.exports = {
+  rules: {
+    '@next/next/no-html-link-for-pages': [
+      'error',
+      { pageExtensions: ['page.tsx', 'mdx'] },
+    ],
+  },
 }
 ```
 
 ## Useful Links
 
 - [next/link API Reference](/docs/pages/api-reference/components/link)
+- [next.config.js Options: pageExtensions](/docs/app/api-reference/next-config-js/pageExtensions)

--- a/packages/eslint-plugin-next/src/utils/get-rule-options.ts
+++ b/packages/eslint-plugin-next/src/utils/get-rule-options.ts
@@ -1,0 +1,42 @@
+import type { Rule } from 'eslint'
+
+type RuleOption =
+  | string
+  | string[]
+  | {
+      pagesDir?: string | string[]
+      pageExtensions?: string | string[]
+    }
+
+/**
+ * Gets the rule options.
+ */
+export default function getRuleOptions(context: Rule.RuleContext) {
+  const options: RuleOption | undefined = context.options?.[0]
+
+  let pagesDir: string[] = []
+  let pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
+
+  if (typeof options === 'string') {
+    pagesDir = [options]
+  } else if (Array.isArray(options)) {
+    pagesDir = options
+  } else if (typeof options === 'object' && options !== null) {
+    if (typeof options.pagesDir === 'string') {
+      pagesDir = [options.pagesDir]
+    } else if (Array.isArray(options.pagesDir)) {
+      pagesDir = options.pagesDir
+    }
+
+    if (typeof options.pageExtensions === 'string') {
+      pageExtensions = [options.pageExtensions]
+    } else if (Array.isArray(options.pageExtensions)) {
+      pageExtensions = options.pageExtensions
+    }
+  }
+
+  return {
+    pagesDir,
+    pageExtensions,
+  }
+}

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -15,8 +15,11 @@ const withAppLinter = new Linter({
 const withCustomPagesLinter = new Linter({
   cwd: withCustomPagesDirectory,
 })
+const withPagesAndExtensionsLinter = new Linter({
+  cwd: path.join(__dirname, 'with-pages-and-extensions'),
+})
 
-const linterConfig: any = {
+const linterConfig: Linter.Config = {
   rules: {
     'no-html-link-for-pages': [2],
   },
@@ -29,7 +32,7 @@ const linterConfig: any = {
     },
   },
 }
-const linterConfigWithCustomDirectory: any = {
+const linterConfigWithCustomDirectory: Linter.Config = {
   ...linterConfig,
   rules: {
     'no-html-link-for-pages': [
@@ -38,7 +41,7 @@ const linterConfigWithCustomDirectory: any = {
     ],
   },
 }
-const linterConfigWithMultipleDirectories = {
+const linterConfigWithMultipleDirectories: Linter.Config = {
   ...linterConfig,
   rules: {
     'no-html-link-for-pages': [
@@ -51,6 +54,18 @@ const linterConfigWithMultipleDirectories = {
   },
 }
 
+const linterConfigWithPagesAndPageExtensions: Linter.Config = {
+  ...linterConfig,
+  rules: {
+    'no-html-link-for-pages': [
+      2,
+      {
+        pageExtensions: ['page.tsx'],
+      },
+    ],
+  },
+}
+
 withoutPagesLinter.defineRules({
   'no-html-link-for-pages': rule,
 })
@@ -58,6 +73,9 @@ withAppLinter.defineRules({
   'no-html-link-for-pages': rule,
 })
 withCustomPagesLinter.defineRules({
+  'no-html-link-for-pages': rule,
+})
+withPagesAndExtensionsLinter.defineRules({
   'no-html-link-for-pages': rule,
 })
 
@@ -204,6 +222,39 @@ export class Blah extends Head {
     return (
       <div>
         <a href='/list/lorem-ipsum/'>Homepage</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+
+const invalidStaticRouterWithPageExtensionsCode = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href="/">Homepage</a>
+        <a href="/about">About</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+
+const validStaticRouterWithPageExtensionsCode = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <Link href="/">Homepage</Link>
+        <Link href="/about">About</Link>
+        <a href="/component">Component</a>
         <h1>Hello title</h1>
       </div>
     );
@@ -369,5 +420,35 @@ describe('no-html-link-for-pages', function () {
       thirdReport.message,
       'Do not use an `<a>` element to navigate to `/list/lorem-ipsum/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
+  })
+
+  it('invalid static route with pageExtensions', function () {
+    const report = withPagesAndExtensionsLinter.verify(
+      invalidStaticRouterWithPageExtensionsCode,
+      linterConfigWithPagesAndPageExtensions,
+      {
+        filename: 'foo.js',
+      }
+    )
+    assert.equal(report.length, 2)
+    assert.equal(
+      report[0].message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+    assert.equal(
+      report[1].message,
+      'Do not use an `<a>` element to navigate to `/about/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+
+  it('valid static route with pageExtensions', function () {
+    const report = withPagesAndExtensionsLinter.verify(
+      validStaticRouterWithPageExtensionsCode,
+      linterConfigWithPagesAndPageExtensions,
+      {
+        filename: 'foo.js',
+      }
+    )
+    assert.deepEqual(report, [])
   })
 })

--- a/test/unit/eslint-plugin-next/with-pages-and-extensions/pages/about.page.tsx
+++ b/test/unit/eslint-plugin-next/with-pages-and-extensions/pages/about.page.tsx
@@ -1,0 +1,1 @@
+export default function About() {}

--- a/test/unit/eslint-plugin-next/with-pages-and-extensions/pages/component.tsx
+++ b/test/unit/eslint-plugin-next/with-pages-and-extensions/pages/component.tsx
@@ -1,0 +1,1 @@
+export default function Component() {}

--- a/test/unit/eslint-plugin-next/with-pages-and-extensions/pages/index.page.tsx
+++ b/test/unit/eslint-plugin-next/with-pages-and-extensions/pages/index.page.tsx
@@ -1,0 +1,1 @@
+export default function Home() {}


### PR DESCRIPTION
## For Contributors

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- [x] The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- [x] Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Adding a feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- [x] Related issues/discussions are linked using `fixes #number`
- [ ] e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [x] Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- [x] Minimal description (aim for explaining to someone not on the team to understand the PR)
- [ ] When linking to a Slack thread, you might want to share details of the conclusion
- [x] Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- [ ] Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

This PR is to fix a problem where @next/next/no-html-link-for-pages doesn't work when [pageExtensions](https://nextjs.org/docs/pages/api-reference/next-config-js/pageExtensions) are configured.

As to why a new option should be provided, [see the commend](https://github.com/vercel/next.js/issues/53473#issuecomment-1664118826).

### How?

An ESLint option called pageExtensions is provided.

### Options Type

The rule accepts the following options:

```ts
type NoHTMLLinkForPagesOptions =
  | string
  | string[]
  | {
      pagesDir?: string | string[]
      pageExtensions?: string | string[]
    }
```
The values can be:
- `string` - It's equivalent to the `pagesDir` argument.
- `string[]` - It's equivalent to the `pagesDir` argument.
- An object with the following properties:
  - `pagesDir` - a path to a directory or an array of paths to directories
  - `pageExtensions` - a string or an array of strings representing the extensions of the page files

### Usage

If you set the [`pageExtensions`](/docs/app/api-reference/next-config-js/pageExtensions) config, this rule will not work and the `pageExtensions` option must be set for it to work.

```js
// next.config.js
/** @type {import('next').NextConfig} */
module.exports = {
  pageExtensions: ['page.tsx', 'mdx'],
}
```

```js
// .eslintrc.js
module.exports = {
  rules: {
    '@next/next/no-html-link-for-pages': [
      'error',
      { pageExtensions: ['page.tsx', 'mdx'] },
    ],
  },
}
}
```

Fixes #53473