### PR TITLE
Fixed i18n data route RegExp

### DIFF
--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -249,7 +249,7 @@ export async function setupFsCheck(opts: {
               ? new RegExp(
                   route.dataRouteRegex.replace(
                     `/${escapedBuildId}/`,
-                    `/${escapedBuildId}/(?<nextLocale>.+?)/`
+                    `/${escapedBuildId}/(?<nextLocale>[^/]+?)/`
                   )
                 )
               : new RegExp(route.dataRouteRegex),

--- a/packages/next/src/server/lib/router-utils/setup-dev.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev.ts
@@ -1784,7 +1784,7 @@ async function startWatcher(opts: SetupOpts) {
                 ? new RegExp(
                     route.dataRouteRegex.replace(
                       `/development/`,
-                      `/development/(?<nextLocale>.+?)/`
+                      `/development/(?<nextLocale>[^/]+?)/`
                     )
                   )
                 : new RegExp(route.dataRouteRegex),

--- a/test/e2e/i18n-data-route/components/page.tsx
+++ b/test/e2e/i18n-data-route/components/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export function Page({ page }) {
+  return <p data-page={page}>{page}</p>
+}
+
+export function createGetServerSideProps(page: string) {
+  return async function getServerSideProps(ctx) {
+    const output = ctx.req.headers['x-invoke-output'] ?? null
+    return { props: { page, output } }
+  }
+}

--- a/test/e2e/i18n-data-route/i18n-data-route.test.ts
+++ b/test/e2e/i18n-data-route/i18n-data-route.test.ts
@@ -1,0 +1,83 @@
+import { createNextDescribe } from 'e2e-utils'
+
+const { i18n } = require('./next.config')
+
+const pages = [
+  { url: '/about', page: '/about', params: null },
+  { url: '/blog/about', page: '/[slug]/about', params: { slug: 'blog' } },
+]
+
+function checkDataRoute(data: any, page: string) {
+  expect(data).toHaveProperty('pageProps')
+  expect(data.pageProps).toHaveProperty('page', page)
+  expect(data.pageProps).toHaveProperty('output', page)
+}
+
+createNextDescribe(
+  'i18n-data-route',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    describe('with locale prefix', () => {
+      describe.each(i18n.locales)('/%s', (locale) => {
+        const prefixed = pages.map((page) => ({
+          ...page,
+          url: `/${locale}${page.url}`,
+        }))
+
+        it.each(prefixed)(
+          'should render $page via $url',
+          async ({ url, page }) => {
+            const $ = await next.render$(url)
+            expect($('[data-page]').data('page')).toBe(page)
+          }
+        )
+
+        it.each(prefixed)(
+          'should serve data for $page',
+          async ({ url, page, params }) => {
+            url = `/_next/data/${next.buildId}${url}.json`
+            if (params) {
+              const query = new URLSearchParams(params)
+              // Ensure the query is sorted so it's deterministic.
+              query.sort()
+              url += `?${query.toString()}`
+            }
+
+            const res = await next.fetch(url)
+            expect(res.status).toBe(200)
+            expect(res.headers.get('content-type')).toBe('application/json')
+            const data = await res.json()
+            checkDataRoute(data, page)
+          }
+        )
+      })
+    })
+
+    describe('without locale prefix', () => {
+      it.each(pages)('should render $page via $url', async ({ url, page }) => {
+        const $ = await next.render$(url)
+        expect($('[data-page]').data('page')).toBe(page)
+      })
+
+      it.each(pages)(
+        'should serve data for $page',
+        async ({ url, page, params }) => {
+          url = `/_next/data/${next.buildId}/${i18n.defaultLocale}${url}.json`
+          if (params) {
+            const query = new URLSearchParams(params)
+            // Ensure the query is sorted so it's deterministic.
+            query.sort()
+            url += `?${query.toString()}`
+          }
+          const res = await next.fetch(url)
+          expect(res.status).toBe(200)
+          expect(res.headers.get('content-type')).toBe('application/json')
+          const data = await res.json()
+          checkDataRoute(data, page)
+        }
+      )
+    })
+  }
+)

--- a/test/e2e/i18n-data-route/next.config.js
+++ b/test/e2e/i18n-data-route/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+module.exports = {
+  i18n: {
+    locales: ['en-CA', 'fr-CA'],
+    defaultLocale: 'en-CA',
+  },
+}

--- a/test/e2e/i18n-data-route/pages/[slug]/about/index.tsx
+++ b/test/e2e/i18n-data-route/pages/[slug]/about/index.tsx
@@ -1,0 +1,5 @@
+import { Page, createGetServerSideProps } from '../../../components/page'
+
+export default Page
+
+export const getServerSideProps = createGetServerSideProps('/[slug]/about')

--- a/test/e2e/i18n-data-route/pages/about/index.tsx
+++ b/test/e2e/i18n-data-route/pages/about/index.tsx
@@ -1,0 +1,5 @@
+import { Page, createGetServerSideProps } from '../../components/page'
+
+export default Page
+
+export const getServerSideProps = createGetServerSideProps('/about')


### PR DESCRIPTION
The previous RegExp for data routes when i18n was enabled yielded a pattern like:

```
^\/_next\/data\/development\/(?<nextLocale>.+?)\/about.json$
^\/_next\/data\/development\/(?<nextLocale>.+?)\/blog/about.json$
```

But the capture group for the `nextLocale` did so greedily, where the following:

```
/_next/data/development/en-US/blog/about.json
```

Would actually match both routes.

This changes it to prevent the locale from including a `/` via `[^/]`, resulting in the new expressions:

```
^\/_next\/data\/development\/(?<nextLocale>[^/]+?)\/about.json$
^\/_next\/data\/development\/(?<nextLocale>[^/]+?)\/blog/about.json$
```