### PR TITLE
turbopack: Add ability to skip flakey test cases individually

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -240,7 +240,7 @@ async function main() {
         const info = externalTestsFilterLists[test.file]
         // only run filtered mode when there are failing tests.
         // When the whole test suite passes we can run all tests, including newly added ones.
-        if (info.failed.length > 0) {
+        if (info.failed.length > 0 || info.flakey.length > 0) {
           test.cases = info.passed
         }
         return test

--- a/test/build-turbopack-tests-manifest.js
+++ b/test/build-turbopack-tests-manifest.js
@@ -33,6 +33,9 @@ const SKIPPED_TEST_SUITES = {
   'test/integration/dynamic-routing/test/index.test.js': [
     'Dynamic Routing production mode should have correct cache entries on prefetch',
   ],
+  'test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts': [
+    'ReactRefreshLogBox app turbo Module not found missing global CSS',
+  ],
 }
 
 async function updatePassingTests() {

--- a/test/build-turbopack-tests-manifest.js
+++ b/test/build-turbopack-tests-manifest.js
@@ -20,17 +20,20 @@ const INITIALIZING_TEST_CASES = [
   'should build successfully',
 ]
 
-const SKIPPED_TEST_SUITES = new Set([
-  'test/integration/router-rerender/test/index.test.js',
-  'test/e2e/basepath.test.ts',
-  'test/development/acceptance-app/ReactRefreshRequire.test.ts',
-  'test/integration/dynamic-routing/test/middleware.test.js',
-  'test/integration/css/test/css-modules.test.js',
-  'test/development/acceptance/ReactRefreshRequire.test.ts',
-  'test/integration/custom-routes/test/index.test.js',
-  'test/integration/absolute-assetprefix/test/index.test.js',
-  'test/e2e/middleware-rewrites/test/index.test.ts',
-])
+const SKIPPED_TEST_SUITES = {
+  'test/integration/router-rerender/test/index.test.js': [/.*/],
+  'test/e2e/basepath.test.ts': [/.*/],
+  'test/development/acceptance-app/ReactRefreshRequire.test.ts': [/.*/],
+  'test/integration/dynamic-routing/test/middleware.test.js': [/.*/],
+  'test/integration/css/test/css-modules.test.js': [/.*/],
+  'test/development/acceptance/ReactRefreshRequire.test.ts': [/.*/],
+  'test/integration/custom-routes/test/index.test.js': [/.*/],
+  'test/integration/absolute-assetprefix/test/index.test.js': [/.*/],
+  'test/e2e/middleware-rewrites/test/index.test.ts': [/.*/],
+  'test/integration/dynamic-routing/test/index.test.js': [
+    'Dynamic Routing production mode should have correct cache entries on prefetch',
+  ],
+}
 
 async function updatePassingTests() {
   const passing = { __proto__: null }
@@ -42,17 +45,19 @@ async function updatePassingTests() {
     for (const testResult of result.data.testResults) {
       const filepath = stripWorkingPath(testResult.name)
 
-      if (SKIPPED_TEST_SUITES.has(filepath)) continue
       const fileResults = (passing[filepath] ??= {
         passed: [],
         failed: [],
         pending: [],
+        flakey: [],
         runtimeError,
       })
+      const skips = SKIPPED_TEST_SUITES[filepath] ?? []
 
       let initializationFailed = false
       for (const testCase of testResult.assertionResults) {
         let { fullName, status } = testCase
+
         if (
           status === 'failed' &&
           INITIALIZING_TEST_CASES.some((name) => fullName.includes(name))
@@ -61,6 +66,10 @@ async function updatePassingTests() {
         } else if (initializationFailed) {
           status = 'failed'
         }
+        if (shouldSkip(fullName, skips)) {
+          status = 'flakey'
+        }
+
         const statusArray = fileResults[status]
         if (!statusArray) {
           throw new Error(`unexpected status "${status}"`)
@@ -87,11 +96,9 @@ async function updatePassingTests() {
       const newData = passing[file]
       const oldData = oldPassingData[file]
       if (!newData) continue
-      // We only want to keep test cases from the old data that are still exiting
-      oldData.passed = oldData.passed.filter(
-        (name) => newData.failed.includes(name) || newData.passed.includes(name)
-      )
-      // Grab test cases that passed before, but fail now
+
+      // We want to find old passing tests that are now failing, and report them.
+      // Tests are allowed transition to skipped or flakey.
       const shouldPass = new Set(
         oldData.passed.filter((name) => newData.failed.includes(name))
       )
@@ -102,9 +109,7 @@ async function updatePassingTests() {
         )
       }
       // Merge the old passing tests with the new ones
-      newData.passed = [
-        ...new Set([...oldData.passed, ...newData.passed]),
-      ].sort()
+      newData.passed = [...new Set([...shouldPass, ...newData.passed])].sort()
       // but remove them also from the failed list
       newData.failed = newData.failed
         .filter((name) => !shouldPass.has(name))
@@ -125,6 +130,19 @@ async function updatePassingTests() {
     PASSING_JSON_PATH,
     await format(JSON.stringify(ordered, null, 2))
   )
+}
+
+function shouldSkip(name, skips) {
+  for (const skip of skips) {
+    if (typeof skip === 'string') {
+      // exact match
+      if (name === skip) return true
+    } else {
+      // regex
+      if (skip.test(name)) return true
+    }
+  }
+  return false
 }
 
 function stripWorkingPath(path) {

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -6,6 +6,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/font/src/google/get-font-axes.test.ts": {
@@ -16,6 +17,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/font/src/google/loader.test.ts": {
@@ -35,6 +37,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/font/src/google/sort-fonts-variant-values.test.ts": {
@@ -46,6 +49,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/font/src/google/validate-google-font-function-call.test.ts": {
@@ -63,6 +67,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/font/src/local/loader.test.ts": {
@@ -75,6 +80,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/font/src/local/pick-font-file-for-fallback-generation.test.ts": {
@@ -88,6 +94,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/font/src/local/validate-local-font-function-call.test.ts": {
@@ -101,6 +108,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts": {
@@ -111,6 +119,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/build/webpack/plugins/next-types-plugin/index.test.ts": {
@@ -121,6 +130,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/navigation.test.ts": {
@@ -129,6 +139,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/promise-queue.test.ts": {
@@ -138,6 +149,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/react-dev-overlay/internal/components/hot-linked-text/get-words-and-whitespaces.test.ts": {
@@ -146,24 +158,28 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/redirect.test.ts": {
     "passed": ["test should throw a redirect error"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.test.tsx": {
     "passed": ["applyRouterStatePatchToTree should apply a patch to the tree"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/compute-changed-path.test.ts": {
     "passed": ["computeChangedPath should return the correct path"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/create-href-from-url.test.ts": {
@@ -176,6 +192,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx": {
@@ -184,12 +201,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/create-optimistic-tree.test.ts": {
     "passed": ["createOptimisticTree should create an optimistic tree"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/create-record-from-thenable.test.ts": {
@@ -199,6 +218,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/create-router-cache-key.test.ts": {
@@ -209,12 +229,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/fill-cache-with-data-property.test.tsx": {
     "passed": ["fillCacheWithDataProperty should add data property"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx": {
@@ -223,6 +245,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx": {
@@ -231,6 +254,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/get-segment-value.test.ts": {
@@ -241,6 +265,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx": {
@@ -249,6 +274,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx": {
@@ -257,6 +283,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.test.ts": {
@@ -266,6 +293,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/read-record-value.test.ts": {
@@ -275,12 +303,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx": {
     "passed": ["findHeadInCache should find the head"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx": {
@@ -298,6 +328,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx": {
@@ -307,6 +338,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx": {
@@ -318,6 +350,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/reducers/restore-reducer.test.tsx": {
@@ -327,6 +360,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx": {
@@ -337,6 +371,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/client/components/router-reducer/should-hard-navigate.test.tsx": {
@@ -347,12 +382,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/lib/format-server-error.test.ts": {
     "passed": ["formatServerError should not append message several times"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/lib/metadata/resolve-metadata.test.ts": {
@@ -377,6 +414,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/lib/metadata/resolvers/resolve-opengraph.test.ts": {
@@ -387,6 +425,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/lib/metadata/resolvers/resolve-title.test.ts": {
@@ -396,6 +435,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/lib/metadata/resolvers/resolve-url.test.ts": {
@@ -407,6 +447,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/dev/parse-version-info.test.ts": {
@@ -426,6 +467,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/helpers/i18n-provider.test.ts": {
@@ -446,6 +488,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/helpers/interception-routes.test.ts": {
@@ -458,6 +501,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/normalizers/absolute-filename-normalizer.test.ts": {
@@ -468,6 +512,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/route-matcher-managers/default-route-matcher-manager.test.ts": {
@@ -482,6 +527,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/route-matcher-providers/app-page-route-matcher-provider.test.ts": {
@@ -494,6 +540,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/route-matcher-providers/app-route-route-matcher-provider.test.ts": {
@@ -505,6 +552,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/route-matcher-providers/dev/dev-app-page-route-matcher-provider.test.ts": {
@@ -516,6 +564,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.test.ts": {
@@ -526,6 +575,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.test.ts": {
@@ -537,6 +587,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/route-matcher-providers/dev/dev-pages-route-matcher-provider.test.ts": {
@@ -549,6 +600,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/route-matcher-providers/dev/helpers/file-reader/batched-file-reader.test.ts": {
@@ -558,6 +610,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/route-matcher-providers/pages-api-route-matcher-provider.test.ts": {
@@ -569,6 +622,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/future/route-matcher-providers/pages-route-matcher-provider.test.ts": {
@@ -583,6 +637,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/lib/mock-request.test.ts": {
@@ -594,12 +649,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/node-polyfill-crypto.test.ts": {
     "passed": ["node-polyfill-crypto overwrite crypto"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/web/spec-extension/adapters/headers.test.ts": {
@@ -622,6 +679,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts": {
@@ -631,6 +689,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/server/web/utils.test.ts": {
@@ -642,6 +701,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/shared/lib/get-hostname.test.ts": {
@@ -665,6 +725,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/shared/lib/router/adapters.test.tsx": {
@@ -680,6 +741,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/shared/lib/router/utils/app-paths.test.ts": {
@@ -691,6 +753,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "packages/next/src/shared/lib/router/utils/route-regex.test.ts": {
@@ -703,6 +766,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/ReactRefresh.test.ts": {
@@ -712,6 +776,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts": {
@@ -728,12 +793,14 @@
       "ReactRefreshLogBox app default Module not found missing global CSS",
       "ReactRefreshLogBox app default Node.js builtins"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts": {
     "passed": [],
     "failed": ["ReactRefreshLogBox app scss syntax errors"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/ReactRefreshLogBox.test.ts": {
@@ -779,6 +846,7 @@
       "ReactRefreshLogBox app turbo internal package errors",
       "ReactRefreshLogBox app turbo non-Error errors are handled properly"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts": {
@@ -789,12 +857,14 @@
       "ReactRefreshLogBox app <Link> with multiple children",
       "ReactRefreshLogBox app server-side only compilation errors"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/ReactRefreshModule.test.ts": {
     "passed": [],
     "failed": ["ReactRefreshModule app should allow any variable names"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/ReactRefreshRegression.test.ts": {
@@ -812,6 +882,31 @@
     "pending": [
       "ReactRefreshRegression app styled-components hydration mismatch"
     ],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/development/acceptance-app/ReactRefreshRequire.test.ts": {
+    "passed": [],
+    "failed": [],
+    "pending": [],
+    "flakey": [
+      "ReactRefreshRequire app re-runs accepted modules",
+      "ReactRefreshRequire app propagates a hot update to closest accepted module",
+      "ReactRefreshRequire app propagates hot update to all inverse dependencies",
+      "ReactRefreshRequire app runs dependencies before dependents",
+      "ReactRefreshRequire app provides fresh value for module.exports in parents",
+      "ReactRefreshRequire app provides fresh value for exports.* in parents",
+      "ReactRefreshRequire app provides fresh value for ES6 named import in parents",
+      "ReactRefreshRequire app provides fresh value for ES6 default import in parents",
+      "ReactRefreshRequire app stops update propagation after module-level errors",
+      "ReactRefreshRequire app can continue hot updates after module-level errors with module.exports",
+      "ReactRefreshRequire app can continue hot updates after module-level errors with ES6 exports",
+      "ReactRefreshRequire app does not accumulate stale exports over time",
+      "ReactRefreshRequire app bails out if update bubbles to the root via the only path",
+      "ReactRefreshRequire app bails out if the update bubbles to the root via one of the paths",
+      "ReactRefreshRequire app propagates a module that stops accepting in next version",
+      "ReactRefreshRequire app can replace a module before it is loaded"
+    ],
     "runtimeError": false
   },
   "test/development/acceptance-app/app-hmr-changes.test.ts": {
@@ -820,6 +915,7 @@
       "Error overlay - RSC build errors should handle successive HMR changes with errors correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/component-stack.test.ts": {
@@ -828,6 +924,7 @@
       "Component Stack in error overlay should show a component stack on hydration error"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/dynamic-error.test.ts": {
@@ -836,6 +933,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/editor-links.test.ts": {
@@ -846,6 +944,7 @@
       "Error overlay - editor links should be possible to open source file on build error"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/error-message-url.test.ts": {
@@ -856,6 +955,7 @@
       "Error overlay - error message urls should be possible to click url in build error"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/error-recovery.test.ts": {
@@ -884,6 +984,7 @@
       "Error recovery app default stuck error",
       "Error recovery app default syntax > runtime error"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/hydration-error.test.ts": {
@@ -898,6 +999,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/invalid-imports.test.ts": {
@@ -908,6 +1010,7 @@
       "Error Overlay invalid imports should show error when using styled-jsx in server component"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/rsc-build-errors.test.ts": {
@@ -932,6 +1035,7 @@
     "pending": [
       "Error overlay - RSC build errors should throw an error when getStaticProps is used"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/server-components.test.ts": {
@@ -955,6 +1059,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance-app/version-staleness.test.ts": {
@@ -965,6 +1070,7 @@
       "Error Overlay version staleness should show version staleness in render error",
       "Error Overlay version staleness should show version staleness in runtime error"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance/ReactRefresh.test.ts": {
@@ -974,6 +1080,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts": {
@@ -991,6 +1098,7 @@
       "ReactRefreshLogBox default empty _app shows logbox",
       "ReactRefreshLogBox default empty _document shows logbox"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance/ReactRefreshLogBox-builtins.test.ts": {
@@ -1008,12 +1116,14 @@
       "ReactRefreshLogBox default Module not found (missing global CSS)",
       "ReactRefreshLogBox default Node.js builtins"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance/ReactRefreshLogBox-scss.test.ts": {
     "passed": [],
     "failed": [],
     "pending": ["ReactRefreshLogBox scss syntax errors"],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance/ReactRefreshLogBox.test.ts": {
@@ -1041,6 +1151,7 @@
       "ReactRefreshLogBox default unterminated JSX",
       "ReactRefreshLogBox turbo internal package errors"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance/ReactRefreshLogBoxMisc.test.ts": {
@@ -1051,12 +1162,14 @@
       "ReactRefreshLogBox <Link> with multiple children",
       "ReactRefreshLogBox server-side only compilation errors"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance/ReactRefreshModule.test.ts": {
     "passed": [],
     "failed": ["ReactRefreshModule should allow any variable names"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance/ReactRefreshRegression.test.ts": {
@@ -1071,6 +1184,31 @@
       "ReactRefreshRegression shows an overlay for a server-side error"
     ],
     "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/development/acceptance/ReactRefreshRequire.test.ts": {
+    "passed": [],
+    "failed": [],
+    "pending": [],
+    "flakey": [
+      "ReactRefreshRequire re-runs accepted modules",
+      "ReactRefreshRequire propagates a hot update to closest accepted module",
+      "ReactRefreshRequire propagates hot update to all inverse dependencies",
+      "ReactRefreshRequire runs dependencies before dependents",
+      "ReactRefreshRequire provides fresh value for module.exports in parents",
+      "ReactRefreshRequire provides fresh value for exports.* in parents",
+      "ReactRefreshRequire provides fresh value for ES6 named import in parents",
+      "ReactRefreshRequire provides fresh value for ES6 default import in parents",
+      "ReactRefreshRequire stops update propagation after module-level errors",
+      "ReactRefreshRequire can continue hot updates after module-level errors with module.exports",
+      "ReactRefreshRequire can continue hot updates after module-level errors with ES6 exports",
+      "ReactRefreshRequire does not accumulate stale exports over time",
+      "ReactRefreshRequire bails out if update bubbles to the root via the only path",
+      "ReactRefreshRequire bails out if the update bubbles to the root via one of the paths",
+      "ReactRefreshRequire propagates a module that stops accepting in next version",
+      "ReactRefreshRequire can replace a module before it is loaded"
+    ],
     "runtimeError": false
   },
   "test/development/acceptance/component-stack.test.ts": {
@@ -1079,6 +1217,7 @@
       "Component Stack in error overlay should show a component stack on hydration error"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance/error-recovery.test.ts": {
@@ -1100,6 +1239,7 @@
       "ReactRefreshLogBox default stuck error",
       "ReactRefreshLogBox default syntax > runtime error"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance/hydration-error.test.ts": {
@@ -1108,6 +1248,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/acceptance/server-component-compiler-errors-in-pages.test.ts": {
@@ -1117,6 +1258,7 @@
       "Error Overlay for server components compiler errors in pages importing 'server-only' in pages"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/api-cors-with-rewrite/index.test.ts": {
@@ -1125,6 +1267,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/api-route-errors/index.test.ts": {
@@ -1135,12 +1278,14 @@
       "api-route-errors cli output unhandled rejection"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/app-dir/basic/basic.test.ts": {
     "passed": ["basic app-dir tests should reload app pages without error"],
     "failed": [],
     "pending": ["basic app-dir tests should reload app pages without error"],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/app-dir/multiple-compiles-single-route/multiple-compiles-single-route.test.ts": {
@@ -1149,12 +1294,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/app-dir/strict-mode-enabled-by-default/strict-mode-enabled-by-default.test.ts": {
     "passed": ["Strict Mode enabled by default should work using browser"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/app-hmr/hmr.test.ts": {
@@ -1168,6 +1315,7 @@
       "app-dir-hmr filesystem changes should update server components pages when env files is changed (nodejs)"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/development/app-render-error-log/app-render-error-log.test.ts": {
@@ -1177,12 +1325,14 @@
       "app-render-error-log should log the correct values on app-render error with edge runtime"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/asset-prefix.test.ts": {
     "passed": ["asset-prefix should load the app properly without reloading"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/barrel-optimization.test.ts": {
@@ -1196,6 +1346,7 @@
       "optimizePackageImports should support visx"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/define-class-fields.test.ts": {
@@ -1206,12 +1357,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/emotion-swc.test.ts": {
     "passed": ["emotion SWC option should have styling from the css prop"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/gssp-ssr-change-reloading/test/index.test.ts": {
@@ -1232,6 +1385,7 @@
       "GS(S)P Server-Side Change Reloading should update page when getStaticProps is changed only for /another/index"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/hmr.test.ts": {
@@ -1294,6 +1448,7 @@
       "basic HMR, basePath: \"/docs\" should have correct compile timing after fixing error"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/legacy-decorators.test.ts": {
@@ -1302,6 +1457,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/misc.test.ts": {
@@ -1323,6 +1479,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/next-dynamic.test.ts": {
@@ -1399,6 +1556,7 @@
       "basic next/dynamic usage, basePath: \"/docs\" with \"swc\" compiler Dynamic import ssr:true option Should render the component on the server side"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/development/basic/next-rs-api.test.ts": {
@@ -1430,6 +1588,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/node-builtins.test.ts": {
@@ -1443,6 +1602,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/project-directory-rename.test.ts": {
@@ -1451,6 +1611,7 @@
     "pending": [
       "Project Directory Renaming should detect project dir rename and restart"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/styled-components-disabled.test.ts": {
@@ -1459,6 +1620,7 @@
       "styled-components SWC transform should have hydration mismatch with styled-components transform disabled"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/styled-components.test.ts": {
@@ -1472,18 +1634,21 @@
       "styled-components SWC transform should enable the display name transform by default"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/tailwind-jit.test.ts": {
     "passed": ["TailwindCSS JIT works with JIT enabled"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/basic/theme-ui.test.ts": {
     "passed": ["theme-ui SWC option should have theme provided styling"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/client-dev-overlay/index.test.ts": {
@@ -1495,6 +1660,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/correct-tsconfig-defaults/index.test.ts": {
@@ -1504,12 +1670,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/dotenv-default-expansion/index.test.ts": {
     "passed": ["Dotenv default expansion should work"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/experimental-https-server/https-server.generated-key.test.ts": {
@@ -1518,6 +1686,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/experimental-https-server/https-server.provided-key.test.ts": {
@@ -1527,6 +1696,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/gssp-notfound/index.test.ts": {
@@ -1535,6 +1705,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/jsconfig-path-reloading/index.test.ts": {
@@ -1548,6 +1719,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/middleware-errors/index.test.ts": {
@@ -1572,6 +1744,7 @@
       "middleware - development errors when throwing while loading the module renders the error correctly and recovers"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/middleware-warnings/index.test.ts": {
@@ -1587,6 +1760,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/next-font/build-errors.test.ts": {
@@ -1596,6 +1770,7 @@
       "build-errors should show a next/font error when input is wrong"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/next-font/deprecated-package.test.ts": {
@@ -1605,12 +1780,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/next-font/font-loader-in-document-error.test.ts": {
     "passed": [],
     "failed": ["font-loader-in-document-error next/font inside _document"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/pages-dir/client-navigation/index.test.ts": {
@@ -1757,6 +1934,7 @@
       "Client Navigation runtime errors should show redbox when a client side error is thrown outside a component"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/pages-dir/custom-app-hmr/index.test.ts": {
@@ -1765,18 +1943,21 @@
       "custom-app-hmr should not do full reload when simply editing _app.js"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/project-directory-with-styled-jsx-suffix/index.test.ts": {
     "passed": ["project directory with styled-jsx suffix should work"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/repeated-dev-edits/repeated-dev-edits.test.ts": {
     "passed": ["repeated-dev-edits should not break the hydration "],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/tsconfig-path-reloading/index.test.ts": {
@@ -1790,6 +1971,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/typescript-auto-install/index.test.ts": {
@@ -1799,12 +1981,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/watch-config-file/index.test.ts": {
     "passed": ["watch-config-file should output config file change"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/development/webpack-issuer-deprecation-warning/index.test.ts": {
@@ -1813,6 +1997,7 @@
       "webpack-issuer-deprecation-warning should not appear deprecation warning about webpack module issuer"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/404-page-router/index.test.ts": {
@@ -1846,6 +2031,7 @@
       "404-page-router 404-page-router with basePath of true and i18n of true and middleware false should not throw any errors when re-fetching the route info"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir-legacy-edge-runtime-config/index.test.ts": {
@@ -1854,6 +2040,7 @@
       "app-dir edge runtime config should warn the legacy object config export"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/_allow-underscored-root-directory/_allow-underscored-root-directory.test.ts": {
@@ -1865,6 +2052,7 @@
       "_allow-underscored-root-directory should serve app path with %5F"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/actions-navigation/index.test.ts": {
@@ -1874,6 +2062,7 @@
       "app-dir action handling should handle actions correctly after navigation / redirection events"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/actions/app-action-export.test.ts": {
@@ -1882,6 +2071,7 @@
       "app-dir action handling - next export should error when use export output for server actions"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/actions/app-action-invalid.test.ts": {
@@ -1891,6 +2081,7 @@
       "app-dir action invalid config skip test for dev mode"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts": {
@@ -1900,6 +2091,7 @@
       "app-dir action progressive enhancement should support formData and redirect without JS"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts": {
@@ -1912,6 +2104,7 @@
       "app-dir action size limit invalid config skip test for dev mode"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/actions/app-action.test.ts": {
@@ -1958,6 +2151,7 @@
     "pending": [
       "app-dir action handling fetch actions should handle revalidateTag + redirect"
     ],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/app-a11y/index.test.ts": {
@@ -1969,6 +2163,7 @@
       "app a11y features route announcer should not announce the initital title"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-alias/app-alias.test.ts": {
@@ -1980,6 +2175,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-basepath/index.test.ts": {
@@ -1993,6 +2189,7 @@
       "app dir - basepath should support Link with basePath prefixed"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-client-cache/client-cache.test.ts": {
@@ -2013,6 +2210,7 @@
       "app dir client cache semantics prefetch={undefined} - default should refetch below the fold after 30 seconds"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-compilation/index.test.ts": {
@@ -2022,6 +2220,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-css-pageextensions/index.test.ts": {
@@ -2030,6 +2229,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-css/index.test.ts": {
@@ -2084,6 +2284,7 @@
       "app dir css css support multiple entries should only load chunks for the css module that is used by the specific entrypoint",
       "app dir css css support server layouts should support global css inside server layouts"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-edge-root-layout/index.test.ts": {
@@ -2093,6 +2294,7 @@
       "app-dir edge runtime root layout should not emit metadata files into bad paths"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-edge/app-edge.test.ts": {
@@ -2108,6 +2310,7 @@
       "app-dir edge SSR should warn about the re-export of a pages runtime/preferredRegion config"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-external/app-external.test.ts": {
@@ -2134,6 +2337,7 @@
       "app dir - external dependency should have proper tree-shaking for known modules in CJS"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts": {
@@ -2143,6 +2347,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-middleware/app-middleware.test.ts": {
@@ -2165,6 +2370,7 @@
       "app-dir with middleware should filter correctly after middleware rewrite"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/app-prefetch-false/app-prefetch-false.test.ts": {
@@ -2173,6 +2379,7 @@
     ],
     "failed": [],
     "pending": ["app-prefetch-false should skip test in dev mode"],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-prefetch/prefetching.test.ts": {
@@ -2190,6 +2397,7 @@
       "app dir prefetching should show layout eagerly when prefetched with loading one level down"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-rendering/rendering.test.ts": {
@@ -2206,6 +2414,7 @@
     "pending": [
       "app dir rendering mixed static and dynamic should generate static data during build and use it"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-routes-trailing-slash/app-routes-trailing-slash.test.ts": {
@@ -2215,6 +2424,7 @@
       "app-routes-trailing-slash should handle trailing slash for node runtime"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-routes/app-custom-route-base-path.test.ts": {
@@ -2285,6 +2495,7 @@
     "pending": [
       "app-custom-routes basic fetch request with a response response supports the NextResponse.rewrite() helper"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-routes/app-custom-routes.test.ts": {
@@ -2355,6 +2566,7 @@
     "pending": [
       "app-custom-routes basic fetch request with a response response supports the NextResponse.rewrite() helper"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-simple-routes/app-simple-routes.test.ts": {
@@ -2364,6 +2576,7 @@
       "app-simple-routes works with simple routes renders a node route"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-static/app-fetch-logging.test.ts": {
@@ -2376,6 +2589,7 @@
       "app-dir - data fetching with cache logging with verbose logging should only log requests in dev mode"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/app-static/app-static-custom-cache-handler-esm.test.ts": {
@@ -2385,6 +2599,7 @@
       "app-static-custom-cache-handler-esm should skip"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/app-static/app-static-custom-handler.test.ts": {
@@ -2459,6 +2674,7 @@
       "app-dir static/dynamic handling useSearchParams client should have empty search params on force-static",
       "app-dir static/dynamic handling useSearchParams server response should have empty search params on force-static"
     ],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/app-static/app-static.test.ts": {
@@ -2542,6 +2758,7 @@
       "app-dir static/dynamic handling useSearchParams client should have empty search params on force-static",
       "app-dir static/dynamic handling useSearchParams server response should have empty search params on force-static"
     ],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/app-validation/validation.test.ts": {
@@ -2550,6 +2767,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app/index.test.ts": {
@@ -2685,6 +2903,7 @@
       "app dir should not rerender layout when navigating between routes in the same layout",
       "app dir template component should render the template that is a server component and rerender on navigation"
     ],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/app/standalone.test.ts": {
@@ -2694,6 +2913,7 @@
       "output: standalone with app dir should work correctly with output standalone"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/app/useReportWebVitals.test.ts": {
@@ -2702,6 +2922,7 @@
       "useReportWebVitals hook should send web-vitals to vercel-insights"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/app/vercel-speed-insights.test.ts": {
@@ -2714,6 +2935,7 @@
       "vercel speed insights with assetPrefix Vercel analytics should send web vitals to Vercel analytics",
       "vercel speed insights without assetPrefix Vercel analytics should send web vitals to Vercel analytics"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/asset-prefix/asset-prefix.test.ts": {
@@ -2725,6 +2947,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/async-component-preload/async-component-preload.test.ts": {
@@ -2733,6 +2956,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/autoscroll-with-css-modules/index.test.ts": {
@@ -2742,6 +2966,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/back-button-download-bug/back-button-download-bug.test.ts": {
@@ -2750,6 +2975,7 @@
     "pending": [
       "app-dir back button download bug app-dir back button download bug should redirect route when clicking link"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/build-size/index.test.ts": {
@@ -2759,6 +2985,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/create-root-layout/create-root-layout.test.ts": {
@@ -2771,6 +2998,7 @@
       "app-dir create root layout page.tsx create root layout"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/crypto-globally-available/crypto-globally-available.test.ts": {
@@ -2780,12 +3008,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/deopted-into-client-rendering-warning/deopted-into-client-rendering-warning.test.ts": {
     "passed": ["should not show deopted into client rendering warning"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/draft-mode/draft-mode.test.ts": {
@@ -2814,6 +3044,7 @@
       "app dir - draft mode in nodejs runtime should use initial rand when draft mode is disabled on /with-cookies"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/dynamic-href/dynamic-href.test.ts": {
@@ -2825,6 +3056,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/dynamic/dynamic.test.ts": {
@@ -2836,6 +3068,7 @@
       "app dir - next/dynamic should handle ssr: false in pages when appDir is enabled"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/edge-runtime-node-compatibility/edge-runtime-node-compatibility.test.ts": {
@@ -2845,6 +3078,7 @@
       "edge runtime node compatibility [pages/api] supports node:buffer"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/emotion-js/index.test.ts": {
@@ -2853,6 +3087,7 @@
       "app dir - emotion-js should render emotion-js css with compiler.emotion option correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/error-boundary-navigation/index.test.ts": {
@@ -2867,6 +3102,7 @@
       "app dir - not found navigation should be able to navigate to other page from root not-found page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/error-boundary-navigation/override-node-env.test.ts": {
@@ -2888,12 +3124,14 @@
       "app dir - not found navigation should be able to navigate to other page from root not-found page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/front-redirect-issue/front-redirect-issue.test.ts": {
     "passed": ["app dir - front redirect issue should redirect"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/global-error/basic/index.test.ts": {
@@ -2906,6 +3144,7 @@
       "app dir - global error should trigger error component when an error happens during rendering"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/global-error/layout-error/index.test.ts": {
@@ -2914,6 +3153,7 @@
       "app dir - global error - layout error should render global error for error in server components"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/headers-static-bailout/headers-static-bailout.test.ts": {
@@ -2925,6 +3165,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/hello-world/hello-world.test.ts": {
@@ -2936,6 +3177,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/hooks/hooks.test.ts": {
@@ -2963,6 +3205,7 @@
       "app dir - hooks useSelectedLayoutSegments should have the correct layout segments at /hooks/use-selected-layout-segment/rewritten-middleware"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.js": {
@@ -2980,6 +3223,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/import/import.test.ts": {
@@ -2991,6 +3235,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts": {
@@ -2999,6 +3244,7 @@
       "interception-middleware-rewrite should support intercepting routes with a middleware rewrite"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/interoperability-with-pages/navigation.test.ts": {
@@ -3010,6 +3256,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/layout-params/layout-params.test.ts": {
@@ -3023,6 +3270,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/mdx/mdx.test.ts": {
@@ -3050,6 +3298,7 @@
       "mdx without-mdx-rs pages directory should work using browser with mdx import"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/metadata-dynamic-routes/index.test.ts": {
@@ -3082,6 +3331,7 @@
       "app dir - metadata dynamic routes text routes should not throw if client components are imported but not used"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/metadata-edge/index.test.ts": {
@@ -3091,6 +3341,7 @@
       "app dir - Metadata API on the Edge runtime should render OpenGraph image meta tag correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/metadata-missing-metadata-base/index.test.ts": {
@@ -3099,6 +3350,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/metadata-suspense/index.test.ts": {
@@ -3107,6 +3359,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/metadata/metadata.test.ts": {
@@ -3160,6 +3413,7 @@
       "app dir - metadata twitter should support twitter card summary_large_image when image present"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/navigation/navigation.test.ts": {
@@ -3206,6 +3460,7 @@
       "app dir - navigation relative hashes and queries should work with both relative hashes and queries"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/next-config/index.test.ts": {
@@ -3214,6 +3469,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/next-font/next-font.test.ts": {
@@ -3249,6 +3505,7 @@
       "app-old app dir next-font preload should preload correctly with server components"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/next-image/next-image-https.test.ts": {
@@ -3257,6 +3514,7 @@
       "app dir next-image (with https) only runs on CI as it requires administrator privileges"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/next-image/next-image.test.ts": {
@@ -3275,6 +3533,7 @@
       "app dir next-image ssr content should render images on /client route"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/not-found-default/index.test.ts": {
@@ -3288,6 +3547,7 @@
       "app dir - not found with default 404 page should render default not found for group routes if not found is not defined"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/not-found/basic/index.test.ts": {
@@ -3310,6 +3570,7 @@
       "app dir - not-found - basic with runtime = edge should use the not-found page for non-matching routes"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/not-found/conflict-route/index.test.ts": {
@@ -3321,6 +3582,7 @@
       "app dir - not-found - conflict route with runtime = edge should use the not-found page for non-matching routes"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/not-found/css-precedence/index.test.ts": {
@@ -3329,6 +3591,7 @@
       "app dir css should load css while navigation between not-found and page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts": {
@@ -3338,6 +3601,7 @@
       "app dir - group routes with root not-found should render root not found for group routes if hit 404"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/not-found/group-route/index.test.ts": {
@@ -3347,12 +3611,14 @@
       "app dir - not-found - group route with runtime = edge should use the not-found page under group routes"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts": {
     "passed": [],
     "failed": ["pages-to-app-routing should work using browser"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts": {
@@ -3383,6 +3649,7 @@
       "parallel-routes-and-interception route intercepting with dynamic routes should render intercepted route"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts": {
@@ -3391,6 +3658,7 @@
       "parallel-routes-and-interception should not render the @children slot when the @slot is not found"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/params-hooks-compat/index.test.ts": {
@@ -3400,6 +3668,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts": {
@@ -3418,12 +3687,14 @@
       "redirects and rewrites navigation using link should rewrite from middleware correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/root-layout-redirect/root-layout-redirect.test.ts": {
     "passed": [],
     "failed": ["root-layout-redirect should work using browser"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/root-layout-render-once/index.test.ts": {
@@ -3432,6 +3703,7 @@
       "app-dir root layout render once should only render root layout once"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/root-layout/root-layout.test.ts": {
@@ -3450,6 +3722,7 @@
       "app-dir root layout Missing required tags should error on page load on static generation",
       "app-dir root layout Missing required tags should error on page navigation"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/route-page-manifest-bug/route-page-manifest-bug.test.ts": {
@@ -3458,6 +3731,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts": {
@@ -3481,6 +3755,7 @@
     "pending": [
       "router autoscrolling on navigation router.refresh() should not scroll the page when we hot reload"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/router-stuck-dynamic-static-segment/router-stuck-dynamic-static-segment.test.ts": {
@@ -3489,6 +3764,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/rsc-basic/rsc-basic.test.ts": {
@@ -3533,6 +3809,7 @@
     "pending": [
       "app dir - rsc basics should support partial hydration with inlined server data in browser"
     ],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/search-params-react-key/layout-params.test.ts": {
@@ -3541,6 +3818,7 @@
       "app dir - search params keys should keep the React router instance the same when changing the search params"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/searchparams-static-bailout/searchparams-static-bailout.test.ts": {
@@ -3553,6 +3831,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts": {
@@ -3562,6 +3841,7 @@
       "server-actions-relative-redirect should work with relative redirect"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/set-cookies/set-cookies.test.ts": {
@@ -3575,6 +3855,7 @@
       "set-cookies for node runtime for /pages should set two set-cookie headers"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/similar-pages-paths/similar-pages-paths.test.ts": {
@@ -3583,6 +3864,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/test-template/{{ toFileName name }}/{{ toFileName name }}.test.ts": {
@@ -3594,6 +3876,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/third-parties/basic.test.ts": {
@@ -3603,6 +3886,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/trailingslash/trailingslash.test.ts": {
@@ -3615,6 +3899,7 @@
       "app-dir trailingSlash handling should render link with trailing slash"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/underscore-ignore-app-paths/underscore-ignore-app-paths.test.ts": {
@@ -3624,6 +3909,7 @@
     ],
     "failed": ["underscore-ignore-app-paths should serve app path with %5F"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/use-params/use-params.test.ts": {
@@ -3636,6 +3922,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts": {
@@ -3651,6 +3938,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/with-babel/with-babel.test.ts": {
@@ -3660,6 +3948,7 @@
       "with babel should support babel in app dir"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/app-dir/with-exported-function-config/with-exported-function-config.test.ts": {
@@ -3668,6 +3957,7 @@
       "with-exported-function-config should have correct values in function config manifest"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/basepath-trailing-slash.test.ts": {
@@ -3679,18 +3969,162 @@
       "basePath + trailingSlash should correctly replace state when same asPath but different url"
     ],
     "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/basepath.test.ts": {
+    "passed": [],
+    "failed": [],
+    "pending": [],
+    "flakey": [
+      "basePath should navigate to /404 correctly client-side",
+      "basePath should navigate to /_error correctly client-side",
+      "basePath should navigate to external site and back",
+      "basePath should handle query/hash correctly during query updating #hello? $search",
+      "basePath should handle query/hash correctly during query updating #? $search",
+      "basePath should handle query/hash correctly during query updating ## $search",
+      "basePath should handle query/hash correctly during query updating ##? $search",
+      "basePath should handle query/hash correctly during query updating ##hello? $search",
+      "basePath should handle query/hash correctly during query updating ##hello $search",
+      "basePath should handle query/hash correctly during query updating #hello?world $search",
+      "basePath should handle query/hash correctly during query updating #a ?hello=world",
+      "basePath should handle query/hash correctly during query updating #a ?hello",
+      "basePath should handle query/hash correctly during query updating #a ?hello=",
+      "basePath should navigate back correctly to a dynamic route",
+      "basePath should respect basePath in amphtml link rel",
+      "basePath should 404 for public file without basePath",
+      "basePath should serve public file with basePath correctly",
+      "basePath should rewrite with basePath by default",
+      "basePath should not rewrite without basePath without disabling",
+      "basePath should not rewrite with basePath when set to false",
+      "basePath should rewrite without basePath when set to false",
+      "basePath should redirect with basePath by default",
+      "basePath should not redirect without basePath without disabling",
+      "basePath should not redirect with basePath when set to false",
+      "basePath should redirect without basePath when set to false",
+      "basePath should add header with basePath by default",
+      "basePath should not add header without basePath without disabling",
+      "basePath should not add header with basePath when set to false",
+      "basePath should add header without basePath when set to false",
+      "basePath should not update URL for a 404",
+      "basePath should handle 404 urls that start with basePath",
+      "basePath should navigate back to a non-basepath 404 that starts with basepath",
+      "basePath should update dynamic params after mount correctly",
+      "basePath should navigate to index page with getStaticProps",
+      "basePath should navigate to nested index page with getStaticProps",
+      "basePath should work with nested folder with same name as basePath",
+      "basePath should work with normal dynamic page",
+      "basePath should work with hash links",
+      "basePath should work with catch-all page",
+      "basePath should redirect trailing slash correctly",
+      "basePath should redirect trailing slash on root correctly",
+      "basePath should navigate an absolute url",
+      "basePath should navigate an absolute local url with basePath",
+      "basePath should navigate an absolute local url without basePath",
+      "basePath should 404 when manually adding basePath with <Link>",
+      "basePath should 404 when manually adding basePath with router.push",
+      "basePath should 404 when manually adding basePath with router.replace",
+      "basePath should show the hello page under the /docs prefix",
+      "basePath should have correct router paths on first load of /",
+      "basePath should have correct router paths on first load of /hello",
+      "basePath should fetch data for getStaticProps without reloading",
+      "basePath should fetch data for getServerSideProps without reloading",
+      "basePath should have correct href for a link",
+      "basePath should have correct href for a link to /",
+      "basePath should show 404 for page not under the /docs prefix",
+      "basePath should show the other-page page under the /docs prefix",
+      "basePath should have basePath field on Router",
+      "basePath should navigate to the page without refresh",
+      "basePath should use urls with basepath in router events",
+      "basePath should use urls with basepath in router events for hash changes",
+      "basePath should use urls with basepath in router events for cancelled routes",
+      "basePath should use urls with basepath in router events for failed route change",
+      "basePath should allow URL query strings without refresh",
+      "basePath should allow URL query strings on index without refresh",
+      "basePath should correctly replace state when same asPath but different url",
+      "basePath should navigate to /404 correctly client-side",
+      "basePath should navigate to /_error correctly client-side",
+      "basePath should navigate to external site and back",
+      "basePath should handle query/hash correctly during query updating #hello? $search",
+      "basePath should handle query/hash correctly during query updating #? $search",
+      "basePath should handle query/hash correctly during query updating ## $search",
+      "basePath should handle query/hash correctly during query updating ##? $search",
+      "basePath should handle query/hash correctly during query updating ##hello? $search",
+      "basePath should handle query/hash correctly during query updating ##hello $search",
+      "basePath should handle query/hash correctly during query updating #hello?world $search",
+      "basePath should handle query/hash correctly during query updating #a ?hello=world",
+      "basePath should handle query/hash correctly during query updating #a ?hello",
+      "basePath should handle query/hash correctly during query updating #a ?hello=",
+      "basePath should navigate back correctly to a dynamic route",
+      "basePath should respect basePath in amphtml link rel",
+      "basePath should add basePath to routes-manifest",
+      "basePath should prefetch pages correctly when manually called",
+      "basePath should prefetch pages correctly in viewport with <Link>",
+      "basePath should 404 for public file without basePath",
+      "basePath should serve public file with basePath correctly",
+      "basePath should rewrite with basePath by default",
+      "basePath should not rewrite without basePath without disabling",
+      "basePath should not rewrite with basePath when set to false",
+      "basePath should rewrite without basePath when set to false",
+      "basePath should redirect with basePath by default",
+      "basePath should not redirect without basePath without disabling",
+      "basePath should not redirect with basePath when set to false",
+      "basePath should redirect without basePath when set to false",
+      "basePath should add header with basePath by default",
+      "basePath should not add header without basePath without disabling",
+      "basePath should not add header with basePath when set to false",
+      "basePath should add header without basePath when set to false",
+      "basePath should not update URL for a 404",
+      "basePath should handle 404 urls that start with basePath",
+      "basePath should navigate back to a non-basepath 404 that starts with basepath",
+      "basePath should update dynamic params after mount correctly",
+      "basePath should navigate to index page with getStaticProps",
+      "basePath should navigate to nested index page with getStaticProps",
+      "basePath should work with nested folder with same name as basePath",
+      "basePath should work with normal dynamic page",
+      "basePath should work with hash links",
+      "basePath should work with catch-all page",
+      "basePath should redirect trailing slash correctly",
+      "basePath should redirect trailing slash on root correctly",
+      "basePath should navigate an absolute url",
+      "basePath should navigate an absolute local url with basePath",
+      "basePath should navigate an absolute local url without basePath",
+      "basePath should 404 when manually adding basePath with <Link>",
+      "basePath should 404 when manually adding basePath with router.push",
+      "basePath should 404 when manually adding basePath with router.replace",
+      "basePath should show the hello page under the /docs prefix",
+      "basePath should have correct router paths on first load of /",
+      "basePath should have correct router paths on first load of /hello",
+      "basePath should fetch data for getStaticProps without reloading",
+      "basePath should fetch data for getServerSideProps without reloading",
+      "basePath should have correct href for a link",
+      "basePath should have correct href for a link to /",
+      "basePath should show 404 for page not under the /docs prefix",
+      "basePath should show the other-page page under the /docs prefix",
+      "basePath should have basePath field on Router",
+      "basePath should navigate to the page without refresh",
+      "basePath should use urls with basepath in router events",
+      "basePath should use urls with basepath in router events for hash changes",
+      "basePath should use urls with basepath in router events for cancelled routes",
+      "basePath should use urls with basepath in router events for failed route change",
+      "basePath should allow URL query strings without refresh",
+      "basePath should allow URL query strings on index without refresh",
+      "basePath should correctly replace state when same asPath but different url"
+    ],
     "runtimeError": false
   },
   "test/e2e/browserslist-extends/index.test.ts": {
     "passed": ["browserslist-extends should work"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/browserslist/browserslist.test.ts": {
     "passed": [],
     "failed": ["Browserslist should apply browserslist target"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/cancel-request/stream-cancel.test.ts": {
@@ -3713,6 +4147,7 @@
       "streaming responses cancel inner stream after disconnect node pages api cancels stream that never sent data"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/children-page/index.test.ts": {
@@ -3722,18 +4157,21 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/config-promise-export/async-function.test.ts": {
     "passed": ["async export should work"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/config-promise-export/promise.test.ts": {
     "passed": ["promise export should work"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/config-schema-check/index.test.ts": {
@@ -3744,6 +4182,7 @@
       "next.config.js schema validating - invalid config should warn the invalid next config"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/conflicting-app-page-error/index.test.ts": {
@@ -3758,6 +4197,7 @@
       "Conflict between app file and pages file should support hmr with conflicts"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/custom-app-render/custom-app-render.test.ts": {
@@ -3767,6 +4207,7 @@
       "custom-app-render should render /render"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/disable-js-preload/test/index.test.js": {
@@ -3776,6 +4217,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/dynamic-route-interpolation/index.test.ts": {
@@ -3790,6 +4232,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/edge-api-endpoints-can-receive-body/index.test.ts": {
@@ -3799,6 +4242,7 @@
       "Edge API endpoints can receive body reads the body from index"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/edge-async-local-storage/index.test.ts": {
@@ -3808,6 +4252,7 @@
       "edge api can use async local storage cans use multiple instances per request"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/edge-can-read-request-body/index.test.ts": {
@@ -3821,6 +4266,7 @@
       "Edge can read request body middleware reads an URL encoded form data"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/edge-can-use-wasm-files/index.test.ts": {
@@ -3833,6 +4279,7 @@
       "middleware can use wasm files with the experimental modes on uses the wasm file"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/edge-compiler-can-import-blob-assets/index.test.ts": {
@@ -3846,6 +4293,7 @@
       "Edge Compiler can import asset assets extracts all the assets from the bundle"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/edge-compiler-module-exports-preference/index.test.ts": {
@@ -3854,6 +4302,7 @@
       "Edge compiler module exports preference favors the browser export"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/edge-configurable-runtime/index.test.ts": {
@@ -3874,6 +4323,7 @@
       "Configurable runtime for src/pages and API routes In start mode does not build with page on the edge runtime"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/edge-pages-support/edge-document.test.ts": {
@@ -3882,6 +4332,7 @@
       "edge render - custom _document with edge runtime should render page properly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/edge-pages-support/index.test.ts": {
@@ -3899,6 +4350,7 @@
       "edge-render-getserversideprops should respond to _next/data for index correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/edge-runtime-uses-edge-light-import-specifier-for-packages/edge-runtime-uses-edge-light-import-specifier-for-packages.test.ts": {
@@ -3909,6 +4361,7 @@
       "edge-runtime uses edge-light import specifier for packages pages/api endpoints import the correct module"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/favicon-short-circuit/favicon-short-circuit.test.ts": {
@@ -3919,6 +4372,7 @@
       "favicon-short-circuit should not short circuit the favicon in production"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts": {
@@ -3928,6 +4382,7 @@
       "fetch failures have good stack traces in edge runtime when returning `fetch` using an unknown domain, stack traces are preserved"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/getserversideprops/test/index.test.ts": {
@@ -3990,12 +4445,14 @@
       "getServerSideProps should render 404 correctly when notFound is returned client-transition (non-dynamic)"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/handle-non-hoisted-swc-helpers/index.test.ts": {
     "passed": ["handle-non-hoisted-swc-helpers should work"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/hello-world/hello-world.test.ts": {
@@ -4007,6 +4464,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/i18n-api-support/index.test.ts": {
@@ -4017,6 +4475,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/i18n-data-fetching-redirect/index.test.ts": {
@@ -4048,6 +4507,7 @@
       "i18n-data-fetching-redirect Redirect to locale from context next/link gssp-redirect sv"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/i18n-data-route/i18n-data-route.test.ts": {
@@ -4067,6 +4527,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/i18n-default-locale-redirect/i18n-default-locale-redirect.test.ts": {
@@ -4076,6 +4537,7 @@
       "i18-default-locale-redirect should request a path prefixed with non-default locale"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/i18n-disallow-multiple-locales/i18n-disallow-multiple-locales.test.ts": {
@@ -4140,6 +4602,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/i18n-ignore-redirect-source-locale/redirects-with-basepath.test.ts": {
@@ -4163,6 +4626,7 @@
       "i18n-ignore-redirect-source-locale with basepath get redirected to the new page, from: /sv to: sv"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/i18n-ignore-redirect-source-locale/redirects.test.ts": {
@@ -4186,6 +4650,7 @@
       "i18n-ignore-redirect-source-locale get redirected to the new page, from: /sv to: sv"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts": {
@@ -4206,6 +4671,7 @@
       "i18n-ignore-rewrite-source-locale with basepath get _next/static/ files by skipping locale in rewrite, locale: /sv"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts": {
@@ -4226,6 +4692,7 @@
       "i18n-ignore-rewrite-source-locale get _next/static/ files by skipping locale in rewrite, locale: /sv"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/ignore-invalid-popstateevent/with-i18n.test.ts": {
@@ -4236,6 +4703,7 @@
       "i18n: Event with stale state - static route previously was dynamic Ignore event without query param"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/ignore-invalid-popstateevent/without-i18n.test.ts": {
@@ -4245,6 +4713,7 @@
       "Event with stale state - static route previously was dynamic Ignore event without query param"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/instrumentation-hook-src/instrumentation-hook-src.test.ts": {
@@ -4257,6 +4726,7 @@
     "pending": [
       "instrumentation-hook-src should reload the server when the instrumentation hook changes"
     ],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/instrumentation-hook/instrumentation-hook.test.ts": {
@@ -4274,6 +4744,7 @@
     "pending": [
       "Instrumentation Hook general should reload the server when the instrumentation hook changes"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/link-with-api-rewrite/index.test.ts": {
@@ -4283,6 +4754,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/manual-client-base-path/index.test.ts": {
@@ -4297,6 +4769,7 @@
       "manual-client-base-path should not warn for flag in output"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/middleware-base-path/test/index.test.ts": {
@@ -4306,6 +4779,7 @@
       "Middleware base tests should execute from absolute paths"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/middleware-custom-matchers-basepath/test/index.test.ts": {
@@ -4315,6 +4789,7 @@
       "Middleware custom matchers basePath should match has query on client routing"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/middleware-custom-matchers-i18n/test/index.test.ts": {
@@ -4327,6 +4802,7 @@
       "Middleware custom matchers i18n should match has query on client routing"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/middleware-custom-matchers/test/index.test.ts": {
@@ -4345,6 +4821,7 @@
       "Middleware custom matchers should match source path"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/middleware-dynamic-basepath-matcher/test/index.test.ts": {
@@ -4354,6 +4831,7 @@
     ],
     "failed": ["Middleware custom matchers basePath should match query path"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/middleware-fetches-with-any-http-method/index.test.ts": {
@@ -4363,6 +4841,7 @@
       "Middleware fetches with any HTTP method passes the method when providing a Request object"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/middleware-fetches-with-body/index.test.ts": {
@@ -4380,6 +4859,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/middleware-general/test/index.test.ts": {
@@ -4470,6 +4950,7 @@
       "Middleware Runtime without i18n should work with notFound: true correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/middleware-matcher/index.test.ts": {
@@ -4513,6 +4994,7 @@
       "using root matcher adds the header to the /index"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/middleware-redirects/test/index.test.ts": {
@@ -4538,6 +5020,7 @@
       "Middleware Redirect should redirect with a fragment"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/middleware-request-header-overrides/test/index.test.ts": {
@@ -4554,6 +5037,7 @@
       "Middleware Request Headers Overrides getServerSideProps Backend Updates headers"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/middleware-responses/test/index.test.ts": {
@@ -4575,12 +5059,135 @@
       "Middleware Responses should respond with two headers"
     ],
     "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/middleware-rewrites/test/index.test.ts": {
+    "passed": [],
+    "failed": [],
+    "pending": [],
+    "flakey": [
+      "Middleware Rewrite should handle next.config.js rewrite with body correctly",
+      "Middleware Rewrite should handle middleware rewrite with body correctly",
+      "Middleware Rewrite should handle static dynamic rewrite from middleware correctly",
+      "Middleware Rewrite should handle static rewrite from next.config.js correctly",
+      "Middleware Rewrite should not have un-necessary data request on rewrite",
+      "Middleware Rewrite should not mix component cache when navigating between dynamic routes",
+      "Middleware Rewrite should have props for afterFiles rewrite to SSG page",
+      "Middleware Rewrite should hard navigate on 404 for data request",
+      "Middleware Rewrite includes the locale in rewrites by default",
+      "Middleware Rewrite should rewrite correctly when navigating via history",
+      "Middleware Rewrite should rewrite correctly when navigating via history after query update",
+      "Middleware Rewrite should return HTML/data correctly for pre-rendered page",
+      "Middleware Rewrite should override with rewrite internally correctly",
+      "Middleware Rewrite should rewrite to data urls for incoming data request internally rewritten",
+      "Middleware Rewrite should override with rewrite externally correctly",
+      "Middleware Rewrite should rewrite to the external url for incoming data request externally rewritten",
+      "Middleware Rewrite should rewrite to fallback: true page successfully",
+      "Middleware Rewrite should allow to opt-out prefetch caching",
+      "Middleware Rewrite should allow to rewrite keeping the locale in pathname",
+      "Middleware Rewrite should allow to rewrite to a different locale",
+      "Middleware Rewrite should behave consistently on recursive rewrites",
+      "Middleware Rewrite should allow to switch locales",
+      "Middleware Rewrite should allow to rewrite to a `beforeFiles` rewrite config",
+      "Middleware Rewrite should allow to rewrite to a `afterFiles` rewrite config",
+      "Middleware Rewrite should have correct query info for dynamic route after query hydration",
+      "Middleware Rewrite should handle shallow navigation correctly (non-dynamic page)",
+      "Middleware Rewrite should handle shallow navigation correctly (dynamic page)",
+      "Middleware Rewrite should resolve dynamic route after rewrite correctly",
+      "Middleware Rewrite should add a cookie and rewrite to a/b test",
+      "Middleware Rewrite should clear query parameters",
+      "Middleware Rewrite should rewrite to about page",
+      "Middleware Rewrite support colons in path",
+      "Middleware Rewrite can rewrite to path with colon",
+      "Middleware Rewrite can rewrite from path with colon",
+      "Middleware Rewrite can rewrite from path with colon and retain query parameter",
+      "Middleware Rewrite can rewrite to path with colon and retain query parameter",
+      "Middleware Rewrite should rewrite when not using localhost",
+      "Middleware Rewrite should rewrite to Vercel",
+      "Middleware Rewrite should rewrite without hard navigation",
+      "Middleware Rewrite should not call middleware with shallow push",
+      "Middleware Rewrite should correctly rewriting to a different dynamic path",
+      "Middleware Rewrite should not have unexpected errors",
+      "Middleware Rewrite /fr should add a cookie and rewrite to a/b test",
+      "Middleware Rewrite /fr should clear query parameters",
+      "Middleware Rewrite /fr should rewrite to about page",
+      "Middleware Rewrite /fr support colons in path",
+      "Middleware Rewrite /fr can rewrite to path with colon",
+      "Middleware Rewrite /fr can rewrite from path with colon",
+      "Middleware Rewrite /fr can rewrite from path with colon and retain query parameter",
+      "Middleware Rewrite /fr can rewrite to path with colon and retain query parameter",
+      "Middleware Rewrite /fr should rewrite when not using localhost",
+      "Middleware Rewrite /fr should rewrite to Vercel",
+      "Middleware Rewrite /fr should rewrite without hard navigation",
+      "Middleware Rewrite /fr should not call middleware with shallow push",
+      "Middleware Rewrite /fr should correctly rewriting to a different dynamic path",
+      "Middleware Rewrite should not have unexpected errors",
+      "Middleware Rewrite should handle next.config.js rewrite with body correctly",
+      "Middleware Rewrite should handle middleware rewrite with body correctly",
+      "Middleware Rewrite should handle static dynamic rewrite from middleware correctly",
+      "Middleware Rewrite should handle static rewrite from next.config.js correctly",
+      "Middleware Rewrite should not have un-necessary data request on rewrite",
+      "Middleware Rewrite should not mix component cache when navigating between dynamic routes",
+      "Middleware Rewrite should have props for afterFiles rewrite to SSG page",
+      "Middleware Rewrite should hard navigate on 404 for data request",
+      "Middleware Rewrite includes the locale in rewrites by default",
+      "Middleware Rewrite should rewrite correctly when navigating via history",
+      "Middleware Rewrite should rewrite correctly when navigating via history after query update",
+      "Middleware Rewrite should return HTML/data correctly for pre-rendered page",
+      "Middleware Rewrite should override with rewrite internally correctly",
+      "Middleware Rewrite should rewrite to data urls for incoming data request internally rewritten",
+      "Middleware Rewrite should override with rewrite externally correctly",
+      "Middleware Rewrite should rewrite to the external url for incoming data request externally rewritten",
+      "Middleware Rewrite should rewrite to fallback: true page successfully",
+      "Middleware Rewrite should allow to opt-out prefetch caching",
+      "Middleware Rewrite should not prefetch non-SSG routes",
+      "Middleware Rewrite should allow to rewrite keeping the locale in pathname",
+      "Middleware Rewrite should allow to rewrite to a different locale",
+      "Middleware Rewrite should behave consistently on recursive rewrites",
+      "Middleware Rewrite should allow to switch locales",
+      "Middleware Rewrite should allow to rewrite to a `beforeFiles` rewrite config",
+      "Middleware Rewrite should allow to rewrite to a `afterFiles` rewrite config",
+      "Middleware Rewrite should have correct query info for dynamic route after query hydration",
+      "Middleware Rewrite should handle shallow navigation correctly (non-dynamic page)",
+      "Middleware Rewrite should handle shallow navigation correctly (dynamic page)",
+      "Middleware Rewrite should resolve dynamic route after rewrite correctly",
+      "Middleware Rewrite should add a cookie and rewrite to a/b test",
+      "Middleware Rewrite should clear query parameters",
+      "Middleware Rewrite should rewrite to about page",
+      "Middleware Rewrite support colons in path",
+      "Middleware Rewrite can rewrite to path with colon",
+      "Middleware Rewrite can rewrite from path with colon",
+      "Middleware Rewrite can rewrite from path with colon and retain query parameter",
+      "Middleware Rewrite can rewrite to path with colon and retain query parameter",
+      "Middleware Rewrite should rewrite when not using localhost",
+      "Middleware Rewrite should rewrite to Vercel",
+      "Middleware Rewrite should rewrite without hard navigation",
+      "Middleware Rewrite should not call middleware with shallow push",
+      "Middleware Rewrite should correctly rewriting to a different dynamic path",
+      "Middleware Rewrite should not have unexpected errors",
+      "Middleware Rewrite /fr should add a cookie and rewrite to a/b test",
+      "Middleware Rewrite /fr should clear query parameters",
+      "Middleware Rewrite /fr should rewrite to about page",
+      "Middleware Rewrite /fr support colons in path",
+      "Middleware Rewrite /fr can rewrite to path with colon",
+      "Middleware Rewrite /fr can rewrite from path with colon",
+      "Middleware Rewrite /fr can rewrite from path with colon and retain query parameter",
+      "Middleware Rewrite /fr can rewrite to path with colon and retain query parameter",
+      "Middleware Rewrite /fr should rewrite when not using localhost",
+      "Middleware Rewrite /fr should rewrite to Vercel",
+      "Middleware Rewrite /fr should rewrite without hard navigation",
+      "Middleware Rewrite /fr should not call middleware with shallow push",
+      "Middleware Rewrite /fr should correctly rewriting to a different dynamic path",
+      "Middleware Rewrite should not have unexpected errors"
+    ],
     "runtimeError": false
   },
   "test/e2e/middleware-shallow-link/index.test.ts": {
     "passed": ["browser-shallow-navigation should render the correct page"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/middleware-trailing-slash/test/index.test.ts": {
@@ -4616,6 +5223,7 @@
       "Middleware Runtime trailing slash should validate & parse request url from any route"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/module-layer/index.test.ts": {
@@ -4627,6 +5235,7 @@
       "module layer with server-only in server targets should render routes marked with restriction marks without errors"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/multi-zone/multi-zone.test.ts": {
@@ -4639,6 +5248,7 @@
       "multi-zone should correctly respond for /second/blog/post-1"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/new-link-behavior/child-a-tag-error.test.ts": {
@@ -4647,6 +5257,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/new-link-behavior/index.test.ts": {
@@ -4661,6 +5272,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/new-link-behavior/material-ui.test.ts": {
@@ -4669,12 +5281,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/new-link-behavior/stitches.test.ts": {
     "passed": ["New Link Behavior with stitches should render <a>"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/new-link-behavior/typescript.test.ts": {
@@ -4684,12 +5298,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/next-font/basepath.test.ts": {
     "passed": [],
     "failed": ["next/font/google basepath preload correct files"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/next-font/google-fetch-error.test.ts": {
@@ -4699,6 +5315,7 @@
       "next/font/google fetch error should use a fallback font in dev"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/next-font/index.test.ts": {
@@ -4745,6 +5362,7 @@
       "next/font app-old preload page without fonts"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/next-font/with-font-declarations-file.test.ts": {
@@ -4755,6 +5373,7 @@
       "next/font/google with-font-declarations-file preload correct files at /roboto"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/next-font/with-proxy.test.ts": {
@@ -4763,6 +5382,7 @@
       "next/font/google with proxy should use a proxy agent when proxy environment variable is set"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/next-font/without-preloaded-fonts.test.ts": {
@@ -4775,6 +5395,7 @@
       "next/font/google without-preloaded-fonts without _app without preload"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/next-head/index.test.ts": {
@@ -4787,6 +5408,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/next-image-forward-ref/index.test.ts": {
@@ -4795,6 +5417,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/next-script/index.test.ts": {
@@ -4811,6 +5434,7 @@
       "experimental.nextScriptWorkers: true with required Partytown dependency for inline script Inline worker script through dangerouslySetInnerHtml is modified by Partytown to execute on a worker thread"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts": {
@@ -4823,6 +5447,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/nonce-head-manager/index.test.ts": {
@@ -4832,6 +5457,7 @@
       "should set-up next should not re-execute the script when re-rendering with CSP header"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/og-api/index.test.ts": {
@@ -4846,6 +5472,7 @@
       "og-api should work in pages/api"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/opentelemetry/opentelemetry.test.ts": {
@@ -4858,6 +5485,7 @@
       "opentelemetry pages should handle getStaticProps when fallback: 'blocking'"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/optimized-loading/test/index.test.ts": {
@@ -4871,6 +5499,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/pages-performance-mark/index.test.ts": {
@@ -4879,12 +5508,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/postcss-config-cjs/index.test.ts": {
     "passed": ["postcss-config-cjs works with postcss.config.cjs files"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/prerender-crawler.test.ts": {
@@ -4895,6 +5526,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/prerender-native-module.test.ts": {
@@ -4905,6 +5537,7 @@
     ],
     "failed": ["prerender native module should output traces"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/prerender.test.ts": {
@@ -5010,6 +5643,7 @@
     "pending": [
       "Prerender should reload page on failed data request, and retry"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/proxy-request-with-middleware/test/index.test.ts": {
@@ -5019,6 +5653,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/reload-scroll-backforward-restoration/index.test.ts": {
@@ -5028,6 +5663,7 @@
       "reload-scroll-back-restoration should restore the scroll position on navigating forward"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/repeated-forward-slashes-error/repeated-forward-slashes-error.test.ts": {
@@ -5036,6 +5672,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/skip-trailing-slash-redirect/index.test.ts": {
@@ -5074,6 +5711,7 @@
       "skip-trailing-slash-redirect should provide original _next/data URL with skipMiddlewareUrlNormalize"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/ssr-react-context/index.test.ts": {
@@ -5084,6 +5722,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/streaming-ssr/index.test.ts": {
@@ -5102,6 +5741,7 @@
       "streaming SSR with custom next configs should render styled-jsx styles in streaming"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/styled-jsx/index.test.ts": {
@@ -5113,6 +5753,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/swc-warnings/index.test.ts": {
@@ -5122,6 +5763,7 @@
       "swc warnings by default should have warning"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/e2e/switchable-runtime/index.test.ts": {
@@ -5163,6 +5805,7 @@
       "Switchable runtime Switchable runtime (prod) should support client side navigation to ssr rsc pages",
       "Switchable runtime Switchable runtime (prod) should support client side navigation to static rsc pages"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/test-template/{{ toFileName name }}/{{ toFileName name }}.test.ts": {
@@ -5174,12 +5817,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/test-utils-tests/basic/basic.test.ts": {
     "passed": ["createNextDescribe should work"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/third-parties/index.test.ts": {
@@ -5189,6 +5834,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/trailingslash-with-rewrite/index.test.ts": {
@@ -5197,6 +5843,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/transpile-packages/index.test.ts": {
@@ -5208,6 +5855,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/type-module-interop/index.test.ts": {
@@ -5219,6 +5867,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/typescript-version-no-warning/typescript-version-no-warning.test.ts": {
@@ -5228,6 +5877,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/typescript-version-warning/typescript-version-warning.test.ts": {
@@ -5237,6 +5887,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/undici-fetch/index.test.ts": {
@@ -5248,6 +5899,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/yarn-pnp/test/with-eslint.test.ts": {
@@ -5256,6 +5908,7 @@
       "yarn PnP should compile and serve the index page correctly with-eslint"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/yarn-pnp/test/with-mdx.test.ts": {
@@ -5264,6 +5917,7 @@
       "yarn PnP should compile and serve the index page correctly with-mdx"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/e2e/yarn-pnp/test/with-next-sass.test.ts": {
@@ -5272,6 +5926,7 @@
       "yarn PnP should compile and serve the index page correctly with-next-sass"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/404-page-app/test/index.test.js": {
@@ -5284,6 +5939,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/404-page-custom-error/test/index.test.js": {
@@ -5300,6 +5956,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/404-page-ssg/test/index.test.js": {
@@ -5319,6 +5976,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/404-page/test/index.test.js": {
@@ -5348,6 +6006,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/500-page/test/gsp-gssp.test.js": {
@@ -5361,6 +6020,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/500-page/test/index.test.js": {
@@ -5383,6 +6043,20 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/absolute-assetprefix/test/index.test.js": {
+    "passed": [],
+    "failed": [],
+    "pending": [],
+    "flakey": [
+      "absolute assetPrefix with path prefix should not fetch static data from a CDN",
+      "absolute assetPrefix with path prefix should fetch from cache correctly",
+      "absolute assetPrefix with path prefix should work with getStaticPaths prerendered",
+      "absolute assetPrefix with path prefix should work with getStaticPaths fallback",
+      "absolute assetPrefix with path prefix should work with getServerSideProps"
+    ],
     "runtimeError": false
   },
   "test/integration/amp-export-validation/test/index.test.js": {
@@ -5395,6 +6069,7 @@
       "AMP Validation on Export shows warning and error when throwing error",
       "AMP Validation on Export throws error on AMP error"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/amphtml-custom-optimizer/test/index.test.js": {
@@ -5404,12 +6079,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/amphtml-custom-validator/test/index.test.js": {
     "passed": ["AMP Custom Validator should build and start successfully"],
     "failed": ["AMP Custom Validator should run in dev mode successfully"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/amphtml-fragment-style/test/index.test.js": {
@@ -5418,6 +6095,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/amphtml-ssg/test/index.test.js": {
@@ -5439,6 +6117,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/amphtml/test/index.test.js": {
@@ -5483,6 +6162,7 @@
       "AMP Usage AMP dev mode should detect the changes and display it",
       "AMP Usage AMP dev mode should not reload unless the page is edited for an AMP page"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/api-body-parser/test/index.test.js": {
@@ -5493,6 +6173,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/api-catch-all/test/index.test.js": {
@@ -5508,6 +6189,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/api-support/test/index.test.js": {
@@ -5617,6 +6299,7 @@
       "API routes Server support should return error exceeded body limit",
       "API routes dev support should return error exceeded body limit"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-aspath/test/index.test.js": {
@@ -5625,6 +6308,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-config-asset-prefix/test/index.test.js": {
@@ -5633,6 +6317,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-dir-export/test/config.test.ts": {
@@ -5645,6 +6330,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-dir-export/test/dynamic-missing-gsp-dev.test.ts": {
@@ -5654,6 +6340,7 @@
       "should error when dynamic route is missing generateStaticParams"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-dir-export/test/dynamic-missing-gsp-prod.test.ts": {
@@ -5663,6 +6350,7 @@
       "should error when dynamic route is missing generateStaticParams"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-dir-export/test/dynamicapiroute-dev.test.ts": {
@@ -5674,6 +6362,7 @@
       "should work in dev with dynamicApiRoute undefined"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-dir-export/test/dynamicapiroute-prod.test.ts": {
@@ -5685,6 +6374,7 @@
       "should work in prod with dynamicApiRoute undefined"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-dir-export/test/dynamicpage-dev.test.ts": {
@@ -5695,6 +6385,7 @@
       "should work in dev with dynamicPage undefined"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-dir-export/test/dynamicpage-prod.test.ts": {
@@ -5705,6 +6396,7 @@
       "should work in prod with dynamicPage undefined"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-dir-export/test/start.test.ts": {
@@ -5715,6 +6407,7 @@
       "app dir with output export (next start) should warn during next start with output standalone"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-dir-export/test/trailing-slash-dev.test.ts": {
@@ -5724,6 +6417,7 @@
       "should work in dev with trailingSlash 'true'"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-dir-export/test/trailing-slash-start.test.ts": {
@@ -5733,6 +6427,7 @@
       "should work in prod with trailingSlash 'true'"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-document-add-hmr/test/index.test.js": {
@@ -5742,6 +6437,7 @@
       "_app/_document add HMR should HMR when _app is added",
       "_app/_document add HMR should HMR when _document is added"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-document-import-order/test/index.test.js": {
@@ -5754,6 +6450,7 @@
       "on dev server _app chunks should be attached to de dom before page chunks"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-document-remove-hmr/test/index.test.js": {
@@ -5763,6 +6460,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-document-style-fragment/test/index.test.js": {
@@ -5771,6 +6469,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-document/test/index.test.js": {
@@ -5797,6 +6496,7 @@
       "Document and App should not have any missing key warnings"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-dynamic-error/test/index.test.ts": {
@@ -5805,12 +6505,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-functional/test/index.test.js": {
     "passed": [],
     "failed": ["Document and App should not have any missing key warnings"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-tree/test/index.test.js": {
@@ -5824,6 +6526,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/app-types/app-types.test.js": {
@@ -5834,6 +6537,7 @@
       "app type checking production mode should type check invalid entry exports"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/async-modules/test/index.test.js": {
@@ -5858,6 +6562,7 @@
       "Async modules dev mode can render async error page",
       "Async modules production mode can render async AMP pages"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/auto-export-error-bail/test/index.test.js": {
@@ -5866,6 +6571,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/auto-export-query-error/test/index.test.js": {
@@ -5874,6 +6580,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/auto-export/test/index.test.js": {
@@ -5893,6 +6600,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/babel-custom/test/index.test.js": {
@@ -5904,6 +6612,7 @@
       "Babel should allow setting targets.browsers"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/babel/test/index.test.js": {
@@ -5912,6 +6621,7 @@
       "Babel Rendering via HTTP Should compile a page with flowtype correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/basepath-root-catch-all/test/index.test.js": {
@@ -5921,6 +6631,7 @@
       "production mode should use correct data URL for root catch-all"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/bigint/test/index.test.js": {
@@ -5932,6 +6643,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/broken-webpack-plugin/test/index.test.js": {
@@ -5940,6 +6652,7 @@
       "Handles a broken webpack plugin (precompile) should render error correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/build-indicator/test/index.test.js": {
@@ -5953,6 +6666,7 @@
       "Build Activity Indicator Enabled Shows the build indicator when a page is built during navigation"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/build-output/test/index.test.js": {
@@ -5974,6 +6688,7 @@
       "Build Output Basic Application Output (experimental: {\"gzipSize\":false}) should not deviate from snapshot",
       "Build Output Basic Application Output (experimental: {}) should not deviate from snapshot"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/build-trace-extra-entries-turbo/test/index.test.js": {
@@ -5982,6 +6697,7 @@
       "build trace with extra entries should build and trace correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/build-trace-extra-entries/test/index.test.js": {
@@ -5990,6 +6706,7 @@
       "build trace with extra entries should build and trace correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/build-warnings/test/index.test.js": {
@@ -6004,6 +6721,7 @@
       "Build warnings should shown warning about minification for minimizer"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/catches-missing-getStaticProps/test/index.test.js": {
@@ -6013,6 +6731,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/chunking/test/index.test.js": {
@@ -6029,6 +6748,7 @@
       "Chunking should use all url friendly names"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/clean-distdir/test/index.test.js": {
@@ -6038,6 +6758,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/cli/test/index.test.js": {
@@ -6104,6 +6825,7 @@
     ],
     "failed": ["CLI Usage dev -p conflict", "CLI Usage dev -p reserved"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/client-404/test/index.test.js": {
@@ -6116,6 +6838,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/client-navigation-a11y/test/index.test.js": {
@@ -6129,6 +6852,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/client-shallow-routing/test/index.test.js": {
@@ -6140,12 +6864,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/compression/test/index.test.js": {
     "passed": ["Compression should compress responses by default"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/config-devtool-dev/test/index.test.js": {
@@ -6154,6 +6880,7 @@
       "devtool set in development mode in next config should warn and revert when a devtool is set in development mode"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/config-experimental-warning/test/index.test.js": {
@@ -6169,6 +6896,7 @@
       "Config Experimental Warning should show warning with config from object with experimental and multiple keys"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/config-mjs/test/index.test.js": {
@@ -6182,6 +6910,7 @@
       "Configuration should have config available on the client"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/config-output-export/test/index.test.ts": {
@@ -6203,6 +6932,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/config-promise-error/test/index.test.js": {
@@ -6211,6 +6941,7 @@
       "Promise in next config should warn when a promise is returned on webpack"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/config-resolve-alias/test/index.test.js": {
@@ -6219,6 +6950,7 @@
       "Invalid resolve alias should show relevant error when webpack resolve alias is wrong"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/config-syntax-error/test/index.test.js": {
@@ -6228,6 +6960,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/config-validation/test/index.test.ts": {
@@ -6237,6 +6970,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/config/test/index.test.js": {
@@ -6250,6 +6984,7 @@
       "Configuration should have config available on the client"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/conflicting-public-file-page/test/index.test.js": {
@@ -6259,6 +6994,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/conflicting-ssg-paths/test/index.test.js": {
@@ -6269,6 +7005,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/create-next-app/index.test.ts": {
@@ -6291,6 +7028,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/create-next-app/package-manager.test.ts": {
@@ -6313,6 +7051,7 @@
     ],
     "failed": ["should use Bun as the package manager on supplying --use-bun"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/create-next-app/templates-app.test.ts": {
@@ -6324,6 +7063,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/create-next-app/templates-pages.test.ts": {
@@ -6339,6 +7079,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/critical-css/test/index.test.js": {
@@ -6351,6 +7092,7 @@
       "CSS optimization for SSR apps should inline critical CSS (dynamic)"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css-client-nav/test/index.test.js": {
@@ -6368,6 +7110,7 @@
       "CSS Module client-side navigation production should be able to client-side navigate from red to blue"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css-customization/test/index.test.js": {
@@ -6395,6 +7138,7 @@
       "CSS Customization should've emitted a source map"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css-features/test/browserslist.test.js": {
@@ -6406,6 +7150,7 @@
       "Browserslist: Old should've emitted a single CSS file"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css-features/test/css-modules.test.js": {
@@ -6420,6 +7165,7 @@
       "Custom Properties: Fail for global element in CSS Modules should fail to build"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css-features/test/index.test.js": {
@@ -6433,12 +7179,14 @@
       "Inline Comments: Minify should've emitted a single CSS file"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css-minify/test/index.test.js": {
     "passed": [],
     "failed": ["css-minify should minify correctly by removing whitespace"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css-modules/test/index.test.js": {
@@ -6476,6 +7224,7 @@
       "Invalid CSS Module Usage in node_modules should fail to build",
       "Invalid Global CSS Module Usage in node_modules should fail to build"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css/test/basic-global-support.test.js": {
@@ -6501,6 +7250,7 @@
       "Nested @import() Global Support should've emitted a single CSS file"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css/test/css-and-styled-jsx.test.js": {
@@ -6512,6 +7262,7 @@
       "Ordering with styled-jsx (prod) should have compiled successfully"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css/test/css-compilation.test.js": {
@@ -6533,6 +7284,40 @@
       "CSS Support React Lifecyce Order (production) should have the correct color on mount after navigation"
     ],
     "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/css/test/css-modules.test.js": {
+    "passed": [],
+    "failed": [],
+    "pending": [],
+    "flakey": [
+      "Basic CSS Modules Ordering Development Mode should have correct color on index page (on load)",
+      "Basic CSS Modules Ordering Development Mode should have correct color on index page (on hover)",
+      "Basic CSS Modules Ordering Development Mode should have correct color on index page (on nav)",
+      "Basic CSS Modules Ordering Production Mode should have correct color on index page (on load)",
+      "Basic CSS Modules Ordering Production Mode should have correct color on index page (on hover)",
+      "Basic CSS Modules Ordering Production Mode should have correct color on index page (on nav)",
+      "should handle unresolved files gracefully should build correctly",
+      "should handle unresolved files gracefully should have correct file references in CSS output",
+      "Data URLs should compile successfully",
+      "Data URLs should have emitted expected files",
+      "Ordering with Global CSS and Modules (dev) should not execute scripts in any order",
+      "Ordering with Global CSS and Modules (dev) should have the correct color (css ordering)",
+      "Ordering with Global CSS and Modules (dev) should have the correct color (css ordering) during hot reloads",
+      "Ordering with Global CSS and Modules (prod) should have compiled successfully",
+      "Ordering with Global CSS and Modules (prod) should have the correct color (css ordering)",
+      "CSS Modules Composes Ordering Development Mode should have correct color on index page (on load)",
+      "CSS Modules Composes Ordering Development Mode should have correct color on index page (on hover)",
+      "CSS Modules Composes Ordering Development Mode should have correct color on index page (on nav from index)",
+      "CSS Modules Composes Ordering Development Mode should have correct color on index page (on nav from other)",
+      "CSS Modules Composes Ordering Production Mode should have correct color on index page (on load)",
+      "CSS Modules Composes Ordering Production Mode should have correct color on index page (on hover)",
+      "CSS Modules Composes Ordering Production Mode should not change color on hover",
+      "CSS Modules Composes Ordering Production Mode should have correct CSS injection order",
+      "CSS Modules Composes Ordering Production Mode should have correct color on index page (on nav from index)",
+      "CSS Modules Composes Ordering Production Mode should have correct color on index page (on nav from other)"
+    ],
     "runtimeError": false
   },
   "test/integration/css/test/css-rendering.test.js": {
@@ -6553,6 +7338,7 @@
       "CSS Support Page hydrates with CSS and not waiting on dependencies Production Mode should route from black to red without dependencies"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css/test/dev-css-handling.test.js": {
@@ -6566,6 +7352,7 @@
       "Can hot reload CSS without losing state should update CSS color without remounting <input>"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/css/test/valid-invalid-css.test.js": {
@@ -6579,6 +7366,7 @@
       "Valid and Invalid Global CSS with Custom App should fail to build"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/custom-error-page-exception/test/index.test.js": {
@@ -6587,6 +7375,7 @@
     "pending": [
       "Custom error page exception should handle errors from _error render"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/custom-error/test/index.test.js": {
@@ -6599,6 +7388,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/custom-page-extension/test/index.test.js": {
@@ -6610,6 +7400,7 @@
       "Custom page extension production mode should work with normal page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/custom-routes-catchall/test/index.test.js": {
@@ -6625,6 +7416,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/custom-routes-i18n-index-redirect/test/index.test.js": {
@@ -6634,6 +7426,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/custom-routes-i18n/test/index.test.js": {
@@ -6650,12 +7443,234 @@
       "Custom routes i18n production mode should navigate on the client with rewrites correctly"
     ],
     "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/custom-routes/test/index.test.js": {
+    "passed": [],
+    "failed": [],
+    "pending": [],
+    "flakey": [
+      "Custom routes dev mode should honor caseSensitiveRoutes config for /to-ANOTHER",
+      "Custom routes dev mode should honor caseSensitiveRoutes config for /HELLO-world",
+      "Custom routes dev mode should honor caseSensitiveRoutes config for /docs/GITHUB",
+      "Custom routes dev mode should honor caseSensitiveRoutes config for /add-HEADER",
+      "Custom routes dev mode should successfully rewrite a WebSocket request",
+      "Custom routes dev mode should successfully rewrite a WebSocket request to a page",
+      "Custom routes dev mode should not rewrite for _next/data route when a match is found",
+      "Custom routes dev mode should handle has query encoding correctly",
+      "Custom routes dev mode should handle external beforeFiles rewrite correctly",
+      "Custom routes dev mode should handle beforeFiles rewrite to dynamic route correctly",
+      "Custom routes dev mode should handle beforeFiles rewrite to partly dynamic route correctly",
+      "Custom routes dev mode should support long URLs for rewrites",
+      "Custom routes dev mode should resolveHref correctly navigating through history",
+      "Custom routes dev mode should continue in beforeFiles rewrites",
+      "Custom routes dev mode should not hang when proxy rewrite fails",
+      "Custom routes dev mode should parse params correctly for rewrite to auto-export dynamic page",
+      "Custom routes dev mode should provide params correctly for rewrite to auto-export non-dynamic page",
+      "Custom routes dev mode should handle one-to-one rewrite successfully",
+      "Custom routes dev mode should handle chained rewrites successfully",
+      "Custom routes dev mode should handle param like headers properly",
+      "Custom routes dev mode should not match dynamic route immediately after applying header",
+      "Custom routes dev mode should handle chained redirects successfully",
+      "Custom routes dev mode should not match redirect for /_next",
+      "Custom routes dev mode should redirect successfully with permanent: false",
+      "Custom routes dev mode should redirect with params successfully",
+      "Custom routes dev mode should redirect with hash successfully",
+      "Custom routes dev mode should redirect successfully with provided statusCode",
+      "Custom routes dev mode should redirect successfully with catchall",
+      "Custom routes dev mode should server static files through a rewrite",
+      "Custom routes dev mode should rewrite with params successfully",
+      "Custom routes dev mode should not append params when one is used in destination path",
+      "Custom routes dev mode should double redirect successfully",
+      "Custom routes dev mode should allow params in query for rewrite",
+      "Custom routes dev mode should have correct params for catchall rewrite",
+      "Custom routes dev mode should have correct encoding for params with catchall rewrite",
+      "Custom routes dev mode should have correct query for catchall rewrite",
+      "Custom routes dev mode should have correct header for catchall rewrite",
+      "Custom routes dev mode should allow params in query for redirect",
+      "Custom routes dev mode should have correctly encoded params in query for redirect",
+      "Custom routes dev mode should overwrite param values correctly",
+      "Custom routes dev mode should handle query for rewrite correctly",
+      "Custom routes dev mode should not allow rewrite to override page file",
+      "Custom routes dev mode show allow redirect to override the page",
+      "Custom routes dev mode should work successfully on the client",
+      "Custom routes dev mode should work with rewrite when manually specifying href/as",
+      "Custom routes dev mode should work with rewrite when only specifying href",
+      "Custom routes dev mode should work with rewrite when only specifying href and ends in dynamic route",
+      "Custom routes dev mode should match a page after a rewrite",
+      "Custom routes dev mode should match dynamic route after rewrite",
+      "Custom routes dev mode should match public file after rewrite",
+      "Custom routes dev mode should match /_next file after rewrite",
+      "Custom routes dev mode should allow redirecting to external resource",
+      "Custom routes dev mode should apply headers for exact match",
+      "Custom routes dev mode should apply headers for multi match",
+      "Custom routes dev mode should apply params for header key/values",
+      "Custom routes dev mode should support URL for header key/values",
+      "Custom routes dev mode should apply params header key/values with URL",
+      "Custom routes dev mode should apply params header key/values with URL that has port",
+      "Custom routes dev mode should support named pattern for header key/values",
+      "Custom routes dev mode should support proxying to external resource",
+      "Custom routes dev mode should support unnamed parameters correctly",
+      "Custom routes dev mode should support named like unnamed parameters correctly",
+      "Custom routes dev mode should add refresh header for 308 redirect",
+      "Custom routes dev mode should have correctly encoded query in location and refresh headers",
+      "Custom routes dev mode should handle basic api rewrite successfully",
+      "Custom routes dev mode should handle api rewrite with un-named param successfully",
+      "Custom routes dev mode should handle api rewrite with param successfully",
+      "Custom routes dev mode should handle encoded value in the pathname correctly",
+      "Custom routes dev mode should handle unnamed parameters with multi-match successfully",
+      "Custom routes dev mode should handle named regex parameters with multi-match successfully",
+      "Custom routes dev mode should redirect with URL in query correctly",
+      "Custom routes dev mode should redirect with URL in query correctly non-encoded",
+      "Custom routes dev mode should match missing header headers correctly",
+      "Custom routes dev mode should match missing query headers correctly",
+      "Custom routes dev mode should match missing cookie headers correctly",
+      "Custom routes dev mode should match missing header redirect correctly",
+      "Custom routes dev mode should match missing query redirect correctly",
+      "Custom routes dev mode should match missing cookie redirect correctly",
+      "Custom routes dev mode should match missing header rewrite correctly",
+      "Custom routes dev mode should match missing query rewrite correctly",
+      "Custom routes dev mode should match missing cookie rewrite correctly",
+      "Custom routes dev mode should match has header rewrite correctly",
+      "Custom routes dev mode should match has query rewrite correctly",
+      "Custom routes dev mode should match has cookie rewrite correctly",
+      "Custom routes dev mode should match has host rewrite correctly",
+      "Custom routes dev mode should pass has segment for rewrite correctly",
+      "Custom routes dev mode should not pass non captured has value for rewrite correctly",
+      "Custom routes dev mode should pass captured has value for rewrite correctly",
+      "Custom routes dev mode should match has rewrite correctly before files",
+      "Custom routes dev mode should match has header redirect correctly",
+      "Custom routes dev mode should match has query redirect correctly",
+      "Custom routes dev mode should match has cookie redirect correctly",
+      "Custom routes dev mode should match has host redirect correctly",
+      "Custom routes dev mode should match has host redirect and insert in destination correctly",
+      "Custom routes dev mode should match has query redirect with duplicate query key",
+      "Custom routes dev mode should match has header for header correctly",
+      "Custom routes dev mode should match has query for header correctly",
+      "Custom routes dev mode should match has cookie for header correctly",
+      "Custom routes dev mode should match has host for header correctly",
+      "Custom routes no-op rewrite should not error for no-op rewrite and auto export dynamic route",
+      "Custom routes server mode should honor caseSensitiveRoutes config for /to-ANOTHER",
+      "Custom routes server mode should honor caseSensitiveRoutes config for /HELLO-world",
+      "Custom routes server mode should honor caseSensitiveRoutes config for /docs/GITHUB",
+      "Custom routes server mode should honor caseSensitiveRoutes config for /add-HEADER",
+      "Custom routes server mode should successfully rewrite a WebSocket request",
+      "Custom routes server mode should successfully rewrite a WebSocket request to a page",
+      "Custom routes server mode should not rewrite for _next/data route when a match is found",
+      "Custom routes server mode should handle has query encoding correctly",
+      "Custom routes server mode should handle external beforeFiles rewrite correctly",
+      "Custom routes server mode should handle beforeFiles rewrite to dynamic route correctly",
+      "Custom routes server mode should handle beforeFiles rewrite to partly dynamic route correctly",
+      "Custom routes server mode should support long URLs for rewrites",
+      "Custom routes server mode should resolveHref correctly navigating through history",
+      "Custom routes server mode should continue in beforeFiles rewrites",
+      "Custom routes server mode should not hang when proxy rewrite fails",
+      "Custom routes server mode should parse params correctly for rewrite to auto-export dynamic page",
+      "Custom routes server mode should provide params correctly for rewrite to auto-export non-dynamic page",
+      "Custom routes server mode should handle one-to-one rewrite successfully",
+      "Custom routes server mode should handle chained rewrites successfully",
+      "Custom routes server mode should handle param like headers properly",
+      "Custom routes server mode should not match dynamic route immediately after applying header",
+      "Custom routes server mode should handle chained redirects successfully",
+      "Custom routes server mode should not match redirect for /_next",
+      "Custom routes server mode should redirect successfully with permanent: false",
+      "Custom routes server mode should redirect with params successfully",
+      "Custom routes server mode should redirect with hash successfully",
+      "Custom routes server mode should redirect successfully with provided statusCode",
+      "Custom routes server mode should redirect successfully with catchall",
+      "Custom routes server mode should server static files through a rewrite",
+      "Custom routes server mode should rewrite with params successfully",
+      "Custom routes server mode should not append params when one is used in destination path",
+      "Custom routes server mode should double redirect successfully",
+      "Custom routes server mode should allow params in query for rewrite",
+      "Custom routes server mode should have correct params for catchall rewrite",
+      "Custom routes server mode should have correct encoding for params with catchall rewrite",
+      "Custom routes server mode should have correct query for catchall rewrite",
+      "Custom routes server mode should have correct header for catchall rewrite",
+      "Custom routes server mode should allow params in query for redirect",
+      "Custom routes server mode should have correctly encoded params in query for redirect",
+      "Custom routes server mode should overwrite param values correctly",
+      "Custom routes server mode should handle query for rewrite correctly",
+      "Custom routes server mode should not allow rewrite to override page file",
+      "Custom routes server mode show allow redirect to override the page",
+      "Custom routes server mode should work successfully on the client",
+      "Custom routes server mode should work with rewrite when manually specifying href/as",
+      "Custom routes server mode should work with rewrite when only specifying href",
+      "Custom routes server mode should work with rewrite when only specifying href and ends in dynamic route",
+      "Custom routes server mode should match a page after a rewrite",
+      "Custom routes server mode should match dynamic route after rewrite",
+      "Custom routes server mode should match public file after rewrite",
+      "Custom routes server mode should match /_next file after rewrite",
+      "Custom routes server mode should allow redirecting to external resource",
+      "Custom routes server mode should apply headers for exact match",
+      "Custom routes server mode should apply headers for multi match",
+      "Custom routes server mode should apply params for header key/values",
+      "Custom routes server mode should support URL for header key/values",
+      "Custom routes server mode should apply params header key/values with URL",
+      "Custom routes server mode should apply params header key/values with URL that has port",
+      "Custom routes server mode should support named pattern for header key/values",
+      "Custom routes server mode should support proxying to external resource",
+      "Custom routes server mode should support unnamed parameters correctly",
+      "Custom routes server mode should support named like unnamed parameters correctly",
+      "Custom routes server mode should add refresh header for 308 redirect",
+      "Custom routes server mode should have correctly encoded query in location and refresh headers",
+      "Custom routes server mode should handle basic api rewrite successfully",
+      "Custom routes server mode should handle api rewrite with un-named param successfully",
+      "Custom routes server mode should handle api rewrite with param successfully",
+      "Custom routes server mode should handle encoded value in the pathname correctly",
+      "Custom routes server mode should handle unnamed parameters with multi-match successfully",
+      "Custom routes server mode should handle named regex parameters with multi-match successfully",
+      "Custom routes server mode should redirect with URL in query correctly",
+      "Custom routes server mode should redirect with URL in query correctly non-encoded",
+      "Custom routes server mode should match missing header headers correctly",
+      "Custom routes server mode should match missing query headers correctly",
+      "Custom routes server mode should match missing cookie headers correctly",
+      "Custom routes server mode should match missing header redirect correctly",
+      "Custom routes server mode should match missing query redirect correctly",
+      "Custom routes server mode should match missing cookie redirect correctly",
+      "Custom routes server mode should match missing header rewrite correctly",
+      "Custom routes server mode should match missing query rewrite correctly",
+      "Custom routes server mode should match missing cookie rewrite correctly",
+      "Custom routes server mode should match has header rewrite correctly",
+      "Custom routes server mode should match has query rewrite correctly",
+      "Custom routes server mode should match has cookie rewrite correctly",
+      "Custom routes server mode should match has host rewrite correctly",
+      "Custom routes server mode should pass has segment for rewrite correctly",
+      "Custom routes server mode should not pass non captured has value for rewrite correctly",
+      "Custom routes server mode should pass captured has value for rewrite correctly",
+      "Custom routes server mode should match has rewrite correctly before files",
+      "Custom routes server mode should match has header redirect correctly",
+      "Custom routes server mode should match has query redirect correctly",
+      "Custom routes server mode should match has cookie redirect correctly",
+      "Custom routes server mode should match has host redirect correctly",
+      "Custom routes server mode should match has host redirect and insert in destination correctly",
+      "Custom routes server mode should match has query redirect with duplicate query key",
+      "Custom routes server mode should match has header for header correctly",
+      "Custom routes server mode should match has query for header correctly",
+      "Custom routes server mode should match has cookie for header correctly",
+      "Custom routes server mode should match has host for header correctly",
+      "Custom routes server mode should output routes-manifest successfully",
+      "Custom routes server mode should have redirects/rewrites in build output with debug flag",
+      "Custom routes server mode should not show warning for custom routes when not next export",
+      "Custom routes server mode should not show warning for experimental has usage",
+      "Custom routes export should not show warning for custom routes when not next export",
+      "Custom routes export should not show warning for custom routes when next export on Vercel",
+      "Custom routes export should show warning for custom routes with next export",
+      "Custom routes should load custom routes when only one type is used dev mode should work with just headers",
+      "Custom routes should load custom routes when only one type is used dev mode should work with just rewrites",
+      "Custom routes should load custom routes when only one type is used dev mode should work with just redirects",
+      "Custom routes should load custom routes when only one type is used production mode should work with just headers",
+      "Custom routes should load custom routes when only one type is used production mode should work with just rewrites",
+      "Custom routes should load custom routes when only one type is used production mode should work with just redirects"
+    ],
     "runtimeError": false
   },
   "test/integration/custom-server-types/test/index.test.js": {
     "passed": ["Custom Server TypeScript should build server.ts correctly"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/custom-server/test/index.test.js": {
@@ -6698,6 +7713,7 @@
       "Custom Server using HTTPS with generateEtags enabled response includes etag header",
       "Custom Server using HTTPS with middleware $title should read the expected url protocol in middleware"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/data-fetching-errors/test/index.test.js": {
@@ -6715,6 +7731,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/dedupes-scripts/test/index.test.js": {
@@ -6723,12 +7740,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/development-hmr-refresh/test/index.test.js": {
     "passed": ["page should not reload when the file is not changed"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/development-runtime-config/test/index.test.js": {
@@ -6739,6 +7758,7 @@
       "should work with runtime-config in next.config.js with runtime-config"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/disable-js/test/index.test.js": {
@@ -6753,6 +7773,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/dist-dir/test/index.test.js": {
@@ -6768,6 +7789,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/document-file-dependencies/test/index.test.js": {
@@ -6779,6 +7801,7 @@
       "File Dependencies production mode should apply styles defined in global and module css files in 404 page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/document-head-warnings/test/index.test.js": {
@@ -6789,6 +7812,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/draft-mode/test/index.test.ts": {
@@ -6815,6 +7839,7 @@
       "Test Draft Mode Server Mode should start production application"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/duplicate-pages/test/index.test.js": {
@@ -6824,6 +7849,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/dynamic-optional-routing-root-fallback/test/index.test.js": {
@@ -6837,6 +7863,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/dynamic-optional-routing-root-static-paths/test/index.test.js": {
@@ -6850,6 +7877,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/dynamic-optional-routing/test/index.test.js": {
@@ -6914,6 +7942,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/dynamic-require/test/index.test.js": {
@@ -6922,6 +7951,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/dynamic-route-rename/test/index.test.js": {
@@ -6930,6 +7960,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/dynamic-routing/test/index.test.js": {
@@ -7071,7 +8102,6 @@
       "Dynamic Routing production mode [ssg: catch-all] should pass params in getStaticProps during client navigation (multi) no as",
       "Dynamic Routing production mode [ssg: catch-all] should pass params in getStaticProps during client navigation (single interpolated)",
       "Dynamic Routing production mode [ssg: catch-all] should pass params in getStaticProps during client navigation (single)",
-      "Dynamic Routing production mode should have correct cache entries on prefetch",
       "Dynamic Routing production mode should navigate to a dynamic page successfully",
       "Dynamic Routing production mode should navigate to a dynamic page successfully interpolated",
       "Dynamic Routing production mode should navigate to a dynamic page successfully interpolated with additional query values",
@@ -7087,6 +8117,165 @@
     ],
     "pending": [
       "Dynamic Routing dev mode should not have error after pinging WebSocket"
+    ],
+    "flakey": [
+      "Dynamic Routing production mode should have correct cache entries on prefetch"
+    ],
+    "runtimeError": false
+  },
+  "test/integration/dynamic-routing/test/middleware.test.js": {
+    "passed": [],
+    "failed": [],
+    "pending": [],
+    "flakey": [
+      "Dynamic Routing dev mode should not have error after pinging WebSocket",
+      "Dynamic Routing dev mode should support long URLs for dynamic routes",
+      "Dynamic Routing dev mode should handle only query on dynamic route",
+      "Dynamic Routing dev mode should handle only hash on dynamic route",
+      "Dynamic Routing dev mode should navigate with hash to dynamic route with link",
+      "Dynamic Routing dev mode should navigate with hash to dynamic route with router",
+      "Dynamic Routing dev mode should not have any query values when not defined",
+      "Dynamic Routing dev mode should render normal route",
+      "Dynamic Routing dev mode should render another normal route",
+      "Dynamic Routing dev mode should render dynamic page",
+      "Dynamic Routing dev mode should prioritize a non-dynamic page",
+      "Dynamic Routing dev mode should render nested dynamic page",
+      "Dynamic Routing dev mode should render optional dynamic page",
+      "Dynamic Routing dev mode should render nested optional dynamic page",
+      "Dynamic Routing dev mode should not error when requesting dynamic page with /api",
+      "Dynamic Routing dev mode should render dynamic route with query",
+      "Dynamic Routing dev mode should not have any console warnings on initial load",
+      "Dynamic Routing dev mode should not have any console warnings when navigating to dynamic route",
+      "Dynamic Routing dev mode should navigate to a dynamic page successfully",
+      "Dynamic Routing dev mode should navigate to a dynamic page with href with differing query and as correctly",
+      "Dynamic Routing dev mode should navigate to a dynamic page successfully no as",
+      "Dynamic Routing dev mode should navigate to a dynamic page successfully interpolated",
+      "Dynamic Routing dev mode should navigate to a dynamic page successfully interpolated with additional query values",
+      "Dynamic Routing dev mode should allow calling Router.push on mount successfully",
+      "Dynamic Routing dev mode should navigate optional dynamic page",
+      "Dynamic Routing dev mode should navigate optional dynamic page with value",
+      "Dynamic Routing dev mode should navigate to a nested dynamic page successfully",
+      "Dynamic Routing dev mode should navigate to a nested dynamic page successfully no as",
+      "Dynamic Routing dev mode should navigate to a nested dynamic page successfully interpolated",
+      "Dynamic Routing dev mode should pass params in getInitialProps during SSR",
+      "Dynamic Routing dev mode should pass params in getInitialProps during client navigation",
+      "Dynamic Routing dev mode [catch all] should not match root on SSR",
+      "Dynamic Routing dev mode [catch all] should pass param in getInitialProps during SSR",
+      "Dynamic Routing dev mode [catch all] should pass params in getInitialProps during SSR",
+      "Dynamic Routing dev mode [catch all] should strip trailing slash",
+      "Dynamic Routing dev mode [catch all] should not decode slashes (start)",
+      "Dynamic Routing dev mode [catch all] should not decode slashes (end)",
+      "Dynamic Routing dev mode [catch all] should not decode slashes (middle)",
+      "Dynamic Routing dev mode [catch-all] should pass params in getInitialProps during client navigation (single)",
+      "Dynamic Routing dev mode [catch-all] should pass params in getInitialProps during client navigation (multi)",
+      "Dynamic Routing dev mode [catch-all] should pass params in getInitialProps during client navigation (encoded)",
+      "Dynamic Routing dev mode [catch-all] shouldn't fail on colon followed by double digits in the path",
+      "Dynamic Routing dev mode [ssg: catch all] should pass param in getStaticProps during SSR",
+      "Dynamic Routing dev mode [ssg: catch all] should pass params in getStaticProps during SSR",
+      "Dynamic Routing dev mode [nested ssg: catch all] should pass param in getStaticProps during SSR",
+      "Dynamic Routing dev mode [nested ssg: catch all] should pass params in getStaticProps during SSR",
+      "Dynamic Routing dev mode [predefined ssg: catch all] should pass param in getStaticProps during SSR",
+      "Dynamic Routing dev mode [predefined ssg: catch all] should pass params in getStaticProps during SSR",
+      "Dynamic Routing dev mode [predefined ssg: prerendered catch all] should pass param in getStaticProps during SSR",
+      "Dynamic Routing dev mode [predefined ssg: prerendered catch all] should pass params in getStaticProps during SSR",
+      "Dynamic Routing dev mode [ssg: catch-all] should pass params in getStaticProps during client navigation (single)",
+      "Dynamic Routing dev mode [ssg: catch-all] should pass params in getStaticProps during client navigation (single interpolated)",
+      "Dynamic Routing dev mode [ssg: catch-all] should pass params in getStaticProps during client navigation (multi)",
+      "Dynamic Routing dev mode [ssg: catch-all] should pass params in getStaticProps during client navigation (multi) no as",
+      "Dynamic Routing dev mode [ssg: catch-all] should pass params in getStaticProps during client navigation (multi interpolated)",
+      "Dynamic Routing dev mode [nested ssg: catch-all] should pass params in getStaticProps during client navigation (single)",
+      "Dynamic Routing dev mode [nested ssg: catch-all] should pass params in getStaticProps during client navigation (multi)",
+      "Dynamic Routing dev mode should update dynamic values on mount",
+      "Dynamic Routing dev mode should not have placeholder query values for SSS",
+      "Dynamic Routing dev mode should update with a hash in the URL",
+      "Dynamic Routing dev mode should scroll to a hash on mount",
+      "Dynamic Routing dev mode should scroll to a hash on client-side navigation",
+      "Dynamic Routing dev mode should prioritize public files over dynamic route",
+      "Dynamic Routing dev mode should serve file with space from public folder",
+      "Dynamic Routing dev mode should serve file with plus from public folder",
+      "Dynamic Routing dev mode should serve file from public folder encoded",
+      "Dynamic Routing dev mode should serve file with %20 from public folder",
+      "Dynamic Routing dev mode should serve file with space from static folder",
+      "Dynamic Routing dev mode should serve file with plus from static folder",
+      "Dynamic Routing dev mode should serve file from static folder encoded",
+      "Dynamic Routing dev mode should serve file with %20 from static folder",
+      "Dynamic Routing dev mode should respond with bad request with invalid encoding",
+      "Dynamic Routing dev mode should not preload buildManifest for non-auto export dynamic pages",
+      "Dynamic Routing dev mode should resolve dynamic route href for page added later",
+      "Dynamic Routing dev mode should work with HMR correctly",
+      "Dynamic Routing production mode should have correct cache entries on prefetch",
+      "Dynamic Routing production mode should support long URLs for dynamic routes",
+      "Dynamic Routing production mode should handle only query on dynamic route",
+      "Dynamic Routing production mode should handle only hash on dynamic route",
+      "Dynamic Routing production mode should navigate with hash to dynamic route with link",
+      "Dynamic Routing production mode should navigate with hash to dynamic route with router",
+      "Dynamic Routing production mode should not have any query values when not defined",
+      "Dynamic Routing production mode should render normal route",
+      "Dynamic Routing production mode should render another normal route",
+      "Dynamic Routing production mode should render dynamic page",
+      "Dynamic Routing production mode should prioritize a non-dynamic page",
+      "Dynamic Routing production mode should render nested dynamic page",
+      "Dynamic Routing production mode should render optional dynamic page",
+      "Dynamic Routing production mode should render nested optional dynamic page",
+      "Dynamic Routing production mode should not error when requesting dynamic page with /api",
+      "Dynamic Routing production mode should render dynamic route with query",
+      "Dynamic Routing production mode should navigate to a dynamic page successfully",
+      "Dynamic Routing production mode should navigate to a dynamic page with href with differing query and as correctly",
+      "Dynamic Routing production mode should navigate to a dynamic page successfully no as",
+      "Dynamic Routing production mode should navigate to a dynamic page successfully interpolated",
+      "Dynamic Routing production mode should navigate to a dynamic page successfully interpolated with additional query values",
+      "Dynamic Routing production mode should allow calling Router.push on mount successfully",
+      "Dynamic Routing production mode should navigate optional dynamic page",
+      "Dynamic Routing production mode should navigate optional dynamic page with value",
+      "Dynamic Routing production mode should navigate to a nested dynamic page successfully",
+      "Dynamic Routing production mode should navigate to a nested dynamic page successfully no as",
+      "Dynamic Routing production mode should navigate to a nested dynamic page successfully interpolated",
+      "Dynamic Routing production mode should pass params in getInitialProps during SSR",
+      "Dynamic Routing production mode should pass params in getInitialProps during client navigation",
+      "Dynamic Routing production mode [catch all] should not match root on SSR",
+      "Dynamic Routing production mode [catch all] should pass param in getInitialProps during SSR",
+      "Dynamic Routing production mode [catch all] should pass params in getInitialProps during SSR",
+      "Dynamic Routing production mode [catch all] should strip trailing slash",
+      "Dynamic Routing production mode [catch all] should not decode slashes (start)",
+      "Dynamic Routing production mode [catch all] should not decode slashes (end)",
+      "Dynamic Routing production mode [catch all] should not decode slashes (middle)",
+      "Dynamic Routing production mode [catch-all] should pass params in getInitialProps during client navigation (single)",
+      "Dynamic Routing production mode [catch-all] should pass params in getInitialProps during client navigation (multi)",
+      "Dynamic Routing production mode [catch-all] should pass params in getInitialProps during client navigation (encoded)",
+      "Dynamic Routing production mode [catch-all] shouldn't fail on colon followed by double digits in the path",
+      "Dynamic Routing production mode [ssg: catch all] should pass param in getStaticProps during SSR",
+      "Dynamic Routing production mode [ssg: catch all] should pass params in getStaticProps during SSR",
+      "Dynamic Routing production mode [nested ssg: catch all] should pass param in getStaticProps during SSR",
+      "Dynamic Routing production mode [nested ssg: catch all] should pass params in getStaticProps during SSR",
+      "Dynamic Routing production mode [predefined ssg: catch all] should pass param in getStaticProps during SSR",
+      "Dynamic Routing production mode [predefined ssg: catch all] should pass params in getStaticProps during SSR",
+      "Dynamic Routing production mode [predefined ssg: prerendered catch all] should pass param in getStaticProps during SSR",
+      "Dynamic Routing production mode [predefined ssg: prerendered catch all] should pass params in getStaticProps during SSR",
+      "Dynamic Routing production mode [ssg: catch-all] should pass params in getStaticProps during client navigation (single)",
+      "Dynamic Routing production mode [ssg: catch-all] should pass params in getStaticProps during client navigation (single interpolated)",
+      "Dynamic Routing production mode [ssg: catch-all] should pass params in getStaticProps during client navigation (multi)",
+      "Dynamic Routing production mode [ssg: catch-all] should pass params in getStaticProps during client navigation (multi) no as",
+      "Dynamic Routing production mode [ssg: catch-all] should pass params in getStaticProps during client navigation (multi interpolated)",
+      "Dynamic Routing production mode [nested ssg: catch-all] should pass params in getStaticProps during client navigation (single)",
+      "Dynamic Routing production mode [nested ssg: catch-all] should pass params in getStaticProps during client navigation (multi)",
+      "Dynamic Routing production mode should update dynamic values on mount",
+      "Dynamic Routing production mode should not have placeholder query values for SSS",
+      "Dynamic Routing production mode should update with a hash in the URL",
+      "Dynamic Routing production mode should scroll to a hash on mount",
+      "Dynamic Routing production mode should scroll to a hash on client-side navigation",
+      "Dynamic Routing production mode should prioritize public files over dynamic route",
+      "Dynamic Routing production mode should serve file with space from public folder",
+      "Dynamic Routing production mode should serve file with plus from public folder",
+      "Dynamic Routing production mode should serve file from public folder encoded",
+      "Dynamic Routing production mode should serve file with %20 from public folder",
+      "Dynamic Routing production mode should serve file with space from static folder",
+      "Dynamic Routing production mode should serve file with plus from static folder",
+      "Dynamic Routing production mode should serve file from static folder encoded",
+      "Dynamic Routing production mode should serve file with %20 from static folder",
+      "Dynamic Routing production mode should respond with bad request with invalid encoding",
+      "Dynamic Routing production mode should not preload buildManifest for non-auto export dynamic pages",
+      "Dynamic Routing production mode should output a routes-manifest correctly",
+      "Dynamic Routing production mode should output a pages-manifest correctly"
     ],
     "runtimeError": false
   },
@@ -7115,6 +8304,7 @@
       "Edge runtime configurable guards Multiple functions with different configurations warns in dev for unallowed code"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/edge-runtime-dynamic-code/test/index.test.js": {
@@ -7135,6 +8325,7 @@
       "Page using eval in dev mode does issue dynamic code evaluation warnings"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/edge-runtime-module-errors/test/index.test.js": {
@@ -7163,6 +8354,7 @@
       "Edge runtime code with imports Middleware using Buffer polyfill does not throw in production at runtime"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/edge-runtime-module-errors/test/module-imports.test.js": {
@@ -7187,6 +8379,7 @@
       "Edge runtime code with imports Middleware statically importing node.js module throws unsupported module error in production at runtime and prints error on logs"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/edge-runtime-response-error/test/index.test.js": {
@@ -7199,12 +8392,14 @@
       "Edge runtime code with imports test error if response is not Response type Middleware build test Response"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/edge-runtime-streaming-error/test/index.test.ts": {
     "passed": ["dev mode logs the error correctly"],
     "failed": ["production mode logs the error correctly"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/edge-runtime-with-node.js-apis/test/index.test.ts": {
@@ -7297,6 +8492,7 @@
       "Middleware using Node.js API production mode warns for setImmediate during build"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/empty-object-getInitialProps/test/index.test.js": {
@@ -7307,12 +8503,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/empty-project/test/index.test.js": {
     "passed": ["Empty Project Should not time out and return 404"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/env-config/test/index.test.js": {
@@ -7351,6 +8549,7 @@
       "Env Config test environment should provide env for SSG"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/error-in-error/test/index.test.js": {
@@ -7360,6 +8559,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/error-load-fail/test/index.test.js": {
@@ -7368,6 +8568,7 @@
       "Failing to load _error handles failing to load _error correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/error-plugin-stack-overflow/test/index.test.js": {
@@ -7376,6 +8577,7 @@
       "Reports stack trace when webpack plugin stack overflows shows details in next build"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/errors-on-output-to-public/test/index.test.js": {
@@ -7385,6 +8587,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/errors-on-output-to-static/test/index.test.js": {
@@ -7393,6 +8596,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/eslint/test/lint-cache.test.js": {
@@ -7406,6 +8610,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/eslint/test/next-build.test.js": {
@@ -7425,6 +8630,7 @@
       "Next Build eslint ignored directories do not fail the build"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/eslint/test/next-lint.test.js": {
@@ -7458,6 +8664,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-404/test/index.test.js": {
@@ -7468,6 +8675,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-default-map/test/index.test.js": {
@@ -7481,6 +8689,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-dynamic-pages/test/index.test.js": {
@@ -7490,6 +8699,7 @@
       "Export Dyanmic Pages should of exported with correct asPath"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/integration/export-fallback-true-error/test/index.test.js": {
@@ -7499,6 +8709,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-getInitialProps-warn/test/index.test.js": {
@@ -7507,6 +8718,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-image-default/test/index.test.js": {
@@ -7516,6 +8728,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-image-loader-legacy/test/index.test.js": {
@@ -7533,6 +8746,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-image-loader/test/index.test.js": {
@@ -7554,6 +8768,7 @@
       "Export with unoptimized next/image component should export successfully"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-index-not-found-gsp/test/index.test.ts": {
@@ -7563,6 +8778,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-intent/test/index.test.js": {
@@ -7583,6 +8799,7 @@
       "Application Export Intent Output Custom Export should have the expected outputs for export"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-no-build/test/index.test.js": {
@@ -7591,6 +8808,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-progress-status-message/test/index.test.js": {
@@ -7600,6 +8818,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/export-subfolders/test/index.test.js": {
@@ -7608,6 +8827,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/externals-esm-loose/test/index.test.js": {
@@ -7618,6 +8838,7 @@
       "Handle ESM externals with esmExternals: 'loose' should render the static page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/externals-esm/test/index.test.js": {
@@ -7628,6 +8849,7 @@
       "Handle ESM externals with esmExternals: true should render the static page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/fallback-false-rewrite/test/index.test.js": {
@@ -7649,12 +8871,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/fallback-modules/test/index.test.js": {
     "passed": ["Build Output Crypto Application should not include crypto"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/fallback-route-params/test/index.test.js": {
@@ -7666,6 +8890,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/fetch-polyfill-ky-universal/test/index.test.js": {
@@ -7680,6 +8905,7 @@
       "Fetch polyfill with ky-universal Server support includes polyfilled fetch when using getServerSideProps"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/fetch-polyfill/test/index.test.js": {
@@ -7698,6 +8924,7 @@
       "Fetch polyfill Server support includes polyfilled fetch when using getServerSideProps"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/file-serving/test/index.test.js": {
@@ -9017,6 +10244,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/filesystempublicroutes/test/index.test.js": {
@@ -9027,6 +10255,7 @@
       "FileSystemPublicRoutes should still handle /_next routes"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/firebase-grpc/test/index.test.js": {
@@ -9037,6 +10266,7 @@
     "pending": [
       "Building Firebase Throws an error when building with firebase dependency with worker_threads"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/font-optimization/test/index.test.js": {
@@ -9072,12 +10302,14 @@
       "Font Optimization with-typekit Font optimization for SSR apps should work when build is cached"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/future/test/index.test.js": {
     "passed": ["excludeDefaultMomentLocales should load momentjs"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/getinitialprops/test/index.test.js": {
@@ -9093,6 +10325,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/getserversideprops-export-error/test/index.test.js": {
@@ -9102,6 +10335,7 @@
       "getServerSideProps production mode should show error for GSSP during export"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/getserversideprops-preview/test/index.test.js": {
@@ -9126,6 +10360,7 @@
       "ServerSide Props Preview Mode Server Mode should throw error when setting too large of preview data"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/gip-identifier/test/index.test.js": {
@@ -9141,6 +10376,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/gsp-build-errors/test/index.test.js": {
@@ -9154,6 +10390,7 @@
     ],
     "failed": ["GSP build errors should fail build from module not found"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/gsp-extension/test/index.test.js": {
@@ -9164,6 +10401,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/gssp-pageProps-merge/test/index.test.js": {
@@ -9175,6 +10413,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/gssp-redirect-base-path/test/index.test.js": {
@@ -9224,6 +10463,7 @@
       "GS(S)P Redirect Support production mode should not replace history of the origin page when GSSP page is navigated to client-side (internal normal)"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/gssp-redirect-with-rewrites/test/index.test.js": {
@@ -9234,6 +10474,7 @@
       "getServerSideProps redirects should use a client-side navigation for a rewritten URL"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/gssp-redirect/test/index.test.js": {
@@ -9290,12 +10531,14 @@
       "GS(S)P Redirect Support production mode should not replace history of the origin page when GSSP page is navigated to client-side (internal normal)"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/handles-export-errors/test/index.test.js": {
     "passed": ["Handles Errors During Export Does not crash workers"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/hashbang/test/index.test.js": {
@@ -9309,6 +10552,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/hydrate-then-render/test/index.test.js": {
@@ -9317,6 +10561,7 @@
       "hydrate/render ordering correctly measures hydrate followed by render"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/hydration/test/index.test.js": {
@@ -9331,6 +10576,7 @@
       "Hydration production mode should be able to navigate after loading //"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/i18n-support-base-path/test/index.test.js": {
@@ -9518,6 +10764,7 @@
       "i18n Support basePath production mode should redirect to locale domain correctly client-side",
       "i18n Support basePath production mode should render the correct href for locale domain"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/i18n-support-catchall/test/index.test.js": {
@@ -9536,6 +10783,7 @@
       "i18n Support Root Catch-all production mode should preload data correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/i18n-support-custom-error/test/index.test.js": {
@@ -9552,6 +10800,7 @@
       "Custom routes i18n production mode should work also on client side routing"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/i18n-support-fallback-rewrite-legacy/test/index.test.js": {
@@ -9563,6 +10812,7 @@
       "i18n Support production mode should not rewrite for index page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/i18n-support-fallback-rewrite/test/index.test.js": {
@@ -9574,6 +10824,7 @@
       "i18n Support production mode should not rewrite for index page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/i18n-support-index-rewrite/test/index.test.js": {
@@ -9586,6 +10837,7 @@
       "Custom routes i18n production mode should handle index rewrite on client correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/i18n-support-same-page-hash-change/test/index.test.js": {
@@ -9600,6 +10852,7 @@
       "Hash changes i18n production mode should update props on locale change with same hash (dynamic page)"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/i18n-support/test/index.test.js": {
@@ -9802,6 +11055,7 @@
       "i18n Support production mode should redirect to locale domain correctly client-side",
       "i18n Support production mode should render the correct href for locale domain"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/image-generation/test/index.test.ts": {
@@ -9810,6 +11064,7 @@
       "Image Generation Prod should generate the image without errors"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/image-optimizer/test/content-disposition-type.test.ts": {
@@ -9934,6 +11189,7 @@
       "with contentDispositionType attachment dev support with next.config.js should return home page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/image-optimizer/test/index.test.ts": {
@@ -9966,6 +11222,7 @@
       "Image Optimizer Server support for headers in next.config.js should set max-age header"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/image-optimizer/test/minimum-cache-ttl.test.ts": {
@@ -10090,6 +11347,7 @@
       "with minimumCacheTTL of 5 sec dev support with next.config.js should return home page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/image-optimizer/test/old-sharp.test.ts": {
@@ -10153,6 +11411,7 @@
       "with outdated sharp Server support with next.config.js should use cached image file when parameters are the same for animated gif"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/image-optimizer/test/sharp.test.ts": {
@@ -10369,6 +11628,7 @@
       "with latest sharp dev support with next.config.js should return home page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/image-optimizer/test/squoosh.test.ts": {
@@ -10589,12 +11849,14 @@
       "with squoosh dev support with next.config.js should return home page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/import-assertion/test/index.test.js": {
     "passed": ["import-assertion dev should handle json assertions"],
     "failed": ["import-assertion prod should handle json assertions"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/index-index/test/index.test.js": {
@@ -10636,6 +11898,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/initial-ref/test/index.test.js": {
@@ -10645,6 +11908,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/invalid-config-values/test/index.test.js": {
@@ -10654,6 +11918,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/invalid-custom-routes/test/index.test.js": {
@@ -10681,6 +11946,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/invalid-document-image-import/test/index.test.js": {
@@ -10690,6 +11956,7 @@
       "Invalid static image import in _document Should fail to build when no next.config.js"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/invalid-href/test/index.test.js": {
@@ -10712,6 +11979,7 @@
       "Invalid hrefs production mode doesn't fail on invalid url"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/invalid-middleware-matchers/test/index.test.js": {
@@ -10724,6 +11992,7 @@
       "Errors on invalid custom middleware matchers production mode should error when source length is exceeded"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/invalid-multi-match/test/index.test.js": {
@@ -10733,6 +12002,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/invalid-page-automatic-static-optimization/test/index.test.js": {
@@ -10742,6 +12012,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/invalid-revalidate-values/test/index.test.js": {
@@ -10755,6 +12026,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/invalid-server-options/test/index.test.js": {
@@ -10770,6 +12042,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/jsconfig-baseurl/test/index.test.js": {
@@ -10779,12 +12052,14 @@
       "TypeScript Features should build should trace correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/jsconfig-empty/test/index.test.js": {
     "passed": [],
     "failed": ["Empty JSConfig Support should compile successfully"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/jsconfig/test/index.test.js": {
@@ -10794,12 +12069,14 @@
       "jsconfig.json should fail on invalid jsconfig.json"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/json-serialize-original-error/test/index.test.js": {
     "passed": ["JSON Serialization should fail with original error"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/link-ref/test/index.test.js": {
@@ -10816,6 +12093,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/link-with-encoding/test/index.test.js": {
@@ -10839,6 +12117,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/link-with-multiple-child/test/index.test.js": {
@@ -10849,6 +12128,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/link-without-router/test/index.test.js": {
@@ -10858,12 +12138,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/middleware-basic/test/index.test.js": {
     "passed": ["dev mode loads a middleware"],
     "failed": [],
     "pending": ["production mode loads a middleware"],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/middleware-build-errors/test/index.test.js": {
@@ -10878,6 +12160,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/middleware-dev-update/test/index.test.js": {
@@ -10889,6 +12172,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/middleware-overrides-node.js-api/test/index.test.ts": {
@@ -10897,6 +12181,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/middleware-prefetch/tests/index.test.js": {
@@ -10906,6 +12191,7 @@
       "Middleware Production Prefetch prefetch correctly for unexistent routes"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/middleware-src/test/index.test.js": {
@@ -10920,6 +12206,7 @@
       "Middleware in src/ folder production mode should warn about middleware on export"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/missing-document-component-error/test/index.test.js": {
@@ -10932,6 +12219,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/mixed-ssg-serverprops-error/test/index.test.js": {
@@ -10944,6 +12232,7 @@
       "Mixed getStaticProps and getServerSideProps error should error with getStaticProps but no default export"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-dynamic-css/test/index.test.js": {
@@ -10953,6 +12242,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-dynamic-lazy-compilation/test/index.test.js": {
@@ -10966,6 +12256,7 @@
       "next/dynamic production mode should render server value"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/integration/next-dynamic/test/index.test.js": {
@@ -10978,6 +12269,7 @@
       "next/dynamic production mode should render dynamic server rendered values on client mount"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/asset-prefix/test/index.test.ts": {
@@ -10988,6 +12280,7 @@
       "Image Component assetPrefix Tests dev mode should include assetPrefix when placeholder=blur during next dev"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/base-path/test/index.test.ts": {
@@ -11019,6 +12312,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/base-path/test/static.test.ts": {
@@ -11041,6 +12335,7 @@
       "Static Image Component Tests for basePath production mode Should use immutable cache-control header for static import"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/basic/test/index.test.ts": {
@@ -11102,6 +12397,7 @@
     "pending": [
       "Image Component Tests Client-side Image Component Tests should NOT add a preload tag for a priority image"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/custom-resolver/test/index.test.ts": {
@@ -11115,6 +12411,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/default/test/index.test.ts": {
@@ -11192,6 +12489,7 @@
       "Image Component Tests server mode should emit image for next/dynamic with non ssr case"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/default/test/static.test.ts": {
@@ -11210,6 +12508,7 @@
       "Static Image Component Tests should load staticprops imported image"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/image-from-node-modules/test/index.test.ts": {
@@ -11219,6 +12518,7 @@
       "Image Component Tests In Prod Mode should apply image config for node_modules"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/no-intersection-observer-fallback/test/index.test.ts": {
@@ -11228,6 +12528,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/noscript/test/index.test.ts": {
@@ -11237,6 +12538,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/react-virtualized/test/index.test.ts": {
@@ -11245,6 +12547,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/svgo-webpack/test/index.test.ts": {
@@ -11254,6 +12557,7 @@
       "svgo-webpack with Image Component next dev should print error when invalid Image usage"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/trailing-slash/test/index.test.ts": {
@@ -11263,6 +12567,7 @@
       "Image Component Trailing Slash Tests server mode should include trailing slash when trailingSlash is set on config file during next start"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/typescript/test/index.test.ts": {
@@ -11276,6 +12581,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/unicode/test/index.test.ts": {
@@ -11293,6 +12599,7 @@
       "Image Component Unicode Image URL server mode should load static unicode image"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-legacy/unoptimized/test/index.test.ts": {
@@ -11302,6 +12609,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/app-dir/test/index.test.ts": {
@@ -11402,6 +12710,7 @@
       "Image Component Default Tests server mode should work with image with blob src"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/app-dir/test/static.test.ts": {
@@ -11439,6 +12748,7 @@
       "Static Image Component Tests production mode should load direct imported image"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/asset-prefix/test/index.test.js": {
@@ -11449,6 +12759,7 @@
       "Image Component assetPrefix Tests dev mode should include assetPrefix when placeholder=blur during next dev"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/base-path/test/index.test.js": {
@@ -11467,6 +12778,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/base-path/test/static.test.js": {
@@ -11496,6 +12808,7 @@
       "Static Image Component Tests for basePath production mode should have <head> containing <meta name=\"viewport\"> followed by <link rel=\"preload\"> for priority image"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/both-basepath-trailingslash/test/index.test.ts": {
@@ -11508,6 +12821,7 @@
       "Image Component basePath + trailingSlash Tests server mode should correctly load image src from import"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/default/test/index.test.ts": {
@@ -11609,6 +12923,7 @@
       "Image Component Default Tests server mode should work with sizes and automatically use responsive srcset"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/default/test/static.test.ts": {
@@ -11648,12 +12963,14 @@
       "Static Image Component Tests production mode should use width prop to adjust both width and height"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/export-config/test/index.test.ts": {
     "passed": [],
     "failed": ["next/image with output export config dev mode should error"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/image-from-node-modules/test/index.test.ts": {
@@ -11663,6 +12980,7 @@
       "Image Component from node_modules prod mode should apply image config for node_modules"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/invalid-image-import/test/index.test.ts": {
@@ -11672,6 +12990,7 @@
       "Missing Import Image Tests server mode should show error"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/loader-config-default-loader-with-file/test/index.test.ts": {
@@ -11688,6 +13007,7 @@
       "Image Loader Config server mode - getImgProps should work with loaderFile config, leaving default image optimization enabled"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/loader-config-edge-runtime/test/index.test.ts": {
@@ -11703,6 +13023,7 @@
       "Image Loader Config with Edge Runtime server mode should add \"srcset\" to img2 based on the loader prop"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/loader-config/test/index.test.ts": {
@@ -11718,12 +13039,14 @@
       "Image Loader Config server mode - getImgProps should work with loaderFile config"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/middleware/test/index.test.ts": {
     "passed": ["Image with middleware in edge func dev mode should not error"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/react-virtualized/test/index.test.ts": {
@@ -11732,6 +13055,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/svgo-webpack/test/index.test.ts": {
@@ -11741,6 +13065,7 @@
       "svgo-webpack with Image Component next dev should print error when invalid Image usage"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/trailing-slash/test/index.test.ts": {
@@ -11751,6 +13076,7 @@
       "Image Component Trailing Slash Tests server mode should include trailing slash when trailingSlash is set on config file during next start"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/typescript/test/index.test.ts": {
@@ -11764,6 +13090,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/unicode/test/index.test.ts": {
@@ -11781,6 +13108,7 @@
       "Image Component Unicode Image URL server mode should load static unicode image"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/next-image-new/unoptimized/test/index.test.ts": {
@@ -11792,6 +13120,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/no-duplicate-compile-error/test/index.test.js": {
@@ -11800,12 +13129,14 @@
       "no duplicate compile error output should not show compile error on page refresh"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/no-op-export/test/index.test.js": {
     "passed": ["no-op export should not error for all server-side pages build"],
     "failed": ["no-op export should not error for empty exportPathMap"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/no-override-next-props/test/index.test.js": {
@@ -11814,6 +13145,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/no-page-props/test/index.test.js": {
@@ -11832,6 +13164,7 @@
       "Error no pageProps production mode should navigate between pages correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/node-fetch-keep-alive/test/index.test.js": {
@@ -11847,6 +13180,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/non-next-dist-exclude/test/index.test.js": {
@@ -11855,6 +13189,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/non-standard-node-env-warning/test/index.test.js": {
@@ -11871,6 +13206,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/not-found-revalidate/test/index.test.js": {
@@ -11882,6 +13218,7 @@
       "SSG notFound revalidate production mode should revalidate after notFound is returned for fallback: true"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/nullish-config/test/index.test.js": {
@@ -11894,6 +13231,7 @@
       "Nullish configs in next.config.js production mode should ignore configs set to `undefined` in next.config.js"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/numeric-sep/test/index.test.js": {
@@ -11902,6 +13240,7 @@
       "Numeric Separator Support should successfully build for a JavaScript file"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/ondemand/test/index.test.js": {
@@ -11915,6 +13254,7 @@
       "On Demand Entries should navigate to pages with dynamic imports"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/optional-chaining-nullish-coalescing/test/index.test.js": {
@@ -11926,6 +13266,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/page-config/test/index.test.js": {
@@ -11942,6 +13283,7 @@
       "Page Config shows valid error when page config is a string"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/page-extensions/test/index.test.js": {
@@ -11954,6 +13296,7 @@
       "Page Extensions should use the default pageExtensions if set to undefined"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/plugin-mdx-rs/test/index.test.js": {
@@ -11964,12 +13307,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/polyfilling-minimal/test/index.test.js": {
     "passed": [],
     "failed": ["Polyfilling (minimal) should compile successfully"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/polyfills/test/index.test.js": {
@@ -11979,6 +13324,7 @@
     ],
     "failed": ["Polyfills should alias fetch"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/port-env-var/test/index.test.js": {
@@ -11988,6 +13334,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/preload-viewport/test/index.test.js": {
@@ -12017,6 +13364,7 @@
       "Prefetching Links in viewport should prefetch with a different asPath for a prefetched page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/prerender-fallback-encoding/test/index.test.js": {
@@ -12036,12 +13384,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/prerender-invalid-catchall-params/test/index.test.js": {
     "passed": ["Invalid Prerender Catchall Params should fail the build"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/prerender-invalid-paths/test/index.test.js": {
@@ -12050,6 +13400,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/prerender-no-revalidate/test/index.test.js": {
@@ -12065,6 +13416,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/prerender-preview/test/index.test.js": {
@@ -12095,6 +13447,7 @@
       "Prerender Preview Mode Server Mode should throw error when setting too large of preview data"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/prerender-revalidate/test/index.test.js": {
@@ -12119,6 +13472,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/prerender/test/index.test.js": {
@@ -12131,6 +13485,7 @@
       "SSG Prerender export mode should navigate between pages successfully"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/preview-fallback/test/index.test.js": {
@@ -12150,6 +13505,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/production-browser-sourcemaps/test/index.test.js": {
@@ -12160,6 +13516,7 @@
       "Production browser sourcemaps Server support correctly generated the source map"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/production-build-dir/test/index.test.js": {
@@ -12168,6 +13525,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/production-config/test/index.test.js": {
@@ -12181,12 +13539,14 @@
       "Production Config Usage env should fail with leading __ in env key"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/production-nav/test/index.test.js": {
     "passed": [],
     "failed": ["Production Usage should navigate forward and back correctly"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/production-start-no-build/test/index.test.js": {
@@ -12195,6 +13555,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/production/test/index.test.js": {
@@ -12320,6 +13681,7 @@
       "Production Usage With Security Related Issues should handle invalid URL properly",
       "Production Usage With basic usage should allow etag header support with getServerSideProps"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/project-dir-delete/index.test.ts": {
@@ -12328,6 +13690,7 @@
     "pending": [
       "Project Directory Delete Handling should gracefully exit on project dir delete"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/query-with-encoding/test/index.test.js": {
@@ -12351,6 +13714,7 @@
       "Query String with Encoding trailing space should have correct query on simple client-side <Link>"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/re-export-all-exports-from-page-disallowed/test/index.test.js": {
@@ -12360,6 +13724,7 @@
       "Re-export all exports from page is disallowed shows error when a page re-export all exports"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/react-18/test/index.test.js": {
@@ -12390,6 +13755,7 @@
       "Concurrent mode in the experimental-edge runtime prod should not have invalid config warning"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/react-profiling-mode/test/index.test.js": {
@@ -12402,6 +13768,7 @@
       "React Profiling Mode with config enabled should have used the react-dom profiling bundle for pages"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/react-streaming/test/index.test.js": {
@@ -12416,6 +13783,7 @@
       "streaming prod prod should support streaming for fizz response"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/read-only-source-hmr/test/index.test.js": {
@@ -12426,12 +13794,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/relay-analytics-disabled/test/index.test.js": {
     "passed": ["Analytics relayer (disabled) Does not relay any data"],
     "failed": ["Analytics relayer (disabled) Does not include the code"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/relay-analytics/test/index.test.js": {
@@ -12441,6 +13811,7 @@
       "Analytics relayer with exported method reports attribution"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/relay-graphql-swc-multi-project/test/index.test.js": {
@@ -12452,6 +13823,7 @@
       "Relay Compiler Transform - Multi Project Config production mode project-b should resolve index page correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/relay-graphql-swc-single-project/test/index.test.js": {
@@ -12461,24 +13833,28 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/render-error-on-module-error/test/index.test.js": {
     "passed": [],
     "failed": ["Module Init Error should render error page"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/render-error-on-top-level-error/with-get-initial-props/test/index.test.js": {
     "passed": [],
     "failed": ["Top Level Error should render error page with getInitialProps"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/render-error-on-top-level-error/without-get-initial-props/test/index.test.js": {
     "passed": [],
     "failed": ["Top Level Error should render error page"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/repeated-slashes/test/index.test.js": {
@@ -12557,6 +13933,7 @@
       "404 handling pages/404 production next start should have no error from encoded slashes in router push"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/required-server-files-ssr-404/test/index.test.js": {
@@ -12585,6 +13962,7 @@
       "Required Server Files should return data correctly with x-matched-path for optional catch-all route"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/integration/revalidate-as-path/test/index.test.js": {
@@ -12596,6 +13974,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/rewrite-with-browser-history/test/index.test.js": {
@@ -12605,6 +13984,7 @@
       "rewrites persist with browser history actions production mode back-button should go back to rewritten path successfully"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/rewrites-client-resolving/test/index.test.js": {
@@ -12623,6 +14003,7 @@
       "Client-side rewrites resolving production mode should break rewrites chain when normal page matches"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/rewrites-destination-query-array/test/index.test.js": {
@@ -12632,6 +14013,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/rewrites-has-condition/test/index.test.js": {
@@ -12643,6 +14025,7 @@
       "rewrites has condition production mode should navigate to a simple rewrite without error"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/rewrites-manual-href-as/test/index.test.js": {
@@ -12654,6 +14037,7 @@
       "rewrites manual href/as production mode should allow manual href/as on index page"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/root-optional-revalidate/test/index.test.js": {
@@ -12664,6 +14048,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/route-index/test/index.test.js": {
@@ -12681,6 +14066,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/route-indexes/test/index.test.js": {
@@ -12720,6 +14106,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/route-load-cancel-css/test/index.test.js": {
@@ -12728,6 +14115,7 @@
       "route cancel via CSS should cancel slow page loads on re-navigation"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/route-load-cancel/test/index.test.js": {
@@ -12738,6 +14126,7 @@
       "next/dynamic production mode should cancel slow page loads on re-navigation"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/router-hash-navigation/test/index.test.js": {
@@ -12747,6 +14136,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/router-is-ready-app-gip/test/index.test.js": {
@@ -12763,6 +14153,7 @@
       "router.isReady with appGip production mode isReady should be true immediately for getStaticProps page without query"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/router-is-ready/test/index.test.js": {
@@ -12791,6 +14182,7 @@
       "router.isReady production mode isReady should be true immediately for getStaticProps page without query"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/router-prefetch/test/index.test.js": {
@@ -12801,6 +14193,21 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/router-rerender/test/index.test.js": {
+    "passed": [],
+    "failed": [],
+    "pending": [],
+    "flakey": [
+      "router rerender dev mode with middleware should not trigger unncessary rerenders when middleware is used",
+      "router rerender dev mode with rewrites should not trigger unncessary rerenders when rewrites are used",
+      "router rerender dev mode with rewrites should rerender with the correct query parameter if present with rewrites",
+      "router rerender production mode with middleware should not trigger unncessary rerenders when middleware is used",
+      "router rerender production mode with rewrites should not trigger unncessary rerenders when rewrites are used",
+      "router rerender production mode with rewrites should rerender with the correct query parameter if present with rewrites"
+    ],
     "runtimeError": false
   },
   "test/integration/scroll-back-restoration/test/index.test.js": {
@@ -12810,6 +14217,7 @@
       "Scroll Restoration Support server mode should restore the scroll position on navigating back"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/scroll-forward-restoration/test/index.test.js": {
@@ -12819,6 +14227,7 @@
       "Scroll Restoration Support server mode should restore the scroll position on navigating forward"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/scss-modules/test/basic-scss.test.js": {
@@ -12841,6 +14250,7 @@
       "Has CSS Module in computed styles in Production should have compiled successfully"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/scss-modules/test/dynamic-route.test.js": {
@@ -12855,6 +14265,7 @@
       "Dynamic Route CSS Module Usage should've emitted a single CSS file"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/scss-modules/test/valid-invalid.test.js": {
@@ -12871,6 +14282,7 @@
       "Invalid CSS Global Module Usage in node_modules should fail to build",
       "Invalid CSS Module Usage in node_modules should fail to build"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/scss/test/basic-global-support.test.js": {
@@ -12897,6 +14309,7 @@
       "Nested @import() Global Support should've emitted a single CSS file"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/scss/test/basic-scss.test.js": {
@@ -12912,6 +14325,7 @@
       "SCSS Support Has CSS in computed styles in Production should've preloaded the CSS file and injected it in <head>"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/scss/test/css-and-styled-jsx.test.js": {
@@ -12923,6 +14337,7 @@
       "Ordering with styled-jsx (prod) should have compiled successfully"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/scss/test/dev-css-handling.test.js": {
@@ -12933,6 +14348,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/scss/test/scss-loader-handling.test.js": {
@@ -12953,6 +14369,7 @@
       "SCSS Support Preprocessor loader order should compile successfully"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/scss/test/valid-invalid-scss.test.js": {
@@ -12964,6 +14381,7 @@
       "Valid and Invalid Global CSS with Custom App should fail to build"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/server-asset-modules/test/index.test.js": {
@@ -12973,6 +14391,7 @@
       "serverside asset modules production mode should enable reading local files in api routes"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/server-side-dev-errors/test/index.test.js": {
@@ -12989,6 +14408,7 @@
       "server-side dev errors should show server-side error for uncaught rejection correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/src-dir-support-double-dir/test/index.test.js": {
@@ -13000,6 +14420,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/src-dir-support/test/index.test.js": {
@@ -13023,6 +14444,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/ssg-data-404/test/index.test.js": {
@@ -13032,6 +14454,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/ssg-dynamic-routes-404-page/test/index.test.js": {
@@ -13042,6 +14465,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/static-404/test/index.test.js": {
@@ -13052,6 +14476,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/static-page-name/test/index.test.js": {
@@ -13063,6 +14488,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/styled-jsx-plugin/test/index.test.js": {
@@ -13071,6 +14497,7 @@
       "styled-jsx using in node_modules production mode should serve a page correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/telemetry/test/config.test.js": {
@@ -13096,6 +14523,7 @@
       "config telemetry emits telemetry for usage of swc"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/telemetry/test/index.test.js": {
@@ -13125,6 +14553,7 @@
       "Telemetry CLI logs completed `next build` with warnings"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/telemetry/test/page-features.test.js": {
@@ -13135,12 +14564,14 @@
       "page features telemetry detects --turbo correctly for `next dev`"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/trailing-slash-dist/test/index.test.js": {
     "passed": ["Trailing slash in distDir dev mode supports trailing slash"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/trailing-slashes-href-resolving/test/index.test.js": {
@@ -13161,6 +14592,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/trailing-slashes-rewrite/test/index.test.js": {
@@ -13178,6 +14610,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/trailing-slashes/test/index.test.js": {
@@ -13344,6 +14777,7 @@
       "Trailing slashes production mode, with basepath, trailingSlash: true /docs/linker?href=/about should push route to /docs/about/"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/tsconfig-verifier/test/index.test.js": {
@@ -13363,6 +14797,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/turbopack-unsupported-log/index.test.ts": {
@@ -13374,6 +14809,7 @@
       "turbopack unsupported features log should warn with next.config.js with unsupported field"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/turbotrace-with-webpack-worker/test/index.test.js": {
@@ -13382,6 +14818,7 @@
       "build trace with extra entries should build and trace correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typeof-window-replace/test/index.test.js": {
@@ -13392,6 +14829,7 @@
       "typeof window replace Replaces `typeof window` with undefined for server code"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typescript-app-type-declarations/test/index.test.js": {
@@ -13402,12 +14840,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typescript-baseurl/test/index.test.js": {
     "passed": ["TypeScript Features default behavior should render the page"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typescript-custom-tsconfig/test/index.test.js": {
@@ -13416,6 +14856,7 @@
       "Custom TypeScript Config should warn when using custom typescript path"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typescript-external-dir/project/test/index.test.js": {
@@ -13424,6 +14865,7 @@
       "TypeScript Features default behavior should render the page with external TS/TSX dependencies"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typescript-filtered-files/test/index.test.js": {
@@ -13432,6 +14874,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typescript-hmr/test/index.test.js": {
@@ -13441,6 +14884,7 @@
     ],
     "failed": [],
     "pending": ["TypeScript HMR should recover from a type error"],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typescript-ignore-errors/test/index.test.js": {
@@ -13453,6 +14897,7 @@
       "TypeScript with error handling options ignoreBuildErrors: true Next builds the application despite type errors without incremental mode"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typescript-only-remove-type-imports/test/index.test.js": {
@@ -13464,6 +14909,7 @@
       "TypeScript onlyRemoveTypeImports production mode should render a page with type import correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typescript-paths/test/index.test.js": {
@@ -13482,6 +14928,7 @@
       "typescript paths without baseurl default behavior should not resolve to .d.ts files"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typescript-workspaces-paths/packages/www/test/index.test.js": {
@@ -13495,6 +14942,7 @@
       "TypeScript Features default behavior should not resolve to .d.ts files"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/typescript/test/index.test.js": {
@@ -13519,6 +14967,7 @@
     "pending": [
       "TypeScript Features default behavior should report type checking to stdout"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/undefined-webpack-config/test/index.test.js": {
@@ -13527,6 +14976,7 @@
     "pending": [
       "undefined webpack config error should show in production mode"
     ],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/url-imports/test/index.test.js": {
@@ -13552,6 +15002,7 @@
       "Handle url imports with next dev should respond on value api"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/url/test/index.test.js": {
@@ -13575,6 +15026,7 @@
       "Handle new URL asset references in next dev should respond on size api"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/webpack-config-extensionalias/test/index.test.js": {
@@ -13583,6 +15035,7 @@
       "webpack config with extensionAlias setting should run correctly with an tsx file import with .js extension"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/webpack-config-mainjs/test/index.test.js": {
@@ -13591,6 +15044,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/webpack-require-hook/test/index.test.js": {
@@ -13600,6 +15054,7 @@
       "Handles Webpack Require Hook dev mode Applies and does not error during development"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/with-electron/test/index.test.js": {
@@ -13608,6 +15063,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/with-router/test/index.test.js": {
@@ -13619,6 +15075,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/integration/worker-webpack5/test/index.test.js": {
@@ -13628,12 +15085,14 @@
       "Web Workers with webpack 5 server mode should pass on both client and worker"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/app-dir-edge-runtime-with-wasm/index.test.ts": {
     "passed": [],
     "failed": ["app-dir edge runtime with wasm should have built"],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/production/app-dir-hide-suppressed-error-during-next-export/index.test.ts": {
@@ -13642,6 +15101,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/app-dir-prefetch-non-iso-url/index.test.ts": {
@@ -13651,12 +15111,14 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/app-dir/app-only-flag/app-only-flag.test.ts": {
     "passed": ["app-only-flag should serve app route"],
     "failed": ["app-only-flag should not serve about route"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/app-dir/build-output/index.test.ts": {
@@ -13665,6 +15127,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/app-dir/revalidate/revalidate.test.ts": {
@@ -13673,6 +15136,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/bfcache-routing/index.test.ts": {
@@ -13681,6 +15145,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/build-spinners/index.test.ts": {
@@ -13693,6 +15158,7 @@
       "build-spinners should handle build spinners correctly page dir (compile workers)"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/ci-missing-typescript-deps/index.test.ts": {
@@ -13701,6 +15167,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/custom-error-500/index.test.ts": {
@@ -13710,6 +15177,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/custom-server/custom-server.test.ts": {
@@ -13722,6 +15190,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/dependencies-can-use-env-vars-in-middlewares/index.test.ts": {
@@ -13732,6 +15201,7 @@
       "dependencies can use env vars in middlewares uses the environment variables"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/deployment-id-handling/deployment-id-handling.test.ts": {
@@ -13744,6 +15214,7 @@
       "deployment-id-handling should have deployment id env available"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/disable-fallback-polyfills/index.test.ts": {
@@ -13755,6 +15226,7 @@
       "Disable fallback polyfills Reduced bundle size when polyfills are disabled"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/edge-config-validations/index.test.ts": {
@@ -13763,6 +15235,7 @@
       "Edge config validations fails to build when unstable_allowDynamic is not a string"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/edge-runtime-is-addressable/index.test.ts": {
@@ -13773,6 +15246,7 @@
       "Edge Runtime is addressable removes the undefined branch with dead code elimination"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/edge-safe-dynamic-code/index.test.ts": {
@@ -13781,6 +15255,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/emit-decorator-metadata/index.test.ts": {
@@ -13791,24 +15266,28 @@
       "emitDecoratorMetadata SWC option should compile with emitDecoratorMetadata enabled for API"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/enoent-during-require/index.test.ts": {
     "passed": ["ENOENT during require should show ENOENT error correctly"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/escheck-output/index.test.ts": {
     "passed": [],
     "failed": ["ES Check .next output should emit ES2020 with default"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/eslint-plugin-deps/index.test.ts": {
     "passed": ["eslint plugin deps should work"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/export/index.test.ts": {
@@ -13857,6 +15336,7 @@
       "static export should only output 404.html without trailingSlash"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/exported-runtimes-value-validation/index.test.ts": {
@@ -13867,6 +15347,7 @@
       "Exported runtimes value validation warns on unrecognized runtimes value"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/fallback-export-error/index.test.ts": {
@@ -13879,6 +15360,7 @@
       "fallback export error should not error with valid exportPathMap"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/fatal-render-errror/index.test.ts": {
@@ -13890,18 +15372,21 @@
       "fatal-render-errror should handle fatal error in _app and _error without loop on direct visit"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/generate-middleware-source-maps/index.test.ts": {
     "passed": ["Middleware source maps generates a source map for Edge API"],
     "failed": ["Middleware source maps generates a source map for Middleware"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/handle-already-sent-response/handle-already-sent-response.test.ts": {
     "passed": ["handle already sent response should work with fetch"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/ipc-forbidden-headers/ipc-forbidden-headers.test.ts": {
@@ -13911,60 +15396,70 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/jest/index.test.ts": {
     "passed": [],
     "failed": ["next/jest should work"],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/production/jest/new-link-behavior.test.ts": {
     "passed": ["next/jest newLinkBehavior should use new link behavior"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/jest/next-image-preload/next-image-preload.test.ts": {
     "passed": ["next/jest Should not throw preload is undefined error"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/jest/relay/relay-jest.test.ts": {
     "passed": [],
     "failed": ["next/jest should work"],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/production/jest/remove-react-properties/remove-react-properties-jest.test.ts": {
     "passed": [],
     "failed": ["next/jest data-testid should be removed in production"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/jest/rsc/lib/utils.test.js": {
     "passed": ["works with server-only code"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/jest/transpile-packages.test.ts": {
     "passed": ["next/jest should work"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/middleware-typescript/test/index.test.ts": {
     "passed": [],
     "failed": ["middleware-typescript should have built and started"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/next-font/babel-unsupported.test.ts": {
     "passed": [],
     "failed": ["@next/fon babel unsupported Build error when using babel"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/next-font/telemetry-old.test.ts": {
@@ -13974,6 +15469,7 @@
       "@next/font used telemetry should send @next/font/google and @next/font/local usage event"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/next-font/telemetry.test.ts": {
@@ -13983,6 +15479,7 @@
       "next/font used telemetry should send next/font/google and next/font/local usage event"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/pnpm-support/index.test.ts": {
@@ -13992,12 +15489,14 @@
       "pnpm support should execute client-side JS on each page in output: \"standalone\""
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/postcss-plugin-config-as-string/index.test.ts": {
     "passed": ["PostCSS plugin config as string should work"],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/prerender-prefetch/index.test.ts": {
@@ -14018,6 +15517,7 @@
       "Prerender prefetch with optimisticClientCache enabled should update cache using router.push with unstable_skipClientCache"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/reading-request-body-in-middleware/index.test.ts": {
@@ -14031,6 +15531,7 @@
       "reading request body in middleware returns root: true for root calls"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/standalone-mode/basic/index.test.ts": {
@@ -14042,6 +15543,7 @@
       "standalone mode - metadata routes should handle private _next unmatched route correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/standalone-mode/ipv6/index.test.ts": {
@@ -14050,6 +15552,7 @@
       "standalone mode: ipv6 hostname should load the page without any errors"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/production/standalone-mode/no-app-routes/index.test.ts": {
@@ -14058,12 +15561,14 @@
       "standalone mode - no app routes should handle pages rendering correctly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/standalone-mode/optimizecss/index.test.ts": {
     "passed": [],
     "failed": ["standalone mode and optimizeCss should work"],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/production/standalone-mode/required-server-files/required-server-files-app.test.ts": {
@@ -14076,6 +15581,7 @@
       "should set-up next should send cache tags in minimal mode for ISR"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts": {
@@ -14112,6 +15618,7 @@
       "should set-up next should set correct SWR headers with notFound gssp"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/production/standalone-mode/required-server-files/required-server-files.test.ts": {
@@ -14170,6 +15677,7 @@
       "should set-up next should warn when \"next\" is imported directly"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/production/standalone-mode/response-cache/index.test.ts": {
@@ -14181,12 +15689,14 @@
       "minimal-mode-response-cache should have correct responses"
     ],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/production/standalone-mode/type-module/index.test.ts": {
     "passed": [],
     "failed": ["type-module should work"],
     "pending": [],
+    "flakey": [],
     "runtimeError": true
   },
   "test/production/supports-module-resolution-nodenext/supports-moduleresolution-nodenext.test.ts": {
@@ -14195,6 +15705,7 @@
     ],
     "failed": [],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   },
   "test/production/typescript-basic/index.test.ts": {
@@ -14204,6 +15715,7 @@
     ],
     "failed": ["TypeScript basic should work with babel"],
     "pending": [],
+    "flakey": [],
     "runtimeError": false
   }
 }

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -783,7 +783,6 @@
     "passed": [
       "ReactRefreshLogBox app turbo Module not found",
       "ReactRefreshLogBox app turbo Module not found empty import trace",
-      "ReactRefreshLogBox app turbo Module not found missing global CSS",
       "ReactRefreshLogBox app turbo Node.js builtins"
     ],
     "failed": [],
@@ -793,7 +792,9 @@
       "ReactRefreshLogBox app default Module not found missing global CSS",
       "ReactRefreshLogBox app default Node.js builtins"
     ],
-    "flakey": [],
+    "flakey": [
+      "ReactRefreshLogBox app turbo Module not found missing global CSS"
+    ],
     "runtimeError": false
   },
   "test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts": {


### PR DESCRIPTION
### What?

Refines our manual test file skipping into skipping individual test cases that are flakey.

### Why?

Some of the cases inside these skipped files are consistently passing, and we want to run those cases. If an individual case is found to be flakey, we should be able to skip only it while building our test manifest.

### How?

At the moment, I'm preserving the all currently skipped tests so that we can quickly fix a flake. But in a follow up PR, I'll remove the `/.*/` regexes and list the flakey tests explicitly.

Closes WEB-1650