### PR TITLE
use pnpm for `next-with-deps`

### DIFF
--- a/scripts/next-with-deps.sh
+++ b/scripts/next-with-deps.sh
@@ -29,7 +29,7 @@ done
 
 if [ ! -z $HAS_CONFLICTING_DEP ] || [ ! -d "$PROJECT_DIR/node_modules" ];then
   cd $PROJECT_DIR
-  yarn install
+  pnpm i --ignore-workspace
   for dep in ${CONFLICTING_DEPS[@]};do 
     rm -rf node_modules/$dep
   done


### PR DESCRIPTION
This fixes the "Usage Error: This project is configured to use pnpm" error when running `next-with-deps` since we [enforce a package manager](https://github.com/vercel/next.js/blob/canary/package.json#L252)