### PR TITLE
test: run e2e test in ramdisk

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -37,11 +37,14 @@ async function createNextInstall({
   dirSuffix = '',
   onlyPackages = false,
   keepRepoDir = false,
+  subTmpDir = null,
 }) {
   return await parentSpan
     .traceChild('createNextInstall')
     .traceAsyncFn(async (rootSpan) => {
-      const tmpDir = await fs.realpath(process.env.NEXT_TEST_DIR || os.tmpdir())
+      const tmpDir = await fs.realpath(
+        process.env.NEXT_TEST_DIR || subTmpDir || os.tmpdir()
+      )
       const origRepoDir = path.join(__dirname, '../../')
       const installDir = path.join(
         tmpDir,

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -1,6 +1,9 @@
 import os from 'os'
 import path from 'path'
-import fs from 'fs-extra'
+import { randomBytes } from 'crypto'
+import fs from 'fs'
+import fsp from 'fs/promises'
+import fse from 'fs-extra'
 import treeKill from 'tree-kill'
 import type { NextConfig } from 'next'
 import { FileRef } from '../e2e-utils'
@@ -15,6 +18,9 @@ import { renderViaHTTP, fetchViaHTTP } from 'next-test-utils'
 import cheerio from 'cheerio'
 import { BrowserInterface } from '../browsers/base'
 import escapeStringRegexp from 'escape-string-regexp'
+
+import { isCI } from 'next/dist/telemetry/ci-info'
+import { cleanupRAMDisk, createRAMDisk } from '../ramdisk'
 
 type Event = 'stdout' | 'stderr' | 'error' | 'destroy'
 export type InstallCommand =
@@ -71,6 +77,8 @@ export class NextInstance {
   public forcedPort?: string
   public dirSuffix: string = ''
 
+  private ramdisk?: string | undefined
+
   constructor(opts: NextInstanceOpts) {
     Object.assign(this, opts)
 
@@ -95,24 +103,24 @@ export class NextInstance {
     if (files instanceof FileRef) {
       // if a FileRef is passed directly to `files` we copy the
       // entire folder to the test directory
-      const stats = await fs.stat(files.fsPath)
+      const stats = await fsp.stat(files.fsPath)
 
       if (!stats.isDirectory()) {
         throw new Error(
           `FileRef passed to "files" in "createNext" is not a directory ${files.fsPath}`
         )
       }
-      await fs.copy(files.fsPath, this.testDir)
+      await fse.copy(files.fsPath, this.testDir)
     } else {
       for (const filename of Object.keys(files)) {
         const item = files[filename]
         const outputFilename = path.join(this.testDir, filename)
 
         if (typeof item === 'string') {
-          await fs.ensureDir(path.dirname(outputFilename))
-          await fs.writeFile(outputFilename, item)
+          await fsp.mkdir(path.dirname(outputFilename), { recursive: true })
+          await fsp.writeFile(outputFilename, item)
         } else {
-          await fs.copy(item.fsPath, outputFilename)
+          await fse.copy(item.fsPath, outputFilename)
         }
       }
     }
@@ -138,7 +146,7 @@ export class NextInstance {
         const skipIsolatedNext = !!process.env.NEXT_SKIP_ISOLATE
         const tmpDir = skipIsolatedNext
           ? path.join(__dirname, '../../tmp')
-          : process.env.NEXT_TEST_DIR || (await fs.realpath(os.tmpdir()))
+          : process.env.NEXT_TEST_DIR || (await fsp.realpath(os.tmpdir()))
         this.testDir = path.join(
           tmpDir,
           `next-test-${Date.now()}-${(Math.random() * 1000) | 0}${
@@ -160,8 +168,8 @@ export class NextInstance {
 
         if (skipInstall || skipIsolatedNext) {
           const pkgScripts = (this.packageJson['scripts'] as {}) || {}
-          await fs.ensureDir(this.testDir)
-          await fs.writeFile(
+          await fsp.mkdir(this.testDir, { recursive: true })
+          await fsp.writeFile(
             path.join(this.testDir, 'package.json'),
             JSON.stringify(
               {
@@ -196,8 +204,25 @@ export class NextInstance {
             !this.packageJson &&
             !(global as any).isNextDeploy
           ) {
-            await fs.copy(process.env.NEXT_TEST_STARTER, this.testDir)
+            await fse.copy(process.env.NEXT_TEST_STARTER, this.testDir)
           } else {
+            if (
+              // when NEXT_TEST_DIR is specified, it usually means we want to inspect the test dir
+              !process.env.NEXT_TEST_DIR &&
+              // if we are running test in CI, we don't want ramdisks to cause OOM
+              !isCI &&
+              // if we want to preserve the test directory, it usually means we want to inspect the test dir
+              !process.env.NEXT_TEST_SKIP_CLEANUP &&
+              // if the current platform doesn't support ramdisk, we don't use ramdisk
+              (process.platform === 'darwin' || process.platform === 'linux')
+            ) {
+              this.ramdisk = rootSpan
+                .traceChild('create ramdisk')
+                .traceFn(() =>
+                  createRAMDisk(`next${randomBytes(16).toString('hex')}`)
+                )
+            }
+
             this.testDir = await createNextInstall({
               parentSpan: rootSpan,
               dependencies: finalDependencies,
@@ -205,6 +230,7 @@ export class NextInstance {
               installCommand: this.installCommand,
               packageJson: this.packageJson,
               dirSuffix: this.dirSuffix,
+              subTmpDir: this.ramdisk ?? null,
             })
           }
           require('console').log('created next.js install, writing test files')
@@ -220,7 +246,7 @@ export class NextInstance {
           file.startsWith('next.config.')
         )
 
-        if (await fs.pathExists(path.join(this.testDir, 'next.config.js'))) {
+        if (fs.existsSync(path.join(this.testDir, 'next.config.js'))) {
           nextConfigFile = 'next.config.js'
         }
 
@@ -236,7 +262,7 @@ export class NextInstance {
         ) {
           const functions = []
 
-          await fs.writeFile(
+          await fsp.writeFile(
             path.join(this.testDir, 'next.config.js'),
             `
         module.exports = ` +
@@ -270,7 +296,7 @@ export class NextInstance {
             this.testDir,
             nextConfigFile || 'next.config.js'
           )
-          const content = await fs.readFile(fileName, 'utf8')
+          const content = await fsp.readFile(fileName, 'utf8')
 
           if (content.includes('basePath')) {
             this.basePath =
@@ -278,7 +304,7 @@ export class NextInstance {
               ''
           }
 
-          await fs.writeFile(
+          await fsp.writeFile(
             fileName,
             `${content}\n` +
               `
@@ -328,9 +354,12 @@ export class NextInstance {
       'yarn.lock',
       'pnpm-lock.yaml',
     ]
-    for (const file of await fs.readdir(this.testDir)) {
+    for (const file of await fsp.readdir(this.testDir)) {
       if (!keptFiles.includes(file)) {
-        await fs.remove(path.join(this.testDir, file))
+        await fsp.rm(path.join(this.testDir, file), {
+          recursive: true,
+          force: true,
+        })
       }
     }
     await this.writeInitialFiles()
@@ -381,7 +410,7 @@ export class NextInstance {
       await this.stop().catch(console.error)
 
       if (process.env.TRACE_PLAYWRIGHT) {
-        await fs
+        await fse
           .copy(
             path.join(this.testDir, '.next/trace'),
             path.join(
@@ -400,7 +429,10 @@ export class NextInstance {
       }
 
       if (!process.env.NEXT_TEST_SKIP_CLEANUP) {
-        await fs.remove(this.testDir)
+        await fsp.rm(this.testDir, { recursive: true, force: true })
+        if (this.ramdisk) {
+          cleanupRAMDisk(this.ramdisk)
+        }
       }
       require('console').log(`destroyed next instance`)
     } catch (err) {
@@ -425,14 +457,16 @@ export class NextInstance {
   }
 
   // TODO: block these in deploy mode
-  public async hasFile(filename: string) {
-    return fs.pathExists(path.join(this.testDir, filename))
+  public hasFile(filename: string) {
+    return fs.existsSync(path.join(this.testDir, filename))
   }
   public async readFile(filename: string) {
-    return fs.readFile(path.join(this.testDir, filename), 'utf8')
+    return fsp.readFile(path.join(this.testDir, filename), 'utf8')
   }
   public async readJSON(filename: string) {
-    return fs.readJSON(path.join(this.testDir, filename))
+    return JSON.parse(
+      await fsp.readFile(path.join(this.testDir, filename), 'utf-8')
+    )
   }
   private async handleDevWatchDelayBeforeChange(filename: string) {
     // This is a temporary workaround for turbopack starting watching too late.
@@ -461,9 +495,9 @@ export class NextInstance {
     await this.handleDevWatchDelayBeforeChange(filename)
 
     const outputPath = path.join(this.testDir, filename)
-    const newFile = !(await fs.pathExists(outputPath))
-    await fs.ensureDir(path.dirname(outputPath))
-    await fs.writeFile(outputPath, content)
+    const newFile = !fs.existsSync(outputPath)
+    await fsp.mkdir(path.dirname(outputPath), { recursive: true })
+    await fse.writeFile(outputPath, content)
 
     if (newFile) {
       await this.handleDevWatchDelayAfterChange(filename)
@@ -472,7 +506,7 @@ export class NextInstance {
   public async renameFile(filename: string, newFilename: string) {
     await this.handleDevWatchDelayBeforeChange(filename)
 
-    await fs.rename(
+    await fsp.rename(
       path.join(this.testDir, filename),
       path.join(this.testDir, newFilename)
     )
@@ -481,7 +515,7 @@ export class NextInstance {
   public async renameFolder(foldername: string, newFoldername: string) {
     await this.handleDevWatchDelayBeforeChange(foldername)
 
-    await fs.move(
+    await fsp.rename(
       path.join(this.testDir, foldername),
       path.join(this.testDir, newFoldername)
     )
@@ -490,7 +524,10 @@ export class NextInstance {
   public async deleteFile(filename: string) {
     await this.handleDevWatchDelayBeforeChange(filename)
 
-    await fs.remove(path.join(this.testDir, filename))
+    await fsp.rm(path.join(this.testDir, filename), {
+      recursive: true,
+      force: true,
+    })
     await this.handleDevWatchDelayAfterChange(filename)
   }
 

--- a/test/lib/ramdisk.js
+++ b/test/lib/ramdisk.js
@@ -1,0 +1,151 @@
+// @ts-check
+const { existsSync, unlinkSync, mkdirSync } = require('fs')
+const path = require('path')
+const pc = require('next/dist/lib/picocolors')
+const { sync: execa } = require('execa')
+const { platform } = require('process')
+const { tmpdir } = require('os')
+
+/**
+ * Create a ramdisk for later usage
+ *
+ * @param {number} blocks
+ * @param {string} root
+ * @returns {string}
+ */
+const create = (blocks, root) => {
+  if (platform === 'darwin' || platform === 'linux') {
+    require('console').warn(
+      pc.blue('ramdisk:'),
+      'Initializing RAMdisk. You may be prompted for credentials'
+    )
+    const { stdout: diskPath } =
+      platform === 'darwin'
+        ? execa('hdiutil', ['attach', '-nomount', `ram://${blocks}`])
+        : execa('sudo', ['mkdir', '-p', root])
+
+    return diskPath.trim()
+  }
+
+  throw new Error('Unsupported platform!')
+}
+
+/**
+ * Actually mount the ramdisk to the specified path
+ *
+ * @param {number} bytes
+ * @param {string} diskPath
+ * @param {string} name
+ * @param {string} root
+ * @returns {void}
+ */
+const mount = (bytes, diskPath, name, root) => {
+  if (platform === 'darwin') {
+    require('console').warn(
+      pc.blue('ramdisk:'),
+      `Mouting RAMdisk at ${diskPath}. You may be prompted for credentials`
+    )
+    execa('diskutil', ['erasevolume', 'APFS', name, diskPath])
+    return
+  }
+  if (platform === 'linux') {
+    require('console').warn(
+      pc.blue('ramdisk:'),
+      `Mouting RAMdisk at ${root}. You may be prompted for credentials`
+    )
+    execa('sudo', [
+      'mount',
+      '-t',
+      'tmpfs',
+      '-o',
+      `size=${bytes}`,
+      'tmpfs',
+      root,
+    ])
+    return
+  }
+
+  throw new Error('Unsupported platform!')
+}
+
+/** @type {Set<string>} */
+const createdRAMDisks = new Set()
+
+/**
+ * Is a path a RAMDisk created by this module?
+ */
+const isRAMDisk = (path) => createdRAMDisks.has(path)
+module.exports.isRAMDisk = isRAMDisk
+
+/**
+ * Unmount the ramdisk at the specified path
+ *
+ * @param {string} root
+ * @returns {void}
+ */
+const cleanupRAMDisk = (root) => {
+  if (platform === 'darwin' || platform === 'linux') {
+    const commands = {
+      darwin: `hdiutil detach ${root}`,
+      linux: `sudo umount ${root}`,
+    }
+
+    require('console').warn(
+      pc.yellow('ramdisk:'),
+      `Unmouting RAMdisk at ${root}. You may be prompted for credentials`
+    )
+
+    if (platform === 'darwin') {
+      execa('hdiutil', ['detach', root])
+      return
+    }
+
+    execa('sudo', ['umount', root])
+    return
+  }
+
+  return unlinkSync(root)
+}
+module.exports.cleanupRAMDisk = cleanupRAMDisk
+
+/**
+ * Create the ramdisk, returned the path
+ *
+ * @param {string} name
+ * @param {number} [bytes]
+ * @param {number} [blockSize]
+ * @returns {string}
+ */
+const createRAMDisk = (
+  name,
+  bytes = 1024 * 1024 * 1024, // 1 GiB
+  blockSize = 512
+) => {
+  if (platform === 'darwin' || platform === 'linux') {
+    const root = platform === 'darwin' ? `/Volumes/${name}` : `/mnt/${name}`
+    const blocks = bytes / blockSize
+
+    if (!existsSync(root)) {
+      const diskPath = create(blocks, root)
+      mount(bytes, diskPath, name, root)
+    }
+
+    require('console').warn(
+      pc.green('ramdisk:'),
+      `RAMdisk is avaliable at ${root}.`
+    )
+
+    return root
+  }
+
+  require('console').warn(
+    pc.red('ramdisk:'),
+    'The current platform does not support RAMdisks. Using a temporary directory instead.'
+  )
+
+  const root = path.join(tmpdir(), '.fake-ramdisk', name)
+  mkdirSync(root, { recursive: true })
+
+  return root
+}
+module.exports.createRAMDisk = createRAMDisk


### PR DESCRIPTION
This is an attempt to improve the e2e test performance / save precious SSD life span on local development by setting up isolated Next.js inside a RAMDisk.

**Before**

![image](https://github.com/vercel/next.js/assets/40715044/9c4d2c0a-b639-4f69-aa21-771f61bfc734)

**After**

![image](https://github.com/vercel/next.js/assets/40715044/f6259d2c-916c-4d35-9cbe-ca5d1dfacceb)

There isn't any performance improvement regarding speed on macOS (the time saved by running on ramdisk counterbalances the time spent creating the ramdisk itself), but setting up ramdisk on macOS is significantly slower compared to on Linux anyway.