### PR TITLE
Route Ensuring Fixes

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1436,6 +1436,8 @@ export async function isPageStatic({
           distDir,
           page: originalAppPath || page,
           isAppPath: pageType === 'app',
+          // TODO: generate or pass a definition
+          definition: null,
         })
       }
       const Comp = componentsResult.Component || {}
@@ -1679,6 +1681,7 @@ export async function hasCustomGetInitialProps(
     distDir,
     page,
     isAppPath: false,
+    definition: null,
   })
   let mod = components.ComponentMod
 
@@ -1701,6 +1704,7 @@ export async function getDefinedNamedExports(
     distDir,
     page,
     isAppPath: false,
+    definition: null,
   })
 
   return Object.keys(components.ComponentMod).filter((key) => {

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -324,6 +324,8 @@ export default async function exportPage({
           distDir,
           page,
           isAppPath: isAppDir,
+          // TODO: generate or pass a definition
+          definition: null,
         })
         curRenderOpts = {
           ...components,

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -3,7 +3,7 @@ import type { UrlObject } from 'url'
 import type { Duplex } from 'stream'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type getBaseWebpackConfig from '../../build/webpack-config'
-import type { RouteMatch } from '../future/route-matches/route-match'
+import type { RouteDefinition } from '../future/route-definitions/route-definition'
 import type { Update as TurbopackUpdate } from '../../build/swc'
 import type { VersionInfo } from './parse-version-info'
 
@@ -131,14 +131,10 @@ export interface NextJsHotReloaderInterface {
   ensurePage({
     page,
     clientOnly,
-    appPaths,
-    match,
-    isApp,
+    definition,
   }: {
     page: string
     clientOnly: boolean
-    appPaths?: ReadonlyArray<string> | null
-    isApp?: boolean
-    match?: RouteMatch
+    definition: RouteDefinition | null
   }): Promise<void>
 }

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -65,6 +65,8 @@ export async function loadStaticPaths({
     distDir,
     page: originalAppPath || pathname,
     isAppPath: !!isAppPath,
+    // TODO: we should be able to generate this
+    definition: null,
   })
 
   if (!components.getStaticPaths && !isAppPath) {

--- a/packages/next/src/server/future/route-definitions/pages-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/pages-route-definition.ts
@@ -1,9 +1,18 @@
-import type { RouteKind } from '../route-kind'
 import type { LocaleRouteDefinition } from './locale-route-definition'
 import type { RouteDefinition } from './route-definition'
 
+import { RouteKind } from '../route-kind'
+
 export interface PagesRouteDefinition
-  extends RouteDefinition<RouteKind.PAGES> {}
+  extends RouteDefinition<RouteKind.PAGES>,
+    RouteDefinition<RouteKind.PAGES> {}
 
 export interface PagesLocaleRouteDefinition
-  extends LocaleRouteDefinition<RouteKind.PAGES> {}
+  extends LocaleRouteDefinition<RouteKind.PAGES>,
+    RouteDefinition<RouteKind.PAGES> {}
+
+export function isPagesRouteDefinition(
+  definition: RouteDefinition
+): definition is PagesRouteDefinition {
+  return definition.kind === RouteKind.PAGES
+}

--- a/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.ts
+++ b/packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.ts
@@ -285,7 +285,7 @@ export class DefaultRouteMatcherManager implements RouteMatcherManager {
     // If this pathname looks like a dynamic route, then we couldn't have a
     // static match for it because you can't escape the dynamic route parameters
     // when creating the page. So we can skip the static matchers.
-    if (!isDynamicRoute(pathname)) {
+    if (!isDynamicRoute(normalized.pathname)) {
       for (const matcher of this.matchers.static) {
         const match = this.validate(matcher, normalized)
         if (!match) continue

--- a/packages/next/src/server/future/route-matcher-managers/dev-route-matcher-manager.ts
+++ b/packages/next/src/server/future/route-matcher-managers/dev-route-matcher-manager.ts
@@ -11,7 +11,7 @@ import * as Log from '../../../build/output/log'
 import chalk from 'next/dist/compiled/chalk'
 
 export interface RouteEnsurer {
-  ensure(match: RouteMatch): Promise<void>
+  ensure(definition: RouteDefinition): Promise<void>
 }
 
 export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
@@ -75,7 +75,7 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
     for await (const development of super.matchAll(pathname, options)) {
       // We're here, which means that we haven't seen this match yet, so we
       // should try to ensure it and recompile the production matcher.
-      await this.ensurer.ensure(development)
+      await this.ensurer.ensure(development.definition)
       await this.production.forceReload()
 
       // Iterate over the production matches again, this time we should be able

--- a/packages/next/src/server/future/route-matcher-providers/app-page-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/app-page-route-matcher-provider.ts
@@ -22,7 +22,11 @@ export class AppPageRouteMatcherProvider extends ManifestRouteMatcherProvider<Ap
 
   private prepare(manifest: Manifest) {
     // This matcher only matches app pages.
-    const pages = Object.keys(manifest).filter((page) => isAppPageRoute(page))
+    const pages = Object.keys(manifest)
+      .filter((page) => isAppPageRoute(page))
+      // Sort the pathnames to ensure that the order of the matchers is
+      // deterministic.
+      .sort()
 
     // Collect all the app paths for each page. This could include any parallel
     // routes.

--- a/packages/next/src/server/future/route-matcher-providers/app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/app-route-route-matcher-provider.ts
@@ -22,7 +22,11 @@ export class AppRouteRouteMatcherProvider extends ManifestRouteMatcherProvider<A
     manifest: Manifest
   ): Promise<ReadonlyArray<AppRouteRouteMatcher>> {
     // This matcher only matches app routes.
-    const pages = Object.keys(manifest).filter((page) => isAppRouteRoute(page))
+    const pages = Object.keys(manifest)
+      .filter((page) => isAppRouteRoute(page))
+      // Sort the pathnames to ensure that the order of the matchers is
+      // deterministic.
+      .sort()
 
     // Format the routes.
     const matchers: Array<AppRouteRouteMatcher> = []

--- a/packages/next/src/server/future/route-matcher-providers/builders/app-route-definition-builder.ts
+++ b/packages/next/src/server/future/route-matcher-providers/builders/app-route-definition-builder.ts
@@ -1,6 +1,5 @@
 import type { PagesManifest } from '../../../../build/webpack/plugins/pages-manifest-plugin'
-import type { AppPageRouteDefinition } from '../../route-definitions/app-page-route-definition'
-import type { AppRouteRouteDefinition } from '../../route-definitions/app-route-route-definition'
+import type { AppRouteDefinition } from '../../route-definitions/app-route-definition'
 
 import { isAppRouteRoute } from '../../../../lib/is-app-route-route'
 import { AppBundlePathNormalizer } from '../../normalizers/built/app/app-bundle-path-normalizer'
@@ -13,10 +12,7 @@ export class AppRouteDefinitionBuilder {
     bundlePath: new AppBundlePathNormalizer(),
   }
 
-  private readonly definitions = new Map<
-    string,
-    AppPageRouteDefinition | AppRouteRouteDefinition
-  >()
+  private readonly definitions = new Map<string, AppRouteDefinition>()
   private readonly appPaths = new Map<string, string[]>()
 
   static fromManifest(manifest: PagesManifest): AppRouteDefinitionBuilder {
@@ -27,6 +23,14 @@ export class AppRouteDefinitionBuilder {
     }
 
     return routes
+  }
+
+  /**
+   * Clear all the definitions and app paths.
+   */
+  public clear(): void {
+    this.definitions.clear()
+    this.appPaths.clear()
   }
 
   public toManifest(): PagesManifest {
@@ -93,9 +97,7 @@ export class AppRouteDefinitionBuilder {
     return Array.from(this.appPaths.keys()).sort()
   }
 
-  public get(
-    pathname: string
-  ): AppPageRouteDefinition | AppRouteRouteDefinition | null {
+  public get(pathname: string): AppRouteDefinition | null {
     const appPaths = this.appPaths.get(pathname)
     if (!Array.isArray(appPaths)) return null
 
@@ -113,11 +115,8 @@ export class AppRouteDefinitionBuilder {
    *
    * @returns the entries of the app paths
    */
-  public toSortedDefinitions(): ReadonlyArray<
-    AppPageRouteDefinition | AppRouteRouteDefinition
-  > {
-    const definitions: Array<AppPageRouteDefinition | AppRouteRouteDefinition> =
-      []
+  public toSortedDefinitions(): ReadonlyArray<AppRouteDefinition> {
+    const definitions: Array<AppRouteDefinition> = []
     for (const pathname of this.pathnames()) {
       // We know that this will always return a value because we only add
       // pathnames that have app paths.

--- a/packages/next/src/server/future/route-matcher-providers/pages-api-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/pages-api-route-matcher-provider.ts
@@ -23,9 +23,11 @@ export class PagesAPIRouteMatcherProvider extends ManifestRouteMatcherProvider<P
     manifest: Manifest
   ): Promise<ReadonlyArray<PagesAPIRouteMatcher>> {
     // This matcher is only for Pages API routes.
-    const pathnames = Object.keys(manifest).filter((pathname) =>
-      isAPIRoute(pathname)
-    )
+    const pathnames = Object.keys(manifest)
+      .filter((pathname) => isAPIRoute(pathname))
+      // Sort the pathnames to ensure that the order of the matchers is
+      // deterministic.
+      .sort()
 
     const matchers: Array<PagesAPIRouteMatcher> = []
 

--- a/packages/next/src/server/future/route-matcher-providers/pages-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/pages-route-matcher-provider.ts
@@ -46,6 +46,9 @@ export class PagesRouteMatcherProvider extends ManifestRouteMatcherProvider<
 
         return true
       })
+      // Sort the pathnames to ensure that the order of the matchers is
+      // deterministic.
+      .sort()
 
     const matchers: Array<PagesRouteMatcher | PagesLocaleRouteMatcher> = []
     for (const page of pathnames) {

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -144,6 +144,8 @@ export async function initialize(opts: {
       await devInstance?.hotReloader.ensurePage({
         page: '/_error',
         clientOnly: false,
+        // Error pages do not have a route definition.
+        definition: null,
       })
     },
     async getCompilationError(page: string) {

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -32,7 +32,6 @@ import {
   MiddlewareRouteMatch,
   getMiddlewareRouteMatcher,
 } from '../../../shared/lib/router/utils/middleware-route-matcher'
-
 import {
   APP_PATH_ROUTES_MANIFEST,
   BUILD_ID_FILE,
@@ -43,6 +42,7 @@ import {
 } from '../../../shared/lib/constants'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
 import { normalizeMetadataRoute } from '../../../lib/metadata/get-metadata-route'
+import { AppRouteDefinitionBuilder } from '../../future/route-matcher-providers/builders/app-route-definition-builder'
 
 export type FsOutput = {
   type:
@@ -126,6 +126,9 @@ export async function setupFsCheck(opts: {
   const publicFolderItems = new Set<string>()
   const nextStaticFolderItems = new Set<string>()
   const legacyStaticFolderItems = new Set<string>()
+
+  // TODO: (wyattjoh) maybe this isn't updated fast enough, we may need the directory scan from the dev matchers
+  const appRoutes = new AppRouteDefinitionBuilder()
 
   const appFiles = new Set<string>()
   const pageFiles = new Set<string>()
@@ -379,6 +382,7 @@ export async function setupFsCheck(opts: {
     buildId,
     handleLocale,
 
+    appRoutes,
     appFiles,
     pageFiles,
     dynamicRoutes,

--- a/packages/next/src/server/require.ts
+++ b/packages/next/src/server/require.ts
@@ -104,12 +104,7 @@ export function getPagePath(
   return pagePath
 }
 
-export function requirePage(
-  page: string,
-  distDir: string,
-  isAppPath: boolean
-): any {
-  const pagePath = getPagePath(page, distDir, undefined, isAppPath)
+export function requirePagePath(pagePath: string, page: string) {
   if (pagePath.endsWith('.html')) {
     return promises.readFile(pagePath, 'utf8').catch((err) => {
       throw new MissingStaticPage(page, err.message)
@@ -120,6 +115,15 @@ export function requirePage(
     ? // @ts-ignore
       __non_webpack_require__(pagePath)
     : require(pagePath)
+}
+
+export function requirePage(
+  page: string,
+  distDir: string,
+  isAppPath: boolean
+): any {
+  const pagePath = getPagePath(page, distDir, undefined, isAppPath)
+  return requirePagePath(pagePath, page)
 }
 
 export function requireFontManifest(distDir: string) {


### PR DESCRIPTION
This fixes some issues related to route compilation by ensuring that pages (such as app pages) have the correct information available in order to call `ensurePage`.

Fixes #53837
