### PR TITLE
test(turbopack): explicitly clean up instance for turbopack

### DIFF
--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -198,6 +198,8 @@ export async function createNext(
     } catch (_) {}
 
     if (process.env.NEXT_TEST_CONTINUE_ON_ERROR) {
+      // Other test should continue to create new instance if NEXT_TEST_CONTINUE_ON_ERROR explicitly specified.
+      nextInstance = undefined
       throw err
     } else {
       process.exit(1)


### PR DESCRIPTION
### What?

Minor improvement to test fixture to clean up the instance if explicitly specified to continue test. This is required to run turbopack related tests.

Closes WEB-1634