### PR TITLE
chore: run repro validation only on bug reports

### DIFF
--- a/.github/workflows/issue_validator.yml
+++ b/.github/workflows/issue_validator.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Nissuer
-        uses: balazsorban44/nissuer@1.3.5
+        uses: balazsorban44/nissuer@1.4.0
         with:
           label-area-prefix: 'area:'
           label-area-section: 'Which area\(s\) are affected\? \(Select all that apply\)(.*)### Additional context'
@@ -32,3 +32,4 @@ jobs:
           reproduction-hosts: 'github.com,codesandbox.io'
           reproduction-link-section: '### Link to the code that reproduces this issue(.*)### To Reproduce'
           reproduction-invalid-label: 'invalid link'
+          reproduction-issue-labels: 'template: bug'


### PR DESCRIPTION
### What?

Continues #55525

Adding filtering for repro validation checks

### Why?

#55589 should not have been closed

### How?

https://github.com/balazsorban44/nissuer/commit/ecbf8b42139fc1442f134ed4671b71db5f04715c
