### PR TITLE
fix(turbopack): coerce importsource for emotion

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -216,8 +216,13 @@ pub async fn get_client_module_options_context(
     } else {
         None
     };
-    let jsx_runtime_options =
-        get_jsx_transform_options(project_path, mode, Some(resolve_options_context));
+    let jsx_runtime_options = get_jsx_transform_options(
+        project_path,
+        mode,
+        Some(resolve_options_context),
+        false,
+        next_config,
+    );
     let webpack_rules =
         *maybe_add_babel_loader(project_path, *next_config.webpack_rules().await?).await?;
     let webpack_rules = maybe_add_sass_loader(next_config.sass_config(), webpack_rules).await?;

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -265,7 +265,8 @@ pub async fn get_server_module_options_context(
     } else {
         None
     };
-    let jsx_runtime_options = get_jsx_transform_options(project_path, mode, None);
+    let jsx_runtime_options =
+        get_jsx_transform_options(project_path, mode, None, true, next_config);
 
     let source_transforms: Vec<Vc<TransformPlugin>> = vec![
         *get_swc_ecma_transform_plugin(project_path, next_config).await?,

--- a/test/development/basic/emotion-swc.test.ts
+++ b/test/development/basic/emotion-swc.test.ts
@@ -1,36 +1,25 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
-import { shouldRunTurboDevTest } from '../../lib/next-test-utils'
+import { nextTestSetup, FileRef } from 'e2e-utils'
 
 describe('emotion SWC option', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    const useTurbo = !!process.env.TEST_WASM ? false : shouldRunTurboDevTest()
-    next = await createNext({
-      files: {
-        'jsconfig.json': new FileRef(
-          join(__dirname, 'emotion-swc/jsconfig.json')
-        ),
-        pages: new FileRef(join(__dirname, 'emotion-swc/pages')),
-        shared: new FileRef(join(__dirname, 'emotion-swc/shared')),
-        // Stopgap until turobpack supports full next.config.js for `reactStrictMode`
-        'next.config.js': new FileRef(
-          useTurbo
-            ? join(__dirname, 'emotion-swc/next.turbopack.config.js')
-            : join(__dirname, 'emotion-swc/next.config.js')
-        ),
-      },
-      dependencies: {
-        '@emotion/cache': '^10.0.29',
-        '@emotion/core': '^10.0.35',
-        '@emotion/styled': '^10.0.27',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'jsconfig.json': new FileRef(
+        join(__dirname, 'emotion-swc/jsconfig.json')
+      ),
+      pages: new FileRef(join(__dirname, 'emotion-swc/pages')),
+      shared: new FileRef(join(__dirname, 'emotion-swc/shared')),
+      'next.config.js': new FileRef(
+        join(__dirname, 'emotion-swc/next.config.js')
+      ),
+    },
+    dependencies: {
+      '@emotion/cache': '^10.0.29',
+      '@emotion/core': '^10.0.35',
+      '@emotion/styled': '^10.0.27',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should have styling from the css prop', async () => {
     let browser

--- a/test/development/basic/emotion-swc/next.turbopack.config.js
+++ b/test/development/basic/emotion-swc/next.turbopack.config.js
@@ -1,9 +1,0 @@
-/** @type {import('next').NextConfig} */
-
-const nextConfig = {
-  compiler: {
-    emotion: true,
-  },
-}
-
-module.exports = nextConfig


### PR DESCRIPTION
### What?

This PR fixes import source for turbopack's compiler.emotion config, mimics the current webpack configuration behavior.

Unfortunately this does not fixes the whole emotion transform with appdir yet, it looks like there are additional problems with server components.

Closes WEB-1655