### PR TITLE
re-add dev OOM restart behavior

### DIFF
--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -6,8 +6,6 @@ import { formatHostname } from './format-hostname'
 import next from '../next'
 import { PropagateToWorkersField } from './router-utils/types'
 
-export const WORKER_SELF_EXIT_CODE = 77
-
 let result:
   | undefined
   | {

--- a/packages/next/src/server/lib/setup-server-worker.ts
+++ b/packages/next/src/server/lib/setup-server-worker.ts
@@ -6,7 +6,6 @@ import http, { IncomingMessage, ServerResponse } from 'http'
 import '../require-hook'
 import '../node-polyfill-fetch'
 
-import { warn } from '../../build/output/log'
 import { Duplex } from 'stream'
 
 process.on('unhandledRejection', (err) => {
@@ -17,7 +16,7 @@ process.on('uncaughtException', (err) => {
   console.error(err)
 })
 
-export const WORKER_SELF_EXIT_CODE = 77
+export const OUT_OF_MEMORY_EXIT_CODE = 77
 
 const MAXIMUM_HEAP_SIZE_ALLOWED =
   (v8.getHeapStatistics().heap_size_limit / 1024 / 1024) * 0.9
@@ -63,11 +62,8 @@ export async function initializeServerWorker(
           process.memoryUsage().heapUsed / 1024 / 1024 >
           MAXIMUM_HEAP_SIZE_ALLOWED
         ) {
-          warn(
-            'The server is running out of memory, restarting to free up memory.'
-          )
           server.close()
-          process.exit(WORKER_SELF_EXIT_CODE)
+          process.exit(OUT_OF_MEMORY_EXIT_CODE)
         }
       })
   })

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -221,10 +221,10 @@ export async function startServer({
       }
 
       try {
-        const cleanup = () => {
+        const cleanup = (code: number | null) => {
           debug('start-server process cleanup')
           server.close()
-          process.exit(0)
+          process.exit(code ?? 0)
         }
         const exception = (err: Error) => {
           // This is the render worker, we keep the process alive


### PR DESCRIPTION
This behavior was lost during some recent refactors. This reboots the dev server when the right exit code is emitted (indicating out of memory)

[Slack x-ref](https://vercel.slack.com/archives/C03KAR5DCKC/p1693316911620709)