### PR TITLE
Fix missing custom headers and cache-control header for /_next/static

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -390,12 +390,12 @@ export async function initialize(opts: {
           return
         }
 
-        if (
-          !res.getHeader('cache-control') &&
-          matchedOutput.type === 'nextStaticFolder'
-        ) {
+        if (matchedOutput.type === 'nextStaticFolder') {
           if (opts.dev) {
-            res.setHeader('Cache-Control', 'no-store, must-revalidate')
+            res.setHeader(
+              'Cache-Control',
+              'no-cache, no-store, max-age=0, must-revalidate'
+            )
           } else {
             res.setHeader(
               'Cache-Control',

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -197,10 +197,7 @@ export function getResolveRoutes(
         initialLocaleResult.detectedLocale || defaultLocale
 
       // ensure locale is present for resolving routes
-      if (
-        !initialLocaleResult.detectedLocale &&
-        !initialLocaleResult.pathname.startsWith('/_next/')
-      ) {
+      if (!initialLocaleResult.detectedLocale) {
         parsedUrl.pathname = addPathPrefix(
           initialLocaleResult.pathname === '/'
             ? `/${defaultLocale}`


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see `fixes #number`

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

This PR tries to fix a quite unexpected behaviour.

That is, when i18n is not configured in next.config, the server returns custom headers specified in next.config in the response for static assets (/_next/static). Whereas the server returns no custom headers when i18n is configured.

This inconsistency is especially an issue when the missing headers are security related.

Another related issue is: without i18n, the server respects the cache-control header in next.config somehow for static assets and does not overwrite it as mentioned here in https://nextjs.org/docs/pages/building-your-application/deploying/production-checklist#caching. With i18n, the cache-control header is indeed overwritten.

These inconsistencies seem to spread over dev, start and standalone mode.


Fixes #54159 