### PR TITLE
webpack: tweak config for split chunks

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1731,6 +1731,9 @@ export default async function getBaseWebpackConfig(
                   reuseExistingChunk: true,
                   test: /[\\/]node_modules[\\/]/,
                   minSize: 0,
+                  minChunks: 0,
+                  maxAsyncRequests: 300,
+                  maxInitialRequests: 300,
                   name: (module: webpack.Module) => {
                     const moduleId = module.nameForCondition()!
                     const rootModule = extractRootNodeModule(moduleId)
@@ -1743,6 +1746,9 @@ export default async function getBaseWebpackConfig(
                     }
                   },
                 },
+                // disable the default chunk groups
+                default: false,
+                defaultVendors: false,
               },
             }
           }

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1731,7 +1731,7 @@ export default async function getBaseWebpackConfig(
                   reuseExistingChunk: true,
                   test: /[\\/]node_modules[\\/]/,
                   minSize: 0,
-                  minChunks: 0,
+                  minChunks: 1,
                   maxAsyncRequests: 300,
                   maxInitialRequests: 300,
                   name: (module: webpack.Module) => {


### PR DESCRIPTION
Slight tweaks to the dev config for split chunks.

I disabled the default groups for chunking to make sure we only chunked the ones from the node_modules + augmented the number of parallel requests possible per Tobias suggestion.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
