### PR TITLE
fix: do not return value from file-system-cache if it is stale

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -487,7 +487,7 @@ export class IncrementalCache {
         isStale,
         curRevalidate,
         revalidateAfter,
-        value: cacheData.value,
+        value: isStale ? null : cacheData.value,
       }
     }
 


### PR DESCRIPTION
This PR fixes behavior when staticky generated page will continue serving by Next.js Server when `getStaticProps` returns `notFound: true` and `isrMemoryCacheSize` is 0 or less than page size. With this fix page will not be served but from will stay in filesystem. When next time `getStaticProps` will return props Next.js Server will write new version of a page to filesystem.

Fixes [46578](https://github.com/vercel/next.js/issues/46578) [45946](https://github.com/vercel/next.js/issues/45946) [37945](https://github.com/vercel/next.js/issues/37945)