### PR TITLE
Fix(i18n): Inaccessible public folder on non-default domains

### DIFF
--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -450,7 +450,8 @@ export async function setupFsCheck(opts: {
         let curItemPath = itemPath
         let curDecodedItemPath = decodedItemPath
 
-        const isDynamicOutput = type === 'pageFile' || type === 'appFile'
+        const isDynamicOutput =
+          type === 'pageFile' || type === 'appFile' || type === 'publicFolder'
 
         if (i18n) {
           const localeResult = handleLocale(


### PR DESCRIPTION
Changes in #52492 made `public` folder accessible only on default domain if using i18n. PR fixes this by making public directory contents accessible from all i18n domains as the original solution did. 

Fixes #54765 