### PR TITLE
refactor: Use Edge Runtime helpers

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -138,6 +138,7 @@
     "@edge-runtime/cookies": "3.4.1",
     "@edge-runtime/ponyfill": "2.4.0",
     "@edge-runtime/primitives": "3.1.1",
+    "@edge-runtime/node-utils": "2.1.1",
     "@hapi/accept": "5.0.2",
     "@jest/transform": "29.5.0",
     "@jest/types": "29.5.0",

--- a/packages/next/src/compiled/@edge-runtime/node-utils/index.d.ts
+++ b/packages/next/src/compiled/@edge-runtime/node-utils/index.d.ts
@@ -1,0 +1,54 @@
+import { IncomingMessage, ServerResponse, IncomingHttpHeaders } from 'http';
+import { Headers, ReadableStream as ReadableStream$1, Request, FetchEvent, Response } from '@edge-runtime/primitives';
+import { OutgoingHttpHeaders, ServerResponse as ServerResponse$1, IncomingMessage as IncomingMessage$1 } from 'node:http';
+import { Readable } from 'node:stream';
+import * as _edge_runtime_primitives_types_events from '@edge-runtime/primitives/types/events';
+
+interface BuildDependencies {
+    Headers: typeof Headers;
+    ReadableStream: typeof ReadableStream$1;
+    Request: typeof Request;
+    Uint8Array: typeof Uint8Array;
+    FetchEvent: typeof FetchEvent;
+}
+interface RequestOptions {
+    defaultOrigin: string;
+}
+type NodeHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void> | void;
+type WebHandler = (req: Request, event: FetchEvent) => Promise<Response> | Response | null | undefined;
+
+declare function buildToNodeHandler(dependencies: BuildDependencies, options: RequestOptions): (webHandler: WebHandler) => NodeHandler;
+
+declare function toOutgoingHeaders(headers?: Headers & {
+    raw?: () => Record<string, string>;
+}): OutgoingHttpHeaders;
+declare function mergeIntoServerResponse(headers: OutgoingHttpHeaders, serverResponse: ServerResponse$1): void;
+
+interface FromWebOptions {
+    objectMode?: boolean;
+    highWaterMark?: number;
+    encoding?: BufferEncoding;
+    signal?: AbortSignal;
+}
+/**
+ * Code adapted from Node's stream.Readable.fromWeb(), because it has to run on Node@14
+ * @see https://github.com/nodejs/node/blob/bd462ad81bc30e547e52e699ee3b6fa3d7c882c9/lib/internal/webstreams/adapters.js#L458
+ */
+declare function toToReadable(webStream: ReadableStream, options?: FromWebOptions): Readable;
+
+declare function buildToFetchEvent(dependencies: BuildDependencies): (request: Request) => _edge_runtime_primitives_types_events.FetchEvent;
+
+interface Dependencies$1 {
+    Headers: typeof Headers;
+}
+declare function buildToHeaders({ Headers }: Dependencies$1): (nodeHeaders: IncomingHttpHeaders) => Headers;
+
+declare function buildToRequest(dependencies: BuildDependencies): (request: IncomingMessage$1, options: RequestOptions) => Request;
+
+interface Dependencies {
+    ReadableStream: typeof ReadableStream;
+    Uint8Array: typeof Uint8Array;
+}
+declare function buildToReadableStream(dependencies: Dependencies): (stream: Readable) => ReadableStream<any>;
+
+export { BuildDependencies, NodeHandler, RequestOptions, WebHandler, buildToFetchEvent, buildToHeaders, buildToNodeHandler, buildToReadableStream, buildToRequest, mergeIntoServerResponse, toOutgoingHeaders, toToReadable };

