### PR TITLE
Fix TS error in "Composition Patterns" documentation

### DIFF
--- a/docs/02-app/01-building-your-application/03-rendering/03-composition-patterns.mdx
+++ b/docs/02-app/01-building-your-application/03-rendering/03-composition-patterns.mdx
@@ -82,7 +82,21 @@ npm install server-only
 
 Then import the package into any module that contains server-only code:
 
-```js filename="lib/data.js"
+```ts filename="lib/data.ts" switcher
+import 'server-only'
+
+export async function getData() {
+  const res = await fetch('https://external-service.com/data', {
+    headers: {
+      authorization: process.env.API_KEY!,
+    },
+  })
+
+  return res.json()
+}
+```
+
+```js filename="lib/data.js" switcher
 import 'server-only'
 
 export async function getData() {

--- a/docs/02-app/01-building-your-application/03-rendering/03-composition-patterns.mdx
+++ b/docs/02-app/01-building-your-application/03-rendering/03-composition-patterns.mdx
@@ -46,7 +46,7 @@ For example, take the following data-fetching function:
 export async function getData() {
   const res = await fetch('https://external-service.com/data', {
     headers: {
-      authorization: process.env.API_KEY,
+      authorization: process.env.API_KEY!,
     },
   })
 


### PR DESCRIPTION
### Why?

The code in [this section](https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns#keeping-server-only-code-out-of-the-client-environment)

```tsx
export async function getData() {
  const res = await fetch('https://external-service.com/data', {
    headers: {
      authorization: process.env.API_KEY,
    },
  })
 
  return res.json()
}
```

actually doesn't pass TypeScript,

```
./app/page.tsx:3:5
Type error: Type '{ authorization: string | undefined; }' is not assignable to type 'HeadersInit | undefined'.
  Type '{ authorization: string | undefined; }' is not assignable to type 'undefined'.

  1 | async function getData() {
  2 |   const res = await fetch("https://external-service.com/data", {
> 3 |     headers: {
    |     ^
  4 |       authorization: process.env.API_KEY,
  5 |     },
  6 |   });
```

That's because `process.env.API_KEY` can be `undefined`.

### How?

Since the example is just an illustrative example, this is not too important, but I believe all TS examples in the documentation should still pass type checking so I just add a non-null assertion `!`.