### PR TITLE
test(turbopack): remove escape hatches for custom turbopack bindings

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -234,7 +234,6 @@ const nextDev: CliCommand = async (args) => {
 
   if (process.env.TURBOPACK) {
     await validateTurboNextConfig({
-      isCustomTurbopack: !!process.env.__INTERNAL_CUSTOM_TURBOPACK_BINDINGS,
       ...devServerOptions,
       isDev: true,
     })

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -85,11 +85,9 @@ const prodSpecificTurboNextConfigOptions = [
 // check for babelrc, swc plugins
 export async function validateTurboNextConfig({
   dir,
-  isCustomTurbopack,
   isDev,
 }: {
   allowRetry?: boolean
-  isCustomTurbopack?: boolean
   dir: string
   port: number
   hostname?: string
@@ -212,9 +210,7 @@ export async function validateTurboNextConfig({
   if (!hasWarningOrError) {
     thankYouMessage = chalk.dim(thankYouMessage)
   }
-  if (!isCustomTurbopack) {
-    console.log(turbopackGradient + thankYouMessage)
-  }
+  console.log(turbopackGradient + thankYouMessage)
 
   let feedbackMessage = `Learn more about Next.js v13 and Turbopack: ${chalk.underline(
     'https://nextjs.link/with-turbopack'
@@ -252,7 +248,7 @@ export async function validateTurboNextConfig({
       .join('')}`
   }
 
-  if (unsupportedParts && !isCustomTurbopack) {
+  if (unsupportedParts) {
     const pkgManager = getPkgManager(dir)
 
     console.error(
@@ -269,23 +265,12 @@ If you cannot make the changes above, but still want to try out\nNext.js v13 wit
         `
     )
 
-    if (!isCustomTurbopack) {
-      console.warn(feedbackMessage)
+    console.warn(feedbackMessage)
 
-      process.exit(1)
-    } else {
-      console.warn('\n')
-      console.warn(
-        `${chalk.bold.yellow(
-          'Warning:'
-        )} Unsupported config found; but continuing with custom Turbopack binary.\n`
-      )
-    }
+    process.exit(1)
   }
 
-  if (!isCustomTurbopack) {
-    console.log(feedbackMessage)
-  }
+  console.log(feedbackMessage)
 
   return rawNextConfig
 }


### PR DESCRIPTION
### What?

This was a stopgap for the previous turbopack to ignore some config validation, but we shouldn't need it anymore with new turbopack to run test correctly.

Closes WEB-1626