### PR TITLE
docs: updates generateMetadata function signature

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/04-metadata.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/04-metadata.mdx
@@ -57,7 +57,7 @@ type Props = {
 
 export async function generateMetadata(
   { params, searchParams }: Props,
-  parent?: ResolvingMetadata
+  parent: ResolvingMetadata
 ): Promise<Metadata> {
   // read route params
   const id = params.id
@@ -66,7 +66,7 @@ export async function generateMetadata(
   const product = await fetch(`https://.../${id}`).then((res) => res.json())
 
   // optionally access and extend (rather than replace) parent metadata
-  const previousImages = (await parent)?.openGraph?.images || []
+  const previousImages = (await parent).openGraph?.images || []
 
   return {
     title: product.title,
@@ -88,7 +88,7 @@ export async function generateMetadata({ params, searchParams }, parent) {
   const product = await fetch(`https://.../${id}`).then((res) => res.json())
 
   // optionally access and extend (rather than replace) parent metadata
-  const previousImages = (await parent)?.openGraph?.images || []
+  const previousImages = (await parent).openGraph?.images || []
 
   return {
     title: product.title,

--- a/docs/02-app/01-building-your-application/06-optimizing/04-metadata.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/04-metadata.mdx
@@ -66,7 +66,7 @@ export async function generateMetadata(
   const product = await fetch(`https://.../${id}`).then((res) => res.json())
 
   // optionally access and extend (rather than replace) parent metadata
-  const previousImages = (await parent).openGraph?.images || []
+  const previousImages = (await parent)?.openGraph?.images || []
 
   return {
     title: product.title,
@@ -88,7 +88,7 @@ export async function generateMetadata({ params, searchParams }, parent) {
   const product = await fetch(`https://.../${id}`).then((res) => res.json())
 
   // optionally access and extend (rather than replace) parent metadata
-  const previousImages = (await parent).openGraph?.images || []
+  const previousImages = (await parent)?.openGraph?.images || []
 
   return {
     title: product.title,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

Change optional arg to non-optional arg of `parent` in the `generateMetadata` API function example in oder to avoid the error shown below.
 
![Screenshot 2023-08-27 at 15 23 02](https://github.com/vercel/next.js/assets/103655828/a39dc0c0-ab1b-4a26-9ac0-1e9ddcfd11da)