### PR TITLE
Ensure that barrel files behind wildcards are transformed into shortpath

### DIFF
--- a/packages/next-swc/crates/core/tests/fixture/optimize-barrel/wildcard/2/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/optimize-barrel/wildcard/2/input.js
@@ -1,0 +1,5 @@
+import { d } from 'd'
+export const a = 1
+export { b } from 'b'
+export * from 'c'
+export { d as e }

--- a/packages/next-swc/crates/core/tests/fixture/optimize-barrel/wildcard/2/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/optimize-barrel/wildcard/2/output.js
@@ -1,0 +1,2 @@
+export const __next_private_export_map__ = '[["a","",""],["b","b","b"],["e","d","d"]]';
+export * from "__barrel_optimize__?names=__PLACEHOLDER__!=!c";

--- a/test/development/basic/barrel-optimization/app/recursive/shortcut/page.js
+++ b/test/development/basic/barrel-optimization/app/recursive/shortcut/page.js
@@ -1,0 +1,5 @@
+import { foo } from 'my-lib'
+
+export default function Page() {
+  return <h1>{foo}</h1>
+}

--- a/test/development/basic/barrel-optimization/node_modules_bak/my-lib/a.js
+++ b/test/development/basic/barrel-optimization/node_modules_bak/my-lib/a.js
@@ -1,1 +1,2 @@
 export * from './b'
+export { foo } from './foo'

--- a/test/development/basic/barrel-optimization/node_modules_bak/my-lib/foo.js
+++ b/test/development/basic/barrel-optimization/node_modules_bak/my-lib/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo'


### PR DESCRIPTION
This fix ensures the case that if you `import { foo } from './index'`, where:

index.js:

```js
export * from './subpkg'
```

subpkg.js:

```js

const unrelatedExpressions = ...

export { foo } from './foo'
export { bar } from './bar'
```

Previously we'll transform the proxy to the second module to `export { foo } from './subpkg'`. With this fix it will be correctly optimized as `export { foo } from './foo'` which is a shorter path.