### PR TITLE
docs: Renamed function that is used by other name

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/03-forms-and-mutations.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/03-forms-and-mutations.mdx
@@ -529,7 +529,7 @@ Server Actions can also return [serializable objects](https://developer.mozilla.
 ```ts filename="app/actions.ts" switcher
 'use server'
 
-export async function create(prevState: any, formData: FormData) {
+export async function createTodo(prevState: any, formData: FormData) {
   try {
     await createItem(formData.get('todo'))
     return revalidatePath('/')


### PR DESCRIPTION
In "app/actions.ts" the function is named like create(), but in "app/add-form.tsx" file "createTodo" function is imported and used. This is related to TypeScript examples, .js files are ok.

### What?

Renamed a function.

### Why?

There are two example files in docs ([Error Handling](https://nextjs.org/docs/app/building-your-application/data-fetching/forms-and-mutations#error-handling) section) and the `app/add-form.tsx` is importing function `create` from `app/actions.ts` by another name (`createTodo`).

### How?

Fixed by renaming function to `createTodo`, to match .js file with the same example.