### PR TITLE
fix: use rsc when `next/image` does not need state

### DIFF
--- a/packages/next/src/client/image-component.tsx
+++ b/packages/next/src/client/image-component.tsx
@@ -352,7 +352,7 @@ function ImagePreload({
   )
 }
 
-export const Image = forwardRef<HTMLImageElement | null, ImageProps>(
+export const ClientImage = forwardRef<HTMLImageElement | null, ImageProps>(
   (props, forwardedRef) => {
     const pagesRouter = useContext(RouterContext)
     // We're in the app directory if there is no pages router.

--- a/packages/next/src/shared/lib/image-external.tsx
+++ b/packages/next/src/shared/lib/image-external.tsx
@@ -4,7 +4,7 @@ import type { ImageProps, ImageLoader, StaticImageData } from './get-img-props'
 import { getImgProps } from './get-img-props'
 import { warnOnce } from './utils/warn-once'
 import { ClientImage } from '../../client/image-component'
-
+import { RouterContext } from '../lib/router-context'
 import React from 'react'
 
 // @ts-ignore - This is replaced by webpack alias
@@ -27,7 +27,9 @@ const unstable_getImgProps = (imgProps: ImageProps) => {
 }
 
 export default function Image(imgProps: ImageProps) {
+  const pagesRouter = React.useContext(RouterContext)
   if (
+    pagesRouter ||
     imgProps.placeholder ||
     Object.entries(imgProps).some(
       ([key, value]) => key.startsWith('on') || typeof value === 'function'

--- a/packages/next/src/shared/lib/image-external.tsx
+++ b/packages/next/src/shared/lib/image-external.tsx
@@ -3,20 +3,21 @@ import type { ImageProps, ImageLoader, StaticImageData } from './get-img-props'
 
 import { getImgProps } from './get-img-props'
 import { warnOnce } from './utils/warn-once'
-import { Image } from '../../client/image-component'
+import { ClientImage } from '../../client/image-component'
+
+import React from 'react'
 
 // @ts-ignore - This is replaced by webpack alias
 import defaultLoader from 'next/dist/shared/lib/image-loader'
+
+// This is replaced by webpack define plugin
+const imgConf = process.env.__NEXT_IMAGE_OPTS as any as ImageConfigComplete
 
 const unstable_getImgProps = (imgProps: ImageProps) => {
   warnOnce(
     'Warning: unstable_getImgProps() is experimental and may change or be removed at any time. Use at your own risk.'
   )
-  const { props } = getImgProps(imgProps, {
-    defaultLoader,
-    // This is replaced by webpack define plugin
-    imgConf: process.env.__NEXT_IMAGE_OPTS as any as ImageConfigComplete,
-  })
+  const { props } = getImgProps(imgProps, { defaultLoader, imgConf })
   for (const [key, value] of Object.entries(props)) {
     if (value === undefined) {
       delete props[key as keyof typeof props]
@@ -25,7 +26,20 @@ const unstable_getImgProps = (imgProps: ImageProps) => {
   return { props }
 }
 
-export default Image
+export default function Image(imgProps: ImageProps) {
+  if (
+    imgProps.placeholder ||
+    Object.entries(imgProps).some(
+      ([key, value]) => key.startsWith('on') || typeof value === 'function'
+    )
+  ) {
+    // TODO: remove preload from client component
+    return <ClientImage {...imgProps} />
+  } else {
+    const { props } = getImgProps(imgProps, { defaultLoader, imgConf })
+    return <img {...props} data-nimg="rsc" />
+  }
+}
 
 export {
   ImageProps,

--- a/packages/next/src/shared/lib/image-external.tsx
+++ b/packages/next/src/shared/lib/image-external.tsx
@@ -4,8 +4,8 @@ import type { ImageProps, ImageLoader, StaticImageData } from './get-img-props'
 import { getImgProps } from './get-img-props'
 import { warnOnce } from './utils/warn-once'
 import { ClientImage } from '../../client/image-component'
-import { RouterContext } from '../lib/router-context'
 import React from 'react'
+import ReactDOM from 'react-dom'
 
 // @ts-ignore - This is replaced by webpack alias
 import defaultLoader from 'next/dist/shared/lib/image-loader'
@@ -27,9 +27,8 @@ const unstable_getImgProps = (imgProps: ImageProps) => {
 }
 
 export default function Image(imgProps: ImageProps) {
-  const pagesRouter = React.useContext(RouterContext)
   if (
-    pagesRouter ||
+    !ReactDOM.preload ||
     imgProps.placeholder ||
     Object.entries(imgProps).some(
       ([key, value]) => key.startsWith('on') || typeof value === 'function'


### PR DESCRIPTION
Fixes [NEXT-1562](https://linear.app/vercel/issue/NEXT-1562/)