### PR TITLE
docs: add media atrribute for generateMetadata icons

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -650,6 +650,11 @@ export const metadata = {
 }
 ```
 
+```html filename="<head> output" hideLineNumbers
+<link rel="icon" href="/light-icon.png" media="(prefers-color-scheme: light)" />
+<link rel="icon" href="/dark-icon.png" media="(prefers-color-scheme: dark)" />
+```
+
 > **Good to know**: The `msapplication-*` meta tags are no longer supported in Chromium builds of Microsoft Edge, and thus no longer needed.
 
 ### `themeColor`

--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -631,6 +631,25 @@ export const metadata = {
 />
 ```
 
+**With media attribute**
+
+```jsx filename="layout.js / page.js"
+export const metadata = {
+  icons: {
+    icon: [
+      {
+        url: '/light-icon.png',
+        media: '(prefers-color-scheme: light)',
+      },
+      {
+        url: '/dark-icon.png',
+        media: '(prefers-color-scheme: dark)',
+      },
+    ],
+  },
+}
+```
+
 > **Good to know**: The `msapplication-*` meta tags are no longer supported in Chromium builds of Microsoft Edge, and thus no longer needed.
 
 ### `themeColor`


### PR DESCRIPTION
Since `metadata.icons` could be set based on the color scheme, added an example to [genereateMetadata - icons](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#icons).

Related to: #54433