### PR TITLE
Update parallelizing tasks with webpackBuildWorker config

### DIFF
--- a/packages/next/src/build/build-context.ts
+++ b/packages/next/src/build/build-context.ts
@@ -5,7 +5,6 @@ import type { __ApiPreviewProps } from '../server/api-utils'
 import type { NextConfigComplete } from '../server/config-shared'
 import type { Span } from '../trace'
 import type getBaseWebpackConfig from './webpack-config'
-import type { PagesManifest } from './webpack/plugins/pages-manifest-plugin'
 import type { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
 
 // A layer for storing data that is used by plugins to communicate with each
@@ -48,12 +47,6 @@ export function getPluginState() {
 export const NextBuildContext: Partial<{
   compilerIdx?: number
   pluginState: Record<string, any>
-  serializedPagesManifestEntries: {
-    edgeServerPages?: PagesManifest
-    nodeServerPages?: PagesManifest
-    edgeServerAppPaths?: PagesManifest
-    nodeServerAppPaths?: PagesManifest
-  }
   // core fields
   dir: string
   buildId: string

--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -1,4 +1,4 @@
-import type { Span } from '../trace'
+import { Span } from '../trace'
 import type { NextConfigComplete } from '../server/config-shared'
 
 import {
@@ -18,11 +18,14 @@ import { PageInfo } from './utils'
 import { loadBindings } from './swc'
 import { nonNullable } from '../lib/non-nullable'
 import * as ciEnvironment from '../telemetry/ci-info'
+import debugOriginal from 'next/dist/compiled/debug'
 import { isMatch } from 'next/dist/compiled/micromatch'
 import { defaultOverrides } from '../server/require-hook'
 import { nodeFileTrace } from 'next/dist/compiled/@vercel/nft'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
+
+const debug = debugOriginal('next:build:build-traces')
 
 export async function collectBuildTraces({
   dir,
@@ -31,7 +34,7 @@ export async function collectBuildTraces({
   pageKeys,
   pageInfos,
   staticPages,
-  nextBuildSpan,
+  nextBuildSpan = new Span({ name: 'build' }),
   hasSsrAmpPages,
   buildTraceContext,
   outputFileTracingRoot,
@@ -42,14 +45,16 @@ export async function collectBuildTraces({
     app?: string[]
     pages: string[]
   }
-  staticPages: Set<string>
+  staticPages: string[]
   hasSsrAmpPages: boolean
   outputFileTracingRoot: string
-  pageInfos: Map<string, PageInfo>
-  nextBuildSpan: Span
+  pageInfos: [string, PageInfo][]
+  nextBuildSpan?: Span
   config: NextConfigComplete
   buildTraceContext?: BuildTraceContext
 }) {
+  const startTime = Date.now()
+  debug('starting build traces')
   let turboTasksForTrace: unknown
   let bindings = await loadBindings()
 
@@ -99,7 +104,7 @@ export async function collectBuildTraces({
           // The turbo trace doesn't provide the traced file type and reason at present
           // let's write the traced files into the first [entry].nft.json
           const [[, entryName]] = Array.from<[string, string]>(
-            entryNameMap.entries()
+            Object.entries(entryNameMap)
           ).filter(([k]) => k.startsWith(buildTraceContextAppDir))
           const traceOutputPath = path.join(
             outputPath,
@@ -119,7 +124,7 @@ export async function collectBuildTraces({
           const outputPagesPath = path.join(outputPath, '..', 'pages')
           return (
             !f.startsWith(outputPagesPath) ||
-            !staticPages.has(
+            !staticPages.includes(
               // strip `outputPagesPath` and file ext from absolute
               f.substring(outputPagesPath.length, f.length - 3)
             )
@@ -369,10 +374,13 @@ export async function collectBuildTraces({
           }
         }
 
+        const { entryNameFilesMap } = buildTraceContext?.chunksTrace || {}
+
         await Promise.all(
           [
-            ...(buildTraceContext?.chunksTrace?.entryNameFilesMap.entries() ||
-              new Map()),
+            ...(entryNameFilesMap
+              ? Object.entries(entryNameFilesMap)
+              : new Map()),
           ].map(async ([entryName, entryNameFiles]) => {
             const isApp = entryName.startsWith('app/')
             const isPages = entryName.startsWith('pages/')
@@ -387,7 +395,7 @@ export async function collectBuildTraces({
 
             // we don't need to trace for automatically statically optimized
             // pages as they don't have server bundles
-            if (staticPages.has(route)) {
+            if (staticPages.includes(route)) {
               return
             }
             const entryOutputPath = path.join(
@@ -504,7 +512,7 @@ export async function collectBuildTraces({
 
     for (let page of pageKeys.pages) {
       // edge routes have no trace files
-      const pageInfo = pageInfos.get(page)
+      const [, pageInfo] = pageInfos.find((item) => item[0] === page) || []
       if (pageInfo?.runtime === 'edge') {
         continue
       }
@@ -584,4 +592,6 @@ export async function collectBuildTraces({
       )
     }
   })
+
+  debug(`finished build tracing ${Date.now() - startTime}ms`)
 }

--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -9,7 +9,29 @@ import path from 'path'
 
 const debug = origDebug('next:build:webpack-build')
 
-async function webpackBuildWithWorker() {
+const ORDERED_COMPILER_NAMES = [
+  'server',
+  'edge-server',
+  'client',
+] as (keyof typeof COMPILER_INDEXES)[]
+
+let pluginState: Record<any, any> = {}
+
+function deepMerge(target: any, source: any) {
+  const result = { ...target, ...source }
+  for (const key of Object.keys(result)) {
+    result[key] = Array.isArray(target[key])
+      ? (target[key] = [...target[key], ...(source[key] || [])])
+      : typeof target[key] == 'object' && typeof source[key] == 'object'
+      ? deepMerge(target[key], source[key])
+      : structuredClone(result[key])
+  }
+  return result
+}
+
+async function webpackBuildWithWorker(
+  compilerNames: typeof ORDERED_COMPILER_NAMES = ORDERED_COMPILER_NAMES
+) {
   const {
     config,
     telemetryPlugin,
@@ -17,6 +39,8 @@ async function webpackBuildWithWorker() {
     nextBuildSpan,
     ...prunedBuildContext
   } = NextBuildContext
+
+  prunedBuildContext.pluginState = pluginState
 
   const getWorker = (compilerName: string) => {
     const _worker = new Worker(path.join(__dirname, 'impl.js'), {
@@ -37,7 +61,7 @@ async function webpackBuildWithWorker() {
       _child: ChildProcess
     }[]) {
       worker._child.on('exit', (code, signal) => {
-        if (code || signal) {
+        if (code || (signal && signal !== 'SIGINT')) {
           console.error(
             `Compiler ${compilerName} unexpectedly exited with code: ${code} and signal: ${signal}`
           )
@@ -52,14 +76,8 @@ async function webpackBuildWithWorker() {
     duration: 0,
     buildTraceContext: {} as BuildTraceContext,
   }
-  // order matters here
-  const ORDERED_COMPILER_NAMES = [
-    'server',
-    'edge-server',
-    'client',
-  ] as (keyof typeof COMPILER_INDEXES)[]
 
-  for (const compilerName of ORDERED_COMPILER_NAMES) {
+  for (const compilerName of compilerNames) {
     const worker = getWorker(compilerName)
 
     const curResult = await worker.workerMain({
@@ -70,18 +88,8 @@ async function webpackBuildWithWorker() {
     await worker.end()
 
     // Update plugin state
-    prunedBuildContext.pluginState = curResult.pluginState
-
-    prunedBuildContext.serializedPagesManifestEntries = {
-      edgeServerAppPaths:
-        curResult.serializedPagesManifestEntries?.edgeServerAppPaths,
-      edgeServerPages:
-        curResult.serializedPagesManifestEntries?.edgeServerPages,
-      nodeServerAppPaths:
-        curResult.serializedPagesManifestEntries?.nodeServerAppPaths,
-      nodeServerPages:
-        curResult.serializedPagesManifestEntries?.nodeServerPages,
-    }
+    pluginState = deepMerge(pluginState, curResult.pluginState)
+    prunedBuildContext.pluginState = pluginState
 
     combinedResult.duration += curResult.duration
 
@@ -91,9 +99,8 @@ async function webpackBuildWithWorker() {
       if (entryNameMap) {
         combinedResult.buildTraceContext.entriesTrace =
           curResult.buildTraceContext.entriesTrace
-        combinedResult.buildTraceContext.entriesTrace!.entryNameMap = new Map(
+        combinedResult.buildTraceContext.entriesTrace!.entryNameMap =
           entryNameMap
-        )
       }
 
       if (curResult.buildTraceContext?.chunksTrace) {
@@ -104,23 +111,28 @@ async function webpackBuildWithWorker() {
             curResult.buildTraceContext.chunksTrace!
 
           combinedResult.buildTraceContext.chunksTrace!.entryNameFilesMap =
-            new Map(entryNameFilesMap)
+            entryNameFilesMap
         }
       }
     }
   }
-  buildSpinner?.stopAndPersist()
-  Log.event('Compiled successfully')
+
+  if (compilerNames.length === 3) {
+    buildSpinner?.stopAndPersist()
+    Log.event('Compiled successfully')
+  }
 
   return combinedResult
 }
 
-export async function webpackBuild() {
+export async function webpackBuild(
+  compilerNames?: typeof ORDERED_COMPILER_NAMES
+) {
   const config = NextBuildContext.config!
 
   if (config.experimental.webpackBuildWorker) {
     debug('using separate compiler workers')
-    return await webpackBuildWithWorker()
+    return await webpackBuildWithWorker(compilerNames)
   } else {
     debug('building all compilers in same process')
     const webpackBuildImpl = require('./impl').webpackBuildImpl

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2036,6 +2036,7 @@ export default async function getBaseWebpackConfig(
       isNodeOrEdgeCompilation &&
         new PagesManifestPlugin({
           dev,
+          distDir,
           isEdgeRuntime: isEdgeServer,
           appDirEnabled: hasAppDir,
         }),

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2036,9 +2036,9 @@ export default async function getBaseWebpackConfig(
       isNodeOrEdgeCompilation &&
         new PagesManifestPlugin({
           dev,
-          distDir,
-          isEdgeRuntime: isEdgeServer,
           appDirEnabled: hasAppDir,
+          isEdgeRuntime: isEdgeServer,
+          distDir: !dev ? distDir : undefined,
         }),
       // MiddlewarePlugin should be after DefinePlugin so  NEXT_PUBLIC_*
       // replacement is done before its process.env.* handling

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -120,12 +120,12 @@ export interface BuildTraceContext {
     appDir: string
     outputPath: string
     depModArray: string[]
-    entryNameMap: Map<string, string>
+    entryNameMap: Record<string, string>
   }
   chunksTrace?: {
     action: TurbotraceAction
     outputPath: string
-    entryNameFilesMap: Map<string, Array<string>>
+    entryNameFilesMap: Record<string, Array<string>>
   }
 }
 
@@ -224,7 +224,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
           logLevel: this.turbotrace?.logLevel,
         },
         outputPath,
-        entryNameFilesMap,
+        entryNameFilesMap: Object.fromEntries(entryNameFilesMap),
       }
 
       for (const [entrypoint, entryFiles] of entryFilesMap) {
@@ -436,7 +436,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
               },
               appDir: this.rootDir,
               depModArray: Array.from(depModMap.keys()),
-              entryNameMap,
+              entryNameMap: Object.fromEntries(entryNameMap),
               outputPath: compilation.outputOptions.path!,
             }
 

--- a/packages/next/src/build/webpack/plugins/pages-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/pages-manifest-plugin.ts
@@ -1,4 +1,6 @@
-import { webpack, sources } from 'next/dist/compiled/webpack/webpack'
+import path from 'path'
+import fs from 'fs/promises'
+import { webpack } from 'next/dist/compiled/webpack/webpack'
 import {
   PAGES_MANIFEST,
   APP_PATHS_MANIFEST,
@@ -20,24 +22,28 @@ export default class PagesManifestPlugin
   implements webpack.WebpackPluginInstance
 {
   dev: boolean
+  distDir: string
   isEdgeRuntime: boolean
   appDirEnabled: boolean
 
   constructor({
     dev,
+    distDir,
     isEdgeRuntime,
     appDirEnabled,
   }: {
     dev: boolean
+    distDir: string
     isEdgeRuntime: boolean
     appDirEnabled: boolean
   }) {
     this.dev = dev
+    this.distDir = distDir
     this.isEdgeRuntime = isEdgeRuntime
     this.appDirEnabled = appDirEnabled
   }
 
-  createAssets(compilation: any, assets: any) {
+  async createAssets(compilation: any) {
     const entrypoints = compilation.entrypoints
     const pages: PagesManifest = {}
     const appPaths: PagesManifest = {}
@@ -92,45 +98,56 @@ export default class PagesManifestPlugin
       nodeServerAppPaths = appPaths
     }
 
-    assets[
-      `${!this.dev && !this.isEdgeRuntime ? '../' : ''}` + PAGES_MANIFEST
-    ] = new sources.RawSource(
-      JSON.stringify(
-        {
-          ...edgeServerPages,
-          ...nodeServerPages,
-        },
-        null,
-        2
-      )
-    )
-
-    if (this.appDirEnabled) {
-      assets[
-        `${!this.dev && !this.isEdgeRuntime ? '../' : ''}` + APP_PATHS_MANIFEST
-      ] = new sources.RawSource(
+    // handle parallel compilers writing to the same
+    // manifest path by merging existing manifest with new
+    const writeMergedManifest = async (
+      manifestPath: string,
+      entries: Record<string, string>
+    ) => {
+      await fs.mkdir(path.dirname(manifestPath), { recursive: true })
+      await fs.writeFile(
+        manifestPath,
         JSON.stringify(
           {
-            ...edgeServerAppPaths,
-            ...nodeServerAppPaths,
+            ...(await fs
+              .readFile(manifestPath, 'utf8')
+              .then((res) => JSON.parse(res))
+              .catch(() => ({}))),
+            ...entries,
           },
           null,
           2
         )
       )
     }
+
+    const pagesManifestPath = path.join(this.distDir, 'server', PAGES_MANIFEST)
+    await writeMergedManifest(pagesManifestPath, {
+      ...edgeServerPages,
+      ...nodeServerPages,
+    })
+
+    if (this.appDirEnabled) {
+      const appPathsManifestPath = path.join(
+        this.distDir,
+        'server',
+        APP_PATHS_MANIFEST
+      )
+      await writeMergedManifest(appPathsManifestPath, {
+        ...edgeServerAppPaths,
+        ...nodeServerAppPaths,
+      })
+    }
   }
 
   apply(compiler: webpack.Compiler): void {
     compiler.hooks.make.tap('NextJsPagesManifest', (compilation) => {
-      compilation.hooks.processAssets.tap(
+      compilation.hooks.processAssets.tapPromise(
         {
           name: 'NextJsPagesManifest',
           stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
         },
-        (assets: any) => {
-          this.createAssets(compilation, assets)
-        }
+        () => this.createAssets(compilation)
       )
     })
   }

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -69,7 +69,7 @@ export class Worker {
         }[]) {
           worker._child?.on('exit', (code, signal) => {
             // log unexpected exit if .end() wasn't called
-            if ((code || signal) && this._worker) {
+            if ((code || (signal && signal !== 'SIGINT')) && this._worker) {
               console.error(
                 `Static worker unexpectedly exited with code: ${code} and signal: ${signal}`
               )


### PR DESCRIPTION
This updates to make build/server tracing parallelized with our webpack compilations so that it can start right after the server compilation is finished instead of after all compilations are finished. This parallelizing requires the `experimental.webpackBuildWorker` config be enabled and doesn't change behavior without it. 

Part of this also cleans up our plugin state restoring/handling to use serializable structures instead of serializing/deserializing manually.