### PR TITLE
Fix: Ensure first stale request to have updated server data

### DIFF
--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -50,6 +50,7 @@ interface Window {
 interface NextFetchRequestConfig {
   revalidate?: number | false
   tags?: string[]
+  forceFreshOnStale?: boolean
 }
 
 interface RequestInit {


### PR DESCRIPTION
   Fixes: #54784

Although I figured out where was the problem and developed a fix, I'm not really sure if the request processing is done h$
for this project.

This is where the cache processing is made but on the first stale, it was going with the old cached data, I overrided the$
response that is added to the pending Revalidates queue.

EDIT:

Added an option to allow having the response return new fresh data on stale.

I can use the cache header directive to set this option but i'm afraid i would break some logic that begins on line 178 of the patch-fetch file..

Wondering how that lock works and if we need to keep the cacheKey locked until the incrementalCache is updated with this option..