### PR TITLE
Remove the left padding in `next info` output

### DIFF
--- a/docs/02-app/02-api-reference/08-next-cli.mdx
+++ b/docs/02-app/02-api-reference/08-next-cli.mdx
@@ -158,19 +158,19 @@ will give you information like this example:
 
 ```bash filename="Terminal"
 
-    Operating System:
-      Platform: linux
-      Arch: x64
-      Version: #22-Ubuntu SMP Fri Nov 5 13:21:36 UTC 2021
-    Binaries:
-      Node: 16.13.0
-      npm: 8.1.0
-      Yarn: 1.22.17
-      pnpm: 6.24.2
-    Relevant packages:
-      next: 12.0.8
-      react: 17.0.2
-      react-dom: 17.0.2
+Operating System:
+  Platform: linux
+  Arch: x64
+  Version: #22-Ubuntu SMP Fri Nov 5 13:21:36 UTC 2021
+Binaries:
+  Node: 16.13.0
+  npm: 8.1.0
+  Yarn: 1.22.17
+  pnpm: 6.24.2
+Relevant packages:
+  next: 12.0.8
+  react: 17.0.2
+  react-dom: 17.0.2
 
 ```
 

--- a/packages/next/src/cli/next-info.ts
+++ b/packages/next/src/cli/next-info.ts
@@ -83,17 +83,17 @@ function getBinaryVersion(binaryName: string) {
 function printHelp() {
   console.log(
     `
-    Description
-      Prints relevant details about the current system which can be used to report Next.js bugs
+Description
+  Prints relevant details about the current system which can be used to report Next.js bugs
 
-    Usage
-      $ next info
+Usage
+  $ next info
 
-    Options
-      --help, -h    Displays this message
-      --verbose     Collect additional information for debugging
+Options
+  --help, -h    Displays this message
+  --verbose     Collect additional information for debugging
 
-    Learn more: ${chalk.cyan('https://nextjs.org/docs/api-reference/cli#info')}`
+Learn more: ${chalk.cyan('https://nextjs.org/docs/api-reference/cli#info')}`
   )
 }
 
@@ -105,23 +105,23 @@ async function printDefaultInfo() {
   const nextConfig = await getNextConfig()
 
   console.log(`
-    Operating System:
-      Platform: ${os.platform()}
-      Arch: ${os.arch()}
-      Version: ${os.version()}
-    Binaries:
-      Node: ${process.versions.node}
-      npm: ${getBinaryVersion('npm')}
-      Yarn: ${getBinaryVersion('yarn')}
-      pnpm: ${getBinaryVersion('pnpm')}
-    Relevant Packages:
-      next: ${installedRelease}
-      eslint-config-next: ${getPackageVersion('eslint-config-next')}
-      react: ${getPackageVersion('react')}
-      react-dom: ${getPackageVersion('react-dom')}
-      typescript: ${getPackageVersion('typescript')}
-    Next.js Config:
-      output: ${nextConfig.output}
+Operating System:
+  Platform: ${os.platform()}
+  Arch: ${os.arch()}
+  Version: ${os.version()}
+Binaries:
+  Node: ${process.versions.node}
+  npm: ${getBinaryVersion('npm')}
+  Yarn: ${getBinaryVersion('yarn')}
+  pnpm: ${getBinaryVersion('pnpm')}
+Relevant Packages:
+  next: ${installedRelease}
+  eslint-config-next: ${getPackageVersion('eslint-config-next')}
+  react: ${getPackageVersion('react')}
+  react-dom: ${getPackageVersion('react-dom')}
+  typescript: ${getPackageVersion('typescript')}
+Next.js Config:
+  output: ${nextConfig.output}
 
 `)
 

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -792,23 +792,23 @@ describe('CLI Usage', () => {
     function matchInfoOutput(stdout, { nextConfigOutput = '.*' } = {}) {
       expect(stdout).toMatch(
         new RegExp(`
-    Operating System:
-      Platform: .*
-      Arch: .*
-      Version: .*
-    Binaries:
-      Node: .*
-      npm: .*
-      Yarn: .*
-      pnpm: .*
-    Relevant Packages:
-      next: .*
-      eslint-config-next: .*
-      react: .*
-      react-dom: .*
-      typescript: .*
-    Next.js Config:
-      output: ${nextConfigOutput}
+Operating System:
+  Platform: .*
+  Arch: .*
+  Version: .*
+Binaries:
+  Node: .*
+  npm: .*
+  Yarn: .*
+  pnpm: .*
+Relevant Packages:
+  next: .*
+  eslint-config-next: .*
+  react: .*
+  react-dom: .*
+  typescript: .*
+Next.js Config:
+  output: ${nextConfigOutput}
 `)
       )
     }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

## Why?

Although the left padding makes the output looks good in the terminal, it causes this weird alignment in almost all bug reports:

```yaml
Operating System:
      Platform: win32
      Arch: x64
      Version: Windows 10 Pro
    Binaries:
      Node: 18.12.0
      npm: N/A
      Yarn: N/A
      pnpm: N/A
    Relevant Packages:
      next: 13.5.2-canary.2
      eslint-config-next: 13.5.2
      react: 18.2.0
      react-dom: 18.2.0
      typescript: 5.2.2
    Next.js Config:
      output: N/A
```

If I want it to look nice in the bug report

```yaml
Operating System:
  Platform: darwin
  Arch: arm64
  Version: Darwin Kernel Version 23.0.0: Thu Aug 17 21:23:02 PDT 2023; root:xnu-10002.1.11~3/RELEASE_ARM64_T8112
Binaries:
  Node: 20.3.1
  npm: 9.6.7
  Yarn: 1.22.19
  pnpm: 8.6.12
Relevant Packages:
  next: 13.5.2
  eslint-config-next: N/A
  react: 18.2.0
  react-dom: 18.2.0
  typescript: 5.2.2
Next.js Config:
  output: N/A
```

I have to paste this to a text editor and manually remove the first four spaces on every lines.

### How?

This PR removes that four-space padding to make future bug reports look a bit nicer.