### PR TITLE
Remove app dir warning test

### DIFF
--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -19,17 +19,6 @@ async function collectStdout(appDir) {
   return stdout
 }
 
-async function collectStderr(appDir) {
-  let stderr = ''
-  const port = await findPort()
-  app = await launchApp(appDir, port, {
-    onStderr(msg) {
-      stderr += msg
-    },
-  })
-  return stderr
-}
-
 describe('Config Experimental Warning', () => {
   afterEach(() => {
     configFile.write('')

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -123,19 +123,4 @@ describe('Config Experimental Warning', () => {
     expect(stdout).toMatch(' · workerThreads')
     expect(stdout).toMatch(' · scrollRestoration')
   })
-
-  it('should show warning for dropped experimental.appDir option', async () => {
-    configFile.write(`
-      module.exports = {
-        experimental: {
-          appDir: true,
-        }
-      }
-    `)
-
-    const stderr = await collectStderr(appDir)
-    expect(stderr).toMatch(
-      'App router is available by default now, `experimental.appDir` option can be safely removed.'
-    )
-  })
 })


### PR DESCRIPTION
This test was failing in Turbopack because the option no longer exists. Fine to remove it for now.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
