### PR TITLE
chore: bump `nissuer`

### DIFF
--- a/.github/workflows/issue_validator.yml
+++ b/.github/workflows/issue_validator.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Nissuer
-        uses: balazsorban44/nissuer@1.4.0
+        uses: balazsorban44/nissuer@1.5.0
         with:
           label-area-prefix: 'area:'
           label-area-section: 'Which area\(s\) are affected\? \(Select all that apply\)(.*)### Additional context'


### PR DESCRIPTION
### What?

This introduces a weighting measurement when determining comments as unhelpful.

### Why?

Too many "same issue" comments in general, but it's hard to do an exact match with only regex.

### How?

Exact code can be found here:
https://github.com/balazsorban44/nissuer/blob/b3363e794827624199a889aa7c617c81a1b215dd/index.js#L203-L213

In short, by default if a comment is less than 30% different from unhelpful words, the whole comment will be considered unhelpful.

[Slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1695287105298299)