### PR TITLE
Hotfix: Temporarily disable static type checking for route handler return type

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -107,19 +107,6 @@ if ('${method}' in entry) {
       '${method}'
     >
   >()
-  checkFields<
-    Diff<
-      {
-        __tag__: '${method}',
-        __return_type__: Response | Promise<Response>
-      },
-      {
-        __tag__: '${method}',
-        __return_type__: ReturnType<MaybeField<TEntry, '${method}'>>
-      },
-      '${method}'
-    >
-  >()
 }
 `
       ).join('')


### PR DESCRIPTION
### Why?

#51394 added static type checking for route handlers return type, so all route handlers must return `Response | Promise<Response>`.

But the checker cannot detect when the function always throws, for example

```ts
export function GET() {
  throw new Error(); // can be notFound(), redirect()
}
```

because `GET` is inferred as `() => void`, not as `() => never`, adding `| never` to the type checker can't fix it.

I can't find a way to get this to work (see the "Notes" section below for more details), so this PR disables that entire type checking so route handlers like the above can pass. Hopefully this change is temporary.

### How?

Remove the part where the TS plugin checks for the return type of route handlers.

### Notes

Without this PR, the following still works, because the return type is made known to TypeScript:

```ts
// Explicit return type
export function GET(): Response {
  throw new Error();
}
```

Allowing `never` in the TS plugin

```diff
-      __return_type__: Response | Promise<Response>
+      __return_type__: Response | Promise<Response> | never
```

will also make the following work:

```ts
// Arrow function
export const GET = () => {
  throw new Error();
}
```

because `GET` is inferred to return `never`. However, using regular function declaration won't work because it is inferred to return `void` (see https://github.com/microsoft/TypeScript/pull/8767 and https://github.com/microsoft/TypeScript/issues/16608). I can't figure out how to get type checking to work without requiring users to either use arrow functions or explicitly define the return type.

Interested people can go to this [minimal TypeScript example](https://www.typescriptlang.org/play?#code/GYVwdgxgLglg9mABAQwBQEpEG8BQjFQAWATnAO6JgCmFAosacRgNw4C+OA9Jyg+YqEiwEAZ15VEEOAyrQANgE9EMMMCoyAJgBpEAIxBRExKgHMQc5MQHho8MGLkwA1hLSZLEsHCgA6HFPtDXUQAXkQMUIA+bDwCEn5qOj4mdFY2Vm5EKgAPAAdHCBhDYygQYiQoBVyJMmknMSg4OB19QyJkYqoARxAYYzEIQmQwEyoGuEQQEXVJOA0qHEFbBEkMAC5KEABbXRncfCJSCkTEekYWdkWbYSQNCP2jKlLyxABGNKuhOyz72ICRQwBDRFb5hKDEEBUVj4GDAcJAkEITCHBI0U7JC74EplJDvS5LG4CX5Yp44xAAImQ5I+BO+JmJj2eYA+n2WSEGsicAB4AII6ABCWWyUCoYA0Yh5kXuHBwlWqiB5cjk5CoGlC4UwIWiYG2uysAB9KFQAG7qVj+Qic3lKlXaAhVKhwOHIKWpRCZADKhDg5jVuWQIhELQMAmQMDkFqtiuVZFVOjljrhuldzHdPC9PrkfoDYlQCjG6EjEG50dt8YdTskKbTiAzvsQ-sD4XzIkLHOL1pjcft1UrGmrnu99cbuZbbctHdLsbtCcrVAH6aHWYbOebBaLJZt0-LvbhwAXtaXauAYbka9bG87ZZ7icQJgPdeXJ-D58LOGQiBEHRgImAMDGCpbqqqaDpm2aBsGhjPhGwRfrAv7-hKQEaCBi5gSuTZ5uuECft+CEAVOwE1o+4GjuuapwT+f4EchqGHuhI6vjgEiUfhSFdihxFHhhZEXnCrHUextp0SRoYvlhF4mLh8GCYBHEidx0FMUAA) and try to fix.