### PR TITLE
fix(create-next-app): app breaks with TypeScript and Tailwind when using `pnpm@8`

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -207,9 +207,9 @@ export const installTemplate = async ({
   if (tailwind) {
     packageJson.devDependencies = {
       ...packageJson.devDependencies,
-      autoprefixer: '^10',
-      postcss: '^8',
-      tailwindcss: '^3',
+      autoprefixer: 'latest',
+      postcss: 'latest',
+      tailwindcss: 'latest',
     }
   }
 

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -9,6 +9,7 @@ import path from 'path'
 import { cyan, bold } from 'picocolors'
 import { Sema } from 'async-sema'
 import { version } from '../package.json'
+import { peerDependencies as NextPeerDependencies } from '../../next/package.json'
 
 import { GetTemplateFileArgs, InstallTemplateArgs } from './types'
 
@@ -182,8 +183,8 @@ export const installTemplate = async ({
      * Default dependencies.
      */
     dependencies: {
-      react: '^18',
-      'react-dom': '^18',
+      react: NextPeerDependencies.react,
+      'react-dom': NextPeerDependencies['react-dom'],
       next: process.env.NEXT_PRIVATE_TEST_VERSION ?? version,
     },
     devDependencies: {},
@@ -197,8 +198,8 @@ export const installTemplate = async ({
       ...packageJson.devDependencies,
       typescript: '^5',
       '@types/node': '^20',
-      '@types/react': '^18',
-      '@types/react-dom': '^18',
+      '@types/react': NextPeerDependencies.react,
+      '@types/react-dom': NextPeerDependencies['react-dom'],
     }
   }
 


### PR DESCRIPTION
cc @balazsorban44 
I've looked at your PR #55730 and don't want to go against your intention, but we're facing an issue with `pnpm@8`.

### Reproduction

> Codesandbox uses pnpm@7.1.0 so couldn't reproduce.

https://github.com/devjiwonchoi/create-next-app-pnpm-repro

### Why?

Using `pnpm create next-app`, the app breaks with the following message:
`TypeError: Cannot read properties of undefined (reading 'config')`

### How?

- TypeScript and ESM support on tailwind config was introduced on [v3.3.0](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.3.0)
- Had an issue when updating `tailwind` only, `RangeError: Maximum call stack size exceeded`, which can be resolved by `autoprefixer@10.1.0`

#### Option 1
- Pin Tailwind-related dependencies (tailwindcss, postcss, autoprefixer) to their **stable** versions

#### Option 2
- Let Tailwind-related dependencies (tailwindcss, postcss, autoprefixer) to their **latest** versions

Fixes #56394 

### Additional Information

- The app does not break when using `pnpm@7`

- This PR will also resolve lots of `peerDependencies` warnings

Current:

```
 WARN  Issues with peer dependencies found
.
├─┬ autoprefixer 10.0.0
│ └── ✕ unmet peer postcss@^8.0.2: found 8.0.0
├─┬ tailwindcss 3.0.0
│ ├── ✕ unmet peer postcss@^8.0.9: found 8.0.0
│ ├─┬ postcss-js 4.0.1
│ │ └── ✕ unmet peer postcss@^8.4.21: found 8.0.0
│ ├─┬ postcss-load-config 3.1.4
│ │ └── ✕ unmet peer postcss@>=8.0.9: found 8.0.0
│ └─┬ postcss-nested 6.0.0
│   └── ✕ unmet peer postcss@^8.2.14: found 8.0.0
└─┬ next 13.5.4
  ├── ✕ unmet peer react@^18.2.0: found 18.0.0
  └── ✕ unmet peer react-dom@^18.2.0: found 18.0.0
```