### PR TITLE
Turbopack: Setup HMR for client-only changes in App dir

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -477,6 +477,10 @@ function createRSCAliases(
     ] = `next/dist/compiled/scheduler${bundledReactChannel}/tracing-profiling`
   }
 
+  alias[
+    '@vercel/turbopack-ecmascript-runtime/dev/client/hmr-client.ts'
+  ] = `next/dist/client/dev/noop-turbopack-hmr`
+
   return alias
 }
 

--- a/packages/next/src/client/app-next-dev-turbopack.ts
+++ b/packages/next/src/client/app-next-dev-turbopack.ts
@@ -3,6 +3,7 @@
 import { appBootstrap } from './app-bootstrap'
 
 window.next.version += '-turbo'
+;(self as any).__webpack_hash__ = ''
 
 appBootstrap(() => {
   require('./app-turbopack')

--- a/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
@@ -501,7 +501,7 @@ export default function HotReload({
     }
 
     return () => websocket && websocket.removeEventListener('message', handler)
-  }, [sendMessage, router, webSocketRef, dispatcher])
+  }, [sendMessage, router, webSocketRef, dispatcher, processTurbopackMessage])
 
   return (
     <ReactDevOverlay onReactError={handleOnReactError} state={state}>

--- a/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useRef } from 'react'
+import { ReactNode } from 'react'
 import React, {
   useCallback,
   useEffect,
@@ -39,8 +39,6 @@ import type { VersionInfo } from '../../../server/dev/parse-version-info'
 import {
   HMR_ACTIONS_SENT_TO_BROWSER,
   HMR_ACTION_TYPES,
-  TurbopackConnectedAction,
-  TurbopackMessageAction,
 } from '../../../server/dev/hot-reloader-types'
 
 interface Dispatcher {

--- a/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
@@ -477,11 +477,6 @@ export default function HotReload({
 
   useEffect(() => {
     const handler = (event: MessageEvent<any>) => {
-      // webpack's heartbeat event.
-      if (event.data === '\uD83D\uDC93') {
-        return
-      }
-
       try {
         const obj = JSON.parse(event.data)
         const handledByTurbopack = processTurbopackMessage?.(obj)

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/use-websocket.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/use-websocket.ts
@@ -63,12 +63,12 @@ export function useTurbopack(sendMessage: ReturnType<typeof useSendMessage>) {
   }, [])
 
   useEffect(() => {
-    const { current } = turbopackState
+    const { current: initCurrent } = turbopackState
     // TODO(WEB-1589): only install if `process.turbopack` set.
-    if (current.init) {
+    if (initCurrent.init) {
       return
     }
-    current.init = true
+    initCurrent.init = true
 
     import(
       // @ts-expect-error requires "moduleResolution": "node16" in tsconfig.json and not .ts extension
@@ -88,7 +88,7 @@ export function useTurbopack(sendMessage: ReturnType<typeof useSendMessage>) {
         sendMessage,
       })
     })
-  }, [])
+  }, [sendMessage])
 
   return processTurbopackMessage
 }

--- a/packages/next/src/client/dev/noop-turbopack-hmr.ts
+++ b/packages/next/src/client/dev/noop-turbopack-hmr.ts
@@ -1,0 +1,3 @@
+// The Turbopack HMR client can't be properly omitted at the moment (WEB-1589),
+// so instead we remap its import to this file in webpack builds.
+export function connect() {}

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -28,7 +28,7 @@ interface ServerErrorAction {
   errorJSON: string
 }
 
-interface TurboPackMessageAction {
+export interface TurbopackMessageAction {
   type: HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_MESSAGE
   data: TurbopackUpdate | TurbopackUpdate[]
 }
@@ -87,12 +87,13 @@ interface DevPagesManifestUpdateAction {
   ]
 }
 
-export interface TurboPackConnectedAction {
+export interface TurbopackConnectedAction {
   type: HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_CONNECTED
 }
 
 export type HMR_ACTION_TYPES =
-  | TurboPackMessageAction
+  | TurbopackMessageAction
+  | TurbopackConnectedAction
   | BuildingAction
   | SyncAction
   | BuiltAction

--- a/packages/next/src/server/lib/router-utils/setup-dev.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev.ts
@@ -100,7 +100,7 @@ import {
   HMR_ACTION_TYPES,
   NextJsHotReloaderInterface,
   ReloadPageAction,
-  TurboPackConnectedAction,
+  TurbopackConnectedAction,
 } from '../../dev/hot-reloader-types'
 import type { Update as TurbopackUpdate } from '../../../build/swc'
 import { debounce } from '../../utils'
@@ -356,10 +356,14 @@ async function startWatcher(opts: SetupOpts) {
       }
 
       hotReloader.send({
-        action: HMR_ACTIONS_SENT_TO_BROWSER.BUILT,
+        action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC,
         hash: String(++hmrHash),
         errors: [...errors.values()],
         warnings: [],
+        versionInfo: {
+          installed: '0.0.0',
+          staleness: 'unknown',
+        },
       })
       hmrBuilding = false
 
@@ -984,7 +988,7 @@ async function startWatcher(opts: SetupOpts) {
             }
           })
 
-          const turbopackConnected: TurboPackConnectedAction = {
+          const turbopackConnected: TurbopackConnectedAction = {
             type: HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_CONNECTED,
           }
           client.send(JSON.stringify(turbopackConnected))


### PR DESCRIPTION
### What?

This sets up the Turbopack HMR client to listen for client-only changes in App Pages. In the [initial PR](https://github.com/vercel/next.js/pull/54772), I incorrectly assumed that client-only changes would trigger a page refresh, so we didn't need an actual HMR client listening for changes. But, that's wrong, and it was a bug in our change event listeners that caused the refresh (we detected a change from a sourcemap that was reemitted and considered part of the RSC server bundle).

### Why?

HMR makes development tolerable.

### How?

We initialize the Turbopack HMR client and have it send and receive messages from `HotReloader`'s web socket. If a client change is detected, Turbopack's HMR runtime will reevaluate the module and update the page accordingly.

### TODO:

There's a bug in our Turbopack "compile time" evaluation. We should be able to detect that the client bundle is compiled by Turbopack via the `process.turbopack` and `process.env.TURBOPACK` values (they're compiled to truthy expressions by Turbopack). But for some reason, neither is working!

This means that we're including the turbopack HMR client in the wepback bundle, and doing some function calls (that will never actually do anything). While not ideal, it's so negligible that it shouldn't block merging this.

Closes WEB-1588