### PR TITLE
Fix cli log next.js color

### DIFF
--- a/packages/next/src/lib/picocolors.ts
+++ b/packages/next/src/lib/picocolors.ts
@@ -65,6 +65,9 @@ export const green = enabled ? formatter('\x1b[32m', '\x1b[39m') : String
 export const yellow = enabled ? formatter('\x1b[33m', '\x1b[39m') : String
 export const blue = enabled ? formatter('\x1b[34m', '\x1b[39m') : String
 export const magenta = enabled ? formatter('\x1b[35m', '\x1b[39m') : String
+export const purple = enabled
+  ? formatter('\x1b[38;2;173;127;168m', '\x1b[39m')
+  : String
 export const cyan = enabled ? formatter('\x1b[36m', '\x1b[39m') : String
 export const white = enabled ? formatter('\x1b[37m', '\x1b[39m') : String
 export const gray = enabled ? formatter('\x1b[90m', '\x1b[39m') : String

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -18,7 +18,7 @@ import { formatHostname } from './format-hostname'
 import { initialize } from './router-server'
 import { checkIsNodeDebugging } from './is-node-debugging'
 import { CONFIG_FILES } from '../../shared/lib/constants'
-import { bold, magenta } from '../../lib/picocolors'
+import { bold, purple } from '../../lib/picocolors'
 
 const debug = setupDebug('next:start-server')
 
@@ -92,11 +92,7 @@ function logStartInfo({
   formatDurationText: string
 }) {
   Log.bootstrap(
-    bold(
-      magenta(
-        `${`${Log.prefixes.ready} Next.js`} ${process.env.__NEXT_VERSION}`
-      )
-    )
+    bold(purple(`${Log.prefixes.ready} Next.js ${process.env.__NEXT_VERSION}`))
   )
   Log.bootstrap(`- Local:        ${appUrl}`)
   if (hostname) {


### PR DESCRIPTION
The color of "Next.js <version>" in CLI was changed to `magenta` accidentally in #55992 , this PR added the original color back