### PR TITLE
Fix output log extra new line

### DIFF
--- a/packages/next/src/build/spinner.ts
+++ b/packages/next/src/build/spinner.ts
@@ -15,7 +15,7 @@ export default function createSpinner(
 
   const prefixText = ` ${Log.prefixes.info} ${text}`
   // Add \r at beginning to reset the current line of loading status text
-  const suffixText = `\r ${Log.prefixes.event} ${text}`
+  const suffixText = `\r\x1b[K ${Log.prefixes.event} ${text}`
 
   if (process.stdout.isTTY) {
     spinner = ora({

--- a/packages/next/src/build/spinner.ts
+++ b/packages/next/src/build/spinner.ts
@@ -13,9 +13,9 @@ export default function createSpinner(
 ) {
   let spinner: undefined | ora.Ora
 
-  const prefixText = ` ${Log.prefixes.info} ${text}`
+  const prefixText = ` ${Log.prefixes.info} ${text} `
   // Add \r at beginning to reset the current line of loading status text
-  const suffixText = `\r\x1b[K ${Log.prefixes.event} ${text}`
+  const suffixText = `\r ${Log.prefixes.event} ${text} `
 
   if (process.stdout.isTTY) {
     spinner = ora({

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -126,9 +126,11 @@ const createProgress = (total: number, label: string) => {
     const isFinished = curProgress === total
     // Use \r to reset current line with spinner.
     // If it's 100% progressed, then we don't need to break a new line to avoid logging from routes while building.
-    const newText = `\r\x1b[K ${
+    const newText = `\r ${
       isFinished ? Log.prefixes.event : Log.prefixes.info
-    } ${label} (${curProgress}/${total})${isFinished ? '' : '\r\x1b[K'}`
+    } ${label} (${curProgress}/${total}) ${
+      isFinished ? '' : process.stdout.isTTY ? '\n' : '\r'
+    }`
     if (progressSpinner) {
       progressSpinner.text = newText
     } else {

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -126,9 +126,9 @@ const createProgress = (total: number, label: string) => {
     const isFinished = curProgress === total
     // Use \r to reset current line with spinner.
     // If it's 100% progressed, then we don't need to break a new line to avoid logging from routes while building.
-    const newText = `\r ${
+    const newText = `\r\x1b[K ${
       isFinished ? Log.prefixes.event : Log.prefixes.info
-    } ${label} (${curProgress}/${total})${isFinished ? '' : '\n'}`
+    } ${label} (${curProgress}/${total})${isFinished ? '' : '\r\x1b[K'}`
     if (progressSpinner) {
       progressSpinner.text = newText
     } else {


### PR DESCRIPTION
For progress spinner, only log new line when `process.stdout.isTTY`

## After

![image](https://github.com/vercel/next.js/assets/4800338/cb850b22-0985-4129-ba5e-961f3c914701)

## Before

![image](https://github.com/vercel/next.js/assets/4800338/5c69d964-74dd-432f-901d-ad86a4307422)

Adding extra space make sure there's loading bar between prefix text and spinner 

![image](https://github.com/vercel/next.js/assets/4800338/b99f7ec6-af9d-445b-a6ea-3d1592b4553d)


Closes NEXT-1647