### PR TITLE
Ensure `ImageResponse` extends `Response`

### DIFF
--- a/packages/next/src/server/web/spec-extension/image-response.ts
+++ b/packages/next/src/server/web/spec-extension/image-response.ts
@@ -1,4 +1,4 @@
-export class ImageResponse {
+export class ImageResponse extends Response {
   public static displayName = 'NextImageResponse'
   constructor(
     ...args: ConstructorParameters<
@@ -36,7 +36,7 @@ export class ImageResponse {
 
     const options = args[1] || {}
 
-    return new Response(readable, {
+    super(readable, {
       headers: {
         'content-type': 'image/png',
         'cache-control':


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### Why?

The `ImageResponse` class constructor returns a `Response` instance, but doesn't extend `Response`, so it doesn't pass the type check introduced in #51394.

### How?

Make the `ImageResponse` class a subclass of `Response`.

### Notes

I can't find any tests to check for the types so didn't add any tests here; but shouldn't there be one?