### PR TITLE
Remove i18n support from Pages API

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -662,11 +662,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
     // Match api routes under `pages/api/`.
     matchers.push(
-      new PagesAPIRouteMatcherProvider(
-        this.distDir,
-        manifestLoader,
-        this.i18nProvider
-      )
+      new PagesAPIRouteMatcherProvider(this.distDir, manifestLoader)
     )
 
     // If the app directory is enabled, then add the app matchers and handlers.

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -224,12 +224,7 @@ export default class DevServer extends Server {
         )
       )
       matchers.push(
-        new DevPagesAPIRouteMatcherProvider(
-          pagesDir,
-          extensions,
-          fileReader,
-          this.localeNormalizer
-        )
+        new DevPagesAPIRouteMatcherProvider(pagesDir, extensions, fileReader)
       )
     }
 

--- a/packages/next/src/server/future/route-definitions/locale-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/locale-route-definition.ts
@@ -7,7 +7,7 @@ export interface LocaleRouteDefinition<K extends RouteKind = RouteKind>
    * When defined it means that this route is locale aware. When undefined,
    * it means no special handling has to occur to process locales.
    */
-  i18n?: {
+  i18n: {
     /**
      * Describes the locale for the route. If this is undefined, then it
      * indicates that this route can handle _any_ locale.

--- a/packages/next/src/server/future/route-definitions/pages-api-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/pages-api-route-definition.ts
@@ -1,5 +1,5 @@
-import { RouteKind } from '../route-kind'
-import { LocaleRouteDefinition } from './locale-route-definition'
+import type { RouteKind } from '../route-kind'
+import type { RouteDefinition } from './route-definition'
 
 export interface PagesAPIRouteDefinition
-  extends LocaleRouteDefinition<RouteKind.PAGES_API> {}
+  extends RouteDefinition<RouteKind.PAGES_API> {}

--- a/packages/next/src/server/future/route-definitions/pages-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/pages-route-definition.ts
@@ -1,5 +1,9 @@
-import { RouteKind } from '../route-kind'
-import { LocaleRouteDefinition } from './locale-route-definition'
+import type { RouteKind } from '../route-kind'
+import type { LocaleRouteDefinition } from './locale-route-definition'
+import type { RouteDefinition } from './route-definition'
 
 export interface PagesRouteDefinition
+  extends RouteDefinition<RouteKind.PAGES> {}
+
+export interface PagesLocaleRouteDefinition
   extends LocaleRouteDefinition<RouteKind.PAGES> {}

--- a/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.test.ts
+++ b/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.test.ts
@@ -1,6 +1,6 @@
 import { AppPageRouteDefinition } from '../route-definitions/app-page-route-definition'
 import { LocaleRouteDefinition } from '../route-definitions/locale-route-definition'
-import { PagesRouteDefinition } from '../route-definitions/pages-route-definition'
+import { PagesLocaleRouteDefinition } from '../route-definitions/pages-route-definition'
 import { RouteKind } from '../route-kind'
 import { RouteMatcherProvider } from '../route-matcher-providers/route-matcher-provider'
 import { LocaleRouteMatcher } from '../route-matchers/locale-route-matcher'
@@ -113,7 +113,7 @@ describe('DefaultRouteMatcherManager', () => {
 
   it('calls the locale route matcher when one is provided', async () => {
     const manager = new DefaultRouteMatcherManager()
-    const definition: PagesRouteDefinition = {
+    const definition: PagesLocaleRouteDefinition = {
       kind: RouteKind.PAGES,
       filename: '',
       bundlePath: '',

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.ts
@@ -1,11 +1,8 @@
-import { FileReader } from './helpers/file-reader/file-reader'
-import {
-  PagesAPILocaleRouteMatcher,
-  PagesAPIRouteMatcher,
-} from '../../route-matchers/pages-api-route-matcher'
+import type { FileReader } from './helpers/file-reader/file-reader'
+
+import { PagesAPIRouteMatcher } from '../../route-matchers/pages-api-route-matcher'
 import { RouteKind } from '../../route-kind'
 import path from 'path'
-import { LocaleRouteNormalizer } from '../../normalizers/locale-route-normalizer'
 import { FileCacheRouteMatcherProvider } from './file-cache-route-matcher-provider'
 import { DevPagesNormalizers } from '../../normalizers/built/pages'
 
@@ -16,8 +13,7 @@ export class DevPagesAPIRouteMatcherProvider extends FileCacheRouteMatcherProvid
   constructor(
     private readonly pagesDir: string,
     private readonly extensions: ReadonlyArray<string>,
-    reader: FileReader,
-    private readonly localeNormalizer?: LocaleRouteNormalizer
+    reader: FileReader
   ) {
     super(pagesDir, reader)
 
@@ -62,28 +58,15 @@ export class DevPagesAPIRouteMatcherProvider extends FileCacheRouteMatcherProvid
       const page = this.normalizers.page.normalize(filename)
       const bundlePath = this.normalizers.bundlePath.normalize(filename)
 
-      if (this.localeNormalizer) {
-        matchers.push(
-          new PagesAPILocaleRouteMatcher({
-            kind: RouteKind.PAGES_API,
-            pathname,
-            page,
-            bundlePath,
-            filename,
-            i18n: {},
-          })
-        )
-      } else {
-        matchers.push(
-          new PagesAPIRouteMatcher({
-            kind: RouteKind.PAGES_API,
-            pathname,
-            page,
-            bundlePath,
-            filename,
-          })
-        )
-      }
+      matchers.push(
+        new PagesAPIRouteMatcher({
+          kind: RouteKind.PAGES_API,
+          pathname,
+          page,
+          bundlePath,
+          filename,
+        })
+      )
     }
 
     return matchers

--- a/packages/next/src/server/future/route-matcher-providers/pages-api-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/pages-api-route-matcher-provider.ts
@@ -1,26 +1,19 @@
-import { isAPIRoute } from '../../../lib/is-api-route'
-import { PAGES_MANIFEST } from '../../../shared/lib/constants'
-import { RouteKind } from '../route-kind'
-import {
-  PagesAPILocaleRouteMatcher,
-  PagesAPIRouteMatcher,
-} from '../route-matchers/pages-api-route-matcher'
-import {
+import type {
   Manifest,
   ManifestLoader,
 } from './helpers/manifest-loaders/manifest-loader'
+
+import { isAPIRoute } from '../../../lib/is-api-route'
+import { PAGES_MANIFEST } from '../../../shared/lib/constants'
+import { RouteKind } from '../route-kind'
+import { PagesAPIRouteMatcher } from '../route-matchers/pages-api-route-matcher'
 import { ManifestRouteMatcherProvider } from './manifest-route-matcher-provider'
-import { I18NProvider } from '../helpers/i18n-provider'
 import { PagesNormalizers } from '../normalizers/built/pages'
 
 export class PagesAPIRouteMatcherProvider extends ManifestRouteMatcherProvider<PagesAPIRouteMatcher> {
   private readonly normalizers: PagesNormalizers
 
-  constructor(
-    distDir: string,
-    manifestLoader: ManifestLoader,
-    private readonly i18nProvider?: I18NProvider
-  ) {
+  constructor(distDir: string, manifestLoader: ManifestLoader) {
     super(PAGES_MANIFEST, manifestLoader)
 
     this.normalizers = new PagesNormalizers(distDir)
@@ -37,33 +30,15 @@ export class PagesAPIRouteMatcherProvider extends ManifestRouteMatcherProvider<P
     const matchers: Array<PagesAPIRouteMatcher> = []
 
     for (const page of pathnames) {
-      if (this.i18nProvider) {
-        // Match the locale on the page name, or default to the default locale.
-        const { detectedLocale, pathname } = this.i18nProvider.analyze(page)
-
-        matchers.push(
-          new PagesAPILocaleRouteMatcher({
-            kind: RouteKind.PAGES_API,
-            pathname,
-            page,
-            bundlePath: this.normalizers.bundlePath.normalize(page),
-            filename: this.normalizers.filename.normalize(manifest[page]),
-            i18n: {
-              locale: detectedLocale,
-            },
-          })
-        )
-      } else {
-        matchers.push(
-          new PagesAPIRouteMatcher({
-            kind: RouteKind.PAGES_API,
-            pathname: page,
-            page,
-            bundlePath: this.normalizers.bundlePath.normalize(page),
-            filename: this.normalizers.filename.normalize(manifest[page]),
-          })
-        )
-      }
+      matchers.push(
+        new PagesAPIRouteMatcher({
+          kind: RouteKind.PAGES_API,
+          pathname: page,
+          page,
+          bundlePath: this.normalizers.bundlePath.normalize(page),
+          filename: this.normalizers.filename.normalize(manifest[page]),
+        })
+      )
     }
 
     return matchers

--- a/packages/next/src/server/future/route-matcher-providers/pages-route-matcher-provider.test.ts
+++ b/packages/next/src/server/future/route-matcher-providers/pages-route-matcher-provider.test.ts
@@ -1,6 +1,9 @@
 import { PAGES_MANIFEST, SERVER_DIRECTORY } from '../../../shared/lib/constants'
 import { I18NProvider } from '../helpers/i18n-provider'
-import { PagesRouteDefinition } from '../route-definitions/pages-route-definition'
+import {
+  PagesLocaleRouteDefinition,
+  PagesRouteDefinition,
+} from '../route-definitions/pages-route-definition'
 import { RouteKind } from '../route-kind'
 import { ManifestLoader } from './helpers/manifest-loaders/manifest-loader'
 import { PagesRouteMatcherProvider } from './pages-route-matcher-provider'
@@ -16,7 +19,7 @@ describe('PagesRouteMatcherProvider', () => {
   describe('locale matching', () => {
     describe.each<{
       manifest: Record<string, string>
-      routes: ReadonlyArray<PagesRouteDefinition>
+      routes: ReadonlyArray<PagesLocaleRouteDefinition>
       i18n: { locales: Array<string>; defaultLocale: string }
     }>([
       {

--- a/packages/next/src/server/future/route-matchers/pages-api-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/pages-api-route-matcher.ts
@@ -1,7 +1,4 @@
-import { PagesAPIRouteDefinition } from '../route-definitions/pages-api-route-definition'
-import { LocaleRouteMatcher } from './locale-route-matcher'
 import { RouteMatcher } from './route-matcher'
+import { PagesAPIRouteDefinition } from '../route-definitions/pages-api-route-definition'
 
 export class PagesAPIRouteMatcher extends RouteMatcher<PagesAPIRouteDefinition> {}
-
-export class PagesAPILocaleRouteMatcher extends LocaleRouteMatcher<PagesAPIRouteDefinition> {}

--- a/packages/next/src/server/future/route-matchers/pages-route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/pages-route-matcher.ts
@@ -1,7 +1,11 @@
-import { PagesRouteDefinition } from '../route-definitions/pages-route-definition'
+import type {
+  PagesLocaleRouteDefinition,
+  PagesRouteDefinition,
+} from '../route-definitions/pages-route-definition'
+
 import { LocaleRouteMatcher } from './locale-route-matcher'
 import { RouteMatcher } from './route-matcher'
 
 export class PagesRouteMatcher extends RouteMatcher<PagesRouteDefinition> {}
 
-export class PagesLocaleRouteMatcher extends LocaleRouteMatcher<PagesRouteDefinition> {}
+export class PagesLocaleRouteMatcher extends LocaleRouteMatcher<PagesLocaleRouteDefinition> {}

--- a/packages/next/src/server/future/route-matches/pages-route-match.ts
+++ b/packages/next/src/server/future/route-matches/pages-route-match.ts
@@ -1,5 +1,12 @@
-import type { PagesRouteDefinition } from '../route-definitions/pages-route-definition'
+import type {
+  PagesLocaleRouteDefinition,
+  PagesRouteDefinition,
+} from '../route-definitions/pages-route-definition'
 import type { LocaleRouteMatch } from './locale-route-match'
+import type { RouteMatch } from './route-match'
 
 export interface PagesRouteMatch
-  extends LocaleRouteMatch<PagesRouteDefinition> {}
+  extends LocaleRouteMatch<PagesLocaleRouteDefinition> {}
+
+export interface PagesLocaleRouteMatch
+  extends RouteMatch<PagesRouteDefinition> {}


### PR DESCRIPTION
Inadvertantantly, the routes within `pages/api/` supported locale matching in development. This was not intended, and this removes that particular issue.