### PR TITLE
Export RedirectType from next/navigation

### DIFF
--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -238,5 +238,5 @@ export function useSelectedLayoutSegment(
   return selectedLayoutSegments[0]
 }
 
-export { redirect, permanentRedirect } from './redirect'
+export { redirect, permanentRedirect, RedirectType } from './redirect'
 export { notFound } from './not-found'

--- a/packages/next/src/client/components/redirect-boundary.tsx
+++ b/packages/next/src/client/components/redirect-boundary.tsx
@@ -26,7 +26,6 @@ function HandleRedirect({
   const router = useRouter()
 
   useEffect(() => {
-    // @ts-ignore startTransition exists
     React.startTransition(() => {
       if (redirectType === RedirectType.push) {
         router.push(redirect, {})

--- a/packages/third-parties/scripts/update-third-parties.js
+++ b/packages/third-parties/scripts/update-third-parties.js
@@ -23,10 +23,7 @@ function generateComponent(thirdParty) {
     let props = ''
 
     if (stylesheets?.length > 0) {
-      // TODO: Remove ts-ignore after new <Script> component is published
-      // New <Script> accepts stylesheet as a param. Otherwise it throws error
       props += `
-      // @ts-ignore
       stylesheets={${JSON.stringify(stylesheets)}}`
     }
 

--- a/packages/third-parties/src/google/index.tsx
+++ b/packages/third-parties/src/google/index.tsx
@@ -30,7 +30,6 @@ export function YoutubeEmbed(args: Types.YoutubeEmbed) {
       <Script
         src={`https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.js`}
         strategy="lazyOnload"
-        // @ts-ignore
         stylesheets={[
           'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.css',
         ]}

--- a/test/development/acceptance-app/fixtures/app-hmr-changes/app/(post)/components/tweet.tsx
+++ b/test/development/acceptance-app/fixtures/app-hmr-changes/app/(post)/components/tweet.tsx
@@ -22,7 +22,6 @@ export async function Tweet({ id, caption }: TweetArgs) {
   return (
     <div className="my-6">
       <div className="flex justify-center">
-        {/* @ts-ignore */}
         <ReactTweet id={id} components={components} />
       </div>
       {caption && <Caption>{caption}</Caption>}

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -1,7 +1,6 @@
 import { createNextDescribe } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
 
-// @ts-ignore
 import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
 
 const browserConfigWithFixedTime = {

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/twitter-image.tsx
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/twitter-image.tsx
@@ -1,5 +1,4 @@
 import { ImageResponse } from 'next/server'
-// @ts-ignore
 import { ImageResponse as ImageResponse2 } from '@vercel/og'
 
 // Node.js: Using @vercel/og external package, and should be aliased to "next/server" ImageResponse

--- a/test/e2e/app-dir/metadata/app/basic-edge/client.tsx
+++ b/test/e2e/app-dir/metadata/app/basic-edge/client.tsx
@@ -4,7 +4,6 @@ import ReactDOM from 'react-dom'
 
 // NOTE: atm preload/prefetch/prefetchDNS are only supported in the SSR and client, not in RSC yet
 export default function Client() {
-  // @ts-ignore
   ReactDOM.preload('/api/preload', { as: 'script' })
   // @ts-ignore
   ReactDOM.preconnect('/preconnect-url', { crossOrigin: 'use-credentials' })

--- a/test/e2e/app-dir/metadata/app/basic/client.tsx
+++ b/test/e2e/app-dir/metadata/app/basic/client.tsx
@@ -4,7 +4,6 @@ import ReactDOM from 'react-dom'
 
 // NOTE: atm preload/prefetch/prefetchDNS are only supported in the SSR and client, not in RSC yet
 export default function Client() {
-  // @ts-ignore
   ReactDOM.preload('/api/preload', { as: 'script' })
   // @ts-ignore
   ReactDOM.preconnect('/preconnect-url', { crossOrigin: 'use-credentials' })

--- a/test/e2e/app-dir/navigation/app/assertion/page/page.js
+++ b/test/e2e/app-dir/navigation/app/assertion/page/page.js
@@ -1,6 +1,5 @@
 import { strict as assert } from 'node:assert'
 import Link from 'next/link'
-// @ts-ignore
 import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
 
 export default function Page({ searchParams }) {

--- a/test/e2e/app-dir/navigation/app/assertion/route/route.js
+++ b/test/e2e/app-dir/navigation/app/assertion/route/route.js
@@ -1,5 +1,4 @@
 import { strict as assert } from 'node:assert'
-// @ts-ignore
 import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
 
 export function GET(request) {

--- a/test/e2e/app-dir/navigation/app/redirect/servercomponent-2/page.js
+++ b/test/e2e/app-dir/navigation/app/redirect/servercomponent-2/page.js
@@ -1,6 +1,6 @@
-import { permanentRedirect } from 'next/navigation'
+import { permanentRedirect, RedirectType } from 'next/navigation'
 
 export default function Page() {
-  permanentRedirect('/redirect/result')
+  permanentRedirect('/redirect/result', RedirectType.push)
   return <></>
 }

--- a/test/e2e/app-dir/navigation/middleware.js
+++ b/test/e2e/app-dir/navigation/middleware.js
@@ -1,6 +1,5 @@
 // @ts-check
 import { NextResponse } from 'next/server'
-// @ts-ignore
 import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
 
 if (NEXT_RSC_UNION_QUERY !== '_rsc') {

--- a/test/unit/next-babel-loader-dev.test.ts
+++ b/test/unit/next-babel-loader-dev.test.ts
@@ -40,7 +40,6 @@ const babel = async (code: string, queryOpts = {} as any) => {
       callback,
       emitWarning() {},
       query: options,
-      // @ts-ignore exists
       getOptions: function () {
         return options
       },

--- a/test/unit/next-babel-loader-prod.test.ts
+++ b/test/unit/next-babel-loader-prod.test.ts
@@ -41,7 +41,6 @@ const babel = async (code: string, queryOpts = {} as any) => {
       callback,
       emitWarning() {},
       query: options,
-      // @ts-ignore exists
       getOptions: function () {
         return options
       },


### PR DESCRIPTION
A continuation of #51864 with RedirectType used in an e2e test and some ts-ignores removed from the codebase. Happy to split it into two PRs but I left comments in the two consequential files 