### PR TITLE
Remove unused option and unified ready message into start server

### DIFF
--- a/packages/next/src/build/output/store.ts
+++ b/packages/next/src/build/output/store.ts
@@ -138,7 +138,6 @@ store.subscribe((state) => {
   }
 
   if (trigger === 'initial') {
-    Log.event('ready')
     trigger = ''
   } else if (trigger) {
     if (loadingLogTimer) {

--- a/packages/next/src/server/lib/router-utils/setup-dev.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev.ts
@@ -953,8 +953,6 @@ async function startWatcher(opts: SetupOpts) {
         // Not implemented yet.
       },
       async start() {
-        // Align with nextjs logging for ready start event
-        Log.event('ready')
         // Not implemented yet.
       },
       async stop() {

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -132,6 +132,7 @@ function logStartInfo({
 
   // New line after the bootstrap info
   Log.info('')
+  Log.event('ready')
 }
 
 export async function startServer({

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -132,7 +132,6 @@ function logStartInfo({
 
   // New line after the bootstrap info
   Log.info('')
-  Log.event('ready')
 }
 
 export async function startServer({
@@ -278,6 +277,17 @@ export async function startServer({
         )
       }
 
+      if (logReady) {
+        logStartInfo({
+          port,
+          actualHostname,
+          appUrl,
+          hostname,
+          envInfo,
+          expFeatureInfo,
+        })
+      }
+
       // expose the main port to render workers
       process.env.PORT = port + ''
 
@@ -318,16 +328,7 @@ export async function startServer({
         process.exit(1)
       }
 
-      if (logReady) {
-        logStartInfo({
-          port,
-          actualHostname,
-          appUrl,
-          hostname,
-          envInfo,
-          expFeatureInfo,
-        })
-      }
+      Log.event('ready')
 
       resolve()
     })

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -86,6 +86,54 @@ export async function getRequestHandlers({
   })
 }
 
+function logStartInfo({
+  port,
+  actualHostname,
+  appUrl,
+  hostname,
+  envInfo,
+  expFeatureInfo,
+}: {
+  port: number
+  actualHostname: string
+  appUrl: string
+  hostname: string
+  envInfo: string[] | undefined
+  expFeatureInfo: string[] | undefined
+}) {
+  Log.bootstrap(
+    chalk.bold(
+      chalk.hex('#ad7fa8')(
+        ` ${`${Log.prefixes.ready} Next.js`} ${process.env.__NEXT_VERSION}`
+      )
+    )
+  )
+  Log.bootstrap(` - Local:        ${appUrl}`)
+  if (hostname) {
+    Log.bootstrap(
+      ` - Network:      ${actualHostname}${
+        (port + '').startsWith(':') ? '' : ':'
+      }${port}`
+    )
+  }
+  if (envInfo?.length) Log.bootstrap(` - Environments: ${envInfo.join(', ')}`)
+
+  if (expFeatureInfo?.length) {
+    Log.bootstrap(` - Experiments (use at your own risk):`)
+    // only show maximum 3 flags
+    for (const exp of expFeatureInfo.slice(0, 3)) {
+      Log.bootstrap(`    · ${exp}`)
+    }
+    /* ${expFeatureInfo.length - 3} more */
+    if (expFeatureInfo.length > 3) {
+      Log.bootstrap(`    · ...`)
+    }
+  }
+
+  // New line after the bootstrap info
+  Log.info('')
+}
+
 export async function startServer({
   dir,
   port,
@@ -229,44 +277,8 @@ export async function startServer({
         )
       }
 
-      if (logReady) {
-        Log.bootstrap(
-          chalk.bold(
-            chalk.hex('#ad7fa8')(
-              ` ${`${Log.prefixes.ready} Next.js`} ${
-                process.env.__NEXT_VERSION
-              }`
-            )
-          )
-        )
-        Log.bootstrap(` - Local:        ${appUrl}`)
-        if (hostname) {
-          Log.bootstrap(
-            ` - Network:      ${actualHostname}${
-              (port + '').startsWith(':') ? '' : ':'
-            }${port}`
-          )
-        }
-        if (envInfo?.length)
-          Log.bootstrap(` - Environments: ${envInfo.join(', ')}`)
-
-        if (expFeatureInfo?.length) {
-          Log.bootstrap(` - Experiments (use at your own risk):`)
-          // only show maximum 3 flags
-          for (const exp of expFeatureInfo.slice(0, 3)) {
-            Log.bootstrap(`    · ${exp}`)
-          }
-          /* ${expFeatureInfo.length - 3} more */
-          if (expFeatureInfo.length > 3) {
-            Log.bootstrap(`    · ...`)
-          }
-        }
-        // expose the main port to render workers
-        process.env.PORT = port + ''
-
-        // New line after the bootstrap info
-        Log.info('')
-      }
+      // expose the main port to render workers
+      process.env.PORT = port + ''
 
       try {
         const cleanup = (code: number | null) => {
@@ -303,6 +315,17 @@ export async function startServer({
         handlersError()
         console.error(err)
         process.exit(1)
+      }
+
+      if (logReady) {
+        logStartInfo({
+          port,
+          actualHostname,
+          appUrl,
+          hostname,
+          envInfo,
+          expFeatureInfo,
+        })
       }
 
       resolve()

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -33,7 +33,6 @@ if (process.env.NEXT_CPU_PROF) {
 export interface StartServerOptions {
   dir: string
   port: number
-  logReady?: boolean
   isDev: boolean
   hostname: string
   allowRetry?: boolean
@@ -143,7 +142,6 @@ export async function startServer({
   allowRetry,
   keepAliveTimeout,
   isExperimentalTestProxy,
-  logReady = true,
   selfSignedCertificate,
   envInfo,
   expFeatureInfo,
@@ -277,16 +275,14 @@ export async function startServer({
         )
       }
 
-      if (logReady) {
-        logStartInfo({
-          port,
-          actualHostname,
-          appUrl,
-          hostname,
-          envInfo,
-          expFeatureInfo,
-        })
-      }
+      logStartInfo({
+        port,
+        actualHostname,
+        appUrl,
+        hostname,
+        envInfo,
+        expFeatureInfo,
+      })
 
       // expose the main port to render workers
       process.env.PORT = port + ''

--- a/test/integration/nullish-config/test/index.test.js
+++ b/test/integration/nullish-config/test/index.test.js
@@ -28,7 +28,7 @@ const runTests = (type) => {
     const stdout = await getStdout()
 
     if (type === 'dev') {
-      expect(stdout).toMatch(/- Local:/i)
+      expect(stdout).toMatch(/ready/i)
     } else {
       expect(stdout).toMatch(/Compiled successfully/i)
     }
@@ -53,7 +53,7 @@ const runTests = (type) => {
     const stdout = await getStdout()
 
     if (type === 'dev') {
-      expect(stdout).toMatch(/- Local:/i)
+      expect(stdout).toMatch(/ready/i)
     } else {
       expect(stdout).toMatch(/Compiled successfully/i)
     }


### PR DESCRIPTION
Remove the `logReady` optional option introduced in #52492, never being passdown but alwasy `true` by default.
