### PR TITLE
turbopack: Rewrite ESM modules to CJS during client transition

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -6,7 +6,6 @@ use turbopack_binding::turbopack::{
         module::Module,
         reference_type::{EntryReferenceSubType, ReferenceType},
         source::Source,
-        virtual_source::VirtualSource,
     },
     ecmascript::chunk::EcmascriptChunkPlaceable,
     turbopack::{

--- a/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -2,9 +2,11 @@ use anyhow::{bail, Result};
 use turbo_tasks::{Value, Vc};
 use turbopack_binding::turbopack::{
     core::{
+        file_source::FileSource,
         module::Module,
         reference_type::{EntryReferenceSubType, ReferenceType},
         source::Source,
+        virtual_source::VirtualSource,
     },
     ecmascript::chunk::EcmascriptChunkPlaceable,
     turbopack::{
@@ -45,8 +47,19 @@ impl Transition for NextEcmascriptClientReferenceTransition {
         context: Vc<ModuleAssetContext>,
         _reference_type: Value<ReferenceType>,
     ) -> Result<Vc<Box<dyn Module>>> {
+        let ident = source.ident().await?;
+        let ident_path = ident.path.await?;
+        let client_source = if ident_path.path.contains("next/dist/esm/") {
+            let path = ident
+                .path
+                .root()
+                .join(ident_path.path.replace("next/dist/esm/", "next/dist/"));
+            Vc::upcast(FileSource::new_with_query(path, ident.query))
+        } else {
+            source
+        };
         let client_module = self.client_transition.process(
-            source,
+            client_source,
             context,
             Value::new(ReferenceType::Entry(
                 EntryReferenceSubType::AppClientComponent,


### PR DESCRIPTION
### What?

I'm not sure if this is necessary, but while investigating #55689 I found that the RSC code that we send to the client continues to use the ESM outputs during resolution.

The problem is that the RSC server code uses ESM, then tries to send that down to the client. We have a `NextSharedRuntimeResolvePlugin` which handles rewriting _some_ modules (the shared runtimes) to CJS, but that doesn't apply to the main entry points that are RSC rendered, like `app-router`.

### Why?

Webpack seems to only resolve to CJS routes.

### How?

We manually rewrite "transition" entry points to the CJS output, just like the resolve plugin.

Closes WEB-1618