### PR TITLE
misc: split app-render into smaller functions

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -33,14 +33,14 @@ export function createMetadataComponents({
   pathname,
   searchParams,
   getDynamicParamFromSegment,
-  appUsingSizeAdjust,
+  appUsingSizeAdjustment,
   errorType,
 }: {
   tree: LoaderTree
   pathname: string
   searchParams: { [key: string]: any }
   getDynamicParamFromSegment: GetDynamicParamFromSegment
-  appUsingSizeAdjust: boolean
+  appUsingSizeAdjustment: boolean
   errorType?: 'not-found' | 'redirect'
 }): [React.ComponentType, React.ComponentType] {
   const metadataContext = {
@@ -110,7 +110,7 @@ export function createMetadataComponents({
       IconsMetadata({ icons: metadata.icons }),
     ])
 
-    if (appUsingSizeAdjust) elements.push(<meta name="next-size-adjust" />)
+    if (appUsingSizeAdjustment) elements.push(<meta name="next-size-adjust" />)
 
     return (
       <>

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -37,6 +37,7 @@ import {
   NEXT_CACHE_REVALIDATED_TAGS_HEADER,
   NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
 } from '../../lib/constants'
+import type { AppRenderContext, GenerateFlight } from './app-render'
 
 function nodeToWebReadableStream(nodeReadable: import('stream').Readable) {
   if (process.env.NEXT_RUNTIME !== 'edge') {
@@ -246,21 +247,18 @@ export async function handleAction({
   staticGenerationStore,
   requestStore,
   serverActionsBodySizeLimit,
+  ctx,
 }: {
   req: IncomingMessage
   res: ServerResponse
   ComponentMod: any
   page: string
   serverActionsManifest: any
-  generateFlight: (options: {
-    actionResult: ActionResult
-    formState?: any
-    skipFlight: boolean
-    asNotFound?: boolean
-  }) => Promise<RenderResult>
+  generateFlight: GenerateFlight
   staticGenerationStore: StaticGenerationStore
   requestStore: RequestStore
   serverActionsBodySizeLimit?: SizeLimit
+  ctx: AppRenderContext
 }): Promise<
   | undefined
   | {
@@ -449,7 +447,7 @@ export async function handleAction({
             requestStore,
           })
 
-          actionResult = await generateFlight({
+          actionResult = await generateFlight(ctx, {
             actionResult: Promise.resolve(returnVal),
             // if the page was not revalidated, we can skip the rendering the flight tree
             skipFlight: !staticGenerationStore.pathWasRevalidated,

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -21,7 +21,6 @@ import {
 import RenderResult from '../render-result'
 import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
 import { FlightRenderResult } from './flight-render-result'
-import type { ActionResult } from './types'
 import type { ActionAsyncStorage } from '../../client/components/action-async-storage.external'
 import {
   filterReqHeaders,
@@ -514,7 +513,7 @@ export async function handleAction({
           } catch {}
           return {
             type: 'done',
-            result: await generateFlight({
+            result: await generateFlight(ctx, {
               skipFlight: false,
               actionResult: promise,
               asNotFound: true,
@@ -536,7 +535,7 @@ export async function handleAction({
 
         return {
           type: 'done',
-          result: await generateFlight({
+          result: await generateFlight(ctx, {
             actionResult: promise,
             // if the page was not revalidated, we can skip the rendering the flight tree
             skipFlight: !staticGenerationStore.pathWasRevalidated,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1,10 +1,8 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import type {
   ActionResult,
-  ChildProp,
   DynamicParamTypesShort,
   FlightData,
-  FlightDataPath,
   FlightRouterState,
   FlightSegmentPath,
   RenderOpts,
@@ -25,10 +23,7 @@ import {
   streamToBufferedResult,
   cloneTransformStream,
 } from '../stream-utils/node-web-streams-helper'
-import {
-  canSegmentBeOverridden,
-  matchSegment,
-} from '../../client/components/match-segments'
+import { canSegmentBeOverridden } from '../../client/components/match-segments'
 import { stripInternalQueries } from '../internal-utils'
 import {
   NEXT_ROUTER_PREFETCH,
@@ -38,8 +33,6 @@ import {
 import { createMetadataComponents } from '../../lib/metadata/metadata'
 import { RequestAsyncStorageWrapper } from '../async-storage/request-async-storage-wrapper'
 import { StaticGenerationAsyncStorageWrapper } from '../async-storage/static-generation-async-storage-wrapper'
-import { isClientReference } from '../../lib/client-reference'
-import { getLayoutOrPageModule } from '../lib/app-dir-module'
 import type { LoaderTree } from '../lib/app-dir-module'
 import { isNotFoundError } from '../../client/components/not-found'
 import {
@@ -51,9 +44,8 @@ import { addImplicitTags, patchFetch } from '../lib/patch-fetch'
 import { AppRenderSpan } from '../lib/trace/constants'
 import { getTracer } from '../lib/trace/tracer'
 import { interopDefault } from './interop-default'
-import { preloadComponent } from './preload-component'
 import { FlightRenderResult } from './flight-render-result'
-import { createErrorHandler } from './create-error-handler'
+import { createErrorHandler, type ErrorHandler } from './create-error-handler'
 import {
   getShortDynamicParamType,
   dynamicParamTypes,
@@ -62,13 +54,9 @@ import { getSegmentParam } from './get-segment-param'
 import { getCssInlinedLinkTags } from './get-css-inlined-link-tags'
 import { getPreloadableFonts } from './get-preloadable-fonts'
 import { getScriptNonceFromHeader } from './get-script-nonce-from-header'
-import { renderToString } from './render-to-string'
 import { parseAndValidateFlightRouterState } from './parse-and-validate-flight-router-state'
 import { validateURL } from './validate-url'
-import {
-  addSearchParamsIfPageSegment,
-  createFlightRouterStateFromLoaderTree,
-} from './create-flight-router-state-from-loader-tree'
+import { createFlightRouterStateFromLoaderTree } from './create-flight-router-state-from-loader-tree'
 import { handleAction } from './action-handler'
 import { NEXT_DYNAMIC_NO_SSR_CODE } from '../../shared/lib/lazy-dynamic/no-ssr-error'
 import { warn } from '../../build/output/log'
@@ -76,6 +64,11 @@ import { appendMutableCookies } from '../web/spec-extension/adapters/request-coo
 import { createServerInsertedHTML } from './server-inserted-html'
 import { getRequiredScripts } from './required-scripts'
 import { addPathPrefix } from '../../shared/lib/router/utils/add-path-prefix'
+import type { AppPageModule } from '../future/route-modules/app-page/module'
+import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
+import { makeGetServerInsertedHTML } from './make-get-server-inserted-html'
+import { walkTreeWithFlightRouterState } from './walk-tree-with-flight-router-state'
+import { createComponentTree } from './create-component-tree'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -86,6 +79,37 @@ export type GetDynamicParamFromSegment = (
   treeSegment: Segment
   type: DynamicParamTypesShort
 } | null
+
+type AppRenderBaseContext = {
+  staticGenerationStore: StaticGenerationStore
+  requestStore: RequestStore
+  componentMod: AppPageModule
+  renderOpts: RenderOpts
+}
+
+// TODO-APP: improve type
+type ServerContext = [string, any]
+
+export type AppRenderContext = AppRenderBaseContext & {
+  getDynamicParamFromSegment: GetDynamicParamFromSegment
+  query: NextParsedUrlQuery
+  isPrefetch: boolean
+  providedSearchParams: NextParsedUrlQuery
+  requestTimestamp: number
+  searchParamsProps: { searchParams: NextParsedUrlQuery }
+  appUsingSizeAdjustment: boolean
+  providedFlightRouterState?: FlightRouterState
+  requestId: string
+  defaultRevalidate: StaticGenerationStore['revalidate']
+  pagePath: string
+  clientReferenceManifest: ClientReferenceManifest
+  assetPrefix: string
+  serverContexts: ServerContext[]
+  flightDataRendererErrorHandler: ErrorHandler
+  serverComponentsErrorHandler: ErrorHandler
+  isNotFoundPath: boolean
+  res: ServerResponse
+}
 
 function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
   // Align the segment with parallel-route-default in next-app-loader
@@ -142,7 +166,7 @@ function findDynamicParamFromRouterState(
   return null
 }
 
-function hasLoadingComponentInTree(tree: LoaderTree): boolean {
+export function hasLoadingComponentInTree(tree: LoaderTree): boolean {
   const [, parallelRoutes, { loading }] = tree
 
   if (loading) {
@@ -154,19 +178,395 @@ function hasLoadingComponentInTree(tree: LoaderTree): boolean {
   ) as boolean
 }
 
-type AppRenderContext = {
-  staticGenerationStore: StaticGenerationStore
-  requestStore: RequestStore
+export type CreateSegmentPath = (child: FlightSegmentPath) => FlightSegmentPath
+
+function getAssetQueryString(ctx: AppRenderContext, addTimestamp: boolean) {
+  const isDev = process.env.NODE_ENV === 'development'
+  let qs = ''
+
+  if (isDev && addTimestamp) {
+    qs += `?v=${ctx.requestTimestamp}`
+  }
+
+  if (ctx.renderOpts.deploymentId) {
+    qs += `${isDev ? '&' : '?'}dpl=${ctx.renderOpts.deploymentId}`
+  }
+  return qs
 }
 
-const wrappedRender = async (
+/**
+ * Returns a function that parses the dynamic segment and return the associated value.
+ */
+function makeGetDynamicParamFromSegment(
+  params: { [key: string]: any },
+  providedFlightRouterState: FlightRouterState | undefined
+): GetDynamicParamFromSegment {
+  return function getDynamicParamFromSegment(
+    // [slug] / [[slug]] / [...slug]
+    segment: string
+  ) {
+    const segmentParam = getSegmentParam(segment)
+    if (!segmentParam) {
+      return null
+    }
+
+    const key = segmentParam.param
+
+    let value = params[key]
+
+    // this is a special marker that will be present for interception routes
+    if (value === '__NEXT_EMPTY_PARAM__') {
+      value = undefined
+    }
+
+    if (Array.isArray(value)) {
+      value = value.map((i) => encodeURIComponent(i))
+    } else if (typeof value === 'string') {
+      value = encodeURIComponent(value)
+    }
+
+    if (!value) {
+      // Handle case where optional catchall does not have a value, e.g. `/dashboard/[...slug]` when requesting `/dashboard`
+      if (segmentParam.type === 'optional-catchall') {
+        const type = dynamicParamTypes[segmentParam.type]
+        return {
+          param: key,
+          value: null,
+          type: type,
+          // This value always has to be a string.
+          treeSegment: [key, '', type],
+        }
+      }
+      return findDynamicParamFromRouterState(providedFlightRouterState, segment)
+    }
+
+    const type = getShortDynamicParamType(segmentParam.type)
+
+    return {
+      param: key,
+      // The value that is passed to user code.
+      value: value,
+      // The value that is rendered in the router tree.
+      treeSegment: [key, Array.isArray(value) ? value.join('/') : value, type],
+      type: type,
+    }
+  }
+}
+
+export async function createComponentAndStyles({
+  filePath,
+  getComponent,
+  injectedCSS,
+  ctx,
+}: {
+  filePath: string
+  getComponent: () => any
+  injectedCSS: Set<string>
+  ctx: AppRenderContext
+}): Promise<any> {
+  const cssHrefs = getCssInlinedLinkTags(
+    ctx.clientReferenceManifest,
+    filePath,
+    injectedCSS
+  )
+
+  const styles = cssHrefs
+    ? cssHrefs.map((href, index) => {
+        // In dev, Safari and Firefox will cache the resource during HMR:
+        // - https://github.com/vercel/next.js/issues/5860
+        // - https://bugs.webkit.org/show_bug.cgi?id=187726
+        // Because of this, we add a `?v=` query to bypass the cache during
+        // development. We need to also make sure that the number is always
+        // increasing.
+        const fullHref = `${ctx.assetPrefix}/_next/${href}${getAssetQueryString(
+          ctx,
+          true
+        )}`
+
+        // `Precedence` is an opt-in signal for React to handle resource
+        // loading and deduplication, etc. It's also used as the key to sort
+        // resources so they will be injected in the correct order.
+        // During HMR, it's critical to use different `precedence` values
+        // for different stylesheets, so their order will be kept.
+        // https://github.com/facebook/react/pull/25060
+        const precedence =
+          process.env.NODE_ENV === 'development' ? 'next_' + href : 'next'
+
+        return (
+          <link
+            rel="stylesheet"
+            href={fullHref}
+            // @ts-ignore
+            precedence={precedence}
+            crossOrigin={ctx.renderOpts.crossOrigin}
+            key={index}
+          />
+        )
+      })
+    : null
+
+  const Comp = interopDefault(await getComponent())
+
+  return [Comp, styles]
+}
+
+export function getLayerAssets({
+  ctx,
+  layoutOrPagePath,
+  injectedCSS: injectedCSSWithCurrentLayout,
+  injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
+}: {
+  layoutOrPagePath: string | undefined
+  injectedCSS: Set<string>
+  injectedFontPreloadTags: Set<string>
+  ctx: AppRenderContext
+}): React.ReactNode {
+  const stylesheets: string[] = layoutOrPagePath
+    ? getCssInlinedLinkTags(
+        ctx.clientReferenceManifest,
+        layoutOrPagePath,
+        injectedCSSWithCurrentLayout,
+        true
+      )
+    : []
+
+  const preloadedFontFiles = layoutOrPagePath
+    ? getPreloadableFonts(
+        ctx.renderOpts.nextFontManifest,
+        layoutOrPagePath,
+        injectedFontPreloadTagsWithCurrentLayout
+      )
+    : null
+
+  if (preloadedFontFiles) {
+    if (preloadedFontFiles.length) {
+      for (let i = 0; i < preloadedFontFiles.length; i++) {
+        const fontFilename = preloadedFontFiles[i]
+        const ext = /\.(woff|woff2|eot|ttf|otf)$/.exec(fontFilename)![1]
+        const type = `font/${ext}`
+        const href = `${ctx.assetPrefix}/_next/${fontFilename}`
+        ctx.componentMod.preloadFont(href, type, ctx.renderOpts.crossOrigin)
+      }
+    } else {
+      try {
+        let url = new URL(ctx.assetPrefix)
+        ctx.componentMod.preconnect(url.origin, 'anonymous')
+      } catch (error) {
+        // assetPrefix must not be a fully qualified domain name. We assume
+        // we should preconnect to same origin instead
+        ctx.componentMod.preconnect('/', 'anonymous')
+      }
+    }
+  }
+
+  const styles = stylesheets
+    ? stylesheets.map((href, index) => {
+        // In dev, Safari and Firefox will cache the resource during HMR:
+        // - https://github.com/vercel/next.js/issues/5860
+        // - https://bugs.webkit.org/show_bug.cgi?id=187726
+        // Because of this, we add a `?v=` query to bypass the cache during
+        // development. We need to also make sure that the number is always
+        // increasing.
+        const fullHref = `${ctx.assetPrefix}/_next/${href}${getAssetQueryString(
+          ctx,
+          true
+        )}`
+
+        // `Precedence` is an opt-in signal for React to handle resource
+        // loading and deduplication, etc. It's also used as the key to sort
+        // resources so they will be injected in the correct order.
+        // During HMR, it's critical to use different `precedence` values
+        // for different stylesheets, so their order will be kept.
+        // https://github.com/facebook/react/pull/25060
+        const precedence =
+          process.env.NODE_ENV === 'development' ? 'next_' + href : 'next'
+
+        ctx.componentMod.preloadStyle(fullHref, ctx.renderOpts.crossOrigin)
+
+        return (
+          <link
+            rel="stylesheet"
+            href={fullHref}
+            // @ts-ignore
+            precedence={precedence}
+            crossOrigin={ctx.renderOpts.crossOrigin}
+            key={index}
+          />
+        )
+      })
+    : null
+
+  return styles
+}
+
+export type GenerateFlight = typeof generateFlight
+
+// Handle Flight render request. This is only used when client-side navigating. E.g. when you `router.push('/dashboard')` or `router.reload()`.
+async function generateFlight(
+  ctx: AppRenderContext,
+  options?: {
+    actionResult: ActionResult
+    skipFlight: boolean
+    asNotFound?: boolean
+  }
+): Promise<RenderResult> {
+  // Flight data that is going to be passed to the browser.
+  // Currently a single item array but in the future multiple patches might be combined in a single request.
+  let flightData: FlightData | null = null
+
+  const {
+    componentMod: { tree: loaderTree, renderToReadableStream },
+    getDynamicParamFromSegment,
+    appUsingSizeAdjustment,
+    staticGenerationStore: { urlPathname },
+    providedSearchParams,
+    requestId,
+    providedFlightRouterState,
+  } = ctx
+
+  if (!options?.skipFlight) {
+    const [MetadataTree, MetadataOutlet] = createMetadataComponents({
+      tree: loaderTree,
+      pathname: urlPathname,
+      searchParams: providedSearchParams,
+      getDynamicParamFromSegment,
+      appUsingSizeAdjustment,
+    })
+    flightData = (
+      await walkTreeWithFlightRouterState({
+        ctx,
+        createSegmentPath: (child) => child,
+        loaderTreeToFilter: loaderTree,
+        parentParams: {},
+        flightRouterState: providedFlightRouterState,
+        isFirst: true,
+        // For flight, render metadata inside leaf page
+        rscPayloadHead: (
+          // Adding requestId as react key to make metadata remount for each render
+          <MetadataTree key={requestId} />
+        ),
+        injectedCSS: new Set(),
+        injectedFontPreloadTags: new Set(),
+        rootLayoutIncluded: false,
+        asNotFound: ctx.isNotFoundPath || options?.asNotFound,
+        metadataOutlet: <MetadataOutlet />,
+      })
+    ).map((path) => path.slice(1)) // remove the '' (root) segment
+  }
+
+  const buildIdFlightDataPair = [ctx.renderOpts.buildId, flightData]
+
+  // For app dir, use the bundled version of Flight server renderer (renderToReadableStream)
+  // which contains the subset React.
+  const flightReadableStream = renderToReadableStream(
+    options
+      ? [options.actionResult, buildIdFlightDataPair]
+      : buildIdFlightDataPair,
+    ctx.clientReferenceManifest.clientModules,
+    {
+      context: ctx.serverContexts,
+      onError: ctx.flightDataRendererErrorHandler,
+    }
+  ).pipeThrough(createBufferedTransformStream())
+
+  return new FlightRenderResult(flightReadableStream)
+}
+
+/**
+ * A new React Component that renders the provided React Component
+ * using Flight which can then be rendered to HTML.
+ */
+function createServerComponentsRenderer(
+  ctx: AppRenderContext,
+  loaderTreeToRender: LoaderTree,
+  preinitScripts: () => void,
+  formState: null | any,
+  serverComponentsRenderOpts: any,
+  nonce: string | undefined
+) {
+  return createServerComponentRenderer<{
+    asNotFound: boolean
+  }>(
+    async (props) => {
+      preinitScripts()
+      // Create full component tree from root to leaf.
+      const injectedCSS = new Set<string>()
+      const injectedFontPreloadTags = new Set<string>()
+      const {
+        getDynamicParamFromSegment,
+        query,
+        providedSearchParams,
+        appUsingSizeAdjustment,
+        componentMod: { AppRouter, GlobalError },
+        staticGenerationStore: { urlPathname },
+      } = ctx
+      const initialTree = createFlightRouterStateFromLoaderTree(
+        loaderTreeToRender,
+        getDynamicParamFromSegment,
+        query
+      )
+
+      const [MetadataTree, MetadataOutlet] = createMetadataComponents({
+        tree: loaderTreeToRender,
+        errorType: props.asNotFound ? 'not-found' : undefined,
+        pathname: urlPathname,
+        searchParams: providedSearchParams,
+        getDynamicParamFromSegment: getDynamicParamFromSegment,
+        appUsingSizeAdjustment: appUsingSizeAdjustment,
+      })
+
+      const { Component: ComponentTree, styles } = await createComponentTree({
+        ctx,
+        createSegmentPath: (child) => child,
+        loaderTree: loaderTreeToRender,
+        parentParams: {},
+        firstItem: true,
+        injectedCSS,
+        injectedFontPreloadTags,
+        rootLayoutIncluded: false,
+        asNotFound: props.asNotFound,
+        metadataOutlet: <MetadataOutlet />,
+      })
+
+      return (
+        <>
+          {styles}
+          <AppRouter
+            buildId={ctx.renderOpts.buildId}
+            assetPrefix={ctx.assetPrefix}
+            initialCanonicalUrl={urlPathname}
+            initialTree={initialTree}
+            initialHead={
+              <>
+                {ctx.res.statusCode > 400 && (
+                  <meta name="robots" content="noindex" />
+                )}
+                {/* Adding requestId as react key to make metadata remount for each render */}
+                <MetadataTree key={ctx.requestId} />
+              </>
+            }
+            globalErrorComponent={GlobalError}
+          >
+            <ComponentTree />
+          </AppRouter>
+        </>
+      )
+    },
+    ctx.componentMod,
+    { ...serverComponentsRenderOpts, formState },
+    ctx.serverComponentsErrorHandler,
+    nonce
+  )
+}
+
+async function renderToHTMLOrFlightImpl(
   req: IncomingMessage,
   res: ServerResponse,
   pagePath: string,
   query: NextParsedUrlQuery,
   renderOpts: RenderOpts,
-  ctx: AppRenderContext
-) => {
+  baseCtx: AppRenderBaseContext
+) {
   const isFlight = req.headers[RSC.toLowerCase()] !== undefined
   const isNotFoundPath = pagePath === '/404'
 
@@ -174,7 +574,7 @@ const wrappedRender = async (
   // consistent and won't change during this request. This is important to
   // avoid that resources can be deduped by React Float if the same resource is
   // rendered or preloaded multiple times: `<link href="a.css?v={Date.now()}"/>`.
-  const DEV_REQUEST_TS = Date.now()
+  const requestTimestamp = Date.now()
 
   const {
     buildManifest,
@@ -184,10 +584,8 @@ const wrappedRender = async (
     dev,
     nextFontManifest,
     supportsDynamicHTML,
-    nextConfigOutput,
     serverActionsBodySizeLimit,
     buildId,
-    deploymentId,
     appDirDevErrorLogger,
     assetPrefix = '',
   } = renderOpts
@@ -204,7 +602,7 @@ const wrappedRender = async (
 
   const extraRenderResultMeta: RenderResultMetadata = {}
 
-  const appUsingSizeAdjust = !!nextFontManifest?.appUsingSizeAdjust
+  const appUsingSizeAdjustment = !!nextFontManifest?.appUsingSizeAdjust
 
   // TODO: fix this typescript
   const clientReferenceManifest = renderOpts.clientReferenceManifest!
@@ -254,23 +652,13 @@ const wrappedRender = async (
 
   // Pull out the hooks/references from the component.
   const {
-    staticGenerationBailout,
-    LayoutRouter,
-    RenderFromTemplateContext,
     createSearchParamsBailoutProxy,
-    StaticGenerationSearchParamsBailoutProvider,
-    serverHooks: { DynamicServerError },
-    NotFoundBoundary,
-    renderToReadableStream,
     AppRouter,
     GlobalError,
     tree: loaderTree,
-    preloadFont,
-    preconnect,
-    preloadStyle,
   } = ComponentMod
 
-  const { staticGenerationStore, requestStore } = ctx
+  const { staticGenerationStore, requestStore } = baseCtx
   const { urlPathname } = staticGenerationStore
 
   staticGenerationStore.fetchMetrics = []
@@ -296,7 +684,6 @@ const wrappedRender = async (
    * The metadata items array created in next-app-loader with all relevant information
    * that we need to resolve the final metadata.
    */
-
   let requestId: string
 
   if (process.env.NEXT_RUNTIME === 'edge') {
@@ -317,955 +704,44 @@ const wrappedRender = async (
    * It has to hold values that can't change while rendering from the common layout down.
    * An example of this would be that `headers` are available but `searchParams` are not because that'd mean we have to render from the root layout down on all requests.
    */
-
   const serverContexts: Array<[string, any]> = [
     ['WORKAROUND', null], // TODO-APP: First value has a bug currently where the value is not set on the second request: https://github.com/facebook/react/issues/24849
   ]
-
-  type CreateSegmentPath = (child: FlightSegmentPath) => FlightSegmentPath
 
   /**
    * Dynamic parameters. E.g. when you visit `/dashboard/vercel` which is rendered by `/dashboard/[slug]` the value will be {"slug": "vercel"}.
    */
   const params = renderOpts.params ?? {}
 
-  /**
-   * Parse the dynamic segment and return the associated value.
-   */
-  const getDynamicParamFromSegment: GetDynamicParamFromSegment = (
-    // [slug] / [[slug]] / [...slug]
-    segment: string
-  ) => {
-    const segmentParam = getSegmentParam(segment)
-    if (!segmentParam) {
-      return null
-    }
-
-    const key = segmentParam.param
-
-    let value = params[key]
-
-    // this is a special marker that will be present for interception routes
-    if (value === '__NEXT_EMPTY_PARAM__') {
-      value = undefined
-    }
-
-    if (Array.isArray(value)) {
-      value = value.map((i) => encodeURIComponent(i))
-    } else if (typeof value === 'string') {
-      value = encodeURIComponent(value)
-    }
-
-    if (!value) {
-      // Handle case where optional catchall does not have a value, e.g. `/dashboard/[...slug]` when requesting `/dashboard`
-      if (segmentParam.type === 'optional-catchall') {
-        const type = dynamicParamTypes[segmentParam.type]
-        return {
-          param: key,
-          value: null,
-          type: type,
-          // This value always has to be a string.
-          treeSegment: [key, '', type],
-        }
-      }
-      return findDynamicParamFromRouterState(providedFlightRouterState, segment)
-    }
-
-    const type = getShortDynamicParamType(segmentParam.type)
-
-    return {
-      param: key,
-      // The value that is passed to user code.
-      value: value,
-      // The value that is rendered in the router tree.
-      treeSegment: [key, Array.isArray(value) ? value.join('/') : value, type],
-      type: type,
-    }
-  }
-
-  let defaultRevalidate: false | undefined | number = false
-
-  const getAssetQueryString = (addTimestamp: boolean) => {
-    const isDev = process.env.NODE_ENV === 'development'
-    let qs = ''
-
-    if (isDev && addTimestamp) {
-      qs += `?v=${DEV_REQUEST_TS}`
-    }
-
-    if (deploymentId) {
-      qs += `${isDev ? '&' : '?'}dpl=${deploymentId}`
-    }
-    return qs
-  }
-
-  const createComponentAndStyles = async ({
-    filePath,
-    getComponent,
-    injectedCSS,
-  }: {
-    filePath: string
-    getComponent: () => any
-    injectedCSS: Set<string>
-  }): Promise<any> => {
-    const cssHrefs = getCssInlinedLinkTags(
-      clientReferenceManifest,
-      filePath,
-      injectedCSS
-    )
-
-    const styles = cssHrefs
-      ? cssHrefs.map((href, index) => {
-          // In dev, Safari and Firefox will cache the resource during HMR:
-          // - https://github.com/vercel/next.js/issues/5860
-          // - https://bugs.webkit.org/show_bug.cgi?id=187726
-          // Because of this, we add a `?v=` query to bypass the cache during
-          // development. We need to also make sure that the number is always
-          // increasing.
-          const fullHref = `${assetPrefix}/_next/${href}${getAssetQueryString(
-            true
-          )}`
-
-          // `Precedence` is an opt-in signal for React to handle resource
-          // loading and deduplication, etc. It's also used as the key to sort
-          // resources so they will be injected in the correct order.
-          // During HMR, it's critical to use different `precedence` values
-          // for different stylesheets, so their order will be kept.
-          // https://github.com/facebook/react/pull/25060
-          const precedence =
-            process.env.NODE_ENV === 'development' ? 'next_' + href : 'next'
-
-          return (
-            <link
-              rel="stylesheet"
-              href={fullHref}
-              // @ts-ignore
-              precedence={precedence}
-              crossOrigin={renderOpts.crossOrigin}
-              key={index}
-            />
-          )
-        })
-      : null
-
-    const Comp = interopDefault(await getComponent())
-
-    return [Comp, styles]
-  }
-
-  const getLayerAssets = ({
-    layoutOrPagePath,
-    injectedCSS: injectedCSSWithCurrentLayout,
-    injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
-  }: {
-    layoutOrPagePath: string | undefined
-    injectedCSS: Set<string>
-    injectedFontPreloadTags: Set<string>
-  }): React.ReactNode => {
-    const stylesheets: string[] = layoutOrPagePath
-      ? getCssInlinedLinkTags(
-          clientReferenceManifest,
-          layoutOrPagePath,
-          injectedCSSWithCurrentLayout,
-          true
-        )
-      : []
-
-    const preloadedFontFiles = layoutOrPagePath
-      ? getPreloadableFonts(
-          nextFontManifest,
-          layoutOrPagePath,
-          injectedFontPreloadTagsWithCurrentLayout
-        )
-      : null
-
-    if (preloadedFontFiles) {
-      if (preloadedFontFiles.length) {
-        for (let i = 0; i < preloadedFontFiles.length; i++) {
-          const fontFilename = preloadedFontFiles[i]
-          const ext = /\.(woff|woff2|eot|ttf|otf)$/.exec(fontFilename)![1]
-          const type = `font/${ext}`
-          const href = `${assetPrefix}/_next/${fontFilename}`
-          preloadFont(href, type, renderOpts.crossOrigin)
-        }
-      } else {
-        try {
-          let url = new URL(assetPrefix)
-          preconnect(url.origin, 'anonymous')
-        } catch (error) {
-          // assetPrefix must not be a fully qualified domain name. We assume
-          // we should preconnect to same origin instead
-          preconnect('/', 'anonymous')
-        }
-      }
-    }
-
-    const styles = stylesheets
-      ? stylesheets.map((href, index) => {
-          // In dev, Safari and Firefox will cache the resource during HMR:
-          // - https://github.com/vercel/next.js/issues/5860
-          // - https://bugs.webkit.org/show_bug.cgi?id=187726
-          // Because of this, we add a `?v=` query to bypass the cache during
-          // development. We need to also make sure that the number is always
-          // increasing.
-          const fullHref = `${assetPrefix}/_next/${href}${getAssetQueryString(
-            true
-          )}`
-
-          // `Precedence` is an opt-in signal for React to handle resource
-          // loading and deduplication, etc. It's also used as the key to sort
-          // resources so they will be injected in the correct order.
-          // During HMR, it's critical to use different `precedence` values
-          // for different stylesheets, so their order will be kept.
-          // https://github.com/facebook/react/pull/25060
-          const precedence =
-            process.env.NODE_ENV === 'development' ? 'next_' + href : 'next'
-
-          preloadStyle(fullHref, renderOpts.crossOrigin)
-
-          return (
-            <link
-              rel="stylesheet"
-              href={fullHref}
-              // @ts-ignore
-              precedence={precedence}
-              crossOrigin={renderOpts.crossOrigin}
-              key={index}
-            />
-          )
-        })
-      : null
-
-    return styles
-  }
-
-  const parseLoaderTree = (tree: LoaderTree) => {
-    const [segment, parallelRoutes, components] = tree
-    const { layout } = components
-    let { page } = components
-    // a __DEFAULT__ segment means that this route didn't match any of the
-    // segments in the route, so we should use the default page
-
-    page = segment === '__DEFAULT__' ? components.defaultPage : page
-
-    const layoutOrPagePath = layout?.[1] || page?.[1]
-
-    return {
-      page,
-      segment,
-      components,
-      layoutOrPagePath,
-      parallelRoutes,
-    }
-  }
-
-  /**
-   * Use the provided loader tree to create the React Component tree.
-   */
-  const createComponentTree = async ({
-    createSegmentPath,
-    loaderTree: tree,
-    parentParams,
-    firstItem,
-    rootLayoutIncluded,
-    injectedCSS,
-    injectedFontPreloadTags,
-    asNotFound,
-    metadataOutlet,
-  }: {
-    createSegmentPath: CreateSegmentPath
-    loaderTree: LoaderTree
-    parentParams: { [key: string]: any }
-    rootLayoutIncluded: boolean
-    firstItem?: boolean
-    injectedCSS: Set<string>
-    injectedFontPreloadTags: Set<string>
-    asNotFound?: boolean
-    metadataOutlet?: React.ReactNode
-  }): Promise<{
-    Component: React.ComponentType
-    styles: React.ReactNode
-  }> => {
-    const { page, layoutOrPagePath, segment, components, parallelRoutes } =
-      parseLoaderTree(tree)
-
-    const {
-      layout,
-      template,
-      error,
-      loading,
-      'not-found': notFound,
-    } = components
-
-    const injectedCSSWithCurrentLayout = new Set(injectedCSS)
-    const injectedFontPreloadTagsWithCurrentLayout = new Set(
-      injectedFontPreloadTags
-    )
-
-    const styles = getLayerAssets({
-      layoutOrPagePath,
-      injectedCSS: injectedCSSWithCurrentLayout,
-      injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
-    })
-
-    const [Template, templateStyles] = template
-      ? await createComponentAndStyles({
-          filePath: template[1],
-          getComponent: template[0],
-          injectedCSS: injectedCSSWithCurrentLayout,
-        })
-      : [React.Fragment]
-
-    const [ErrorComponent, errorStyles] = error
-      ? await createComponentAndStyles({
-          filePath: error[1],
-          getComponent: error[0],
-          injectedCSS: injectedCSSWithCurrentLayout,
-        })
-      : []
-
-    const [Loading, loadingStyles] = loading
-      ? await createComponentAndStyles({
-          filePath: loading[1],
-          getComponent: loading[0],
-          injectedCSS: injectedCSSWithCurrentLayout,
-        })
-      : []
-
-    const isLayout = typeof layout !== 'undefined'
-    const isPage = typeof page !== 'undefined'
-    const [layoutOrPageMod] = await getLayoutOrPageModule(tree)
-
-    /**
-     * Checks if the current segment is a root layout.
-     */
-    const rootLayoutAtThisLevel = isLayout && !rootLayoutIncluded
-    /**
-     * Checks if the current segment or any level above it has a root layout.
-     */
-    const rootLayoutIncludedAtThisLevelOrAbove =
-      rootLayoutIncluded || rootLayoutAtThisLevel
-
-    const [NotFound, notFoundStyles] = notFound
-      ? await createComponentAndStyles({
-          filePath: notFound[1],
-          getComponent: notFound[0],
-          injectedCSS: injectedCSSWithCurrentLayout,
-        })
-      : []
-
-    let dynamic = layoutOrPageMod?.dynamic
-
-    if (nextConfigOutput === 'export') {
-      if (!dynamic || dynamic === 'auto') {
-        dynamic = 'error'
-      } else if (dynamic === 'force-dynamic') {
-        staticGenerationStore.forceDynamic = true
-        staticGenerationStore.dynamicShouldError = true
-        staticGenerationBailout(`output: export`, {
-          dynamic,
-          link: 'https://nextjs.org/docs/advanced-features/static-html-export',
-        })
-      }
-    }
-
-    if (typeof dynamic === 'string') {
-      // the nested most config wins so we only force-static
-      // if it's configured above any parent that configured
-      // otherwise
-      if (dynamic === 'error') {
-        staticGenerationStore.dynamicShouldError = true
-      } else if (dynamic === 'force-dynamic') {
-        staticGenerationStore.forceDynamic = true
-        staticGenerationBailout(`force-dynamic`, { dynamic })
-      } else {
-        staticGenerationStore.dynamicShouldError = false
-        if (dynamic === 'force-static') {
-          staticGenerationStore.forceStatic = true
-        } else {
-          staticGenerationStore.forceStatic = false
-        }
-      }
-    }
-
-    if (typeof layoutOrPageMod?.fetchCache === 'string') {
-      staticGenerationStore.fetchCache = layoutOrPageMod?.fetchCache
-    }
-
-    if (typeof layoutOrPageMod?.revalidate === 'number') {
-      defaultRevalidate = layoutOrPageMod.revalidate as number
-
-      if (
-        typeof staticGenerationStore.revalidate === 'undefined' ||
-        (typeof staticGenerationStore.revalidate === 'number' &&
-          staticGenerationStore.revalidate > defaultRevalidate)
-      ) {
-        staticGenerationStore.revalidate = defaultRevalidate
-      }
-
-      if (staticGenerationStore.isStaticGeneration && defaultRevalidate === 0) {
-        const dynamicUsageDescription = `revalidate: 0 configured ${segment}`
-        staticGenerationStore.dynamicUsageDescription = dynamicUsageDescription
-
-        throw new DynamicServerError(dynamicUsageDescription)
-      }
-    }
-
-    if (staticGenerationStore?.dynamicUsageErr) {
-      throw staticGenerationStore.dynamicUsageErr
-    }
-
-    const LayoutOrPage = layoutOrPageMod
-      ? interopDefault(layoutOrPageMod)
-      : undefined
-
-    /**
-     * The React Component to render.
-     */
-    let Component = LayoutOrPage
-    const parallelKeys = Object.keys(parallelRoutes)
-    const hasSlotKey = parallelKeys.length > 1
-
-    if (hasSlotKey && rootLayoutAtThisLevel) {
-      Component = (componentProps: any) => {
-        const NotFoundComponent = NotFound
-        const RootLayoutComponent = LayoutOrPage
-        return (
-          <NotFoundBoundary
-            notFound={
-              <>
-                {styles}
-                <RootLayoutComponent>
-                  {notFoundStyles}
-                  <NotFoundComponent />
-                </RootLayoutComponent>
-              </>
-            }
-          >
-            <RootLayoutComponent {...componentProps} />
-          </NotFoundBoundary>
-        )
-      }
-    }
-
-    if (dev) {
-      const { isValidElementType } = require('next/dist/compiled/react-is')
-      if (
-        (isPage || typeof Component !== 'undefined') &&
-        !isValidElementType(Component)
-      ) {
-        throw new Error(
-          `The default export is not a React Component in page: "${pagePath}"`
-        )
-      }
-
-      if (
-        typeof ErrorComponent !== 'undefined' &&
-        !isValidElementType(ErrorComponent)
-      ) {
-        throw new Error(
-          `The default export of error is not a React Component in page: ${segment}`
-        )
-      }
-
-      if (typeof Loading !== 'undefined' && !isValidElementType(Loading)) {
-        throw new Error(
-          `The default export of loading is not a React Component in ${segment}`
-        )
-      }
-
-      if (typeof NotFound !== 'undefined' && !isValidElementType(NotFound)) {
-        throw new Error(
-          `The default export of notFound is not a React Component in ${segment}`
-        )
-      }
-    }
-
-    // Handle dynamic segment params.
-    const segmentParam = getDynamicParamFromSegment(segment)
-    /**
-     * Create object holding the parent params and current params
-     */
-    const currentParams =
-      // Handle null case where dynamic param is optional
-      segmentParam && segmentParam.value !== null
-        ? {
-            ...parentParams,
-            [segmentParam.param]: segmentParam.value,
-          }
-        : // Pass through parent params to children
-          parentParams
-    // Resolve the segment param
-    const actualSegment = segmentParam ? segmentParam.treeSegment : segment
-
-    // This happens outside of rendering in order to eagerly kick off data fetching for layouts / the page further down
-    const parallelRouteMap = await Promise.all(
-      Object.keys(parallelRoutes).map(
-        async (parallelRouteKey): Promise<[string, React.ReactNode]> => {
-          const isChildrenRouteKey = parallelRouteKey === 'children'
-          const currentSegmentPath: FlightSegmentPath = firstItem
-            ? [parallelRouteKey]
-            : [actualSegment, parallelRouteKey]
-
-          const parallelRoute = parallelRoutes[parallelRouteKey]
-
-          const childSegment = parallelRoute[0]
-          const childSegmentParam = getDynamicParamFromSegment(childSegment)
-          const notFoundComponent =
-            NotFound && isChildrenRouteKey ? <NotFound /> : undefined
-
-          function getParallelRoutePair(
-            currentChildProp: ChildProp,
-            currentStyles: React.ReactNode
-          ): [string, React.ReactNode] {
-            // This is turned back into an object below.
-            return [
-              parallelRouteKey,
-              <LayoutRouter
-                parallelRouterKey={parallelRouteKey}
-                segmentPath={createSegmentPath(currentSegmentPath)}
-                loading={Loading ? <Loading /> : undefined}
-                loadingStyles={loadingStyles}
-                // TODO-APP: Add test for loading returning `undefined`. This currently can't be tested as the `webdriver()` tab will wait for the full page to load before returning.
-                hasLoading={Boolean(Loading)}
-                error={ErrorComponent}
-                errorStyles={errorStyles}
-                template={
-                  <Template>
-                    <RenderFromTemplateContext />
-                  </Template>
-                }
-                templateStyles={templateStyles}
-                notFound={notFoundComponent}
-                notFoundStyles={notFoundStyles}
-                childProp={currentChildProp}
-                styles={currentStyles}
-              />,
-            ]
-          }
-
-          // if we're prefetching and that there's a Loading component, we bail out
-          // otherwise we keep rendering for the prefetch.
-          // We also want to bail out if there's no Loading component in the tree.
-          let currentStyles = undefined
-          let childElement = null
-          const childPropSegment = addSearchParamsIfPageSegment(
-            childSegmentParam ? childSegmentParam.treeSegment : childSegment,
-            query
-          )
-          if (
-            !(
-              isPrefetch &&
-              (Loading || !hasLoadingComponentInTree(parallelRoute))
-            )
-          ) {
-            // Create the child component
-            const { Component: ChildComponent, styles: childComponentStyles } =
-              await createComponentTree({
-                createSegmentPath: (child) => {
-                  return createSegmentPath([...currentSegmentPath, ...child])
-                },
-                loaderTree: parallelRoute,
-                parentParams: currentParams,
-                rootLayoutIncluded: rootLayoutIncludedAtThisLevelOrAbove,
-                injectedCSS: injectedCSSWithCurrentLayout,
-                injectedFontPreloadTags:
-                  injectedFontPreloadTagsWithCurrentLayout,
-                asNotFound,
-                metadataOutlet,
-              })
-
-            currentStyles = childComponentStyles
-            childElement = <ChildComponent />
-          }
-
-          const childProp: ChildProp = {
-            current: childElement,
-            segment: childPropSegment,
-          }
-
-          return getParallelRoutePair(childProp, currentStyles)
-        }
-      )
-    )
-
-    // Convert the parallel route map into an object after all promises have been resolved.
-    const parallelRouteComponents = parallelRouteMap.reduce(
-      (list, [parallelRouteKey, Comp]) => {
-        list[parallelRouteKey] = Comp
-        return list
-      },
-      {} as { [key: string]: React.ReactNode }
-    )
-
-    // When the segment does not have a layout or page we still have to add the layout router to ensure the path holds the loading component
-    if (!Component) {
-      return {
-        Component: () => <>{parallelRouteComponents.children}</>,
-        styles,
-      }
-    }
-
-    const isClientComponent = isClientReference(layoutOrPageMod)
-
-    // If it's a not found route, and we don't have any matched parallel
-    // routes, we try to render the not found component if it exists.
-    let notFoundComponent = {}
-    if (
-      NotFound &&
-      asNotFound &&
-      // In development, it could hit the parallel-route-default not found, so we only need to check the segment.
-      // Or if there's no parallel routes means it reaches the end.
-      !parallelRouteMap.length
-    ) {
-      notFoundComponent = {
-        children: (
-          <>
-            <meta name="robots" content="noindex" />
-            {process.env.NODE_ENV === 'development' && (
-              <meta name="next-error" content="not-found" />
-            )}
-            {notFoundStyles}
-            <NotFound />
-          </>
-        ),
-      }
-    }
-
-    const props = {
-      ...parallelRouteComponents,
-      ...notFoundComponent,
-      // TODO-APP: params and query have to be blocked parallel route names. Might have to add a reserved name list.
-      // Params are always the current params that apply to the layout
-      // If you have a `/dashboard/[team]/layout.js` it will provide `team` as a param but not anything further down.
-      params: currentParams,
-      // Query is only provided to page
-      ...(() => {
-        if (isClientComponent && isStaticGeneration) {
-          return {}
-        }
-
-        if (isPage) {
-          return searchParamsProps
-        }
-      })(),
-    }
-
-    // Eagerly execute layout/page component to trigger fetches early.
-    if (!isClientComponent) {
-      Component = await Promise.resolve().then(() =>
-        preloadComponent(Component, props)
-      )
-    }
-
-    return {
-      Component: () => {
-        return (
-          <>
-            {isPage ? metadataOutlet : null}
-            {/* <Component /> needs to be the first element because we use `findDOMNode` in layout router to locate it. */}
-            {isPage && isClientComponent ? (
-              <StaticGenerationSearchParamsBailoutProvider
-                propsForComponent={props}
-                Component={Component}
-                isStaticGeneration={isStaticGeneration}
-              />
-            ) : (
-              <Component {...props} />
-            )}
-            {/* This null is currently critical. The wrapped Component can render null and if there was not fragment
-              surrounding it this would look like a pending tree data state on the client which will cause an errror
-              and break the app. Long-term we need to move away from using null as a partial tree identifier since it
-              is a valid return type for the components we wrap. Once we make this change we can safely remove the
-              fragment. The reason the extra null here is required is that fragments which only have 1 child are elided.
-              If the Component above renders null the actual treedata will look like `[null, null]`. If we remove the extra
-              null it will look like `null` (the array is elided) and this is what confuses the client router.
-              TODO-APP update router to use a Symbol for partial tree detection */}
-            {null}
-          </>
-        )
-      },
-      styles,
-    }
-  }
-
-  // Handle Flight render request. This is only used when client-side navigating. E.g. when you `router.push('/dashboard')` or `router.reload()`.
-  const generateFlight = async (options?: {
-    actionResult: ActionResult
-    skipFlight: boolean
-    asNotFound?: boolean
-  }): Promise<RenderResult> => {
-    /**
-     * Use router state to decide at what common layout to render the page.
-     * This can either be the common layout between two pages or a specific place to start rendering from using the "refetch" marker in the tree.
-     */
-    const walkTreeWithFlightRouterState = async ({
-      createSegmentPath,
-      loaderTreeToFilter,
-      parentParams,
-      isFirst,
-      flightRouterState,
-      parentRendered,
-      rscPayloadHead,
-      injectedCSS,
-      injectedFontPreloadTags,
-      rootLayoutIncluded,
-      asNotFound,
-      metadataOutlet,
-    }: {
-      createSegmentPath: CreateSegmentPath
-      loaderTreeToFilter: LoaderTree
-      parentParams: { [key: string]: string | string[] }
-      isFirst: boolean
-      flightRouterState?: FlightRouterState
-      parentRendered?: boolean
-      rscPayloadHead: React.ReactNode
-      injectedCSS: Set<string>
-      injectedFontPreloadTags: Set<string>
-      rootLayoutIncluded: boolean
-      asNotFound?: boolean
-      metadataOutlet: React.ReactNode
-    }): Promise<FlightDataPath[]> => {
-      const [segment, parallelRoutes, components] = loaderTreeToFilter
-
-      const parallelRoutesKeys = Object.keys(parallelRoutes)
-
-      const { layout } = components
-      const isLayout = typeof layout !== 'undefined'
-
-      /**
-       * Checks if the current segment is a root layout.
-       */
-      const rootLayoutAtThisLevel = isLayout && !rootLayoutIncluded
-      /**
-       * Checks if the current segment or any level above it has a root layout.
-       */
-      const rootLayoutIncludedAtThisLevelOrAbove =
-        rootLayoutIncluded || rootLayoutAtThisLevel
-
-      // Because this function walks to a deeper point in the tree to start rendering we have to track the dynamic parameters up to the point where rendering starts
-      const segmentParam = getDynamicParamFromSegment(segment)
-      const currentParams =
-        // Handle null case where dynamic param is optional
-        segmentParam && segmentParam.value !== null
-          ? {
-              ...parentParams,
-              [segmentParam.param]: segmentParam.value,
-            }
-          : parentParams
-      const actualSegment: Segment = addSearchParamsIfPageSegment(
-        segmentParam ? segmentParam.treeSegment : segment,
-        query
-      )
-
-      /**
-       * Decide if the current segment is where rendering has to start.
-       */
-      const renderComponentsOnThisLevel =
-        // No further router state available
-        !flightRouterState ||
-        // Segment in router state does not match current segment
-        !matchSegment(actualSegment, flightRouterState[0]) ||
-        // Last item in the tree
-        parallelRoutesKeys.length === 0 ||
-        // Explicit refresh
-        flightRouterState[3] === 'refetch'
-
-      const shouldSkipComponentTree =
-        isPrefetch &&
-        !Boolean(components.loading) &&
-        (flightRouterState ||
-          // If there is no flightRouterState, we need to check the entire loader tree, as otherwise we'll be only checking the root
-          !hasLoadingComponentInTree(loaderTree))
-
-      if (!parentRendered && renderComponentsOnThisLevel) {
-        const overriddenSegment =
-          flightRouterState &&
-          canSegmentBeOverridden(actualSegment, flightRouterState[0])
-            ? flightRouterState[0]
-            : null
-
-        return [
-          [
-            overriddenSegment ?? actualSegment,
-            createFlightRouterStateFromLoaderTree(
-              // Create router state using the slice of the loaderTree
-              loaderTreeToFilter,
-              getDynamicParamFromSegment,
-              query
-            ),
-            shouldSkipComponentTree
-              ? null
-              : // Create component tree using the slice of the loaderTree
-                // @ts-expect-error TODO-APP: fix async component type
-                React.createElement(async () => {
-                  const { Component } = await createComponentTree(
-                    // This ensures flightRouterPath is valid and filters down the tree
-                    {
-                      createSegmentPath,
-                      loaderTree: loaderTreeToFilter,
-                      parentParams: currentParams,
-                      firstItem: isFirst,
-                      injectedCSS,
-                      injectedFontPreloadTags,
-                      // This is intentionally not "rootLayoutIncludedAtThisLevelOrAbove" as createComponentTree starts at the current level and does a check for "rootLayoutAtThisLevel" too.
-                      rootLayoutIncluded,
-                      asNotFound,
-                      metadataOutlet,
-                    }
-                  )
-
-                  return <Component />
-                }),
-            shouldSkipComponentTree
-              ? null
-              : (() => {
-                  const { layoutOrPagePath } =
-                    parseLoaderTree(loaderTreeToFilter)
-
-                  const styles = getLayerAssets({
-                    layoutOrPagePath,
-                    injectedCSS: new Set(injectedCSS),
-                    injectedFontPreloadTags: new Set(injectedFontPreloadTags),
-                  })
-
-                  return (
-                    <>
-                      {styles}
-                      {rscPayloadHead}
-                    </>
-                  )
-                })(),
-          ],
-        ]
-      }
-
-      // If we are not rendering on this level we need to check if the current
-      // segment has a layout. If so, we need to track all the used CSS to make
-      // the result consistent.
-      const layoutPath = layout?.[1]
-      const injectedCSSWithCurrentLayout = new Set(injectedCSS)
-      const injectedFontPreloadTagsWithCurrentLayout = new Set(
-        injectedFontPreloadTags
-      )
-      if (layoutPath) {
-        getCssInlinedLinkTags(
-          clientReferenceManifest,
-          layoutPath,
-          injectedCSSWithCurrentLayout,
-          true
-        )
-        getPreloadableFonts(
-          nextFontManifest,
-          layoutPath,
-          injectedFontPreloadTagsWithCurrentLayout
-        )
-      }
-
-      // Walk through all parallel routes.
-      const paths: FlightDataPath[] = (
-        await Promise.all(
-          parallelRoutesKeys.map(async (parallelRouteKey) => {
-            // for (const parallelRouteKey of parallelRoutesKeys) {
-            const parallelRoute = parallelRoutes[parallelRouteKey]
-
-            const currentSegmentPath: FlightSegmentPath = isFirst
-              ? [parallelRouteKey]
-              : [actualSegment, parallelRouteKey]
-
-            const path = await walkTreeWithFlightRouterState({
-              createSegmentPath: (child) => {
-                return createSegmentPath([...currentSegmentPath, ...child])
-              },
-              loaderTreeToFilter: parallelRoute,
-              parentParams: currentParams,
-              flightRouterState:
-                flightRouterState && flightRouterState[1][parallelRouteKey],
-              parentRendered: parentRendered || renderComponentsOnThisLevel,
-              isFirst: false,
-              rscPayloadHead,
-              injectedCSS: injectedCSSWithCurrentLayout,
-              injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
-              rootLayoutIncluded: rootLayoutIncludedAtThisLevelOrAbove,
-              asNotFound,
-              metadataOutlet,
-            })
-
-            return path
-              .map((item) => {
-                // we don't need to send over default routes in the flight data
-                // because they are always ignored by the client, unless it's a refetch
-                if (
-                  item[0] === '__DEFAULT__' &&
-                  flightRouterState &&
-                  !!flightRouterState[1][parallelRouteKey][0] &&
-                  flightRouterState[1][parallelRouteKey][3] !== 'refetch'
-                ) {
-                  return null
-                }
-                return [actualSegment, parallelRouteKey, ...item]
-              })
-              .filter(Boolean) as FlightDataPath[]
-          })
-        )
-      ).flat()
-
-      return paths
-    }
-
-    // Flight data that is going to be passed to the browser.
-    // Currently a single item array but in the future multiple patches might be combined in a single request.
-
-    let flightData: FlightData | null = null
-    if (!options?.skipFlight) {
-      const [MetadataTree, MetadataOutlet] = createMetadataComponents({
-        tree: loaderTree,
-        pathname: urlPathname,
-        searchParams: providedSearchParams,
-        getDynamicParamFromSegment,
-        appUsingSizeAdjust,
-      })
-      flightData = (
-        await walkTreeWithFlightRouterState({
-          createSegmentPath: (child) => child,
-          loaderTreeToFilter: loaderTree,
-          parentParams: {},
-          flightRouterState: providedFlightRouterState,
-          isFirst: true,
-          // For flight, render metadata inside leaf page
-          rscPayloadHead: (
-            // Adding requestId as react key to make metadata remount for each render
-            <MetadataTree key={requestId} />
-          ),
-          injectedCSS: new Set(),
-          injectedFontPreloadTags: new Set(),
-          rootLayoutIncluded: false,
-          asNotFound: isNotFoundPath || options?.asNotFound,
-          metadataOutlet: <MetadataOutlet />,
-        })
-      ).map((path) => path.slice(1)) // remove the '' (root) segment
-    }
-
-    const buildIdFlightDataPair = [buildId, flightData]
-
-    // For app dir, use the bundled version of Flight server renderer (renderToReadableStream)
-    // which contains the subset React.
-    const flightReadableStream = renderToReadableStream(
-      options
-        ? [options.actionResult, buildIdFlightDataPair]
-        : buildIdFlightDataPair,
-      clientReferenceManifest.clientModules,
-      {
-        context: serverContexts,
-        onError: flightDataRendererErrorHandler,
-      }
-    ).pipeThrough(createBufferedTransformStream())
-
-    return new FlightRenderResult(flightReadableStream)
+  const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
+    params,
+    providedFlightRouterState
+  )
+
+  const ctx: AppRenderContext = {
+    ...baseCtx,
+    getDynamicParamFromSegment,
+    query,
+    isPrefetch,
+    providedSearchParams,
+    requestTimestamp,
+    searchParamsProps,
+    appUsingSizeAdjustment,
+    providedFlightRouterState,
+    requestId,
+    defaultRevalidate: false,
+    pagePath,
+    clientReferenceManifest,
+    assetPrefix,
+    flightDataRendererErrorHandler,
+    serverComponentsErrorHandler,
+    serverContexts,
+    isNotFoundPath,
+    res,
   }
 
   if (isFlight && !staticGenerationStore.isStaticGeneration) {
-    return generateFlight()
+    return generateFlight(ctx)
   }
 
   // Get the nonce from the incoming request if it has one.
@@ -1284,91 +760,15 @@ const wrappedRender = async (
 
   const validateRootLayout = dev
     ? {
-        validateRootLayout: {
-          assetPrefix: renderOpts.assetPrefix,
-          getTree: () =>
-            createFlightRouterStateFromLoaderTree(
-              loaderTree,
-              getDynamicParamFromSegment,
-              query
-            ),
-        },
+        assetPrefix: renderOpts.assetPrefix,
+        getTree: () =>
+          createFlightRouterStateFromLoaderTree(
+            loaderTree,
+            getDynamicParamFromSegment,
+            query
+          ),
       }
-    : {}
-
-  /**
-   * A new React Component that renders the provided React Component
-   * using Flight which can then be rendered to HTML.
-   */
-  const createServerComponentsRenderer = (
-    loaderTreeToRender: LoaderTree,
-    preinitScripts: () => void,
-    formState: null | any
-  ) =>
-    createServerComponentRenderer<{
-      asNotFound: boolean
-    }>(
-      async (props) => {
-        preinitScripts()
-        // Create full component tree from root to leaf.
-        const injectedCSS = new Set<string>()
-        const injectedFontPreloadTags = new Set<string>()
-        const initialTree = createFlightRouterStateFromLoaderTree(
-          loaderTreeToRender,
-          getDynamicParamFromSegment,
-          query
-        )
-
-        const [MetadataTree, MetadataOutlet] = createMetadataComponents({
-          tree: loaderTreeToRender,
-          errorType: props.asNotFound ? 'not-found' : undefined,
-          pathname: urlPathname,
-          searchParams: providedSearchParams,
-          getDynamicParamFromSegment: getDynamicParamFromSegment,
-          appUsingSizeAdjust: appUsingSizeAdjust,
-        })
-
-        const { Component: ComponentTree, styles } = await createComponentTree({
-          createSegmentPath: (child) => child,
-          loaderTree: loaderTreeToRender,
-          parentParams: {},
-          firstItem: true,
-          injectedCSS,
-          injectedFontPreloadTags,
-          rootLayoutIncluded: false,
-          asNotFound: props.asNotFound,
-          metadataOutlet: <MetadataOutlet />,
-        })
-
-        return (
-          <>
-            {styles}
-            <AppRouter
-              buildId={buildId}
-              assetPrefix={assetPrefix}
-              initialCanonicalUrl={urlPathname}
-              initialTree={initialTree}
-              initialHead={
-                <>
-                  {res.statusCode > 400 && (
-                    <meta name="robots" content="noindex" />
-                  )}
-                  {/* Adding requestId as react key to make metadata remount for each render */}
-                  <MetadataTree key={requestId} />
-                </>
-              }
-              globalErrorComponent={GlobalError}
-            >
-              <ComponentTree />
-            </AppRouter>
-          </>
-        )
-      },
-      ComponentMod,
-      { ...serverComponentsRenderOpts, formState },
-      serverComponentsErrorHandler,
-      nonce
-    )
+    : undefined
 
   const { HeadManagerContext } =
     require('../../shared/lib/head-manager-context.shared-runtime') as typeof import('../../shared/lib/head-manager-context.shared-runtime')
@@ -1410,6 +810,7 @@ const wrappedRender = async (
           )
           .map((polyfill) => ({
             src: `${assetPrefix}/_next/${polyfill}${getAssetQueryString(
+              ctx,
               false
             )}`,
             integrity: subresourceIntegrityManifest?.[polyfill],
@@ -1423,13 +824,16 @@ const wrappedRender = async (
         assetPrefix,
         renderOpts.crossOrigin,
         subresourceIntegrityManifest,
-        getAssetQueryString(true),
+        getAssetQueryString(ctx, true),
         nonce
       )
       const ServerComponentsRenderer = createServerComponentsRenderer(
+        ctx,
         tree,
         preinitScripts,
-        formState
+        formState,
+        serverComponentsRenderOpts,
+        nonce
       )
       const content = (
         <HeadManagerContext.Provider
@@ -1444,59 +848,10 @@ const wrappedRender = async (
         </HeadManagerContext.Provider>
       )
 
-      let polyfillsFlushed = false
-      let flushedErrorMetaTagsUntilIndex = 0
-      const getServerInsertedHTML = (serverCapturedErrors: Error[]) => {
-        // Loop through all the errors that have been captured but not yet
-        // flushed.
-        const errorMetaTags = []
-        for (
-          ;
-          flushedErrorMetaTagsUntilIndex < serverCapturedErrors.length;
-          flushedErrorMetaTagsUntilIndex++
-        ) {
-          const error = serverCapturedErrors[flushedErrorMetaTagsUntilIndex]
-
-          if (isNotFoundError(error)) {
-            errorMetaTags.push(
-              <meta name="robots" content="noindex" key={error.digest} />,
-              process.env.NODE_ENV === 'development' ? (
-                <meta name="next-error" content="not-found" key="next-error" />
-              ) : null
-            )
-          } else if (isRedirectError(error)) {
-            const redirectUrl = getURLFromRedirectError(error)
-            const isPermanent =
-              getRedirectStatusCodeFromError(error) === 308 ? true : false
-            if (redirectUrl) {
-              errorMetaTags.push(
-                <meta
-                  httpEquiv="refresh"
-                  content={`${isPermanent ? 0 : 1};url=${redirectUrl}`}
-                  key={error.digest}
-                />
-              )
-            }
-          }
-        }
-
-        const flushed = renderToString({
-          ReactDOMServer: require('react-dom/server.edge'),
-          element: (
-            <>
-              {polyfillsFlushed
-                ? null
-                : polyfills?.map((polyfill) => {
-                    return <script key={polyfill.src} {...polyfill} />
-                  })}
-              {renderServerInsertedHTML()}
-              {errorMetaTags}
-            </>
-          ),
-        })
-        polyfillsFlushed = true
-        return flushed
-      }
+      const getServerInsertedHTML = makeGetServerInsertedHTML({
+        polyfills,
+        renderServerInsertedHTML,
+      })
 
       try {
         const fizzStream = await renderToInitialFizzStream({
@@ -1518,7 +873,7 @@ const wrappedRender = async (
             staticGenerationStore.isStaticGeneration || generateStaticHTML,
           getServerInsertedHTML: () => getServerInsertedHTML(allCapturedErrors),
           serverInsertedHTMLToHead: true,
-          ...validateRootLayout,
+          validateRootLayout,
         })
 
         return result
@@ -1595,7 +950,7 @@ const wrappedRender = async (
           assetPrefix,
           renderOpts.crossOrigin,
           subresourceIntegrityManifest,
-          getAssetQueryString(false),
+          getAssetQueryString(ctx, false),
           nonce
         )
 
@@ -1608,7 +963,7 @@ const wrappedRender = async (
               errorType,
               searchParams: providedSearchParams,
               getDynamicParamFromSegment,
-              appUsingSizeAdjust,
+              appUsingSizeAdjustment,
             })
 
             const head = (
@@ -1668,7 +1023,7 @@ const wrappedRender = async (
             generateStaticHTML: staticGenerationStore.isStaticGeneration,
             getServerInsertedHTML: () => getServerInsertedHTML([]),
             serverInsertedHTMLToHead: true,
-            ...validateRootLayout,
+            validateRootLayout,
           })
         } catch (finalErr: any) {
           if (
@@ -1696,6 +1051,7 @@ const wrappedRender = async (
     staticGenerationStore: staticGenerationStore,
     requestStore: requestStore,
     serverActionsBodySizeLimit,
+    ctx,
   })
 
   let formState: null | any = null
@@ -1750,7 +1106,7 @@ const wrappedRender = async (
     // TODO-APP: derive this from same pass to prevent additional
     // render during static generation
     const stringifiedFlightPayload = await streamToBufferedResult(
-      await generateFlight()
+      await generateFlight(ctx)
     )
 
     if (staticGenerationStore.forceStatic === false) {
@@ -1759,7 +1115,7 @@ const wrappedRender = async (
 
     extraRenderResultMeta.pageData = stringifiedFlightPayload
     extraRenderResultMeta.revalidate =
-      staticGenerationStore.revalidate ?? defaultRevalidate
+      staticGenerationStore.revalidate ?? ctx.defaultRevalidate
 
     // provide bailout info for debugging
     if (extraRenderResultMeta.revalidate === 0) {
@@ -1800,9 +1156,11 @@ export const renderToHTMLOrFlight: AppPageRender = (
         renderOpts.ComponentMod.staticGenerationAsyncStorage,
         { urlPathname: pathname, renderOpts },
         (staticGenerationStore) =>
-          wrappedRender(req, res, pagePath, query, renderOpts, {
+          renderToHTMLOrFlightImpl(req, res, pagePath, query, renderOpts, {
             requestStore,
             staticGenerationStore,
+            componentMod: renderOpts.ComponentMod,
+            renderOpts,
           })
       )
   )

--- a/packages/next/src/server/app-render/create-component-and-styles.tsx
+++ b/packages/next/src/server/app-render/create-component-and-styles.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { interopDefault } from './interop-default'
+import { getCssInlinedLinkTags } from './get-css-inlined-link-tags'
+import type { AppRenderContext } from './app-render'
+import { getAssetQueryString } from './get-asset-query-string'
+
+export async function createComponentAndStyles({
+  filePath,
+  getComponent,
+  injectedCSS,
+  ctx,
+}: {
+  filePath: string
+  getComponent: () => any
+  injectedCSS: Set<string>
+  ctx: AppRenderContext
+}): Promise<any> {
+  const cssHrefs = getCssInlinedLinkTags(
+    ctx.clientReferenceManifest,
+    filePath,
+    injectedCSS
+  )
+
+  const styles = cssHrefs
+    ? cssHrefs.map((href, index) => {
+        // In dev, Safari and Firefox will cache the resource during HMR:
+        // - https://github.com/vercel/next.js/issues/5860
+        // - https://bugs.webkit.org/show_bug.cgi?id=187726
+        // Because of this, we add a `?v=` query to bypass the cache during
+        // development. We need to also make sure that the number is always
+        // increasing.
+        const fullHref = `${ctx.assetPrefix}/_next/${href}${getAssetQueryString(
+          ctx,
+          true
+        )}`
+
+        // `Precedence` is an opt-in signal for React to handle resource
+        // loading and deduplication, etc. It's also used as the key to sort
+        // resources so they will be injected in the correct order.
+        // During HMR, it's critical to use different `precedence` values
+        // for different stylesheets, so their order will be kept.
+        // https://github.com/facebook/react/pull/25060
+        const precedence =
+          process.env.NODE_ENV === 'development' ? 'next_' + href : 'next'
+
+        return (
+          <link
+            rel="stylesheet"
+            href={fullHref}
+            // @ts-ignore
+            precedence={precedence}
+            crossOrigin={ctx.renderOpts.crossOrigin}
+            key={index}
+          />
+        )
+      })
+    : null
+
+  const Comp = interopDefault(await getComponent())
+
+  return [Comp, styles]
+}

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -1,0 +1,469 @@
+import type { ChildProp, FlightSegmentPath } from './types'
+import React from 'react'
+import { isClientReference } from '../../lib/client-reference'
+import { getLayoutOrPageModule } from '../lib/app-dir-module'
+import type { LoaderTree } from '../lib/app-dir-module'
+import { interopDefault } from './interop-default'
+import { preloadComponent } from './preload-component'
+import { addSearchParamsIfPageSegment } from './create-flight-router-state-from-loader-tree'
+import { parseLoaderTree } from './parse-loader-tree'
+import {
+  type CreateSegmentPath,
+  type AppRenderContext,
+  getLayerAssets,
+  createComponentAndStyles,
+  hasLoadingComponentInTree,
+} from './app-render'
+
+/**
+ * Use the provided loader tree to create the React Component tree.
+ */
+
+export async function createComponentTree({
+  createSegmentPath,
+  loaderTree: tree,
+  parentParams,
+  firstItem,
+  rootLayoutIncluded,
+  injectedCSS,
+  injectedFontPreloadTags,
+  asNotFound,
+  metadataOutlet,
+  ctx,
+}: {
+  createSegmentPath: CreateSegmentPath
+  loaderTree: LoaderTree
+  parentParams: { [key: string]: any }
+  rootLayoutIncluded: boolean
+  firstItem?: boolean
+  injectedCSS: Set<string>
+  injectedFontPreloadTags: Set<string>
+  asNotFound?: boolean
+  metadataOutlet?: React.ReactNode
+  ctx: AppRenderContext
+}): Promise<{
+  Component: React.ComponentType
+  styles: React.ReactNode
+}> {
+  const {
+    renderOpts: { nextConfigOutput },
+    staticGenerationStore,
+    componentMod: {
+      staticGenerationBailout,
+      NotFoundBoundary,
+      LayoutRouter,
+      RenderFromTemplateContext,
+      StaticGenerationSearchParamsBailoutProvider,
+      serverHooks: { DynamicServerError },
+    },
+    pagePath,
+    getDynamicParamFromSegment,
+    query,
+    isPrefetch,
+    searchParamsProps,
+  } = ctx
+
+  const { page, layoutOrPagePath, segment, components, parallelRoutes } =
+    parseLoaderTree(tree)
+
+  const { layout, template, error, loading, 'not-found': notFound } = components
+
+  const injectedCSSWithCurrentLayout = new Set(injectedCSS)
+  const injectedFontPreloadTagsWithCurrentLayout = new Set(
+    injectedFontPreloadTags
+  )
+
+  const styles = getLayerAssets({
+    ctx,
+    layoutOrPagePath,
+    injectedCSS: injectedCSSWithCurrentLayout,
+    injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
+  })
+
+  const [Template, templateStyles] = template
+    ? await createComponentAndStyles({
+        ctx,
+        filePath: template[1],
+        getComponent: template[0],
+        injectedCSS: injectedCSSWithCurrentLayout,
+      })
+    : [React.Fragment]
+
+  const [ErrorComponent, errorStyles] = error
+    ? await createComponentAndStyles({
+        ctx,
+        filePath: error[1],
+        getComponent: error[0],
+        injectedCSS: injectedCSSWithCurrentLayout,
+      })
+    : []
+
+  const [Loading, loadingStyles] = loading
+    ? await createComponentAndStyles({
+        ctx,
+        filePath: loading[1],
+        getComponent: loading[0],
+        injectedCSS: injectedCSSWithCurrentLayout,
+      })
+    : []
+
+  const isLayout = typeof layout !== 'undefined'
+  const isPage = typeof page !== 'undefined'
+  const [layoutOrPageMod] = await getLayoutOrPageModule(tree)
+
+  /**
+   * Checks if the current segment is a root layout.
+   */
+  const rootLayoutAtThisLevel = isLayout && !rootLayoutIncluded
+  /**
+   * Checks if the current segment or any level above it has a root layout.
+   */
+  const rootLayoutIncludedAtThisLevelOrAbove =
+    rootLayoutIncluded || rootLayoutAtThisLevel
+
+  const [NotFound, notFoundStyles] = notFound
+    ? await createComponentAndStyles({
+        ctx,
+        filePath: notFound[1],
+        getComponent: notFound[0],
+        injectedCSS: injectedCSSWithCurrentLayout,
+      })
+    : []
+
+  let dynamic = layoutOrPageMod?.dynamic
+
+  if (nextConfigOutput === 'export') {
+    if (!dynamic || dynamic === 'auto') {
+      dynamic = 'error'
+    } else if (dynamic === 'force-dynamic') {
+      staticGenerationStore.forceDynamic = true
+      staticGenerationStore.dynamicShouldError = true
+      staticGenerationBailout(`output: export`, {
+        dynamic,
+        link: 'https://nextjs.org/docs/advanced-features/static-html-export',
+      })
+    }
+  }
+
+  if (typeof dynamic === 'string') {
+    // the nested most config wins so we only force-static
+    // if it's configured above any parent that configured
+    // otherwise
+    if (dynamic === 'error') {
+      staticGenerationStore.dynamicShouldError = true
+    } else if (dynamic === 'force-dynamic') {
+      staticGenerationStore.forceDynamic = true
+      staticGenerationBailout(`force-dynamic`, { dynamic })
+    } else {
+      staticGenerationStore.dynamicShouldError = false
+      if (dynamic === 'force-static') {
+        staticGenerationStore.forceStatic = true
+      } else {
+        staticGenerationStore.forceStatic = false
+      }
+    }
+  }
+
+  if (typeof layoutOrPageMod?.fetchCache === 'string') {
+    staticGenerationStore.fetchCache = layoutOrPageMod?.fetchCache
+  }
+
+  if (typeof layoutOrPageMod?.revalidate === 'number') {
+    ctx.defaultRevalidate = layoutOrPageMod.revalidate as number
+
+    if (
+      typeof staticGenerationStore.revalidate === 'undefined' ||
+      (typeof staticGenerationStore.revalidate === 'number' &&
+        staticGenerationStore.revalidate > ctx.defaultRevalidate)
+    ) {
+      staticGenerationStore.revalidate = ctx.defaultRevalidate
+    }
+
+    if (
+      staticGenerationStore.isStaticGeneration &&
+      ctx.defaultRevalidate === 0
+    ) {
+      const dynamicUsageDescription = `revalidate: 0 configured ${segment}`
+      staticGenerationStore.dynamicUsageDescription = dynamicUsageDescription
+
+      throw new DynamicServerError(dynamicUsageDescription)
+    }
+  }
+
+  if (staticGenerationStore?.dynamicUsageErr) {
+    throw staticGenerationStore.dynamicUsageErr
+  }
+
+  const LayoutOrPage = layoutOrPageMod
+    ? interopDefault(layoutOrPageMod)
+    : undefined
+
+  /**
+   * The React Component to render.
+   */
+  let Component = LayoutOrPage
+  const parallelKeys = Object.keys(parallelRoutes)
+  const hasSlotKey = parallelKeys.length > 1
+
+  if (hasSlotKey && rootLayoutAtThisLevel) {
+    Component = (componentProps: any) => {
+      const NotFoundComponent = NotFound
+      const RootLayoutComponent = LayoutOrPage
+      return (
+        <NotFoundBoundary
+          notFound={
+            <>
+              {styles}
+              <RootLayoutComponent>
+                {notFoundStyles}
+                <NotFoundComponent />
+              </RootLayoutComponent>
+            </>
+          }
+        >
+          <RootLayoutComponent {...componentProps} />
+        </NotFoundBoundary>
+      )
+    }
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    const { isValidElementType } = require('next/dist/compiled/react-is')
+    if (
+      (isPage || typeof Component !== 'undefined') &&
+      !isValidElementType(Component)
+    ) {
+      throw new Error(
+        `The default export is not a React Component in page: "${pagePath}"`
+      )
+    }
+
+    if (
+      typeof ErrorComponent !== 'undefined' &&
+      !isValidElementType(ErrorComponent)
+    ) {
+      throw new Error(
+        `The default export of error is not a React Component in page: ${segment}`
+      )
+    }
+
+    if (typeof Loading !== 'undefined' && !isValidElementType(Loading)) {
+      throw new Error(
+        `The default export of loading is not a React Component in ${segment}`
+      )
+    }
+
+    if (typeof NotFound !== 'undefined' && !isValidElementType(NotFound)) {
+      throw new Error(
+        `The default export of notFound is not a React Component in ${segment}`
+      )
+    }
+  }
+
+  // Handle dynamic segment params.
+  const segmentParam = getDynamicParamFromSegment(segment)
+  /**
+   * Create object holding the parent params and current params
+   */
+  const currentParams =
+    // Handle null case where dynamic param is optional
+    segmentParam && segmentParam.value !== null
+      ? {
+          ...parentParams,
+          [segmentParam.param]: segmentParam.value,
+        }
+      : // Pass through parent params to children
+        parentParams
+  // Resolve the segment param
+  const actualSegment = segmentParam ? segmentParam.treeSegment : segment
+
+  // This happens outside of rendering in order to eagerly kick off data fetching for layouts / the page further down
+  const parallelRouteMap = await Promise.all(
+    Object.keys(parallelRoutes).map(
+      async (parallelRouteKey): Promise<[string, React.ReactNode]> => {
+        const isChildrenRouteKey = parallelRouteKey === 'children'
+        const currentSegmentPath: FlightSegmentPath = firstItem
+          ? [parallelRouteKey]
+          : [actualSegment, parallelRouteKey]
+
+        const parallelRoute = parallelRoutes[parallelRouteKey]
+
+        const childSegment = parallelRoute[0]
+        const childSegmentParam = getDynamicParamFromSegment(childSegment)
+        const notFoundComponent =
+          NotFound && isChildrenRouteKey ? <NotFound /> : undefined
+
+        function getParallelRoutePair(
+          currentChildProp: ChildProp,
+          currentStyles: React.ReactNode
+        ): [string, React.ReactNode] {
+          // This is turned back into an object below.
+          return [
+            parallelRouteKey,
+            <LayoutRouter
+              parallelRouterKey={parallelRouteKey}
+              segmentPath={createSegmentPath(currentSegmentPath)}
+              loading={Loading ? <Loading /> : undefined}
+              loadingStyles={loadingStyles}
+              // TODO-APP: Add test for loading returning `undefined`. This currently can't be tested as the `webdriver()` tab will wait for the full page to load before returning.
+              hasLoading={Boolean(Loading)}
+              error={ErrorComponent}
+              errorStyles={errorStyles}
+              template={
+                <Template>
+                  <RenderFromTemplateContext />
+                </Template>
+              }
+              templateStyles={templateStyles}
+              notFound={notFoundComponent}
+              notFoundStyles={notFoundStyles}
+              childProp={currentChildProp}
+              styles={currentStyles}
+            />,
+          ]
+        }
+
+        // if we're prefetching and that there's a Loading component, we bail out
+        // otherwise we keep rendering for the prefetch.
+        // We also want to bail out if there's no Loading component in the tree.
+        let currentStyles = undefined
+        let childElement = null
+        const childPropSegment = addSearchParamsIfPageSegment(
+          childSegmentParam ? childSegmentParam.treeSegment : childSegment,
+          query
+        )
+        if (
+          !(
+            isPrefetch &&
+            (Loading || !hasLoadingComponentInTree(parallelRoute))
+          )
+        ) {
+          // Create the child component
+          const { Component: ChildComponent, styles: childComponentStyles } =
+            await createComponentTree({
+              createSegmentPath: (child) => {
+                return createSegmentPath([...currentSegmentPath, ...child])
+              },
+              loaderTree: parallelRoute,
+              parentParams: currentParams,
+              rootLayoutIncluded: rootLayoutIncludedAtThisLevelOrAbove,
+              injectedCSS: injectedCSSWithCurrentLayout,
+              injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
+              asNotFound,
+              metadataOutlet,
+              ctx,
+            })
+
+          currentStyles = childComponentStyles
+          childElement = <ChildComponent />
+        }
+
+        const childProp: ChildProp = {
+          current: childElement,
+          segment: childPropSegment,
+        }
+
+        return getParallelRoutePair(childProp, currentStyles)
+      }
+    )
+  )
+
+  // Convert the parallel route map into an object after all promises have been resolved.
+  const parallelRouteComponents = parallelRouteMap.reduce(
+    (list, [parallelRouteKey, Comp]) => {
+      list[parallelRouteKey] = Comp
+      return list
+    },
+    {} as { [key: string]: React.ReactNode }
+  )
+
+  // When the segment does not have a layout or page we still have to add the layout router to ensure the path holds the loading component
+  if (!Component) {
+    return {
+      Component: () => <>{parallelRouteComponents.children}</>,
+      styles,
+    }
+  }
+
+  const isClientComponent = isClientReference(layoutOrPageMod)
+
+  // If it's a not found route, and we don't have any matched parallel
+  // routes, we try to render the not found component if it exists.
+  let notFoundComponent = {}
+  if (
+    NotFound &&
+    asNotFound &&
+    // In development, it could hit the parallel-route-default not found, so we only need to check the segment.
+    // Or if there's no parallel routes means it reaches the end.
+    !parallelRouteMap.length
+  ) {
+    notFoundComponent = {
+      children: (
+        <>
+          <meta name="robots" content="noindex" />
+          {process.env.NODE_ENV === 'development' && (
+            <meta name="next-error" content="not-found" />
+          )}
+          {notFoundStyles}
+          <NotFound />
+        </>
+      ),
+    }
+  }
+
+  const props = {
+    ...parallelRouteComponents,
+    ...notFoundComponent,
+    // TODO-APP: params and query have to be blocked parallel route names. Might have to add a reserved name list.
+    // Params are always the current params that apply to the layout
+    // If you have a `/dashboard/[team]/layout.js` it will provide `team` as a param but not anything further down.
+    params: currentParams,
+    // Query is only provided to page
+    ...(() => {
+      if (isClientComponent && staticGenerationStore.isStaticGeneration) {
+        return {}
+      }
+
+      if (isPage) {
+        return searchParamsProps
+      }
+    })(),
+  }
+
+  // Eagerly execute layout/page component to trigger fetches early.
+  if (!isClientComponent) {
+    Component = await Promise.resolve().then(() =>
+      preloadComponent(Component, props)
+    )
+  }
+
+  return {
+    Component: () => {
+      return (
+        <>
+          {isPage ? metadataOutlet : null}
+          {/* <Component /> needs to be the first element because we use `findDOMNode` in layout router to locate it. */}
+          {isPage && isClientComponent ? (
+            <StaticGenerationSearchParamsBailoutProvider
+              propsForComponent={props}
+              Component={Component}
+              isStaticGeneration={staticGenerationStore.isStaticGeneration}
+            />
+          ) : (
+            <Component {...props} />
+          )}
+          {/* This null is currently critical. The wrapped Component can render null and if there was not fragment
+                      surrounding it this would look like a pending tree data state on the client which will cause an errror
+                      and break the app. Long-term we need to move away from using null as a partial tree identifier since it
+                      is a valid return type for the components we wrap. Once we make this change we can safely remove the
+                      fragment. The reason the extra null here is required is that fragments which only have 1 child are elided.
+                      If the Component above renders null the actual treedata will look like `[null, null]`. If we remove the extra
+                      null it will look like `null` (the array is elided) and this is what confuses the client router.
+                      TODO-APP update router to use a Symbol for partial tree detection */}
+          {null}
+        </>
+      )
+    },
+    styles,
+  }
+}

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -7,13 +7,10 @@ import { interopDefault } from './interop-default'
 import { preloadComponent } from './preload-component'
 import { addSearchParamsIfPageSegment } from './create-flight-router-state-from-loader-tree'
 import { parseLoaderTree } from './parse-loader-tree'
-import {
-  type CreateSegmentPath,
-  type AppRenderContext,
-  getLayerAssets,
-  createComponentAndStyles,
-  hasLoadingComponentInTree,
-} from './app-render'
+import type { CreateSegmentPath, AppRenderContext } from './app-render'
+import { createComponentAndStyles } from './create-component-and-styles'
+import { getLayerAssets } from './get-layer-assets'
+import { hasLoadingComponentInTree } from './has-loading-component-in-tree'
 
 /**
  * Use the provided loader tree to create the React Component tree.

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -6,6 +6,8 @@ import { isRedirectError } from '../../client/components/redirect'
 import { NEXT_DYNAMIC_NO_SSR_CODE } from '../../shared/lib/lazy-dynamic/no-ssr-error'
 import { SpanStatusCode, getTracer } from '../lib/trace/tracer'
 
+export type ErrorHandler = (err: any) => string
+
 /**
  * Create error handler for renderers.
  * Tolerate dynamic server errors during prerendering so console
@@ -28,7 +30,7 @@ export function createErrorHandler({
   errorLogger?: (err: any) => Promise<void>
   capturedErrors: Error[]
   allCapturedErrors?: Error[]
-}) {
+}): ErrorHandler {
   return (err: any): string => {
     if (allCapturedErrors) allCapturedErrors.push(err)
 

--- a/packages/next/src/server/app-render/get-asset-query-string.ts
+++ b/packages/next/src/server/app-render/get-asset-query-string.ts
@@ -1,0 +1,18 @@
+import type { AppRenderContext } from './app-render'
+
+export function getAssetQueryString(
+  ctx: AppRenderContext,
+  addTimestamp: boolean
+) {
+  const isDev = process.env.NODE_ENV === 'development'
+  let qs = ''
+
+  if (isDev && addTimestamp) {
+    qs += `?v=${ctx.requestTimestamp}`
+  }
+
+  if (ctx.renderOpts.deploymentId) {
+    qs += `${isDev ? '&' : '?'}dpl=${ctx.renderOpts.deploymentId}`
+  }
+  return qs
+}

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { getCssInlinedLinkTags } from './get-css-inlined-link-tags'
+import { getPreloadableFonts } from './get-preloadable-fonts'
+import type { AppRenderContext } from './app-render'
+import { getAssetQueryString } from './get-asset-query-string'
+
+export function getLayerAssets({
+  ctx,
+  layoutOrPagePath,
+  injectedCSS: injectedCSSWithCurrentLayout,
+  injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
+}: {
+  layoutOrPagePath: string | undefined
+  injectedCSS: Set<string>
+  injectedFontPreloadTags: Set<string>
+  ctx: AppRenderContext
+}): React.ReactNode {
+  const stylesheets: string[] = layoutOrPagePath
+    ? getCssInlinedLinkTags(
+        ctx.clientReferenceManifest,
+        layoutOrPagePath,
+        injectedCSSWithCurrentLayout,
+        true
+      )
+    : []
+
+  const preloadedFontFiles = layoutOrPagePath
+    ? getPreloadableFonts(
+        ctx.renderOpts.nextFontManifest,
+        layoutOrPagePath,
+        injectedFontPreloadTagsWithCurrentLayout
+      )
+    : null
+
+  if (preloadedFontFiles) {
+    if (preloadedFontFiles.length) {
+      for (let i = 0; i < preloadedFontFiles.length; i++) {
+        const fontFilename = preloadedFontFiles[i]
+        const ext = /\.(woff|woff2|eot|ttf|otf)$/.exec(fontFilename)![1]
+        const type = `font/${ext}`
+        const href = `${ctx.assetPrefix}/_next/${fontFilename}`
+        ctx.componentMod.preloadFont(href, type, ctx.renderOpts.crossOrigin)
+      }
+    } else {
+      try {
+        let url = new URL(ctx.assetPrefix)
+        ctx.componentMod.preconnect(url.origin, 'anonymous')
+      } catch (error) {
+        // assetPrefix must not be a fully qualified domain name. We assume
+        // we should preconnect to same origin instead
+        ctx.componentMod.preconnect('/', 'anonymous')
+      }
+    }
+  }
+
+  const styles = stylesheets
+    ? stylesheets.map((href, index) => {
+        // In dev, Safari and Firefox will cache the resource during HMR:
+        // - https://github.com/vercel/next.js/issues/5860
+        // - https://bugs.webkit.org/show_bug.cgi?id=187726
+        // Because of this, we add a `?v=` query to bypass the cache during
+        // development. We need to also make sure that the number is always
+        // increasing.
+        const fullHref = `${ctx.assetPrefix}/_next/${href}${getAssetQueryString(
+          ctx,
+          true
+        )}`
+
+        // `Precedence` is an opt-in signal for React to handle resource
+        // loading and deduplication, etc. It's also used as the key to sort
+        // resources so they will be injected in the correct order.
+        // During HMR, it's critical to use different `precedence` values
+        // for different stylesheets, so their order will be kept.
+        // https://github.com/facebook/react/pull/25060
+        const precedence =
+          process.env.NODE_ENV === 'development' ? 'next_' + href : 'next'
+
+        ctx.componentMod.preloadStyle(fullHref, ctx.renderOpts.crossOrigin)
+
+        return (
+          <link
+            rel="stylesheet"
+            href={fullHref}
+            // @ts-ignore
+            precedence={precedence}
+            crossOrigin={ctx.renderOpts.crossOrigin}
+            key={index}
+          />
+        )
+      })
+    : null
+
+  return styles
+}

--- a/packages/next/src/server/app-render/has-loading-component-in-tree.tsx
+++ b/packages/next/src/server/app-render/has-loading-component-in-tree.tsx
@@ -1,0 +1,13 @@
+import type { LoaderTree } from '../lib/app-dir-module'
+
+export function hasLoadingComponentInTree(tree: LoaderTree): boolean {
+  const [, parallelRoutes, { loading }] = tree
+
+  if (loading) {
+    return true
+  }
+
+  return Object.values(parallelRoutes).some((parallelRoute) =>
+    hasLoadingComponentInTree(parallelRoute)
+  ) as boolean
+}

--- a/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+++ b/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { isNotFoundError } from '../../client/components/not-found'
+import {
+  getURLFromRedirectError,
+  isRedirectError,
+} from '../../client/components/redirect'
+import { getRedirectStatusCodeFromError } from '../../client/components/get-redirect-status-code-from-error'
+import { renderToString } from './render-to-string'
+
+export function makeGetServerInsertedHTML({
+  polyfills,
+  renderServerInsertedHTML,
+}: {
+  polyfills: JSX.IntrinsicElements['script'][]
+  renderServerInsertedHTML: () => React.ReactNode
+}) {
+  let flushedErrorMetaTagsUntilIndex = 0
+  let polyfillsFlushed = false
+
+  return function getServerInsertedHTML(serverCapturedErrors: Error[]) {
+    // Loop through all the errors that have been captured but not yet
+    // flushed.
+    const errorMetaTags = []
+    for (
+      ;
+      flushedErrorMetaTagsUntilIndex < serverCapturedErrors.length;
+      flushedErrorMetaTagsUntilIndex++
+    ) {
+      const error = serverCapturedErrors[flushedErrorMetaTagsUntilIndex]
+
+      if (isNotFoundError(error)) {
+        errorMetaTags.push(
+          <meta name="robots" content="noindex" key={error.digest} />,
+          process.env.NODE_ENV === 'development' ? (
+            <meta name="next-error" content="not-found" key="next-error" />
+          ) : null
+        )
+      } else if (isRedirectError(error)) {
+        const redirectUrl = getURLFromRedirectError(error)
+        const isPermanent =
+          getRedirectStatusCodeFromError(error) === 308 ? true : false
+        if (redirectUrl) {
+          errorMetaTags.push(
+            <meta
+              httpEquiv="refresh"
+              content={`${isPermanent ? 0 : 1};url=${redirectUrl}`}
+              key={error.digest}
+            />
+          )
+        }
+      }
+    }
+
+    const flushed = renderToString({
+      ReactDOMServer: require('react-dom/server.edge'),
+      element: (
+        <>
+          {polyfillsFlushed
+            ? null
+            : polyfills?.map((polyfill) => {
+                return <script key={polyfill.src} {...polyfill} />
+              })}
+          {renderServerInsertedHTML()}
+          {errorMetaTags}
+        </>
+      ),
+    })
+    polyfillsFlushed = true
+    return flushed
+  }
+}

--- a/packages/next/src/server/app-render/parse-loader-tree.ts
+++ b/packages/next/src/server/app-render/parse-loader-tree.ts
@@ -1,0 +1,20 @@
+import type { LoaderTree } from '../lib/app-dir-module'
+
+export function parseLoaderTree(tree: LoaderTree) {
+  const [segment, parallelRoutes, components] = tree
+  const { layout } = components
+  let { page } = components
+  // a __DEFAULT__ segment means that this route didn't match any of the
+  // segments in the route, so we should use the default page
+  page = segment === '__DEFAULT__' ? components.defaultPage : page
+
+  const layoutOrPagePath = layout?.[1] || page?.[1]
+
+  return {
+    page,
+    segment,
+    components,
+    layoutOrPagePath,
+    parallelRoutes,
+  }
+}

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -17,12 +17,9 @@ import {
   createFlightRouterStateFromLoaderTree,
 } from './create-flight-router-state-from-loader-tree'
 import { parseLoaderTree } from './parse-loader-tree'
-import {
-  type CreateSegmentPath,
-  type AppRenderContext,
-  hasLoadingComponentInTree,
-  getLayerAssets,
-} from './app-render'
+import { type CreateSegmentPath, type AppRenderContext } from './app-render'
+import { getLayerAssets } from './get-layer-assets'
+import { hasLoadingComponentInTree } from './has-loading-component-in-tree'
 import { createComponentTree } from './create-component-tree'
 
 /**

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -17,7 +17,7 @@ import {
   createFlightRouterStateFromLoaderTree,
 } from './create-flight-router-state-from-loader-tree'
 import { parseLoaderTree } from './parse-loader-tree'
-import { type CreateSegmentPath, type AppRenderContext } from './app-render'
+import type { CreateSegmentPath, AppRenderContext } from './app-render'
 import { getLayerAssets } from './get-layer-assets'
 import { hasLoadingComponentInTree } from './has-loading-component-in-tree'
 import { createComponentTree } from './create-component-tree'

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -1,0 +1,257 @@
+import type {
+  FlightDataPath,
+  FlightRouterState,
+  FlightSegmentPath,
+  Segment,
+} from './types'
+import React from 'react'
+import {
+  canSegmentBeOverridden,
+  matchSegment,
+} from '../../client/components/match-segments'
+import type { LoaderTree } from '../lib/app-dir-module'
+import { getCssInlinedLinkTags } from './get-css-inlined-link-tags'
+import { getPreloadableFonts } from './get-preloadable-fonts'
+import {
+  addSearchParamsIfPageSegment,
+  createFlightRouterStateFromLoaderTree,
+} from './create-flight-router-state-from-loader-tree'
+import { parseLoaderTree } from './parse-loader-tree'
+import {
+  type CreateSegmentPath,
+  type AppRenderContext,
+  hasLoadingComponentInTree,
+  getLayerAssets,
+} from './app-render'
+import { createComponentTree } from './create-component-tree'
+
+/**
+ * Use router state to decide at what common layout to render the page.
+ * This can either be the common layout between two pages or a specific place to start rendering from using the "refetch" marker in the tree.
+ */
+export async function walkTreeWithFlightRouterState({
+  createSegmentPath,
+  loaderTreeToFilter,
+  parentParams,
+  isFirst,
+  flightRouterState,
+  parentRendered,
+  rscPayloadHead,
+  injectedCSS,
+  injectedFontPreloadTags,
+  rootLayoutIncluded,
+  asNotFound,
+  metadataOutlet,
+  ctx,
+}: {
+  createSegmentPath: CreateSegmentPath
+  loaderTreeToFilter: LoaderTree
+  parentParams: { [key: string]: string | string[] }
+  isFirst: boolean
+  flightRouterState?: FlightRouterState
+  parentRendered?: boolean
+  rscPayloadHead: React.ReactNode
+  injectedCSS: Set<string>
+  injectedFontPreloadTags: Set<string>
+  rootLayoutIncluded: boolean
+  asNotFound?: boolean
+  metadataOutlet: React.ReactNode
+  ctx: AppRenderContext
+}): Promise<FlightDataPath[]> {
+  const {
+    renderOpts: { nextFontManifest },
+    query,
+    isPrefetch,
+    getDynamicParamFromSegment,
+    componentMod: { tree: loaderTree },
+  } = ctx
+
+  const [segment, parallelRoutes, components] = loaderTreeToFilter
+
+  const parallelRoutesKeys = Object.keys(parallelRoutes)
+
+  const { layout } = components
+  const isLayout = typeof layout !== 'undefined'
+
+  /**
+   * Checks if the current segment is a root layout.
+   */
+  const rootLayoutAtThisLevel = isLayout && !rootLayoutIncluded
+  /**
+   * Checks if the current segment or any level above it has a root layout.
+   */
+  const rootLayoutIncludedAtThisLevelOrAbove =
+    rootLayoutIncluded || rootLayoutAtThisLevel
+
+  // Because this function walks to a deeper point in the tree to start rendering we have to track the dynamic parameters up to the point where rendering starts
+  const segmentParam = getDynamicParamFromSegment(segment)
+  const currentParams =
+    // Handle null case where dynamic param is optional
+    segmentParam && segmentParam.value !== null
+      ? {
+          ...parentParams,
+          [segmentParam.param]: segmentParam.value,
+        }
+      : parentParams
+  const actualSegment: Segment = addSearchParamsIfPageSegment(
+    segmentParam ? segmentParam.treeSegment : segment,
+    query
+  )
+
+  /**
+   * Decide if the current segment is where rendering has to start.
+   */
+  const renderComponentsOnThisLevel =
+    // No further router state available
+    !flightRouterState ||
+    // Segment in router state does not match current segment
+    !matchSegment(actualSegment, flightRouterState[0]) ||
+    // Last item in the tree
+    parallelRoutesKeys.length === 0 ||
+    // Explicit refresh
+    flightRouterState[3] === 'refetch'
+
+  const shouldSkipComponentTree =
+    isPrefetch &&
+    !Boolean(components.loading) &&
+    (flightRouterState ||
+      // If there is no flightRouterState, we need to check the entire loader tree, as otherwise we'll be only checking the root
+      !hasLoadingComponentInTree(loaderTree))
+
+  if (!parentRendered && renderComponentsOnThisLevel) {
+    const overriddenSegment =
+      flightRouterState &&
+      canSegmentBeOverridden(actualSegment, flightRouterState[0])
+        ? flightRouterState[0]
+        : null
+
+    return [
+      [
+        overriddenSegment ?? actualSegment,
+        createFlightRouterStateFromLoaderTree(
+          // Create router state using the slice of the loaderTree
+          loaderTreeToFilter,
+          getDynamicParamFromSegment,
+          query
+        ),
+        shouldSkipComponentTree
+          ? null
+          : // Create component tree using the slice of the loaderTree
+
+            // @ts-expect-error TODO-APP: fix async component type
+            React.createElement(async () => {
+              const { Component } = await createComponentTree(
+                // This ensures flightRouterPath is valid and filters down the tree
+                {
+                  ctx,
+                  createSegmentPath,
+                  loaderTree: loaderTreeToFilter,
+                  parentParams: currentParams,
+                  firstItem: isFirst,
+                  injectedCSS,
+                  injectedFontPreloadTags,
+                  // This is intentionally not "rootLayoutIncludedAtThisLevelOrAbove" as createComponentTree starts at the current level and does a check for "rootLayoutAtThisLevel" too.
+                  rootLayoutIncluded,
+                  asNotFound,
+                  metadataOutlet,
+                }
+              )
+
+              return <Component />
+            }),
+        shouldSkipComponentTree
+          ? null
+          : (() => {
+              const { layoutOrPagePath } = parseLoaderTree(loaderTreeToFilter)
+
+              const styles = getLayerAssets({
+                ctx,
+                layoutOrPagePath,
+                injectedCSS: new Set(injectedCSS),
+                injectedFontPreloadTags: new Set(injectedFontPreloadTags),
+              })
+
+              return (
+                <>
+                  {styles}
+                  {rscPayloadHead}
+                </>
+              )
+            })(),
+      ],
+    ]
+  }
+
+  // If we are not rendering on this level we need to check if the current
+  // segment has a layout. If so, we need to track all the used CSS to make
+  // the result consistent.
+  const layoutPath = layout?.[1]
+  const injectedCSSWithCurrentLayout = new Set(injectedCSS)
+  const injectedFontPreloadTagsWithCurrentLayout = new Set(
+    injectedFontPreloadTags
+  )
+  if (layoutPath) {
+    getCssInlinedLinkTags(
+      ctx.clientReferenceManifest,
+      layoutPath,
+      injectedCSSWithCurrentLayout,
+      true
+    )
+    getPreloadableFonts(
+      nextFontManifest,
+      layoutPath,
+      injectedFontPreloadTagsWithCurrentLayout
+    )
+  }
+
+  // Walk through all parallel routes.
+  const paths: FlightDataPath[] = (
+    await Promise.all(
+      parallelRoutesKeys.map(async (parallelRouteKey) => {
+        // for (const parallelRouteKey of parallelRoutesKeys) {
+        const parallelRoute = parallelRoutes[parallelRouteKey]
+
+        const currentSegmentPath: FlightSegmentPath = isFirst
+          ? [parallelRouteKey]
+          : [actualSegment, parallelRouteKey]
+
+        const path = await walkTreeWithFlightRouterState({
+          ctx,
+          createSegmentPath: (child) => {
+            return createSegmentPath([...currentSegmentPath, ...child])
+          },
+          loaderTreeToFilter: parallelRoute,
+          parentParams: currentParams,
+          flightRouterState:
+            flightRouterState && flightRouterState[1][parallelRouteKey],
+          parentRendered: parentRendered || renderComponentsOnThisLevel,
+          isFirst: false,
+          rscPayloadHead,
+          injectedCSS: injectedCSSWithCurrentLayout,
+          injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
+          rootLayoutIncluded: rootLayoutIncludedAtThisLevelOrAbove,
+          asNotFound,
+          metadataOutlet,
+        })
+
+        return path
+          .map((item) => {
+            // we don't need to send over default routes in the flight data
+            // because they are always ignored by the client, unless it's a refetch
+            if (
+              item[0] === '__DEFAULT__' &&
+              flightRouterState &&
+              !!flightRouterState[1][parallelRouteKey][0] &&
+              flightRouterState[1][parallelRouteKey][3] !== 'refetch'
+            ) {
+              return null
+            }
+            return [actualSegment, parallelRouteKey, ...item]
+          })
+          .filter(Boolean) as FlightDataPath[]
+      })
+    )
+  ).flat()
+
+  return paths
+}


### PR DESCRIPTION
This PR splits apart the function used to render App Router pages into smaller chunks for better readability + testing. A lot of the complexity is tied by the fact that a lot of the code of the function relied on closures so I had to coalesce a lot of the captured variables used into one big context that is then passed around during render.

There are a lot of things to slim down further but I don't have the energy to dig more.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
