### PR TITLE
benchmark sharp wasm

### DIFF
--- a/bench/image-opt/bench.cjs
+++ b/bench/image-opt/bench.cjs
@@ -1,0 +1,106 @@
+const { join } = require('path');
+const { readFile } = require('fs/promises');
+
+const images = [
+  '../../examples/image-component/public/cat.jpg',
+  '../../examples/image-component/public/dog.jpg',
+  '../../examples/image-component/public/mountains.jpg',
+  '../../examples/image-component/public/vercel.png',
+  '../../examples/with-expo-typescript/public/demo.png',
+  '../../examples/with-sfcc/public/hero.jpg',
+  '../../test/integration/image-optimizer/app/public/test.jpg',
+  '../../test/integration/image-optimizer/app/public/test.png',
+  '../../test/integration/image-optimizer/app/public/test.webp',
+  '../../test/integration/image-optimizer/app/public/test.avif',
+].map(f => join(__dirname, f))
+
+const pad = (ms) => {
+  const [left, _right] = ms.toFixed(3).split('.')
+  // less than 1 ms is not useful, so ignore for now
+  return `${left.padStart(4, '0')}ms`
+}
+
+async function bench(func, width, quality) {
+  console.log(`\nBenchmark f=${func.name}, w=${width}, q=${quality}`)
+  for (const pkg of ['sharp-native', 'sharp-wasm', 'squoosh']) {
+    let sum = 0
+    let max = Number.NEGATIVE_INFINITY
+    let min = Number.POSITIVE_INFINITY
+    for (const image of images) {
+      const buffer = await readFile(image)
+      const start = performance.now()
+      const result = await func(pkg, buffer, width, quality)
+      if (result.length === 0) {
+        throw new Error('result was length 0')
+      }
+      const end = performance.now()
+      const time = (end - start)
+      sum += time
+      max = Math.max(max, time)
+      min = Math.min(min, time)
+    }
+    
+    const avg = sum / images.length
+    const p90 = (sum - max) / (images.length - 1)
+    console.log(`      ${pkg.padStart(12)}: avg ${pad(avg)}, p90 ${pad(p90)}, max ${pad(max)}, min ${pad(min)}`)
+  }
+}
+
+async function webp(pkg, buffer, width, quality) {
+  if (pkg.startsWith('sharp')) {
+    const sharp = require(`/Users/styfle/Code/foo/${pkg}/node_modules/sharp`);
+    const optimized = await sharp(buffer).resize(width, undefined, {
+      withoutEnlargement: true,
+    }).webp({ quality }).toBuffer()
+    return optimized;
+  } else if (pkg === 'squoosh') {
+    const { processBuffer } = require('next/dist/server/lib/squoosh/main')
+    const operations = [];
+    operations.push({ type: 'resize', width })
+    const optimized = await processBuffer(buffer, operations, 'webp', quality)
+    return optimized;
+  } else {
+    throw new Error(`Unknown package ${pkg}`)
+  }
+}
+
+async function avif(pkg, buffer, width, quality) {
+  if (pkg.startsWith('sharp')) {
+    const sharp = require(`/Users/styfle/Code/foo/${pkg}/node_modules/sharp`);
+    const transformer = sharp(buffer)
+    transformer.resize(width, undefined, {
+      withoutEnlargement: true,
+    })
+    const avifQuality = quality - 15
+    transformer.avif({
+      quality: Math.max(avifQuality, 0),
+      chromaSubsampling: '4:2:0', // same as webp
+    })
+    const result = await transformer.toBuffer()
+    return result
+  } else if (pkg === 'squoosh') {
+    const { processBuffer } = require('next/dist/server/lib/squoosh/main')
+    const operations = [];
+    operations.push({ type: 'resize', width })
+    const result = await processBuffer(buffer, operations, 'avif', quality)
+    return result
+  } else {
+    throw new Error(`Unknown package ${pkg}`)
+  }
+}
+
+async function main() {
+  console.log(`Running benchmarks on ${process.platform} (${process.arch}) with ${images.length} images...`)
+  await bench(webp, 2048, 75)
+  await bench(webp, 1080, 75)
+  await bench(webp, 256, 50)
+
+  await bench(avif, 2048, 75)
+  await bench(avif, 1080, 75)
+  await bench(avif, 256, 50)
+  
+  console.log(`Benchmark complete.`)
+  process.exit(0)
+}
+
+main().then(console.log).catch(console.error)

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -47,7 +47,7 @@ const BLUR_QUALITY = 70 // should match `next-image-loader`
 let sharp: typeof import('sharp') | undefined
 
 try {
-  sharp = require(process.env.NEXT_SHARP_PATH || 'sharp')
+  sharp = require('/Users/styfle/Code/foo/sharp-wasm/node_modules/sharp')
   if (sharp && sharp.concurrency() > 1) {
     // Reducing concurrency should reduce the memory usage too.
     // We more aggressively reduce in dev but also reduce in prod.

--- a/test/integration/image-optimizer/test/sharp-wasm.test.ts
+++ b/test/integration/image-optimizer/test/sharp-wasm.test.ts
@@ -1,0 +1,9 @@
+import { join } from 'path'
+import { setupTests } from './util'
+
+const appDir = join(__dirname, '../app')
+const imagesDir = join(appDir, '.next', 'cache', 'images')
+
+describe('with sharm wasm', () => {
+  setupTests({ isSharp: true, isOutdatedSharp: false, appDir, imagesDir })
+})


### PR DESCRIPTION
```
Running benchmarks on darwin (arm64) with 10 images...

Benchmark f=webp, w=2048, q=75
      sharp-native: avg 0121ms, p90 0104ms, max 0271ms, min 0007ms
        sharp-wasm: avg 0206ms, p90 0161ms, max 0612ms, min 0015ms
           squoosh: avg 0411ms, p90 0308ms, max 1338ms, min 0015ms

Benchmark f=webp, w=1080, q=75
      sharp-native: avg 0079ms, p90 0070ms, max 0160ms, min 0007ms
        sharp-wasm: avg 0105ms, p90 0091ms, max 0233ms, min 0012ms
           squoosh: avg 0282ms, p90 0242ms, max 0640ms, min 0017ms

Benchmark f=webp, w=256, q=50
      sharp-native: avg 0020ms, p90 0019ms, max 0032ms, min 0004ms
        sharp-wasm: avg 0035ms, p90 0032ms, max 0061ms, min 0007ms
           squoosh: avg 0107ms, p90 0093ms, max 0227ms, min 0017ms

Benchmark f=avif, w=2048, q=75
      sharp-native: avg 0611ms, p90 0473ms, max 1857ms, min 0034ms
        sharp-wasm: avg 5703ms, p90 4444ms, max 17030ms, min 0215ms
           squoosh: avg 2131ms, p90 1535ms, max 7498ms, min 0082ms

Benchmark f=avif, w=1080, q=75
      sharp-native: avg 0367ms, p90 0272ms, max 1219ms, min 0033ms
        sharp-wasm: avg 2550ms, p90 1842ms, max 8925ms, min 0213ms
           squoosh: avg 1314ms, p90 0959ms, max 4516ms, min 0081ms

Benchmark f=avif, w=256, q=50
      sharp-native: avg 0056ms, p90 0047ms, max 0137ms, min 0020ms
        sharp-wasm: avg 0188ms, p90 0156ms, max 0482ms, min 0078ms
           squoosh: avg 0189ms, p90 0162ms, max 0428ms, min 0050ms
Benchmark complete.
```