### PR TITLE
Turbopack: remap `next/head` on client in App Pages

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -110,6 +110,10 @@ pub async fn get_next_client_import_map(
                 request_to_import_mapping(app_dir, "next/dist/compiled/react-server-dom-webpack/*"),
             );
             import_map.insert_exact_alias(
+                "next/head",
+                request_to_import_mapping(project_path, "next/dist/client/components/noop-head"),
+            );
+            import_map.insert_exact_alias(
                 "next/dynamic",
                 request_to_import_mapping(project_path, "next/dist/shared/lib/app-dynamic"),
             );


### PR DESCRIPTION
### What?

Remaps `next/head` to `next/dist/client/components/noop-head` on the client inside an App Page.

### Why?

Because webpack bundles do it.

### How?

We were just missing an import remap. 🤦 

Closes WEB-1573