### PR TITLE
only override NODE_EXTRA_CA_CERTS when using experimental https flag

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -245,14 +245,17 @@ const nextDev: CliCommand = async (args) => {
   async function startServer(options: StartServerOptions) {
     return new Promise<void>((resolve) => {
       let resolved = false
+      const defaultEnv = (initialEnv || process.env) as typeof process.env
 
       child = fork(startServerPath, {
         stdio: 'inherit',
         env: {
-          ...((initialEnv || process.env) as typeof process.env),
+          ...defaultEnv,
           TURBOPACK: process.env.TURBOPACK,
           NEXT_PRIVATE_WORKER: '1',
-          NODE_EXTRA_CA_CERTS: options.selfSignedCertificate?.rootCA,
+          NODE_EXTRA_CA_CERTS: options.selfSignedCertificate
+            ? options.selfSignedCertificate.rootCA
+            : defaultEnv.NODE_EXTRA_CA_CERTS,
         },
       })
 


### PR DESCRIPTION
This was unintentionally preventing this flag from being sent on `process.env` even if you weren't using `--experimental-https`. 

[x-ref](https://github.com/vercel/next.js/pull/55775#issuecomment-1741870873)