### PR TITLE
Update release stats install/build executing

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -7,14 +7,8 @@ const addComment = require('./add-comment')
 const actionInfo = require('./prepare/action-info')()
 const { mainRepoDir, diffRepoDir } = require('./constants')
 const loadStatsConfig = require('./prepare/load-stats-config')
-const {
-  cloneRepo,
-  checkoutRef,
-  mergeBranch,
-  getCommitId,
-  linkPackages,
-  getLastStable,
-} = require('./prepare/repo-setup')(actionInfo)
+const { cloneRepo, mergeBranch, getCommitId, linkPackages, getLastStable } =
+  require('./prepare/repo-setup')(actionInfo)
 
 const allowedActions = new Set(['synchronize', 'opened'])
 
@@ -109,21 +103,19 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
         const usePnpm = await fs.pathExists(path.join(dir, 'pnpm-lock.yaml'))
 
         if (!statsConfig.skipInitialInstall) {
-          await exec(
+          await exec.spawnPromise(
             `cd ${dir}${
               usePnpm
                 ? // --no-frozen-lockfile is used here to tolerate lockfile
                   // changes from merging latest changes
                   ` && pnpm install --no-frozen-lockfile`
                 : ' && yarn install --network-timeout 1000000'
-            }`,
-            false
+            }`
           )
 
-          await exec(
+          await exec.spawnPromise(
             statsConfig.initialBuildCommand ||
-              `cd ${dir} && ${usePnpm ? 'pnpm build' : 'echo built'}`,
-            false
+              `cd ${dir} && ${usePnpm ? 'pnpm build' : 'echo built'}`
           )
         }
       }

--- a/.github/actions/next-stats-action/src/util/exec.js
+++ b/.github/actions/next-stats-action/src/util/exec.js
@@ -34,4 +34,18 @@ exec.spawn = function spawn(command = '', opts = {}) {
   return child
 }
 
+exec.spawnPromise = function spawnPromise(command = '', opts = {}) {
+  return new Promise((resolve, reject) => {
+    const child = exec.spawn(command)
+    child.on('exit', (code, signal) => {
+      if (code || signal) {
+        return reject(
+          new Error(`bad exit code/signal code: ${code} signal: ${signal}`)
+        )
+      }
+      resolve()
+    })
+  })
+}
+
 module.exports = exec

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -229,6 +229,7 @@ jobs:
 
     name: stable - ${{ matrix.settings.target }} - node@16
     runs-on: ${{ matrix.settings.host }}
+    timeout-minutes: 30
     steps:
       # https://github.com/actions/virtual-environments/issues/1187
       - name: tune linux network
@@ -509,6 +510,7 @@ jobs:
       - 'linux'
       - 'x64'
       - 'metal'
+    timeout-minutes: 25
     needs: [publishRelease]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -31,6 +31,7 @@ jobs:
   stats:
     name: PR Stats
     needs: build
+    timeout-minutes: 25
     runs-on:
       - 'self-hosted'
       - 'linux'


### PR DESCRIPTION
Aims to make debugging the release stats failure easier as currently we don't see the logs are the command is executing

x-ref: https://github.com/vercel/next.js/actions/runs/5976635577/job/16221230094
x-ref: https://github.com/vercel/next.js/pull/54536