### PR TITLE
feat(turbopack): attach type metadata for static metadata item

### DIFF
--- a/packages/next-swc/crates/next-core/src/loader_tree.rs
+++ b/packages/next-swc/crates/next-core/src/loader_tree.rs
@@ -23,7 +23,10 @@ use crate::{
         MetadataWithAltItem,
     },
     mode::NextMode,
-    next_app::{metadata::image::dynamic_image_metadata_source, AppPage},
+    next_app::{
+        metadata::{get_content_type, image::dynamic_image_metadata_source},
+        AppPage,
+    },
     next_image::module::{BlurPlaceholderMode, StructuredImageModuleType},
 };
 
@@ -291,6 +294,7 @@ impl LoaderTreeBuilder {
         let helper_import = "import { fillMetadataSegment } from \
                              \"next/dist/lib/metadata/get-metadata-route\""
             .to_string();
+
         if !self.imports.contains(&helper_import) {
             self.imports.push(helper_import);
         }
@@ -328,6 +332,9 @@ impl LoaderTreeBuilder {
                 "{s}  sizes: `${{{identifier}.width}}x${{{identifier}.height}}`,"
             )?;
         }
+
+        let content_type = get_content_type(path).await?;
+        writeln!(self.loader_tree_code, "{s}  type: `{content_type}`,")?;
 
         if let Some(alt_path) = alt_path {
             let identifier = magic_identifier::mangle(&format!("{name} alt text #{i}"));

--- a/packages/next-swc/crates/next-core/src/next_app/metadata/route.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/metadata/route.rs
@@ -15,6 +15,7 @@ use turbopack_binding::{
     },
 };
 
+use super::get_content_type;
 use crate::{
     app_structure::MetadataItem,
     mode::NextMode,
@@ -61,38 +62,6 @@ pub fn get_app_metadata_route_entry(
         page,
         project_root,
     )
-}
-
-async fn get_content_type(path: Vc<FileSystemPath>) -> Result<String> {
-    let stem = &*path.file_stem().await?;
-    let ext = &*path.extension().await?;
-
-    let name = stem.as_deref().unwrap_or_default();
-    let mut ext = ext.as_str();
-    if ext == "jpg" {
-        ext = "jpeg"
-    }
-
-    if name == "favicon" && ext == "ico" {
-        return Ok("image/x-icon".to_string());
-    }
-    if name == "sitemap" {
-        return Ok("application/xml".to_string());
-    }
-    if name == "robots" {
-        return Ok("text/plain".to_string());
-    }
-    if name == "manifest" {
-        return Ok("application/manifest+json".to_string());
-    }
-
-    if ext == "png" || ext == "jpeg" || ext == "ico" || ext == "svg" {
-        return Ok(mime_guess::from_ext(ext)
-            .first_or_octet_stream()
-            .to_string());
-    }
-
-    Ok("text/plain".to_string())
 }
 
 const CACHE_HEADER_NONE: &str = "no-cache, no-store";

--- a/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/implicit-metadata/input/app/test.tsx
+++ b/packages/next-swc/crates/next-dev-tests/tests/integration/next/app/implicit-metadata/input/app/test.tsx
@@ -49,6 +49,7 @@ export default function Test() {
         'og:image': expect.stringMatching(/^.+\/opengraph-image\.png\?.+$/),
         'og:image:width': '114',
         'og:image:height': '114',
+        'og:image:type': 'image/png',
         'og:image:alt': 'This is an alt text.',
       })
     })

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -23,6 +23,8 @@ interface Options {
   basePath: string
 }
 
+// [NOTE] For turbopack
+// refer loader_tree's write_static|dynamic_metadata for corresponding features
 async function nextMetadataImageLoader(this: any, content: Buffer) {
   const options: Options = this.getOptions()
   const { type, segment, pageExtensions, basePath } = options


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Trying to mimic https://github.com/vercel/next.js/blob/32e066ff6cf593244daf5a9f7c55009c94a4e29e/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts#L160C7-L160C12, when there's a static metadata turbopack does not includes `type` properties. This partially fulfills existing metadata test cases for checking those values.

Closes WEB-1551