### PR TITLE
Add socket.io packages to server external packages

### DIFF
--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -45,5 +45,7 @@
   "ts-node",
   "typescript",
   "vscode-oniguruma",
-  "webpack"
+  "webpack",
+  "socket.io",
+  "socket.io-client"
 ]


### PR DESCRIPTION
For socket.io integration, keep related packages not bundled

x-ref: https://github.com/vercel/next.js/issues/49334#issuecomment-1752026177