### PR TITLE
remove unnecessary structuredClone

### DIFF
--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -24,7 +24,7 @@ function deepMerge(target: any, source: any) {
       ? (target[key] = [...target[key], ...(source[key] || [])])
       : typeof target[key] == 'object' && typeof source[key] == 'object'
       ? deepMerge(target[key], source[key])
-      : structuredClone(result[key])
+      : result[key]
   }
   return result
 }


### PR DESCRIPTION
An issue discovered from #56502 in azure pipeline

```
> Build error occurred
ReferenceError: structuredClone is not defined
```

`structuredClone` is not supported until nodejs 17, here we actually don't need to use `structuredClone` as the values are almost primitives, the deepMerge case we're using mainly objects and array, which are already handled above