### PR TITLE
add `cargo fmt` to lint staged

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -27,6 +27,12 @@ module.exports = {
       `git add ${escapedFileNames}`,
     ]
   },
+  '**/*.rs': (filenames) => {
+    const escapedFileNames = filenames
+      .map((filename) => (isWin ? filename : escape([filename])))
+      .join(' ')
+    return [`cargo fmt -- ${escapedFileNames}`, `git add ${escapedFileNames}`]
+  },
 }
 
 function escape(str) {


### PR DESCRIPTION
Keep forgetting to run `cargo fmt` before committing

Closes WEB-1707