### PR TITLE
Turbopack: Allow Pages entrypoint template to import user's `.ts` files

### DIFF
--- a/packages/next-swc/crates/next-core/src/middleware.rs
+++ b/packages/next-swc/crates/next-core/src/middleware.rs
@@ -29,7 +29,7 @@ pub async fn get_middleware_module(
     project_root: Vc<FileSystemPath>,
     userland_module: Vc<Box<dyn Module>>,
 ) -> Result<Vc<Box<dyn Module>>> {
-    let template_file = "build/templates/middleware.js";
+    let template_file = "middleware.js";
 
     // Load the file from the next.js codebase.
     let file = load_next_js_template(project_root, template_file.to_string()).await?;

--- a/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
@@ -70,7 +70,7 @@ pub async fn get_app_page_entry(
     let original_name = page.to_string();
     let pathname = AppPath::from(page.clone()).to_string();
 
-    let template_file = "build/templates/app-page.js";
+    let template_file = "app-page.js";
 
     // Load the file from the next.js codebase.
     let file = load_next_js_template(project_root, template_file.to_string()).await?;

--- a/packages/next-swc/crates/next-core/src/next_app/app_route_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_route_entry.rs
@@ -56,7 +56,7 @@ pub async fn get_app_route_entry(
 
     let path = source.ident().path();
 
-    let template_file = "build/templates/app-route.js";
+    let template_file = "app-route.js";
 
     // Load the file from the next.js codebase.
     let file = load_next_js_template(project_root, template_file.to_string()).await?;

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -159,7 +159,7 @@ pub async fn get_client_resolve_options_context(
         enable_typescript: true,
         enable_react: true,
         rules: vec![(
-            foreign_code_context_condition(next_config).await?,
+            foreign_code_context_condition(next_config, project_path).await?,
             module_options_context.clone().cell(),
         )],
         ..module_options_context
@@ -256,7 +256,7 @@ pub async fn get_client_module_options_context(
         decorators: Some(decorators_options),
         rules: vec![
             (
-                foreign_code_context_condition(next_config).await?,
+                foreign_code_context_condition(next_config, project_path).await?,
                 module_options_context.clone().cell(),
             ),
             // If the module is an internal asset (i.e overlay, fallback) coming from the embedded

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -125,7 +125,7 @@ pub async fn get_edge_resolve_options_context(
         enable_typescript: true,
         enable_react: true,
         rules: vec![(
-            foreign_code_context_condition(next_config).await?,
+            foreign_code_context_condition(next_config, project_path).await?,
             resolve_options_context.clone().cell(),
         )],
         ..resolve_options_context

--- a/packages/next-swc/crates/next-core/src/next_pages/page_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_pages/page_entry.rs
@@ -46,15 +46,15 @@ pub async fn create_page_ssr_entry_module(
     let template_file = match (&reference_type, runtime) {
         (ReferenceType::Entry(EntryReferenceSubType::Page), _) => {
             // Load the Page entry file.
-            "build/templates/pages.js"
+            "pages.js"
         }
         (ReferenceType::Entry(EntryReferenceSubType::PagesApi), NextRuntime::NodeJs) => {
             // Load the Pages API entry file.
-            "build/templates/pages-api.js"
+            "pages-api.js"
         }
         (ReferenceType::Entry(EntryReferenceSubType::PagesApi), NextRuntime::Edge) => {
             // Load the Pages API entry file.
-            "build/templates/pages-edge-api.js"
+            "pages-edge-api.js"
         }
         _ => bail!("Invalid path type"),
     };

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -98,7 +98,8 @@ pub async fn get_server_resolve_options_context(
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_server_import_map =
         get_next_server_import_map(project_path, ty, mode, next_config, execution_context);
-    let foreign_code_context_condition = foreign_code_context_condition(next_config).await?;
+    let foreign_code_context_condition =
+        foreign_code_context_condition(next_config, project_path).await?;
     let root_dir = project_path.root().resolve().await?;
     let module_feature_report_resolve_plugin = ModuleFeatureReportResolvePlugin::new(project_path);
     let unsupported_modules_resolve_plugin = UnsupportedModulesResolvePlugin::new(project_path);
@@ -215,7 +216,8 @@ pub async fn get_server_module_options_context(
     let custom_rules = get_next_server_transforms_rules(next_config, ty.into_value(), mode).await?;
     let internal_custom_rules = get_next_server_internal_transforms_rules(ty.into_value()).await?;
 
-    let foreign_code_context_condition = foreign_code_context_condition(next_config).await?;
+    let foreign_code_context_condition =
+        foreign_code_context_condition(next_config, project_path).await?;
     let enable_postcss_transform = Some(PostCssTransformOptions {
         postcss_package: Some(get_postcss_package_mapping(project_path)),
         ..Default::default()

--- a/packages/next-swc/crates/next-core/src/util.rs
+++ b/packages/next-swc/crates/next-core/src/util.rs
@@ -27,6 +27,8 @@ use crate::{
     next_import_map::get_next_package,
 };
 
+const NEXT_TEMPLATE_PATH: &str = "dist/esm/build/templates";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, TaskInput)]
 pub enum PathType {
     PagesPage,
@@ -87,7 +89,7 @@ pub async fn foreign_code_context_condition(
     let transpile_packages = next_config.transpile_packages().await?;
 
     let not_next_template_dir = ContextCondition::not(ContextCondition::InPath(
-        get_next_package(project_path).join(format!("dist/esm/build/templates")),
+        get_next_package(project_path).join(NEXT_TEMPLATE_PATH.to_string()),
     ));
 
     let result = if transpile_packages.is_empty() {
@@ -362,7 +364,8 @@ pub fn virtual_next_js_template_path(
     project_path: Vc<FileSystemPath>,
     file: String,
 ) -> Vc<FileSystemPath> {
-    get_next_package(project_path).join(format!("dist/esm/build/templates/{file}"))
+    debug_assert!(!file.contains('/'));
+    get_next_package(project_path).join(format!("{NEXT_TEMPLATE_PATH}/{file}"))
 }
 
 pub async fn load_next_js_templateon<T: DeserializeOwned>(

--- a/packages/next-swc/crates/next-core/src/util.rs
+++ b/packages/next-swc/crates/next-core/src/util.rs
@@ -82,10 +82,19 @@ pub fn get_asset_path_from_pathname(pathname: &str, ext: &str) -> String {
 
 pub async fn foreign_code_context_condition(
     next_config: Vc<NextConfig>,
+    project_path: Vc<FileSystemPath>,
 ) -> Result<ContextCondition> {
     let transpile_packages = next_config.transpile_packages().await?;
+
+    let not_next_template_dir = ContextCondition::not(ContextCondition::InPath(
+        get_next_package(project_path).join(format!("dist/esm/build/templates")),
+    ));
+
     let result = if transpile_packages.is_empty() {
-        ContextCondition::InDirectory("node_modules".to_string())
+        ContextCondition::all(vec![
+            ContextCondition::InDirectory("node_modules".to_string()),
+            not_next_template_dir,
+        ])
     } else {
         ContextCondition::all(vec![
             ContextCondition::InDirectory("node_modules".to_string()),
@@ -95,6 +104,7 @@ pub async fn foreign_code_context_condition(
                     .map(|package| ContextCondition::InDirectory(format!("node_modules/{package}")))
                     .collect(),
             )),
+            not_next_template_dir,
         ])
     };
     Ok(result)
@@ -334,11 +344,9 @@ fn parse_config_from_js_value(module: Vc<Box<dyn Module>>, value: &JsValue) -> N
 #[turbo_tasks::function]
 pub async fn load_next_js_template(
     project_path: Vc<FileSystemPath>,
-    path: String,
+    file: String,
 ) -> Result<Vc<Rope>> {
-    let file_path = get_next_package(project_path)
-        .join("dist/esm".to_string())
-        .join(path);
+    let file_path = virtual_next_js_template_path(project_path, file);
 
     let content = &*file_path.read().await?;
 
@@ -352,11 +360,9 @@ pub async fn load_next_js_template(
 #[turbo_tasks::function]
 pub fn virtual_next_js_template_path(
     project_path: Vc<FileSystemPath>,
-    path: String,
+    file: String,
 ) -> Vc<FileSystemPath> {
-    get_next_package(project_path)
-        .join("dist/esm".to_string())
-        .join(path)
+    get_next_package(project_path).join(format!("dist/esm/build/templates/{file}"))
 }
 
 pub async fn load_next_js_templateon<T: DeserializeOwned>(


### PR DESCRIPTION
### What?

This adds an exception for the entrypoint templates directory which will prevent the restricted resolve options from taking over. So, the templates entrypoint will be able to import with the user's default resolve options, which enables a `_app.ts` import.

### Why?

The entrypoint templates need to be able to import the user's code as if the template were use code itself.

### How?

The [Pages entrypoint](https://github.com/vercel/next.js/blob/85d30b62db4606bf56a6a9533494c9e14d55e1cc/packages/next/src/build/templates/pages.ts#L9-L10) template [imports the user's `_app` file](https://github.com/vercel/next.js/blob/85d30b62db4606bf56a6a9533494c9e14d55e1cc/packages/next-swc/crates/next-core/src/next_pages/page_entry.rs#L83-L84) via a special `@vercel/turbopack-next/pages/_app` which is [import mapped](https://github.com/vercel/next.js/blob/85d30b62db4606bf56a6a9533494c9e14d55e1cc/packages/next-swc/crates/next-core/src/next_import_map.rs#L404-L411) to the user's `/pages/_app` file. If the user is using `/pages/_app.js` file, everything is OK. But a problem pops up if the user is using a `.ts` (or similar non-standard extension).

Why? In order to prevent a foobar node modules from importing TS/CSS/etc files, we apply a restricted set of `ResolveOptions` when the base file (the file that is doing the import) is inside a `node_modules` directory. In this case, we stop allowing `.ts`/`.tsx`/`.css` file extension imports and only allow `.js`/`.json`/`.node` (the standard node extensions).

Well, the shared entrypoint templates are _technically_ inside the `node_modules/next/dist/esm/build/templates/` directory, ie they are node modules. So we applied the restricted resolve options when it was importing `@vercel/turbopack-next/pages/_app`. Even though we're able to correctly read the user's `/pages` directory, we ignore a `/pages/_app.ts` file that would otherwise be found if the user code did the import.

Depends on https://github.com/vercel/turbo/pull/5938.

Closes WEB-1545