### PR TITLE
Add missing install env for release stats

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -528,6 +528,7 @@ jobs:
       - uses: ./.github/actions/next-stats-action
         env:
           PR_STATS_COMMENT_TOKEN: ${{ secrets.PR_STATS_COMMENT_TOKEN }}
+          NEXT_SKIP_NATIVE_POSTINSTALL: 1
 
   upload_turbopack_bytesize:
     name: Upload Turbopack Bytesize trace to Datadog


### PR DESCRIPTION
This should fix the stalled action as it seems we aren't skipping this postinstall step when we should be which explains why it was passing for PR stats but not release stats

x-ref: https://github.com/vercel/next.js/actions/runs/5980582756/job/16227150469