### PR TITLE
Break-up install and build steps for PR stats

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -108,22 +108,24 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
       if (!actionInfo.skipClone) {
         const usePnpm = await fs.pathExists(path.join(dir, 'pnpm-lock.yaml'))
 
-        await exec(
-          `cd ${dir}${
-            usePnpm
-              ? // --no-frozen-lockfile is used here to tolerate lockfile
-                // changes from merging latest changes
-                ` && pnpm install --no-frozen-lockfile`
-              : ' && yarn install --network-timeout 1000000'
-          }`,
-          false
-        )
+        if (!statsConfig.skipInitialInstall) {
+          await exec(
+            `cd ${dir}${
+              usePnpm
+                ? // --no-frozen-lockfile is used here to tolerate lockfile
+                  // changes from merging latest changes
+                  ` && pnpm install --no-frozen-lockfile`
+                : ' && yarn install --network-timeout 1000000'
+            }`,
+            false
+          )
 
-        await exec(
-          statsConfig.initialBuildCommand ||
-            `cd ${dir} && ${usePnpm ? 'pnpm build' : 'echo built'}`,
-          false
-        )
+          await exec(
+            statsConfig.initialBuildCommand ||
+              `cd ${dir} && ${usePnpm ? 'pnpm build' : 'echo built'}`,
+            false
+          )
+        }
       }
 
       await fs

--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -108,22 +108,22 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
       if (!actionInfo.skipClone) {
         const usePnpm = await fs.pathExists(path.join(dir, 'pnpm-lock.yaml'))
 
-        let buildCommand = `cd ${dir}${
-          !statsConfig.skipInitialInstall
-            ? usePnpm
-              ? // --no-frozen-lockfile is used here to tolerate lockfile
-                // changes from merging latest changes
-                ` && pnpm install --no-frozen-lockfile && pnpm run build`
-              : ' && yarn install --network-timeout 1000000'
-            : ''
-        }`
+        await exec(
+          `cd ${dir}${
+            !statsConfig.skipInitialInstall
+              ? usePnpm
+                ? // --no-frozen-lockfile is used here to tolerate lockfile
+                  // changes from merging latest changes
+                  ` && pnpm install --no-frozen-lockfile`
+                : ' && yarn install --network-timeout 1000000'
+              : ''
+          }`,
+          false
+        )
 
         if (statsConfig.initialBuildCommand) {
-          buildCommand += ` && ${statsConfig.initialBuildCommand}`
+          await exec(`cd ${dir}${statsConfig.initialBuildCommand}`, false)
         }
-        // allow high timeout for install + building all packages
-        // in case of noisy environment slowing down initial repo build
-        await exec(buildCommand, false, { timeout: 10 * 60 * 1000 })
       }
 
       await fs

--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -110,20 +110,20 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
 
         await exec(
           `cd ${dir}${
-            !statsConfig.skipInitialInstall
-              ? usePnpm
-                ? // --no-frozen-lockfile is used here to tolerate lockfile
-                  // changes from merging latest changes
-                  ` && pnpm install --no-frozen-lockfile`
-                : ' && yarn install --network-timeout 1000000'
-              : ''
+            usePnpm
+              ? // --no-frozen-lockfile is used here to tolerate lockfile
+                // changes from merging latest changes
+                ` && pnpm install --no-frozen-lockfile`
+              : ' && yarn install --network-timeout 1000000'
           }`,
           false
         )
 
-        if (statsConfig.initialBuildCommand) {
-          await exec(`cd ${dir}${statsConfig.initialBuildCommand}`, false)
-        }
+        await exec(
+          statsConfig.initialBuildCommand ||
+            `cd ${dir} && ${usePnpm ? 'pnpm build' : 'echo built'}`,
+          false
+        )
       }
 
       await fs


### PR DESCRIPTION
Breaks up these commands to track down the timeout for release stats. 

x-ref: https://github.com/vercel/next.js/actions/runs/5969590815/job/16195862006