### PR TITLE
fix `react-server-dom-webpack` cache invalidation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,10 +28,11 @@
 
 # Tooling & Telemetry
 
-/packages/next/src/build/                     @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling
-/packages/next/src/telemetry/                 @timneutkens @ijjk @shuding @padmaia
-/packages/next-swc/                           @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling
-Cargo.toml                                    @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling
-Cargo.lock                                    @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling
-/.cargo/config.toml                           @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling
-/.config/nextest.toml                         @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling
+/packages/next/src/build/                                @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling
+/packages/next/src/server/lib/router-utils/setup-dev.ts  @timneutkens @ijjk @shuding @huozhi @feedthejim @ztanner @wyattjoh @vercel/web-tooling
+/packages/next/src/telemetry/                            @timneutkens @ijjk @shuding @padmaia
+/packages/next-swc/                                      @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling
+Cargo.toml                                               @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling
+Cargo.lock                                               @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling
+/.cargo/config.toml                                      @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling
+/.config/nextest.toml                                    @timneutkens @ijjk @shuding @huozhi @vercel/web-tooling

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -21,9 +21,10 @@ export function useFlightResponse(
     return flightResponseRef.current
   }
   // react-server-dom-webpack/client.edge must not be hoisted for require cache clearing to work correctly
-  const {
-    createFromReadableStream,
-  } = require(`react-server-dom-webpack/client.edge`)
+  const { createFromReadableStream } = process.env.NEXT_MINIMAL
+    ? // @ts-ignore
+      __non_webpack_require__(`react-server-dom-webpack/client.edge`)
+    : require(`react-server-dom-webpack/client.edge`)
 
   const [renderStream, forwardStream] = req.tee()
   const res = createFromReadableStream(renderStream, {

--- a/packages/next/src/server/lib/router-utils/setup-dev.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev.ts
@@ -407,7 +407,6 @@ async function startWatcher(opts: SetupOpts) {
     }
 
     const buildManifests = new Map<string, BuildManifest>()
-    const fallbackBuildManifests = new Map<string, BuildManifest>()
     const appBuildManifests = new Map<string, AppBuildManifest>()
     const pagesManifests = new Map<string, PagesManifest>()
     const appPathsManifests = new Map<string, PagesManifest>()
@@ -433,16 +432,6 @@ async function startWatcher(opts: SetupOpts) {
       type: 'app' | 'pages' = 'pages'
     ): Promise<void> {
       buildManifests.set(
-        pageName,
-        await loadPartialManifest(BUILD_MANIFEST, pageName, type)
-      )
-    }
-
-    async function loadFallbackBuildManifest(
-      pageName: string,
-      type: 'app' | 'pages' = 'pages'
-    ): Promise<void> {
-      fallbackBuildManifests.set(
         pageName,
         await loadPartialManifest(BUILD_MANIFEST, pageName, type)
       )
@@ -711,7 +700,9 @@ async function startWatcher(opts: SetupOpts) {
 
     async function writeFallbackBuildManifest(): Promise<void> {
       const fallbackBuildManifest = mergeBuildManifests(
-        fallbackBuildManifests.values()
+        [buildManifests.get('_app'), buildManifests.get('_error')].filter(
+          Boolean
+        ) as BuildManifest[]
       )
       const fallbackBuildManifestPath = path.join(
         distDir,
@@ -1015,7 +1006,6 @@ async function startWatcher(opts: SetupOpts) {
             processIssues('_app', writtenEndpoint)
           }
           await loadBuildManifest('_app')
-          await loadFallbackBuildManifest('_app')
           await loadPagesManifest('_app')
 
           if (globalEntries.document) {
@@ -1036,7 +1026,6 @@ async function startWatcher(opts: SetupOpts) {
             processIssues(page, writtenEndpoint)
           }
           await loadBuildManifest('_error')
-          await loadFallbackBuildManifest('_error')
           await loadPagesManifest('_error')
 
           await writeBuildManifest()
@@ -1110,7 +1099,6 @@ async function startWatcher(opts: SetupOpts) {
               processIssues('_app', writtenEndpoint)
             }
             await loadBuildManifest('_app')
-            await loadFallbackBuildManifest('_app')
             await loadPagesManifest('_app')
 
             if (globalEntries.document) {

--- a/packages/next/src/server/lib/router-utils/setup-dev.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev.ts
@@ -314,8 +314,8 @@ async function startWatcher(opts: SetupOpts) {
     async function processResult(
       result: TurbopackResult<WrittenEndpoint>
     ): Promise<TurbopackResult<WrittenEndpoint>> {
-      const hasAppPaths = result.serverPaths.some((path) =>
-        path.startsWith('server/app')
+      const hasAppPaths = result.serverPaths.some((p) =>
+        p.startsWith('server/app')
       )
 
       if (hasAppPaths) {


### PR DESCRIPTION
### What?
Webpack wrapped the external import in a new module, making `require.cache` invalidation impossible.

This also adds a basic fallback manifest for turbopack.

Closes WEB-1522
