### PR TITLE
Invoked Request Updates

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -42,6 +42,7 @@ function swapDistFolderWithEsmDistFolder(path: string) {
 }
 
 function getRouteModuleOptions(page: string) {
+  // TODO: see if we need to support the locale aware definition as well
   const options: Omit<PagesRouteModuleOptions, 'userland' | 'components'> = {
     definition: {
       kind: RouteKind.PAGES,

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -224,12 +224,7 @@ export default class DevServer extends Server {
         )
       )
       matchers.push(
-        new DevPagesAPIRouteMatcherProvider(
-          pagesDir,
-          extensions,
-          fileReader,
-          this.localeNormalizer
-        )
+        new DevPagesAPIRouteMatcherProvider(pagesDir, extensions, fileReader)
       )
     }
 
@@ -268,7 +263,7 @@ export default class DevServer extends Server {
 
     await super.prepareImpl()
     await this.runInstrumentationHookIfAvailable()
-    await this.matchers.reload()
+    await this.matchers.load()
     this.setDevReady!()
 
     // This is required by the tracing subsystem.

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -521,7 +521,7 @@ export function onDemandEntryHandler({
   let curInvalidator: Invalidator = getInvalidator(
     multiCompiler.outputPath
   ) as any
-  let curEntries = getEntries(multiCompiler.outputPath) as any
+  const curEntries = getEntries(multiCompiler.outputPath)
 
   if (!curInvalidator) {
     curInvalidator = new Invalidator(multiCompiler)

--- a/packages/next/src/server/future/helpers/i18n-provider.test.ts
+++ b/packages/next/src/server/future/helpers/i18n-provider.test.ts
@@ -1,5 +1,5 @@
 import { DomainLocale } from '../../config'
-import { I18NProvider, LocaleAnalysisResult } from './i18n-provider'
+import { I18NProvider, LocaleInfo } from './i18n-provider'
 
 describe('I18NProvider', () => {
   const config = {
@@ -71,7 +71,7 @@ describe('I18NProvider', () => {
     it.each<{
       pathname: string
       defaultLocale: string | undefined
-      expected: LocaleAnalysisResult
+      expected: LocaleInfo
     }>([
       // Verify un-prefixed index routes.
       {

--- a/packages/next/src/server/future/normalizers/base-path-normalizer.ts
+++ b/packages/next/src/server/future/normalizers/base-path-normalizer.ts
@@ -1,0 +1,73 @@
+import type { Normalizer } from './normalizer'
+
+export type BasePathInfo = {
+  /**
+   * The pathname without the prefix.
+   */
+  pathname: string
+
+  /**
+   * True if the pathname had the prefix.
+   */
+  hadBasePath: boolean
+}
+
+export class BasePathNormalizer implements Normalizer {
+  public readonly basePath: string
+
+  constructor(basePath: string) {
+    if (!basePath || !basePath.startsWith('/')) {
+      throw new Error(
+        `Invariant: basePath must start with a /, got ${basePath}`
+      )
+    }
+
+    this.basePath = basePath
+  }
+
+  /**
+   * Analyzes the pathname to see if it has the basePath prefix.
+   *
+   * @param pathname the pathname to analyze
+   */
+  public analyze(pathname: string): BasePathInfo {
+    let hadBasePath: boolean = false
+    if (pathname === this.basePath) {
+      hadBasePath = true
+      pathname = '/'
+    } else if (pathname.startsWith(this.basePath + '/')) {
+      hadBasePath = true
+      pathname = pathname.slice(this.basePath.length)
+    }
+    return { pathname, hadBasePath }
+  }
+
+  /**
+   * Removes the basePath from the pathname if it exists.
+   *
+   * @param pathname the pathname that may have the basePath prefix
+   * @returns the pathname without the basePath prefix
+   */
+  public normalize(pathname: string): string {
+    const { pathname: normalized } = this.analyze(pathname)
+    return normalized
+  }
+
+  /**
+   * Adds the basePath to the pathname.
+   *
+   * @param pathname the pathname to add the basePath to
+   * @returns the pathname with the basePath added
+   */
+  public denormalize(pathname: string): string {
+    if (pathname === '/') {
+      return this.basePath
+    }
+
+    if (!pathname.startsWith('/')) {
+      pathname = '/' + pathname
+    }
+
+    return this.basePath + pathname
+  }
+}

--- a/packages/next/src/server/future/normalizers/match-options-normalizer.ts
+++ b/packages/next/src/server/future/normalizers/match-options-normalizer.ts
@@ -1,0 +1,45 @@
+import type { Normalizer } from './normalizer'
+
+import { Normalizers } from './normalizers'
+import { wrapNormalizerFn } from './wrap-normalizer-fn'
+import { ensureLeadingSlash } from '../../../shared/lib/page-path/ensure-leading-slash'
+import { removeTrailingSlash } from '../../../shared/lib/router/utils/remove-trailing-slash'
+import { MatchOptions } from '../route-matcher-managers/route-matcher-manager'
+
+export type NormalizedMatchOptions = {
+  readonly pathname: string
+  readonly options: Readonly<MatchOptions>
+}
+
+export class MatchOptionsNormalizer
+  implements Normalizer<NormalizedMatchOptions>
+{
+  private static pathname = new Normalizers([
+    wrapNormalizerFn(ensureLeadingSlash),
+    wrapNormalizerFn(removeTrailingSlash),
+  ])
+
+  public normalize({
+    pathname,
+    options,
+  }: NormalizedMatchOptions): NormalizedMatchOptions {
+    // Ensure that any trailing slashes are removed as well as adding a leading
+    // slash if it doesn't have one.
+    pathname = MatchOptionsNormalizer.pathname.normalize(pathname)
+
+    // If the locale information is available on the options, then we need to
+    // normalize the pathname for matching as well.
+    let { i18n } = options
+    if (i18n) {
+      i18n = {
+        ...i18n,
+        pathname: MatchOptionsNormalizer.pathname.normalize(i18n.pathname),
+      }
+    }
+
+    // Create a new options object so we don't mutate the original.
+    options = { ...options, i18n }
+
+    return { pathname, options }
+  }
+}

--- a/packages/next/src/server/future/normalizers/match-options-normalizer.ts
+++ b/packages/next/src/server/future/normalizers/match-options-normalizer.ts
@@ -35,10 +35,16 @@ export class MatchOptionsNormalizer
         ...i18n,
         pathname: MatchOptionsNormalizer.pathname.normalize(i18n.pathname),
       }
-    }
 
-    // Create a new options object so we don't mutate the original.
-    options = { ...options, i18n }
+      // Create a new options object so we don't mutate the original.
+      options = { ...options, i18n }
+
+      // If the locale was inferred from the default locale (i.e. the user did
+      // not navigate to a locale prefixed path), then we need to remove the
+      // locale from the pathname so that it can be matched correctly. Any
+      // matcher that is not i18n aware will use this pathname for matching.
+      if (i18n.inferredFromDefault) pathname = i18n.pathname
+    }
 
     return { pathname, options }
   }

--- a/packages/next/src/server/future/normalizers/normalizer.ts
+++ b/packages/next/src/server/future/normalizers/normalizer.ts
@@ -1,3 +1,3 @@
-export interface Normalizer {
-  normalize(pathname: string): string
+export interface Normalizer<Input = string> {
+  normalize(input: Input): Input
 }

--- a/packages/next/src/server/future/normalizers/normalizers.ts
+++ b/packages/next/src/server/future/normalizers/normalizers.ts
@@ -4,17 +4,17 @@ import { Normalizer } from './normalizer'
  * Normalizers combines many normalizers into a single normalizer interface that
  * will normalize the inputted pathname with each normalizer in order.
  */
-export class Normalizers implements Normalizer {
-  constructor(private readonly normalizers: Array<Normalizer> = []) {}
+export class Normalizers<Input = string> implements Normalizer<Input> {
+  constructor(private readonly normalizers: Array<Normalizer<Input>> = []) {}
 
-  public push(normalizer: Normalizer) {
+  public push(normalizer: Normalizer<Input>) {
     this.normalizers.push(normalizer)
   }
 
-  public normalize(pathname: string): string {
-    return this.normalizers.reduce<string>(
+  public normalize(input: Input): Input {
+    return this.normalizers.reduce<Input>(
       (normalized, normalizer) => normalizer.normalize(normalized),
-      pathname
+      input
     )
   }
 }

--- a/packages/next/src/server/future/route-definitions/amp-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/amp-route-definition.ts
@@ -1,0 +1,17 @@
+import type { RouteKind } from '../route-kind'
+import type { RouteDefinition } from './route-definition'
+
+export interface AMPRouteDefinition<K extends RouteKind = RouteKind>
+  extends RouteDefinition<K> {
+  /**
+   * The AMP variant of this page if it exists. If this page is the AMP variant,
+   * then this will be undefined.
+   */
+  amp?: AMPRouteDefinition<K>
+}
+
+export function isAMPRouteDefinition(
+  definition: RouteDefinition
+): definition is AMPRouteDefinition {
+  return 'amp' in definition
+}

--- a/packages/next/src/server/future/route-definitions/locale-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/locale-route-definition.ts
@@ -1,5 +1,5 @@
-import { RouteKind } from '../route-kind'
-import { RouteDefinition } from './route-definition'
+import type { RouteKind } from '../route-kind'
+import type { RouteDefinition } from './route-definition'
 
 export interface LocaleRouteDefinition<K extends RouteKind = RouteKind>
   extends RouteDefinition<K> {
@@ -7,11 +7,16 @@ export interface LocaleRouteDefinition<K extends RouteKind = RouteKind>
    * When defined it means that this route is locale aware. When undefined,
    * it means no special handling has to occur to process locales.
    */
-  i18n?: {
+  i18n: {
     /**
      * Describes the locale for the route. If this is undefined, then it
      * indicates that this route can handle _any_ locale.
      */
-    locale?: string
+    detectedLocale: string | undefined
+
+    /**
+     * The pathname with the locale stripped if it was present.
+     */
+    pathname: string
   }
 }

--- a/packages/next/src/server/future/route-definitions/pages-api-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/pages-api-route-definition.ts
@@ -1,5 +1,5 @@
 import { RouteKind } from '../route-kind'
-import { LocaleRouteDefinition } from './locale-route-definition'
+import { RouteDefinition } from './route-definition'
 
 export interface PagesAPIRouteDefinition
-  extends LocaleRouteDefinition<RouteKind.PAGES_API> {}
+  extends RouteDefinition<RouteKind.PAGES_API> {}

--- a/packages/next/src/server/future/route-definitions/pages-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/pages-route-definition.ts
@@ -1,5 +1,9 @@
-import { RouteKind } from '../route-kind'
-import { LocaleRouteDefinition } from './locale-route-definition'
+import type { RouteKind } from '../route-kind'
+import type { LocaleRouteDefinition } from './locale-route-definition'
+import type { RouteDefinition } from './route-definition'
 
 export interface PagesRouteDefinition
+  extends RouteDefinition<RouteKind.PAGES> {}
+
+export interface PagesLocaleRouteDefinition
   extends LocaleRouteDefinition<RouteKind.PAGES> {}

--- a/packages/next/src/server/future/route-definitions/pages-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/pages-route-definition.ts
@@ -1,9 +1,12 @@
-import type { RouteKind } from '../route-kind'
 import type { LocaleRouteDefinition } from './locale-route-definition'
 import type { RouteDefinition } from './route-definition'
+import type { RouteKind } from '../route-kind'
+import type { AMPRouteDefinition } from './amp-route-definition'
 
 export interface PagesRouteDefinition
-  extends RouteDefinition<RouteKind.PAGES> {}
+  extends RouteDefinition<RouteKind.PAGES>,
+    AMPRouteDefinition<RouteKind.PAGES> {}
 
 export interface PagesLocaleRouteDefinition
-  extends LocaleRouteDefinition<RouteKind.PAGES> {}
+  extends LocaleRouteDefinition<RouteKind.PAGES>,
+    AMPRouteDefinition<RouteKind.PAGES> {}

--- a/packages/next/src/server/future/route-definitions/route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/route-definition.ts
@@ -1,9 +1,25 @@
 import { RouteKind } from '../route-kind'
 
 export interface RouteDefinition<K extends RouteKind = RouteKind> {
+  /**
+   * The kind of route this is.
+   */
   readonly kind: K
+
+  /**
+   * In development this represents the bundlePath representation of the given
+   * route.
+   *
+   * TODO: look into deprecating this, it should be replaced by `kind` and `page`
+   */
   readonly bundlePath: string
+
+  /**
+   * In development, this represents the absolute path to the source file while
+   * in production this represents the path to the built file.
+   */
   readonly filename: string
+
   /**
    * Describes the pathname including all internal modifiers such as
    * intercepting routes, parallel routes and route/page suffixes that are not

--- a/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.test.ts
+++ b/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.test.ts
@@ -14,6 +14,7 @@ describe('DefaultRouteMatcherManager', () => {
     const manager = new DefaultRouteMatcherManager()
     await expect(
       manager.match('/some/not/real/path', {
+        amp: undefined,
         i18n: undefined,
         matchedOutputPathname: undefined,
       })
@@ -21,6 +22,7 @@ describe('DefaultRouteMatcherManager', () => {
     manager.push({ matchers: jest.fn(async () => []) })
     await expect(
       manager.match('/some/not/real/path', {
+        amp: undefined,
         i18n: undefined,
         matchedOutputPathname: undefined,
       })
@@ -28,6 +30,7 @@ describe('DefaultRouteMatcherManager', () => {
     await manager.load()
     await expect(
       manager.match('/some/not/real/path', {
+        amp: undefined,
         i18n: undefined,
         matchedOutputPathname: undefined,
       })
@@ -39,6 +42,7 @@ describe('DefaultRouteMatcherManager', () => {
     await manager.load()
     await expect(
       manager.match('/some/not/real/path', {
+        amp: undefined,
         i18n: undefined,
         matchedOutputPathname: undefined,
       })
@@ -59,13 +63,21 @@ describe('DefaultRouteMatcherManager', () => {
     }>([
       {
         pathname: '/some/[slug]/path',
-        options: { i18n: undefined, matchedOutputPathname: undefined },
+        options: {
+          amp: undefined,
+          i18n: undefined,
+          matchedOutputPathname: undefined,
+        },
         definitions: [],
         expected: undefined,
       },
       {
         pathname: '/some/[slug]/path',
-        options: { i18n: undefined, matchedOutputPathname: undefined },
+        options: {
+          amp: undefined,
+          i18n: undefined,
+          matchedOutputPathname: undefined,
+        },
         definitions: [
           {
             kind: RouteKind.APP_PAGE,
@@ -107,6 +119,7 @@ describe('DefaultRouteMatcherManager', () => {
     {
       pathname: '/nl-NL/some/path',
       options: {
+        amp: undefined,
         i18n: {
           detectedLocale: 'nl-NL',
           pathname: '/some/path',
@@ -129,6 +142,7 @@ describe('DefaultRouteMatcherManager', () => {
     {
       pathname: '/en-US/some/path',
       options: {
+        amp: undefined,
         i18n: {
           detectedLocale: 'en-US',
           pathname: '/some/path',
@@ -151,6 +165,7 @@ describe('DefaultRouteMatcherManager', () => {
     {
       pathname: '/some/path',
       options: {
+        amp: undefined,
         i18n: {
           detectedLocale: undefined,
           pathname: '/some/path',
@@ -208,6 +223,7 @@ describe('DefaultRouteMatcherManager', () => {
     await manager.load()
 
     const options: MatchOptions = {
+      amp: undefined,
       i18n: {
         detectedLocale: undefined,
         pathname: '/some/path',
@@ -237,6 +253,7 @@ describe('DefaultRouteMatcherManager', () => {
     await manager.load()
 
     const options: MatchOptions = {
+      amp: undefined,
       i18n: {
         detectedLocale: 'en-US',
         pathname: '/some/path',

--- a/packages/next/src/server/future/route-matcher-managers/helpers/group-matcher-results.ts
+++ b/packages/next/src/server/future/route-matcher-managers/helpers/group-matcher-results.ts
@@ -1,0 +1,75 @@
+import { RouteMatcher } from '../../route-matchers/route-matcher'
+
+type GroupedMatcherResults = {
+  /**
+   * all is a map of all the matchers, keyed by their pathname. There may be
+   * multiple matchers for the same pathname, so the value is an array of
+   * matchers.
+   */
+  readonly all: ReadonlyMap<string, ReadonlyArray<RouteMatcher>>
+
+  /**
+   * duplicates is a map of all the duplicate matchers, keyed by their
+   * pathname. This will only contain references to those matchers where more
+   * than one matcher exists for the same pathname.
+   */
+  readonly duplicates: ReadonlyMap<string, ReadonlyArray<RouteMatcher>>
+}
+
+/**
+ * This will group the given matchers into two groups: all and duplicates.
+ *
+ * @param matchers the matchers to group
+ * @returns the grouped matchers
+ */
+export function groupMatcherResults(
+  matchers: ReadonlyArray<RouteMatcher>
+): GroupedMatcherResults {
+  const all = new Map<string, RouteMatcher[]>()
+  const duplicates = new Map<string, RouteMatcher[]>()
+
+  for (const matcher of matchers) {
+    // Reset duplicated matches when reloading from pages conflicting state.
+    if (matcher.duplicated) delete matcher.duplicated
+
+    // Test to see if the matcher being added is a duplicate.
+    let matched = all.get(matcher.definition.pathname)
+    if (matched && matched.length > 0) {
+      // We got a duplicate! This means that along with the current
+      // matcher, there is already a matcher for the same pathname. Let's
+      // grab the first one, as all the matchers will share the same
+      // array reference anyways.
+      const [other] = matched
+
+      // Check to see if this there is already a duplicate array for this
+      // pathname. If there is, then we can just push the matcher into it.
+      // Otherwise, we need to create a new array with the original
+      // duplicate first.
+      let others = duplicates.get(matcher.definition.pathname)
+      if (!others) {
+        // There was no duplicate array, so create a new one with the
+        // original duplicate first. Then add this array reference to the
+        // duplicates map.
+        others = [other]
+        duplicates.set(matcher.definition.pathname, others)
+
+        // Add the new reference to the original matcher, this is the
+        // first time it's been duplicated.
+        other.duplicated = others
+      }
+
+      // Push the new matcher into the array of duplicates and set the
+      // array reference on the new matcher. This is the first time it's
+      // been duplicated.
+      others.push(matcher)
+      matcher.duplicated = others
+    } else {
+      // There was no match, so create a new array with the matcher in it.
+      // Then add this array reference to the all map.
+      matched = [matcher]
+      all.set(matcher.definition.pathname, matched)
+    }
+  }
+
+  return { all, duplicates }
+}

--- a/packages/next/src/server/future/route-matcher-managers/helpers/group-matcher-results.ts
+++ b/packages/next/src/server/future/route-matcher-managers/helpers/group-matcher-results.ts
@@ -6,7 +6,7 @@ type GroupedMatcherResults = {
    * multiple matchers for the same pathname, so the value is an array of
    * matchers.
    */
-  readonly all: ReadonlyMap<string, ReadonlyArray<RouteMatcher>>
+  readonly byPathname: ReadonlyMap<string, ReadonlyArray<RouteMatcher>>
 
   /**
    * duplicates is a map of all the duplicate matchers, keyed by their
@@ -25,7 +25,7 @@ type GroupedMatcherResults = {
 export function groupMatcherResults(
   matchers: ReadonlyArray<RouteMatcher>
 ): GroupedMatcherResults {
-  const all = new Map<string, RouteMatcher[]>()
+  const byPathname = new Map<string, RouteMatcher[]>()
   const duplicates = new Map<string, RouteMatcher[]>()
 
   for (const matcher of matchers) {
@@ -33,13 +33,13 @@ export function groupMatcherResults(
     if (matcher.duplicated) delete matcher.duplicated
 
     // Test to see if the matcher being added is a duplicate.
-    let matched = all.get(matcher.definition.pathname)
-    if (matched && matched.length > 0) {
+    let byThisPathname = byPathname.get(matcher.definition.pathname)
+    if (byThisPathname && byThisPathname.length > 0) {
       // We got a duplicate! This means that along with the current
       // matcher, there is already a matcher for the same pathname. Let's
       // grab the first one, as all the matchers will share the same
       // array reference anyways.
-      const [other] = matched
+      const [other] = byThisPathname
 
       // Check to see if this there is already a duplicate array for this
       // pathname. If there is, then we can just push the matcher into it.
@@ -63,13 +63,14 @@ export function groupMatcherResults(
       // been duplicated.
       others.push(matcher)
       matcher.duplicated = others
+      byThisPathname.push(matcher)
     } else {
       // There was no match, so create a new array with the matcher in it.
       // Then add this array reference to the all map.
-      matched = [matcher]
-      all.set(matcher.definition.pathname, matched)
+      byThisPathname = [matcher]
+      byPathname.set(matcher.definition.pathname, byThisPathname)
     }
   }
 
-  return { all, duplicates }
+  return { byPathname, duplicates }
 }

--- a/packages/next/src/server/future/route-matcher-managers/helpers/sort-dynamic-matchers.ts
+++ b/packages/next/src/server/future/route-matcher-managers/helpers/sort-dynamic-matchers.ts
@@ -1,0 +1,63 @@
+import { getSortedRoutes } from '../../../../shared/lib/router/utils'
+import { RouteMatcher } from '../../route-matchers/route-matcher'
+
+/**
+ * sortDynamicMatchers sorts the given dynamic matchers by their pathnames
+ * according to the rules of `getSortedRoutes`.
+ *
+ * @param matchers the matchers to sort
+ * @returns the sorted matchers
+ */
+export function sortDynamicMatchers(
+  matchers: ReadonlyArray<RouteMatcher>
+): ReadonlyArray<RouteMatcher> {
+  // As `getSortedRoutes` only takes an array of strings, we need to create
+  // a map of the pathnames (used for sorting) and the matchers. When we
+  // have locales, there may be multiple matches for the same pathname. To
+  // handle this, we keep a map of all the indexes (in `reference`) and
+  // merge them in later.
+
+  const reference = new Map<string, number[]>()
+  const pathnames = new Array<string>()
+  for (let index = 0; index < matchers.length; index++) {
+    // Grab the pathname from the definition.
+    const pathname = matchers[index].definition.pathname
+
+    // Grab the index in the dynamic array, push it into the reference.
+    let indexes = reference.get(pathname)
+    if (!indexes) {
+      // If we couldn't get a reference for this then this is the first
+      // time we've seen this pathname, so create a new array and set it. We
+      // mutate the array later, so we don't need to set it again as it's
+      // a reference.
+      indexes = []
+      reference.set(pathname, indexes)
+
+      // Push the pathname into the array of pathnames.
+      pathnames.push(pathname)
+    }
+    indexes.push(index)
+  }
+
+  // Sort the array of pathnames.
+  const sorted = getSortedRoutes(pathnames)
+
+  // For each of the sorted pathnames, iterate over them, grabbing the list
+  // of indexes and merging them back into the new `sortedDynamicMatchers`
+  // array. The order of the same matching pathname doesn't matter because
+  // they will have other matching characteristics (like the locale) that
+  // is considered.
+  const sortedDynamicMatchers: Array<RouteMatcher> = []
+  for (const pathname of sorted) {
+    const indexes = reference.get(pathname)
+    if (!Array.isArray(indexes)) {
+      throw new Error('Invariant: expected to find identity in indexes map')
+    }
+
+    const dynamicMatches = indexes.map((index) => matchers[index])
+
+    sortedDynamicMatchers.push(...dynamicMatches)
+  }
+
+  return sortedDynamicMatchers
+}

--- a/packages/next/src/server/future/route-matcher-managers/route-matcher-manager.ts
+++ b/packages/next/src/server/future/route-matcher-managers/route-matcher-manager.ts
@@ -5,6 +5,12 @@ import { RouteMatcherProvider } from '../route-matcher-providers/route-matcher-p
 
 export type MatchOptions = {
   /**
+   * If true, this indicates to the matcher that the request should be treated
+   * as an AMP request.
+   */
+  amp: boolean | undefined
+
+  /**
    * If defined, this indicates to the matcher that the request should be
    * treated as locale-aware. If this is undefined, it means that this
    * application was not configured for additional locales.

--- a/packages/next/src/server/future/route-matcher-providers/app-page-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/app-page-route-matcher-provider.ts
@@ -23,7 +23,11 @@ export class AppPageRouteMatcherProvider extends ManifestRouteMatcherProvider<Ap
     manifest: Manifest
   ): Promise<ReadonlyArray<AppPageRouteMatcher>> {
     // This matcher only matches app pages.
-    const pages = Object.keys(manifest).filter((page) => isAppPageRoute(page))
+    const pages = Object.keys(manifest)
+      .filter((page) => isAppPageRoute(page))
+      // Sort the pathnames to ensure that the order of the matchers is
+      // deterministic.
+      .sort()
 
     // Collect all the app paths for each page. This could include any parallel
     // routes.

--- a/packages/next/src/server/future/route-matcher-providers/app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/app-route-route-matcher-provider.ts
@@ -22,7 +22,11 @@ export class AppRouteRouteMatcherProvider extends ManifestRouteMatcherProvider<A
     manifest: Manifest
   ): Promise<ReadonlyArray<AppRouteRouteMatcher>> {
     // This matcher only matches app routes.
-    const pages = Object.keys(manifest).filter((page) => isAppRouteRoute(page))
+    const pages = Object.keys(manifest)
+      .filter((page) => isAppRouteRoute(page))
+      // Sort the pathnames to ensure that the order of the matchers is
+      // deterministic.
+      .sort()
 
     // Format the routes.
     const matchers: Array<AppRouteRouteMatcher> = []

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.ts
@@ -1,11 +1,8 @@
-import { FileReader } from './helpers/file-reader/file-reader'
-import {
-  PagesAPILocaleRouteMatcher,
-  PagesAPIRouteMatcher,
-} from '../../route-matchers/pages-api-route-matcher'
+import type { FileReader } from './helpers/file-reader/file-reader'
+
+import { PagesAPIRouteMatcher } from '../../route-matchers/pages-api-route-matcher'
 import { RouteKind } from '../../route-kind'
 import path from 'path'
-import { LocaleRouteNormalizer } from '../../normalizers/locale-route-normalizer'
 import { FileCacheRouteMatcherProvider } from './file-cache-route-matcher-provider'
 import { DevPagesNormalizers } from '../../normalizers/built/pages'
 
@@ -16,8 +13,7 @@ export class DevPagesAPIRouteMatcherProvider extends FileCacheRouteMatcherProvid
   constructor(
     private readonly pagesDir: string,
     private readonly extensions: ReadonlyArray<string>,
-    reader: FileReader,
-    private readonly localeNormalizer?: LocaleRouteNormalizer
+    reader: FileReader
   ) {
     super(pagesDir, reader)
 
@@ -62,28 +58,15 @@ export class DevPagesAPIRouteMatcherProvider extends FileCacheRouteMatcherProvid
       const page = this.normalizers.page.normalize(filename)
       const bundlePath = this.normalizers.bundlePath.normalize(filename)
 
-      if (this.localeNormalizer) {
-        matchers.push(
-          new PagesAPILocaleRouteMatcher({
-            kind: RouteKind.PAGES_API,
-            pathname,
-            page,
-            bundlePath,
-            filename,
-            i18n: {},
-          })
-        )
-      } else {
-        matchers.push(
-          new PagesAPIRouteMatcher({
-            kind: RouteKind.PAGES_API,
-            pathname,
-            page,
-            bundlePath,
-            filename,
-          })
-        )
-      }
+      matchers.push(
+        new PagesAPIRouteMatcher({
+          kind: RouteKind.PAGES_API,
+          pathname,
+          page,
+          bundlePath,
+          filename,
+        })
+      )
     }
 
     return matchers

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-pages-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-pages-route-matcher-provider.ts
@@ -9,7 +9,9 @@ import { LocaleRouteNormalizer } from '../../normalizers/locale-route-normalizer
 import { FileCacheRouteMatcherProvider } from './file-cache-route-matcher-provider'
 import { DevPagesNormalizers } from '../../normalizers/built/pages'
 
-export class DevPagesRouteMatcherProvider extends FileCacheRouteMatcherProvider<PagesRouteMatcher> {
+export class DevPagesRouteMatcherProvider extends FileCacheRouteMatcherProvider<
+  PagesRouteMatcher | PagesLocaleRouteMatcher
+> {
   private readonly expression: RegExp
   private readonly normalizers: DevPagesNormalizers
 
@@ -52,8 +54,8 @@ export class DevPagesRouteMatcherProvider extends FileCacheRouteMatcherProvider<
 
   protected async transform(
     files: ReadonlyArray<string>
-  ): Promise<ReadonlyArray<PagesRouteMatcher>> {
-    const matchers: Array<PagesRouteMatcher> = []
+  ): Promise<ReadonlyArray<PagesRouteMatcher | PagesLocaleRouteMatcher>> {
+    const matchers: Array<PagesRouteMatcher | PagesLocaleRouteMatcher> = []
     for (const filename of files) {
       // If the file isn't a match for this matcher, then skip it.
       if (!this.test(filename)) continue
@@ -70,7 +72,13 @@ export class DevPagesRouteMatcherProvider extends FileCacheRouteMatcherProvider<
             page,
             bundlePath,
             filename,
-            i18n: {},
+            i18n: {
+              // In development we don't have specific routes per locale, so
+              // we can just set this to undefined to have it accept all
+              // locales.
+              detectedLocale: undefined,
+              pathname,
+            },
           })
         )
       } else {

--- a/packages/next/src/server/future/route-matcher-providers/dev/helpers/file-reader/default-file-reader.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/helpers/file-reader/default-file-reader.ts
@@ -12,7 +12,7 @@ export type DefaultFileReaderOptions = Pick<
 
 /**
  * Reads all the files in the directory and its subdirectories following any
- * symbolic links.
+ * symbolic links and returns a sorted list of the files.
  */
 export class DefaultFileReader implements FileReader {
   /**
@@ -45,9 +45,9 @@ export class DefaultFileReader implements FileReader {
       ignoreFilter: this.options.ignoreFilter,
       ignorePartFilter: this.options.ignorePartFilter,
 
-      // We don't need to sort the results because we're not depending on the
-      // order of the results.
-      sortPathnames: false,
+      // We want to sort the pathnames so that we can compare them with other
+      // pathnames.
+      sortPathnames: true,
 
       // We want absolute pathnames because we're going to be comparing them
       // with other absolute pathnames.

--- a/packages/next/src/server/future/route-matcher-providers/pages-api-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/pages-api-route-matcher-provider.ts
@@ -1,26 +1,19 @@
-import { isAPIRoute } from '../../../lib/is-api-route'
-import { PAGES_MANIFEST } from '../../../shared/lib/constants'
-import { RouteKind } from '../route-kind'
-import {
-  PagesAPILocaleRouteMatcher,
-  PagesAPIRouteMatcher,
-} from '../route-matchers/pages-api-route-matcher'
-import {
+import type {
   Manifest,
   ManifestLoader,
 } from './helpers/manifest-loaders/manifest-loader'
+
+import { isAPIRoute } from '../../../lib/is-api-route'
+import { PAGES_MANIFEST } from '../../../shared/lib/constants'
+import { RouteKind } from '../route-kind'
+import { PagesAPIRouteMatcher } from '../route-matchers/pages-api-route-matcher'
 import { ManifestRouteMatcherProvider } from './manifest-route-matcher-provider'
-import { I18NProvider } from '../helpers/i18n-provider'
 import { PagesNormalizers } from '../normalizers/built/pages'
 
 export class PagesAPIRouteMatcherProvider extends ManifestRouteMatcherProvider<PagesAPIRouteMatcher> {
   private readonly normalizers: PagesNormalizers
 
-  constructor(
-    distDir: string,
-    manifestLoader: ManifestLoader,
-    private readonly i18nProvider?: I18NProvider
-  ) {
+  constructor(distDir: string, manifestLoader: ManifestLoader) {
     super(PAGES_MANIFEST, manifestLoader)
 
     this.normalizers = new PagesNormalizers(distDir)
@@ -37,33 +30,15 @@ export class PagesAPIRouteMatcherProvider extends ManifestRouteMatcherProvider<P
     const matchers: Array<PagesAPIRouteMatcher> = []
 
     for (const page of pathnames) {
-      if (this.i18nProvider) {
-        // Match the locale on the page name, or default to the default locale.
-        const { detectedLocale, pathname } = this.i18nProvider.analyze(page)
-
-        matchers.push(
-          new PagesAPILocaleRouteMatcher({
-            kind: RouteKind.PAGES_API,
-            pathname,
-            page,
-            bundlePath: this.normalizers.bundlePath.normalize(page),
-            filename: this.normalizers.filename.normalize(manifest[page]),
-            i18n: {
-              locale: detectedLocale,
-            },
-          })
-        )
-      } else {
-        matchers.push(
-          new PagesAPIRouteMatcher({
-            kind: RouteKind.PAGES_API,
-            pathname: page,
-            page,
-            bundlePath: this.normalizers.bundlePath.normalize(page),
-            filename: this.normalizers.filename.normalize(manifest[page]),
-          })
-        )
-      }
+      matchers.push(
+        new PagesAPIRouteMatcher({
+          kind: RouteKind.PAGES_API,
+          pathname: page,
+          page,
+          bundlePath: this.normalizers.bundlePath.normalize(page),
+          filename: this.normalizers.filename.normalize(manifest[page]),
+        })
+      )
     }
 
     return matchers

--- a/packages/next/src/server/future/route-matcher-providers/pages-api-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/pages-api-route-matcher-provider.ts
@@ -23,9 +23,11 @@ export class PagesAPIRouteMatcherProvider extends ManifestRouteMatcherProvider<P
     manifest: Manifest
   ): Promise<ReadonlyArray<PagesAPIRouteMatcher>> {
     // This matcher is only for Pages API routes.
-    const pathnames = Object.keys(manifest).filter((pathname) =>
-      isAPIRoute(pathname)
-    )
+    const pathnames = Object.keys(manifest)
+      .filter((pathname) => isAPIRoute(pathname))
+      // Sort the pathnames to ensure that the order of the matchers is
+      // deterministic.
+      .sort()
 
     const matchers: Array<PagesAPIRouteMatcher> = []
 

--- a/packages/next/src/server/future/route-matcher-providers/pages-route-matcher-provider.test.ts
+++ b/packages/next/src/server/future/route-matcher-providers/pages-route-matcher-provider.test.ts
@@ -1,6 +1,9 @@
 import { PAGES_MANIFEST, SERVER_DIRECTORY } from '../../../shared/lib/constants'
 import { I18NProvider } from '../helpers/i18n-provider'
-import { PagesRouteDefinition } from '../route-definitions/pages-route-definition'
+import {
+  PagesLocaleRouteDefinition,
+  PagesRouteDefinition,
+} from '../route-definitions/pages-route-definition'
 import { RouteKind } from '../route-kind'
 import { ManifestLoader } from './helpers/manifest-loaders/manifest-loader'
 import { PagesRouteMatcherProvider } from './pages-route-matcher-provider'
@@ -16,7 +19,7 @@ describe('PagesRouteMatcherProvider', () => {
   describe('locale matching', () => {
     describe.each<{
       manifest: Record<string, string>
-      routes: ReadonlyArray<PagesRouteDefinition>
+      routes: ReadonlyArray<PagesLocaleRouteDefinition>
       i18n: { locales: Array<string>; defaultLocale: string }
     }>([
       {
@@ -40,7 +43,10 @@ describe('PagesRouteMatcherProvider', () => {
             filename: `<root>/${SERVER_DIRECTORY}/pages/blog/[slug].js`,
             page: '/blog/[slug]',
             bundlePath: 'pages/blog/[slug]',
-            i18n: {},
+            i18n: {
+              detectedLocale: undefined,
+              pathname: '/blog/[slug]',
+            },
           },
           {
             kind: RouteKind.PAGES,
@@ -49,7 +55,8 @@ describe('PagesRouteMatcherProvider', () => {
             page: '/en-US',
             bundlePath: 'pages/en-US',
             i18n: {
-              locale: 'en-US',
+              detectedLocale: 'en-US',
+              pathname: '/',
             },
           },
           {
@@ -59,7 +66,8 @@ describe('PagesRouteMatcherProvider', () => {
             page: '/fr',
             bundlePath: 'pages/fr',
             i18n: {
-              locale: 'fr',
+              detectedLocale: 'fr',
+              pathname: '/',
             },
           },
           {
@@ -69,7 +77,8 @@ describe('PagesRouteMatcherProvider', () => {
             page: '/nl-NL',
             bundlePath: 'pages/nl-NL',
             i18n: {
-              locale: 'nl-NL',
+              detectedLocale: 'nl-NL',
+              pathname: '/',
             },
           },
           {
@@ -79,7 +88,8 @@ describe('PagesRouteMatcherProvider', () => {
             page: '/en-US/404',
             bundlePath: 'pages/en-US/404',
             i18n: {
-              locale: 'en-US',
+              detectedLocale: 'en-US',
+              pathname: '/404',
             },
           },
           {
@@ -89,7 +99,8 @@ describe('PagesRouteMatcherProvider', () => {
             page: '/fr/404',
             bundlePath: 'pages/fr/404',
             i18n: {
-              locale: 'fr',
+              detectedLocale: 'fr',
+              pathname: '/404',
             },
           },
           {
@@ -99,7 +110,8 @@ describe('PagesRouteMatcherProvider', () => {
             page: '/nl-NL/404',
             bundlePath: 'pages/nl-NL/404',
             i18n: {
-              locale: 'nl-NL',
+              detectedLocale: 'nl-NL',
+              pathname: '/404',
             },
           },
         ],
@@ -122,8 +134,8 @@ describe('PagesRouteMatcherProvider', () => {
 
         expect(loader.load).toBeCalledWith(PAGES_MANIFEST)
         const routes = matchers.map((matcher) => matcher.definition)
-        expect(routes).toContainEqual(route)
         expect(routes).toHaveLength(expected.length)
+        expect(routes).toContainEqual(route)
       })
     })
   })

--- a/packages/next/src/server/future/route-matcher-providers/pages-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/pages-route-matcher-provider.ts
@@ -12,6 +12,7 @@ import {
 import { ManifestRouteMatcherProvider } from './manifest-route-matcher-provider'
 import { I18NProvider } from '../helpers/i18n-provider'
 import { PagesNormalizers } from '../normalizers/built/pages'
+import { denormalizePagePath } from '../../../shared/lib/page-path/denormalize-page-path'
 
 export class PagesRouteMatcherProvider extends ManifestRouteMatcherProvider<
   PagesRouteMatcher | PagesLocaleRouteMatcher
@@ -46,35 +47,94 @@ export class PagesRouteMatcherProvider extends ManifestRouteMatcherProvider<
 
         return true
       })
+      // Sort the pathnames to ensure that the order of the matchers is
+      // deterministic.
+      .sort()
+
+    // Keep track of all the AMP pages so we can link them to the non-amp
+    // pages later.
+    const ampPages = new Map<
+      string,
+      PagesRouteMatcher | PagesLocaleRouteMatcher
+    >()
 
     const matchers: Array<PagesRouteMatcher | PagesLocaleRouteMatcher> = []
     for (const page of pathnames) {
       // In pages, the page is the same as the pathname.
-      const pathname = page
+      let pathname = page
+
+      // The page is an AMP page if the page ends with `.amp`.
+      const ampPage = page.endsWith('.amp')
+
+      // The user does not access the AMP pages via the `.amp` extension, so
+      // remove it from the pathname.
+      if (ampPage) {
+        pathname = denormalizePagePath(pathname.slice(0, -4))
+      }
+
+      let matcher: PagesRouteMatcher | PagesLocaleRouteMatcher
       if (this.i18nProvider) {
         const i18n = this.i18nProvider.analyze(pathname)
 
-        matchers.push(
-          new PagesLocaleRouteMatcher({
-            kind: RouteKind.PAGES,
-            pathname: i18n.pathname,
-            page,
-            bundlePath: this.normalizers.bundlePath.normalize(page),
-            filename: this.normalizers.filename.normalize(manifest[page]),
-            i18n,
-          })
-        )
+        matcher = new PagesLocaleRouteMatcher({
+          kind: RouteKind.PAGES,
+          pathname: i18n.pathname,
+          page,
+          bundlePath: this.normalizers.bundlePath.normalize(page),
+          filename: this.normalizers.filename.normalize(manifest[page]),
+          i18n,
+        })
       } else {
-        matchers.push(
-          new PagesRouteMatcher({
-            kind: RouteKind.PAGES,
-            pathname,
-            page,
-            bundlePath: this.normalizers.bundlePath.normalize(page),
-            filename: this.normalizers.filename.normalize(manifest[page]),
-          })
+        matcher = new PagesRouteMatcher({
+          kind: RouteKind.PAGES,
+          pathname,
+          page,
+          bundlePath: this.normalizers.bundlePath.normalize(page),
+          filename: this.normalizers.filename.normalize(manifest[page]),
+        })
+      }
+
+      // If this is an AMP page, then we need to link it to the non-AMP page.
+      if (ampPage) {
+        ampPages.set(pathname, matcher)
+      } else {
+        matchers.push(matcher)
+      }
+    }
+
+    // Attach the AMP pages to the non-AMP pages if they exist.
+    for (const matcher of matchers) {
+      const amp = ampPages.get(matcher.definition.page)
+
+      // We don't have an AMP page for this page, so skip it.
+      if (!amp) continue
+
+      // If the AMP page is not the same type as the non-AMP page, then this is
+      // an error!
+      if (amp.constructor !== matcher.constructor) {
+        throw new Error(
+          `Invariant: expected the AMP page '${amp.definition.page}' to be the same type as the non-AMP page '${matcher.definition.page}'`
         )
       }
+
+      // Remove the AMP page from the list of AMP pages so we don't re-add it.
+      ampPages.delete(matcher.definition.page)
+
+      // Attach the AMP page definition to the non-AMP page.
+      matcher.definition.amp = amp.definition
+    }
+
+    // If we haven't attached all the AMP pages, then we have some AMP pages
+    // that don't have a non-AMP page, this is an error!
+    if (ampPages.size > 0) {
+      const orphaned = Array.from(ampPages.keys())
+        .sort()
+        .map((pathname) => `'${pathname}'`)
+        .join(', ')
+
+      throw new Error(
+        `Invariant: expected all generated '.amp' pages to have a non-AMP page, but the following AMP pages do not have a non-AMP page: ${orphaned}`
+      )
     }
 
     return matchers

--- a/packages/next/src/server/future/route-matchers/app-page-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/app-page-route-matcher.ts
@@ -1,8 +1,11 @@
-import { RouteMatcher } from './route-matcher'
-import { AppPageRouteDefinition } from '../route-definitions/app-page-route-definition'
+import type { AppPageRouteDefinition } from '../route-definitions/app-page-route-definition'
 
-export class AppPageRouteMatcher extends RouteMatcher<AppPageRouteDefinition> {
+import { DefaultRouteMatcher } from './default-route-matcher'
+
+export class AppPageRouteMatcher extends DefaultRouteMatcher<AppPageRouteDefinition> {
   public get identity(): string {
-    return `${this.definition.pathname}?__nextPage=${this.definition.page}`
+    return `${this.definition.pathname}?__nextPage=${encodeURIComponent(
+      this.definition.page
+    )}`
   }
 }

--- a/packages/next/src/server/future/route-matchers/app-route-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/app-route-route-matcher.ts
@@ -1,4 +1,5 @@
-import { RouteMatcher } from './route-matcher'
-import { AppRouteRouteDefinition } from '../route-definitions/app-route-route-definition'
+import type { AppRouteRouteDefinition } from '../route-definitions/app-route-route-definition'
 
-export class AppRouteRouteMatcher extends RouteMatcher<AppRouteRouteDefinition> {}
+import { DefaultRouteMatcher } from './default-route-matcher'
+
+export class AppRouteRouteMatcher extends DefaultRouteMatcher<AppRouteRouteDefinition> {}

--- a/packages/next/src/server/future/route-matchers/default-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/default-route-matcher.ts
@@ -1,0 +1,41 @@
+import type { RouteMatch } from '../route-matches/route-match'
+import type { RouteDefinition } from '../route-definitions/route-definition'
+import type { PathnameMatcher } from './helpers/pathname-matcher'
+
+import { RouteMatcher, type RouteMatcherOptions } from './route-matcher'
+import { DynamicPathnameMatcher } from './helpers/dynamic-pathname-matcher'
+import { createPathnameMatcher } from './helpers/create-pathname-matcher'
+
+type DefaultMatcherMatchOptions = RouteMatcherOptions
+
+export class DefaultRouteMatcher<
+  D extends RouteDefinition = RouteDefinition,
+  M extends DefaultMatcherMatchOptions = DefaultMatcherMatchOptions
+> extends RouteMatcher<D, M> {
+  private readonly matcher: PathnameMatcher
+
+  constructor(definition: D) {
+    super(definition)
+    this.matcher = createPathnameMatcher(definition.pathname)
+  }
+
+  /**
+   * Identity returns the identity part of the matcher. This is used to compare
+   * a unique matcher to another. This is also used when sorting dynamic routes,
+   * so it must contain the pathname part.
+   */
+  public get identity(): string {
+    return this.definition.pathname
+  }
+
+  public get isDynamic() {
+    return this.matcher instanceof DynamicPathnameMatcher
+  }
+
+  public match({ pathname }: M): RouteMatch<D> | null {
+    const result = this.matcher.match(pathname)
+    if (!result) return null
+
+    return { definition: this.definition, params: result.params }
+  }
+}

--- a/packages/next/src/server/future/route-matchers/default-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/default-route-matcher.ts
@@ -6,11 +6,11 @@ import { RouteMatcher, type RouteMatcherOptions } from './route-matcher'
 import { DynamicPathnameMatcher } from './helpers/dynamic-pathname-matcher'
 import { createPathnameMatcher } from './helpers/create-pathname-matcher'
 
-type DefaultMatcherMatchOptions = RouteMatcherOptions
+export type DefaultRouteMatchOptions = RouteMatcherOptions
 
 export class DefaultRouteMatcher<
   D extends RouteDefinition = RouteDefinition,
-  M extends DefaultMatcherMatchOptions = DefaultMatcherMatchOptions
+  M extends DefaultRouteMatchOptions = DefaultRouteMatchOptions
 > extends RouteMatcher<D, M> {
   private readonly matcher: PathnameMatcher
 

--- a/packages/next/src/server/future/route-matchers/helpers/create-pathname-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/helpers/create-pathname-matcher.ts
@@ -1,0 +1,19 @@
+import type { PathnameMatcher } from './pathname-matcher'
+
+import { isDynamicRoute } from '../../../../shared/lib/router/utils'
+import { DynamicPathnameMatcher } from './dynamic-pathname-matcher'
+import { StaticPathnameMatcher } from './static-pathname-matcher'
+
+/**
+ * createPathnameMatcher creates a PathnameMatcher for the given pathname.
+ *
+ * @param pathname the pathname to create a matcher for
+ * @returns the created PathnameMatcher
+ */
+export function createPathnameMatcher(pathname: string): PathnameMatcher {
+  if (isDynamicRoute(pathname)) {
+    return new DynamicPathnameMatcher(pathname)
+  }
+
+  return new StaticPathnameMatcher(pathname)
+}

--- a/packages/next/src/server/future/route-matchers/helpers/dynamic-pathname-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/helpers/dynamic-pathname-matcher.ts
@@ -1,0 +1,18 @@
+import { getRouteMatcher } from '../../../../shared/lib/router/utils/route-matcher'
+import { getRouteRegex } from '../../../../shared/lib/router/utils/route-regex'
+import { type PathnameMatchResult, PathnameMatcher } from './pathname-matcher'
+
+/**
+ * DynamicPathnameMatcher is a matcher that matches a dynamic pathname by
+ * matching against the given regex.
+ */
+export class DynamicPathnameMatcher extends PathnameMatcher {
+  private readonly matcher = getRouteMatcher(getRouteRegex(this.pathname))
+
+  public match(pathname: string): PathnameMatchResult | null {
+    const params = this.matcher(pathname)
+    if (!params) return null
+
+    return { params }
+  }
+}

--- a/packages/next/src/server/future/route-matchers/helpers/pathname-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/helpers/pathname-matcher.ts
@@ -1,0 +1,19 @@
+export type PathnameMatchResult = {
+  /**
+   * The params for the route if the route is dynamic.
+   */
+  params?: Record<string, string | string[]>
+}
+
+export abstract class PathnameMatcher {
+  constructor(public readonly pathname: string) {}
+
+  /**
+   * Matches the given pathname against the route and returns any params if the
+   * route was dynamic.
+   *
+   * @param pathname the pathname to match against
+   * @returns the match result or null if the route did not match
+   */
+  public abstract match(pathname: string): PathnameMatchResult | null
+}

--- a/packages/next/src/server/future/route-matchers/helpers/static-pathname-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/helpers/static-pathname-matcher.ts
@@ -1,0 +1,13 @@
+import { PathnameMatchResult, PathnameMatcher } from './pathname-matcher'
+
+/**
+ * StaticPathnameMatcher is a matcher that matches a static pathname by direct
+ * comparison.
+ */
+export class StaticPathnameMatcher extends PathnameMatcher {
+  public match(pathname: string): PathnameMatchResult | null {
+    if (pathname !== this.pathname) return null
+
+    return {}
+  }
+}

--- a/packages/next/src/server/future/route-matchers/locale-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/locale-route-matcher.ts
@@ -1,27 +1,50 @@
-import type { LocaleAnalysisResult } from '../helpers/i18n-provider'
+import type { LocaleInfo } from '../helpers/i18n-provider'
 import type { LocaleRouteDefinition } from '../route-definitions/locale-route-definition'
 import type { LocaleRouteMatch } from '../route-matches/locale-route-match'
+import type { PathnameMatcher } from './helpers/pathname-matcher'
+
+import { createPathnameMatcher } from './helpers/create-pathname-matcher'
+import { DynamicPathnameMatcher } from './helpers/dynamic-pathname-matcher'
 import { RouteMatcher } from './route-matcher'
 
-export type LocaleMatcherMatchOptions = {
-  /**
-   * If defined, this indicates to the matcher that the request should be
-   * treated as locale-aware. If this is undefined, it means that this
-   * application was not configured for additional locales.
-   */
-  i18n?: LocaleAnalysisResult
-}
+type LocaleMatcherMatchOptions = LocaleInfo
 
 export class LocaleRouteMatcher<
-  D extends LocaleRouteDefinition = LocaleRouteDefinition
-> extends RouteMatcher<D> {
+  D extends LocaleRouteDefinition = LocaleRouteDefinition,
+  M extends LocaleMatcherMatchOptions = LocaleMatcherMatchOptions
+> extends RouteMatcher<D, M> {
+  /**
+   * is returns true if the given RouteMatcher is a LocaleRouteMatcher.
+   *
+   * @param m the RouteMatcher to check
+   * @returns true if the given RouteMatcher is a LocaleRouteMatcher
+   */
+  public static is(
+    m: RouteMatcher
+  ): m is LocaleRouteMatcher<LocaleRouteDefinition, LocaleMatcherMatchOptions> {
+    return m instanceof LocaleRouteMatcher
+  }
+
+  private readonly matcher: PathnameMatcher
+
+  constructor(definition: D) {
+    super(definition)
+    this.matcher = createPathnameMatcher(definition.i18n.pathname)
+  }
+
   /**
    * Identity returns the identity part of the matcher. This is used to compare
    * a unique matcher to another. This is also used when sorting dynamic routes,
    * so it must contain the pathname part as well.
    */
   public get identity(): string {
-    return `${this.definition.pathname}?__nextLocale=${this.definition.i18n?.locale}`
+    return `${this.definition.i18n.pathname}?__nextLocale=${encodeURIComponent(
+      this.definition.i18n.detectedLocale ?? ''
+    )}`
+  }
+
+  public get isDynamic() {
+    return this.matcher instanceof DynamicPathnameMatcher
   }
 
   /**
@@ -32,54 +55,34 @@ export class LocaleRouteMatcher<
    * @param options The options to use when matching.
    * @returns The match result, or `null` if there was no match.
    */
-  public match(
-    pathname: string,
-    options?: LocaleMatcherMatchOptions
-  ): LocaleRouteMatch<D> | null {
-    // This is like the parent `match` method but instead this injects the
-    // additional `options` into the
-    const result = this.test(pathname, options)
+  public match(options: M): LocaleRouteMatch<D> | null {
+    // If we have detected a locale and it does not match this route's locale,
+    // then this isn't a match!
+    if (
+      this.definition.i18n.detectedLocale &&
+      options.detectedLocale &&
+      this.definition.i18n.detectedLocale !== options.detectedLocale
+    ) {
+      return null
+    }
+
+    const result = this.matcher.match(options.pathname)
     if (!result) return null
+
+    let inferredFromDefinition = false
+    let detectedLocale = options.detectedLocale
+    if (!detectedLocale) {
+      detectedLocale = this.definition.i18n.detectedLocale
+      inferredFromDefinition = true
+    }
 
     return {
       definition: this.definition,
       params: result.params,
-      detectedLocale:
-        // If the options have a detected locale, then use that, otherwise use
-        // the route's locale.
-        options?.i18n?.detectedLocale ?? this.definition.i18n?.locale,
+      i18n: {
+        detectedLocale,
+        inferredFromDefinition: inferredFromDefinition,
+      },
     }
-  }
-
-  /**
-   * Test will attempt to match the given pathname against this route while
-   * also taking into account the locale information.
-   *
-   * @param pathname The pathname to match against.
-   * @param options The options to use when matching.
-   * @returns The match result, or `null` if there was no match.
-   */
-  public test(pathname: string, options?: LocaleMatcherMatchOptions) {
-    // If this route has locale information and we have detected a locale, then
-    // we need to compare the detected locale to the route's locale.
-    if (this.definition.i18n && options?.i18n) {
-      // If we have detected a locale and it does not match this route's locale,
-      // then this isn't a match!
-      if (
-        this.definition.i18n.locale &&
-        options.i18n.detectedLocale &&
-        this.definition.i18n.locale !== options.i18n.detectedLocale
-      ) {
-        return null
-      }
-
-      // Perform regular matching against the locale stripped pathname now, the
-      // locale information matches!
-      return super.test(options.i18n.pathname)
-    }
-
-    // If we don't have locale information, then we can just perform regular
-    // matching.
-    return super.test(pathname)
   }
 }

--- a/packages/next/src/server/future/route-matchers/pages-api-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/pages-api-route-matcher.ts
@@ -1,7 +1,4 @@
 import { PagesAPIRouteDefinition } from '../route-definitions/pages-api-route-definition'
-import { LocaleRouteMatcher } from './locale-route-matcher'
-import { RouteMatcher } from './route-matcher'
+import { DefaultRouteMatcher } from './default-route-matcher'
 
-export class PagesAPIRouteMatcher extends RouteMatcher<PagesAPIRouteDefinition> {}
-
-export class PagesAPILocaleRouteMatcher extends LocaleRouteMatcher<PagesAPIRouteDefinition> {}
+export class PagesAPIRouteMatcher extends DefaultRouteMatcher<PagesAPIRouteDefinition> {}

--- a/packages/next/src/server/future/route-matchers/pages-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/pages-route-matcher.ts
@@ -1,7 +1,11 @@
-import { PagesRouteDefinition } from '../route-definitions/pages-route-definition'
+import type {
+  PagesLocaleRouteDefinition,
+  PagesRouteDefinition,
+} from '../route-definitions/pages-route-definition'
+
+import { DefaultRouteMatcher } from './default-route-matcher'
 import { LocaleRouteMatcher } from './locale-route-matcher'
-import { RouteMatcher } from './route-matcher'
 
-export class PagesRouteMatcher extends RouteMatcher<PagesRouteDefinition> {}
+export class PagesRouteMatcher extends DefaultRouteMatcher<PagesRouteDefinition> {}
 
-export class PagesLocaleRouteMatcher extends LocaleRouteMatcher<PagesRouteDefinition> {}
+export class PagesLocaleRouteMatcher extends LocaleRouteMatcher<PagesLocaleRouteDefinition> {}

--- a/packages/next/src/server/future/route-matchers/route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/route-matcher.ts
@@ -1,19 +1,37 @@
-import type { RouteMatch } from '../route-matches/route-match'
 import type { RouteDefinition } from '../route-definitions/route-definition'
+import type { RouteMatch } from '../route-matches/route-match'
 
-import { isDynamicRoute } from '../../../shared/lib/router/utils'
-import {
-  getRouteMatcher,
-  type RouteMatchFn,
-} from '../../../shared/lib/router/utils/route-matcher'
-import { getRouteRegex } from '../../../shared/lib/router/utils/route-regex'
-
-type RouteMatchResult = {
-  params?: Record<string, string | string[]>
+export interface RouteMatcherOptions {
+  /**
+   * The pathname to match against.
+   */
+  pathname: string
 }
 
-export class RouteMatcher<D extends RouteDefinition = RouteDefinition> {
-  private readonly dynamic?: RouteMatchFn
+export abstract class RouteMatcher<
+  D extends RouteDefinition = RouteDefinition,
+  M extends RouteMatcherOptions = RouteMatcherOptions
+> {
+  /**
+   * True if this is a dynamic route. This changes the behavior of the matcher
+   * requiring it to be sorted alongside other dynamic routes to ensure the
+   * correct precedence.
+   */
+  public abstract readonly isDynamic: boolean
+
+  /**
+   * Identity returns the identity part of the matcher. This is used to compare
+   * a unique matcher to another. This is also used when sorting dynamic routes,
+   * so it must contain the pathname part.
+   */
+  public abstract readonly identity: string
+
+  /**
+   * Match will attempt to match the given options against this route.
+   *
+   * @param options The options to match against.
+   */
+  public abstract match(options: M): RouteMatch<D> | null
 
   /**
    * When set, this is an array of all the other matchers that are duplicates of
@@ -22,44 +40,12 @@ export class RouteMatcher<D extends RouteDefinition = RouteDefinition> {
    */
   public duplicated?: Array<RouteMatcher>
 
-  constructor(public readonly definition: D) {
-    if (isDynamicRoute(definition.pathname)) {
-      this.dynamic = getRouteMatcher(getRouteRegex(definition.pathname))
-    }
-  }
-
   /**
-   * Identity returns the identity part of the matcher. This is used to compare
-   * a unique matcher to another. This is also used when sorting dynamic routes,
-   * so it must contain the pathname part.
+   * The definition that this matcher is for.
    */
-  public get identity(): string {
-    return this.definition.pathname
-  }
+  public readonly definition: D
 
-  public get isDynamic() {
-    return this.dynamic !== undefined
-  }
-
-  public match(pathname: string): RouteMatch<D> | null {
-    const result = this.test(pathname)
-    if (!result) return null
-
-    return { definition: this.definition, params: result.params }
-  }
-
-  public test(pathname: string): RouteMatchResult | null {
-    if (this.dynamic) {
-      const params = this.dynamic(pathname)
-      if (!params) return null
-
-      return { params }
-    }
-
-    if (pathname === this.definition.pathname) {
-      return {}
-    }
-
-    return null
+  constructor(definition: D) {
+    this.definition = definition
   }
 }

--- a/packages/next/src/server/future/route-matchers/route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/route-matcher.ts
@@ -1,4 +1,5 @@
 import type { RouteDefinition } from '../route-definitions/route-definition'
+import type { MatchOptions } from '../route-matcher-managers/route-matcher-manager'
 import type { RouteMatch } from '../route-matches/route-match'
 
 export interface RouteMatcherOptions {
@@ -6,6 +7,11 @@ export interface RouteMatcherOptions {
    * The pathname to match against.
    */
   pathname: string
+
+  /**
+   * The options to match against.
+   */
+  options: MatchOptions
 }
 
 export abstract class RouteMatcher<

--- a/packages/next/src/server/future/route-matches/locale-route-match.ts
+++ b/packages/next/src/server/future/route-matches/locale-route-match.ts
@@ -3,5 +3,31 @@ import type { RouteMatch } from './route-match'
 
 export interface LocaleRouteMatch<R extends LocaleRouteDefinition>
   extends RouteMatch<R> {
-  readonly detectedLocale?: string
+  /**
+   * Contains all the information about the locale for this route match.
+   */
+  readonly i18n: {
+    /**
+     * The detected locale based on the route match.
+     */
+    readonly detectedLocale: string | undefined
+
+    /**
+     * Whether the detected locale was inferred from the route definition as it
+     * wasn't explicitly provided.
+     */
+    readonly inferredFromDefinition: boolean
+  }
+}
+
+/**
+ * Checks if the given match is a locale route match.
+ *
+ * @param match the match to check
+ * @returns true if the match is a locale route match, false otherwise
+ */
+export function isLocaleRouteMatch(
+  match: RouteMatch
+): match is LocaleRouteMatch<LocaleRouteDefinition> {
+  return 'i18n' in match
 }

--- a/packages/next/src/server/future/route-matches/locale-route-match.ts
+++ b/packages/next/src/server/future/route-matches/locale-route-match.ts
@@ -17,6 +17,12 @@ export interface LocaleRouteMatch<R extends LocaleRouteDefinition>
      * wasn't explicitly provided.
      */
     readonly inferredFromDefinition: boolean
+
+    /**
+     * Whether the detected locale was inferred from the default locale as it
+     * wasn't explicitly provided.
+     */
+    readonly inferredFromDefault: boolean
   }
 }
 

--- a/packages/next/src/server/future/route-matches/pages-route-match.ts
+++ b/packages/next/src/server/future/route-matches/pages-route-match.ts
@@ -1,5 +1,11 @@
-import type { PagesRouteDefinition } from '../route-definitions/pages-route-definition'
+import type {
+  PagesLocaleRouteDefinition,
+  PagesRouteDefinition,
+} from '../route-definitions/pages-route-definition'
 import type { LocaleRouteMatch } from './locale-route-match'
+import { RouteMatch } from './route-match'
 
-export interface PagesRouteMatch
-  extends LocaleRouteMatch<PagesRouteDefinition> {}
+export interface PagesLocaleRouteMatch
+  extends LocaleRouteMatch<PagesLocaleRouteDefinition> {}
+
+export interface PagesRouteMatch extends RouteMatch<PagesRouteDefinition> {}

--- a/packages/next/src/server/future/route-modules/pages/module.ts
+++ b/packages/next/src/server/future/route-modules/pages/module.ts
@@ -6,7 +6,10 @@ import type {
   NextComponentType,
   PageConfig,
 } from '../../../../../types'
-import type { PagesRouteDefinition } from '../../route-definitions/pages-route-definition'
+import type {
+  PagesLocaleRouteDefinition,
+  PagesRouteDefinition,
+} from '../../route-definitions/pages-route-definition'
 import type { NextParsedUrlQuery } from '../../../request-meta'
 import type { RenderOpts } from '../../../render'
 import type RenderResult from '../../../render-result'
@@ -71,7 +74,10 @@ type PagesComponents = {
 }
 
 export interface PagesRouteModuleOptions
-  extends RouteModuleOptions<PagesRouteDefinition, PagesUserlandModule> {
+  extends RouteModuleOptions<
+    PagesRouteDefinition | PagesLocaleRouteDefinition,
+    PagesUserlandModule
+  > {
   readonly components: PagesComponents
 }
 
@@ -99,7 +105,7 @@ export interface PagesRouteHandlerContext extends RouteModuleHandleContext {
 }
 
 export class PagesRouteModule extends RouteModule<
-  PagesRouteDefinition,
+  PagesRouteDefinition | PagesLocaleRouteDefinition,
   PagesUserlandModule
 > {
   private readonly components: PagesComponents

--- a/packages/next/src/server/lib/invoked-request.ts
+++ b/packages/next/src/server/lib/invoked-request.ts
@@ -1,0 +1,77 @@
+import type { NextParsedUrlQuery } from '../request-meta'
+import type { BaseNextRequest } from '../base-http'
+
+import { URL } from 'url'
+
+export const InvokedRequestHeaders = {
+  output: 'x-invoke-output',
+  path: 'x-invoke-path',
+  status: 'x-invoke-status',
+  query: 'x-invoke-query',
+  error: 'x-invoke-error',
+}
+
+export class InvokedRequest {
+  constructor(
+    public readonly pathname: string,
+    public readonly output: string | undefined = undefined,
+    public readonly statusCode: number | undefined = undefined,
+    public readonly query: NextParsedUrlQuery | undefined = undefined,
+    public readonly error: Error | null = null
+  ) {}
+
+  static parse(req: Pick<BaseNextRequest, 'headers'>): InvokedRequest | null {
+    const headers: Record<
+      keyof typeof InvokedRequestHeaders,
+      string | string[] | undefined
+    > = {
+      output: req.headers[InvokedRequestHeaders.output],
+      path: req.headers[InvokedRequestHeaders.path],
+      status: req.headers[InvokedRequestHeaders.status],
+      query: req.headers[InvokedRequestHeaders.query],
+      error: req.headers[InvokedRequestHeaders.error],
+    }
+
+    if (!headers.path || typeof headers.path !== 'string') return null
+
+    const { pathname } = new URL(headers.path, 'http://n')
+
+    // If defined, the output must be a non-empty string.
+    if (Array.isArray(headers.output) || headers.output === '') return null
+
+    if (Array.isArray(headers.status)) return null
+
+    // Parse the status code if it exists, throw an error if it's an invalid
+    // value.
+    let status: number | undefined
+    if (headers.status) {
+      const parsed = parseInt(headers.status, 10)
+      if (Number.isNaN(parsed)) {
+        throw new Error(
+          `Invalid status code received from invoked function: ${headers.status}`
+        )
+      }
+
+      status = parsed
+    }
+
+    if (Array.isArray(headers.query)) return null
+
+    // Parse the query if it exists, throw an error if it's an invalid value.
+    let query: NextParsedUrlQuery | undefined
+    if (headers.query) {
+      query = JSON.parse(decodeURIComponent(headers.query))
+    }
+
+    if (Array.isArray(headers.error)) return null
+
+    // Parse the error if it exists.
+    let error: Error | null = null
+    if (typeof headers.error === 'string') {
+      const { message } = JSON.parse(headers.error || '{}')
+      error = new Error(message)
+    }
+
+    return new InvokedRequest(pathname, headers.output, status, query, error)
+  }
+}

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -567,7 +567,7 @@ export default class NextNodeServer extends BaseServer {
       let page = ctx.pathname
       if (isAppPath) {
         // When it's an array, we need to pass all parallel routes to the loader.
-        page = appPaths[0]
+        page = appPaths[appPaths.length - 1]
       }
 
       for (const edgeFunctionsPage of edgeFunctionsPages) {
@@ -834,6 +834,7 @@ export default class NextNodeServer extends BaseServer {
 
       const options: MatchOptions = {
         i18n: this.i18nProvider?.fromQuery(pathname, query),
+        matchedOutputPathname: undefined,
       }
       const match = await this.matchers.match(pathname, options)
 
@@ -1416,7 +1417,7 @@ export default class NextNodeServer extends BaseServer {
   protected async ensureMiddleware() {}
   protected async ensureEdgeFunction(_params: {
     page: string
-    appPaths: string[] | null
+    appPaths: ReadonlyArray<string> | null
   }) {}
 
   /**
@@ -1732,7 +1733,7 @@ export default class NextNodeServer extends BaseServer {
     query: ParsedUrlQuery
     params: Params | undefined
     page: string
-    appPaths: string[] | null
+    appPaths: ReadonlyArray<string> | null
     match?: RouteMatch
     onWarning?: (warning: Error) => void
   }): Promise<FetchEventResult | null> {

--- a/packages/next/src/server/require.ts
+++ b/packages/next/src/server/require.ts
@@ -104,12 +104,7 @@ export function getPagePath(
   return pagePath
 }
 
-export function requirePage(
-  page: string,
-  distDir: string,
-  isAppPath: boolean
-): any {
-  const pagePath = getPagePath(page, distDir, undefined, isAppPath)
+export function requirePagePath(pagePath: string, page: string) {
   if (pagePath.endsWith('.html')) {
     return promises.readFile(pagePath, 'utf8').catch((err) => {
       throw new MissingStaticPage(page, err.message)
@@ -120,6 +115,15 @@ export function requirePage(
     ? // @ts-ignore
       __non_webpack_require__(pagePath)
     : require(pagePath)
+}
+
+export function requirePage(
+  page: string,
+  distDir: string,
+  isAppPath: boolean
+): any {
+  const pagePath = getPagePath(page, distDir, undefined, isAppPath)
+  return requirePagePath(pagePath, page)
 }
 
 export function requireFontManifest(distDir: string) {

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -9,7 +9,7 @@ import './globals'
 
 import { adapter, type AdapterOptions } from './adapter'
 import { IncrementalCache } from '../lib/incremental-cache'
-import { RouteMatcher } from '../future/route-matchers/route-matcher'
+import { AppRouteRouteMatcher } from '../future/route-matchers/app-route-route-matcher'
 import { removeTrailingSlash } from '../../shared/lib/router/utils/remove-trailing-slash'
 import { removePathPrefix } from '../../shared/lib/router/utils/remove-path-prefix'
 
@@ -21,7 +21,7 @@ type WrapOptions = Partial<Pick<AdapterOptions, 'page'>>
  * Note that this class should only be used in the edge runtime.
  */
 export class EdgeRouteModuleWrapper {
-  private readonly matcher: RouteMatcher
+  private readonly matcher: AppRouteRouteMatcher
 
   /**
    * The constructor is wrapped with private to ensure that it can only be
@@ -31,7 +31,7 @@ export class EdgeRouteModuleWrapper {
    */
   private constructor(private readonly routeModule: AppRouteRouteModule) {
     // TODO: (wyattjoh) possibly allow the module to define it's own matcher
-    this.matcher = new RouteMatcher(routeModule.definition)
+    this.matcher = new AppRouteRouteMatcher(routeModule.definition)
   }
 
   /**
@@ -63,6 +63,8 @@ export class EdgeRouteModuleWrapper {
   }
 
   private async handler(request: NextRequest): Promise<Response> {
+    // TODO: harmonize the pathname normalization between the server and here
+
     // Get the pathname for the matcher. Pathnames should not have trailing
     // slashes for matching.
     let pathname = removeTrailingSlash(new URL(request.url).pathname)
@@ -75,7 +77,7 @@ export class EdgeRouteModuleWrapper {
     }
 
     // Get the match for this request.
-    const match = this.matcher.match(pathname)
+    const match = this.matcher.match({ pathname })
     if (!match) {
       throw new Error(
         `Invariant: no match found for request. Pathname '${pathname}' should have matched '${this.matcher.definition.pathname}'`

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -77,7 +77,14 @@ export class EdgeRouteModuleWrapper {
     }
 
     // Get the match for this request.
-    const match = this.matcher.match({ pathname })
+    const match = this.matcher.match({
+      pathname,
+      options: {
+        i18n: undefined,
+        matchedOutputPathname: undefined,
+        amp: undefined,
+      },
+    })
     if (!match) {
       throw new Error(
         `Invariant: no match found for request. Pathname '${pathname}' should have matched '${this.matcher.definition.pathname}'`

--- a/packages/next/src/shared/lib/router/utils/remove-trailing-slash.ts
+++ b/packages/next/src/shared/lib/router/utils/remove-trailing-slash.ts
@@ -6,5 +6,9 @@
  *   - `/` -> `/`
  */
 export function removeTrailingSlash(route: string) {
-  return route.replace(/\/$/, '') || '/'
+  if (route === '/' || !route.endsWith('/')) {
+    return route
+  }
+
+  return route.slice(0, -1)
 }


### PR DESCRIPTION
Enables the use of the invoked output value to grab the matcher from the matcher manager as a `O(n)` where `n` is the number of matchers that share the same output path.
