### PR TITLE
turbopack: Extract as_chunk into shared ChunkType trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "serde",
  "smallvec",
@@ -3515,7 +3515,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "serde",
@@ -7368,7 +7368,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7400,7 +7400,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7412,7 +7412,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7441,7 +7441,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7458,7 +7458,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "base16",
  "hex",
@@ -7500,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7514,7 +7514,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7524,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "mimalloc",
 ]
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7557,7 +7557,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7588,7 +7588,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7628,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7650,7 +7650,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7674,7 +7674,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7703,7 +7703,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7725,7 +7725,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7749,7 +7749,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7786,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7820,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "serde",
  "serde_json",
@@ -7831,7 +7831,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7854,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7871,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7887,7 +7887,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7907,7 +7907,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "serde",
@@ -7922,7 +7922,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7937,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7972,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "serde",
@@ -7988,7 +7988,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7999,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.2#624521ff91ac654c11072581867f558c26d285ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231006.4#8439948663a049728a48386cf4791693e264260e"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ swc_core = { version = "0.83.28", features = [
 testing = { version = "0.34.1" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231006.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231006.4" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231006.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231006.4" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231006.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231006.4" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/src/next_client_component/with_client_chunks.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_component/with_client_chunks.rs
@@ -1,15 +1,15 @@
 use anyhow::{Context, Result};
 use indoc::formatdoc;
-use turbo_tasks::{TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{TryJoinIterExt, ValueToString, Vc};
 use turbopack_binding::{
     turbo::tasks_fs::FileSystemPath,
     turbopack::{
         core::{
             asset::{Asset, AssetContent},
             chunk::{
-                availability_info::AvailabilityInfo, Chunk, ChunkData, ChunkItem, ChunkItemExt,
-                ChunkableModule, ChunkableModuleReference, ChunkingContext, ChunkingContextExt,
-                ChunkingType, ChunkingTypeOption, ChunksData,
+                ChunkData, ChunkItem, ChunkItemExt, ChunkType, ChunkableModule,
+                ChunkableModuleReference, ChunkingContext, ChunkingContextExt, ChunkingType,
+                ChunkingTypeOption, ChunksData,
             },
             ident::AssetIdent,
             module::Module,
@@ -18,11 +18,11 @@ use turbopack_binding::{
             reference::{ModuleReference, ModuleReferences, SingleOutputAssetReference},
             resolve::ModuleResolveResult,
         },
-        ecmascript::chunk::EcmascriptChunkData,
+        ecmascript::chunk::{EcmascriptChunkData, EcmascriptChunkType},
         turbopack::ecmascript::{
             chunk::{
-                EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkItemContent,
-                EcmascriptChunkPlaceable, EcmascriptChunkingContext, EcmascriptExports,
+                EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+                EcmascriptChunkingContext, EcmascriptExports,
             },
             utils::StringifyJs,
         },
@@ -239,12 +239,13 @@ impl ChunkItem for WithClientChunksChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.context.with_layer("rsc".to_string())),
-            Vc::upcast(self.inner),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.inner)
     }
 }
 

--- a/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -8,7 +8,8 @@ use turbopack_binding::turbopack::{
     core::{
         asset::{Asset, AssetContent},
         chunk::{
-            availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkableModule, ChunkingContext,
+            availability_info::AvailabilityInfo, ChunkItem, ChunkType, ChunkableModule,
+            ChunkingContext,
         },
         code_builder::CodeBuilder,
         context::AssetContext,
@@ -20,8 +21,8 @@ use turbopack_binding::turbopack::{
     },
     ecmascript::{
         chunk::{
-            EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkItemContent,
-            EcmascriptChunkPlaceable, EcmascriptChunkingContext, EcmascriptExports,
+            EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+            EcmascriptChunkType, EcmascriptChunkingContext, EcmascriptExports,
         },
         utils::StringifyJs,
         EcmascriptModuleAsset,
@@ -238,12 +239,13 @@ impl ChunkItem for ProxyModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.client_proxy_asset),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.client_proxy_asset)
     }
 }
 

--- a/packages/next-swc/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_server_component/server_component_module.rs
@@ -1,22 +1,20 @@
 use anyhow::{bail, Context, Result};
 use indoc::formatdoc;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_binding::turbopack::{
     core::{
         asset::{Asset, AssetContent},
-        chunk::{
-            availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkItemExt, ChunkableModule,
-            ChunkingContext,
-        },
+        chunk::{ChunkItem, ChunkItemExt, ChunkType, ChunkableModule, ChunkingContext},
         ident::AssetIdent,
         module::Module,
         reference::ModuleReferences,
     },
+    ecmascript::chunk::EcmascriptChunkType,
     turbopack::ecmascript::{
         chunk::{
-            EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkItemContent,
-            EcmascriptChunkPlaceable, EcmascriptChunkingContext, EcmascriptExports,
+            EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+            EcmascriptChunkingContext, EcmascriptExports,
         },
         utils::StringifyJs,
     },
@@ -161,11 +159,12 @@ impl ChunkItem for BuildServerComponentChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.context),
-            Vc::upcast(self.inner),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.inner)
     }
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -191,7 +191,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.4",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1058,8 +1058,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.2(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.4
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.4(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -26757,9 +26757,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.2(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.4(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.4}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231006.4'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

Step 3 in our chunking refactors extracts ChunkItem::as_chunk into a new ChunkType trait. This new trait isn't useful yet, but will eventually allow us to collect ChunkItems of a similar type into a lists, and perform chunking over all similar items at once.

### Why?

In the end we want to avoid creating chunks from modules directly, but enforce everything going through the ChunkingContext to be chunked. This allows us to replace the existing chunking algorithm with a much more efficient one that avoid duplication between chunks in first place and doesn't require a post-chunking optimization.

### How?

https://github.com/vercel/turbo/pull/6123

Re: https://github.com/vercel/next.js/pull/56504

Closes WEB-1724