### PR TITLE
Enable externalDir by default

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -422,7 +422,6 @@ pub struct ExperimentalConfig {
     disable_optimized_loading: Option<bool>,
     disable_postcss_preset_env: Option<bool>,
     esm_externals: Option<serde_json::Value>,
-    external_dir: Option<bool>,
     fallback_node_polyfills: Option<bool>,
     font_loaders: Option<serde_json::Value>,
     force_swc_transforms: Option<bool>,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1598,15 +1598,8 @@ export default async function getBaseWebpackConfig(
     // Default behavior: bundle the code!
   }
 
-  const shouldIncludeExternalDirs =
-    config.experimental.externalDir || !!config.transpilePackages
-
   const codeCondition = {
     test: /\.(tsx|ts|js|cjs|mjs|jsx)$/,
-    ...(shouldIncludeExternalDirs
-      ? // Allowing importing TS/TSX files from outside of the root dir.
-        {}
-      : { include: [dir, ...babelIncludeRegexes] }),
     exclude: (excludePath: string) => {
       if (babelIncludeRegexes.some((r) => r.test(excludePath))) {
         return false

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -314,9 +314,6 @@ const configSchema = {
         extensionAlias: {
           type: 'object',
         },
-        externalDir: {
-          type: 'boolean',
-        },
         externalMiddlewareRewritesResolve: {
           type: 'boolean',
         },

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -181,7 +181,6 @@ export interface ExperimentalConfig {
   optimizeCss?: boolean | Record<string, unknown>
   nextScriptWorkers?: boolean
   scrollRestoration?: boolean
-  externalDir?: boolean
   amp?: {
     optimizer?: any
     validator?: string
@@ -715,7 +714,6 @@ export const defaultConfig: NextConfig = {
     optimizeCss: false,
     nextScriptWorkers: false,
     scrollRestoration: false,
-    externalDir: false,
     disableOptimizedLoading: false,
     gzipSize: true,
     craCompat: false,

--- a/test/integration/relay-graphql-swc-multi-project/project-a/next.config.js
+++ b/test/integration/relay-graphql-swc-multi-project/project-a/next.config.js
@@ -7,6 +7,5 @@ module.exports = {
       artifactDirectory: './__generated__',
       language: relay.projects['project-b'].language,
     },
-    externalDir: true,
   },
 }

--- a/test/integration/relay-graphql-swc-multi-project/project-b/next.config.js
+++ b/test/integration/relay-graphql-swc-multi-project/project-b/next.config.js
@@ -7,6 +7,5 @@ module.exports = {
       artifactDirectory: './__generated__',
       language: relay.projects['project-b'].language,
     },
-    externalDir: true,
   },
 }

--- a/test/integration/typescript-external-dir/project/next.config.js
+++ b/test/integration/typescript-external-dir/project/next.config.js
@@ -3,7 +3,4 @@ module.exports = {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,
   },
-  experimental: {
-    externalDir: true,
-  },
 }


### PR DESCRIPTION
This moves the `externalDir` to stable. This experimental flag has existed for a while and basically changes the default in Next.js of not compiling `.ts` / `.tsx` and transpiling JS outside of the current application directory. It was specifically added to support monorepos better as these generally have code in directories that are not the application directory but are set up to not do any compilation. If you use `transpilePackages` currently this option would already have been enabled to aid with that monorepo setup.

This PR ensures the change is enabled for all applications.

For more details see #22867.


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
