### PR TITLE
(docs): Fix inconsistency in App Router, MDX section, replaced reference '_app.js' with 'layout.js'

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
@@ -347,7 +347,17 @@ export default function Post(props) {
 }
 ```
 
+<AppOnly>
+
+If you use it across the site you may want to add the provider to `layout.js` so all MDX pages pick up the custom element config.
+
+</AppOnly>
+
+<PagesOnly>
+
 If you use it across the site you may want to add the provider to `_app.js` so all MDX pages pick up the custom element config.
+
+</PagesOnly>
 
 ## Deep Dive: How do you transform markdown into HTML?
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

The MDX: Custom Elements section refer's `_app.js` in both pages and app router. 
Changed the `_app.js` to `layout.js` for the app router.

### Why?

The mention of `_app.js` creates confusion for new user's used to app router.

![image](https://github.com/vercel/next.js/assets/75237697/98dc38ee-5520-4994-88c2-a8e8dd6f8996)


### How?

Used `<AppOnly>` to set change the line containing `app.js` with `layout.js` for the app router, similarly used `<PagesOnly>`
