### PR TITLE
chore: add extra error info for rsc info helper

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -286,8 +286,9 @@ async function tryToReadFile(filePath: string, shouldThrow: boolean) {
     return await fs.readFile(filePath, {
       encoding: 'utf8',
     })
-  } catch (error) {
+  } catch (error: any) {
     if (shouldThrow) {
+      error.message = `Next.js ERROR: Failed to read file ${filePath}:\n${error.message}`
       throw error
     }
   }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2865,7 +2865,6 @@ export default async function build(
 
           // If there's /not-found inside app, we prefer it over the pages 404
           if (hasStaticApp404) {
-            // await moveExportedPage('/_error', '/404', '/404', false, 'html')
             await moveExportedAppNotFoundTo404()
           } else {
             // Only move /404 to /404 when there is no custom 404 as in that case we don't know about the 404 page

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -91,7 +91,7 @@ export function createValidFileMatcher(
       pageExtensions
     )}$`
   )
-  const leafOnlyNotFoundFileRegex = new RegExp(
+  const rootNotFoundFileRegex = new RegExp(
     `^not-found\\.${getExtensionRegexString(pageExtensions)}$`
   )
   /** TODO-METADATA: support other metadata routes
@@ -136,7 +136,7 @@ export function createValidFileMatcher(
       return false
     }
     const rest = filePath.slice(appDirPath.length + 1)
-    return leafOnlyNotFoundFileRegex.test(rest)
+    return rootNotFoundFileRegex.test(rest)
   }
 
   return {


### PR DESCRIPTION
When I was working on #54199 , if the file path is wrong the next app build error only shows "can't read file from ...", it took me hours to figure out where it actually fails in next build command. Adding an prefix for the error message so that could identify it easier.

Also clean up other unused comments and incorrect named variables