### PR TITLE
Revert "fix: Invoke cancel, only if the stream is not closed (#55684)"

### DIFF
--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -58,7 +58,7 @@ export async function pipeReadable(
     // will also ensure the read promise rejects and frees our resources.
     if (!readerDone) {
       readerDone = true
-      if (!reader.closed) reader.cancel().catch(() => {})
+      reader.cancel().catch(() => {})
     }
   }
   writable.on('close', onClose)
@@ -88,7 +88,7 @@ export async function pipeReadable(
     // If we broke out of the loop because of a client disconnect, and the
     // close event hasn't yet fired, we can early cancel.
     if (!readerDone) {
-      if (!reader.closed) reader.cancel().catch(() => {})
+      reader.cancel().catch(() => {})
     }
 
     // If the client hasn't disconnected yet, end the writable so that the


### PR DESCRIPTION
This is causing test failures. `reader.closed` is a Promise (not a boolean) so this wouldn't have solved the issue 

[x-ref](https://github.com/vercel/next.js/actions/runs/6266707570/job/17018892465#step:29:704)
[x-ref](https://github.com/vercel/next.js/actions/runs/6266641982/job/17018064501#step:29:670)