### PR TITLE
fix(ts): allow auto-import of `next/navigation`

### DIFF
--- a/packages/next/index.d.ts
+++ b/packages/next/index.d.ts
@@ -10,6 +10,7 @@
 /// <reference path="./head.d.ts" />
 /// <reference path="./image.d.ts" />
 /// <reference path="./link.d.ts" />
+/// <reference path="./navigation.d.ts" />
 /// <reference path="./router.d.ts" />
 /// <reference path="./script.d.ts" />
 /// <reference path="./server.d.ts" />


### PR DESCRIPTION
Fix auto-import of `next/navigation` when a method is referenced in VSCode

Closes NEXT-1649
Fixes #55741
