### PR TITLE
fix: Invoke cancel, only if the stream is not closed

### DIFF
--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -58,7 +58,7 @@ export async function pipeReadable(
     // will also ensure the read promise rejects and frees our resources.
     if (!readerDone) {
       readerDone = true
-      reader.cancel().catch(() => {})
+      if (!reader.closed) reader.cancel().catch(() => {})
     }
   }
   writable.on('close', onClose)
@@ -88,7 +88,7 @@ export async function pipeReadable(
     // If we broke out of the loop because of a client disconnect, and the
     // close event hasn't yet fired, we can early cancel.
     if (!readerDone) {
-      reader.cancel().catch(() => {})
+      if (!reader.closed) reader.cancel().catch(() => {})
     }
 
     // If the client hasn't disconnected yet, end the writable so that the


### PR DESCRIPTION
### What?

Attempt at fixing #55608

### How?

Guard the call to stream cancel, by checking if the stream's not already closed

Fixes #55608

Not sure how to test this one. e2e perhaps?

it fixes specifically the error triggered on this reproduction repo: https://github.com/willianrod/next-readable-stream-error
