### PR TITLE
Fix notFound status code with ISR in app

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2238,6 +2238,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           html: result,
           pageData: metadata.pageData,
           headers,
+          status: isAppPath ? res.statusCode : undefined,
         },
         revalidate: metadata.revalidate,
       }
@@ -2491,6 +2492,10 @@ export default abstract class Server<ServerOptions extends Options = Options> {
               typeof cachedData.pageData +
               '. This is a bug in Next.js.'
           )
+        }
+
+        if (cachedData.status) {
+          res.statusCode = cachedData.status
         }
 
         return {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -47,6 +47,15 @@ createNextDescribe(
       })
     }
 
+    it('should correctly handle statusCode with notFound + ISR', async () => {
+      for (let i = 0; i < 5; i++) {
+        const res = await next.fetch('/articles/non-existent')
+        expect(res.status).toBe(404)
+        expect(await res.text()).toContain('This page could not be found')
+        await waitFor(500)
+      }
+    })
+
     it('should correctly include headers instance in cache key', async () => {
       const res = await next.fetch('/variable-revalidate/headers-instance')
       expect(res.status).toBe(200)
@@ -700,6 +709,12 @@ createNextDescribe(
             'variable-revalidate-edge/post-method-request/page_client-reference-manifest.js',
             'partial-gen-params-no-additional-lang/[lang]/[slug]/page_client-reference-manifest.js',
             'partial-gen-params-no-additional-slug/[lang]/[slug]/page_client-reference-manifest.js',
+            'articles/[slug]/page.js',
+            'articles/[slug]/page_client-reference-manifest.js',
+            'articles/non-existent.html',
+            'articles/non-existent.rsc',
+            'articles/works.html',
+            'articles/works.rsc',
           ].sort()
         )
       })
@@ -751,6 +766,22 @@ createNextDescribe(
               ],
               "initialRevalidateSeconds": false,
               "srcRoute": "/",
+            },
+            "/articles/works": Object {
+              "dataRoute": "/articles/works.rsc",
+              "experimentalBypassFor": Array [
+                Object {
+                  "key": "Next-Action",
+                  "type": "header",
+                },
+                Object {
+                  "key": "content-type",
+                  "type": "header",
+                  "value": "multipart/form-data",
+                },
+              ],
+              "initialRevalidateSeconds": 1,
+              "srcRoute": "/articles/[slug]",
             },
             "/blog/seb": Object {
               "dataRoute": "/blog/seb.rsc",
@@ -1404,6 +1435,23 @@ createNextDescribe(
         `)
         expect(curManifest.dynamicRoutes).toMatchInlineSnapshot(`
           Object {
+            "/articles/[slug]": Object {
+              "dataRoute": "/articles/[slug].rsc",
+              "dataRouteRegex": "^\\\\/articles\\\\/([^\\\\/]+?)\\\\.rsc$",
+              "experimentalBypassFor": Array [
+                Object {
+                  "key": "Next-Action",
+                  "type": "header",
+                },
+                Object {
+                  "key": "content-type",
+                  "type": "header",
+                  "value": "multipart/form-data",
+                },
+              ],
+              "fallback": null,
+              "routeRegex": "^\\\\/articles\\\\/([^\\\\/]+?)(?:\\\\/)?$",
+            },
             "/blog/[author]": Object {
               "dataRoute": "/blog/[author].rsc",
               "dataRouteRegex": "^\\\\/blog\\\\/([^\\\\/]+?)\\\\.rsc$",

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -47,15 +47,6 @@ createNextDescribe(
       })
     }
 
-    it('should correctly handle statusCode with notFound + ISR', async () => {
-      for (let i = 0; i < 5; i++) {
-        const res = await next.fetch('/articles/non-existent')
-        expect(res.status).toBe(404)
-        expect(await res.text()).toContain('This page could not be found')
-        await waitFor(500)
-      }
-    })
-
     it('should correctly include headers instance in cache key', async () => {
       const res = await next.fetch('/variable-revalidate/headers-instance')
       expect(res.status).toBe(200)
@@ -711,8 +702,6 @@ createNextDescribe(
             'partial-gen-params-no-additional-slug/[lang]/[slug]/page_client-reference-manifest.js',
             'articles/[slug]/page.js',
             'articles/[slug]/page_client-reference-manifest.js',
-            'articles/non-existent.html',
-            'articles/non-existent.rsc',
             'articles/works.html',
             'articles/works.rsc',
           ].sort()
@@ -1637,6 +1626,15 @@ createNextDescribe(
         )
       })
     }
+
+    it('should correctly handle statusCode with notFound + ISR', async () => {
+      for (let i = 0; i < 5; i++) {
+        const res = await next.fetch('/articles/non-existent')
+        expect(res.status).toBe(404)
+        expect(await res.text()).toContain('This page could not be found')
+        await waitFor(500)
+      }
+    })
 
     it('should cache correctly for fetchCache = default-cache', async () => {
       const res = await next.fetch('/default-cache')

--- a/test/e2e/app-dir/app-static/app/articles/[slug]/page.tsx
+++ b/test/e2e/app-dir/app-static/app/articles/[slug]/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from 'next/navigation'
+
+export interface Props {
+  params: {
+    slug: string
+  }
+}
+
+const Article = ({ params }: Props) => {
+  const { slug } = params
+
+  if (slug !== 'works') {
+    return notFound()
+  }
+  return <div>Articles page with slug</div>
+}
+
+export const revalidate = 1
+export const dynamicParams = true
+
+export async function generateStaticParams() {
+  return [
+    {
+      slug: 'works', // Anything not this should be a 404 with no ISR
+    },
+  ]
+}
+
+export default Article


### PR DESCRIPTION
This ensures we properly set/restore the status code with ISR paths in app router so that when we set the 404 status code with `notFound` it is persisted properly. 

Fixes: https://github.com/vercel/next.js/issues/43831
Closes: https://github.com/vercel/next.js/issues/48342
x-ref: https://github.com/vercel/next.js/issues/49387#issuecomment-1722575969