### PR TITLE
perf: remove react dom legacy from app router

### DIFF
--- a/packages/next/src/build/noop-react-dom-server-legacy.ts
+++ b/packages/next/src/build/noop-react-dom-server-legacy.ts
@@ -1,0 +1,10 @@
+const ERROR_MESSAGE =
+  'Internal Error: do not use legacy react-dom/server APIs. If you encountered this error, please open an issue on the Next.js repo.'
+
+export function renderToString() {
+  throw new Error(ERROR_MESSAGE)
+}
+
+export function renderToStaticMarkup() {
+  throw new Error(ERROR_MESSAGE)
+}

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -222,7 +222,6 @@ function createRSCAliases(
         'react/jsx-dev-runtime$': `next/dist/server/future/route-modules/app-page/vendored/shared/react-jsx-dev-runtime`,
         react$: `next/dist/server/future/route-modules/app-page/vendored/${opts.layer}/react`,
         'react-dom$': `next/dist/server/future/route-modules/app-page/vendored/${opts.layer}/react-dom`,
-        'react-dom/server.edge$': `next/dist/server/future/route-modules/app-page/vendored/${opts.layer}/react-dom-server-edge`,
         'react-server-dom-webpack/client.edge$': `next/dist/server/future/route-modules/app-page/vendored/${opts.layer}/react-server-dom-webpack-client-edge`,
       })
     } else if (opts.layer === WEBPACK_LAYERS.reactServerComponents) {

--- a/packages/next/webpack.config.js
+++ b/packages/next/webpack.config.js
@@ -21,7 +21,7 @@ const pagesExternals = [
 ]
 
 function makeAppAliases(reactChannel = '') {
-  const alias = {
+  return {
     react$: `next/dist/compiled/react${reactChannel}`,
     'react/shared-subset$': `next/dist/compiled/react${reactChannel}/react.shared-subset`,
     'react-dom/server-rendering-stub$': `next/dist/compiled/react-dom${reactChannel}/server-rendering-stub`,
@@ -36,9 +36,10 @@ function makeAppAliases(reactChannel = '') {
     'react-server-dom-webpack/client.edge$': `next/dist/compiled/react-server-dom-webpack${reactChannel}/client.edge`,
     'react-server-dom-webpack/server.edge$': `next/dist/compiled/react-server-dom-webpack${reactChannel}/server.edge`,
     'react-server-dom-webpack/server.node$': `next/dist/compiled/react-server-dom-webpack${reactChannel}/server.node`,
+    // optimisations to ignore the legacy build of react-dom/server
+    './cjs/react-dom-server-legacy.browser.production.min.js': `next/dist/build/noop-react-dom-server-legacy`,
+    './cjs/react-dom-server-legacy.browser.development.js': `next/dist/build/noop-react-dom-server-legacy`,
   }
-
-  return alias
 }
 
 const appAliases = makeAppAliases()


### PR DESCRIPTION
This PR includes changes to Next.js bundling in order to aliases references to the `react-dom/server` legacy build to a no-op in order to save KBs. We don't use any of the legacy methods so it's best to just shave it off. This should improve cold boots for both edge and regular servers.

Before:
<img width="622" alt="CleanShot 2023-09-27 at 13 30 47@2x" src="https://github.com/vercel/next.js/assets/11064311/fa383000-c71e-420e-9daa-b8d93ff242e7">

After:
<img width="622" alt="CleanShot 2023-09-27 at 13 31 32@2x" src="https://github.com/vercel/next.js/assets/11064311/702f083a-705f-4b12-9133-9bb7eb02109e">

A win of 70KBs.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
