### PR TITLE
Warn experimental.appDir option can be removed

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -324,6 +324,7 @@ function assignDefaults(
     }
   }
 
+  // TODO: remove this in next major or minor version after 13.5
   warnOptionHasBeenDeprecated(
     result,
     'experimental.appDir',

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -22,6 +22,30 @@ import { pathHasPrefix } from '../shared/lib/router/utils/path-has-prefix'
 
 export { DomainLocale, NextConfig, normalizeConfig } from './config-shared'
 
+export function warnOptionHasBeenDeprecated(
+  config: NextConfig,
+  nestedPropertyKey: string,
+  reason: string,
+  silent: boolean
+) {
+  if (!silent) {
+    let current = config
+    let found = true
+    const nestedPropertyKeys = nestedPropertyKey.split('.')
+    for (const key of nestedPropertyKeys) {
+      if (current[key] !== undefined) {
+        current = current[key]
+      } else {
+        found = false
+        break
+      }
+    }
+    if (found) {
+      Log.warn(reason)
+    }
+  }
+}
+
 export function warnOptionHasBeenMovedOutOfExperimental(
   config: NextConfig,
   oldKey: string,
@@ -300,6 +324,12 @@ function assignDefaults(
     }
   }
 
+  warnOptionHasBeenDeprecated(
+    result,
+    'experimental.appDir',
+    'App router is enabled by default now, `experimental.appDir` option can be safely removed.',
+    silent
+  )
   warnOptionHasBeenMovedOutOfExperimental(
     result,
     'relay',

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -328,7 +328,7 @@ function assignDefaults(
   warnOptionHasBeenDeprecated(
     result,
     'experimental.appDir',
-    'App router is enabled by default now, `experimental.appDir` option can be safely removed.',
+    'App router is available by default now, `experimental.appDir` option can be safely removed.',
     silent
   )
   warnOptionHasBeenMovedOutOfExperimental(

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -135,7 +135,7 @@ describe('Config Experimental Warning', () => {
 
     const stderr = await collectStderr(appDir)
     expect(stderr).toMatch(
-      'App router is enabled by default now, `experimental.appDir` option can be safely removed.'
+      'App router is available by default now, `experimental.appDir` option can be safely removed.'
     )
   })
 })

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -22,8 +22,18 @@ async function collectStdout(appDir) {
       stdout += msg
     },
   })
-  await fetchViaHTTP(port, '/')
   return stdout
+}
+
+async function collectStderr(appDir) {
+  let stderr = ''
+  const port = await findPort()
+  app = await launchApp(appDir, port, {
+    onStderr(msg) {
+      stderr += msg
+    },
+  })
+  return stderr
 }
 
 describe('Config Experimental Warning', () => {
@@ -47,10 +57,6 @@ describe('Config Experimental Warning', () => {
       }
     `)
 
-    // await nextBuild(appDir, [])
-    // const { stdout } = await nextStart(appDir, await findPort(), {
-    //   stdout: true,
-    // })
     const stdout = await collectStdout(appDir)
     expect(stdout).not.toMatch(' - Experiments (use at your own risk):')
   })
@@ -61,10 +67,7 @@ describe('Config Experimental Warning', () => {
         images: {},
       }
     `)
-    // await nextBuild(appDir, [])
-    // const { stdout } = await nextStart(appDir, await findPort(), {
-    //   stdout: true,
-    // })
+
     const stdout = await collectStdout(appDir)
     expect(stdout).not.toMatch(' - Experiments (use at your own risk):')
   })
@@ -77,10 +80,7 @@ describe('Config Experimental Warning', () => {
         }
       }
     `)
-    // await nextBuild(appDir, [])
-    // const { stdout } = await nextStart(appDir, await findPort(), {
-    //   stdout: true,
-    // })
+
     const stdout = await collectStdout(appDir)
     expect(stdout).toMatch(' - Experiments (use at your own risk):')
     expect(stdout).toMatch(' · workerThreads')
@@ -94,10 +94,7 @@ describe('Config Experimental Warning', () => {
         }
       })
     `)
-    // await nextBuild(appDir, [])
-    // const { stdout } = await nextStart(appDir, await findPort(), {
-    //   stdout: true,
-    // })
+
     const stdout = await collectStdout(appDir)
     expect(stdout).toMatch(' - Experiments (use at your own risk):')
     expect(stdout).toMatch(' · workerThreads')
@@ -111,10 +108,7 @@ describe('Config Experimental Warning', () => {
         }
       })
     `)
-    // await nextBuild(appDir, [])
-    // const { stdout } = await nextStart(appDir, await findPort(), {
-    //   stdout: true,
-    // })
+
     const stdout = await collectStdout(appDir)
     expect(stdout).not.toMatch(' - Experiments (use at your own risk):')
     expect(stdout).not.toMatch(' · workerThreads')
@@ -129,10 +123,25 @@ describe('Config Experimental Warning', () => {
         }
       }
     `)
-    // const { stdout } = await nextBuild(appDir, [], { stdout: true })
+
     const stdout = await collectStdout(appDir)
     expect(stdout).toMatch(' - Experiments (use at your own risk):')
     expect(stdout).toMatch(' · workerThreads')
     expect(stdout).toMatch(' · scrollRestoration')
+  })
+
+  it('should show warning for dropped experimental.appDir option', async () => {
+    configFile.write(`
+      module.exports = {
+        experimental: {
+          appDir: true,
+        }
+      }
+    `)
+
+    const stderr = await collectStderr(appDir)
+    expect(stderr).toMatch(
+      'App router is enabled by default now, `experimental.appDir` option can be safely removed.'
+    )
   })
 })

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -1,13 +1,7 @@
 /* eslint-env jest */
 
 import { join } from 'path'
-import {
-  killApp,
-  launchApp,
-  findPort,
-  File,
-  fetchViaHTTP,
-} from 'next-test-utils'
+import { killApp, launchApp, findPort, File } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
 const configFile = new File(join(appDir, '/next.config.js'))

--- a/test/unit/warn-removed-experimental-config.test.ts
+++ b/test/unit/warn-removed-experimental-config.test.ts
@@ -1,4 +1,7 @@
-import { warnOptionHasBeenMovedOutOfExperimental } from 'next/dist/server/config'
+import {
+  warnOptionHasBeenMovedOutOfExperimental,
+  warnOptionHasBeenDeprecated,
+} from 'next/dist/server/config'
 
 describe('warnOptionHasBeenMovedOutOfExperimental', () => {
   let spy: jest.SpyInstance
@@ -100,5 +103,27 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
 
     expect(config.experimental.foo).toBe('bar')
     expect(config.deep.prop.baz).toBe('bar')
+  })
+})
+
+describe('warnOptionHasBeenDeprecated', () => {
+  let spy: jest.SpyInstance
+  beforeAll(() => {
+    spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  it('should warn experimental.appDir has been deprecated', () => {
+    const config = {
+      experimental: {
+        appDir: true,
+      },
+    } as any
+    warnOptionHasBeenDeprecated(
+      config,
+      'experimental.appDir',
+      'experimental.appDir has been removed',
+      false
+    )
+    expect(spy).toBeCalled()
   })
 })


### PR DESCRIPTION
We have dropped `experimental.appDir` option, to share the insights that can be removed, add a warning `"App router is enabled by default now, <experimental.appDir> option can be safely removed.'" `