### PR TITLE
perf: add option to bundle pages externals

### DIFF
--- a/packages/next/src/build/handle-externals.ts
+++ b/packages/next/src/build/handle-externals.ts
@@ -372,7 +372,8 @@ export function makeExternalHandler({
         config.transpilePackages,
         resolvedExternalPackageDirs
       ) ||
-      (isEsm && isAppLayer)
+      (isEsm && isAppLayer) ||
+      (!isAppLayer && config.experimental.bundlePagesExternals)
 
     if (/node_modules[/\\].*\.[mc]?js$/.test(res)) {
       if (isWebpackServerLayer(layer)) {

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -520,6 +520,9 @@ const configSchema = {
         serverSourceMaps: {
           type: 'boolean',
         },
+        bundlePagesExternals: {
+          type: 'boolean',
+        },
       },
       type: 'object',
     },

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -330,6 +330,10 @@ export interface ExperimentalConfig {
    * @internal Used by the Next.js internals only.
    */
   trustHostHeader?: boolean
+  /**
+   * Enables the bundling of node_modules packages (externals) for pages server-side bundles.
+   */
+  bundlePagesExternals?: boolean
 }
 
 export type ExportPathMap = {
@@ -769,6 +773,7 @@ export const defaultConfig: NextConfig = {
     turbotrace: undefined,
     typedRoutes: false,
     instrumentationHook: false,
+    bundlePagesExternals: false,
   },
 }
 

--- a/test/integration/externals-pages-bundle/next.config.js
+++ b/test/integration/externals-pages-bundle/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    bundlePagesExternals: true,
+  },
+}

--- a/test/integration/externals-pages-bundle/node_modules/external-package/index.js
+++ b/test/integration/externals-pages-bundle/node_modules/external-package/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  foo: 'bar',
+}

--- a/test/integration/externals-pages-bundle/node_modules/external-package/package.json
+++ b/test/integration/externals-pages-bundle/node_modules/external-package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "external-package",
+  "version": "1.0.0",
+  "description": "External package",
+  "main": "index.js"
+}

--- a/test/integration/externals-pages-bundle/pages/index.js
+++ b/test/integration/externals-pages-bundle/pages/index.js
@@ -1,0 +1,13 @@
+import { foo } from 'external-package'
+
+export async function getServerSideProps() {
+  return {
+    props: {
+      foo,
+    },
+  }
+}
+
+export default function Index({ foo }) {
+  return <div>{foo}</div>
+}

--- a/test/integration/externals-pages-bundle/test/index.test.js
+++ b/test/integration/externals-pages-bundle/test/index.test.js
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+
+import fs from 'fs-extra'
+import { join } from 'path'
+import { nextBuild } from 'next-test-utils'
+
+const appDir = join(__dirname, '../')
+
+describe('bundle pages externals with config.experimental.bundlePagesExternals', () => {
+  it('should have no externals with the config set', async () => {
+    await nextBuild(appDir, [], { stdout: true })
+    const output = await fs.readFile(
+      join(appDir, '.next/server/pages/index.js'),
+      'utf8'
+    )
+    expect(output).not.toContain('require("external-package")')
+  })
+})


### PR DESCRIPTION
This PR adds an option to forcefully bundle node_modules packages in `pages` on the server. This should benefit cold boots for projects that uses pages, at the cost of build time increase.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
