### PR TITLE
[EXPERIMENTAL] Route enter/exit transitions with Glue Component.

### DIFF
--- a/examples/with-framer-motion-app-dir/.gitignore
+++ b/examples/with-framer-motion-app-dir/.gitignore
@@ -1,0 +1,35 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-framer-motion-app-dir/README.md
+++ b/examples/with-framer-motion-app-dir/README.md
@@ -1,0 +1,29 @@
+# framer-motion example
+
+Framer [`Motion`](https://github.com/framer/motion) is a production-ready animation library. By using a custom [`<App>`](https://nextjs.org/docs/advanced-features/custom-app) along with Motion's [`AnimatePresence`](https://www.framer.com/api/motion/animate-presence/) component, transitions between Next pages becomes simple and declarative.
+
+Using the `Glue` functionality of the appDir enables exit transitions on your pages for a seamless user experience, tailored to each parallel route.
+
+## Deploy your own
+
+Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example) or preview live with [StackBlitz](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-framer-motion)
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-framer-motion&project-name=with-framer-motion&repository-name=with-framer-motion)
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-framer-motion with-framer-motion-app
+```
+
+```bash
+yarn create next-app --example with-framer-motion with-framer-motion-app
+```
+
+```bash
+pnpm create next-app --example with-framer-motion with-framer-motion-app
+```
+
+Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-framer-motion-app-dir/app/@sidebar/[...segment]/page.tsx
+++ b/examples/with-framer-motion-app-dir/app/@sidebar/[...segment]/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Page({ params: { segment } }) {
+  return <div>Segment: {segment}</div>
+}

--- a/examples/with-framer-motion-app-dir/app/@sidebar/default.tsx
+++ b/examples/with-framer-motion-app-dir/app/@sidebar/default.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function DefaultSidebar() {
+  return <div>Default sidebar</div>
+}

--- a/examples/with-framer-motion-app-dir/app/@sidebar/page.tsx
+++ b/examples/with-framer-motion-app-dir/app/@sidebar/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Page() {
+  return <div>Home sidebar</div>
+}

--- a/examples/with-framer-motion-app-dir/app/[...segment]/page.tsx
+++ b/examples/with-framer-motion-app-dir/app/[...segment]/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Page({ params: { segment } }) {
+  return <div>Segment: {segment}</div>
+}

--- a/examples/with-framer-motion-app-dir/app/glue.tsx
+++ b/examples/with-framer-motion-app-dir/app/glue.tsx
@@ -1,0 +1,12 @@
+'use client'
+import React from 'react'
+import { AnimatePresence } from 'framer-motion'
+import { PropsWithChildren } from 'react'
+
+export default function Glue({ children }: PropsWithChildren) {
+  return (
+    <AnimatePresence initial={false} mode="wait">
+      {children}
+    </AnimatePresence>
+  )
+}

--- a/examples/with-framer-motion-app-dir/app/layout.tsx
+++ b/examples/with-framer-motion-app-dir/app/layout.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link'
+import React from 'react'
+
+export default function RootLayout({
+  children,
+  sidebar,
+}: {
+  children: React.ReactNode
+  sidebar: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <nav style={{ display: 'flex', gap: '1em' }}>
+          <p>
+            <Link href="/">Home</Link>
+          </p>
+          <p>
+            <Link href="/hi3">Hi3</Link>
+          </p>
+          <p>
+            <Link href="/hi3/sub">Hi3 sub</Link>
+          </p>
+          <hr />
+          <p>
+            <Link href="/hi4">Hi4</Link>
+          </p>
+          <p>
+            <Link href="/hi4/sub">Hi4 sub</Link>
+          </p>
+          <p>
+            <Link href="/hi4/sub2">Hi4 sub2</Link>
+          </p>
+        </nav>
+        <main style={{ display: 'flex', width: '100vw', gap: '1em' }}>
+          <div style={{ flex: '1' }}>
+            <h1>CHILDREN</h1>
+            {children}
+          </div>
+          <div style={{ flex: '1' }}>
+            <h1>SIDEBAR</h1>
+            {sidebar}
+          </div>
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/examples/with-framer-motion-app-dir/app/page.tsx
+++ b/examples/with-framer-motion-app-dir/app/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Page() {
+  return <div>This is the home page.</div>
+}

--- a/examples/with-framer-motion-app-dir/app/template.tsx
+++ b/examples/with-framer-motion-app-dir/app/template.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import React from 'react'
+import { PropsWithChildren } from 'react'
+
+export default function Template({ children }: PropsWithChildren) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, dur: 1000 }}
+      animate={{ opacity: 1, dur: 1000 }}
+      exit={{ opacity: 0, dur: 1000 }}
+      aria-label="Template"
+    >
+      <hr />
+      {children}
+    </motion.div>
+  )
+}

--- a/examples/with-framer-motion-app-dir/package.json
+++ b/examples/with-framer-motion-app-dir/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "framer-motion": "latest",
+    "next": "latest",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/examples/with-framer-motion-app-dir/tsconfig.json
+++ b/examples/with-framer-motion-app-dir/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -59,6 +59,7 @@ const FILE_TYPES = {
   layout: 'layout',
   template: 'template',
   error: 'error',
+  glue: 'glue',
   loading: 'loading',
   'not-found': 'not-found',
 } as const

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -532,7 +532,8 @@ export default function OuterLayoutRouter({
   notFound: React.ReactNode | undefined
   notFoundStyles: React.ReactNode | undefined
   glue: React.ComponentType<{ children: React.JSX.Element[] }>
-  glueStyles?: React.ReactNode | undefined
+  glueStyles: React.ReactNode | undefined
+  glueScripts: React.ReactNode | undefined
   styles?: React.ReactNode
 }) {
   const context = useContext(LayoutRouterContext)

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -517,6 +517,8 @@ export default function OuterLayoutRouter({
   template,
   notFound,
   notFoundStyles,
+  glue,
+  glueStyles,
   styles,
 }: {
   parallelRouterKey: string
@@ -529,6 +531,8 @@ export default function OuterLayoutRouter({
   template: React.ReactNode
   notFound: React.ReactNode | undefined
   notFoundStyles: React.ReactNode | undefined
+  glue: React.ComponentType<{ children: React.JSX.Element[] }>
+  glueStyles?: React.ReactNode | undefined
   styles?: React.ReactNode
 }) {
   const context = useContext(LayoutRouterContext)
@@ -560,15 +564,20 @@ export default function OuterLayoutRouter({
   // TODO-APP: Add handling of `<Offscreen>` when it's available.
   const preservedSegments: Segment[] = [treeSegment]
 
+  // Allow Glue to be a component
+  const Glue = glue
+
   return (
     <>
       {styles}
-      {preservedSegments.map((preservedSegment) => {
-        const preservedSegmentValue = getSegmentValue(preservedSegment)
-        const cacheKey = createRouterCacheKey(preservedSegment)
+      {glueStyles}
+      <Glue>
+        {preservedSegments.map((preservedSegment) => {
+          const preservedSegmentValue = getSegmentValue(preservedSegment)
+          const cacheKey = createRouterCacheKey(preservedSegment)
 
-        return (
-          /*
+          return (
+            /*
             - Error boundary
               - Only renders error boundary if error component is provided.
               - Rendered for each segment to ensure they have their own error state.
@@ -577,50 +586,51 @@ export default function OuterLayoutRouter({
               - Rendered for each segment to ensure they have their own loading state.
               - Passed to the router during rendering to ensure it can be immediately rendered when suspending on a Flight fetch.
           */
-          <TemplateContext.Provider
-            key={createRouterCacheKey(preservedSegment, true)}
-            value={
-              <ScrollAndFocusHandler segmentPath={segmentPath}>
-                <ErrorBoundary
-                  errorComponent={error}
-                  errorStyles={errorStyles}
-                  errorScripts={errorScripts}
-                >
-                  <LoadingBoundary
-                    hasLoading={Boolean(loading)}
-                    loading={loading?.[0]}
-                    loadingStyles={loading?.[1]}
-                    loadingScripts={loading?.[2]}
+            <TemplateContext.Provider
+              key={createRouterCacheKey(preservedSegment, true)}
+              value={
+                <ScrollAndFocusHandler segmentPath={segmentPath}>
+                  <ErrorBoundary
+                    errorComponent={error}
+                    errorStyles={errorStyles}
+                    errorScripts={errorScripts}
                   >
-                    <NotFoundBoundary
-                      notFound={notFound}
-                      notFoundStyles={notFoundStyles}
+                    <LoadingBoundary
+                      hasLoading={Boolean(loading)}
+                      loading={loading?.[0]}
+                      loadingStyles={loading?.[1]}
+                      loadingScripts={loading?.[2]}
                     >
-                      <RedirectBoundary>
-                        <InnerLayoutRouter
-                          parallelRouterKey={parallelRouterKey}
-                          url={url}
-                          tree={tree}
-                          childNodes={childNodesForParallelRouter!}
-                          segmentPath={segmentPath}
-                          cacheKey={cacheKey}
-                          isActive={
-                            currentChildSegmentValue === preservedSegmentValue
-                          }
-                        />
-                      </RedirectBoundary>
-                    </NotFoundBoundary>
-                  </LoadingBoundary>
-                </ErrorBoundary>
-              </ScrollAndFocusHandler>
-            }
-          >
-            {templateStyles}
-            {templateScripts}
-            {template}
-          </TemplateContext.Provider>
-        )
-      })}
+                      <NotFoundBoundary
+                        notFound={notFound}
+                        notFoundStyles={notFoundStyles}
+                      >
+                        <RedirectBoundary>
+                          <InnerLayoutRouter
+                            parallelRouterKey={parallelRouterKey}
+                            url={url}
+                            tree={tree}
+                            childNodes={childNodesForParallelRouter!}
+                            segmentPath={segmentPath}
+                            cacheKey={cacheKey}
+                            isActive={
+                              currentChildSegmentValue === preservedSegmentValue
+                            }
+                          />
+                        </RedirectBoundary>
+                      </NotFoundBoundary>
+                    </LoadingBoundary>
+                  </ErrorBoundary>
+                </ScrollAndFocusHandler>
+              }
+            >
+              {templateStyles}
+              {templateScripts}
+              {template}
+            </TemplateContext.Provider>
+          )
+        })}
+      </Glue>
     </>
   )
 }

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -106,7 +106,14 @@ async function createComponentTreeInternal({
   const { page, layoutOrPagePath, segment, components, parallelRoutes } =
     parseLoaderTree(tree)
 
-  const { layout, template, error, loading, 'not-found': notFound } = components
+  const {
+    layout,
+    template,
+    error,
+    glue,
+    loading,
+    'not-found': notFound,
+  } = components
 
   const injectedCSSWithCurrentLayout = new Set(injectedCSS)
   const injectedJSWithCurrentLayout = new Set(injectedJS)
@@ -121,6 +128,16 @@ async function createComponentTreeInternal({
     injectedJS: injectedJSWithCurrentLayout,
     injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
   })
+
+  const [GlueComponent, glueStyles, glueScripts] = glue
+    ? await createComponentStylesAndScripts({
+        ctx,
+        filePath: glue[1],
+        getComponent: glue[0],
+        injectedCSS: injectedCSSWithCurrentLayout,
+        injectedJS: injectedJSWithCurrentLayout,
+      })
+    : [React.Fragment]
 
   const [Template, templateStyles, templateScripts] = template
     ? await createComponentStylesAndScripts({
@@ -469,6 +486,9 @@ async function createComponentTreeInternal({
             templateScripts={templateScripts}
             notFound={notFoundComponent}
             notFoundStyles={notFoundStyles}
+            glue={GlueComponent}
+            glueStyles={glueStyles}
+            glueScripts={glueScripts}
             styles={currentStyles}
           />,
           childCacheNodeSeedData,


### PR DESCRIPTION
### Discussion

https://github.com/vercel/next.js/discussions/56594

### What?

A persisted, opt-in, user-provided `glue` client component which slots between a `layout` and a `template`, _actually_ receiving the keyed templates as a child, unlike `layout`. This allows enter and exit transitions like `framer-motion` provides: 

https://github.com/vercel/next.js/assets/30581915/c6db6647-c3ea-4673-bbc6-cdff7cd1bb7c

See `examples/with-framer-motion-app-dir` in this branch for the app code for the above.

EDIT: AnimatePresence does seem to break in this case when route transitions happen too quickly, i.e. you navigate elsewhere while a route is still transitioning out. In this case, nothing shows up (with "wait" mode) or both routes render together (with "sync" mode). I'm not sure why, haven't dug into the interaction between Next' router and `FramerMotion` yet. Waiting for exit to navigate does work consistently, at least.

### Why?

Route exit transitions are long overdue for Next.js 13's `appDir`. I think I speak for a lot of web designers and developers when I say this is a major factor preventing migration from `pages/` to `app/`.

### How?

Closes NEXT-
Fixes https://github.com/vercel/next.js/issues/49596
