### PR TITLE
fix: server actions firing twice after navigation

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -159,21 +159,22 @@ export function serverActionReducer(
       mutable.globalMutable.pendingNavigatePath &&
       mutable.globalMutable.pendingNavigatePath !== href
     ) {
+      mutable.inFlightServerAction.then(() => {
+        if (mutable.actionResultResolved) return
+
+        // if the server action resolves after a navigation took place,
+        // reset ServerActionMutable values & trigger a refresh so that any stale data gets updated
+        mutable.inFlightServerAction = null
+        mutable.globalMutable.pendingNavigatePath = undefined
+        mutable.globalMutable.refresh()
+        mutable.actionResultResolved = true
+      })
+
       return state
     }
   } else {
     mutable.inFlightServerAction = createRecordFromThenable(
-      fetchServerAction(state, action).then((result) => {
-        // if the server action resolves after a navigation took place,
-        // reset ServerActionMutable values & trigger a refresh so that any stale data gets updated
-        if (mutable.globalMutable.pendingNavigatePath) {
-          mutable.inFlightServerAction = null
-          mutable.globalMutable.pendingNavigatePath = undefined
-          mutable.globalMutable.refresh()
-        } else {
-          return result
-        }
-      })
+      fetchServerAction(state, action)
     )
   }
 
@@ -186,7 +187,7 @@ export function serverActionReducer(
       redirectLocation,
       // revalidatedParts,
     } = readRecordValue(
-      action.mutable.inFlightServerAction!
+      mutable.inFlightServerAction!
     ) as Awaited<FetchServerActionResult>
 
     // Make sure the redirection is a push instead of a replace.

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -310,6 +310,39 @@ createNextDescribe(
       }, '1')
     })
 
+    it('should only submit action once when resubmitting an action after navigation', async () => {
+      let requestCount = 0
+
+      const browser = await next.browser('/server', {
+        beforePageLoad(page) {
+          page.on('request', (request) => {
+            const url = new URL(request.url())
+            if (url.pathname === '/server') {
+              requestCount++
+            }
+          })
+        },
+      })
+
+      async function submitForm() {
+        await browser.elementById('name').type('foo')
+        await browser.elementById('submit').click()
+        await check(() => browser.url(), /header/)
+      }
+
+      await submitForm()
+
+      await browser.elementById('navigate-server').click()
+      await check(() => browser.url(), /server/)
+      await browser.waitForIdleNetwork()
+
+      requestCount = 0
+
+      await submitForm()
+
+      expect(requestCount).toBe(1)
+    })
+
     if (isNextStart) {
       it('should not expose action content in sourcemaps', async () => {
         const sourcemap = (


### PR DESCRIPTION
The original logic here was introduced to unblock client side navigations if a server action was in flight, however this introduced a bug where subsequent actions would fetch twice after navigation. 

This was happening because the promise handling was in the wrong spot: previously this would potentially cause both the `then` callback to fire while simultaneously the action reducer would handle the result. Moving it to where we're first checking if there's a pending navigation will more reliably indicate if the action was resolved after we discarded it in the reducer.

Closes NEXT-1589
Fixes #54746

