### PR TITLE
Fix missing async keyword in function declaration

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/opengraph-image.mdx
@@ -162,7 +162,7 @@ export const size = {
 export const contentType = 'image/png'
 
 // Image generation
-export default function Image() {
+export default async function Image() {
   // Font
   const interSemiBold = fetch(
     new URL('./Inter-SemiBold.ttf', import.meta.url)


### PR DESCRIPTION
Just a one word change to fix the example in https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image#generate-images-using-code-js-ts-tsx