### PR TITLE
Add serverError action to list of HMR events

### DIFF
--- a/packages/next/src/client/page-bootstrap.ts
+++ b/packages/next/src/client/page-bootstrap.ts
@@ -17,7 +17,7 @@ export function pageBootrap(assetPrefix: string) {
     let buildIndicatorHandler: (obj: Record<string, any>) => void = () => {}
 
     function devPagesHmrListener(payload: any) {
-      if (payload.action === 'serverError' && payload.errorJSON) {
+      if (payload.action === 'serverError') {
         const { stack, message } = JSON.parse(payload.errorJSON)
         const error = new Error(message)
         error.stack = stack

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -102,6 +102,7 @@ export type HMR_ACTION_TYPES =
   | MiddlewareChangesAction
   | ServerOnlyChangesAction
   | DevPagesManifestUpdateAction
+  | ServerErrorAction
 
 export interface NextJsHotReloaderInterface {
   activeWebpackConfigs?: Array<Awaited<ReturnType<typeof getBaseWebpackConfig>>>

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -18,6 +18,7 @@ export const enum HMR_ACTIONS_SENT_TO_BROWSER {
   PONG = 'pong',
   DEV_PAGES_MANIFEST_UPDATE = 'devPagesManifestUpdate',
   TURBOPACK_MESSAGE = 'turbopack-message',
+  SERVER_ERROR = 'serverError',
 }
 
 interface TurboPackMessageAction {

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -21,7 +21,7 @@ export const enum HMR_ACTIONS_SENT_TO_BROWSER {
   SERVER_ERROR = 'serverError',
 }
 
-export interface ServerErrorAction {
+interface ServerErrorAction {
   action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ERROR
   errorJSON: string
 }

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -21,6 +21,11 @@ export const enum HMR_ACTIONS_SENT_TO_BROWSER {
   SERVER_ERROR = 'serverError',
 }
 
+export interface ServerErrorAction {
+  action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ERROR
+  errorJSON: string
+}
+
 interface TurboPackMessageAction {
   type: HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_MESSAGE
   data: TurbopackUpdate

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -1385,6 +1385,7 @@ export default class HotReloader implements NextJsHotReloaderInterface {
     })
 
     this.onDemandEntries = onDemandEntryHandler({
+      hotReloader: this,
       multiCompiler: this.multiCompiler,
       pagesDir: this.pagesDir,
       appDir: this.appDir,

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -35,6 +35,7 @@ import {
 } from '../../shared/lib/constants'
 import { RouteMatch } from '../future/route-matches/route-match'
 import { isAppPageRouteMatch } from '../future/route-matches/app-page-route-match'
+import { HMR_ACTIONS_SENT_TO_BROWSER } from './hot-reloader-types'
 
 const debug = origDebug('next:on-demand-entry-handler')
 
@@ -949,7 +950,7 @@ export function onDemandEntryHandler({
           if (!bufferedHmrServerError && error) {
             client.send(
               JSON.stringify({
-                action: 'serverError',
+                action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ERROR,
                 errorJSON: stringifyError(error),
               })
             )

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -35,7 +35,10 @@ import {
 } from '../../shared/lib/constants'
 import { RouteMatch } from '../future/route-matches/route-match'
 import { isAppPageRouteMatch } from '../future/route-matches/app-page-route-match'
-import { HMR_ACTIONS_SENT_TO_BROWSER } from './hot-reloader-types'
+import {
+  HMR_ACTIONS_SENT_TO_BROWSER,
+  ServerErrorAction,
+} from './hot-reloader-types'
 
 const debug = origDebug('next:on-demand-entry-handler')
 
@@ -948,12 +951,11 @@ export function onDemandEntryHandler({
 
           // New error occurred: buffered error is flushed and new error occurred
           if (!bufferedHmrServerError && error) {
-            client.send(
-              JSON.stringify({
-                action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ERROR,
-                errorJSON: stringifyError(error),
-              })
-            )
+            const serverErrorAction: ServerErrorAction = {
+              action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ERROR,
+              errorJSON: stringifyError(error),
+            }
+            client.send(JSON.stringify(serverErrorAction))
             bufferedHmrServerError = null
           }
 

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -35,11 +35,8 @@ import {
 } from '../../shared/lib/constants'
 import { RouteMatch } from '../future/route-matches/route-match'
 import { isAppPageRouteMatch } from '../future/route-matches/app-page-route-match'
-import {
-  HMR_ACTIONS_SENT_TO_BROWSER,
-  HMR_ACTION_TYPES,
-  ServerErrorAction,
-} from './hot-reloader-types'
+import { HMR_ACTIONS_SENT_TO_BROWSER } from './hot-reloader-types'
+import HotReloader from './hot-reloader-webpack'
 
 const debug = origDebug('next:on-demand-entry-handler')
 
@@ -503,6 +500,7 @@ async function findRoutePathData(
 }
 
 export function onDemandEntryHandler({
+  hotReloader,
   maxInactiveAge,
   multiCompiler,
   nextConfig,
@@ -511,6 +509,7 @@ export function onDemandEntryHandler({
   rootDir,
   appDir,
 }: {
+  hotReloader: HotReloader
   maxInactiveAge: number
   multiCompiler: webpack.MultiCompiler
   nextConfig: NextConfigComplete
@@ -952,11 +951,10 @@ export function onDemandEntryHandler({
 
           // New error occurred: buffered error is flushed and new error occurred
           if (!bufferedHmrServerError && error) {
-            const serverErrorAction: HMR_ACTION_TYPES = {
+            hotReloader.send({
               action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ERROR,
               errorJSON: stringifyError(error),
-            }
-            client.send(JSON.stringify(serverErrorAction))
+            })
             bufferedHmrServerError = null
           }
 

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -37,6 +37,7 @@ import { RouteMatch } from '../future/route-matches/route-match'
 import { isAppPageRouteMatch } from '../future/route-matches/app-page-route-match'
 import {
   HMR_ACTIONS_SENT_TO_BROWSER,
+  HMR_ACTION_TYPES,
   ServerErrorAction,
 } from './hot-reloader-types'
 
@@ -951,7 +952,7 @@ export function onDemandEntryHandler({
 
           // New error occurred: buffered error is flushed and new error occurred
           if (!bufferedHmrServerError && error) {
-            const serverErrorAction: ServerErrorAction = {
+            const serverErrorAction: HMR_ACTION_TYPES = {
               action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ERROR,
               errorJSON: stringifyError(error),
             }


### PR DESCRIPTION
Adds `serverError` to the list of HMR actions, missed this in the earlier PRs as it wasn't using `hotReloader.send`.

Also ensures on-demand-entry-handler reuses the hotReloader.send method.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
