### PR TITLE
fix reporting of illegal segments when directory only contains irrelevant files

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_app/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/mod.rs
@@ -152,15 +152,18 @@ impl AppPage {
         ) && !matches!(segment, PageSegment::PageType(..))
         {
             bail!(
-                "Invalid segment {}, catch all segment must be the last segment",
-                segment
+                "Invalid segment {:?}, catch all segment must be the last segment (segments: {:?})",
+                segment,
+                self.0
             )
         }
 
         if self.is_complete() {
             bail!(
-                "Invalid segment {}, this page path already has the final PageType appended",
-                segment
+                "Invalid segment {:?}, this page path already has the final PageType appended \
+                 (segments: {:?})",
+                segment,
+                self.0
             )
         }
 
@@ -206,7 +209,7 @@ impl AppPage {
         matches!(self.0.last(), Some(PageSegment::PageType(..)))
     }
 
-    pub fn complete(self, page_type: PageType) -> Result<Self> {
+    pub fn complete(&self, page_type: PageType) -> Result<Self> {
         self.clone_push(PageSegment::PageType(page_type))
     }
 }

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -65,6 +65,16 @@ export class NextStartInstance extends NextInstance {
       startArgs = this.startCommand.split(' ')
     }
 
+    if (process.env.NEXT_SKIP_ISOLATE) {
+      // without isolation yarn can't be used and pnpm must be used instead
+      if (buildArgs[0] === 'yarn') {
+        buildArgs[0] = 'pnpm'
+      }
+      if (startArgs[0] === 'yarn') {
+        startArgs[0] = 'pnpm'
+      }
+    }
+
     console.log('running', buildArgs.join(' '))
     await new Promise<void>((resolve, reject) => {
       try {


### PR DESCRIPTION
### What?

fixes

```
[Error: Invalid segment components, catch all segment must be the last segment

Debug info:
- Execution of directory_tree_to_entrypoints_internal failed
- Invalid segment components, catch all segment must be the last segment] {
  code: 'GenericFailure'
}
```


Closes WEB-1668