### PR TITLE
fix: added support for tests to add resolutions for deps

### DIFF
--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -22,6 +22,12 @@ createNextDescribe(
       'styled-components': 'latest',
       'server-only': 'latest',
     },
+    resolutions: {
+      '@babel/core': '7.22.18',
+      '@babel/parser': '7.22.16',
+      '@babel/types': '7.22.17',
+      '@babel/traverse': '7.22.18',
+    },
   },
   ({ next, isNextDev, isNextStart, isTurbopack }) => {
     if (isNextDev && !isTurbopack) {

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -31,6 +31,7 @@ async function setPnpmResolutionMode(cwd) {
 async function createNextInstall({
   parentSpan = null,
   dependencies = null,
+  resolutions = null,
   installCommand = null,
   packageJson = {},
   dirSuffix = '',
@@ -148,6 +149,8 @@ async function createNextInstall({
             ...packageJson,
             dependencies: combinedDependencies,
             private: true,
+            // Add resolutions if provided.
+            ...(resolutions ? { resolutions } : {}),
           },
           null,
           2
@@ -158,7 +161,10 @@ async function createNextInstall({
       if (installCommand) {
         const installString =
           typeof installCommand === 'function'
-            ? installCommand({ dependencies: combinedDependencies })
+            ? installCommand({
+                dependencies: combinedDependencies,
+                resolutions,
+              })
             : installCommand
 
         console.log('running install command', installString)

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -28,6 +28,7 @@ export type PackageJson = {
 export interface NextInstanceOpts {
   files: FileRef | string | { [filename: string]: string | FileRef }
   dependencies?: { [name: string]: string }
+  resolutions?: { [name: string]: string }
   packageJson?: PackageJson
   nextConfig?: NextConfig
   installCommand?: InstallCommand
@@ -56,6 +57,7 @@ export class NextInstance {
   protected buildCommand?: string
   protected startCommand?: string
   protected dependencies?: PackageJson['dependencies'] = {}
+  protected resolutions?: PackageJson['resolutions']
   protected events: { [eventName: string]: Set<any> } = {}
   public testDir: string
   protected isStopping: boolean = false
@@ -168,6 +170,7 @@ export class NextInstance {
                     process.env.NEXT_TEST_VERSION ||
                     require('next/package.json').version,
                 },
+                ...(this.resolutions ? { resolutions: this.resolutions } : {}),
                 scripts: {
                   // since we can't get the build id as a build artifact, make it
                   // available under the static files
@@ -196,6 +199,7 @@ export class NextInstance {
             this.testDir = await createNextInstall({
               parentSpan: rootSpan,
               dependencies: finalDependencies,
+              resolutions: this.resolutions ?? null,
               installCommand: this.installCommand,
               packageJson: this.packageJson,
               dirSuffix: this.dirSuffix,


### PR DESCRIPTION
Some tests may depend on `latest` to help us catch problems earlier. This adds support for the `resolutions` field for tests to allow pinning of deps that may be problematic upstream.
