### PR TITLE
Fix duplicated dynamic metadata routes in dev mode

### DIFF
--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -1,4 +1,4 @@
-import { isMetadataRoute, isStaticMetadataRouteFile } from './is-metadata-route'
+import { isMetadataRoute, isStaticMetadataRoute } from './is-metadata-route'
 import path from '../../shared/lib/isomorphic/path'
 import { interpolateDynamicPath } from '../../server/server-utils'
 import { getNamedRouteRegex } from '../../shared/lib/router/utils/route-regex'
@@ -61,11 +61,11 @@ export function normalizeMetadataRoute(page: string) {
   }
   let route = page
   let suffix = ''
-  if (route === '/robots') {
+  if (page === '/robots') {
     route += '.txt'
-  } else if (route === '/manifest') {
+  } else if (page === '/manifest') {
     route += '.webmanifest'
-  } else if (route.endsWith('/sitemap')) {
+  } else if (page.endsWith('/sitemap')) {
     route += '.xml'
   } else {
     // Remove the file extension, e.g. /route-path/robots.txt -> /route-path
@@ -75,13 +75,8 @@ export function normalizeMetadataRoute(page: string) {
   // Support both /<metadata-route.ext> and custom routes /<metadata-route>/route.ts.
   // If it's a metadata file route, we need to append /[id]/route to the page.
   if (!route.endsWith('/route')) {
-    const isStaticMetadataFile = isStaticMetadataRouteFile(page)
     const { dir, name: baseName, ext } = path.parse(route)
-
-    const isStaticRoute =
-      page.startsWith('/robots') ||
-      page.startsWith('/manifest') ||
-      isStaticMetadataFile
+    const isStaticRoute = isStaticMetadataRoute(page)
 
     route = path.posix.join(
       dir,

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -114,6 +114,14 @@ export function isStaticMetadataRouteFile(appDirRelativePath: string) {
   return isMetadataRouteFile(appDirRelativePath, [], true)
 }
 
+export function isStaticMetadataRoute(page: string) {
+  return (
+    page === '/robots' ||
+    page === '/manifest' ||
+    isStaticMetadataRouteFile(page)
+  )
+}
+
 /*
  * Remove the 'app' prefix or '/route' suffix, only check the route name since they're only allowed in root app directory
  * e.g.

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -37,7 +37,6 @@ import { RouteMatch } from '../future/route-matches/route-match'
 import { isAppPageRouteMatch } from '../future/route-matches/app-page-route-match'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from './hot-reloader-types'
 import HotReloader from './hot-reloader-webpack'
-import { normalizeMetadataRoute } from '../../lib/metadata/get-metadata-route'
 
 const debug = origDebug('next:on-demand-entry-handler')
 

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -37,6 +37,7 @@ import { RouteMatch } from '../future/route-matches/route-match'
 import { isAppPageRouteMatch } from '../future/route-matches/app-page-route-match'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from './hot-reloader-types'
 import HotReloader from './hot-reloader-webpack'
+import { normalizeMetadataRoute } from '../../lib/metadata/get-metadata-route'
 
 const debug = origDebug('next:on-demand-entry-handler')
 
@@ -101,10 +102,8 @@ export function getEntryKey(
 ) {
   // TODO: handle the /children slot better
   // this is a quick hack to handle when children is provided as children/page instead of /page
-  return `${compilerType}@${pageBundleType}@${page.replace(
-    /(@[^/]+)\/children/g,
-    '$1'
-  )}`
+  const pageKey = page.replace(/(@[^/]+)\/children/g, '$1')
+  return `${compilerType}@${pageBundleType}@${pageKey}`
 }
 
 function getPageBundleType(pageBundlePath: string) {
@@ -521,7 +520,7 @@ export function onDemandEntryHandler({
   let curInvalidator: Invalidator = getInvalidator(
     multiCompiler.outputPath
   ) as any
-  let curEntries = getEntries(multiCompiler.outputPath) as any
+  const curEntries = getEntries(multiCompiler.outputPath) as any
 
   if (!curInvalidator) {
     curInvalidator = new Invalidator(multiCompiler)

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -42,6 +42,7 @@ import {
   ROUTES_MANIFEST,
 } from '../../../shared/lib/constants'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
+import { normalizeMetadataRoute } from '../../../lib/metadata/get-metadata-route'
 
 export type FsOutput = {
   type:
@@ -578,11 +579,14 @@ export async function setupFsCheck(opts: {
                 }
               }
             } else if (type === 'pageFile' || type === 'appFile') {
+              const isAppFile = type === 'appFile'
               if (
                 ensureFn &&
                 (await ensureFn({
                   type,
-                  itemPath: curItemPath,
+                  itemPath: isAppFile
+                    ? normalizeMetadataRoute(curItemPath)
+                    : curItemPath,
                 })?.catch(() => 'ENSURE_FAILED')) === 'ENSURE_FAILED'
               ) {
                 continue

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -114,6 +114,23 @@ createNextDescribe(
           isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.LONG
         )
 
+        if (isNextDev) {
+          await check(async () => {
+            next.hasFile('.next/server/app-paths-manifest.json')
+            return 'success'
+          }, /success/)
+
+          const appPathsManifest = JSON.parse(
+            await next.readFile('.next/server/app-paths-manifest.json')
+          )
+          const entryKeys = Object.keys(appPathsManifest)
+          // Only has one route for twitter-image with catch-all routes in dev
+          expect(entryKeys).not.toContain('/twitter-image')
+          expect(entryKeys).toContain(
+            '/twitter-image/[[...__metadata_id__]]/route'
+          )
+        }
+
         // edge runtime
         res = await next.fetch('/twitter-image2')
         expect(res.headers.get('content-type')).toBe('image/png')


### PR DESCRIPTION
In dev mode, we're using a catch-all route for dynamic metadata routes, e.g. page path `/twitter-image` would become `/twitter-image/[[...metadata_id...]]/route` as a dynamic custom app route.

But we're missing to convert it in filesystem scanning for routing purpose, adding the metadata related normalizing logic for app page to align with other places.