--- a/packages/next/src/compiled/@edge-runtime/node-utils/index.js
+++ b/packages/next/src/compiled/@edge-runtime/node-utils/index.js
@@ -1,0 +1,238 @@
+"use strict";
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// src/index.ts
+var src_exports = {};
+__export(src_exports, {
+  buildToFetchEvent: () => buildToFetchEvent,
+  buildToHeaders: () => buildToHeaders,
+  buildToNodeHandler: () => buildToNodeHandler,
+  buildToReadableStream: () => buildToReadableStream,
+  buildToRequest: () => buildToRequest,
+  mergeIntoServerResponse: () => mergeIntoServerResponse,
+  toOutgoingHeaders: () => toOutgoingHeaders,
+  toToReadable: () => toToReadable
+});
+module.exports = __toCommonJS(src_exports);
+
+// src/node-to-edge/fetch-event.ts
+function buildToFetchEvent(dependencies) {
+  return function toFetchEvent(request) {
+    const event = new dependencies.FetchEvent(request);
+    Object.defineProperty(event, "waitUntil", {
+      configurable: false,
+      enumerable: true,
+      get: () => {
+        throw new Error("waitUntil is not supported yet.");
+      }
+    });
+    return event;
+  };
+}
+
+// src/node-to-edge/headers.ts
+function buildToHeaders({ Headers }) {
+  return function toHeaders(nodeHeaders) {
+    const headers = new Headers();
+    for (let [key, value] of Object.entries(nodeHeaders)) {
+      const values = Array.isArray(value) ? value : [value];
+      for (let v of values) {
+        if (v !== void 0) {
+          headers.append(key, v);
+        }
+      }
+    }
+    return headers;
+  };
+}
+
+// src/node-to-edge/stream.ts
+function buildToReadableStream(dependencies) {
+  const { ReadableStream, Uint8Array: Uint8Array2 } = dependencies;
+  return function toReadableStream(stream) {
+    return new ReadableStream({
+      start(controller) {
+        stream.on("data", (chunk) => {
+          controller.enqueue(new Uint8Array2([...new Uint8Array2(chunk)]));
+        });
+        stream.on("end", () => {
+          controller.close();
+        });
+        stream.on("error", (err) => {
+          controller.error(err);
+        });
+      }
+    });
+  };
+}
+
+// src/node-to-edge/request.ts
+function buildToRequest(dependencies) {
+  const toHeaders = buildToHeaders(dependencies);
+  const toReadableStream = buildToReadableStream(dependencies);
+  const { Request } = dependencies;
+  return function toRequest(request, options) {
+    var _a;
+    return new Request(
+      String(
+        new URL(
+          request.url || "/",
+          computeOrigin(request, options.defaultOrigin)
+        )
+      ),
+      {
+        method: request.method,
+        headers: toHeaders(request.headers),
+        body: !["HEAD", "GET"].includes((_a = request.method) != null ? _a : "") ? toReadableStream(request) : null
+      }
+    );
+  };
+}
+function computeOrigin({ headers }, defaultOrigin) {
+  const authority = headers.host;
+  if (!authority) {
+    return defaultOrigin;
+  }
+  const [, port] = authority.split(":");
+  return `${port === "443" ? "https" : "http"}://${authority}`;
+}
+
+// src/edge-to-node/headers.ts
+var import_cookies = require("@edge-runtime/cookies");
+function toOutgoingHeaders(headers) {
+  var _a, _b;
+  const outputHeaders = {};
+  if (headers) {
+    for (const [name, value] of typeof headers.raw !== "undefined" ? Object.entries(headers.raw()) : headers.entries()) {
+      outputHeaders[name] = value;
+      if (name.toLowerCase() === "set-cookie") {
+        outputHeaders[name] = (_b = (_a = headers.getAll) == null ? void 0 : _a.call(headers, "set-cookie")) != null ? _b : (0, import_cookies.splitCookiesString)(value);
+      }
+    }
+  }
+  return outputHeaders;
+}
+function mergeIntoServerResponse(headers, serverResponse) {
+  for (const [name, value] of Object.entries(headers)) {
+    if (value !== void 0) {
+      serverResponse.setHeader(name, value);
+    }
+  }
+}
+
+// src/edge-to-node/stream.ts
+var import_node_stream = require("stream");
+function toToReadable(webStream, options = {}) {
+  const reader = webStream.getReader();
+  let closed = false;
+  const { highWaterMark, encoding, objectMode = false, signal } = options;
+  const readable = new import_node_stream.Readable({
+    objectMode,
+    highWaterMark,
+    encoding,
+    // @ts-ignore signal exist only since Node@17
+    signal,
+    read() {
+      reader.read().then(
+        (chunk) => {
+          if (chunk.done) {
+            readable.push(null);
+          } else {
+            readable.push(chunk.value);
+          }
+        },
+        (error) => readable.destroy(error)
+      );
+    },
+    destroy(error, callback) {
+      function done() {
+        try {
+          callback(error);
+        } catch (error2) {
+          process.nextTick(() => {
+            throw error2;
+          });
+        }
+      }
+      if (!closed) {
+        reader.cancel(error).then(done, done);
+        return;
+      }
+      done();
+    }
+  });
+  reader.closed.then(
+    () => {
+      closed = true;
+    },
+    (error) => {
+      closed = true;
+      readable.destroy(error);
+    }
+  );
+  return readable;
+}
+
+// src/edge-to-node/handler.ts
+function buildToNodeHandler(dependencies, options) {
+  const toRequest = buildToRequest(dependencies);
+  const toFetchEvent = buildToFetchEvent(dependencies);
+  return function toNodeHandler(webHandler) {
+    return (incomingMessage, serverResponse) => {
+      const request = toRequest(incomingMessage, options);
+      const maybePromise = webHandler(request, toFetchEvent(request));
+      if (maybePromise instanceof Promise) {
+        maybePromise.then(
+          (response) => toServerResponse(response, serverResponse)
+        );
+      } else {
+        toServerResponse(maybePromise, serverResponse);
+      }
+    };
+  };
+}
+function toServerResponse(webResponse, serverResponse) {
+  if (!webResponse) {
+    serverResponse.end();
+    return;
+  }
+  mergeIntoServerResponse(
+    // @ts-ignore getAll() is not standard https://fetch.spec.whatwg.org/#headers-class
+    toOutgoingHeaders(webResponse.headers),
+    serverResponse
+  );
+  serverResponse.statusCode = webResponse.status;
+  serverResponse.statusMessage = webResponse.statusText;
+  if (!webResponse.body) {
+    serverResponse.end();
+    return;
+  }
+  toToReadable(webResponse.body).pipe(serverResponse);
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  buildToFetchEvent,
+  buildToHeaders,
+  buildToNodeHandler,
+  buildToReadableStream,
+  buildToRequest,
+  mergeIntoServerResponse,
+  toOutgoingHeaders,
+  toToReadable
+});

