### PR TITLE
Fixed fallback value to supported in getStaticPaths docs

### DIFF
--- a/docs/03-pages/01-building-your-application/03-data-fetching/02-get-static-paths.mdx
+++ b/docs/03-pages/01-building-your-application/03-data-fetching/02-get-static-paths.mdx
@@ -28,7 +28,7 @@ export const getStaticPaths = (async () => {
         },
       }, // See the "paths" section below
     ],
-    fallback: true, // false or "blocking"
+    fallback: "blocking", // false or "blocking"
   }
 }) satisfies GetStaticPaths
 


### PR DESCRIPTION
### What?
Changed getStaticPaths `fallback` prop value as `true` is not supported.

### Why?
Value `true` is giving build errors (Reproduce guide available in issue).

### How?
According to docs `true` should be working same as `"blocking"`, so changed default example value to `"blocking"`.

Fixes #55432
