### PR TITLE
update turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "serde",
 ]
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "serde",
@@ -7381,7 +7381,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7425,7 +7425,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7440,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7454,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7501,7 +7501,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "base16",
  "hex",
@@ -7513,7 +7513,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7527,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7537,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "mimalloc",
 ]
@@ -7545,7 +7545,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7568,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7599,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7661,7 +7661,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7685,7 +7685,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7736,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7831,7 +7831,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "serde",
  "serde_json",
@@ -7842,7 +7842,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7865,7 +7865,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7882,7 +7882,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7898,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "serde",
@@ -7933,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7948,7 +7948,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7983,7 +7983,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "serde",
@@ -7999,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8010,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230922.3#ad585d32fed92986a4458fd47db2f50f1a3cba75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "serde",
 ]
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "serde",
@@ -7381,7 +7381,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7425,7 +7425,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7440,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7454,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7501,7 +7501,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "base16",
  "hex",
@@ -7513,7 +7513,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7527,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7537,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "mimalloc",
 ]
@@ -7545,7 +7545,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7568,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7599,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7661,7 +7661,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7685,7 +7685,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7736,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7831,7 +7831,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "serde",
  "serde_json",
@@ -7842,7 +7842,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7865,7 +7865,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7882,7 +7882,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7898,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "serde",
@@ -7933,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7948,7 +7948,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7983,7 +7983,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "serde",
@@ -7999,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8010,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.1#ee38896e5ade1116fe10e42e41929cad63000b43"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-230928.2#8227e05f9472032c72c3592c536adda4cf8db015"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,11 @@ swc_core = { version = "0.83.12", features = [
 testing = { version = "0.34.1" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230922.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230928.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230922.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230928.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230922.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230928.1" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,11 @@ swc_core = { version = "0.83.12", features = [
 testing = { version = "0.34.1" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230928.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230928.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230928.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230928.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230928.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-230928.2" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -611,7 +611,6 @@ pub fn get_server_chunking_context(
     BuildChunkingContext::builder(
         project_path,
         node_root,
-        client_root,
         node_root.join("server/chunks".to_string()),
         client_root.join("_next/static/media".to_string()),
         environment,

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -611,6 +611,7 @@ pub fn get_server_chunking_context(
     BuildChunkingContext::builder(
         project_path,
         node_root,
+        client_root,
         node_root.join("server/chunks".to_string()),
         client_root.join("_next/static/media".to_string()),
         environment,

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -193,7 +193,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.2",
     "acorn": "8.5.0",
     "ajv": "8.11.0",
     "amphtml-validator": "1.0.35",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -193,7 +193,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230922.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1",
     "acorn": "8.5.0",
     "ajv": "8.11.0",
     "amphtml-validator": "1.0.35",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1058,8 +1058,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.2(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -26858,9 +26858,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.2(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.2}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.2'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1058,8 +1058,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230922.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230922.2(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -1320,7 +1320,7 @@ importers:
         version: 0.13.4
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.54.0)(webpack@5.86.0)
+        version: 12.4.0(webpack@5.86.0)
       schema-utils2:
         specifier: npm:schema-utils@2.7.1
         version: /schema-utils@2.7.1
@@ -23585,7 +23585,7 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  /sass-loader@12.4.0(sass@1.54.0)(webpack@5.86.0):
+  /sass-loader@12.4.0(webpack@5.86.0):
     resolution: {integrity: sha512-7xN+8khDIzym1oL9XyS6zP6Ges+Bo2B2xbPrjdMHEYyV3AQYhd/wXeru++3ODHF0zMjYmVadblSKrPrjEkL8mg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -23603,7 +23603,6 @@ packages:
     dependencies:
       klona: 2.0.4
       neo-async: 2.6.2
-      sass: 1.54.0
       webpack: 5.86.0(@swc/core@1.3.85)
     dev: true
 
@@ -26859,9 +26858,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230922.2(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230922.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230922.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230928.1'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
* https://github.com/vercel/turbo/pull/6009 <!-- OJ Kwon - ci(workflow): update test filter  -->
* https://github.com/vercel/turbo/pull/6026 <!-- Will Binns-Smith - Remove next-dev references and benchmarks  -->
* https://github.com/vercel/turbo/pull/6038 <!-- Tim Neutkens - Remove test-prod action  -->
* https://github.com/vercel/turbo/pull/6039 <!-- Tim Neutkens - Fix action dependency  -->
* ~https://github.com/vercel/turbo/pull/6036~ <!-- Will Binns-Smith - Turbopack: add support for an asset prefix (and basePath in Next.js)  -->


Closes WEB-1673