### PR TITLE
docs: Clarify that notFound and redirect can't be used in Event Attributes like onClick

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/not-found.mdx
+++ b/docs/02-app/02-api-reference/04-functions/not-found.mdx
@@ -29,7 +29,11 @@ export default async function Profile({ params }) {
 }
 ```
 
-> **Good to know**: `notFound()` does not require you to use `return notFound()` due to using the TypeScript [`never`](https://www.typescriptlang.org/docs/handbook/2/functions.html#never) type.
+> **Good to know**: 
+> 
+> - `notFound()` does not require you to use `return notFound()` due to using the TypeScript [`never`](https://www.typescriptlang.org/docs/handbook/2/functions.html#never) type.
+> - Using `notFound` inside event attributes like `onClick` will not work as it does not get caught by the error boundaries
+
 
 ## Version History
 

--- a/docs/02-app/02-api-reference/04-functions/redirect.mdx
+++ b/docs/02-app/02-api-reference/04-functions/redirect.mdx
@@ -55,7 +55,10 @@ export default async function Profile({ params }) {
 }
 ```
 
-> **Good to know**: `redirect` does not require you to use `return redirect()` as it uses the TypeScript [`never`](https://www.typescriptlang.org/docs/handbook/2/functions.html#never) type.
+> **Good to know**: 
+> 
+> - `redirect` does not require you to use `return redirect()` as it uses the TypeScript [`never`](https://www.typescriptlang.org/docs/handbook/2/functions.html#never) type.
+> - Using `redirect` inside event attributes like `onClick` will not work as it does not get caught by the error boundaries
 
 | Version   | Changes                |
 | --------- | ---------------------- |


### PR DESCRIPTION
### What?

Add a sentence in the good to knows of `notFound` and `redirect` to clearly state that it won't work since throws inside callbacks are uncaught by the error boundaries.

### Why?

To explain the limitations of using notFound and redirect in client components. To also warn others about common pitfalls of using those two funcitons.

### How?

By adding additional information to the existing good to know section of both method's API reference.
