### PR TITLE
App render related code clean up

### DIFF
--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -15,9 +15,8 @@ const INLINE_FLIGHT_PAYLOAD_FORM_STATE = 2
  */
 export function useFlightResponse(
   writable: WritableStream<Uint8Array>,
-  req: ReadableStream<Uint8Array>,
+  flightStream: ReadableStream<Uint8Array>,
   clientReferenceManifest: ClientReferenceManifest,
-  rscChunks: Uint8Array[],
   flightResponseRef: FlightResponseRef,
   formState: null | any,
   nonce?: string
@@ -30,7 +29,7 @@ export function useFlightResponse(
     createFromReadableStream,
   } = require(`react-server-dom-webpack/client.edge`)
 
-  const [renderStream, forwardStream] = req.tee()
+  const [renderStream, forwardStream] = flightStream.tee()
   const res = createFromReadableStream(renderStream, {
     moduleMap: isEdgeRuntime
       ? clientReferenceManifest.edgeSSRModuleMapping
@@ -49,10 +48,6 @@ export function useFlightResponse(
 
   function read() {
     forwardReader.read().then(({ done, value }) => {
-      if (value) {
-        rscChunks.push(value)
-      }
-
       if (!bootstrapped) {
         bootstrapped = true
         writer.write(

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -81,8 +81,8 @@ import {
   streamFromString,
   streamToString,
   chainStreams,
-  renderToInitialStream,
-  continueFromInitialStream,
+  renderToInitialFizzStream,
+  continueFizzStream,
 } from './stream-utils/node-web-streams-helper'
 import { ImageConfigContext } from '../shared/lib/image-config-context.shared-runtime'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
@@ -1297,7 +1297,7 @@ export async function renderToHTMLImpl(
       EnhancedComponent: NextComponentType
     ) => {
       const content = renderContent(EnhancedApp, EnhancedComponent)
-      return await renderToInitialStream({
+      return await renderToInitialFizzStream({
         ReactDOMServer,
         element: content,
       })
@@ -1312,9 +1312,9 @@ export async function renderToHTMLImpl(
           return renderToString(styledJsxInsertedHTML())
         }
 
-        return continueFromInitialStream(initialStream, {
+        return continueFizzStream(initialStream, {
           suffix,
-          dataStream: serverComponentsInlinedTransformStream?.readable,
+          inlinedDataStream: serverComponentsInlinedTransformStream?.readable,
           generateStaticHTML: true,
           getServerInsertedHTML,
           serverInsertedHTMLToHead: false,


### PR DESCRIPTION
This PR renames some confusing parts of app-render to explicitly name things as Fizz or Flight streams. There're also 2 memory optimizations that in `streamToBufferedResult` we don't need to buffer these chunks and `join` them later. Also the `rscChunks` array isn't used but it is kept in memory for the entire request lifetime.