### PR TITLE
server: switch pages to react dom edge renderer

### DIFF
--- a/packages/next/src/server/import-overrides.ts
+++ b/packages/next/src/server/import-overrides.ts
@@ -32,7 +32,8 @@ export const baseOverrides = {
   'react-dom/package.json': 'next/dist/compiled/react-dom/package.json',
   'react-dom/client': 'next/dist/compiled/react-dom/client',
   'react-dom/server': 'next/dist/compiled/react-dom/server',
-  'react-dom/server.browser': 'next/dist/compiled/react-dom/server.browser',
+  // when the require hook applies, we want to use the edge version, for both app and pages
+  'react-dom/server.browser': 'next/dist/compiled/react-dom/server.edge',
   'react-dom/server.edge': 'next/dist/compiled/react-dom/server.edge',
   'react-server-dom-webpack/client':
     'next/dist/compiled/react-server-dom-webpack/client',
@@ -56,8 +57,9 @@ export const experimentalOverrides = {
     'next/dist/compiled/react-dom-experimental/package.json',
   'react-dom/client': 'next/dist/compiled/react-dom-experimental/client',
   'react-dom/server': 'next/dist/compiled/react-dom-experimental/server',
+  // when the require hook applies, we want to use the edge version, for both app and pages
   'react-dom/server.browser':
-    'next/dist/compiled/react-dom-experimental/server.browser',
+    'next/dist/compiled/react-dom-experimental/server.edge',
   'react-dom/server.edge':
     'next/dist/compiled/react-dom-experimental/server.edge',
   'react-server-dom-webpack/client':

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -31,7 +31,7 @@ import type { ClientReferenceManifest } from '../build/webpack/plugins/flight-ma
 import type { NextFontManifest } from '../build/webpack/plugins/next-font-manifest-plugin'
 
 import React from 'react'
-import ReactDOMServer from 'react-dom/server.edge'
+import ReactDOMServer from 'react-dom/server.browser'
 import { StyleRegistry, createStyleRegistry } from 'styled-jsx'
 import {
   GSP_NO_RETURNED_VALUE,

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -31,7 +31,7 @@ import type { ClientReferenceManifest } from '../build/webpack/plugins/flight-ma
 import type { NextFontManifest } from '../build/webpack/plugins/next-font-manifest-plugin'
 
 import React from 'react'
-import ReactDOMServer from 'react-dom/server.browser'
+import ReactDOMServer from 'react-dom/server.edge'
 import { StyleRegistry, createStyleRegistry } from 'styled-jsx'
 import {
   GSP_NO_RETURNED_VALUE,


### PR DESCRIPTION
This PR fixes the warnings that have started to appear because of #54813

```
Warning: Detected multiple renderers concurrently rendering the same context provider. This is currently unsupported.
    at PathnameContextProviderAdapter (/Users/feedthejim/Projects/vercel/next.js/packages/next/dist/shared/lib/router/adapters.shared-runtime.js:84:11)
    at Be (/Users/feedthejim/Projects/vercel/next.js/packages/next/dist/compiled/next-server/pages.runtime.dev.js:1:47625)
    at Ze (/Users/feedthejim/Projects/vercel/next.js/packages/next/dist/compiled/next-server/pages.runtime.dev.js:1:48314)
    at div
    at Ye (/Users/feedthejim/Projects/vercel/next.js/packages/next/dist/compiled/next-server/pages.runtime.dev.js:1:55388)
Warning: Detected multiple renderers concurrently rendering the same context provider. This is currently unsupported.
    at PathnameContextProviderAdapter (/Users/feedthejim/Projects/vercel/next.js/packages/next/dist/shared/lib/router/adapters.shared-runtime.js:84:11)
    at Be (/Users/feedthejim/Projects/vercel/next.js/packages/next/dist/compiled/next-server/pages.runtime.dev.js:1:47625)
    at Ze (/Users/feedthejim/Projects/vercel/next.js/packages/next/dist/compiled/next-server/pages.runtime.dev.js:1:48314)
    at div
    at Ye (/Users/feedthejim/Projects/vercel/next.js/packages/next/dist/compiled/next-server/pages.runtime.dev.js:1:55388)
```

they appear because we are using two variants versions of `react-dom` on the server between pages and app router. This changes so that we only use one when you use app and as such, makes the warning disappear.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
