### PR TITLE
Unify serverError hmr event

### DIFF
--- a/packages/next/src/client/dev/webpack-hot-middleware-client.ts
+++ b/packages/next/src/client/dev/webpack-hot-middleware-client.ts
@@ -11,54 +11,56 @@ export default () => {
       window.next.router.pathname === '/404' ||
       window.next.router.pathname === '/_error'
 
-    if (obj.action === 'reloadPage') {
-      sendMessage(
-        JSON.stringify({
-          event: 'client-reload-page',
-          clientId: window.__nextDevClientId,
-        })
-      )
-      return window.location.reload()
-    }
-    if (obj.action === 'removedPage') {
-      const [page] = obj.data
-      if (page === window.next.router.pathname || isOnErrorPage) {
+    switch (obj.action) {
+      case 'reloadPage': {
         sendMessage(
           JSON.stringify({
-            event: 'client-removed-page',
+            event: 'client-reload-page',
             clientId: window.__nextDevClientId,
-            page,
           })
         )
         return window.location.reload()
       }
-      return
-    }
-    if (obj.action === 'addedPage') {
-      const [page] = obj.data
-      if (
-        (page === window.next.router.pathname &&
-          typeof window.next.router.components[page] === 'undefined') ||
-        isOnErrorPage
-      ) {
-        sendMessage(
-          JSON.stringify({
-            event: 'client-added-page',
-            clientId: window.__nextDevClientId,
-            page,
-          })
-        )
-        return window.location.reload()
+      case 'removedPage': {
+        const [page] = obj.data
+        if (page === window.next.router.pathname || isOnErrorPage) {
+          sendMessage(
+            JSON.stringify({
+              event: 'client-removed-page',
+              clientId: window.__nextDevClientId,
+              page,
+            })
+          )
+          return window.location.reload()
+        }
+        return
       }
-      return
+      case 'addedPage': {
+        const [page] = obj.data
+        if (
+          (page === window.next.router.pathname &&
+            typeof window.next.router.components[page] === 'undefined') ||
+          isOnErrorPage
+        ) {
+          sendMessage(
+            JSON.stringify({
+              event: 'client-added-page',
+              clientId: window.__nextDevClientId,
+              page,
+            })
+          )
+          return window.location.reload()
+        }
+        return
+      }
+      case 'serverError':
+      case 'devPagesManifestUpdate': {
+        return
+      }
+      default: {
+        throw new Error('Unexpected action ' + obj.action)
+      }
     }
-    if (
-      obj.action === 'serverError' ||
-      obj.action === 'devPagesManifestUpdate'
-    ) {
-      return
-    }
-    throw new Error('Unexpected action ' + obj.action)
   })
 
   return devClient

--- a/packages/next/src/client/page-bootstrap.ts
+++ b/packages/next/src/client/page-bootstrap.ts
@@ -17,7 +17,7 @@ export function pageBootrap(assetPrefix: string) {
     let buildIndicatorHandler: (obj: Record<string, any>) => void = () => {}
 
     function devPagesHmrListener(payload: any) {
-      if (payload.event === 'server-error' && payload.errorJSON) {
+      if (payload.action === 'serverError' && payload.errorJSON) {
         const { stack, message } = JSON.parse(payload.errorJSON)
         const error = new Error(message)
         error.stack = stack

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -949,8 +949,7 @@ export function onDemandEntryHandler({
           if (!bufferedHmrServerError && error) {
             client.send(
               JSON.stringify({
-                event: 'server-error', // for pages dir
-                action: 'serverError', // for app dir
+                action: 'serverError',
                 errorJSON: stringifyError(error),
               })
             )


### PR DESCRIPTION
Ensures only one name is used for the event, makes it easier to search for, going to replace this with the constant like the other events in a follow-up PR but this can be landed as-is.
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
