### PR TITLE
Split prerending by route kind

### DIFF
--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -1,0 +1,53 @@
+import path from 'path'
+import fs from 'fs'
+import { IncrementalCache } from '../../server/lib/incremental-cache'
+
+import * as ciEnvironment from '../../telemetry/ci-info'
+
+export function createIncrementalCache(
+  incrementalCacheHandlerPath: string | undefined,
+  isrMemoryCacheSize: number | undefined,
+  fetchCacheKeyPrefix: string | undefined,
+  distDir: string
+) {
+  // Custom cache handler overrides.
+  let CacheHandler: any
+  if (incrementalCacheHandlerPath) {
+    CacheHandler = require(incrementalCacheHandlerPath)
+    CacheHandler = CacheHandler.default || CacheHandler
+  }
+
+  const incrementalCache = new IncrementalCache({
+    dev: false,
+    requestHeaders: {},
+    flushToDisk: true,
+    fetchCache: true,
+    maxMemoryCacheSize: isrMemoryCacheSize,
+    fetchCacheKeyPrefix,
+    getPrerenderManifest: () => ({
+      version: 4,
+      routes: {},
+      dynamicRoutes: {},
+      preview: {
+        previewModeEncryptionKey: '',
+        previewModeId: '',
+        previewModeSigningKey: '',
+      },
+      notFoundRoutes: [],
+    }),
+    fs: {
+      readFile: (f) => fs.promises.readFile(f),
+      readFileSync: (f) => fs.readFileSync(f),
+      writeFile: (f, d) => fs.promises.writeFile(f, d),
+      mkdir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
+      stat: (f) => fs.promises.stat(f),
+    },
+    serverDistDir: path.join(distDir, 'server'),
+    CurCacheHandler: CacheHandler,
+    minimalMode: ciEnvironment.hasNextSupport,
+  })
+
+  ;(globalThis as any).__incrementalCache = incrementalCache
+
+  return incrementalCache
+}

--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -1,8 +1,7 @@
 import path from 'path'
 import fs from 'fs'
 import { IncrementalCache } from '../../server/lib/incremental-cache'
-
-import * as ciEnvironment from '../../telemetry/ci-info'
+import { hasNextSupport } from '../../telemetry/ci-info'
 
 export function createIncrementalCache(
   incrementalCacheHandlerPath: string | undefined,
@@ -44,7 +43,7 @@ export function createIncrementalCache(
     },
     serverDistDir: path.join(distDir, 'server'),
     CurCacheHandler: CacheHandler,
-    minimalMode: ciEnvironment.hasNextSupport,
+    minimalMode: hasNextSupport,
   })
 
   ;(globalThis as any).__incrementalCache = incrementalCache

--- a/packages/next/src/export/helpers/get-params.ts
+++ b/packages/next/src/export/helpers/get-params.ts
@@ -1,0 +1,38 @@
+import {
+  type RouteMatchFn,
+  getRouteMatcher,
+} from '../../shared/lib/router/utils/route-matcher'
+import { getRouteRegex } from '../../shared/lib/router/utils/route-regex'
+
+// The last page and matcher that this function handled.
+let last: {
+  page: string
+  matcher: RouteMatchFn
+} | null = null
+
+/**
+ * Gets the params for the provided page.
+ * @param page the page that contains dynamic path parameters
+ * @param pathname the pathname to match
+ * @returns the matches that were found, throws otherwise
+ */
+export function getParams(page: string, pathname: string) {
+  // Because this is often called on the output of `getStaticPaths` or similar
+  // where the `page` here doesn't change, this will "remember" the last page
+  // it created the RegExp for. If it matches, it'll just re-use it.
+  let matcher: RouteMatchFn
+  if (last?.page === page) {
+    matcher = last.matcher
+  } else {
+    matcher = getRouteMatcher(getRouteRegex(page))
+  }
+
+  const params = matcher(pathname)
+  if (!params) {
+    throw new Error(
+      `The provided export path '${pathname}' doesn't match the '${page}' page.\nRead more: https://nextjs.org/docs/messages/export-path-mismatch`
+    )
+  }
+
+  return params
+}

--- a/packages/next/src/export/helpers/is-dynamic-usage-error.ts
+++ b/packages/next/src/export/helpers/is-dynamic-usage-error.ts
@@ -1,0 +1,10 @@
+import { DYNAMIC_ERROR_CODE } from '../../client/components/hooks-server-context'
+import { isNotFoundError } from '../../client/components/not-found'
+import { isRedirectError } from '../../client/components/redirect'
+import { NEXT_DYNAMIC_NO_SSR_CODE } from '../../shared/lib/lazy-dynamic/no-ssr-error'
+
+export const isDynamicUsageError = (err: any) =>
+  err.digest === DYNAMIC_ERROR_CODE ||
+  isNotFoundError(err) ||
+  err.digest === NEXT_DYNAMIC_NO_SSR_CODE ||
+  isRedirectError(err)

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -1,0 +1,168 @@
+import type { ExportPageResult } from '../types'
+import type { AppPageRender } from '../../server/app-render/app-render'
+import type { RenderOpts } from '../../server/app-render/types'
+import type { OutgoingHttpHeaders } from 'http'
+import type { NextParsedUrlQuery } from '../../server/request-meta'
+
+import fs from 'fs/promises'
+import { MockedRequest, MockedResponse } from '../../server/lib/mock-request'
+import {
+  RSC,
+  NEXT_URL,
+  NEXT_ROUTER_PREFETCH,
+} from '../../client/components/app-router-headers'
+import { isDynamicUsageError } from '../helpers/is-dynamic-usage-error'
+import { NEXT_CACHE_TAGS_HEADER } from '../../lib/constants'
+
+import * as ciEnvironment from '../../telemetry/ci-info'
+
+/**
+ * Lazily loads and runs the app page render function.
+ */
+const render: AppPageRender = (...args) => {
+  return require('../../server/future/route-modules/app-page/module.compiled').renderToHTMLOrFlight(
+    ...args
+  )
+}
+
+export async function generatePrefetchRsc(
+  req: MockedRequest,
+  path: string,
+  res: MockedResponse,
+  pathname: string,
+  query: NextParsedUrlQuery,
+  htmlFilepath: string,
+  renderOpts: RenderOpts
+) {
+  req.headers[RSC.toLowerCase()] = '1'
+  req.headers[NEXT_URL.toLowerCase()] = path
+  req.headers[NEXT_ROUTER_PREFETCH.toLowerCase()] = '1'
+
+  renderOpts.supportsDynamicHTML = true
+  delete renderOpts.isRevalidate
+
+  const prefetchRenderResult = await render(
+    req,
+    res,
+    pathname,
+    query,
+    renderOpts
+  )
+
+  prefetchRenderResult.pipe(res)
+  await res.hasStreamed
+
+  const prefetchRscData = Buffer.concat(res.buffers)
+
+  await fs.writeFile(
+    htmlFilepath.replace(/\.html$/, '.prefetch.rsc'),
+    prefetchRscData
+  )
+}
+
+export async function exportAppPage(
+  req: MockedRequest,
+  res: MockedResponse,
+  page: string,
+  path: string,
+  pathname: string,
+  query: NextParsedUrlQuery,
+  renderOpts: RenderOpts,
+  htmlFilepath: string,
+  debugOutput: boolean,
+  isDynamicError: boolean,
+  isAppPrefetch: boolean
+): Promise<ExportPageResult> {
+  // If the page is `/_not-found`, then we should update the page to be `/404`.
+  if (page === '/_not-found') {
+    pathname = '/404'
+  }
+
+  try {
+    if (isAppPrefetch) {
+      await generatePrefetchRsc(
+        req,
+        path,
+        res,
+        pathname,
+        query,
+        htmlFilepath,
+        renderOpts
+      )
+
+      return { fromBuildExportRevalidate: 0 }
+    }
+
+    const result = await render(req, res, pathname, query, renderOpts)
+    const html = result.toUnchunkedString()
+    const { metadata } = result
+    const flightData = metadata.pageData
+    const revalidate = metadata.revalidate
+
+    if (revalidate === 0) {
+      if (isDynamicError) {
+        throw new Error(
+          `Page with dynamic = "error" encountered dynamic data method on ${path}.`
+        )
+      }
+
+      await generatePrefetchRsc(
+        req,
+        path,
+        res,
+        pathname,
+        query,
+        htmlFilepath,
+        renderOpts
+      )
+
+      const { staticBailoutInfo = {} } = metadata
+
+      if (revalidate === 0 && debugOutput && staticBailoutInfo?.description) {
+        const err = new Error(
+          `Static generation failed due to dynamic usage on ${path}, reason: ${staticBailoutInfo.description}`
+        )
+
+        // Update the stack if it was provided via the bailout info.
+        const { stack } = staticBailoutInfo
+        if (stack) {
+          err.stack = err.message + stack.substring(stack.indexOf('\n'))
+        }
+
+        console.warn(err)
+      }
+
+      return { fromBuildExportRevalidate: 0 }
+    }
+
+    let headers: OutgoingHttpHeaders | undefined
+    if (metadata.fetchTags) {
+      headers = { [NEXT_CACHE_TAGS_HEADER]: metadata.fetchTags }
+    }
+
+    // Writing static HTML to a file.
+    await fs.writeFile(htmlFilepath, html ?? '', 'utf8')
+
+    // Writing the request metadata to a file.
+    const meta = { headers }
+    await fs.writeFile(
+      htmlFilepath.replace(/\.html$/, '.meta'),
+      JSON.stringify(meta)
+    )
+
+    // Writing the RSC payload to a file.
+    await fs.writeFile(htmlFilepath.replace(/\.html$/, '.rsc'), flightData)
+
+    return {
+      fromBuildExportRevalidate: revalidate,
+      // Only include the metadata if the environment has next support.
+      fromBuildExportMeta: ciEnvironment.hasNextSupport ? meta : undefined,
+    }
+  } catch (err: any) {
+    if (!isDynamicUsageError(err)) {
+      throw err
+    }
+
+    return { fromBuildExportRevalidate: 0 }
+  }
+}

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -13,8 +13,7 @@ import {
 } from '../../client/components/app-router-headers'
 import { isDynamicUsageError } from '../helpers/is-dynamic-usage-error'
 import { NEXT_CACHE_TAGS_HEADER } from '../../lib/constants'
