### PR TITLE
Matcher Updates

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -42,6 +42,7 @@ function swapDistFolderWithEsmDistFolder(path: string) {
 }
 
 function getRouteModuleOptions(page: string) {
+  // TODO: see if we need to support the locale aware definition as well
   const options: Omit<PagesRouteModuleOptions, 'userland' | 'components'> = {
     definition: {
       kind: RouteKind.PAGES,

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -519,7 +519,7 @@ export function onDemandEntryHandler({
   let curInvalidator: Invalidator = getInvalidator(
     multiCompiler.outputPath
   ) as any
-  const curEntries = getEntries(multiCompiler.outputPath) as any
+  const curEntries = getEntries(multiCompiler.outputPath)
 
   if (!curInvalidator) {
     curInvalidator = new Invalidator(multiCompiler)

--- a/packages/next/src/server/future/helpers/interception-routes.ts
+++ b/packages/next/src/server/future/helpers/interception-routes.ts
@@ -10,13 +10,11 @@ export const INTERCEPTION_ROUTE_MARKERS = [
 
 export function isInterceptionRouteAppPath(path: string): boolean {
   // TODO-APP: add more serious validation
-  return (
-    path
-      .split('/')
-      .find((segment) =>
-        INTERCEPTION_ROUTE_MARKERS.find((m) => segment.startsWith(m))
-      ) !== undefined
-  )
+  return path
+    .split('/')
+    .some((segment) =>
+      INTERCEPTION_ROUTE_MARKERS.some((m) => segment.startsWith(m))
+    )
 }
 
 export function extractInterceptionRouteInformation(path: string) {

--- a/packages/next/src/server/future/route-definitions/app-page-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/app-page-route-definition.ts
@@ -7,21 +7,6 @@ export interface AppPageRouteDefinition
   readonly appPaths: ReadonlyArray<string>
 }
 
-export interface AppPageInterceptingRouteDefinition
-  extends AppPageRouteDefinition {
-  readonly interceptingRoute: string
-
-  /**
-   * The pathname (including dynamic placeholders) for a route to resolve that
-   * is used for the browser to display in the address bar. This is used in
-   * place of `pathname` when the route is rendering.
-   *
-   * For intercepting routes, this should be the original pathname including
-   * the interception route markers (`(..)(..)`, `(..)`, and `(...)`).
-   */
-  readonly pathnameOverride: string
-}
-
 export function isAppPageRouteDefinition(
   definition: RouteDefinition
 ): definition is AppPageRouteDefinition {

--- a/packages/next/src/server/future/route-definitions/route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/route-definition.ts
@@ -31,11 +31,4 @@ export interface RouteDefinition<K extends RouteKind = RouteKind> {
    * The pathname (including dynamic placeholders) for a route to resolve.
    */
   readonly pathname: string
-
-  /**
-   * The pathname (including dynamic placeholders) for a route to resolve that
-   * is used for the browser to display in the address bar. This is used in
-   * place of `pathname` when the route is rendering.
-   */
-  readonly pathnameOverride?: string
 }

--- a/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.test.ts
+++ b/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.test.ts
@@ -15,18 +15,21 @@ describe('DefaultRouteMatcherManager', () => {
     await expect(
       manager.match('/some/not/real/path', {
         i18n: undefined,
+        matchedOutputPathname: undefined,
       })
     ).resolves.toEqual(null)
     manager.push({ matchers: jest.fn(async () => []) })
     await expect(
       manager.match('/some/not/real/path', {
         i18n: undefined,
+        matchedOutputPathname: undefined,
       })
     ).rejects.toThrow()
     await manager.load()
     await expect(
       manager.match('/some/not/real/path', {
         i18n: undefined,
+        matchedOutputPathname: undefined,
       })
     ).resolves.toEqual(null)
   })
@@ -37,6 +40,7 @@ describe('DefaultRouteMatcherManager', () => {
     await expect(
       manager.match('/some/not/real/path', {
         i18n: undefined,
+        matchedOutputPathname: undefined,
       })
     ).resolves.toEqual(null)
   })
@@ -55,13 +59,13 @@ describe('DefaultRouteMatcherManager', () => {
     }>([
       {
         pathname: '/some/[slug]/path',
-        options: { i18n: undefined },
+        options: { i18n: undefined, matchedOutputPathname: undefined },
         definitions: [],
         expected: undefined,
       },
       {
         pathname: '/some/[slug]/path',
-        options: { i18n: undefined },
+        options: { i18n: undefined, matchedOutputPathname: undefined },
         definitions: [
           {
             kind: RouteKind.APP_PAGE,
@@ -108,6 +112,7 @@ describe('DefaultRouteMatcherManager', () => {
           pathname: '/some/path',
           inferredFromDefault: false,
         },
+        matchedOutputPathname: undefined,
       },
       definition: {
         kind: RouteKind.PAGES,
@@ -129,6 +134,7 @@ describe('DefaultRouteMatcherManager', () => {
           pathname: '/some/path',
           inferredFromDefault: false,
         },
+        matchedOutputPathname: undefined,
       },
       definition: {
         kind: RouteKind.PAGES,
@@ -150,6 +156,7 @@ describe('DefaultRouteMatcherManager', () => {
           pathname: '/some/path',
           inferredFromDefault: false,
         },
+        matchedOutputPathname: undefined,
       },
       definition: {
         kind: RouteKind.PAGES,
@@ -206,6 +213,7 @@ describe('DefaultRouteMatcherManager', () => {
         pathname: '/some/path',
         inferredFromDefault: false,
       },
+      matchedOutputPathname: undefined,
     }
     const match = await manager.match('/en-US/some/path', options)
     expect(match?.definition).toBe(definition)
@@ -234,6 +242,7 @@ describe('DefaultRouteMatcherManager', () => {
         pathname: '/some/path',
         inferredFromDefault: true,
       },
+      matchedOutputPathname: undefined,
     }
     const match = await manager.match('/en-US/some/path', options)
     expect(match?.definition).toBe(definition)

--- a/packages/next/src/server/future/route-matcher-managers/helpers/group-matcher-results.ts
+++ b/packages/next/src/server/future/route-matcher-managers/helpers/group-matcher-results.ts
@@ -2,6 +2,13 @@ import { RouteMatcher } from '../../route-matchers/route-matcher'
 
 type GroupedMatcherResults = {
   /**
+   * all is a map of all the matchers, keyed by their pathname. There may be
+   * multiple matchers for the same pathname, so the value is an array of
+   * matchers.
+   */
+  readonly all: ReadonlyMap<string, ReadonlyArray<RouteMatcher>>
+
+  /**
    * duplicates is a map of all the duplicate matchers, keyed by their
    * pathname. This will only contain references to those matchers where more
    * than one matcher exists for the same pathname.
@@ -65,5 +72,5 @@ export function groupMatcherResults(
     }
   }
 
-  return { duplicates }
+  return { all, duplicates }
 }

--- a/packages/next/src/server/future/route-matcher-managers/route-matcher-manager.ts
+++ b/packages/next/src/server/future/route-matcher-managers/route-matcher-manager.ts
@@ -10,6 +10,14 @@ export type MatchOptions = {
    * application was not configured for additional locales.
    */
   i18n: Readonly<LocaleInfo> | undefined
+
+  /**
+   * The output of the matcher that should be used for matching. When defined,
+   * it will only match with the matchers that share the same output. Variants
+   * like different locales will be matched in order to match the correct
+   * output.
+   */
+  matchedOutputPathname: string | undefined
 }
 
 export interface RouteMatcherManager {

--- a/packages/next/src/server/future/route-matches/app-page-route-match.ts
+++ b/packages/next/src/server/future/route-matches/app-page-route-match.ts
@@ -1,8 +1,5 @@
 import type { RouteMatch } from './route-match'
-import type {
-  AppPageInterceptingRouteDefinition,
-  AppPageRouteDefinition,
-} from '../route-definitions/app-page-route-definition'
+import type { AppPageRouteDefinition } from '../route-definitions/app-page-route-definition'
 
 import { RouteKind } from '../route-kind'
 
@@ -18,6 +15,3 @@ export function isAppPageRouteMatch(
 ): match is AppPageRouteMatch {
   return match.definition.kind === RouteKind.APP_PAGE
 }
-
-export interface AppPageInterceptingRouteMatch
-  extends RouteMatch<AppPageInterceptingRouteDefinition> {}

--- a/packages/next/src/server/future/route-matches/invoked-route-match.ts
+++ b/packages/next/src/server/future/route-matches/invoked-route-match.ts
@@ -1,0 +1,29 @@
+import type { RouteDefinition } from '../route-definitions/route-definition'
+import { RouteMatch } from './route-match'
+
+export interface InvokedRouteMatch<D extends RouteDefinition = RouteDefinition>
+  extends RouteMatch<D> {
+  readonly matchedOutputPathname: string
+}
+
+export function extendInvokedRouteMatch<
+  D extends RouteDefinition,
+  R extends InvokedRouteMatch<D>
+>(
+  routeMatch: RouteMatch<D>,
+  matchedOutputPathname: R['matchedOutputPathname']
+): R {
+  return {
+    ...routeMatch,
+    matchedOutputPathname,
+  } as R
+}
+
+export function isInvokedRouteMatch(
+  routeMatch: RouteMatch
+): routeMatch is InvokedRouteMatch {
+  return (
+    'matchedOutputPathname' in routeMatch &&
+    typeof routeMatch.matchedOutputPathname === 'string'
+  )
+}

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -838,7 +838,9 @@ export default class NextNodeServer extends BaseServer {
 
       const options: MatchOptions = {
         i18n: this.i18nProvider?.fromQuery(pathname, query),
+        matchedOutputPathname: this.matchedOutputPathname(req),
       }
+
       const match = await this.matchers.match(pathname, options)
 
       // If we don't have a match, try to render it anyways.
@@ -847,10 +849,6 @@ export default class NextNodeServer extends BaseServer {
 
         return { finished: true }
       }
-
-      // Add the match to the request so we don't have to re-run the matcher
-      // for the same request.
-      addRequestMeta(req, '_nextMatch', match)
 
       // TODO-APP: move this to a route handler
       const edgeFunctionsPages = this.getEdgeFunctionsPages()

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -4,8 +4,7 @@ import type { ParsedUrlQuery } from 'querystring'
 import type { UrlWithParsedQuery } from 'url'
 import type { BaseNextRequest } from './base-http'
 import type { CloneableBody } from './body-streams'
-import { RouteMatch } from './future/route-matches/route-match'
-import { NEXT_RSC_UNION_QUERY } from '../client/components/app-router-headers'
+import type { NEXT_RSC_UNION_QUERY } from '../client/components/app-router-headers'
 
 // FIXME: (wyattjoh) this is a temporary solution to allow us to pass data between bundled modules
 export const NEXT_REQUEST_META = Symbol.for('NextInternalRequestMeta')
@@ -37,7 +36,6 @@ export interface RequestMeta {
   _nextMiddlewareCookie?: string[]
   _protocol?: string
   _nextDataNormalizing?: boolean
-  _nextMatch?: RouteMatch
   _nextIncrementalCache?: any
   _nextMinimalMode?: boolean
 }
@@ -93,22 +91,6 @@ export function addRequestMeta<K extends keyof RequestMeta>(
 ) {
   const meta = getRequestMeta(request)
   meta[key] = value
-  return setRequestMeta(request, meta)
-}
-
-/**
- * Removes a key from the request metadata.
- *
- * @param request the request to mutate
- * @param key the key to remove
- * @returns the mutated request metadata
- */
-export function removeRequestMeta<K extends keyof RequestMeta>(
-  request: NextIncomingMessage,
-  key: K
-) {
-  const meta = getRequestMeta(request)
-  delete meta[key]
   return setRequestMeta(request, meta)
 }
 

--- a/packages/next/src/shared/lib/router/utils/remove-trailing-slash.ts
+++ b/packages/next/src/shared/lib/router/utils/remove-trailing-slash.ts
@@ -6,5 +6,9 @@
  *   - `/` -> `/`
  */
 export function removeTrailingSlash(route: string) {
-  return route.replace(/\/$/, '') || '/'
+  if (route === '/' || !route.endsWith('/')) {
+    return route
+  }
+
+  return route.slice(0, -1)
 }


### PR DESCRIPTION
This adds support for the matcher system to handle invoke output requests from the routing server. This also updates the matchers to be more flexible and removes the matcher option that was incorrectly added that allowed Pages API routes to resolve with locale prefixes when running locally.
