### PR TITLE
Move Edge SSR event `waitUntil` into the handler

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -225,8 +225,6 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
     }
     const nextFontManifest = maybeJSONParse(self.__NEXT_FONT_MANIFEST)
 
-    globalThis.__next_private_global_wait_until__ = []
-
     const render = getRender({
       pagesType,
       dev: ${dev},
@@ -257,22 +255,12 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
 
     export const ComponentMod = pageMod
 
-    export default async function nHandler (opts, event) {
-      const res = await adapter({
+    export default function nHandler (opts, event) {
+      return adapter({
         ...opts,
         IncrementalCache,
         handler: render
       })
-
-      if (event && event.waitUntil) {
-        event.waitUntil(
-          Promise.all(
-            [res?.waitUntil, ...globalThis.__next_private_global_wait_until__]
-          )
-        )
-      }
-
-      return res
     }`
 
     return transformed

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -5,6 +5,7 @@ import type { BuildManifest } from '../../../../server/get-page-files'
 import type { ReactLoadableManifest } from '../../../../server/load-components'
 import type { ClientReferenceManifest } from '../../plugins/flight-manifest-plugin'
 import type { NextFontManifest } from '../../plugins/next-font-manifest-plugin'
+import type { NextFetchEvent } from '../../../../server/web/spec-extension/fetch-event'
 
 import WebServer from '../../../../server/web-server'
 import {
@@ -15,6 +16,11 @@ import { SERVER_RUNTIME } from '../../../../lib/constants'
 import { PrerenderManifest } from '../../..'
 import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
 import { SizeLimit } from '../../../../../types'
+
+// @ts-ignore
+globalThis.__next_private_global_wait_until__ =
+  // @ts-ignore
+  globalThis.__next_private_global_wait_until__ || []
 
 export function getRender({
   dev,
@@ -143,12 +149,19 @@ export function getRender({
 
   const handler = server.getRequestHandler()
 
-  return async function render(request: Request) {
+  return async function render(request: Request, event: NextFetchEvent) {
     const extendedReq = new WebNextRequest(request)
     const extendedRes = new WebNextResponse()
 
     handler(extendedReq, extendedRes)
     const result = await extendedRes.toResponse()
+
+    if (event && event.waitUntil) {
+      event.waitUntil(
+        // @ts-ignore
+        Promise.all([...globalThis.__next_private_global_wait_until__])
+      )
+    }
 
     // fetchMetrics is attached to the web request that going through the server,
     // wait for the handler result is ready and attach it back to the original request.

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -17,10 +17,14 @@ import { PrerenderManifest } from '../../..'
 import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
 import { SizeLimit } from '../../../../../types'
 
+const NEXT_PRIVATE_GLOBAL_WAIT_UNTIL = Symbol.for(
+  '__next_private_global_wait_until__'
+)
+
 // @ts-ignore
-globalThis.__next_private_global_wait_until__ =
+globalThis[NEXT_PRIVATE_GLOBAL_WAIT_UNTIL] =
   // @ts-ignore
-  globalThis.__next_private_global_wait_until__ || []
+  globalThis[NEXT_PRIVATE_GLOBAL_WAIT_UNTIL] || []
 
 export function getRender({
   dev,
@@ -159,7 +163,7 @@ export function getRender({
     if (event && event.waitUntil) {
       event.waitUntil(
         // @ts-ignore
-        Promise.all([...globalThis.__next_private_global_wait_until__])
+        Promise.all([...globalThis[NEXT_PRIVATE_GLOBAL_WAIT_UNTIL]])
       )
     }
 


### PR DESCRIPTION
Fixes the code added in #56381 where the event isn't passed to the outer function, but the adapter inside.