### PR TITLE
test(fixture): prevent start failure teardowns whole process

### DIFF
--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -196,7 +196,12 @@ export async function createNext(
     try {
       nextInstance.destroy()
     } catch (_) {}
-    process.exit(1)
+
+    if (process.env.NEXT_TEST_CONTINUE_ON_ERROR) {
+      throw err
+    } else {
+      process.exit(1)
+    }
   } finally {
     flushAllTraces()
   }


### PR DESCRIPTION

### What?

In some test failures we've been observing test result is not written at all like


```
Failed to load test output [Error: ENOENT: no such file or directory, open 'test/e2e/app-dir/edge-runtime-node-compatibility/edge-runtime-node-compatibility.test.ts.results.json'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'test/e2e/app-dir/edge-runtime-node-compatibility/edge-runtime-node-compatibility.test.ts.results.json'
}
```

scrolling up, it was due to whole test process was taken down by calling process.exit explicitly.

We want to collect test results for the failures still, so the PR amends it for the cases if it's specified to continue on error.


Closes WEB-1628