### PR TITLE
Remove unused internal env var

### DIFF
--- a/packages/next-swc/crates/next-core/js/src/entry/app-renderer.tsx
+++ b/packages/next-swc/crates/next-core/js/src/entry/app-renderer.tsx
@@ -3,8 +3,6 @@
 import startOperationStreamHandler from '../internal/operation-stream'
 
 import '../polyfill/app-polyfills.ts'
-// TODO: when actions are supported, this should be removed/changed
-process.env.__NEXT_PRIVATE_PREBUNDLED_REACT = 'next'
 import 'next/dist/server/require-hook'
 
 import type { IncomingMessage } from 'node:http'

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -145,7 +145,6 @@ import { createClientRouterFilter } from '../lib/create-client-router-filter'
 import { createValidFileMatcher } from '../server/lib/find-page-file'
 import { startTypeChecking } from './type-check'
 import { generateInterceptionRoutesRewrites } from '../lib/generate-interception-routes-rewrites'
-import { needsExperimentalReact } from '../lib/needs-experimental-react'
 
 import { buildDataRoute } from '../server/lib/router-utils/build-data-route'
 import { defaultOverrides } from '../server/require-hook'
@@ -1256,9 +1255,6 @@ export default async function build(
               __NEXT_INCREMENTAL_CACHE_IPC_PORT: incrementalCacheIpcPort + '',
               __NEXT_INCREMENTAL_CACHE_IPC_KEY:
                 incrementalCacheIpcValidationKey,
-              __NEXT_PRIVATE_PREBUNDLED_REACT: needsExperimentalReact(config)
-                ? 'experimental'
-                : 'next',
             },
           },
           enableWorkerThreads: config.experimental.workerThreads,

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -67,7 +67,6 @@ import { nodeFs } from '../server/lib/node-fs-methods'
 import * as ciEnvironment from '../telemetry/ci-info'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import { denormalizeAppPagePath } from '../shared/lib/page-path/denormalize-app-path'
-import { needsExperimentalReact } from '../lib/needs-experimental-react'
 
 const { AppRouteRouteModule } =
   require('../server/future/route-modules/app-route/module.compiled') as typeof import('../server/future/route-modules/app-route/module')
@@ -1837,7 +1836,6 @@ export async function copyTracedFiles(
     ...serverConfig,
     distDir: `./${path.relative(dir, distDir)}`,
   }
-  const hasExperimentalReact = needsExperimentalReact(nextConfig)
   try {
     const packageJsonPath = path.join(distDir, '../package.json')
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'))
@@ -1994,9 +1992,6 @@ let keepAliveTimeout = parseInt(process.env.KEEP_ALIVE_TIMEOUT, 10)
 const nextConfig = ${JSON.stringify(nextConfig)}
 
 process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(nextConfig)
-process.env.__NEXT_PRIVATE_PREBUNDLED_REACT = ${hasExperimentalReact}
-  ? 'experimental'
-  : 'next'
 
 require('next')
 const { startServer } = require('next/dist/server/lib/start-server')

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -26,7 +26,6 @@ import {
   getReservedPortExplanation,
   isPortIsReserved,
 } from '../lib/helpers/get-reserved-port'
-import { needsExperimentalReact } from '../lib/needs-experimental-react'
 
 let dir: string
 let child: undefined | ReturnType<typeof fork>
@@ -198,10 +197,6 @@ const nextDev: CliCommand = async (args) => {
       )
     },
   })
-
-  process.env.__NEXT_PRIVATE_PREBUNDLED_REACT = needsExperimentalReact(config)
-    ? 'experimental'
-    : 'next'
 
   // we need to reset env if we are going to create
   // the worker process with the esm loader so that the


### PR DESCRIPTION
`__NEXT_PREBUNDLED_REACT` is replaced by `__NEXT_EXPERIMENTAL_REACT` as we're bundling built-in react for app router