### PR TITLE
fix: improve font download chunks

### DIFF
--- a/packages/next/src/server/font-utils.ts
+++ b/packages/next/src/server/font-utils.ts
@@ -34,11 +34,12 @@ function getFontForUA(url: string, UA: string): Promise<String> {
           },
         },
         (res: any) => {
+          res.setEncoding('utf8')
           res.on('data', (chunk: any) => {
             rawData += chunk
           })
           res.on('end', () => {
-            resolve(rawData.toString('utf8'))
+            resolve(rawData)
           })
         }
       )


### PR DESCRIPTION
A small optimization to retrieve the response in UTF8 chunks instead of as a whole.