### PR TITLE
docs: remove typo in `use-selected-layout-segments.mdx`

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/use-selected-layout-segments.mdx
+++ b/docs/02-app/02-api-reference/04-functions/use-selected-layout-segments.mdx
@@ -55,7 +55,6 @@ const segments = useSelectedLayoutSegments(parallelRoutesKey?: string)
 ```
 
 `useSelectedLayoutSegments` _optionally_ accepts a [`parallelRoutesKey`](/docs/app/building-your-application/routing/parallel-routes#useselectedlayoutsegments), which allows you to read the active route segment within that slot.
-s.
 
 ## Returns
 


### PR DESCRIPTION
This pull request removes a typo in `use-selected-layout-segments.mdx`.

![image](https://github.com/vercel/next.js/assets/82393815/3c2717cf-212b-4d99-b403-3f90193adf42)
