### PR TITLE
chore: clean up digestible errors

### DIFF
--- a/packages/next/src/client/components/is-next-router-error.ts
+++ b/packages/next/src/client/components/is-next-router-error.ts
@@ -1,8 +1,6 @@
 import { isNotFoundError } from './not-found'
 import { isRedirectError } from './redirect'
 
-export function isNextRouterError(error: any): boolean {
-  return (
-    error && error.digest && (isRedirectError(error) || isNotFoundError(error))
-  )
+export function isNextRouterError(error: unknown): boolean {
+  return isRedirectError(error) || isNotFoundError(error)
 }

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -243,5 +243,5 @@ export function useSelectedLayoutSegment(
   return selectedLayoutSegments[0]
 }
 
-export { redirect, permanentRedirect, RedirectType } from './redirect'
+export { redirect, permanentRedirect, type RedirectType } from './redirect'
 export { notFound } from './not-found'

--- a/packages/next/src/client/components/not-found.ts
+++ b/packages/next/src/client/components/not-found.ts
@@ -1,16 +1,41 @@
 const NOT_FOUND_ERROR_CODE = 'NEXT_NOT_FOUND'
 
-type NotFoundError = Error & { digest: typeof NOT_FOUND_ERROR_CODE }
+export class NotFoundError extends Error {
+  digest = NOT_FOUND_ERROR_CODE
+}
 
 /**
- * When used in a React server component, this will set the status code to 404.
- * When used in a custom app route it will just send a 404 status.
+ * In a React Server Component (RSC),
+ * it will redirect - using the 404 status -
+ * and render the closest `not-found.js` file.
+ *
+ * @example
+ * ```ts
+ * import { notFound } from 'next/navigation'
+ *
+ * function User() {
+ *   if(userNotFound) notFound()
+ *   return "render user..."
+ * }
+ * ```
+ *
+ * In a Route Handler, it will send a response with a 404 status code.
+ *
+ * @example
+ * ```ts
+ * import { notFound } from 'next/navigation'
+ *
+ * export async function GET() {
+ *   const user = await getUser()
+ *   if(!user) notFound()
+ *   return Response.json(user)
+ * }
+ * ```
+ *
+ * [Documentation](https://nextjs.org/docs/app/api-reference/functions/not-found) | [not-found.js](https://nextjs.org/docs/app/api-reference/file-conventions/not-found) | [React Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components) | [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers)
  */
 export function notFound(): never {
-  // eslint-disable-next-line no-throw-literal
-  const error = new Error(NOT_FOUND_ERROR_CODE)
-  ;(error as NotFoundError).digest = NOT_FOUND_ERROR_CODE
-  throw error
+  throw new NotFoundError()
 }
 
 /**
@@ -19,7 +44,8 @@ export function notFound(): never {
  *
  * @param error the error that may reference a not found error
  * @returns true if the error is a not found error
+ * @internal
  */
-export function isNotFoundError(error: any): error is NotFoundError {
-  return error?.digest === NOT_FOUND_ERROR_CODE
+export function isNotFoundError(error: unknown): error is NotFoundError {
+  return error instanceof NotFoundError
 }

--- a/packages/next/src/client/components/redirect-boundary.tsx
+++ b/packages/next/src/client/components/redirect-boundary.tsx
@@ -27,7 +27,7 @@ function HandleRedirect({
 
   useEffect(() => {
     React.startTransition(() => {
-      if (redirectType === RedirectType.push) {
+      if (redirectType === 'push') {
         router.push(redirect, {})
       } else {
         router.replace(redirect, {})

--- a/packages/next/src/export/helpers/is-dynamic-usage-error.ts
+++ b/packages/next/src/export/helpers/is-dynamic-usage-error.ts
@@ -1,10 +1,19 @@
-import { DYNAMIC_ERROR_CODE } from '../../client/components/hooks-server-context'
-import { isNotFoundError } from '../../client/components/not-found'
-import { isRedirectError } from '../../client/components/redirect'
-import { NEXT_DYNAMIC_NO_SSR_CODE } from '../../shared/lib/lazy-dynamic/no-ssr-error'
+import { DynamicServerError } from '../../client/components/hooks-server-context'
+import { NotFoundError } from '../../client/components/not-found'
+import { RedirectError } from '../../client/components/redirect'
+import { DynamicNoSSRError } from '../../shared/lib/lazy-dynamic/no-ssr-error'
 
-export const isDynamicUsageError = (err: any) =>
-  err.digest === DYNAMIC_ERROR_CODE ||
-  isNotFoundError(err) ||
-  err.digest === NEXT_DYNAMIC_NO_SSR_CODE ||
-  isRedirectError(err)
+type DynamicUsageError =
+  | DynamicServerError
+  | NotFoundError
+  | RedirectError
+  | DynamicNoSSRError
+
+export function isDynamicUsageError(err: unknown): err is DynamicUsageError {
+  return (
+    err instanceof DynamicServerError ||
+    err instanceof NotFoundError ||
+    err instanceof RedirectError ||
+    err instanceof DynamicNoSSRError
+  )
+}

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -9,7 +9,7 @@ import {
   NEXT_URL,
   NEXT_ROUTER_PREFETCH,
 } from '../../client/components/app-router-headers'
-import { isDynamicUsageError } from '../helpers/is-dynamic-usage-error'
+import { isDynamicUsageError } from '../../lib/is-dynamic-usage-error'
 import { NEXT_CACHE_TAGS_HEADER } from '../../lib/constants'
 import { hasNextSupport } from '../../telemetry/ci-info'
 import { lazyRenderAppPage } from '../../server/future/route-modules/app-page/module.render'

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -13,7 +13,7 @@ import {
 } from '../../server/web/spec-extension/adapters/next-request'
 import { toNodeOutgoingHttpHeaders } from '../../server/web/utils'
 import { MockedRequest, MockedResponse } from '../../server/lib/mock-request'
-import { isDynamicUsageError } from '../helpers/is-dynamic-usage-error'
+import { isDynamicUsageError } from '../../lib/is-dynamic-usage-error'
 import { SERVER_DIRECTORY } from '../../shared/lib/constants'
 import { hasNextSupport } from '../../telemetry/ci-info'
 

--- a/packages/next/src/lib/is-dynamic-usage-error.ts
+++ b/packages/next/src/lib/is-dynamic-usage-error.ts
@@ -1,7 +1,7 @@
-import { DynamicServerError } from '../../client/components/hooks-server-context'
-import { NotFoundError } from '../../client/components/not-found'
-import { RedirectError } from '../../client/components/redirect'
-import { DynamicNoSSRError } from '../../shared/lib/lazy-dynamic/no-ssr-error'
+import { DynamicServerError } from '../client/components/hooks-server-context'
+import { NotFoundError } from '../client/components/not-found'
+import { RedirectError } from '../client/components/redirect'
+import { DynamicNoSSRError } from '../shared/lib/lazy-dynamic/no-ssr-error'
 
 type DynamicUsageError =
   | DynamicServerError

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -1,10 +1,7 @@
-import { DYNAMIC_ERROR_CODE } from '../../client/components/hooks-server-context'
 import stringHash from 'next/dist/compiled/string-hash'
 import { formatServerError } from '../../lib/format-server-error'
-import { isNotFoundError } from '../../client/components/not-found'
-import { isRedirectError } from '../../client/components/redirect'
-import { NEXT_DYNAMIC_NO_SSR_CODE } from '../../shared/lib/lazy-dynamic/no-ssr-error'
 import { SpanStatusCode, getTracer } from '../lib/trace/tracer'
+import { isDynamicUsageError } from '../../export/helpers/is-dynamic-usage-error'
 
 /**
  * Create error handler for renderers.
@@ -32,15 +29,7 @@ export function createErrorHandler({
   return (err: any): string => {
     if (allCapturedErrors) allCapturedErrors.push(err)
 
-    if (
-      err &&
-      (err.digest === DYNAMIC_ERROR_CODE ||
-        isNotFoundError(err) ||
-        err.digest === NEXT_DYNAMIC_NO_SSR_CODE ||
-        isRedirectError(err))
-    ) {
-      return err.digest
-    }
+    if (isDynamicUsageError(err)) return err.digest
 
     // Format server errors in development to add more helpful error messages
     if (dev) {

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -1,7 +1,7 @@
 import stringHash from 'next/dist/compiled/string-hash'
 import { formatServerError } from '../../lib/format-server-error'
 import { SpanStatusCode, getTracer } from '../lib/trace/tracer'
-import { isDynamicUsageError } from '../../export/helpers/is-dynamic-usage-error'
+import { isDynamicUsageError } from '../../lib/is-dynamic-usage-error'
 
 /**
  * Create error handler for renderers.

--- a/packages/next/src/server/future/route-modules/app-route/helpers/resolve-handler-error.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/resolve-handler-error.ts
@@ -9,7 +9,7 @@ import {
   handleRedirectResponse,
 } from '../../helpers/response-handlers'
 
-export function resolveHandlerError(err: any): Response | false {
+export function resolveHandlerError(err: unknown): Response | false {
   if (isRedirectError(err)) {
     const redirect = getURLFromRedirectError(err)
     if (!redirect) {

--- a/packages/next/src/shared/lib/lazy-dynamic/dynamic-no-ssr.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/dynamic-no-ssr.tsx
@@ -1,12 +1,10 @@
 'use client'
 
 import React from 'react'
-import { NEXT_DYNAMIC_NO_SSR_CODE } from './no-ssr-error'
+import { DynamicNoSSRError } from './no-ssr-error'
 
 export function suspense() {
-  const error = new Error(NEXT_DYNAMIC_NO_SSR_CODE)
-  ;(error as any).digest = NEXT_DYNAMIC_NO_SSR_CODE
-  throw error
+  throw new DynamicNoSSRError()
 }
 
 type Child = React.ReactElement<any, any>

--- a/packages/next/src/shared/lib/lazy-dynamic/no-ssr-error.ts
+++ b/packages/next/src/shared/lib/lazy-dynamic/no-ssr-error.ts
@@ -1,3 +1,7 @@
 // This has to be a shared module which is shared between client component error boundary and dynamic component
 
 export const NEXT_DYNAMIC_NO_SSR_CODE = 'NEXT_DYNAMIC_NO_SSR_CODE'
+
+export class DynamicNoSSRError extends Error {
+  digest = NEXT_DYNAMIC_NO_SSR_CODE
+}

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2372,6 +2372,7 @@ export async function next_compile(task, opts) {
       'nextbuildjest',
       'nextbuildstatic',
       'nextbuild_esm',
+      'nextexport_esm',
       'pages',
       'pages_esm',
       'lib',
@@ -2465,6 +2466,21 @@ export async function nextbuild(task, opts) {
     })
     .swc('server', { dev: opts.dev })
     .target('dist/build')
+}
+
+export async function nextexport_esm(task, opts) {
+  await task
+    .source('src/export/**/*.+(js|ts|tsx)', {
+      ignore: [
+        '**/fixture/**',
+        '**/tests/**',
+        '**/jest/**',
+        '**/*.test.d.ts',
+        '**/*.test.+(js|ts|tsx)',
+      ],
+    })
+    .swc('server', { dev: opts.dev, esm: true })
+    .target('dist/esm/export')
 }
 
 export async function nextbuild_esm(task, opts) {
@@ -2633,7 +2649,7 @@ export default async function (task) {
   await task.watch('src/server', ['server', 'server_esm', 'server_wasm'], opts)
   await task.watch(
     'src/build',
-    ['nextbuild', 'nextbuild_esm', 'nextbuildjest'],
+    ['nextbuild', 'nextexport_esm', 'nextbuild_esm', 'nextbuildjest'],
     opts
   )
   await task.watch('src/export', 'nextbuildstatic', opts)

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2372,7 +2372,6 @@ export async function next_compile(task, opts) {
       'nextbuildjest',
       'nextbuildstatic',
       'nextbuild_esm',
-      'nextexport_esm',
       'pages',
       'pages_esm',
       'lib',
@@ -2466,21 +2465,6 @@ export async function nextbuild(task, opts) {
     })
     .swc('server', { dev: opts.dev })
     .target('dist/build')
-}
-
-export async function nextexport_esm(task, opts) {
-  await task
-    .source('src/export/**/*.+(js|ts|tsx)', {
-      ignore: [
-        '**/fixture/**',
-        '**/tests/**',
-        '**/jest/**',
-        '**/*.test.d.ts',
-        '**/*.test.+(js|ts|tsx)',
-      ],
-    })
-    .swc('server', { dev: opts.dev, esm: true })
-    .target('dist/esm/export')
 }
 
 export async function nextbuild_esm(task, opts) {
@@ -2649,7 +2633,7 @@ export default async function (task) {
   await task.watch('src/server', ['server', 'server_esm', 'server_wasm'], opts)
   await task.watch(
     'src/build',
-    ['nextbuild', 'nextexport_esm', 'nextbuild_esm', 'nextbuildjest'],
+    ['nextbuild', 'nextbuild_esm', 'nextbuildjest'],
     opts
   )
   await task.watch('src/export', 'nextbuildstatic', opts)


### PR DESCRIPTION
### What?

I noticed we had a lot of inconsistencies internally about how we create the digestible errors. 

### Why?

This unifies how we define these types of errors, and also increases type safety.

I also added better inline documentation to `redirect`, `permanentRedirect` and `notFound` for a better DX in IDEs like VSCode.

Before:
![image](https://github.com/vercel/next.js/assets/18369201/69a02843-bdaa-40be-aef0-e6ebf684425d)

After:
![image](https://github.com/vercel/next.js/assets/18369201/af61ddb8-0163-4116-8265-573131e7c481)


### How?

Instead of hacking on properties on a regular `Error` instance and marking it `any`, we can create sub-classes for each use case.