### PR TITLE
fix: make module polyfills non-enumerable

### DIFF
--- a/packages/next-polyfill-module/src/index.js
+++ b/packages/next-polyfill-module/src/index.js
@@ -3,6 +3,15 @@
 // Contains polyfills for methods missing after browser version(s):
 // Edge 16, Firefox 60, Chrome 61, Safari 10.1
 
+/** Define a non-enumerable property, typical for polyfilled function */
+function definePolyfillProperty(object, name, value) {
+  Object.defineProperty(object, name, {
+    configurable: true,
+    enumerable: false,
+    value,
+  })
+}
+
 /**
  * Available in:
  * Edge: never
@@ -14,10 +23,18 @@
  * https://caniuse.com/mdn-javascript_builtins_string_trimend
  */
 if (!('trimStart' in String.prototype)) {
-  String.prototype.trimStart = String.prototype.trimLeft
+  definePolyfillProperty(
+    String.prototype,
+    'trimStart',
+    String.prototype.trimLeft
+  )
 }
 if (!('trimEnd' in String.prototype)) {
-  String.prototype.trimEnd = String.prototype.trimRight
+  definePolyfillProperty(
+    String.prototype,
+    'trimEnd',
+    String.prototype.trimRight
+  )
 }
 
 /**
@@ -32,6 +49,7 @@ if (!('trimEnd' in String.prototype)) {
 if (!('description' in Symbol.prototype)) {
   Object.defineProperty(Symbol.prototype, 'description', {
     configurable: true,
+    enumerable: false,
     get: function get() {
       var m = /\((.*)\)/.exec(this.toString())
       return m ? m[1] : undefined
@@ -51,15 +69,15 @@ if (!('description' in Symbol.prototype)) {
 // Copied from https://gist.github.com/developit/50364079cf0390a73e745e513fa912d9
 // Licensed Apache-2.0
 if (!Array.prototype.flat) {
-  Array.prototype.flat = function flat(d, c) {
+  definePolyfillProperty(Array.prototype, 'flat', function flat(d, c) {
     return (
       (c = this.concat.apply([], this)),
       d > 1 && c.some(Array.isArray) ? c.flat(d - 1) : c
     )
-  }
-  Array.prototype.flatMap = function (c, a) {
+  })
+  definePolyfillProperty(Array.prototype, 'flatMap', function flatMap(c, a) {
     return this.map(c, a).flat()
-  }
+  })
 }
 
 /**
@@ -74,7 +92,7 @@ if (!Array.prototype.flat) {
 // Modified from https://gist.github.com/developit/e96097d9b657f2a2f3e588ffde433437
 // Licensed Apache-2.0
 if (!Promise.prototype.finally) {
-  Promise.prototype.finally = function (callback) {
+  definePolyfillProperty(Promise.prototype, 'finally', function (callback) {
     if (typeof callback !== 'function') {
       return this.then(callback, callback)
     }
@@ -92,7 +110,7 @@ if (!Promise.prototype.finally) {
         })
       }
     )
-  }
+  })
 }
 
 /**
@@ -108,7 +126,7 @@ if (!Promise.prototype.finally) {
 // Modified from https://github.com/feross/fromentries/blob/29b52a850bb3a47c390937631c2638edf3443942/index.js
 // License MIT
 if (!Object.fromEntries) {
-  Object.fromEntries = function (iterable) {
+  definePolyfillProperty(Object, 'fromEntries', function fromEntries(iterable) {
     // Assume the input is either an iterable object or an array-like object
     return Array.from(iterable).reduce(function (obj, entry) {
       // https://github.com/tc39/proposal-object-from-entries/blob/e4837799c1586a07c101570b27997497e5290c22/polyfill.js#L9-L10
@@ -116,7 +134,7 @@ if (!Object.fromEntries) {
       obj[entry[0]] = entry[1]
       return obj
     }, {})
-  }
+  })
 }
 
 /**
@@ -131,7 +149,7 @@ if (!Object.fromEntries) {
  */
 // Modified from TC39 at proposal polyfill: https://github.com/tc39/proposal-relative-indexing-method#polyfill
 if (!Array.prototype.at) {
-  Array.prototype.at = function at(n) {
+  definePolyfillProperty(Array.prototype, 'at', function at(n) {
     let i = Math.trunc(n) || 0
 
     if (i < 0) i += this.length
@@ -139,5 +157,5 @@ if (!Array.prototype.at) {
     if (i < 0 || i >= this.length) return undefined
 
     return this[i]
-  }
+  })
 }


### PR DESCRIPTION
In Safari 15.2:

```js
for (const i in []) console.log(i)
// -> "at"
```

This is because the polyfills are enumerable, which they shouldn't be.

In latest Chrome:

```js
Object.getOwnPropertyDescriptor(Array.prototype, 'at')
// -> {writable: true, enumerable: false, configurable: true, value: ƒ}
```