### PR TITLE
Decrease default test timeouts

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -77,7 +77,7 @@ env:
 
 jobs:
   build:
-    timeout-minutes: 25
+    timeout-minutes: 15
     runs-on:
       - 'self-hosted'
       - 'linux'

--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -2,6 +2,8 @@ import { FileRef, nextTestSetup } from 'e2e-utils'
 import { sandbox } from 'development-sandbox'
 import path from 'path'
 
+jest.setTimeout(240 * 1000)
+
 describe('Error overlay - RSC build errors', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'app-hmr-changes')),

--- a/test/jest-setup-after-env.ts
+++ b/test/jest-setup-after-env.ts
@@ -5,4 +5,4 @@ expect.extend(matchers)
 
 // A default max-timeout of 90 seconds is allowed
 // per test we should aim to bring this down though
-jest.setTimeout((process.platform === 'win32' ? 180 : 120) * 1000)
+jest.setTimeout((process.platform === 'win32' ? 180 : 60) * 1000)

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -14,7 +14,7 @@ export type { NextInstance }
 // if either test runs for the --turbo or have a custom timeout, set reduced timeout instead.
 // this is due to current --turbo test have a lot of tests fails with timeouts, ends up the whole
 // test job exceeds the 6 hours limit.
-let testTimeout = shouldRunTurboDevTest() ? (240 * 1000) / 4 : 240 * 1000
+let testTimeout = shouldRunTurboDevTest() ? (240 * 1000) / 4 : 120 * 1000
 if (process.env.NEXT_E2E_TEST_TIMEOUT) {
   try {
     testTimeout = parseInt(process.env.NEXT_E2E_TEST_TIMEOUT, 10)

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -26,7 +26,7 @@ import { createNextDescribe } from 'e2e-utils'
 const glob = promisify(globOriginal)
 
 if (process.env.TEST_WASM) {
-  jest.setTimeout(240 * 1000)
+  jest.setTimeout(120 * 1000)
 }
 
 createNextDescribe(


### PR DESCRIPTION
When tests are timing out we shouldn't wait for 4 minutes before it officially fails so this brings down the default test timeouts