### PR TITLE
Update fnm setup for CI

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -85,8 +85,7 @@ jobs:
       - 'metal'
 
     steps:
-      - run: fnm install ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
-      - run: fnm use ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
+      - run: fnm use --install-if-missing ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
       - run: node -v
       - run: corepack enable
       - run: pwd


### PR DESCRIPTION
We can use the cached version if available and only install if it's missing. 

x-ref: https://github.com/vercel/next.js/actions/runs/6267098663/job/17019478099?pr=55764