### PR TITLE
examples: Update strict-csp example with better nonce

### DIFF
--- a/examples/with-strict-csp/middleware.js
+++ b/examples/with-strict-csp/middleware.js
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 
 export function middleware(request) {
-  const nonce = crypto.randomUUID()
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
   const cspHeader = `
     default-src 'self';
     script-src 'self' 'nonce-${nonce}' 'strict-dynamic';


### PR DESCRIPTION
Follow up to https://github.com/vercel/next.js/pull/55039.