### PR TITLE
Add experimental.scrollRestoration for Turbopack

### DIFF
--- a/packages/next-swc/crates/next-core/src/env.rs
+++ b/packages/next-swc/crates/next-core/src/env.rs
@@ -130,6 +130,15 @@ pub async fn env_for_js(
         },
     );
 
+    map.insert(
+        "__NEXT_SCROLL_RESTORATION".to_string(),
+        if next_config.experimental.scroll_restoration.unwrap_or(false) {
+            "true".to_string()
+        } else {
+            "false".to_string()
+        },
+    );
+
     if !test_mode.is_empty() {
         map.insert("__NEXT_TEST_MODE".to_string(), "true".to_string());
     }

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -430,6 +430,7 @@ pub struct ExperimentalConfig {
     pub turbo: Option<ExperimentalTurboConfig>,
     pub turbotrace: Option<serde_json::Value>,
     pub external_middleware_rewrites_resolve: Option<bool>,
+    pub scroll_restoration: Option<bool>,
 
     // ---
     // UNSUPPORTED
@@ -480,7 +481,6 @@ pub struct ExperimentalConfig {
     /// directory.
     ppr: Option<bool>,
     proxy_timeout: Option<f64>,
-    scroll_restoration: Option<bool>,
     /// Enables server actions. Using this feature will enable the
     /// `react@experimental` for the `app` directory. @see https://nextjs.org/docs/app/api-reference/functions/server-actions
     server_actions: Option<bool>,

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -33,6 +33,7 @@ const supportedTurbopackNextConfigOptions = [
   'skipMiddlewareUrlNormalize',
   'skipTrailingSlashRedirect',
   'experimental.externalMiddlewareRewritesResolve',
+  'experimental.scrollRestoration',
   'experimental.serverComponentsExternalPackages',
   'experimental.strictNextHead',
   'experimental.turbo',


### PR DESCRIPTION
Skipping this one was as much work as implementing it, so I've just implemented the flag.

This option is no longer relevant for `app` though.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
