### PR TITLE
refactor: use `fs.existsSync` instead of `accessSync`

### DIFF
--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from 'fs'
+import { promises as fs, existsSync } from 'fs'
 import chalk from 'next/dist/compiled/chalk'
 import path from 'path'
 
@@ -12,7 +12,7 @@ import { hasEslintConfiguration } from './hasEslintConfiguration'
 import { writeOutputFile } from './writeOutputFile'
 
 import { ESLINT_PROMPT_VALUES } from '../constants'
-import { existsSync, findPagesDir } from '../find-pages-dir'
+import { findPagesDir } from '../find-pages-dir'
 import { installDependencies } from '../install-dependencies'
 import { hasNecessaryDependencies } from '../has-necessary-dependencies'
 

--- a/packages/next/src/lib/find-pages-dir.ts
+++ b/packages/next/src/lib/find-pages-dir.ts
@@ -1,22 +1,13 @@
 import fs from 'fs'
 import path from 'path'
 
-export const existsSync = (f: string): boolean => {
-  try {
-    fs.accessSync(f, fs.constants.F_OK)
-    return true
-  } catch (_) {
-    return false
-  }
-}
-
 export function findDir(dir: string, name: 'pages' | 'app'): string | null {
   // prioritize ./${name} over ./src/${name}
   let curDir = path.join(dir, name)
-  if (existsSync(curDir)) return curDir
+  if (fs.existsSync(curDir)) return curDir
 
   curDir = path.join(dir, 'src', name)
-  if (existsSync(curDir)) return curDir
+  if (fs.existsSync(curDir)) return curDir
 
   return null
 }


### PR DESCRIPTION
There is no need to have accessSync since it throws an error, and creation of errors are costly. 