### PR TITLE
Fix importing name multiple times with the `named_import` transform

### DIFF
--- a/packages/next-swc/crates/core/tests/fixture/named-import-transform/1/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/named-import-transform/1/input.js
@@ -1,3 +1,3 @@
-import { A, B, C as F } from 'foo'
+import { A, B, C as F, A as G } from 'foo'
 import D from 'bar'
 import E from 'baz'

--- a/packages/next-swc/crates/core/tests/fixture/named-import-transform/1/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/named-import-transform/1/output.js
@@ -1,3 +1,3 @@
-import { A, B, C as F } from "__barrel_optimize__?names=A,B,C!=!foo";
+import { A, B, C as F, A as G } from "__barrel_optimize__?names=A,B,C!=!foo";
 import D from 'bar';
 import E from 'baz';


### PR DESCRIPTION
Specific case: https://twitter.com/shuding_/status/1704220735726633205


> import { User, User as foo } from 'lucide-react'
In your codebase so `User` got imported twice