### PR TITLE
Unsilence Taskr Webpack errors

### DIFF
--- a/packages/next/taskfile-webpack.js
+++ b/packages/next/taskfile-webpack.js
@@ -20,7 +20,10 @@ module.exports = function (task) {
     return new Promise((resolve) => {
       compiler.run((err, stats) => {
         if (err || stats.hasErrors()) {
-          throw err ?? new Error(stats.toString())
+          return this.emit('plugin_error', {
+            plugin: 'taskfile-webpack',
+            error: err?.message ?? stats.toString(),
+          })
         }
 
         if (process.env.ANALYZE) {

--- a/packages/next/taskfile-webpack.js
+++ b/packages/next/taskfile-webpack.js
@@ -1,35 +1,37 @@
 const webpack = require('webpack')
 
 module.exports = function (task) {
+  // eslint-disable-next-line require-yield
   task.plugin('webpack', {}, function* (_, options) {
     options = options || {}
 
     const compiler = webpack(options.config)
 
     if (options.watch) {
-      compiler.watch({}, (err, stats) => {
+      return compiler.watch({}, (err, stats) => {
         if (err || stats.hasErrors()) {
           console.error(err || stats.toString())
         } else {
           console.log(`${options.name} compiled successfully.`)
         }
       })
-    } else {
-      yield new Promise((resolve, reject) => {
-        compiler.run((err, stats) => {
-          if (err || stats.hasErrors()) {
-            console.error(err || stats.toString())
-            reject(err || stats.toString())
-          }
-          if (process.env.ANALYZE) {
-            require('fs').writeFileSync(
-              require('path').join(__dirname, options.name + '-stats.json'),
-              JSON.stringify(stats.toJson())
-            )
-          }
-          resolve()
-        })
-      })
     }
+
+    return new Promise((resolve) => {
+      compiler.run((err, stats) => {
+        if (err || stats.hasErrors()) {
+          throw err ?? new Error(stats.toString())
+        }
+
+        if (process.env.ANALYZE) {
+          require('fs').writeFileSync(
+            require('path').join(__dirname, options.name + '-stats.json'),
+            JSON.stringify(stats.toJson())
+          )
+        }
+
+        resolve()
+      })
+    })
   })
 }


### PR DESCRIPTION
Discovered while investigating https://github.com/vercel/next.js/pull/56526, turns out errors occuring during webpack builds do not fail the `pnpm build` which kicks off `taskr`. This is because `taskr` runs their plugins within coroutines, which based on the result, was not handling the promise rejections as expected.