### PR TITLE
`create-next-app` templates: Change `bun run dev` commands to `bun dev`

### DIFF
--- a/docs/03-pages/01-building-your-application/06-configuring/12-error-handling.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/12-error-handling.mdx
@@ -7,7 +7,7 @@ This documentation explains how you can handle development, server-side, and cli
 
 ## Handling Errors in Development
 
-When there is a runtime error during the development phase of your Next.js application, you will encounter an **overlay**. It is a modal that covers the webpage. It is **only** visible when the development server runs using `next dev` via `pnpm dev`, `npm run dev`, `yarn dev`, or `bun run dev` and will not be shown in production. Fixing the error will automatically dismiss the overlay.
+When there is a runtime error during the development phase of your Next.js application, you will encounter an **overlay**. It is a modal that covers the webpage. It is **only** visible when the development server runs using `next dev` via `pnpm dev`, `npm run dev`, `yarn dev`, or `bun dev` and will not be shown in production. Fixing the error will automatically dismiss the overlay.
 
 Here is an example of an overlay:
 

--- a/packages/create-next-app/templates/app-tw/js/README-template.md
+++ b/packages/create-next-app/templates/app-tw/js/README-template.md
@@ -11,7 +11,7 @@ yarn dev
 # or
 pnpm dev
 # or
-bun run dev
+bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/packages/create-next-app/templates/app-tw/ts/README-template.md
+++ b/packages/create-next-app/templates/app-tw/ts/README-template.md
@@ -11,7 +11,7 @@ yarn dev
 # or
 pnpm dev
 # or
-bun run dev
+bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/packages/create-next-app/templates/app/js/README-template.md
+++ b/packages/create-next-app/templates/app/js/README-template.md
@@ -11,7 +11,7 @@ yarn dev
 # or
 pnpm dev
 # or
-bun run dev
+bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/packages/create-next-app/templates/app/ts/README-template.md
+++ b/packages/create-next-app/templates/app/ts/README-template.md
@@ -11,7 +11,7 @@ yarn dev
 # or
 pnpm dev
 # or
-bun run dev
+bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/packages/create-next-app/templates/default-tw/js/README-template.md
+++ b/packages/create-next-app/templates/default-tw/js/README-template.md
@@ -11,7 +11,7 @@ yarn dev
 # or
 pnpm dev
 # or
-bun run dev
+bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/packages/create-next-app/templates/default-tw/ts/README-template.md
+++ b/packages/create-next-app/templates/default-tw/ts/README-template.md
@@ -11,7 +11,7 @@ yarn dev
 # or
 pnpm dev
 # or
-bun run dev
+bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/packages/create-next-app/templates/default/js/README-template.md
+++ b/packages/create-next-app/templates/default/js/README-template.md
@@ -11,7 +11,7 @@ yarn dev
 # or
 pnpm dev
 # or
-bun run dev
+bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/packages/create-next-app/templates/default/ts/README-template.md
+++ b/packages/create-next-app/templates/default/ts/README-template.md
@@ -11,7 +11,7 @@ yarn dev
 # or
 pnpm dev
 # or
-bun run dev
+bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.


### PR DESCRIPTION
[As of Bun v1.0.0](https://bun.sh/blog/bun-v1.0#changelog-since-v0-8), `bun dev` runs the "dev" script from package.json. Therefore, as with Yarn and pnpm, the "run" command is not necessary.

This PR changes the `create-next-app` README templates to show `bun dev` instead of `bun run dev`.