### PR TITLE
modify bench scripts to not conflict with dev task

### DIFF
--- a/bench/nested-deps-app-router/package.json
+++ b/bench/nested-deps-app-router/package.json
@@ -2,10 +2,10 @@
   "name": "bench-nested-deps-app-router",
   "scripts": {
     "prepare-bench": "rimraf components && fuzzponent -d 2 -s 206 -o components",
-    "dev": "cross-env NEXT_PRIVATE_LOCAL_WEBPACK=1 next dev",
+    "dev-application": "cross-env NEXT_PRIVATE_LOCAL_WEBPACK=1 next dev",
     "build-application": "cross-env NEXT_PRIVATE_LOCAL_WEBPACK=1 next build",
     "start": "cross-env NEXT_PRIVATE_LOCAL_WEBPACK=1 next start",
-    "dev-nocache": "rimraf .next && pnpm dev",
+    "dev-nocache": "rimraf .next && pnpm dev-application",
     "dev-cpuprofile-nocache": "rimraf .next && cross-env NEXT_PRIVATE_LOCAL_WEBPACK=1 node --cpu-prof ../../node_modules/next/dist/bin/next",
     "build-nocache": "rimraf .next && pnpm build-application"
   },

--- a/bench/nested-deps/package.json
+++ b/bench/nested-deps/package.json
@@ -2,10 +2,10 @@
   "name": "bench-nested-deps",
   "scripts": {
     "prepare-bench": "rimraf components && fuzzponent -d 2 -s 206 -o components",
-    "dev": "cross-env NEXT_PRIVATE_LOCAL_WEBPACK=1 next dev",
+    "dev-application": "cross-env NEXT_PRIVATE_LOCAL_WEBPACK=1 next dev",
     "build-application": "cross-env NEXT_PRIVATE_LOCAL_WEBPACK=1 next build",
     "start": "cross-env NEXT_PRIVATE_LOCAL_WEBPACK=1 next start",
-    "dev-nocache": "rimraf .next && pnpm dev",
+    "dev-nocache": "rimraf .next && pnpm dev-application",
     "dev-cpuprofile-nocache": "rimraf .next && cross-env NEXT_PRIVATE_LOCAL_WEBPACK=1 node --cpu-prof ../../node_modules/next/dist/bin/next",
     "build-nocache": "rimraf .next && pnpm build-application"
   },


### PR DESCRIPTION
I don't believe these benches were intended to run as part of the monorepo `dev` task. This renames the `dev` task to `dev-application` similar to `build-application` (which I assume was aliased for a similar reason)

Fixes #54592
