### PR TITLE
Fix build output logging order

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2080,7 +2080,6 @@ export default async function build(
 
           await exportApp(dir, exportOptions, nextBuildSpan)
 
-          const postBuildSpinner = createSpinner('Finalizing page optimization')
           ssgNotFoundPaths = exportConfig.ssgNotFoundPaths
 
           // remove server bundles that were exported
@@ -2531,12 +2530,10 @@ export default async function build(
             JSON.stringify(pagesManifest, null, 2),
             'utf8'
           )
-
-          if (postBuildSpinner) postBuildSpinner.stopAndPersist()
-          console.log()
         })
       }
 
+      const postBuildSpinner = createSpinner('Finalizing page optimization')
       let buildTracesSpinner = createSpinner(`Collecting build traces`)
 
       // ensure the worker is not left hanging
@@ -2697,20 +2694,6 @@ export default async function build(
         return Promise.reject(err)
       })
 
-      await nextBuildSpan.traceChild('print-tree-view').traceAsyncFn(() =>
-        printTreeView(pageKeys, pageInfos, {
-          distPath: distDir,
-          buildId: buildId,
-          pagesDir,
-          useStaticPages404,
-          pageExtensions: config.pageExtensions,
-          appBuildManifest,
-          buildManifest,
-          middlewareManifest,
-          gzipSize: config.experimental.gzipSize,
-        })
-      )
-
       if (debugOutput) {
         nextBuildSpan
           .traceChild('print-custom-routes')
@@ -2856,6 +2839,23 @@ export default async function build(
         buildTracesSpinner.stopAndPersist()
         buildTracesSpinner = undefined
       }
+
+      if (postBuildSpinner) postBuildSpinner.stopAndPersist()
+      console.log()
+
+      await nextBuildSpan.traceChild('print-tree-view').traceAsyncFn(() =>
+        printTreeView(pageKeys, pageInfos, {
+          distPath: distDir,
+          buildId: buildId,
+          pagesDir,
+          useStaticPages404,
+          pageExtensions: config.pageExtensions,
+          appBuildManifest,
+          buildManifest,
+          middlewareManifest,
+          gzipSize: config.experimental.gzipSize,
+        })
+      )
 
       await nextBuildSpan
         .traceChild('telemetry-flush')


### PR DESCRIPTION
Closes NEXT-1671 

Move "Finalizing" to the bottom, and print tree view after file tracing spinner

### After
```
 ✓ Generating static pages (5/5)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

Route (app)                              Size     First Load JS
┌ ○ /                                    133 B            80 kB
└ ○ /_not-found                          876 B          80.8 kB
+ First Load JS shared by all            79.9 kB
  ├ chunks/main-app-f7da6251716e8121.js  78.2 kB
  └ chunks/webpack-bf1a64d1eafd2816.js   1.66 kB
```

### Before

```
 ✓ Generating static pages (5/5)
 ✓ Finalizing page optimization

   Collecting build traces  .Route (app)                              Size     First Load JS
┌ ○ /                                    133 B            80 kB
└ ○ /_not-found                          876 B          80.8 kB
+ First Load JS shared by all            79.9 kB
  ├ chunks/main-app-f7da6251716e8121.js  78.2 kB
  └ chunks/webpack-bf1a64d1eafd2816.js   1.66 kB


○  (Static)  automatically rendered as static HTML (uses no initial props)

 ✓ Collecting build traces
 ```