### PR TITLE
Add `mui-core` to the default `optimizePackageImports` list

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -724,6 +724,7 @@ function assignDefaults(
       'react-use',
       '@material-ui/icons',
       '@tabler/icons-react',
+      'mui-core',
     ]),
   ]
 


### PR DESCRIPTION
Feedback from https://github.com/vercel/next.js/issues/48748#issuecomment-1714292279.

As per my testing, an App Router route of

```tsx
'use client'

import { Button } from 'mui-core'

export default function Page() {
  return <Button>Hi</Button>
}
```

was improved from `2.4s (1221 modules)` to `1458ms (649 modules)` for the local dev.