### PR TITLE
fix: avoid unnecessary async in file-system-cache

### DIFF
--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -37,6 +37,7 @@ export function createIncrementalCache(
     fs: {
       readFile: fs.promises.readFile,
       readFileSync: fs.readFileSync,
+      existsSync: fs.existsSync,
       writeFile: (f, d) => fs.promises.writeFile(f, d),
       mkdir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
       stat: (f) => fs.promises.stat(f),

--- a/packages/next/src/server/lib/node-fs-methods.ts
+++ b/packages/next/src/server/lib/node-fs-methods.ts
@@ -4,6 +4,7 @@ import type { CacheFs } from '../../shared/lib/utils'
 export const nodeFs: CacheFs = {
   readFile: _fs.promises.readFile,
   readFileSync: _fs.readFileSync,
+  existsSync: _fs.existsSync,
   writeFile: (f, d) => _fs.promises.writeFile(f, d),
   mkdir: (dir) => _fs.promises.mkdir(dir, { recursive: true }),
   stat: (f) => _fs.promises.stat(f),

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -450,6 +450,7 @@ export class MiddlewareNotFoundError extends Error {
 export interface CacheFs {
   readFile: typeof fs.promises.readFile
   readFileSync: typeof fs.readFileSync
+  existsSync: typeof fs.existsSync
   writeFile(f: string, d: any): Promise<void>
   mkdir(dir: string): Promise<void | string>
   stat(f: string): Promise<{ mtime: Date }>


### PR DESCRIPTION
Similar to previous pull request, we replace `await this.fs.readFile(filePath)` with `this.fs.existsSync`