### PR TITLE
Add next.config.js options to turbopack warning file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,6 +67,7 @@
     "nextjs",
     "opentelemetry",
     "Threadsafe",
+    "Turbopack",
     "zipkin"
   ],
   "grammarly.selectors": [

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -495,8 +495,6 @@ pub struct ExperimentalConfig {
     server_source_maps: Option<bool>,
     sri: Option<serde_json::Value>,
     swc_minify: Option<bool>,
-    /// This option is removed
-    swc_minify_debug_options: Option<()>,
     swc_trace_profiling: Option<bool>,
     /// @internal Used by the Next.js internals only.
     trust_host_header: Option<bool>,

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -4,6 +4,8 @@ import { NextConfig } from '../server/config-shared'
 import { PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
 
 const supportedTurbopackNextConfigOptions = [
+  // options that affect compilation
+  'output',
   'crossOrigin',
   'configFileName',
   'env',
@@ -36,37 +38,94 @@ const supportedTurbopackNextConfigOptions = [
   'skipMiddlewareUrlNormalize',
   'skipTrailingSlashRedirect',
   'amp',
-  'experimental.logging.level',
+  'devIndicators',
+  'analyticsId',
+
+  // Options that are ignored as they don't affect Turbopack
+  'webpack',
+  'onDemandEntries',
+  'experimental.cpus',
+
+  // Experimental options that affect compilation
   'experimental.swcPlugins',
+  'experimental.strictNextHead',
   'experimental.manualClientBasePath',
-  'experimental.optimisticClientCache',
   'experimental.middlewarePrefetch',
   'experimental.optimizeCss',
   'experimental.nextScriptWorkers',
+  'experimental.optimisticClientCache',
   'experimental.webVitalsAttribution',
   'experimental.externalMiddlewareRewritesResolve',
-  'experimental.scrollRestoration',
   'experimental.serverComponentsExternalPackages',
-  'experimental.strictNextHead',
-  'experimental.turbo',
   'experimental.mdxRs',
+  'experimental.turbo',
+  'experimental.useDeploymentId',
+  'experimental.useDeploymentIdServerActions',
+  'experimental.deploymentId',
+
+  // Experimental options that don't affect compilation
+  'experimental.proxyTimeout',
+  'experimental.caseSensitiveRoutes',
+  'experimental.workerThreads',
+  'experimental.isrFlushToDisk',
+  'experimental.logging.level',
+  'experimental.logging.fullUrl',
+  'experimental.scrollRestoration',
   'experimental.forceSwcTransforms',
   'experimental.serverActionsBodySizeLimit',
   'experimental.memoryBasedWorkersCount',
-  // options below are not really supported, but ignored
-  'webpack',
-  'devIndicators',
-  'onDemandEntries',
-  'excludeDefaultMomentLocales',
   'experimental.clientRouterFilterRedirects',
-  'experimental.cpus',
-  'experimental.proxyTimeout',
-  'experimental.isrFlushToDisk',
-  'experimental.workerThreads',
-  'experimental.caseSensitiveRoutes',
+  'experimental.webpackBuildWorker',
+  'experimental.appDocumentPreloading',
+  'experimental.incrementalCacheHandlerPath',
+  'experimental.amp',
+  'experimental.disableOptimizedLoading',
+  'experimental.isrMemoryCacheSize',
+  'experimental.largePageDataBytes',
+  'experimental.gzipSize',
+
+  // Left to be implemented
+  'excludeDefaultMomentLocales',
   'experimental.optimizePackageImports',
   'experimental.optimizeServerReact',
-  'experimental.webpackBuildWorker',
+
+  // 'compiler.emotion',
+  // 'compiler.reactRemoveProperties',
+  // 'compiler.relay',
+  // 'compiler.removeConsole',
+  // 'compiler.styledComponents',
+  // 'experimental.clientRouterFilterAllowedRate',
+
+  // clientRouterFilter is `true` by default currently in config-shared.ts,
+  // might be removed as an option altogether.
+  'experimental.clientRouterFilter',
+  'experimental.serverMinification',
+  'experimental.serverSourceMaps',
+  'experimental.trustHostHeader',
+
+  // 'experimental.adjustFontFallbacks',
+  // 'experimental.adjustFontFallbacksWithSizeAdjust',
+  // 'experimental.allowedRevalidateHeaderKeys',
+  // 'experimental.bundlePagesExternals',
+  // 'experimental.extensionAlias',
+  // 'experimental.fallbackNodePolyfills',
+  // 'experimental.fetchCacheKeyPrefix',
+  // 'experimental.instrumentationHook',
+  // 'experimental.ppr',
+  // 'experimental.serverActions',
+  // 'experimental.sri.algorithm',
+  // 'experimental.swcTraceProfiling',
+  // 'experimental.typedRoutes',
+
+  // Might not be needed for Turbopack
+  // 'experimental.craCompat',
+  // 'experimental.disablePostcssPresetEnv',
+  // 'experimental.esmExternals',
+  // 'experimental.externalDir',
+  // This is used to force swc-loader to run regardless of finding Babel.
+  // 'experimental.forceSwcTransforms',
+  // 'experimental.fullySpecified',
+  // 'experimental.urlImports',
 ]
 
 // The following will need to be supported by `next build --turbo`
@@ -75,9 +134,7 @@ const prodSpecificTurboNextConfigOptions = [
   'typescript',
   'staticPageGenerationTimeout',
   'outputFileTracing',
-  'output',
   'generateBuildId',
-  'analyticsId',
   'compress',
   'productionBrowserSourceMaps',
   'optimizeFonts',
@@ -85,20 +142,11 @@ const prodSpecificTurboNextConfigOptions = [
   'staticPageGenerationTimeout',
   'reactProductionProfiling',
   'cleanDistDir',
-  'compiler.reactRemoveProperties',
-  'compiler.removeConsole',
   'experimental.turbotrace',
   'experimental.outputFileTracingRoot',
   'experimental.outputFileTracingExcludes',
   'experimental.outputFileTracingIgnores',
-  'experiemental.outputFileTracingIncludes',
-  'experimental.gzipSize',
-  'experimental.useDeploymentId',
-  'experimental.useDeploymentIdServerActions',
-  'experimental.deploymentId',
-  'experimental.serverMinification',
-  'experimental.serverSourceMaps',
-  'experimenta.trustHostHeader',
+  'experimental.outputFileTracingIncludes',
 ]
 
 // check for babelrc, swc plugins

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -4,7 +4,7 @@ import { NextConfig } from '../server/config-shared'
 import { PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
 
 const supportedTurbopackNextConfigOptions = [
-  // options that affect compilation
+  // Options that affect compilation
   'output',
   'crossOrigin',
   'configFileName',

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -83,25 +83,29 @@ const supportedTurbopackNextConfigOptions = [
   'experimental.isrMemoryCacheSize',
   'experimental.largePageDataBytes',
   'experimental.gzipSize',
+  'experimental.trustHostHeader',
 
-  // Left to be implemented
-  'excludeDefaultMomentLocales',
+  // Left to be implemented (priority)
+  // 'experimental.serverActions',
+  // 'experimental.ppr', // Checked in `needs-experimental-react.ts`
+  // clientRouterFilter is `true` by default currently in config-shared.ts,
+  // might be removed as an option altogether.
+  'experimental.clientRouterFilter',
   'experimental.optimizePackageImports',
-  'experimental.optimizeServerReact',
-
   // 'compiler.emotion',
   // 'compiler.reactRemoveProperties',
   // 'compiler.relay',
   // 'compiler.removeConsole',
   // 'compiler.styledComponents',
-  // 'experimental.clientRouterFilterAllowedRate',
+  // 'experimental.fetchCacheKeyPrefix',
+  // 'experimental.instrumentationHook',
 
-  // clientRouterFilter is `true` by default currently in config-shared.ts,
-  // might be removed as an option altogether.
-  'experimental.clientRouterFilter',
+  // Left to be implemented
+  'excludeDefaultMomentLocales',
+  'experimental.optimizeServerReact',
+  // 'experimental.clientRouterFilterAllowedRate',
   'experimental.serverMinification',
   'experimental.serverSourceMaps',
-  'experimental.trustHostHeader',
 
   // 'experimental.adjustFontFallbacks',
   // 'experimental.adjustFontFallbacksWithSizeAdjust',
@@ -109,15 +113,12 @@ const supportedTurbopackNextConfigOptions = [
   // 'experimental.bundlePagesExternals',
   // 'experimental.extensionAlias',
   // 'experimental.fallbackNodePolyfills',
-  // 'experimental.fetchCacheKeyPrefix',
-  // 'experimental.instrumentationHook',
-  // 'experimental.ppr',
-  // 'experimental.serverActions',
+
   // 'experimental.sri.algorithm',
   // 'experimental.swcTraceProfiling',
   // 'experimental.typedRoutes',
 
-  // Might not be needed for Turbopack
+  // Left to be implemented (Might not be needed for Turbopack)
   // 'experimental.craCompat',
   // 'experimental.disablePostcssPresetEnv',
   // 'experimental.esmExternals',

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -222,10 +222,6 @@ export interface ExperimentalConfig {
   swcTraceProfiling?: boolean
   forceSwcTransforms?: boolean
 
-  /**
-   * This option is removed
-   */
-  swcMinifyDebugOptions?: never
   swcPlugins?: Array<[string, Record<string, unknown>]>
   largePageDataBytes?: number
   /**

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -375,14 +375,6 @@ function assignDefaults(
     silent
   )
 
-  if (typeof result.experimental?.swcMinifyDebugOptions !== 'undefined') {
-    if (!silent) {
-      Log.warn(
-        'SWC minify debug option is not supported anymore, please remove it from your config.'
-      )
-    }
-  }
-
   if ((result.experimental as any).outputStandalone) {
     if (!silent) {
       Log.warn(


### PR DESCRIPTION
Went through all options listed in config-shared.ts and added them to the turbopack warning file so that there is a clear list of what is not implemented yet.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
