### PR TITLE
chore(ci): emit env vars that impact ci results

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -524,6 +524,10 @@ ${ENDGROUP}`)
       if ((!passed || shouldContinueTestsOnError) && isTestJob) {
         try {
           const testsOutput = await fs.readFile(`${test}${RESULTS_EXT}`, 'utf8')
+          testsOutput.processEnv = {
+            NEXT_TEST_MODE = process.env.NEXT_TEST_MODE,
+            HEADLESS = process.env.HEADLESS,
+          }
           await outputSema.acquire()
           if (GROUP) console.log(`${GROUP}Result as JSON for tooling`)
           console.log(

--- a/run-tests.js
+++ b/run-tests.js
@@ -524,15 +524,16 @@ ${ENDGROUP}`)
       if ((!passed || shouldContinueTestsOnError) && isTestJob) {
         try {
           const testsOutput = await fs.readFile(`${test}${RESULTS_EXT}`, 'utf8')
-          testsOutput.processEnv = {
-            NEXT_TEST_MODE = process.env.NEXT_TEST_MODE,
-            HEADLESS = process.env.HEADLESS,
+          const obj = JSON.parse(testsOutput)
+          obj.processEnv = {
+            NEXT_TEST_MODE: process.env.NEXT_TEST_MODE,
+            HEADLESS: process.env.HEADLESS,
           }
           await outputSema.acquire()
           if (GROUP) console.log(`${GROUP}Result as JSON for tooling`)
           console.log(
             `--test output start--`,
-            testsOutput,
+            JSON.stringify(obj),
             `--test output end--`
           )
           if (ENDGROUP) console.log(ENDGROUP)


### PR DESCRIPTION
The values of `NEXT_TEST_MODE` and `HEADLESS` can impact the test results so we should capture these values when CI runs.