### PR TITLE
fix memory leak in require.cache cleanup

### DIFF
--- a/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
+++ b/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
@@ -12,7 +12,7 @@ const originModules = [
   require.resolve('../../../server/require'),
   require.resolve('../../../server/load-components'),
   require.resolve('../../../server/next-server'),
-  require.resolve('../../../server/app-renderer/use-flight-response'),
+  require.resolve('../../../server/app-render/use-flight-response'),
   require.resolve('../../../compiled/react-server-dom-webpack/client.edge'),
   require.resolve(
     '../../../compiled/react-server-dom-webpack-experimental/client.edge'

--- a/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
+++ b/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
@@ -12,6 +12,7 @@ const originModules = [
   require.resolve('../../../server/require'),
   require.resolve('../../../server/load-components'),
   require.resolve('../../../server/next-server'),
+  require.resolve('../../../server/app-renderer/use-flight-response'),
   require.resolve('../../../compiled/react-server-dom-webpack/client.edge'),
   require.resolve(
     '../../../compiled/react-server-dom-webpack-experimental/client.edge'
@@ -20,27 +21,7 @@ const originModules = [
 
 const RUNTIME_NAMES = ['webpack-runtime', 'webpack-api-runtime']
 
-export function deleteAppClientCache() {
-  // ensure we reset the cache for rsc components
-  // loaded via react-server-dom-webpack
-  const reactServerDomModId = require.resolve(
-    'react-server-dom-webpack/client.edge'
-  )
-  const reactServerDomMod = require.cache[reactServerDomModId]
-
-  if (reactServerDomMod) {
-    for (const child of reactServerDomMod.children) {
-      child.parent = null
-      delete require.cache[child.id]
-    }
-  }
-  delete require.cache[reactServerDomModId]
-}
-
-export function deleteCache(filePath: string) {
-  // try to clear it from the fs cache
-  clearManifestCache(filePath)
-
+function deleteFromRequireCache(filePath: string) {
   try {
     filePath = realpathSync(filePath)
   } catch (e) {
@@ -64,6 +45,29 @@ export function deleteCache(filePath: string) {
     return true
   }
   return false
+}
+
+export function deleteAppClientCache() {
+  // ensure we reset the cache for rsc components
+  // loaded via react-server-dom-webpack
+  const reactServerDomModId = require.resolve(
+    'react-server-dom-webpack/client.edge'
+  )
+  const reactServerDomMod = require.cache[reactServerDomModId]
+
+  if (reactServerDomMod) {
+    for (const child of [...reactServerDomMod.children]) {
+      deleteFromRequireCache(child.id)
+    }
+    deleteFromRequireCache(reactServerDomModId)
+  }
+}
+
+export function deleteCache(filePath: string) {
+  // try to clear it from the fs cache
+  clearManifestCache(filePath)
+
+  deleteFromRequireCache(filePath)
 }
 
 const PLUGIN_NAME = 'NextJsRequireCacheHotReloader'


### PR DESCRIPTION
### What?

We need to clear `.parent` and `.children` when deleting from require.cache

### Why?

otherwise we leak memory


Closes WEB-1558