### PR TITLE
docs(router): clarify dynamic route slug is about a file name, not "folder"

### DIFF
--- a/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
@@ -13,7 +13,7 @@ When you don't know the exact segment names ahead of time and want to create rou
 
 ## Convention
 
-A Dynamic Segment can be created by wrapping a filename in square brackets: `[segmentName]`. For example, `[id]` or `[slug]`.
+A Dynamic Segment can be created by wrapping a filename, but not the extension, as the dynamic segment's name in square brackets: `[segmentName]`. For example, `[id]` or `[slug]`.
 
 Dynamic Segments can be accessed from [`useRouter`](/docs/pages/api-reference/functions/use-router).
 

--- a/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
@@ -13,7 +13,7 @@ When you don't know the exact segment names ahead of time and want to create rou
 
 ## Convention
 
-A Dynamic Segment can be created by wrapping a filename (but not the extension) in square brackets: `[segmentName]`. For example, `[id]` or `[slug]`.
+A Dynamic Segment can be created by wrapping a file or folder name in square brackets: `[segmentName]`. For example, `[id]` or `[slug]`.
 
 Dynamic Segments can be accessed from [`useRouter`](/docs/pages/api-reference/functions/use-router).
 

--- a/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
@@ -13,7 +13,7 @@ When you don't know the exact segment names ahead of time and want to create rou
 
 ## Convention
 
-A Dynamic Segment can be created by wrapping a filename, but not the extension, as the dynamic segment's name in square brackets: `[segmentName]`. For example, `[id]` or `[slug]`.
+A Dynamic Segment can be created by wrapping a filename (but not the extension) in square brackets: `[segmentName]`. For example, `[id]` or `[slug]`.
 
 Dynamic Segments can be accessed from [`useRouter`](/docs/pages/api-reference/functions/use-router).
 

--- a/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
@@ -13,7 +13,7 @@ When you don't know the exact segment names ahead of time and want to create rou
 
 ## Convention
 
-A Dynamic Segment can be created by wrapping a **segment name** in square brackets: `[segmentName]`. For example, `[id]` or `[slug]`.
+A Dynamic Segment can be created by wrapping a filename in square brackets: `[segmentName]`. For example, `[id]` or `[slug]`.
 
 Dynamic Segments can be accessed from [`useRouter`](/docs/pages/api-reference/functions/use-router).
 

--- a/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
@@ -30,11 +30,11 @@ export default function Page() {
 }
 ```
 
-| Route                  | Example URL | `params`               |
-| ---------------------- | ----------- | ---------------------- |
-| `pages/blog/[slug].js` | `/blog/a`   | `{ slug: 'a' }`        |
-| `pages/blog/[slug].js` | `/blog/b`   | `{ slug: 'b' }`        |
-| `pages/blog/[slug].js` | `/blog/c`   | `{ slug: 'c' }`        |
+| Route                  | Example URL | `params`        |
+| ---------------------- | ----------- | --------------- |
+| `pages/blog/[slug].js` | `/blog/a`   | `{ slug: 'a' }` |
+| `pages/blog/[slug].js` | `/blog/b`   | `{ slug: 'b' }` |
+| `pages/blog/[slug].js` | `/blog/c`   | `{ slug: 'c' }` |
 
 ## Catch-all Segments
 

--- a/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/02-dynamic-routes.mdx
@@ -13,7 +13,7 @@ When you don't know the exact segment names ahead of time and want to create rou
 
 ## Convention
 
-A Dynamic Segment can be created by wrapping a folder's name in square brackets: `[folderName]`. For example, `[id]` or `[slug]`.
+A Dynamic Segment can be created by wrapping a **segment name** in square brackets: `[segmentName]`. For example, `[id]` or `[slug]`.
 
 Dynamic Segments can be accessed from [`useRouter`](/docs/pages/api-reference/functions/use-router).
 
@@ -30,15 +30,15 @@ export default function Page() {
 }
 ```
 
-| Route                  | Example URL | `params`        |
-| ---------------------- | ----------- | --------------- |
-| `pages/blog/[slug].js` | `/blog/a`   | `{ slug: 'a' }` |
-| `pages/blog/[slug].js` | `/blog/b`   | `{ slug: 'b' }` |
-| `pages/blog/[slug].js` | `/blog/c`   | `{ slug: 'c' }` |
+| Route                  | Example URL | `params`               |
+| ---------------------- | ----------- | ---------------------- |
+| `pages/blog/[slug].js` | `/blog/a`   | `{ slug: 'a' }`        |
+| `pages/blog/[slug].js` | `/blog/b`   | `{ slug: 'b' }`        |
+| `pages/blog/[slug].js` | `/blog/c`   | `{ slug: 'c' }`        |
 
 ## Catch-all Segments
 
-Dynamic Segments can be extended to **catch-all** subsequent segments by adding an ellipsis inside the brackets `[...folderName]`.
+Dynamic Segments can be extended to **catch-all** subsequent segments by adding an ellipsis inside the brackets `[...segmentName]`.
 
 For example, `pages/shop/[...slug].js` will match `/shop/clothes`, but also `/shop/clothes/tops`, `/shop/clothes/tops/t-shirts`, and so on.
 
@@ -50,7 +50,7 @@ For example, `pages/shop/[...slug].js` will match `/shop/clothes`, but also `/sh
 
 ## Optional Catch-all Segments
 
-Catch-all Segments can be made **optional** by including the parameter in double square brackets: `[[...folderName]]`.
+Catch-all Segments can be made **optional** by including the parameter in double square brackets: `[[...segmentName]]`.
 
 For example, `pages/shop/[[...slug]].js` will **also** match `/shop`, in addition to `/shop/clothes`, `/shop/clothes/tops`, `/shop/clothes/tops/t-shirts`.
 


### PR DESCRIPTION
### What?

Update documentation on dynamic routing to clarify the use of segment names within file names, rather than referring to them as "folder names".

### Why?

The original documentation used the example term `folderName` when it was referencing dynamic segment names within filenames.  The paths being described here are file names but not folders, and end in a file extension.  This could confuse readers and developers, especially those new to Next.js, leading to potential misunderstandings and misconfigurations.  Perhaps folderName was a relic of a different example wrapping a folder name to do a nested path or other configuration?  But here it seems out of place.

### How?

- Reviewed the provided documentation sections on dynamic routing.
- Replaced references to "folderName" with a different term "segmentName". 
- Ensured the examples provided in the documentation correctly showcase the use of segment names within filenames.