### PR TITLE
fix: removed unused intercepting route definition references

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2627,10 +2627,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         const result = await this.renderPageComponent(
           {
             ...ctx,
-            // Use the overridden pathname if available, otherwise use the
-            // original pathname.
-            pathname:
-              match.definition.pathnameOverride || match.definition.pathname,
+            pathname: match.definition.pathname,
             renderOpts: {
               ...ctx.renderOpts,
               params: match.params,

--- a/packages/next/src/server/future/route-definitions/app-page-route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/app-page-route-definition.ts
@@ -5,18 +5,3 @@ export interface AppPageRouteDefinition
   extends RouteDefinition<RouteKind.APP_PAGE> {
   readonly appPaths: ReadonlyArray<string>
 }
-
-export interface AppPageInterceptingRouteDefinition
-  extends AppPageRouteDefinition {
-  readonly interceptingRoute: string
-
-  /**
-   * The pathname (including dynamic placeholders) for a route to resolve that
-   * is used for the browser to display in the address bar. This is used in
-   * place of `pathname` when the route is rendering.
-   *
-   * For intercepting routes, this should be the original pathname including
-   * the interception route markers (`(..)(..)`, `(..)`, and `(...)`).
-   */
-  readonly pathnameOverride: string
-}

--- a/packages/next/src/server/future/route-definitions/route-definition.ts
+++ b/packages/next/src/server/future/route-definitions/route-definition.ts
@@ -15,11 +15,4 @@ export interface RouteDefinition<K extends RouteKind = RouteKind> {
    * The pathname (including dynamic placeholders) for a route to resolve.
    */
   readonly pathname: string
-
-  /**
-   * The pathname (including dynamic placeholders) for a route to resolve that
-   * is used for the browser to display in the address bar. This is used in
-   * place of `pathname` when the route is rendering.
-   */
-  readonly pathnameOverride?: string
 }

--- a/packages/next/src/server/future/route-matches/app-page-route-match.ts
+++ b/packages/next/src/server/future/route-matches/app-page-route-match.ts
@@ -1,8 +1,5 @@
 import type { RouteMatch } from './route-match'
-import type {
-  AppPageInterceptingRouteDefinition,
-  AppPageRouteDefinition,
-} from '../route-definitions/app-page-route-definition'
+import type { AppPageRouteDefinition } from '../route-definitions/app-page-route-definition'
 
 import { RouteKind } from '../route-kind'
 
@@ -18,6 +15,3 @@ export function isAppPageRouteMatch(
 ): match is AppPageRouteMatch {
   return match.definition.kind === RouteKind.APP_PAGE
 }
-
-export interface AppPageInterceptingRouteMatch
-  extends RouteMatch<AppPageInterceptingRouteDefinition> {}


### PR DESCRIPTION
This removes unused references to intercepting routes that was not fully implemented.
