### PR TITLE
Pass same mangling option as terser to SWC minifier

### DIFF
--- a/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
@@ -166,7 +166,12 @@ export class TerserPlugin {
                       }
                     : {}),
                   compress: true,
-                  mangle: true,
+                  // This is the same option as terser
+                  mangle: {
+                    toplevel: true,
+                    keep_classnames: true,
+                    keep_fnames: true,
+                  },
                 }
               )
 


### PR DESCRIPTION
### What?

Pass `keep_classnames: true` to the SWC minifier, as we are passing it to `terser`.

### Why?

https://github.com/vercel/next.js/blob/5f7faac1e676be0819dd5d828bffed8a7105a78e/packages/next/src/build/webpack-config.ts#L953-L958

### How?

Closes WEB-1676
Fixes #55682
