### PR TITLE
ensure `fetchServerResponse` is a valid record when stored in router cache

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -319,7 +319,14 @@ export function navigateReducer(
           treePatch,
           // eslint-disable-next-line no-loop-func
           () =>
-            fetchServerResponse(url, currentTree, state.nextUrl, state.buildId)
+            createRecordFromThenable(
+              fetchServerResponse(
+                url,
+                currentTree,
+                state.nextUrl,
+                state.buildId
+              )
+            )
         )
       }
 


### PR DESCRIPTION
Since these values are inserted into the cache and read with `readRecordValue`, they need to have a `status` property otherwise it'll be re-thrown in `navigate-reducer`. Investigating if this resolves an issue where under certain circumstances navigations get stuck suspending. 

Closes NEXT-1643
