### PR TITLE
Use variable for common isNodeOrEdgeCompilation condition

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -183,21 +183,21 @@ export function getDefineEnv({
   middlewareMatchers,
   previewModeId,
 }: {
-  allowedRevalidateHeaderKeys?: string[]
+  allowedRevalidateHeaderKeys: string[] | undefined
   clientRouterFilters: Parameters<
     typeof getBaseWebpackConfig
   >[1]['clientRouterFilters']
   config: NextConfigComplete
   dev: boolean
   distDir: string
-  fetchCacheKeyPrefix?: string
+  fetchCacheKeyPrefix: string | undefined
   hasRewrites: boolean
   isClient: boolean
   isEdgeServer: boolean
   isNodeOrEdgeCompilation: boolean
   isNodeServer: boolean
-  middlewareMatchers?: MiddlewareMatcher[]
-  previewModeId?: string
+  middlewareMatchers: MiddlewareMatcher[] | undefined
+  previewModeId: string | undefined
 }) {
   return {
     // internal field to identify the plugin config

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -169,35 +169,35 @@ function isResourceInPackages(
 }
 
 export function getDefineEnv({
-  dev,
+  allowedRevalidateHeaderKeys,
+  clientRouterFilters,
   config,
+  dev,
   distDir,
-  isClient,
+  fetchCacheKeyPrefix,
   hasRewrites,
-  isNodeServer,
+  isClient,
   isEdgeServer,
   isNodeOrEdgeCompilation,
+  isNodeServer,
   middlewareMatchers,
-  clientRouterFilters,
   previewModeId,
-  fetchCacheKeyPrefix,
-  allowedRevalidateHeaderKeys,
 }: {
-  dev: boolean
-  distDir: string
-  isClient: boolean
-  hasRewrites: boolean
-  isNodeServer: boolean
-  isEdgeServer: boolean
-  isNodeOrEdgeCompilation: boolean
-  middlewareMatchers?: MiddlewareMatcher[]
-  config: NextConfigComplete
+  allowedRevalidateHeaderKeys?: string[]
   clientRouterFilters: Parameters<
     typeof getBaseWebpackConfig
   >[1]['clientRouterFilters']
-  previewModeId?: string
+  config: NextConfigComplete
+  dev: boolean
+  distDir: string
   fetchCacheKeyPrefix?: string
-  allowedRevalidateHeaderKeys?: string[]
+  hasRewrites: boolean
+  isClient: boolean
+  isEdgeServer: boolean
+  isNodeOrEdgeCompilation: boolean
+  isNodeServer: boolean
+  middlewareMatchers?: MiddlewareMatcher[]
+  previewModeId?: string
 }) {
   return {
     // internal field to identify the plugin config
@@ -2413,19 +2413,19 @@ export default async function getBaseWebpackConfig(
         }),
       new webpack.DefinePlugin(
         getDefineEnv({
-          dev,
+          allowedRevalidateHeaderKeys,
+          clientRouterFilters,
           config,
+          dev,
           distDir,
-          isClient,
+          fetchCacheKeyPrefix,
           hasRewrites,
-          isNodeServer,
+          isClient,
           isEdgeServer,
           isNodeOrEdgeCompilation,
+          isNodeServer,
           middlewareMatchers,
-          clientRouterFilters,
           previewModeId,
-          fetchCacheKeyPrefix,
-          allowedRevalidateHeaderKeys,
         })
       ),
       isClient &&

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -176,18 +176,20 @@ export function getDefineEnv({
   hasRewrites,
   isNodeServer,
   isEdgeServer,
+  isNodeOrEdgeCompilation,
   middlewareMatchers,
   clientRouterFilters,
   previewModeId,
   fetchCacheKeyPrefix,
   allowedRevalidateHeaderKeys,
 }: {
-  dev?: boolean
+  dev: boolean
   distDir: string
-  isClient?: boolean
-  hasRewrites?: boolean
-  isNodeServer?: boolean
-  isEdgeServer?: boolean
+  isClient: boolean
+  hasRewrites: boolean
+  isNodeServer: boolean
+  isEdgeServer: boolean
+  isNodeOrEdgeCompilation: boolean
   middlewareMatchers?: MiddlewareMatcher[]
   config: NextConfigComplete
   clientRouterFilters: Parameters<
@@ -352,7 +354,7 @@ export function getDefineEnv({
       config.experimental.webVitalsAttribution
     ),
     'process.env.__NEXT_ASSET_PREFIX': JSON.stringify(config.assetPrefix),
-    ...(isNodeServer || isEdgeServer
+    ...(isNodeOrEdgeCompilation
       ? {
           // Fix bad-actors in the npm ecosystem (e.g. `node-formidable`)
           // This is typically found in unmaintained modules from the
@@ -781,6 +783,9 @@ export default async function getBaseWebpackConfig(
   const isEdgeServer = compilerType === COMPILER_NAMES.edgeServer
   const isNodeServer = compilerType === COMPILER_NAMES.server
 
+  // If the current compilation is aimed at server-side code instead of client-side code.
+  const isNodeOrEdgeCompilation = isNodeServer || isEdgeServer
+
   const hasRewrites =
     rewrites.beforeFiles.length > 0 ||
     rewrites.afterFiles.length > 0 ||
@@ -845,7 +850,7 @@ export default async function getBaseWebpackConfig(
       loader: require.resolve('./babel/loader/index'),
       options: {
         configFile: babelConfigFile,
-        isServer: isNodeServer || isEdgeServer,
+        isServer: isNodeOrEdgeCompilation,
         distDir,
         pagesDir,
         cwd: dir,
@@ -876,7 +881,7 @@ export default async function getBaseWebpackConfig(
     return {
       loader: 'next-swc-loader',
       options: {
-        isServer: isNodeServer || isEdgeServer,
+        isServer: isNodeOrEdgeCompilation,
         rootDir: dir,
         pagesDir,
         appDir,
@@ -937,10 +942,9 @@ export default async function getBaseWebpackConfig(
 
   const pageExtensions = config.pageExtensions
 
-  const outputPath =
-    isNodeServer || isEdgeServer
-      ? path.join(distDir, SERVER_DIRECTORY)
-      : distDir
+  const outputPath = isNodeOrEdgeCompilation
+    ? path.join(distDir, SERVER_DIRECTORY)
+    : distDir
 
   const reactServerCondition = [
     'react-server',
@@ -1886,26 +1890,24 @@ export default async function getBaseWebpackConfig(
       }/_next/`,
       path: !dev && isNodeServer ? path.join(outputPath, 'chunks') : outputPath,
       // On the server we don't use hashes
-      filename:
-        isNodeServer || isEdgeServer
-          ? dev || isEdgeServer
-            ? `[name].js`
-            : `../[name].js`
-          : `static/chunks/${isDevFallback ? 'fallback/' : ''}[name]${
-              dev ? '' : appDir ? '-[chunkhash]' : '-[contenthash]'
-            }.js`,
+      filename: isNodeOrEdgeCompilation
+        ? dev || isEdgeServer
+          ? `[name].js`
+          : `../[name].js`
+        : `static/chunks/${isDevFallback ? 'fallback/' : ''}[name]${
+            dev ? '' : appDir ? '-[chunkhash]' : '-[contenthash]'
+          }.js`,
       library: isClient || isEdgeServer ? '_N_E' : undefined,
       libraryTarget: isClient || isEdgeServer ? 'assign' : 'commonjs2',
       hotUpdateChunkFilename: 'static/webpack/[id].[fullhash].hot-update.js',
       hotUpdateMainFilename:
         'static/webpack/[fullhash].[runtime].hot-update.json',
       // This saves chunks with the name given via `import()`
-      chunkFilename:
-        isNodeServer || isEdgeServer
-          ? '[name].js'
-          : `static/chunks/${isDevFallback ? 'fallback/' : ''}${
-              dev ? '[name]' : '[name].[contenthash]'
-            }.js`,
+      chunkFilename: isNodeOrEdgeCompilation
+        ? '[name].js'
+        : `static/chunks/${isDevFallback ? 'fallback/' : ''}${
+            dev ? '[name]' : '[name].[contenthash]'
+          }.js`,
       strictModuleExceptionHandling: true,
       crossOriginLoading: crossOrigin,
       webassemblyModuleFilename: 'static/wasm/[modulehash].wasm',
@@ -2418,6 +2420,7 @@ export default async function getBaseWebpackConfig(
           hasRewrites,
           isNodeServer,
           isEdgeServer,
+          isNodeOrEdgeCompilation,
           middlewareMatchers,
           clientRouterFilters,
           previewModeId,
@@ -2483,7 +2486,7 @@ export default async function getBaseWebpackConfig(
           resourceRegExp: /react-is/,
           contextRegExp: /next[\\/]dist[\\/]/,
         }),
-      (isNodeServer || isEdgeServer) &&
+      isNodeOrEdgeCompilation &&
         new PagesManifestPlugin({
           dev,
           isEdgeRuntime: isEdgeServer,
@@ -2778,11 +2781,9 @@ export default async function getBaseWebpackConfig(
       process.env.NEXT_WEBPACK_LOGGING.includes('summary-server')
 
     const profile =
-      (profileClient && isClient) ||
-      (profileServer && (isNodeServer || isEdgeServer))
+      (profileClient && isClient) || (profileServer && isNodeOrEdgeCompilation)
     const summary =
-      (summaryClient && isClient) ||
-      (summaryServer && (isNodeServer || isEdgeServer))
+      (summaryClient && isClient) || (summaryServer && isNodeOrEdgeCompilation)
 
     const logDefault = !infra && !profile && !summary
 
@@ -2838,7 +2839,7 @@ export default async function getBaseWebpackConfig(
       : undefined,
     hasAppDir,
     isDevelopment: dev,
-    isServer: isNodeServer || isEdgeServer,
+    isServer: isNodeOrEdgeCompilation,
     isEdgeRuntime: isEdgeServer,
     targetWeb: isClient || isEdgeServer,
     assetPrefix: config.assetPrefix || '',
@@ -2872,13 +2873,13 @@ export default async function getBaseWebpackConfig(
     webpackConfig = config.webpack(webpackConfig, {
       dir,
       dev,
-      isServer: isNodeServer || isEdgeServer,
+      isServer: isNodeOrEdgeCompilation,
       buildId,
       config,
       defaultLoaders,
       totalPages: Object.keys(entrypoints).length,
       webpack,
-      ...(isNodeServer || isEdgeServer
+      ...(isNodeOrEdgeCompilation
         ? {
             nextRuntime: isEdgeServer ? 'edge' : 'nodejs',
           }
@@ -3045,7 +3046,7 @@ export default async function getBaseWebpackConfig(
 
   if (hasUserCssConfig) {
     // only show warning for one build
-    if (isNodeServer || isEdgeServer) {
+    if (isNodeOrEdgeCompilation) {
       console.warn(
         chalk.yellow.bold('Warning: ') +
           chalk.bold(
@@ -3088,7 +3089,7 @@ export default async function getBaseWebpackConfig(
 
   // check if using @zeit/next-typescript and show warning
   if (
-    (isNodeServer || isEdgeServer) &&
+    isNodeOrEdgeCompilation &&
     webpackConfig.module &&
     Array.isArray(webpackConfig.module.rules)
   ) {

--- a/packages/next/src/server/lib/router-utils/setup-dev.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev.ts
@@ -1256,6 +1256,7 @@ async function startWatcher(opts: SetupOpts) {
                   hasRewrites,
                   isNodeServer,
                   isEdgeServer,
+                  isNodeOrEdgeCompilation: isNodeServer || isEdgeServer,
                   clientRouterFilters,
                 })
 

--- a/packages/next/src/server/lib/router-utils/setup-dev.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev.ts
@@ -1249,15 +1249,15 @@ async function startWatcher(opts: SetupOpts) {
                 plugin.definitions.__NEXT_DEFINE_ENV
               ) {
                 const newDefine = getDefineEnv({
-                  dev: true,
+                  clientRouterFilters,
                   config: nextConfig,
+                  dev: true,
                   distDir,
-                  isClient,
                   hasRewrites,
-                  isNodeServer,
+                  isClient,
                   isEdgeServer,
                   isNodeOrEdgeCompilation: isNodeServer || isEdgeServer,
-                  clientRouterFilters,
+                  isNodeServer,
                 })
 
                 Object.keys(plugin.definitions).forEach((key) => {

--- a/packages/next/src/server/lib/router-utils/setup-dev.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev.ts
@@ -1249,15 +1249,19 @@ async function startWatcher(opts: SetupOpts) {
                 plugin.definitions.__NEXT_DEFINE_ENV
               ) {
                 const newDefine = getDefineEnv({
+                  allowedRevalidateHeaderKeys: undefined,
                   clientRouterFilters,
                   config: nextConfig,
                   dev: true,
                   distDir,
+                  fetchCacheKeyPrefix: undefined,
                   hasRewrites,
                   isClient,
                   isEdgeServer,
                   isNodeOrEdgeCompilation: isNodeServer || isEdgeServer,
                   isNodeServer,
+                  middlewareMatchers: undefined,
+                  previewModeId: undefined,
                 })
 
                 Object.keys(plugin.definitions).forEach((key) => {


### PR DESCRIPTION
Noticed this condition was repeated quite often, this pulls it out to the top and reuses the variable.

Also made a small change to `getDefineEnv` to sort the argument similarly between all calls and change optional properties to be required with `undefined` in order to make the list explicit. Looking at the code it seems that `getDefineEnv` in `setup-dev.ts` is missing some information and that will break when `.env` / tsconfig changes 🤔 


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
