### PR TITLE
Remove `react-hot-toast` from the optimizePackageImports list

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -679,7 +679,6 @@ function assignDefaults(
       '@fortawesome/fontawesome-svg-core',
       '@fortawesome/free-solid-svg-icons',
       '@headlessui-float/react',
-      'react-hot-toast',
       '@heroicons/react/20/solid',
       '@heroicons/react/24/solid',
       '@heroicons/react/24/outline',


### PR DESCRIPTION
@MaxLeiter ran into an issue with this, need to investigate.