### PR TITLE
Remove this as any cases

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -473,7 +473,7 @@ export default class DevServer extends Server {
   protected async logErrorWithOriginalStack(
     err?: unknown,
     type?: 'unhandledRejection' | 'uncaughtException' | 'warning' | 'app-dir'
-  ) {
+  ): Promise<void> {
     if (this.isRenderWorker) {
       await invokeIpcMethod({
         fetchHostname: this.fetchHostname,
@@ -729,7 +729,7 @@ export default class DevServer extends Server {
     clientOnly: boolean
     appPaths?: string[] | null
     match?: RouteMatch
-  }) {
+  }): Promise<void> {
     if (this.isRenderWorker) {
       await invokeIpcMethod({
         fetchHostname: this.fetchHostname,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1015,7 +1015,7 @@ export default class NextNodeServer extends BaseServer {
           const { formatServerError } =
             require('../lib/format-server-error') as typeof import('../lib/format-server-error')
           formatServerError(err)
-          await (this as any).logErrorWithOriginalStack(err)
+          await this.logErrorWithOriginalStack(err)
         } else {
           this.logError(err)
         }
@@ -1028,6 +1028,22 @@ export default class NextNodeServer extends BaseServer {
 
       throw err
     }
+  }
+
+  // Used in development only, overloaded in next-dev-server
+  protected async logErrorWithOriginalStack(..._args: any[]): Promise<void> {
+    throw new Error(
+      'logErrorWithOriginalStack can only be called on the development server'
+    )
+  }
+  // Used in development only, overloaded in next-dev-server
+  protected async ensurePage(_opts: {
+    page: string
+    clientOnly: boolean
+    appPaths?: string[] | null
+    match?: RouteMatch
+  }): Promise<void> {
+    throw new Error('ensurePage can only be called on the development server')
   }
 
   /**
@@ -1300,12 +1316,10 @@ export default class NextNodeServer extends BaseServer {
         : '/_not-found'
 
       if (this.renderOpts.dev) {
-        await (this as any)
-          .ensurePage({
-            page: notFoundPathname,
-            clientOnly: false,
-          })
-          .catch(() => {})
+        await this.ensurePage({
+          page: notFoundPathname,
+          clientOnly: false,
+        }).catch(() => {})
       }
 
       if (this.getEdgeFunctionsPages().includes(notFoundPathname)) {


### PR DESCRIPTION
Noticed there were two cases in `next-server.ts` that leverage `this as any` to call functions defined only in next-dev-server.
This change ensures the types are correct, which is useful for refactoring, e.g. renaming the function in `next-dev-server` would cause the original code to break unexpectedly.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
