### PR TITLE
Fix flaky test for size output

### DIFF
--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -16,7 +16,7 @@ createNextDescribe(
       if (!process.env.NEXT_EXPERIMENTAL_COMPILE) {
         it('should have correct size in build output', async () => {
           expect(next.cliOutput).toMatch(
-            /\/dashboard\/another.*? [^0]{1,} [\w]{1,}B/
+            /\/dashboard\/another.*? *?[^0]\d{1,} [\w]{1,}B/
           )
         })
       }


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/actions/runs/6380869104/job/17316148085?pr=56187

Tune the regex that match the correct number but without leading zero