-
-import * as ciEnvironment from '../../telemetry/ci-info'
+import { hasNextSupport } from '../../telemetry/ci-info'
 
 /**
  * Lazily loads and runs the app page render function.
@@ -156,7 +155,7 @@ export async function exportAppPage(
     return {
       fromBuildExportRevalidate: revalidate,
       // Only include the metadata if the environment has next support.
-      fromBuildExportMeta: ciEnvironment.hasNextSupport ? meta : undefined,
+      fromBuildExportMeta: hasNextSupport ? meta : undefined,
     }
   } catch (err: any) {
     if (!isDynamicUsageError(err)) {

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -1,0 +1,119 @@
+import type { ExportPageResult } from '../types'
+import type AppRouteRouteModule from '../../server/future/route-modules/app-route/module'
+import type { AppRouteRouteHandlerContext } from '../../server/future/route-modules/app-route/module'
+import type { IncrementalCache } from '../../server/lib/incremental-cache'
+
+import fs from 'fs/promises'
+import { join } from 'path'
+import { NEXT_CACHE_TAGS_HEADER } from '../../lib/constants'
+import { NodeNextRequest } from '../../server/base-http/node'
+import { RouteModuleLoader } from '../../server/future/helpers/module-loader/route-module-loader'
+import {
+  NextRequestAdapter,
+  signalFromNodeResponse,
+} from '../../server/web/spec-extension/adapters/next-request'
+import { toNodeOutgoingHttpHeaders } from '../../server/web/utils'
+import { MockedRequest, MockedResponse } from '../../server/lib/mock-request'
+import { isDynamicUsageError } from '../helpers/is-dynamic-usage-error'
+import { SERVER_DIRECTORY } from '../../shared/lib/constants'
+
+import * as ciEnvironment from '../../telemetry/ci-info'
+
+export async function exportAppRoute(
+  req: MockedRequest,
+  res: MockedResponse,
+  params: { [key: string]: string | string[] } | undefined,
+  page: string,
+  incrementalCache: IncrementalCache | undefined,
+  distDir: string,
+  htmlFilepath: string
+): Promise<ExportPageResult> {
+  // Ensure that the URL is absolute.
+  req.url = `http://localhost:3000${req.url}`
+
+  // Adapt the request and response to the Next.js request and response.
+  const request = NextRequestAdapter.fromNodeNextRequest(
+    new NodeNextRequest(req),
+    signalFromNodeResponse(res)
+  )
+
+  // Create the context for the handler. This contains the params from
+  // the route and the context for the request.
+  const context: AppRouteRouteHandlerContext = {
+    params,
+    prerenderManifest: {
+      version: 4,
+      routes: {},
+      dynamicRoutes: {},
+      preview: {
+        previewModeEncryptionKey: '',
+        previewModeId: '',
+        previewModeSigningKey: '',
+      },
+      notFoundRoutes: [],
+    },
+    staticGenerationContext: {
+      originalPathname: page,
+      nextExport: true,
+      supportsDynamicHTML: false,
+      incrementalCache,
+      ...(ciEnvironment.hasNextSupport
+        ? {
+            isRevalidate: true,
+          }
+        : {}),
+    },
+  }
+
+  // This is a route handler, which means it has it's handler in the
+  // bundled file already, we should just use that.
+  const filename = join(distDir, SERVER_DIRECTORY, 'app', page)
+
+  try {
+    // Route module loading and handling.
+    const module = await RouteModuleLoader.load<AppRouteRouteModule>(filename)
+    const response = await module.handle(request, context)
+
+    const isValidStatus = response.status < 400 || response.status === 404
+    if (!isValidStatus) {
+      return { fromBuildExportRevalidate: 0 }
+    }
+
+    const blob = await response.blob()
+    const revalidate =
+      context.staticGenerationContext.store?.revalidate || false
+
+    const headers = toNodeOutgoingHttpHeaders(response.headers)
+    const cacheTags = (context.staticGenerationContext as any).fetchTags
+
+    if (cacheTags) {
+      headers[NEXT_CACHE_TAGS_HEADER] = cacheTags
+    }
+
+    if (!headers['content-type'] && blob.type) {
+      headers['content-type'] = blob.type
+    }
+
+    // Writing response body to a file.
+    const body = Buffer.from(await blob.arrayBuffer())
+    await fs.writeFile(htmlFilepath.replace(/\.html$/, '.body'), body, 'utf8')
+
+    // Write the request metadata to a file.
+    const meta = { status: response.status, headers }
+    await fs.writeFile(
+      htmlFilepath.replace(/\.html$/, '.meta'),
+      JSON.stringify(meta)
+    )
+
+    return {
+      fromBuildExportRevalidate: revalidate,
+      fromBuildExportMeta: meta,
+    }
+  } catch (err) {
+    if (!isDynamicUsageError(err)) {
+      throw err
+    }
+
+    return { fromBuildExportRevalidate: 0 }
+  }
+}

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -16,8 +16,7 @@ import { toNodeOutgoingHttpHeaders } from '../../server/web/utils'
 import { MockedRequest, MockedResponse } from '../../server/lib/mock-request'
 import { isDynamicUsageError } from '../helpers/is-dynamic-usage-error'
 import { SERVER_DIRECTORY } from '../../shared/lib/constants'
-
-import * as ciEnvironment from '../../telemetry/ci-info'
+import { hasNextSupport } from '../../telemetry/ci-info'
 
 export async function exportAppRoute(
   req: MockedRequest,
@@ -57,12 +56,11 @@ export async function exportAppRoute(
       nextExport: true,
       supportsDynamicHTML: false,
       incrementalCache,
-      ...(ciEnvironment.hasNextSupport
-        ? {
-            isRevalidate: true,
-          }
-        : {}),
     },
+  }
+
+  if (hasNextSupport) {
+    context.staticGenerationContext.isRevalidate = true
   }
 
   // This is a route handler, which means it has it's handler in the

--- a/packages/next/src/export/routes/pages.ts
+++ b/packages/next/src/export/routes/pages.ts
@@ -1,0 +1,203 @@
+import type { ExportPageResult } from '../types'
+import type { PagesRender, RenderOpts } from '../../server/render'
+import type { LoadComponentsReturnType } from '../../server/load-components'
+import type { AmpValidation } from '../types'
+import type { NextParsedUrlQuery } from '../../server/request-meta'
+
+import fs from 'fs/promises'
+import RenderResult from '../../server/render-result'
+import { dirname, join } from 'path'
+import { MockedRequest, MockedResponse } from '../../server/lib/mock-request'
+import { isInAmpMode } from '../../shared/lib/amp-mode'
+import { SERVER_PROPS_EXPORT_ERROR } from '../../lib/constants'
+import { NEXT_DYNAMIC_NO_SSR_CODE } from '../../shared/lib/lazy-dynamic/no-ssr-error'
+import AmpHtmlValidator from 'next/dist/compiled/amphtml-validator'
+import { FileType, fileExists } from '../../lib/file-exists'
+
+/**
+ * Lazily loads and runs the app page render function.
+ */
+const render: PagesRender = (...args) => {
+  return require('../../server/future/route-modules/pages/module.compiled').renderToHTML(
+    ...args
+  )
+}
+
+export async function exportPages(
+  req: MockedRequest,
+  res: MockedResponse,
+  path: string,
+  page: string,
+  query: NextParsedUrlQuery,
+  htmlFilepath: string,
+  htmlFilename: string,
+  ampPath: string,
+  subFolders: boolean,
+  outDir: string,
+  ampValidatorPath: string | undefined,
+  pagesDataDir: string,
+  buildExport: boolean,
+  isDynamic: boolean,
+  hasOrigQueryValues: boolean,
+  renderOpts: RenderOpts,
+  components: LoadComponentsReturnType
+): Promise<ExportPageResult> {
+  const ampState = {
+    ampFirst: components.pageConfig?.amp === true,
+    hasQuery: Boolean(query.amp),
+    hybrid: components.pageConfig?.amp === 'hybrid',
+  }
+
+  const inAmpMode = isInAmpMode(ampState)
+  const hybridAmp = ampState.hybrid
+
+  if (components.getServerSideProps) {
+    throw new Error(`Error for page ${page}: ${SERVER_PROPS_EXPORT_ERROR}`)
+  }
+
+  // for non-dynamic SSG pages we should have already
+  // prerendered the file
+  if (!buildExport && components.getStaticProps && !isDynamic) {
+    return {}
+  }
+
+  if (components.getStaticProps && !htmlFilepath.endsWith('.html')) {
+    // make sure it ends with .html if the name contains a dot
+    htmlFilepath += '.html'
+    htmlFilename += '.html'
+  }
+
+  let renderResult: RenderResult | undefined
+
+  if (typeof components.Component === 'string') {
+    renderResult = RenderResult.fromStatic(components.Component)
+
+    if (hasOrigQueryValues) {
+      throw new Error(
+        `\nError: you provided query values for ${path} which is an auto-exported page. These can not be applied since the page can no longer be re-rendered on the server. To disable auto-export for this page add \`getInitialProps\`\n`
+      )
+    }
+  } else {
+    /**
+     * This sets environment variable to be used at the time of static export by head.tsx.
+     * Using this from process.env allows targeting SSR by calling
+     * `process.env.__NEXT_OPTIMIZE_FONTS`.
+     * TODO(prateekbh@): Remove this when experimental.optimizeFonts are being cleaned up.
+     */
+    if (renderOpts.optimizeFonts) {
+      process.env.__NEXT_OPTIMIZE_FONTS = JSON.stringify(
+        renderOpts.optimizeFonts
+      )
+    }
+    if (renderOpts.optimizeCss) {
+      process.env.__NEXT_OPTIMIZE_CSS = JSON.stringify(true)
+    }
+    try {
+      renderResult = await render(req, res, page, query, renderOpts)
+    } catch (err: any) {
+      if (err.digest !== NEXT_DYNAMIC_NO_SSR_CODE) {
+        throw err
+      }
+    }
+  }
+
+  const ssgNotFound = renderResult?.metadata.isNotFound
+
+  const ampValidations: AmpValidation[] = []
+
+  const validateAmp = async (
+    rawAmpHtml: string,
+    ampPageName: string,
+    validatorPath?: string
+  ) => {
+    const validator = await AmpHtmlValidator.getInstance(validatorPath)
+    const result = validator.validateString(rawAmpHtml)
+    const errors = result.errors.filter((e) => e.severity === 'ERROR')
+    const warnings = result.errors.filter((e) => e.severity !== 'ERROR')
+
+    if (warnings.length || errors.length) {
+      ampValidations.push({
+        page: ampPageName,
+        result: {
+          errors,
+          warnings,
+        },
+      })
+    }
+  }
+
+  const html =
+    renderResult && !renderResult.isNull ? renderResult.toUnchunkedString() : ''
+
+  let ampRenderResult: RenderResult | undefined
+
+  if (inAmpMode && !renderOpts.ampSkipValidation) {
+    if (!ssgNotFound) {
+      await validateAmp(html, path, ampValidatorPath)
+    }
+  } else if (hybridAmp) {
+    const ampHtmlFilename = subFolders
+      ? join(ampPath, 'index.html')
+      : `${ampPath}.html`
+
+    const ampBaseDir = join(outDir, dirname(ampHtmlFilename))
+    const ampHtmlFilepath = join(outDir, ampHtmlFilename)
+
+    const exists = await fileExists(ampHtmlFilepath, FileType.File)
+    if (!exists) {
+      try {
+        ampRenderResult = await render(
+          req,
+          res,
+          page,
+          { ...query, amp: '1' },
+          renderOpts
+        )
+      } catch (err: any) {
+        if (err.digest !== NEXT_DYNAMIC_NO_SSR_CODE) {
+          throw err
+        }
+      }
+
+      const ampHtml =
+        ampRenderResult && !ampRenderResult.isNull
+          ? ampRenderResult.toUnchunkedString()
+          : ''
+      if (!renderOpts.ampSkipValidation) {
+        await validateAmp(ampHtml, page + '?amp=1')
+      }
+      await fs.mkdir(ampBaseDir, { recursive: true })
+      await fs.writeFile(ampHtmlFilepath, ampHtml, 'utf8')
+    }
+  }
+
+  const metadata = renderResult?.metadata || ampRenderResult?.metadata || {}
+  if (metadata.pageData) {
+    const dataFile = join(
+      pagesDataDir,
+      htmlFilename.replace(/\.html$/, '.json')
+    )
+
+    await fs.mkdir(dirname(dataFile), { recursive: true })
+    await fs.writeFile(dataFile, JSON.stringify(metadata.pageData), 'utf8')
+
+    if (hybridAmp) {
+      await fs.writeFile(
+        dataFile.replace(/\.json$/, '.amp.json'),
+        JSON.stringify(metadata.pageData),
+        'utf8'
+      )
+    }
+  }
+
+  if (!ssgNotFound) {
+    // don't attempt writing to disk if getStaticProps returned not found
+    await fs.writeFile(htmlFilepath, html, 'utf8')
+  }
+
+  return {
+    ampValidations,
+    fromBuildExportRevalidate: metadata.revalidate,
+    ssgNotFound,
+  }
+}

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -1,0 +1,30 @@
+import type { RenderOptsPartial as AppRenderOptsPartial } from '../server/app-render/types'
+import type { RenderOptsPartial as PagesRenderOptsPartial } from '../server/render'
+import type { LoadComponentsReturnType } from '../server/load-components'
+import type { OutgoingHttpHeaders } from 'http'
+import type AmpHtmlValidator from 'next/dist/compiled/amphtml-validator'
+
+export interface AmpValidation {
+  page: string
+  result: {
+    errors: AmpHtmlValidator.ValidationError[]
+    warnings: AmpHtmlValidator.ValidationError[]
+  }
+}
+
+export interface ExportPageResult {
+  ampValidations?: AmpValidation[]
+  fromBuildExportRevalidate?: number | false
+  fromBuildExportMeta?: {
+    status?: number
+    headers?: OutgoingHttpHeaders
+  }
+  error?: boolean
+  ssgNotFound?: boolean
+}
+
+export type WorkerRenderOptsPartial = PagesRenderOptsPartial &
+  AppRenderOptsPartial
+
+export type WorkerRenderOpts = WorkerRenderOptsPartial &
+  LoadComponentsReturnType

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -1,77 +1,43 @@
+import type { FontConfig } from '../server/font-utils'
+import type { ExportPathMap, NextConfigComplete } from '../server/config-shared'
 import type {
-  AppRouteRouteModule,
-  AppRouteRouteHandlerContext,
-} from '../server/future/route-modules/app-route/module'
-import type { FontManifest, FontConfig } from '../server/font-utils'
-import type {
-  DomainLocale,
-  ExportPathMap,
-  NextConfigComplete,
-} from '../server/config-shared'
-import type { OutgoingHttpHeaders } from 'http'
+  ExportPageResult,
+  WorkerRenderOpts,
+  WorkerRenderOptsPartial,
+} from './types'
 
 // Polyfill fetch for the export worker.
 import '../server/node-polyfill-fetch'
 import '../server/node-environment'
