### PR TITLE
docs: updating docs for redirect url

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/10-route-handlers.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/10-route-handlers.mdx
@@ -344,12 +344,20 @@ export async function GET(request) {
 ### Redirects
 
 ```ts filename="app/api/route.ts" switcher
-import { redirect } from 'next/navigation'
+import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET(request: Request) {
-  redirect('https://nextjs.org/')
+export async function GET(request: NextRequest) {
+
+// your URL should be complete you can use something like '/foo',
+//you can also try   
+// const url = req.nextUrl.clone();
+// url.pathname = "/projects";
+// return NextResponse.redirect(url);
+
+ return NextResponse.redirect('https://nextjs.org/')
 }
 ```
+
 
 ```js filename="app/api/route.js" switcher
 import { redirect } from 'next/navigation'


### PR DESCRIPTION
next/navigation doest seem to work on app router and gives some errors


### Improving Documentation

if we use the previous approach it gives the following error

<img width="989" alt="Screenshot 2023-09-02 at 3 53 05 PM" src="https://github.com/vercel/next.js/assets/97094800/440b2bbb-5baf-4ba3-a7ae-72f0cc037127">

- Currently, I mentioned 2 approaches that work



