### PR TITLE
feat(instrumentationHook): Pass in the instance of next-server to allow for instrumentation

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -251,7 +251,7 @@ export default class NextNodeServer extends BaseServer {
           'server',
           INSTRUMENTATION_HOOK_FILENAME
         ))
-        await instrumentationHook.register?.()
+        await instrumentationHook.register?.(this)
       } catch (err: any) {
         if (err.code !== 'MODULE_NOT_FOUND') {
           err.message = `An error occurred while loading instrumentation hook: ${err.message}`

--- a/test/e2e/instrumentation-hook-src/instrumentation-hook-src.test.ts
+++ b/test/e2e/instrumentation-hook-src/instrumentation-hook-src.test.ts
@@ -15,7 +15,7 @@ createNextDescribe(
   ({ next, isNextDev }) => {
     it('should run the instrumentation hook', async () => {
       await next.render('/')
-      await check(() => next.cliOutput, /instrumentation hook/)
+      await check(() => next.cliOutput, /instrumentation hook NextNodeServer/)
     })
     it('should not overlap with a instrumentation page', async () => {
       const page = await next.render('/instrumentation')

--- a/test/e2e/instrumentation-hook-src/src/instrumentation.js
+++ b/test/e2e/instrumentation-hook-src/src/instrumentation.js
@@ -1,8 +1,8 @@
-export function register() {
+export function register(nextServer) {
   if (process.env.NEXT_RUNTIME === 'edge') {
     console.log('instrumentation hook on the edge')
   } else if (process.env.NEXT_RUNTIME === 'nodejs') {
-    console.log('instrumentation hook')
+    console.log(`instrumentation hook ${nextServer.constructor.name}`)
   } else {
     require('this should fail')
   }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

👋🏻 I'm lead engineer on the New Relic Node.js agent team.  I'm testing out ways to avoid friction with our [instrumentation](https://github.com/newrelic/newrelic-node-nextjs).  We have found our route of doing `NODE_OPTIONS='-r @newrelic/next'` is not ideal.  I found this lovely [instrumentationHook](https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation) feature and gave it a shot.  This big issue with it was it's getting called from next-server and that's what our instrumentation actually wraps.  For us to reliably instrument without the need for `NODE_OPTIONS` we need the next-server instance.  I tried to augment an existing test but totally willing to work with you all to land this.  