+
 process.env.NEXT_IS_EXPORT_WORKER = 'true'
 
-import { extname, join, dirname, sep, posix } from 'path'
-import fs, { promises } from 'fs'
-import AmpHtmlValidator from 'next/dist/compiled/amphtml-validator'
-import {
-  loadComponents,
-  LoadComponentsReturnType,
-} from '../server/load-components'
+import { extname, join, dirname, sep } from 'path'
+import fs from 'fs'
+import { loadComponents } from '../server/load-components'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
-import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
-import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
-import {
-  NEXT_CACHE_TAGS_HEADER,
-  SERVER_PROPS_EXPORT_ERROR,
-} from '../lib/constants'
 import { requireFontManifest } from '../server/require'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import { trace } from '../trace'
-import { isInAmpMode } from '../shared/lib/amp-mode'
 import { setHttpClientAndAgentOptions } from '../server/setup-http-agent-env'
-import RenderResult from '../server/render-result'
 import isError from '../lib/is-error'
 import { addRequestMeta } from '../server/request-meta'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
-import { DYNAMIC_ERROR_CODE } from '../client/components/hooks-server-context'
-import { IncrementalCache } from '../server/lib/incremental-cache'
-import { isNotFoundError } from '../client/components/not-found'
-import { isRedirectError } from '../client/components/redirect'
-import { NEXT_DYNAMIC_NO_SSR_CODE } from '../shared/lib/lazy-dynamic/no-ssr-error'
+
 import { createRequestResponseMocks } from '../server/lib/mock-request'
