### PR TITLE
fix: `Cannot redefine property: $$id` error

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
@@ -45,5 +45,5 @@ export function createActionProxy(
     bind: {
       value: bindImpl,
     },
-  }, {configurable: true})
+  }, {configurable: true, writable: false})
 }

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
@@ -45,5 +45,5 @@ export function createActionProxy(
     bind: {
       value: bindImpl,
     },
-  })
+  }, configurable: true)
 }

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
@@ -45,5 +45,5 @@ export function createActionProxy(
     bind: {
       value: bindImpl,
     },
-  }, configurable: true)
+  }, {configurable: true})
 }


### PR DESCRIPTION
Fixes: #54655

`action: any` could already be defined, leading to a `cannot redefine error` on new builds, affecting `server actions`

Introduced by here:
https://github.com/vercel/next.js/pull/54232/files#diff-95a0d700e8c22a337ac8800d4ddf80f44c6369aa2e6acf5bd2b71632f7471c68R35-R48