### PR TITLE
docs: delete duplicate content

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/03-forms-and-mutations.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/03-forms-and-mutations.mdx
@@ -375,10 +375,6 @@ function SubmitButton() {
 }
 ```
 
-> **Good to know:**
->
-> - Displaying loading or error states currently requires using Client Components. We are exploring options for server-side functions to retrieve these values as we move forward in stability for Server Actions.
-
 </AppOnly>
 
 <PagesOnly>


### PR DESCRIPTION
The exact same contents from 378 to 381 lines and from 552 to 554 lines were duplicated, so it was considered an error and deleted.
Thank you.