-import { NodeNextRequest } from '../server/base-http/node'
 import { isAppRouteRoute } from '../lib/is-app-route-route'
-import { toNodeOutgoingHttpHeaders } from '../server/web/utils'
-import { RouteModuleLoader } from '../server/future/helpers/module-loader/route-module-loader'
-import {
-  NextRequestAdapter,
-  signalFromNodeResponse,
-} from '../server/web/spec-extension/adapters/next-request'
 import * as ciEnvironment from '../telemetry/ci-info'
-import {
-  NEXT_ROUTER_PREFETCH,
-  NEXT_URL,
-  RSC,
-} from '../client/components/app-router-headers'
+import { exportAppRoute } from './routes/app-route'
+import { exportAppPage } from './routes/app-page'
+import { exportPages } from './routes/pages'
+import { getParams } from './helpers/get-params'
+import { createIncrementalCache } from './helpers/create-incremental-cache'
 
 const envConfig = require('../shared/lib/runtime-config.external')
 
 ;(globalThis as any).__NEXT_DATA__ = {
   nextExport: true,
-}
-
-interface AmpValidation {
-  page: string
-  result: {
-    errors: AmpHtmlValidator.ValidationError[]
-    warnings: AmpHtmlValidator.ValidationError[]
-  }
 }
 
 type PathMap = ExportPathMap[keyof ExportPathMap]