--- a/packages/next/src/compiled/@edge-runtime/node-utils/package.json
+++ b/packages/next/src/compiled/@edge-runtime/node-utils/package.json
@@ -1,0 +1,1 @@
+{"name":"@edge-runtime/node-utils","version":"2.1.1","main":"./index.js","license":"MPL-2.0"}

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -425,6 +425,36 @@ export async function ncc_edge_runtime_cookies() {
 }
 
 // eslint-disable-next-line camelcase
+externals['@edge-runtime/node-utils'] =
+  'next/dist/compiled/@edge-runtime/node-utils'
+
+export async function ncc_edge_runtime_node_utils() {
+  // `@edge-runtime/node-utils` is precompiled and pre-bundled
+  // so we vendor the package as it is.
+  const dest = 'src/compiled/@edge-runtime/node-utils'
+  const pkg = await fs.readJson(
+    require.resolve('@edge-runtime/node-utils/package.json')
+  )
+  await fs.remove(dest)
+
+  await fs.outputJson(join(dest, 'package.json'), {
+    name: '@edge-runtime/node-utils',
+    version: pkg.version,
+    main: './index.js',
+    license: pkg.license,
+  })
+
+  await fs.copy(
+    require.resolve('@edge-runtime/node-utils/dist/index.js'),
+    join(dest, 'index.js')
+  )
+  await fs.copy(
+    require.resolve('@edge-runtime/node-utils/dist/index.d.ts'),
+    join(dest, 'index.d.ts')
+  )
+}
+
+// eslint-disable-next-line camelcase
 externals['@edge-runtime/primitives'] =
   'next/dist/compiled/@edge-runtime/primitives'
 
@@ -2348,8 +2378,9 @@ export async function ncc(task, opts) {
       'ncc_sass_loader',
       'ncc_jest_worker',
       'ncc_edge_runtime_cookies',
-      'ncc_edge_runtime_primitives',
+      'ncc_edge_runtime_node_utils',
       'ncc_edge_runtime_ponyfill',
+      'ncc_edge_runtime_primitives',
       'ncc_edge_runtime',
       'ncc_mswjs_interceptors',
     ],

--- a/packages/next/types/misc.d.ts
+++ b/packages/next/types/misc.d.ts
@@ -362,6 +362,10 @@ declare module 'next/dist/compiled/@edge-runtime/cookies' {
   export * from '@edge-runtime/cookies'
 }
 
+declare module 'next/dist/compiled/@edge-runtime/node-utils' {
+  export * from '@edge-runtime/node-utils'
+}
+
 declare module 'next/dist/compiled/@edge-runtime/primitives' {
   import * as m from '@edge-runtime/primitives'
   export = m

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -892,6 +892,9 @@ importers:
       '@edge-runtime/cookies':
         specifier: 3.4.1
         version: 3.4.1
+      '@edge-runtime/node-utils':
+        specifier: 2.1.1
+        version: 2.1.1
       '@edge-runtime/ponyfill':
         specifier: 2.4.0
         version: 2.4.0
@@ -5164,6 +5167,11 @@ packages:
     resolution: {integrity: sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew==}
     dev: true
 
+  /@edge-runtime/cookies@3.2.2:
+    resolution: {integrity: sha512-9fa2/l1QzwoDZWlV5bNBBtMVpyzPPXzoObZYXVRs+pE1Rx9Q0LtOgJafCum4/RcYuAaez4HJZV1T3C+YNgKiDQ==}
+    engines: {node: '>=14'}
+    dev: true
+
   /@edge-runtime/cookies@3.4.1:
     resolution: {integrity: sha512-z27BvgPxI73CgSlxU/NAUf1Q/shnqi6cobHEowf6VuLdSjGR3NjI2Y5dZUIBbK2zOJVZbXcHsVzJjz8LklteFQ==}
     engines: {node: '>=16'}
@@ -5183,6 +5191,13 @@ packages:
       '@jest/fake-timers': 29.5.0
       jest-mock: 29.5.0
       jest-util: 29.5.0
+    dev: true
+
+  /@edge-runtime/node-utils@2.1.1:
+    resolution: {integrity: sha512-SsMlddTn22BFbJswyECfJzvmt6N75jfmw+XbJZ56VzyplVyisymZdZLgo44xXd0ptbjRoa5VMIV6S9XHftO7sQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@edge-runtime/cookies': 3.2.2
     dev: true
 
   /@edge-runtime/ponyfill@2.4.0:


### PR DESCRIPTION
- `@edge-runtime/cookies` exports `splitCookiesString` so it can be used rather than re-implement the same function again.
- `@edge-runtime/node-utils` exports `toOutgoingHeaders` that is equivalent to Next.js `toNodeOutgoingHttpHeaders` function.