### PR TITLE
Fix inaccurate statement regarding caching

### DIFF
--- a/docs/02-app/01-building-your-application/04-caching/index.mdx
+++ b/docs/02-app/01-building-your-application/04-caching/index.mdx
@@ -93,7 +93,6 @@ const item = await getItem() // cache HIT
 > **Good to know**:
 >
 > - Request memoization is a React feature, not a Next.js feature. It's included here to show how it interacts with the other caching mechanisms.
-> - Memoization only applies to the `GET` method in `fetch` requests.
 > - Memoization only applies to the React Component tree, this means:
 >   - It applies to `fetch` requests in `generateMetadata`, `generateStaticParams`, Layouts, Pages, and other Server Components.
 >   - It doesn't apply to `fetch` requests in Route Handlers as they are not a part of the React component tree.


### PR DESCRIPTION
### What?
- Remove statement "Memoization only applies to the GET method in fetch requests."

### Why?
- This statement does not seem to be accurate. I see request deduping / memoization with other http methods
