### PR TITLE
chore(pnpm): allow pnpm versions above 8.7.1 in engines field

### DIFF
--- a/.github/actions/next-stats-action/package.json
+++ b/.github/actions/next-stats-action/package.json
@@ -20,7 +20,7 @@
   },
   "engines": {
     "node": ">=16.14.0",
-    "pnpm": "8.7.1"
+    "pnpm": ">=8.7.1"
   },
   "packageManager": "pnpm@8.7.1"
 }

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
   },
   "engines": {
     "node": ">=16.14.0",
-    "pnpm": "8.7.1"
+    "pnpm": ">=8.7.1"
   },
   "packageManager": "pnpm@8.7.1"
 }

--- a/test/.stats-app/package.json
+++ b/test/.stats-app/package.json
@@ -9,7 +9,7 @@
   },
   "engines": {
     "node": ">=16.14.0",
-    "pnpm": "8.7.1"
+    "pnpm": "=>8.7.1"
   },
   "packageManager": "pnpm@8.7.1"
 }


### PR DESCRIPTION
The PNPM version in the package.json's engines field is limited to `8.7.1`, previously changed in [#54873](https://github.com/vercel/next.js/pull/54873/files).

This PR allows versions above 8.7.1 to be used too.
https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines

It's quite limiting to only allow one specific (patch) version of pnpm.

For developers using [corepack](https://pnpm.io/installation#using-corepack) the `packageManager` field will be used still.