### PR TITLE
AppRouteDefinitionBuilder

### DIFF
--- a/packages/next/src/lib/create-client-router-filter.ts
+++ b/packages/next/src/lib/create-client-router-filter.ts
@@ -6,7 +6,7 @@ import { Redirect } from './load-custom-routes'
 import { tryToParsePath } from './try-to-parse-path'
 
 export function createClientRouterFilter(
-  paths: string[],
+  paths: ReadonlyArray<string>,
   redirects: Redirect[],
   allowedErrorRate?: number
 ): {

--- a/packages/next/src/lib/generate-interception-routes-rewrites.ts
+++ b/packages/next/src/lib/generate-interception-routes-rewrites.ts
@@ -44,7 +44,7 @@ function voidParamsBeforeInterceptionMarker(path: string): string {
 }
 
 export function generateInterceptionRoutesRewrites(
-  appPaths: string[]
+  appPaths: ReadonlyArray<string>
 ): Rewrite[] {
   const rewrites: Rewrite[] = []
 

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -269,6 +269,7 @@ export default class DevServer extends Server {
     await super.prepareImpl()
     await this.runInstrumentationHookIfAvailable()
     await this.matchers.reload()
+    this.reloadAppPathRoutes()
     this.setDevReady!()
 
     // This is required by the tracing subsystem.
@@ -401,7 +402,7 @@ export default class DevServer extends Server {
     query: ParsedUrlQuery
     params: Params | undefined
     page: string
-    appPaths: string[] | null
+    appPaths: ReadonlyArray<string> | null
     isAppPath: boolean
   }) {
     try {

--- a/packages/next/src/server/future/route-definitions/app-page-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/app-page-route-definition.ts
@@ -1,5 +1,6 @@
+import type { RouteDefinition } from './route-definition'
+
 import { RouteKind } from '../route-kind'
-import { RouteDefinition } from './route-definition'
 
 export interface AppPageRouteDefinition
   extends RouteDefinition<RouteKind.APP_PAGE> {
@@ -19,4 +20,10 @@ export interface AppPageInterceptingRouteDefinition
    * the interception route markers (`(..)(..)`, `(..)`, and `(...)`).
    */
   readonly pathnameOverride: string
+}
+
+export function isAppPageRouteDefinition(
+  definition: RouteDefinition
+): definition is AppPageRouteDefinition {
+  return definition.kind === RouteKind.APP_PAGE
 }

--- a/packages/next/src/server/future/route-definitions/app-route-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/app-route-route-definition.ts
@@ -1,5 +1,12 @@
-import type { RouteKind } from '../route-kind'
 import type { RouteDefinition } from './route-definition'
+
+import { RouteKind } from '../route-kind'
 
 export interface AppRouteRouteDefinition
   extends RouteDefinition<RouteKind.APP_ROUTE> {}
+
+export function isAppRouteRouteDefinition(
+  definition: RouteDefinition
+): definition is AppRouteRouteDefinition {
+  return definition.kind === RouteKind.APP_ROUTE
+}

--- a/packages/next/src/server/future/route-matcher-providers/app-page-route-matcher-provider.test.ts
+++ b/packages/next/src/server/future/route-matcher-providers/app-page-route-matcher-provider.test.ts
@@ -79,8 +79,8 @@ describe('AppPageRouteMatcherProvider', () => {
           page: '/dashboard/users/page',
           bundlePath: 'app/dashboard/users/page',
           appPaths: [
-            '/dashboard/users/page',
             '/(marketing)/dashboard/users/page',
+            '/dashboard/users/page',
           ],
         },
       },

--- a/packages/next/src/server/future/route-matcher-providers/builders/app-route-definition-builder.test.ts
+++ b/packages/next/src/server/future/route-matcher-providers/builders/app-route-definition-builder.test.ts
@@ -1,0 +1,240 @@
+import { AppPageRouteDefinition } from '../../route-definitions/app-page-route-definition'
+import { AppRouteDefinitionBuilder } from './app-route-definition-builder'
+
+describe('AppRouteDefinitionBuilder', () => {
+  describe('manifest', () => {
+    it('should return an empty builder when the manifest is empty', () => {
+      const manifest = {}
+      const builder = AppRouteDefinitionBuilder.fromManifest(manifest)
+      expect(builder.toManifest()).toEqual(manifest)
+    })
+
+    it('should return a builder with the manifest entries', () => {
+      const manifest = {
+        '/not-found': 'app/not-found.js',
+        '/_not-found': 'app/_not-found.js',
+        '/robots.txt/route': 'app/robots.txt/route.js',
+        '/manifest.webmanifest/route': 'app/manifest.webmanifest/route.js',
+        '/sitemap.xml/route': 'app/sitemap.xml/route.js',
+        '/apple-icon/route': 'app/apple-icon/route.js',
+        '/opengraph-image/route': 'app/opengraph-image/route.js',
+        '/icon/route': 'app/icon/route.js',
+        '/page': 'app/page.js',
+        '/twitter-image/route': 'app/twitter-image/route.js',
+        '/gsp/page': 'app/gsp/page.js',
+        '/font/page': 'app/font/page.js',
+      }
+      const builder = AppRouteDefinitionBuilder.fromManifest(manifest)
+      expect(builder.toManifest()).toEqual(manifest)
+    })
+
+    it('should throw an error when it encounters an invalid entry', () => {
+      const manifest = {
+        '/robots.txt/route': 'app/robots.txt/route.js',
+        '/manifest.webmanifest/route': 'app/manifest.webmanifest/route.js',
+        '/sitemap.xml/route': 'app/sitemap.xml/route.js',
+        '/apple-icon/route': 'app/apple-icon/route.js',
+        '/opengraph-image/route': 'app/opengraph-image/route.js',
+        // This is invalid
+        '/icon/not-valid': 'app/icon/route.js',
+        '/page': 'app/page.js',
+        '/twitter-image/route': 'app/twitter-image/route.js',
+        '/gsp/page': 'app/gsp/page.js',
+        '/font/page': 'app/font/page.js',
+      }
+
+      expect(() =>
+        AppRouteDefinitionBuilder.fromManifest(manifest)
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Unknown route type: /icon/not-valid"`
+      )
+    })
+
+    it('should produce a manifest that can be read by the builder', () => {
+      const builder = new AppRouteDefinitionBuilder()
+      builder.add('/page', 'app/page.js')
+      builder.add('/gsp/page', 'app/gsp/page.js')
+
+      expect(builder.toManifest()).toMatchInlineSnapshot(`
+        Object {
+          "/gsp/page": "app/gsp/page.js",
+          "/page": "app/page.js",
+        }
+      `)
+    })
+  })
+
+  describe('pathnames', () => {
+    it('returns the pathnames sorted', () => {
+      const builder = new AppRouteDefinitionBuilder()
+      builder.add('/page', 'app/page.js')
+      builder.add('/gsp/page', 'app/gsp/page.js')
+
+      expect(builder.pathnames()).toEqual(['/', '/gsp'])
+
+      builder.add('/font/page', 'app/font/page.js')
+
+      expect(builder.pathnames()).toEqual(['/', '/font', '/gsp'])
+
+      builder.add('/help/page', 'app/help/page.js')
+
+      expect(builder.pathnames()).toEqual(['/', '/font', '/gsp', '/help'])
+    })
+  })
+
+  describe('get', () => {
+    it('should return undefined when the page is not defined', () => {
+      const builder = new AppRouteDefinitionBuilder()
+
+      expect(builder.get('/')).toBeNull()
+    })
+
+    it('should return the definition when the page is defined', () => {
+      const builder = new AppRouteDefinitionBuilder()
+      builder.add('/page', 'app/page.js')
+
+      expect(builder.get('/')).toMatchInlineSnapshot(`
+        Object {
+          "appPaths": Array [
+            "/page",
+          ],
+          "bundlePath": "app/page",
+          "filename": "app/page.js",
+          "kind": "APP_PAGE",
+          "page": "/page",
+          "pathname": "/",
+        }
+      `)
+    })
+
+    it('should return the definition with multiple app paths', () => {
+      const builder = AppRouteDefinitionBuilder.fromManifest({
+        '/dashboard/@team/(team)/page': 'app/dashboard/@team/(team)/page.js',
+        '/dashboard/@account/page': 'app/dashboard/@account/page.js',
+      })
+
+      expect(builder.toSortedDefinitions()).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "appPaths": Array [
+              "/dashboard/@account/page",
+              "/dashboard/@team/(team)/page",
+            ],
+            "bundlePath": "app/dashboard/@team/(team)/page",
+            "filename": "app/dashboard/@team/(team)/page.js",
+            "kind": "APP_PAGE",
+            "page": "/dashboard/@team/(team)/page",
+            "pathname": "/dashboard",
+          },
+        ]
+      `)
+    })
+  })
+
+  describe('add', () => {
+    it('should sort the app paths', () => {
+      const builder = new AppRouteDefinitionBuilder()
+
+      // Added out of sort order here to test that the builder will sort them
+      // when it returns the definition.
+      builder.add('/p/@slot/[...slug]/page', 'app/p/@slot/[...slug]/page.js')
+      builder.add('/p/[...slug]/page', 'app/p/[...slug]/page.js')
+      builder.add('/p/foo/page', 'app/p/foo/page.js')
+      builder.add('/p/@slot/foo/page', 'app/p/@slot/foo/page.js')
+
+      expect(builder.get('/p/[...slug]')).toMatchInlineSnapshot(`
+        Object {
+          "appPaths": Array [
+            "/p/@slot/[...slug]/page",
+            "/p/[...slug]/page",
+          ],
+          "bundlePath": "app/p/[...slug]/page",
+          "filename": "app/p/[...slug]/page.js",
+          "kind": "APP_PAGE",
+          "page": "/p/[...slug]/page",
+          "pathname": "/p/[...slug]",
+        }
+      `)
+      expect(builder.get('/p/foo')).toMatchInlineSnapshot(`
+        Object {
+          "appPaths": Array [
+            "/p/@slot/foo/page",
+            "/p/foo/page",
+          ],
+          "bundlePath": "app/p/foo/page",
+          "filename": "app/p/foo/page.js",
+          "kind": "APP_PAGE",
+          "page": "/p/foo/page",
+          "pathname": "/p/foo",
+        }
+      `)
+    })
+
+    it('should use the last app path as the page', () => {
+      const builder = new AppRouteDefinitionBuilder()
+      builder.add('/p/[...slug]/page', 'app/p/[...slug]/page.js')
+      builder.add('/p/@slot/[...slug]/page', 'app/p/@slot/[...slug]/page.js')
+
+      const definition = builder.get('/p/[...slug]') as AppPageRouteDefinition
+
+      expect(definition?.pathname).toEqual('/p/[...slug]')
+      expect(definition?.page).toEqual('/p/[...slug]/page')
+      expect(definition).toMatchInlineSnapshot(`
+        Object {
+          "appPaths": Array [
+            "/p/@slot/[...slug]/page",
+            "/p/[...slug]/page",
+          ],
+          "bundlePath": "app/p/[...slug]/page",
+          "filename": "app/p/[...slug]/page.js",
+          "kind": "APP_PAGE",
+          "page": "/p/[...slug]/page",
+          "pathname": "/p/[...slug]",
+        }
+      `)
+    })
+  })
+
+  describe('toSortedDefinitions', () => {
+    it('should return an empty array when there are no definitions', () => {
+      const builder = new AppRouteDefinitionBuilder()
+
+      expect(builder.toSortedDefinitions()).toEqual([])
+    })
+
+    it('should return the definitions sorted by pathname', () => {
+      const builder = new AppRouteDefinitionBuilder()
+      builder.add('/p/@slot/[...slug]/page', 'app/p/@slot/[...slug]/page.js')
+      builder.add('/p/[...slug]/page', 'app/p/[...slug]/page.js')
+      builder.add('/p/foo/page', 'app/p/foo/page.js')
+      builder.add('/p/@slot/foo/page', 'app/p/@slot/foo/page.js')
+
+      expect(builder.toSortedDefinitions()).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "appPaths": Array [
+              "/p/@slot/[...slug]/page",
+              "/p/[...slug]/page",
+            ],
+            "bundlePath": "app/p/[...slug]/page",
+            "filename": "app/p/[...slug]/page.js",
+            "kind": "APP_PAGE",
+            "page": "/p/[...slug]/page",
+            "pathname": "/p/[...slug]",
+          },
+          Object {
+            "appPaths": Array [
+              "/p/@slot/foo/page",
+              "/p/foo/page",
+            ],
+            "bundlePath": "app/p/foo/page",
+            "filename": "app/p/foo/page.js",
+            "kind": "APP_PAGE",
+            "page": "/p/foo/page",
+            "pathname": "/p/foo",
+          },
+        ]
+      `)
+    })
+  })
+})

--- a/packages/next/src/server/future/route-matcher-providers/builders/app-route-definition-builder.ts
+++ b/packages/next/src/server/future/route-matcher-providers/builders/app-route-definition-builder.ts
@@ -1,0 +1,131 @@
+import type { PagesManifest } from '../../../../build/webpack/plugins/pages-manifest-plugin'
+import type { AppPageRouteDefinition } from '../../route-definitions/app-page-route-definition'
+import type { AppRouteRouteDefinition } from '../../route-definitions/app-route-route-definition'
+
+import { isAppRouteRoute } from '../../../../lib/is-app-route-route'
+import { AppBundlePathNormalizer } from '../../normalizers/built/app/app-bundle-path-normalizer'
+import { AppPathnameNormalizer } from '../../normalizers/built/app/app-pathname-normalizer'
+import { RouteKind } from '../../route-kind'
+
+export class AppRouteDefinitionBuilder {
+  private static readonly normalizers = {
+    pathname: new AppPathnameNormalizer(),
+    bundlePath: new AppBundlePathNormalizer(),
+  }
+
+  private readonly definitions = new Map<
+    string,
+    AppPageRouteDefinition | AppRouteRouteDefinition
+  >()
+  private readonly appPaths = new Map<string, string[]>()
+
+  static fromManifest(manifest: PagesManifest): AppRouteDefinitionBuilder {
+    const routes = new AppRouteDefinitionBuilder()
+
+    for (const [page, filename] of Object.entries(manifest)) {
+      routes.add(page, filename)
+    }
+
+    return routes
+  }
+
+  public toManifest(): PagesManifest {
+    const manifest: PagesManifest = {}
+
+    for (const definition of this.definitions.values()) {
+      manifest[definition.page] = definition.filename
+    }
+
+    return manifest
+  }
+
+  public add(page: string, filename: string): string {
+    const pathname =
+      AppRouteDefinitionBuilder.normalizers.pathname.normalize(page)
+    const bundlePath =
+      AppRouteDefinitionBuilder.normalizers.bundlePath.normalize(page)
+
+    let appPaths = this.appPaths.get(pathname)
+    if (!appPaths) {
+      appPaths = [page]
+      this.appPaths.set(pathname, appPaths)
+    } else {
+      appPaths.push(page)
+
+      // Sort the app paths so that we can compare them with other app paths,
+      // the order must be deterministic.
+      appPaths.sort()
+    }
+
+    // If the page is an app route route, then we can add it to the definitions
+    // map immediately, there is no need to check if it has any app paths.
+    if (isAppRouteRoute(page)) {
+      this.definitions.set(page, {
+        kind: RouteKind.APP_ROUTE,
+        bundlePath,
+        filename,
+        page,
+        pathname,
+      })
+    } else {
+      this.definitions.set(page, {
+        kind: RouteKind.APP_PAGE,
+        bundlePath,
+        filename,
+        page,
+        pathname,
+        // The appPaths array here is a reference to the one in the appPaths map,
+        // so this will re-use the same array (and any sort or push that occurs
+        // in the future).
+        appPaths,
+      })
+    }
+
+    return pathname
+  }
+
+  /**
+   * Get the pathnames that have app paths, sorted.
+   *
+   * @returns the pathnames that have app paths
+   */
+  public pathnames(): ReadonlyArray<string> {
+    return Array.from(this.appPaths.keys()).sort()
+  }
+
+  public get(
+    pathname: string
+  ): AppPageRouteDefinition | AppRouteRouteDefinition | null {
+    const appPaths = this.appPaths.get(pathname)
+    if (!Array.isArray(appPaths)) return null
+
+    // The page is always the last app path.
+    const page = appPaths[appPaths.length - 1]
+
+    // Get the definition for the page. We know that this will always return a
+    // value because we can only get app paths from the app paths map if the
+    // page exists in the definitions map.
+    return this.definitions.get(page)!
+  }
+
+  /**
+   * Get the entries of the app paths.
+   *
+   * @returns the entries of the app paths
+   */
+  public toSortedDefinitions(): ReadonlyArray<
+    AppPageRouteDefinition | AppRouteRouteDefinition
+  > {
+    const definitions: Array<AppPageRouteDefinition | AppRouteRouteDefinition> =
+      []
+    for (const pathname of this.pathnames()) {
+      // We know that this will always return a value because we only add
+      // pathnames that have app paths.
+      const definition = this.get(pathname)!
+
+      definitions.push(definition)
+    }
+
+    return definitions
+  }
+}

--- a/packages/next/src/server/future/route-matcher-providers/dev/helpers/file-reader/default-file-reader.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/helpers/file-reader/default-file-reader.ts
@@ -12,7 +12,7 @@ export type DefaultFileReaderOptions = Pick<
 
 /**
  * Reads all the files in the directory and its subdirectories following any
- * symbolic links.
+ * symbolic links and returns a sorted list of the files.
  */
 export class DefaultFileReader implements FileReader {
   /**
@@ -45,9 +45,9 @@ export class DefaultFileReader implements FileReader {
       ignoreFilter: this.options.ignoreFilter,
       ignorePartFilter: this.options.ignorePartFilter,
 
-      // We don't need to sort the results because we're not depending on the
-      // order of the results.
-      sortPathnames: false,
+      // We want to sort the pathnames so that we can compare them with other
+      // pathnames.
+      sortPathnames: true,
 
       // We want absolute pathnames because we're going to be comparing them
       // with other absolute pathnames.

--- a/packages/next/src/server/lib/router-utils/types.ts
+++ b/packages/next/src/server/lib/router-utils/types.ts
@@ -3,5 +3,6 @@ export type PropagateToWorkersField =
   | 'actualInstrumentationHookFile'
   | 'reloadMatchers'
   | 'loadEnvConfig'
-  | 'appPathRoutes'
+  | 'appPathsManifest'
+  | 'reloadAppPathRoutes'
   | 'middleware'


### PR DESCRIPTION
To normalize the beheviour of the `appPaths` handling within Next.js, this adds a new `AppRouteDefinitionBuilder` abstraction that creates new `AppRouteDefinition`'s using the `app-paths-manifest.json`. This manifest when parsed provides important information such as a route's `kind`, `bundlePath`, `filename`, `page`, `pathname`, and for App Pages, the `appPaths`.

This is required because the handling of pulling the `page` from the `appPaths` was spread around different parts of the framework with different expected orders. This adds sorting to the file listing and `appPaths` to ensure that access of these critical routing parameters is deterministic.