### PR TITLE
fix(next-core): apply postcss for the server side foreign codes

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -367,6 +367,11 @@ pub async fn get_server_module_options_context(
                 ..Default::default()
             };
 
+            // A common module option context to execute transforms if the module matches to
+            // the foreign code context condition.
+            // Currently this skips most of the custom transform, except
+            // related css transtition rules to allow to import css from
+            // external packages.
             let foreign_code_module_options_context = ModuleOptionsContext {
                 custom_rules: internal_custom_rules.clone(),
                 enable_webpack_loaders: foreign_webpack_loaders,
@@ -432,11 +437,13 @@ pub async fn get_server_module_options_context(
                 execution_context: Some(execution_context),
                 ..Default::default()
             };
+
             let foreign_code_module_options_context = ModuleOptionsContext {
                 custom_rules: internal_custom_rules.clone(),
                 enable_webpack_loaders: foreign_webpack_loaders,
                 ..module_options_context.clone()
             };
+
             let internal_module_options_context = ModuleOptionsContext {
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 custom_rules: internal_custom_rules,
@@ -504,11 +511,13 @@ pub async fn get_server_module_options_context(
                 execution_context: Some(execution_context),
                 ..Default::default()
             };
+
             let foreign_code_module_options_context = ModuleOptionsContext {
                 custom_rules: internal_custom_rules.clone(),
                 enable_webpack_loaders: foreign_webpack_loaders,
                 ..module_options_context.clone()
             };
+
             let internal_module_options_context = ModuleOptionsContext {
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 custom_rules: internal_custom_rules,

--- a/packages/next-swc/crates/next-core/src/util.rs
+++ b/packages/next-swc/crates/next-core/src/util.rs
@@ -87,6 +87,13 @@ pub fn get_asset_path_from_pathname(pathname: &str, ext: &str) -> String {
     format!("{}{}", get_asset_prefix_from_pathname(pathname), ext)
 }
 
+/// Returns a context condition that matches all files that are not part of the
+/// user's code, a.k.a `foreign`.
+///
+/// If transpile_packages is not enabled, this matches to any codes under
+/// `node_modules` or next.js internal template ("dist/esm/build/templates")
+/// files. Otherwise, it matches to files under node_modules except for the
+/// packages specified in transpile_packages or next.js internal templates.
 pub async fn foreign_code_context_condition(
     next_config: Vc<NextConfig>,
     project_path: Vc<FileSystemPath>,


### PR DESCRIPTION
### What

closes https://github.com/vercel/next.js/issues/56219, apply foreign (node_modules/) code's css transform correctly and include it into manifest references.

Closes WEB-1731