### PR TITLE
Mark testmode fetches internal

### DIFF
--- a/packages/next/src/experimental/testmode/server.ts
+++ b/packages/next/src/experimental/testmode/server.ts
@@ -99,6 +99,10 @@ async function handleFetch(
   const resp = await originalFetch(`http://localhost:${proxyPort}`, {
     method: 'POST',
     body: JSON.stringify(proxyRequest),
+    next: {
+      // @ts-ignore
+      internal: true,
+    },
   })
   if (!resp.ok) {
     throw new Error(`Proxy request failed: ${resp.status}`)


### PR DESCRIPTION
This avoids polluting traces with proxy requests.