### PR TITLE
Fixed fallback prop value in first example to valid

### DIFF
--- a/docs/03-pages/01-building-your-application/03-data-fetching/02-get-static-paths.mdx
+++ b/docs/03-pages/01-building-your-application/03-data-fetching/02-get-static-paths.mdx
@@ -28,7 +28,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         },
       }, // See the "paths" section below
     ],
-    fallback: true, // false or "blocking"
+    fallback: false, // false or "blocking"
   }
 }
 


### PR DESCRIPTION
Value `true` was giving errors while running `next build` which could be problematic for beginners.