### PR TITLE
Updates MDX docs

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
@@ -21,11 +21,13 @@ Output:
 
 [MDX](https://mdxjs.com/) is a superset of markdown that lets you write [JSX](https://react.dev/learn/writing-markup-with-jsx) directly in your markdown files. It is a powerful way to add dynamic interactivity and embed React components within your content.
 
-Next.js can support both local MDX content inside your application, as well as remote MDX files fetched dynamically on the server. The Next.js plugin handles transforming Markdown and React components into HTML, including support for usage in Server Components (the default in App Router).
+Next.js can support both local MDX content inside your application, as well as remote MDX files fetched dynamically on the server. The Next.js plugin handles transforming markdown and React components into HTML, including support for usage in Server Components (the default in App Router).
 
 ## `@next/mdx`
 
-The `@next/mdx` package is configured in the `next.config.js` file at your projects root. **It sources data from local files**, allowing you to create pages with a `.mdx` extension, directly in your `/pages` or `/app` directory.
+The `@next/mdx` package is used to configure Next.js so it can process markdown and MDX. **It sources data from local files**, allowing you to create pages with a `.mdx` extension, directly in your `/pages` or `/app` directory.
+
+Let's walk through how to configure and use MDX with Next.js.
 
 ## Getting Started
 
@@ -61,17 +63,15 @@ export function useMDXComponents(components) {
 
 </AppOnly>
 
-Update `next.config.js` to configure it to use Markdown and MDX:
+Update the `next.config.js` file at your project's root to configure it to use MDX:
 
 ```js filename="next.config.js"
-const withMDX = require('@next/mdx')({
-  extension: /\.(md|mdx)$/,
-})
+const withMDX = require('@next/mdx')()
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Configure `pageExtensions`` to include markdown files
-  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
+  // Configure `pageExtensions`` to include MDX files
+  pageExtensions: ['js', 'jsx', 'mdx', 'ts', 'tsx'],
   // Optionally, add any other Next.js config below
 }
 
@@ -125,17 +125,20 @@ Checkout my React component:
 <MyComponent />
 ```
 
-Navigating to the `/my-mdx-page` route should display your rendered Markdown.
+Navigating to the `/my-mdx-page` route should display your rendered MDX.
 
 ## Remote MDX
 
-If your Markdown or MDX files or content live _somewhere else_, you can fetch them dynamically on the server. This is useful for fetching content from a separate folder, CMS, database, or anywhere else.
+If your markdown or MDX files or content lives _somewhere else_, you can fetch it dynamically on the server. This is useful for content stored in a separate local folder, CMS, database, or anywhere else.
 
-There are two popular community packages for fetching MDX content: [`next-mdx-remote`](https://github.com/hashicorp/next-mdx-remote#react-server-components-rsc--nextjs-app-directory-support) and [`contentlayer`](https://www.contentlayer.dev/).
+There are two popular community packages for fetching MDX content:
+
+- [`next-mdx-remote`](https://github.com/hashicorp/next-mdx-remote#react-server-components-rsc--nextjs-app-directory-support)
+- [`contentlayer`](https://www.contentlayer.dev/)
 
 > **Good to know**: Please proceed with caution. MDX compiles to JavaScript and is executed on the server. You should only fetch MDX content from a trusted source, otherwise this can lead to remote code execution (RCE).
 
-For example, the following example uses `next-mdx-remote`:
+The following example uses `next-mdx-remote`:
 
 <AppOnly>
 
@@ -205,22 +208,22 @@ export async function getStaticProps() {
 
 </PagesOnly>
 
-Navigating to the `/my-mdx-page-remote` route should display your rendered Markdown.
+Navigating to the `/my-mdx-page-remote` route should display your rendered MDX.
 
 ## Layouts
 
 <AppOnly>
 
-To share a layout around MDX pages, you can use the [built-in layouts support](/docs/app/building-your-application/routing/pages-and-layouts#layouts) with the App Router.
+To share a layout amongst MDX pages, you can use the [built-in layouts support](/docs/app/building-your-application/routing/pages-and-layouts#layouts) with the App Router.
 
-```tsx filename="app/my-mdx-page/layout.tsx"
+```tsx filename="app/my-mdx-page/layout.tsx" switcher
 export default function MdxLayout({ children }: { children: React.ReactNode }) {
   // Create any shared layout or styles here
   return <div style={{ color: 'blue' }}>{children}</div>
 }
 ```
 
-```jsx filename="app/my-mdx-page/layout.js"
+```jsx filename="app/my-mdx-page/layout.js" switcher
 export default function MdxLayout({ children }) {
   // Create any shared layout or styles here
   return <div style={{ color: 'blue' }}>{children}</div>
@@ -233,14 +236,14 @@ export default function MdxLayout({ children }) {
 
 To share a layout around MDX pages, create a layout component:
 
-```tsx filename="components/mdx-layout.tsx"
+```tsx filename="components/mdx-layout.tsx" switcher
 export default function MdxLayout({ children }: { children: React.ReactNode }) {
   // Create any shared layout or styles here
   return <div style={{ color: 'blue' }}>{children}</div>
 }
 ```
 
-```jsx filename="components/mdx-layout.js"
+```jsx filename="components/mdx-layout.js" switcher
 export default function MdxLayout({ children }) {
   // Create any shared layout or styles here
   return <div style={{ color: 'blue' }}>{children}</div>
@@ -249,13 +252,15 @@ export default function MdxLayout({ children }) {
 
 Then, import the layout component into the MDX page, wrap the MDX content in the layout, and export it:
 
-<!-- prettier-ignore -->
 ```mdx
 import MdxLayout from '../components/mdx-layout'
 
 # Welcome to my MDX page!
 
-export default ({ children }) => <MdxLayout>{children}</MdxLayout>
+export default function MDXPage({ children }) {
+  return <MdxLayout>{children}</MdxLayout>;
+
+}
 ```
 
 </PagesOnly>
@@ -274,8 +279,8 @@ import createMDX from '@next/mdx'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Configure `pageExtensions`` to include markdown files
-  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
+  // Configure `pageExtensions`` to include MDX files
+  pageExtensions: ['js', 'jsx', 'mdx', 'ts', 'tsx'],
   // Optionally, add any other Next.js config below
 }
 
@@ -293,7 +298,10 @@ export default withMDX(nextConfig)
 
 ## Frontmatter
 
-Frontmatter is a YAML like key/value pairing that can be used to store data about a page. `@next/mdx` does **not** support frontmatter by default, though there are many solutions for adding frontmatter to your MDX content, such as [gray-matter](https://github.com/jonschlinkert/gray-matter).
+Frontmatter is a YAML like key/value pairing that can be used to store data about a page. `@next/mdx` does **not** support frontmatter by default, though there are many solutions for adding frontmatter to your MDX content, such as:
+
+- [remark-frontmatter](https://github.com/remarkjs/remark-frontmatter)
+- [gray-matter](https://github.com/jonschlinkert/gray-matter).
 
 To access page metadata with `@next/mdx`, you can export a meta object from within the `.mdx` file:
 
@@ -329,7 +337,7 @@ The above generates the following `HTML`:
 </ul>
 ```
 
-When you want to style your own elements to give a custom feel to your website or application, you can pass in shortcodes. These are your own custom components that map to `HTML` elements.
+When you want to style your own elements for a custom feel to your website or application, you can pass in shortcodes. These are your own custom components that map to `HTML` elements.
 
 <AppOnly>
 
@@ -394,7 +402,7 @@ export function useMDXComponents(components) {
 
 ## Deep Dive: How do you transform markdown into HTML?
 
-React does not natively understand Markdown. The markdown plaintext needs to first be transformed into HTML. This can be accomplished with `remark` and `rehype`.
+React does not natively understand markdown. The markdown plaintext needs to first be transformed into HTML. This can be accomplished with `remark` and `rehype`.
 
 `remark` is an ecosystem of tools around markdown. `rehype` is the same, but for HTML. For example, the following code snippet transforms markdown into HTML:
 
@@ -421,7 +429,7 @@ async function main() {
 
 The `remark` and `rehype` ecosystem contains plugins for [syntax highlighting](https://github.com/atomiks/rehype-pretty-code), [linking headings](https://github.com/rehypejs/rehype-autolink-headings), [generating a table of contents](https://github.com/remarkjs/remark-toc), and more.
 
-When using `@next/mdx` as shown below, you **do not** need to use `remark` or `rehype` directly, as it is handled for you.
+When using `@next/mdx` as shown above, you **do not** need to use `remark` or `rehype` directly, as it is handled for you. We're describing it here for a deeper understanding of what the `@next/mdx` package is doing underneath.
 
 ## Using the Rust-based MDX compiler (Experimental)
 

--- a/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
@@ -42,32 +42,18 @@ Create a `mdx-components.tsx` file at the root of your application (the parent f
 ```tsx filename="mdx-components.tsx" switcher
 import type { MDXComponents } from 'mdx/types'
 
-// This file allows you to provide custom React components
-// to be used in MDX files. You can import and use any
-// React component you want, including components from
-// other libraries.
-
 // This file is required to use MDX in `app` directory.
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
-    // Allows customizing built-in components, e.g. to add styling.
-    // h1: ({ children }) => <h1 style={{ fontSize: "100px" }}>{children}</h1>,
     ...components,
   }
 }
 ```
 
 ```js filename="mdx-components.js" switcher
-// This file allows you to provide custom React components
-// to be used in MDX files. You can import and use any
-// React component you want, including components from
-// other libraries.
-
 // This file is required to use MDX in `app` directory.
 export function useMDXComponents(components) {
   return {
-    // Allows customizing built-in components, e.g. to add styling.
-    // h1: ({ children }) => <h1 style={{ fontSize: "100px" }}>{children}</h1>,
     ...components,
   }
 }
@@ -137,11 +123,11 @@ Checkout my React component:
 <MyComponent />
 ```
 
-Navigating to the `/my-mdx-page` route should display your rendered MDX.
+Navigating to the `/my-mdx-page` route should display your rendered Markdown.
 
 ## Remote MDX
 
-If your Markdown or MDX files do _not_ live inside your application, you can fetch them dynamically on the server. This is useful for fetching content from a CMS or other data source.
+If your Markdown or MDX files or content live _somewhere else_, you can fetch them dynamically on the server. This is useful for fetching content from a separate folder, CMS, database, or anywhere else.
 
 There are two popular community packages for fetching MDX content: [`next-mdx-remote`](https://github.com/hashicorp/next-mdx-remote#react-server-components-rsc--nextjs-app-directory-support) and [`contentlayer`](https://www.contentlayer.dev/).
 
@@ -155,6 +141,7 @@ For example, the following example uses `next-mdx-remote`:
 import { MDXRemote } from 'next-mdx-remote/rsc'
 
 export default async function RemoteMdxPage() {
+  // MDX text - can be from a local file, database, CMS, fetch, anywhere...
   const res = await fetch('https://...')
   const markdown = await res.text()
   return <MDXRemote source={markdown} />
@@ -165,6 +152,7 @@ export default async function RemoteMdxPage() {
 import { MDXRemote } from 'next-mdx-remote/rsc'
 
 export default async function RemoteMdxPage() {
+  // MDX text - can be from a local file, database, CMS, fetch, anywhere...
   const res = await fetch('https://...')
   const markdown = await res.text()
   return <MDXRemote source={markdown} />
@@ -175,9 +163,47 @@ export default async function RemoteMdxPage() {
 
 <PagesOnly>
 
-TODO
+```tsx filename="pages/my-mdx-page-remote.tsx" switcher
+import { serialize } from 'next-mdx-remote/serialize'
+import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
+
+interface Props {
+  mdxSource: MDXRemoteSerializeResult
+}
+
+export default function RemoteMdxPage({ mdxSource }: Props) {
+  return <MDXRemote {...mdxSource} />
+}
+
+export async function getStaticProps() {
+  // MDX text - can be from a local file, database, CMS, fetch, anywhere...
+  const res = await fetch('https:...')
+  const mdxText = await res.text()
+  const mdxSource = await serialize(mdxText)
+  return { props: { source: mdxSource } }
+}
+```
+
+```jsx filename="pages/my-mdx-page-remote.js" switcher
+import { serialize } from 'next-mdx-remote/serialize'
+import { MDXRemote } from 'next-mdx-remote'
+
+export default function RemoteMdxPage({ mdxSource }) {
+  return <MDXRemote {...mdxSource} />
+}
+
+export async function getStaticProps() {
+  // MDX text - can be from a local file, database, CMS, fetch, anywhere...
+  const res = await fetch('https:...')
+  const mdxText = await res.text()
+  const mdxSource = await serialize(mdxText)
+  return { props: { source: mdxSource } }
+}
+```
 
 </PagesOnly>
+
+Navigating to the `/my-mdx-page-remote` route should display your rendered Markdown.
 
 ## Layouts
 
@@ -185,30 +211,49 @@ TODO
 
 To share a layout around MDX pages, you can use the [built-in layouts support](/docs/app/building-your-application/routing/pages-and-layouts#layouts) with the App Router.
 
+```tsx filename="app/my-mdx-page/layout.tsx"
+export default function MdxLayout({ children }: { children: React.ReactNode }) {
+  // Create any shared layout or styles here
+  return <div style={{ color: 'blue' }}>{children}</div>
+}
+```
+
+```jsx filename="app/my-mdx-page/layout.js"
+export default function MdxLayout({ children }) {
+  // Create any shared layout or styles here
+  return <div style={{ color: 'blue' }}>{children}</div>
+}
+```
+
 </AppOnly>
 
 <PagesOnly>
 
 To share a layout around MDX pages, create a layout component:
 
-```jsx filename="components/mdx-layout.js"
-export default MdxLayout({ children }) => (
+```tsx filename="components/mdx-layout.tsx"
+export default function MdxLayout({ children }: { children: React.ReactNode }) {
   // Create any shared layout or styles here
-  <div style={color: 'blue'}>{children}</div>
-);
+  return <div style={{ color: 'blue' }}>{children}</div>
+}
 ```
 
-Then, import the layout component into the MDX page:
+```jsx filename="components/mdx-layout.js"
+export default function MdxLayout({ children }) {
+  // Create any shared layout or styles here
+  return <div style={{ color: 'blue' }}>{children}</div>
+}
+```
 
+Then, import the layout component into the MDX page, wrap the MDX content in the layout, and export it:
+
+<!-- prettier-ignore -->
 ```mdx
-import { MdxLayout } from 'components/mdx-layout'
+import MdxLayout from '../components/mdx-layout'
 
 # Welcome to my MDX page!
 
-export default ({ children }) =>
-  <Post meta={meta}>{children}</Post
-
->
+export default ({ children }) => <MdxLayout>{children}</MdxLayout>
 ```
 
 </PagesOnly>
@@ -282,7 +327,11 @@ The above generates the following `HTML`:
 </ul>
 ```
 
-When you want to style your own elements to give a custom feel to your website or application, you can pass in shortcodes. These are your own custom components that map to `HTML` elements. To do this you use the `MDXProvider` and pass a components object as a prop. Each object key in the components object maps to a `HTML` element name.
+When you want to style your own elements to give a custom feel to your website or application, you can pass in shortcodes. These are your own custom components that map to `HTML` elements.
+
+To do this you use the `MDXProvider` and pass a components object as a prop. Each object key in the components object maps to a `HTML` element name.
+
+TODO
 
 To enable you need to specify `providerImportSource: "@mdx-js/react"` in `next.config.js`.
 

--- a/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
@@ -61,10 +61,12 @@ export function useMDXComponents(components) {
 
 </AppOnly>
 
-Update `next.config.js` to configure it to use MDX:
+Update `next.config.js` to configure it to use Markdown and MDX:
 
 ```js filename="next.config.js"
-const withMDX = require('@next/mdx')()
+const withMDX = require('@next/mdx')({
+  extension: /\.(md|mdx)$/,
+})
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
@@ -21,7 +21,7 @@ Output:
 
 [MDX](https://mdxjs.com/) is a superset of markdown that lets you write [JSX](https://react.dev/learn/writing-markup-with-jsx) directly in your markdown files. It is a powerful way to add dynamic interactivity and embed React components within your content.
 
-Next.js can support both local MDX content inside your application, as well as remote MDX files fetched dynamically on the server. The Next.js plugin handles transforming Markdown and React components into HTML, including support for usage in Server Components (default in `app`).
+Next.js can support both local MDX content inside your application, as well as remote MDX files fetched dynamically on the server. The Next.js plugin handles transforming Markdown and React components into HTML, including support for usage in Server Components (the default in App Router).
 
 ## `@next/mdx`
 
@@ -29,15 +29,15 @@ The `@next/mdx` package is configured in the `next.config.js` file at your proje
 
 ## Getting Started
 
-<AppOnly>
-
-Install the `@next/mdx` package:
+Install packages needed to render MDX:
 
 ```bash filename="Terminal"
 npm install @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
 ```
 
-Create `mdx-components.tsx` in the root of your application (the parent folder of `app/` or `src/`):
+<AppOnly>
+
+Create a `mdx-components.tsx` file at the root of your application (the parent folder of `app/` or `src/`):
 
 ```tsx filename="mdx-components.tsx" switcher
 import type { MDXComponents } from 'mdx/types'
@@ -73,87 +73,40 @@ export function useMDXComponents(components) {
 }
 ```
 
-Update `next.config.js` to use `mdxRs`:
+</AppOnly>
+
+Update `next.config.js` to configure it to use MDX:
 
 ```js filename="next.config.js"
+const withMDX = require('@next/mdx')()
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    mdxRs: true,
-  },
+  // Configure `pageExtensions`` to include markdown files
+  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
+  // Optionally, add any other Next.js config below
 }
 
-const withMDX = require('@next/mdx')()
 module.exports = withMDX(nextConfig)
 ```
 
-Add a new file with MDX content to your `app` directory:
+<AppOnly>
 
-```md filename="app/hello.mdx"
-Hello, Next.js!
+Then, create a new MDX page within the `/app` directory:
 
-You can import and use React components in MDX files.
-```
-
-Import the MDX file inside a `page` to display the content:
-
-```tsx filename="app/page.tsx" switcher
-import HelloWorld from './hello.mdx'
-
-export default function Page() {
-  return <HelloWorld />
-}
-```
-
-```jsx filename="app/page.js" switcher
-import HelloWorld from './hello.mdx'
-
-export default function Page() {
-  return <HelloWorld />
-}
+```txt
+  your-project
+  ├── app
+  │   └── my-mdx-page
+  │       └── page.mdx
+  └── package.json
 ```
 
 </AppOnly>
 
 <PagesOnly>
 
-Install the required packages:
-
-```bash filename="Terminal"
-  npm install @next/mdx @mdx-js/loader @mdx-js/react
-```
-
-Require the package and configure to support top level `.mdx` pages. The following adds the `options` object key allowing you to pass in any plugins:
-
-```js
-// next.config.js
-
-const withMDX = require('@next/mdx')({
-  extension: /\.mdx?$/,
-  options: {
-    // If you use remark-gfm, you'll need to use next.config.mjs
-    // as the package is ESM only
-    // https://github.com/remarkjs/remark-gfm#install
-    remarkPlugins: [],
-    rehypePlugins: [],
-    // If you use `MDXProvider`, uncomment the following line.
-    // providerImportSource: "@mdx-js/react",
-  },
-})
-
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  // Configure pageExtensions to include md and mdx
-  pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
-  // Optionally, add any other Next.js config below
-  reactStrictMode: true,
-}
-
-// Merge MDX config with Next.js config
-module.exports = withMDX(nextConfig)
-```
-
-- Create a new MDX page within the `/pages` directory:
+Then, create a new MDX page within the `/pages` directory:
 
 ```txt
   your-project
@@ -162,12 +115,16 @@ module.exports = withMDX(nextConfig)
   └── package.json
 ```
 
-You can now import a React component directly inside your MDX page:
+</PagesOnly>
+
+Now you can use markdown and import React components directly inside your MDX page:
 
 ```mdx
 import { MyComponent } from 'my-components'
 
-My MDX page
+# Welcome to my MDX page!
+
+This is some **bold** and _italics_ text.
 
 This is a list in markdown:
 
@@ -180,66 +137,87 @@ Checkout my React component:
 <MyComponent />
 ```
 
-</PagesOnly>
+Navigating to the `/my-mdx-page` route should display your rendered MDX.
 
 ## Remote MDX
 
 If your Markdown or MDX files do _not_ live inside your application, you can fetch them dynamically on the server. This is useful for fetching content from a CMS or other data source.
 
-There are two popular community packages for fetching MDX content: [`next-mdx-remote`](https://github.com/hashicorp/next-mdx-remote#react-server-components-rsc--nextjs-app-directory-support) and [`contentlayer`](https://www.contentlayer.dev/). For example, the following example uses `next-mdx-remote`:
+There are two popular community packages for fetching MDX content: [`next-mdx-remote`](https://github.com/hashicorp/next-mdx-remote#react-server-components-rsc--nextjs-app-directory-support) and [`contentlayer`](https://www.contentlayer.dev/).
 
 > **Good to know**: Please proceed with caution. MDX compiles to JavaScript and is executed on the server. You should only fetch MDX content from a trusted source, otherwise this can lead to remote code execution (RCE).
 
-```tsx filename="app/page.tsx" switcher
-import { MDXRemote } from 'next-mdx-remote/rsc'
-
-export default async function Home() {
-  const res = await fetch('https://...')
-  const markdown = await res.text()
-  return <MDXRemote source={markdown} />
-}
-```
-
-```jsx filename="app/page.js" switcher
-import { MDXRemote } from 'next-mdx-remote/rsc'
-
-export default async function Home() {
-  const res = await fetch('https://...')
-  const markdown = await res.text()
-  return <MDXRemote source={markdown} />
-}
-```
-
-## Layouts
+For example, the following example uses `next-mdx-remote`:
 
 <AppOnly>
 
-To share a layout around MDX content, you can use the [built-in layouts support](/docs/app/building-your-application/routing/pages-and-layouts#layouts) with the App Router.
+```tsx filename="app/my-mdx-page-remote/page.tsx" switcher
+import { MDXRemote } from 'next-mdx-remote/rsc'
+
+export default async function RemoteMdxPage() {
+  const res = await fetch('https://...')
+  const markdown = await res.text()
+  return <MDXRemote source={markdown} />
+}
+```
+
+```jsx filename="app/my-mdx-page-remote/page.js" switcher
+import { MDXRemote } from 'next-mdx-remote/rsc'
+
+export default async function RemoteMdxPage() {
+  const res = await fetch('https://...')
+  const markdown = await res.text()
+  return <MDXRemote source={markdown} />
+}
+```
 
 </AppOnly>
 
 <PagesOnly>
 
-To add a layout to your MDX page, create a new component and import it into the MDX page. Then you can wrap the MDX page with your layout component:
+TODO
 
-```jsx filename="pages/index.js"
-import { MyLayoutComponent } from 'my-components';
-import HelloWorld from './hello.mdx';
+</PagesOnly>
 
-export const metadata = {
-  author: 'Rich Haines',
-};
+## Layouts
 
-export default Page({ children }) => (
-  <MyLayoutComponent meta={metadata}><HelloWorld /></MyLayoutComponent>
+<AppOnly>
+
+To share a layout around MDX pages, you can use the [built-in layouts support](/docs/app/building-your-application/routing/pages-and-layouts#layouts) with the App Router.
+
+</AppOnly>
+
+<PagesOnly>
+
+To share a layout around MDX pages, create a layout component:
+
+```jsx filename="components/mdx-layout.js"
+export default MdxLayout({ children }) => (
+  // Create any shared layout or styles here
+  <div style={color: 'blue'}>{children}</div>
 );
+```
+
+Then, import the layout component into the MDX page:
+
+```mdx
+import { MdxLayout } from 'components/mdx-layout'
+
+# Welcome to my MDX page!
+
+export default ({ children }) =>
+  <Post meta={meta}>{children}</Post
+
+>
 ```
 
 </PagesOnly>
 
 ## Remark and Rehype Plugins
 
-You can optionally provide `remark` and `rehype` plugins to transform the MDX content. For example, you can use `remark-gfm` to support GitHub Flavored Markdown.
+You can optionally provide `remark` and `rehype` plugins to transform the MDX content.
+
+For example, you can use `remark-gfm` to support GitHub Flavored Markdown.
 
 Since the `remark` and `rehype` ecosystem is ESM only, you'll need to use `next.config.mjs` as the configuration file.
 
@@ -248,17 +226,21 @@ import remarkGfm from 'remark-gfm'
 import createMDX from '@next/mdx'
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  // Configure `pageExtensions`` to include markdown files
+  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
+  // Optionally, add any other Next.js config below
+}
 
 const withMDX = createMDX({
-  extension: /\.mdx?$/,
+  // Add markdown plugins here, as desired
   options: {
     remarkPlugins: [remarkGfm],
     rehypePlugins: [],
-    // If you use `MDXProvider`, uncomment the following line.
-    // providerImportSource: "@mdx-js/react",
   },
 })
+
+// Merge MDX config with Next.js config
 export default withMDX(nextConfig)
 ```
 
@@ -270,7 +252,7 @@ To access page metadata with `@next/mdx`, you can export a meta object from with
 
 ```mdx
 export const meta = {
-  author: 'Rich Haines',
+  author: 'John Doe',
 }
 
 # My MDX page
@@ -313,7 +295,7 @@ const withMDX = require('@next/mdx')({
 })
 ```
 
-Then setup the provider in your page
+Then setup the provider in your page:
 
 ```jsx filename="pages/index.js"
 import { MDXProvider } from '@mdx-js/react'

--- a/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
@@ -39,10 +39,11 @@ npm install @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
 
 Create a `mdx-components.tsx` file at the root of your application (the parent folder of `app/` or `src/`):
 
+> **Good to know**: `mdx-components.tsx` is required to use MDX with App Router and will not work without it.
+
 ```tsx filename="mdx-components.tsx" switcher
 import type { MDXComponents } from 'mdx/types'
 
-// This file is required to use MDX in `app` directory.
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...components,
@@ -51,7 +52,6 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
 ```
 
 ```js filename="mdx-components.js" switcher
-// This file is required to use MDX in `app` directory.
 export function useMDXComponents(components) {
   return {
     ...components,
@@ -329,56 +329,66 @@ The above generates the following `HTML`:
 
 When you want to style your own elements to give a custom feel to your website or application, you can pass in shortcodes. These are your own custom components that map to `HTML` elements.
 
-To do this you use the `MDXProvider` and pass a components object as a prop. Each object key in the components object maps to a `HTML` element name.
+<AppOnly>
 
-TODO
+To do this, open the `mdx-components.tsx` file at the root of your application and add custom elements:
 
-To enable you need to specify `providerImportSource: "@mdx-js/react"` in `next.config.js`.
+</AppOnly>
 
-```js filename="next.config.js"
-const withMDX = require('@next/mdx')({
-  // ...
-  options: {
-    providerImportSource: '@mdx-js/react',
-  },
-})
-```
+<PagesOnly>
 
-Then setup the provider in your page:
+To do this, create a `mdx-components.tsx` file at the root of your application (the parent folder of `pages/` or `src/`) and add custom elements:
 
-```jsx filename="pages/index.js"
-import { MDXProvider } from '@mdx-js/react'
+</PagesOnly>
+
+```tsx filename="mdx-components.tsx" switcher
+import type { MDXComponents } from 'mdx/types'
 import Image from 'next/image'
-import { Heading, InlineCode, Pre, Table, Text } from 'my-components'
 
-const ResponsiveImage = (props) => (
-  <Image
-    alt={props.alt}
-    sizes="100vw"
-    style={{ width: '100%', height: 'auto' }}
-    {...props}
-  />
-)
+// This file allows you to provide custom React components
+// to be used in MDX files. You can import and use any
+// React component you want, including inline styles,
+// components from other libraries, and more.
 
-const components = {
-  img: ResponsiveImage,
-  h1: Heading.H1,
-  h2: Heading.H2,
-  p: Text,
-  pre: Pre,
-  code: InlineCode,
-}
-
-export default function Post(props) {
-  return (
-    <MDXProvider components={components}>
-      <main {...props} />
-    </MDXProvider>
-  )
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+  return {
+    // Allows customizing built-in components, e.g. to add styling.
+    h1: ({ children }) => <h1 style={{ fontSize: '100px' }}>{children}</h1>,
+    img: (props) => (
+      <Image
+        sizes="100vw"
+        style={{ width: '100%', height: 'auto' }}
+        {...props}
+      />
+    ),
+    ...components,
+  }
 }
 ```
 
-If you use it across the site you may want to add the provider to `_app.js` so all MDX pages pick up the custom element config.
+```js filename="mdx-components.js" switcher
+import Image from 'next/image'
+
+// This file allows you to provide custom React components
+// to be used in MDX files. You can import and use any
+// React component you want, including inline styles,
+// components from other libraries, and more.
+
+export function useMDXComponents(components) {
+  return {
+    // Allows customizing built-in components, e.g. to add styling.
+    h1: ({ children }) => <h1 style={{ fontSize: '100px' }}>{children}</h1>,
+    img: (props) => (
+      <Image
+        sizes="100vw"
+        style={{ width: '100%', height: 'auto' }}
+        {...props}
+      />
+    ),
+    ...components,
+  }
+}
+```
 
 ## Deep Dive: How do you transform markdown into HTML?
 


### PR DESCRIPTION
When trying to update my own website to use App Router, I found the current Next.js Docs were missing specifics to get it working (most notably, no mention of `pageExtensions`). Coupled with community feedback, we decided to revisit and rework the entire page.

The page has been walked through and tested on brand new create-next-app projects for both App and Pages Routers to ensure completeness.

Closes [DX-2095](https://linear.app/vercel/issue/DX-2095/improve-nextjs-mdx-docs)

Rendered pages while running locally, in case they are more helpful in seeings the changes and different between routers.

### App Router 

![localhost_3332_docs_pages_building-your-application_configuring_mdx (1)](https://github.com/vercel/next.js/assets/446260/2a2b1a66-c794-4831-ab89-a6a61d02eb84)

### Pages Router

![localhost_3332_docs_pages_building-your-application_configuring_mdx](https://github.com/vercel/next.js/assets/446260/cc60a8a2-a931-4033-aaba-e989a719692d)