### PR TITLE
Update runner labels for PR stats

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -504,22 +504,13 @@ jobs:
 
   releaseStats:
     name: Release Stats
-    runs-on: ubuntu-latest
+    runs-on:
+      - 'self-hosted'
+      - 'linux'
+      - 'x64'
+      - 'metal'
     needs: [publishRelease]
     steps:
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_LTS_VERSION }}
-          check-latest: true
-
-      - uses: actions/cache@v3
-        timeout-minutes: 5
-        id: restore-build
-        with:
-          path: ./*
-          key: ${{ github.sha }}-${{ github.run_number }}
-
       - uses: actions/download-artifact@v3
         with:
           name: next-swc-binaries

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -511,6 +511,10 @@ jobs:
       - 'metal'
     needs: [publishRelease]
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 25
+
       - uses: actions/download-artifact@v3
         with:
           name: next-swc-binaries

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -31,7 +31,11 @@ jobs:
   stats:
     name: PR Stats
     needs: build
-    runs-on: ubuntu-latest
+    runs-on:
+      - 'self-hosted'
+      - 'linux'
+      - 'x64'
+      - 'metal'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Speeds up our stats generation by swapping out the underlying runner, previously this took 13+ minutes now it's around 5 minutes. 