### PR TITLE
Add list of aliased `ahooks` methods to the transform rules

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -713,6 +713,12 @@ function assignDefaults(
       transform: {
         createUpdateEffect:
           'modularize-import-loader?name=createUpdateEffect&from=named&as=default!ahooks/es/createUpdateEffect',
+        clearCache:
+          'modularize-import-loader?name=clearCache&from=named&as=default!ahooks/es/useRequest',
+        useResponsive:
+          'modularize-import-loader?name=useResponsive&from=named&as=default!ahooks/es/useResponsive',
+        configResponsive:
+          'modularize-import-loader?name=configResponsive&from=named&as=default!ahooks/es/useResponsive',
         '*': 'ahooks/es/{{member}}',
       },
     },

--- a/test/development/basic/modularize-imports.test.ts
+++ b/test/development/basic/modularize-imports.test.ts
@@ -11,8 +11,10 @@ describe('modularize-imports', () => {
         app: new FileRef(join(__dirname, 'modularize-imports/app')),
       },
       dependencies: {
+        react: 'latest',
         'lucide-react': '0.264.0',
         '@headlessui/react': '1.7.17',
+        ahooks: '^3.7.8',
       },
     })
   })

--- a/test/development/basic/modularize-imports/app/page.js
+++ b/test/development/basic/modularize-imports/app/page.js
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import {
   IceCream,
   BackpackIcon,
@@ -22,10 +23,21 @@ import {
   LucideEdit3,
   TextSelection,
 } from 'lucide-react'
-
 import { Tab, RadioGroup, Transition } from '@headlessui/react'
+import {
+  createUpdateEffect,
+  clearCache,
+  useResponsive,
+  configResponsive,
+} from 'ahooks'
+
+clearCache()
+configResponsive({})
 
 export default function Page() {
+  createUpdateEffect(useEffect)
+  useResponsive()
+
   return (
     <>
       <IceCream />


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

follow up: https://github.com/vercel/next.js/pull/53051

`ahooks` follows the naming rule of `Name` being exported from `/{{Name}}`, but it has some special aliases such as:

- `createUpdateEffect` exported from `/createUpdateEffect`
- `useResponsive`, `configResponsive` exported from `/useResponsive`
- `clearCache` exported from `/useRequest`

For now we have to add these rules manually.

Fixes https://github.com/alibaba/hooks/issues/2263. In the future we'll still need an automatic way to do this.

The list was created from https://unpkg.com/ahooks@3.7.8/es/index.js.
