### PR TITLE
Fix missing module.compiled trace file and unhandledRejection in ensurePage

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2269,12 +2269,13 @@ export default async function build(
             const moduleTypes = ['app-page', 'pages']
 
             for (const type of moduleTypes) {
+              const modulePath = require.resolve(
+                `next/dist/server/future/route-modules/${type}/module.compiled`
+              )
+              const relativeModulePath = path.relative(root, modulePath)
+
               const contextDir = path.join(
-                path.dirname(
-                  require.resolve(
-                    `next/dist/server/future/route-modules/${type}/module`
-                  )
-                ),
+                path.dirname(modulePath),
                 'vendored',
                 'contexts'
               )
@@ -2287,6 +2288,8 @@ export default async function build(
                 addToTracedFiles(root, itemPath, tracedFiles)
                 addToTracedFiles(root, itemPath, minimalTracedFiles)
               }
+              addToTracedFiles(root, relativeModulePath, tracedFiles)
+              addToTracedFiles(root, relativeModulePath, minimalTracedFiles)
             }
 
             await Promise.all([

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -1487,12 +1487,16 @@ export default class HotReloader implements NextJsHotReloaderInterface {
     if (error) {
       return Promise.reject(error)
     }
-    return this.onDemandEntries?.ensurePage({
+    const res = (await this.onDemandEntries?.ensurePage({
       page,
       clientOnly,
       appPaths,
       match,
       isApp,
-    }) as any
+    })) as any
+
+    if (res && res.err) {
+      throw res.err
+    }
   }
 }


### PR DESCRIPTION
Seems we occasionally have unhandledRejections with `ensurePage` due to the our memoize handling not attaching `.catch` quick enough. This updates to ensure `.catch()` is always present for that promise and re-throwing separately. 

Also, ensures the necessary `module.compiled` files for `route-modules` are included in our build traces. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04KC8A53T7/p1695072157528389?thread_ts=1695060035.024789&cid=C04KC8A53T7)