### PR TITLE
Ensure loader generated export default has name

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-edge-function-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-function-loader.ts
@@ -47,7 +47,7 @@ const nextEdgeFunctionLoader: webpack.LoaderDefinitionFunction<EdgeFunctionLoade
           throw new Error('The Edge Function "pages${page}" must export a \`default\` function');
         }
 
-        export default function (opts) {
+        export default function nHandler (opts) {
           return adapter({
               ...opts,
               IncrementalCache,

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -257,7 +257,7 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
 
     export const ComponentMod = pageMod
 
-    export default async function(opts, event) {
+    export default async function nHandler (opts, event) {
       const res = await adapter({
         ...opts,
         IncrementalCache,

--- a/packages/next/src/build/webpack/loaders/next-middleware-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-middleware-loader.ts
@@ -67,7 +67,7 @@ export default function middlewareLoader(this: any) {
           throw new Error('The Middleware "pages${page}" must export a \`middleware\` or a \`default\` function');
         }
 
-        export default function (opts) {
+        export default function nHandler(opts) {
           return adapter({
             ...opts,
             page: ${JSON.stringify(page)},

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -15,6 +15,15 @@ createNextDescribe(
   },
   ({ next, isNextDev: isDev, isNextStart, isNextDeploy }) => {
     if (isNextStart && !process.env.NEXT_EXPERIMENTAL_COMPILE) {
+      it('should not have loader generated function for edge runtime', async () => {
+        expect(
+          await next.readFile('.next/server/app/dashboard/page.js')
+        ).not.toContain('_stringifiedConfig')
+        expect(await next.readFile('.next/server/middleware.js')).not.toContain(
+          '_middlewareConfig'
+        )
+      })
+
       it('should use RSC prefetch data from build', async () => {
         expect(
           await next.readFile('.next/server/app/linking.prefetch.rsc')


### PR DESCRIPTION
When the function name is omitted webpack generates a name from the loader config which can be really long un-necessarily. Providing a name for the default function alleviates this. cc @shuding who found this

