### PR TITLE
docs: Correct place for passing `extension` option to `createMDX()`

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
@@ -251,8 +251,8 @@ import createMDX from '@next/mdx'
 const nextConfig = {}
 
 const withMDX = createMDX({
+  extension: /\.mdx?$/,
   options: {
-    extension: /\.mdx?$/,
     remarkPlugins: [remarkGfm],
     rehypePlugins: [],
     // If you use `MDXProvider`, uncomment the following line.


### PR DESCRIPTION

### What?

Fixing a little mistake in the documentation, where the placement of the `extension` option for `createMDX()` was described as being inside the `options` property:

```ts
const withMDX = createMDX({
  options: {
    extension: /\.mdx?$/,
```

But it's actually a property of its own:


```ts
const withMDX = createMDX({
  extension: /\.mdx?$/,
```

I confirmed that the latter is correct because:

- It solves an issue I was having: Unable to import `.md` files
- On the same docs page, there's another place where it mentions this `extension` option and the code example is correct there
- The option is described in a similar issue, such as https://github.com/vercel/next.js/issues/45431#issuecomment-1410363864
