### PR TITLE
fix: avoid creation of buffers for read ops

### DIFF
--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -35,8 +35,8 @@ export function createIncrementalCache(
       notFoundRoutes: [],
     }),
     fs: {
-      readFile: (f) => fs.promises.readFile(f),
-      readFileSync: (f) => fs.readFileSync(f),
+      readFile: fs.promises.readFile,
+      readFileSync: fs.readFileSync,
       writeFile: (f, d) => fs.promises.writeFile(f, d),
       mkdir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
       stat: (f) => fs.promises.stat(f),

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -75,7 +75,7 @@ export default class FileSystemCache implements CacheHandler {
     if (!this.tagsManifestPath || !this.fs || tagsManifest) return
     try {
       tagsManifest = JSON.parse(
-        this.fs.readFileSync(this.tagsManifestPath).toString('utf8')
+        this.fs.readFileSync(this.tagsManifestPath, 'utf8')
       )
     } catch (err: any) {
       tagsManifest = { version: 1, items: {} }
@@ -131,9 +131,7 @@ export default class FileSystemCache implements CacheHandler {
         const { mtime } = await this.fs.stat(filePath)
 
         const meta = JSON.parse(
-          (
-            await this.fs.readFile(filePath.replace(/\.body$/, '.meta'))
-          ).toString('utf8')
+          await this.fs.readFile(filePath.replace(/\.body$/, '.meta'), 'utf8')
         )
 
         const cacheEntry: CacheHandlerValue = {
@@ -155,7 +153,7 @@ export default class FileSystemCache implements CacheHandler {
           pathname: fetchCache ? key : `${key}.html`,
           fetchCache,
         })
-        const fileData = (await this.fs.readFile(filePath)).toString('utf-8')
+        const fileData = await this.fs.readFile(filePath, 'utf8')
         const { mtime } = await this.fs.stat(filePath)
 
         if (fetchCache) {
@@ -178,27 +176,25 @@ export default class FileSystemCache implements CacheHandler {
           }
         } else {
           const pageData = isAppPath
-            ? (
+            ? await this.fs.readFile(
+                (
+                  await this.getFsPath({
+                    pathname: `${key}.rsc`,
+                    appDir: true,
+                  })
+                ).filePath,
+                'utf8'
+              )
+            : JSON.parse(
                 await this.fs.readFile(
                   (
                     await this.getFsPath({
-                      pathname: `${key}.rsc`,
-                      appDir: true,
+                      pathname: `${key}.json`,
+                      appDir: false,
                     })
-                  ).filePath
+                  ).filePath,
+                  'utf8'
                 )
-              ).toString('utf8')
-            : JSON.parse(
-                (
-                  await this.fs.readFile(
-                    (
-                      await this.getFsPath({
-                        pathname: `${key}.json`,
-                        appDir: false,
-                      })
-                    ).filePath
-                  )
-                ).toString('utf8')
               )
 
           let meta: { status?: number; headers?: OutgoingHttpHeaders } = {}
@@ -206,9 +202,10 @@ export default class FileSystemCache implements CacheHandler {
           if (isAppPath) {
             try {
               meta = JSON.parse(
-                (
-                  await this.fs.readFile(filePath.replace(/\.html$/, '.meta'))
-                ).toString('utf-8')
+                await this.fs.readFile(
+                  filePath.replace(/\.html$/, '.meta'),
+                  'utf8'
+                )
               )
             } catch {}
           }

--- a/packages/next/src/server/lib/node-fs-methods.ts
+++ b/packages/next/src/server/lib/node-fs-methods.ts
@@ -2,8 +2,8 @@ import _fs from 'fs'
 import type { CacheFs } from '../../shared/lib/utils'
 
 export const nodeFs: CacheFs = {
-  readFile: (f) => _fs.promises.readFile(f),
-  readFileSync: (f) => _fs.readFileSync(f),
+  readFile: _fs.promises.readFile,
+  readFileSync: _fs.readFileSync,
   writeFile: (f, d) => _fs.promises.writeFile(f, d),
   mkdir: (dir) => _fs.promises.mkdir(dir, { recursive: true }),
   stat: (f) => _fs.promises.stat(f),

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -722,14 +722,13 @@ export default class NextNodeServer extends BaseServer {
     )
   }
 
-  protected async getFallback(page: string): Promise<string> {
+  protected getFallback(page: string): Promise<string> {
     page = normalizePagePath(page)
     const cacheFs = this.getCacheFilesystem()
-    const html = await cacheFs.readFile(
-      join(this.serverDistDir, 'pages', `${page}.html`)
+    return cacheFs.readFile(
+      join(this.serverDistDir, 'pages', `${page}.html`),
+      'utf8'
     )
-
-    return html.toString('utf8')
   }
 
   protected async handleNextImageRequest(
@@ -985,10 +984,11 @@ export default class NextNodeServer extends BaseServer {
     return this.runApi(req, res, query, match)
   }
 
-  protected async getPrefetchRsc(pathname: string) {
-    return this.getCacheFilesystem()
-      .readFile(join(this.serverDistDir, 'app', `${pathname}.prefetch.rsc`))
-      .then((res) => res.toString())
+  protected getPrefetchRsc(pathname: string): Promise<string> {
+    return this.getCacheFilesystem().readFile(
+      join(this.serverDistDir, 'app', `${pathname}.prefetch.rsc`),
+      'utf8'
+    )
   }
 
   protected getCacheFilesystem(): CacheFs {

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -7,6 +7,7 @@ import type { NextRouter } from './router/router'
 import type { ParsedUrlQuery } from 'querystring'
 import type { PreviewData } from 'next/types'
 import { COMPILER_NAMES } from './constants'
+import type fs from 'fs'
 
 export type NextComponentType<
   Context extends BaseContext = NextPageContext,
@@ -447,8 +448,8 @@ export class MiddlewareNotFoundError extends Error {
 }
 
 export interface CacheFs {
-  readFile(f: string): Promise<Buffer>
-  readFileSync(f: string): Buffer
+  readFile: typeof fs.promises.readFile
+  readFileSync: typeof fs.readFileSync
   writeFile(f: string, d: any): Promise<void>
   mkdir(dir: string): Promise<void | string>
   stat(f: string): Promise<{ mtime: Date }>


### PR DESCRIPTION
Example usage of `readFileSync().toString()` first creates a `Buffer` instance and later does another C++ call to convert Buffer to UTF-8. This pull request reduces the C++ calls.