### PR TITLE
Start collecting page data during client compilation

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -326,8 +326,8 @@ const filterAndSortList = (
 
 export interface PageInfo {
   isHybridAmp?: boolean
-  size: number
-  totalSize: number
+  size?: number
+  totalSize?: number
   static: boolean
   isSsg: boolean
   ssgPageRoutes: string[] | null
@@ -476,15 +476,15 @@ export async function printTreeView(
         pageInfo
           ? ampFirst
             ? cyan('AMP')
-            : pageInfo.size >= 0
-            ? prettyBytes(pageInfo.size)
+            : (pageInfo.size || 0) >= 0
+            ? prettyBytes(pageInfo.size || 0)
             : ''
           : '',
         pageInfo
           ? ampFirst
             ? cyan('AMP')
-            : pageInfo.size >= 0
-            ? getPrettySize(pageInfo.totalSize)
+            : (pageInfo.size || 0) >= 0
+            ? getPrettySize(pageInfo.totalSize || 0)
             : ''
           : '',
       ])

--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -1,7 +1,4 @@
-import {
-  COMPILER_INDEXES,
-  CompilerNameValues,
-} from '../../shared/lib/constants'
+import { COMPILER_INDEXES } from '../../shared/lib/constants'
 import * as Log from '../output/log'
 import { NextBuildContext } from '../build-context'
 import type { BuildTraceContext } from '../webpack/plugins/next-trace-entrypoints-plugin'


### PR DESCRIPTION
We can start collecting page data and build traces after server compilation is finished so this moves starts those steps before waiting for client compilation to finish. Initially this is gated behind the webpack build workers flag for testing. 