@@ -82,7 +48,9 @@ interface ExportPageInput {
   distDir: string
   outDir: string
   pagesDataDir: string
-  renderOpts: RenderOpts
+  renderOpts: WorkerRenderOptsPartial
+  ampValidatorPath?: string
+  trailingSlash?: boolean
   buildExport?: boolean
   serverRuntimeConfig: { [key: string]: any }
   subFolders?: boolean
@@ -100,698 +68,297 @@ interface ExportPageInput {
   enableExperimentalReact?: boolean
 }
 
-interface ExportPageResults {
-  ampValidations: AmpValidation[]
-  fromBuildExportRevalidate?: number | false
-  fromBuildExportMeta?: {
-    status?: number
-    headers?: OutgoingHttpHeaders
-  }
-  error?: boolean
-  ssgNotFound?: boolean
+export interface ExportPageResults extends ExportPageResult {
   duration: number
 }
 
-interface RenderOpts {
-  runtimeConfig?: { [key: string]: any }
-  params?: { [key: string]: string | string[] }
-  ampPath?: string
-  ampValidatorPath?: string
-  ampSkipValidation?: boolean
-  optimizeFonts?: FontConfig
-  disableOptimizedLoading?: boolean
-  optimizeCss?: any
-  fontManifest?: FontManifest
-  locales?: string[]
-  locale?: string
-  defaultLocale?: string
-  domainLocales?: DomainLocale[]
-  trailingSlash?: boolean
-  supportsDynamicHTML?: boolean
-  incrementalCache?: IncrementalCache
-  strictNextHead?: boolean
-  originalPathname?: string
-  deploymentId?: string
+async function exportPageImpl(input: ExportPageInput) {
+  const {
+    path,
+    pathMap,
+    distDir,
+    pagesDataDir,
+    buildExport = false,
+    serverRuntimeConfig,
+    subFolders = false,
+    optimizeFonts,
+    optimizeCss,
+    disableOptimizedLoading,
+    debugOutput = false,
+    isrMemoryCacheSize,
+    fetchCache,
+    fetchCacheKeyPrefix,
+    incrementalCacheHandlerPath,
+    enableExperimentalReact,
+    ampValidatorPath,
+    trailingSlash,
+  } = input
+
+  if (input.renderOpts.deploymentId) {
+    process.env.NEXT_DEPLOYMENT_ID = input.renderOpts.deploymentId
+  }
+  if (enableExperimentalReact) {
+    process.env.__NEXT_EXPERIMENTAL_REACT = 'true'
+  }
+
+  const {
+    page,
+
+    // Check if this is an `app/` page.
+    _isAppDir: isAppDir = false,
+
+    // Check if this is an `app/` prefix request.
+    _isAppPrefetch: isAppPrefetch = false,
+
+    // Check if this should error when dynamic usage is detected.
+    _isDynamicError: isDynamicError = false,
+
+    // Pull the original query out.
+    query: originalQuery = {},
+  } = pathMap
+
+  try {
+    let query = { ...originalQuery }
+    const pathname = normalizeAppPath(page)
+    const isDynamic = isDynamicRoute(page)
+    const outDir = isAppDir ? join(distDir, 'server/app') : input.outDir
+
+    let params: { [key: string]: string | string[] } | undefined
+
+    const filePath = normalizePagePath(path)
+    const ampPath = `${filePath}.amp`
+    let renderAmpPath = ampPath
+
+    let updatedPath = query.__nextSsgPath || path
+    delete query.__nextSsgPath
+
+    let locale = query.__nextLocale || input.renderOpts.locale
+    delete query.__nextLocale
+
+    if (input.renderOpts.locale) {
+      const localePathResult = normalizeLocalePath(
+        path,
+        input.renderOpts.locales
+      )
+
+      if (localePathResult.detectedLocale) {
+        updatedPath = localePathResult.pathname
+        locale = localePathResult.detectedLocale
+
+        if (locale === input.renderOpts.defaultLocale) {
+          renderAmpPath = `${normalizePagePath(updatedPath)}.amp`
+        }
+      }
+    }
+
+    // We need to show a warning if they try to provide query values
+    // for an auto-exported page since they won't be available
+    const hasOrigQueryValues = Object.keys(originalQuery).length > 0
+
+    // Check if the page is a specified dynamic route
+    const { pathname: nonLocalizedPath } = normalizeLocalePath(
+      path,
+      input.renderOpts.locales
+    )
+
+    if (isDynamic && page !== nonLocalizedPath) {
+      const normalizedPage = isAppDir ? normalizeAppPath(page) : page
+
+      params = getParams(normalizedPage, updatedPath)
+      if (params) {
+        query = {
+          ...query,
+          ...params,
+        }
+      }
+    }
+
+    const { req, res } = createRequestResponseMocks({ url: updatedPath })
+
+    // If this is a status code page, then set the response code.
+    for (const statusCode of [404, 500]) {
+      if (
+        [
+          `/${statusCode}`,
+          `/${statusCode}.html`,
+          `/${statusCode}/index.html`,
+        ].some((p) => p === updatedPath || `/${locale}${p}` === updatedPath)
+      ) {
+        res.statusCode = statusCode
+      }
+    }
+
+    // Ensure that the URL has a trailing slash if it's configured.
+    if (trailingSlash && !req.url?.endsWith('/')) {
+      req.url += '/'
+    }
+
+    if (
+      locale &&
+      buildExport &&
+      input.renderOpts.domainLocales &&
+      input.renderOpts.domainLocales.some(
+        (dl) =>
+          dl.defaultLocale === locale || dl.locales?.includes(locale || '')
+      )
+    ) {
+      addRequestMeta(req, '__nextIsLocaleDomain', true)
+    }
+
+    envConfig.setConfig({
+      serverRuntimeConfig,
+      publicRuntimeConfig: input.renderOpts.runtimeConfig,
+    })
+
+    const getHtmlFilename = (p: string) =>
+      subFolders ? `${p}${sep}index.html` : `${p}.html`
+
+    let htmlFilename = getHtmlFilename(filePath)
+
+    // dynamic routes can provide invalid extensions e.g. /blog/[...slug] returns an
+    // extension of `.slug]`
+    const pageExt = isDynamic || isAppDir ? '' : extname(page)
+    const pathExt = isDynamic || isAppDir ? '' : extname(path)
+
+    // force output 404.html for backwards compat
+    if (path === '/404.html') {
+      htmlFilename = path
+    }
+    // Make sure page isn't a folder with a dot in the name e.g. `v1.2`
+    else if (pageExt !== pathExt && pathExt !== '') {
+      const isBuiltinPaths = ['/500', '/404'].some(
+        (p) => p === path || p === path + '.html'
+      )
+      // If the ssg path has .html extension, and it's not builtin paths, use it directly
+      // Otherwise, use that as the filename instead
+      const isHtmlExtPath = !isBuiltinPaths && path.endsWith('.html')
+      htmlFilename = isHtmlExtPath ? getHtmlFilename(path) : path
+    } else if (path === '/') {
+      // If the path is the root, just use index.html
+      htmlFilename = 'index.html'
+    }
+
+    const baseDir = join(outDir, dirname(htmlFilename))
+    let htmlFilepath = join(outDir, htmlFilename)
+
+    await fs.promises.mkdir(baseDir, { recursive: true })
+
+    // If the fetch cache was enabled, we need to create an incremental
+    // cache instance for this page.
+    const incrementalCache =
+      isAppDir && fetchCache
+        ? createIncrementalCache(
+            incrementalCacheHandlerPath,
+            isrMemoryCacheSize,
+            fetchCacheKeyPrefix,
+            distDir
+          )
+        : undefined
+
+    // Handle App Routes.
+    if (isAppDir && isAppRouteRoute(page)) {
+      return await exportAppRoute(
+        req,
+        res,
+        params,
+        page,
+        incrementalCache,
+        distDir,
+        htmlFilepath
+      )
+    }
+
+    const components = await loadComponents({
+      distDir,
+      page,
+      isAppPath: isAppDir,
+    })
+
+    const renderOpts: WorkerRenderOpts = {
+      ...components,
+      ...input.renderOpts,
+      ampPath: renderAmpPath,
+      params,
+      optimizeFonts,
+      optimizeCss,
+      disableOptimizedLoading,
+      fontManifest: optimizeFonts ? requireFontManifest(distDir) : null,
+      locale,
+      supportsDynamicHTML: false,
+      originalPathname: page,
+    }
+
+    if (ciEnvironment.hasNextSupport) {
+      renderOpts.isRevalidate = true
+    }
+
+    // Handle App Pages
+    if (isAppDir) {
+      // Set the incremental cache on the renderOpts, that's how app page's
+      // consume it.
+      renderOpts.incrementalCache = incrementalCache
+
+      return await exportAppPage(
+        req,
+        res,
+        page,
+        path,
+        pathname,
+        query,
+        renderOpts,
+        htmlFilepath,
+        debugOutput,
+        isDynamicError,
+        isAppPrefetch
+      )
+    }
+
+    return await exportPages(
+      req,
+      res,
+      path,
+      page,
+      query,
+      htmlFilepath,
+      htmlFilename,
+      ampPath,
+      subFolders,
+      outDir,
+      ampValidatorPath,
+      pagesDataDir,
+      buildExport,
+      isDynamic,
+      hasOrigQueryValues,
+      renderOpts,
+      components
+    )
+  } catch (err) {
+    console.error(
+      `\nError occurred prerendering page "${path}". Read more: https://nextjs.org/docs/messages/prerender-error\n` +
+        (isError(err) && err.stack ? err.stack : err)
+    )
+
+    return { error: true }
+  }
 }
 
-export default async function exportPage({
-  parentSpanId,
-  path,
-  pathMap,
-  distDir,
-  outDir,
-  pagesDataDir,
-  renderOpts,
-  buildExport,
-  serverRuntimeConfig,
-  subFolders,
-  optimizeFonts,
-  optimizeCss,
-  disableOptimizedLoading,
-  httpAgentOptions,
-  debugOutput,
-  isrMemoryCacheSize,
-  fetchCache,
-  fetchCacheKeyPrefix,
-  incrementalCacheHandlerPath,
-  enableExperimentalReact,
-}: ExportPageInput): Promise<ExportPageResults> {
+export default async function exportPage(
+  input: ExportPageInput
+): Promise<ExportPageResults> {
+  // Configure the http agent.
   setHttpClientAndAgentOptions({
-    httpAgentOptions,
+    httpAgentOptions: input.httpAgentOptions,
   })
-  const exportPageSpan = trace('export-page-worker', parentSpanId)
 
-  return exportPageSpan.traceAsyncFn(async () => {
-    const start = Date.now()
-    let results: Omit<ExportPageResults, 'duration'> = {
-      ampValidations: [],
-    }
+  const exportPageSpan = trace('export-page-worker', input.parentSpanId)
 
-    try {
-      if (renderOpts.deploymentId) {
-        process.env.NEXT_DEPLOYMENT_ID = renderOpts.deploymentId
-      }
-      if (enableExperimentalReact) {
-        process.env.__NEXT_EXPERIMENTAL_REACT = 'true'
-      }
-      const { query: originalQuery = {} } = pathMap
-      const { page } = pathMap
-      const pathname = normalizeAppPath(page)
-      const isAppDir = Boolean(pathMap._isAppDir)
-      const isAppPrefetch = Boolean(pathMap._isAppPrefetch)
-      const isDynamicError = pathMap._isDynamicError
-      const filePath = normalizePagePath(path)
-      const isDynamic = isDynamicRoute(page)
-      const ampPath = `${filePath}.amp`
-      let renderAmpPath = ampPath
-      let query = { ...originalQuery }
-      let params: { [key: string]: string | string[] } | undefined
-      const isRouteHandler = isAppDir && isAppRouteRoute(page)
+  const start = Date.now()
 
-      if (isAppDir) {
-        outDir = join(distDir, 'server/app')
-      }
-
-      let updatedPath = query.__nextSsgPath || path
-      let locale = query.__nextLocale || renderOpts.locale
-      delete query.__nextLocale
-      delete query.__nextSsgPath
-
-      if (renderOpts.locale) {
-        const localePathResult = normalizeLocalePath(path, renderOpts.locales)
-
-        if (localePathResult.detectedLocale) {
-          updatedPath = localePathResult.pathname
-          locale = localePathResult.detectedLocale
-
-          if (locale === renderOpts.defaultLocale) {
-            renderAmpPath = `${normalizePagePath(updatedPath)}.amp`
-          }
-        }
-      }
-
-      // We need to show a warning if they try to provide query values
-      // for an auto-exported page since they won't be available
-      const hasOrigQueryValues = Object.keys(originalQuery).length > 0
-      const queryWithAutoExportWarn = () => {
-        if (hasOrigQueryValues) {
-          throw new Error(
-            `\nError: you provided query values for ${path} which is an auto-exported page. These can not be applied since the page can no longer be re-rendered on the server. To disable auto-export for this page add \`getInitialProps\`\n`
-          )
-        }
-      }
-
-      // Check if the page is a specified dynamic route
-      const nonLocalizedPath = normalizeLocalePath(
-        path,
-        renderOpts.locales
-      ).pathname
-
-      if (isDynamic && page !== nonLocalizedPath) {
-        const normalizedPage = isAppDir ? normalizeAppPath(page) : page
-
-        params =
-          getRouteMatcher(getRouteRegex(normalizedPage))(updatedPath) ||
-          undefined
-        if (params) {
-          query = {
-            ...query,
-            ...params,
-          }
-        } else {
-          throw new Error(
-            `The provided export path '${updatedPath}' doesn't match the '${page}' page.\nRead more: https://nextjs.org/docs/messages/export-path-mismatch`
-          )
-        }
-      }
-
-      const { req, res } = createRequestResponseMocks({ url: updatedPath })
-
-      for (const statusCode of [404, 500]) {
-        if (
-          [
-            `/${statusCode}`,
-            `/${statusCode}.html`,
-            `/${statusCode}/index.html`,
-          ].some((p) => p === updatedPath || `/${locale}${p}` === updatedPath)
-        ) {
-          res.statusCode = statusCode
-        }
-      }
-
-      if (renderOpts.trailingSlash && !req.url?.endsWith('/')) {
-        req.url += '/'
-      }
-
-      if (
-        locale &&
-        buildExport &&
-        renderOpts.domainLocales &&
-        renderOpts.domainLocales.some(
-          (dl) =>
-            dl.defaultLocale === locale || dl.locales?.includes(locale || '')
-        )
-      ) {
-        addRequestMeta(req, '__nextIsLocaleDomain', true)
-      }
-
-      envConfig.setConfig({
-        serverRuntimeConfig,
-        publicRuntimeConfig: renderOpts.runtimeConfig,
-      })
-
-      const getHtmlFilename = (_path: string) =>
-        subFolders ? `${_path}${sep}index.html` : `${_path}.html`
-      let htmlFilename = getHtmlFilename(filePath)
-
-      // dynamic routes can provide invalid extensions e.g. /blog/[...slug] returns an
-      // extension of `.slug]`
-      const pageExt = isDynamic || isAppDir ? '' : extname(page)
-      const pathExt = isDynamic || isAppDir ? '' : extname(path)
-
-      // force output 404.html for backwards compat
-      if (path === '/404.html') {
-        htmlFilename = path
-      }
-      // Make sure page isn't a folder with a dot in the name e.g. `v1.2`
-      else if (pageExt !== pathExt && pathExt !== '') {
-        const isBuiltinPaths = ['/500', '/404'].some(
-          (p) => p === path || p === path + '.html'
-        )
-        // If the ssg path has .html extension, and it's not builtin paths, use it directly
-        // Otherwise, use that as the filename instead
-        const isHtmlExtPath = !isBuiltinPaths && path.endsWith('.html')
-        htmlFilename = isHtmlExtPath ? getHtmlFilename(path) : path
-      } else if (path === '/') {
-        // If the path is the root, just use index.html
-        htmlFilename = 'index.html'
-      }
-
-      const baseDir = join(outDir, dirname(htmlFilename))
-      let htmlFilepath = join(outDir, htmlFilename)
-
-      await promises.mkdir(baseDir, { recursive: true })
-      let renderResult: RenderResult | undefined
-      let curRenderOpts: RenderOpts = {}
-      const renderToHTML =
-        require('../server/future/route-modules/pages/module.compiled')
-          .renderToHTML as typeof import('../server/render').renderToHTML
-
-      let renderMethod = renderToHTML
-      let inAmpMode = false,
-        hybridAmp = false
-
-      const renderedDuringBuild = (getStaticProps: any) => {
-        return !buildExport && getStaticProps && !isDynamicRoute(path)
-      }
-
-      let components: LoadComponentsReturnType | null = null
-
-      if (!isRouteHandler) {
-        components = await loadComponents({
-          distDir,
-          page: page,
-          isAppPath: isAppDir,
-        })
-        curRenderOpts = {
-          ...components,
-          ...renderOpts,
-          strictNextHead: !!renderOpts.strictNextHead,
-          ampPath: renderAmpPath,
-          params,
-          optimizeFonts,
-          optimizeCss,
-          disableOptimizedLoading,
-          fontManifest: optimizeFonts ? requireFontManifest(distDir) : null,
-          locale: locale as string,
-          supportsDynamicHTML: false,
-          originalPathname: page,
-          ...(ciEnvironment.hasNextSupport
-            ? {
-                isRevalidate: true,
-              }
-            : {}),
-        }
-      }
-
-      // during build we attempt rendering app dir paths
-      // and bail when dynamic dependencies are detected
-      // only fully static paths are fully generated here
-      if (isAppDir) {
-        if (fetchCache) {
-          let CacheHandler: any
-
-          if (incrementalCacheHandlerPath) {
-            CacheHandler = require(incrementalCacheHandlerPath)
-            CacheHandler = CacheHandler.default || CacheHandler
-          }
-          const incrementalCache = new IncrementalCache({
-            dev: false,
-            requestHeaders: {},
-            flushToDisk: true,
-            fetchCache: true,
-            maxMemoryCacheSize: isrMemoryCacheSize,
-            fetchCacheKeyPrefix,
-            getPrerenderManifest: () => ({
-              version: 4,
-              routes: {},
-              dynamicRoutes: {},
-              preview: {
-                previewModeEncryptionKey: '',
-                previewModeId: '',
-                previewModeSigningKey: '',
-              },
-              notFoundRoutes: [],
-            }),
-            fs: {
-              readFile: (f) => fs.promises.readFile(f),
-              readFileSync: (f) => fs.readFileSync(f),
-              writeFile: (f, d) => fs.promises.writeFile(f, d),
-              mkdir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
-              stat: (f) => fs.promises.stat(f),
-            },
-            serverDistDir: join(distDir, 'server'),
-            CurCacheHandler: CacheHandler,
-            minimalMode: ciEnvironment.hasNextSupport,
-          })
-          ;(globalThis as any).__incrementalCache = incrementalCache
-          curRenderOpts.incrementalCache = incrementalCache
-        }
-
-        const isDynamicUsageError = (err: any) =>
-          err.digest === DYNAMIC_ERROR_CODE ||
-          isNotFoundError(err) ||
-          err.digest === NEXT_DYNAMIC_NO_SSR_CODE ||
-          isRedirectError(err)
-
-        const isNotFoundPage = page === '/_not-found'
-
-        const generatePrefetchRsc = async () => {
-          // If we bail for prerendering due to dynamic usage we need to
-          // generate a static prefetch payload to prevent invoking
-          // functions during runtime just for prefetching
-
-          const { renderToHTMLOrFlight } =
-            require('../server/future/route-modules/app-page/module.compiled') as typeof import('../server/app-render/app-render')
-          req.headers[RSC.toLowerCase()] = '1'
-          req.headers[NEXT_URL.toLowerCase()] = path
-          req.headers[NEXT_ROUTER_PREFETCH.toLowerCase()] = '1'
-
-          curRenderOpts.supportsDynamicHTML = true
-          delete (curRenderOpts as any).isRevalidate
-
-          const prefetchRenderResult = await renderToHTMLOrFlight(
-            req as any,
-            res as any,
-            isNotFoundPage ? '/404' : pathname,
-            query,
-            curRenderOpts as any
-          )
-          prefetchRenderResult.pipe(res as import('http').ServerResponse)
-          await res.hasStreamed
-          const prefetchRscData = Buffer.concat(res.buffers).toString()
-
-          await promises.writeFile(
-            htmlFilepath.replace(/\.html$/, '.prefetch.rsc'),
-            prefetchRscData
-          )
-        }
-
-        // for dynamic routes with no generate static params
-        // we generate strictly the prefetch RSC payload to
-        // avoid attempting to render with default params e.g. [slug]
-        if (isAppPrefetch) {
-          await generatePrefetchRsc()
-        } else if (isRouteHandler) {
-          // Ensure that the url for the page is absolute.
-          req.url = `http://localhost:3000${req.url}`
-          const request = NextRequestAdapter.fromNodeNextRequest(
-            new NodeNextRequest(req),
-            signalFromNodeResponse(res)
-          )
-
-          // Create the context for the handler. This contains the params from
-          // the route and the context for the request.
-          const context: AppRouteRouteHandlerContext = {
-            params,
-            prerenderManifest: {
-              version: 4,
-              routes: {},
-              dynamicRoutes: {},
-              preview: {
-                previewModeEncryptionKey: '',
-                previewModeId: '',
-                previewModeSigningKey: '',
-              },
-              notFoundRoutes: [],
-            },
-            staticGenerationContext: {
-              originalPathname: page,
-              nextExport: true,
-              supportsDynamicHTML: false,
-              incrementalCache: curRenderOpts.incrementalCache,
-              ...(ciEnvironment.hasNextSupport
-                ? {
-                    isRevalidate: true,
-                  }
-                : {}),
-            },
-          }
-
-          try {
-            // This is a route handler, which means it has it's handler in the
-            // bundled file already, we should just use that.
-            const filename = posix.join(distDir, 'server', 'app', page)
-
-            // Load the module for the route.
-            const module = await RouteModuleLoader.load<AppRouteRouteModule>(
-              filename
-            )
-            // Call the handler with the request and context from the module.
-            const response = await module.handle(request, context)
-
-            // TODO: (wyattjoh) if cookie headers are present, should we bail?
-
-            // we don't consider error status for static generation
-            // except for 404
-            // TODO: do we want to cache other status codes?
-            const isValidStatus =
-              response.status < 400 || response.status === 404
-
-            if (isValidStatus) {
-              const body = await response.blob()
-              const revalidate =
-                context.staticGenerationContext.store?.revalidate || false
-
-              results.fromBuildExportRevalidate = revalidate
-              const headers = toNodeOutgoingHttpHeaders(response.headers)
-              const cacheTags = (context.staticGenerationContext as any)
-                .fetchTags
-
-              if (cacheTags) {
-                headers[NEXT_CACHE_TAGS_HEADER] = cacheTags
-              }
-
-              if (!headers['content-type'] && body.type) {
-                headers['content-type'] = body.type
-              }
-              results.fromBuildExportMeta = {
-                status: response.status,
-                headers,
-              }
-
-              await promises.writeFile(
-                htmlFilepath.replace(/\.html$/, '.body'),
-                Buffer.from(await body.arrayBuffer()),
-                'utf8'
-              )
-              await promises.writeFile(
-                htmlFilepath.replace(/\.html$/, '.meta'),
-                JSON.stringify({
-                  status: response.status,
-                  headers,
-                })
-              )
-            } else {
-              results.fromBuildExportRevalidate = 0
-            }
-          } catch (err) {
-            if (!isDynamicUsageError(err)) {
-              throw err
-            }
-            results.fromBuildExportRevalidate = 0
-          }
-        } else {
-          const renderToHTMLOrFlight =
-            require('../server/future/route-modules/app-page/module.compiled')
-              .renderToHTMLOrFlight as typeof import('../server/app-render/app-render').renderToHTMLOrFlight
-
-          try {
-            curRenderOpts.params ||= {}
-            const result = await renderToHTMLOrFlight(
-              req as any,
-              res as any,
-              isNotFoundPage ? '/404' : pathname,
-              query,
-              curRenderOpts as any
-            )
-            const html = result.toUnchunkedString()
-            const { metadata } = result
-            const flightData = metadata.pageData
-            const revalidate = metadata.revalidate
-            results.fromBuildExportRevalidate = revalidate
-
-            if (revalidate !== 0) {
-              const cacheTags = metadata.fetchTags
-              const headers = cacheTags
-                ? {
-                    [NEXT_CACHE_TAGS_HEADER]: cacheTags,
-                  }
-                : undefined
-
-              if (ciEnvironment.hasNextSupport) {
-                if (cacheTags) {
-                  results.fromBuildExportMeta = {
-                    headers,
-                  }
-                }
-              }
-
-              await promises.writeFile(htmlFilepath, html ?? '', 'utf8')
-              await promises.writeFile(
-                htmlFilepath.replace(/\.html$/, '.meta'),
-                JSON.stringify({ headers })
-              )
-              await promises.writeFile(
-                htmlFilepath.replace(/\.html$/, '.rsc'),
-                flightData
-              )
-            } else if (isDynamicError) {
-              throw new Error(
-                `Page with dynamic = "error" encountered dynamic data method on ${path}.`
-              )
-            } else {
-              await generatePrefetchRsc()
-            }
-
-            const staticBailoutInfo = metadata.staticBailoutInfo || {}
-
-            if (
-              revalidate === 0 &&
-              debugOutput &&
-              staticBailoutInfo?.description
-            ) {
-              const bailErr = new Error(
-                `Static generation failed due to dynamic usage on ${path}, reason: ${staticBailoutInfo.description}`
-              )
-              const stack = staticBailoutInfo.stack
-
-              if (stack) {
-                bailErr.stack =
-                  bailErr.message + stack.substring(stack.indexOf('\n'))
-              }
-              console.warn(bailErr)
-            }
-          } catch (err: any) {
-            if (!isDynamicUsageError(err)) {
-              throw err
-            }
-          }
-        }
-        return { ...results, duration: Date.now() - start }
-      }
-
-      if (!components) {
-        throw new Error(
-          `invariant: components were not loaded correctly during export for path: ${path}`
-        )
-      }
-
-      const ampState = {
-        ampFirst: components.pageConfig?.amp === true,
-        hasQuery: Boolean(query.amp),
-        hybrid: components.pageConfig?.amp === 'hybrid',
-      }
-      inAmpMode = isInAmpMode(ampState)
-      hybridAmp = ampState.hybrid
-
-      if (components.getServerSideProps) {
-        throw new Error(`Error for page ${page}: ${SERVER_PROPS_EXPORT_ERROR}`)
-      }
-
-      // for non-dynamic SSG pages we should have already
-      // prerendered the file
-      if (renderedDuringBuild(components.getStaticProps)) {
-        return { ...results, duration: Date.now() - start }
-      }
-
-      if (components.getStaticProps && !htmlFilepath.endsWith('.html')) {
-        // make sure it ends with .html if the name contains a dot
-        htmlFilepath += '.html'
-        htmlFilename += '.html'
-      }
-
-      if (typeof components.Component === 'string') {
-        renderResult = RenderResult.fromStatic(components.Component)
-        queryWithAutoExportWarn()
-      } else {
-        /**
-         * This sets environment variable to be used at the time of static export by head.tsx.
-         * Using this from process.env allows targeting SSR by calling
-         * `process.env.__NEXT_OPTIMIZE_FONTS`.
-         * TODO(prateekbh@): Remove this when experimental.optimizeFonts are being cleaned up.
-         */
-        if (optimizeFonts) {
-          process.env.__NEXT_OPTIMIZE_FONTS = JSON.stringify(optimizeFonts)
-        }
-        if (optimizeCss) {
-          process.env.__NEXT_OPTIMIZE_CSS = JSON.stringify(true)
-        }
-        try {
-          renderResult = await renderMethod(
-            req,
-            res,
-            page,
-            query,
-            // @ts-ignore
-            curRenderOpts
-          )
-        } catch (err: any) {
-          if (err.digest !== NEXT_DYNAMIC_NO_SSR_CODE) {
-            throw err
-          }
-        }
-      }
-
-      results.ssgNotFound = renderResult?.metadata.isNotFound
-
-      const validateAmp = async (
-        rawAmpHtml: string,
-        ampPageName: string,
-        validatorPath?: string
-      ) => {
-        const validator = await AmpHtmlValidator.getInstance(validatorPath)
-        const result = validator.validateString(rawAmpHtml)
-        const errors = result.errors.filter((e) => e.severity === 'ERROR')
-        const warnings = result.errors.filter((e) => e.severity !== 'ERROR')
-
-        if (warnings.length || errors.length) {
-          results.ampValidations.push({
-            page: ampPageName,
-            result: {
-              errors,
-              warnings,
-            },
-          })
-        }
-      }
-
-      const html =
-        renderResult && !renderResult.isNull
-          ? renderResult.toUnchunkedString()
-          : ''
-
-      let ampRenderResult: Awaited<ReturnType<typeof renderMethod>> | undefined
-
-      if (inAmpMode && !curRenderOpts.ampSkipValidation) {
-        if (!results.ssgNotFound) {
-          await validateAmp(html, path, curRenderOpts.ampValidatorPath)
-        }
-      } else if (hybridAmp) {
-        // we need to render the AMP version
-        let ampHtmlFilename = `${ampPath}${sep}index.html`
-        if (!subFolders) {
-          ampHtmlFilename = `${ampPath}.html`
-        }
-        const ampBaseDir = join(outDir, dirname(ampHtmlFilename))
-        const ampHtmlFilepath = join(outDir, ampHtmlFilename)
-
-        try {
-          await promises.access(ampHtmlFilepath)
-        } catch (_) {
-          // make sure it doesn't exist from manual mapping
-          try {
-            ampRenderResult = await renderMethod(
-              req,
-              res,
-              page,
-              // @ts-ignore
-              { ...query, amp: '1' },
-              curRenderOpts as any
-            )
-          } catch (err: any) {
-            if (err.digest !== NEXT_DYNAMIC_NO_SSR_CODE) {
-              throw err
-            }
-          }
-
-          const ampHtml =
-            ampRenderResult && !ampRenderResult.isNull
-              ? ampRenderResult.toUnchunkedString()
-              : ''
-          if (!curRenderOpts.ampSkipValidation) {
-            await validateAmp(ampHtml, page + '?amp=1')
-          }
-          await promises.mkdir(ampBaseDir, { recursive: true })
-          await promises.writeFile(ampHtmlFilepath, ampHtml, 'utf8')
-        }
-      }
-
-      const metadata = renderResult?.metadata || ampRenderResult?.metadata || {}
-      if (metadata.pageData) {
-        const dataFile = join(
-          pagesDataDir,
-          htmlFilename.replace(/\.html$/, '.json')
-        )
-
-        await promises.mkdir(dirname(dataFile), { recursive: true })
-        await promises.writeFile(
-          dataFile,
-          JSON.stringify(metadata.pageData),
-          'utf8'
-        )
-
-        if (hybridAmp) {
-          await promises.writeFile(
-            dataFile.replace(/\.json$/, '.amp.json'),
-            JSON.stringify(metadata.pageData),
-            'utf8'
-          )
-        }
-      }
-      results.fromBuildExportRevalidate = metadata.revalidate
-
-      if (!results.ssgNotFound) {
-        // don't attempt writing to disk if getStaticProps returned not found
-        await promises.writeFile(htmlFilepath, html, 'utf8')
-      }
-    } catch (error) {
-      console.error(
-        `\nError occurred prerendering page "${path}". Read more: https://nextjs.org/docs/messages/prerender-error\n` +
-          (isError(error) && error.stack ? error.stack : error)
-      )
-      results.error = true
-    }
-    return { ...results, duration: Date.now() - start }
+  // Export the page.
+  const results = await exportPageSpan.traceAsyncFn(async () => {
+    return await exportPageImpl(input)
   })
+
+  // Return it's results.
+  return { ...results, duration: Date.now() - start }
 }

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -8,6 +8,7 @@ import type {
 
 // Polyfill fetch for the export worker.
 import '../server/node-polyfill-fetch'
+import '../server/node-polyfill-web-streams'
 import '../server/node-environment'
 
 process.env.NEXT_IS_EXPORT_WORKER = 'true'

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -28,7 +28,7 @@ import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 
 import { createRequestResponseMocks } from '../server/lib/mock-request'
 import { isAppRouteRoute } from '../lib/is-app-route-route'
-import * as ciEnvironment from '../telemetry/ci-info'
+import { hasNextSupport } from '../telemetry/ci-info'
 import { exportAppRoute } from './routes/app-route'
 import { exportAppPage } from './routes/app-page'
 import { exportPages } from './routes/pages'
@@ -289,7 +289,7 @@ async function exportPageImpl(input: ExportPageInput) {
       originalPathname: page,
     }
 
-    if (ciEnvironment.hasNextSupport) {
+    if (hasNextSupport) {
       renderOpts.isRevalidate = true
     }
 

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -3,6 +3,7 @@ import type { ServerRuntime, SizeLimit } from '../../../types'
 import { NextConfigComplete } from '../../server/config-shared'
 import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
 import type { NextFontManifest } from '../../build/webpack/plugins/next-font-manifest-plugin'
+import type { ParsedUrlQuery } from 'querystring'
 
 import zod from 'zod'
 
@@ -149,6 +150,7 @@ export type RenderOptsPartial = {
     silent?: boolean
   ) => Promise<NextConfigComplete>
   serverActionsBodySizeLimit?: SizeLimit
+  params?: ParsedUrlQuery
 }
 
 export type RenderOpts = LoadComponentsReturnType & RenderOptsPartial

--- a/packages/next/src/server/lib/mock-request.ts
+++ b/packages/next/src/server/lib/mock-request.ts
@@ -139,7 +139,7 @@ export interface MockedResponseOptions {
   statusCode?: number
   socket?: Socket | null
   headers?: OutgoingHttpHeaders
-  resWriter?: (chunk: Buffer | string) => boolean
+  resWriter?: (chunk: Uint8Array | Buffer | string) => boolean
 }
 
 export class MockedResponse extends Stream.Writable implements ServerResponse {
@@ -232,7 +232,7 @@ export class MockedResponse extends Stream.Writable implements ServerResponse {
     return this.socket
   }
 
-  public write(chunk: Buffer | string) {
+  public write(chunk: Uint8Array | Buffer | string) {
     if (this.resWriter) {
       return this.resWriter(chunk)
     }
@@ -436,7 +436,7 @@ interface RequestResponseMockerOptions {
   headers?: IncomingHttpHeaders
   method?: string
   bodyReadable?: Stream.Readable
-  resWriter?: (chunk: Buffer | string) => boolean
+  resWriter?: (chunk: Uint8Array | Buffer | string) => boolean
   socket?: Socket | null
 }
 

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -6,11 +6,11 @@ export function isAbortError(e: any): e is Error & { name: 'AbortError' } {
  * This is a minimal implementation of a Writable with just enough
  * functionality to handle stream cancellation.
  */
-export interface PipeTarget {
+export interface PipeTarget<R = any> {
   /**
    * Called when new data is read from readable source.
    */
-  write: (chunk: Uint8Array) => unknown
+  write: (chunk: R) => unknown
 
   /**
    * Always called once we read all data (if the writable isn't already
@@ -39,8 +39,8 @@ export interface PipeTarget {
 }
 
 export async function pipeReadable(
-  readable: ReadableStream,
-  writable: PipeTarget
+  readable: ReadableStream<Uint8Array>,
+  writable: PipeTarget<Uint8Array>
 ) {
   const reader = readable.getReader()
   let readerDone = false
@@ -73,6 +73,7 @@ export async function pipeReadable(
       }
 
       if (value) {
+        // TODO: maybe we can remove this buffer?
         writable.write(Buffer.from(value))
         writable.flush?.()
       }

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -73,8 +73,7 @@ export async function pipeReadable(
       }
 
       if (value) {
-        // TODO: maybe we can remove this buffer?
-        writable.write(Buffer.from(value))
+        writable.write(value)
         writable.flush?.()
       }
     }

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -14,7 +14,7 @@ export type RenderResultMetadata = {
   fetchTags?: string
 }
 
-type RenderResultResponse = string | ReadableStream<Uint8Array> | null
+type RenderResultResponse = ReadableStream<Uint8Array> | string | null
 
 export default class RenderResult {
   /**
@@ -97,7 +97,7 @@ export default class RenderResult {
     return this.response
   }
 
-  public async pipe(res: PipeTarget): Promise<void> {
+  public async pipe(res: PipeTarget<Uint8Array>): Promise<void> {
     if (this.response === null) {
       throw new Error('Invariant: response is null. This is a bug in Next.js')
     }

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -245,7 +245,7 @@ export type RenderOptsPartial = {
   ampOptimizerConfig?: { [key: string]: any }
   isDataReq?: boolean
   params?: ParsedUrlQuery
-  previewProps: __ApiPreviewProps
+  previewProps: __ApiPreviewProps | undefined
   basePath: string
   unstable_runtimeJS?: false
   unstable_JsPreload?: false
@@ -602,7 +602,8 @@ export async function renderToHTMLImpl(
   if (
     (isSSG || getServerSideProps) &&
     !isFallback &&
-    process.env.NEXT_RUNTIME !== 'edge'
+    process.env.NEXT_RUNTIME !== 'edge' &&
+    previewProps
   ) {
     // Reads of this are cached on the `req` object, so this should resolve
     // instantly. There's no need to pass this data down from a previous
@@ -1536,12 +1537,20 @@ export async function renderToHTMLImpl(
   return new RenderResult(optimizedHtml, renderResultMeta)
 }
 
-export async function renderToHTML(
+export type PagesRender = (
   req: IncomingMessage,
   res: ServerResponse,
   pathname: string,
   query: NextParsedUrlQuery,
   renderOpts: RenderOpts
-): Promise<RenderResult> {
+) => Promise<RenderResult>
+
+export const renderToHTML: PagesRender = (
+  req,
+  res,
+  pathname,
+  query,
+  renderOpts
+): Promise<RenderResult> => {
   return renderToHTMLImpl(req, res, pathname, query, renderOpts, renderOpts)
 }

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -283,6 +283,11 @@ export type RenderOptsPartial = {
 
 export type RenderOpts = LoadComponentsReturnType & RenderOptsPartial
 
+/**
+ * RenderOptsExtra is being used to split away functionality that's within the
+ * renderOpts. Eventually we can have more explicit render options for each
+ * route kind.
+ */
 export type RenderOptsExtra = {
   App: AppType
   Document: DocumentType
@@ -1551,6 +1556,6 @@ export const renderToHTML: PagesRender = (
   pathname,
   query,
   renderOpts
-): Promise<RenderResult> => {
+) => {
   return renderToHTMLImpl(req, res, pathname, query, renderOpts, renderOpts)
 }

--- a/test/integration/edge-runtime-streaming-error/test/index.test.ts
+++ b/test/integration/edge-runtime-streaming-error/test/index.test.ts
@@ -22,7 +22,10 @@ function test(context: ReturnType<typeof createContext>) {
     await waitFor(200)
     await check(
       () => stripAnsi(context.output),
-      new RegExp(`The first argument must be of type string`, 'm')
+      new RegExp(
+        `The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type boolean`,
+        'm'
+      )
     )
     expect(stripAnsi(context.output)).not.toContain('webpack-internal:')
   }


### PR DESCRIPTION
In order to support updates to the prerendering pipelines, this breaks out some of the prerendering
code into discrete chunks importable for each route kind rather than them all sharing the same
function.

Some small optimizations were made, namely some matcher memoization (only the last one) that should
help with large builds locally.
