### PR TITLE
Improve error handling of Server Actions with skewed deployment

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -446,7 +446,7 @@ export async function handleAction({
         // When this happens, it could be a deployment skew where the action came
         // from a different deployment. We'll just return a 404 with a message logged.
         console.error(
-          'Failed to find Server Action "${actionId}". This request might be from an older or newer deployment.'
+          `Failed to find Server Action "${actionId}". This request might be from an older or newer deployment.`
         )
         return {
           type: 'not-found',

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -284,269 +284,285 @@ export async function handleAction({
     typeof actionId === 'string' &&
     req.method === 'POST'
 
-  if (isFetchAction || isURLEncodedAction || isMultipartAction) {
-    // ensure we avoid caching server actions unexpectedly
-    res.setHeader(
-      'Cache-Control',
-      'no-cache, no-store, max-age=0, must-revalidate'
-    )
-    let bound = []
+  // If it's not a Server Action, skip handling.
+  if (!(isFetchAction || isURLEncodedAction || isMultipartAction)) {
+    return
+  }
 
-    const workerName = 'app' + page
-    const serverModuleMap = new Proxy(
-      {},
-      {
-        get: (_, id: string) => {
-          return {
-            id: serverActionsManifest[
-              process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
-            ][id].workers[workerName],
-            name: id,
-            chunks: [],
-          }
-        },
-      }
-    )
+  // ensure we avoid caching server actions unexpectedly
+  res.setHeader(
+    'Cache-Control',
+    'no-cache, no-store, max-age=0, must-revalidate'
+  )
+  let bound = []
 
-    const { actionAsyncStorage } = ComponentMod as {
-      actionAsyncStorage: ActionAsyncStorage
+  const workerName = 'app' + page
+  const serverModuleMap = new Proxy(
+    {},
+    {
+      get: (_, id: string) => {
+        return {
+          id: serverActionsManifest[
+            process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
+          ][id].workers[workerName],
+          name: id,
+          chunks: [],
+        }
+      },
     }
+  )
 
-    let actionResult: RenderResult | undefined
-    let formState: any | undefined
+  const { actionAsyncStorage } = ComponentMod as {
+    actionAsyncStorage: ActionAsyncStorage
+  }
 
-    try {
-      await actionAsyncStorage.run({ isAction: true }, async () => {
-        if (process.env.NEXT_RUNTIME === 'edge') {
-          // Use react-server-dom-webpack/server.edge
-          const { decodeReply, decodeAction, decodeFormState } = ComponentMod
+  let actionResult: RenderResult | undefined
+  let formState: any | undefined
 
-          const webRequest = req as unknown as WebNextRequest
-          if (!webRequest.body) {
-            throw new Error('invariant: Missing request body.')
-          }
+  try {
+    await actionAsyncStorage.run({ isAction: true }, async () => {
+      if (process.env.NEXT_RUNTIME === 'edge') {
+        // Use react-server-dom-webpack/server.edge
+        const { decodeReply, decodeAction, decodeFormState } = ComponentMod
 
-          if (isMultipartAction) {
-            // TODO-APP: Add streaming support
-            const formData = await webRequest.request.formData()
-            if (isFetchAction) {
-              bound = await decodeReply(formData, serverModuleMap)
-            } else {
-              const action = await decodeAction(formData, serverModuleMap)
-              const actionReturnedState = await action()
-              formState = decodeFormState(actionReturnedState, formData)
+        const webRequest = req as unknown as WebNextRequest
+        if (!webRequest.body) {
+          throw new Error('invariant: Missing request body.')
+        }
 
-              // Skip the fetch path
-              return
-            }
+        if (isMultipartAction) {
+          // TODO-APP: Add streaming support
+          const formData = await webRequest.request.formData()
+          if (isFetchAction) {
+            bound = await decodeReply(formData, serverModuleMap)
           } else {
-            let actionData = ''
+            const action = await decodeAction(formData, serverModuleMap)
+            const actionReturnedState = await action()
+            formState = decodeFormState(actionReturnedState, formData)
 
-            const reader = webRequest.body.getReader()
-            while (true) {
-              const { done, value } = await reader.read()
-              if (done) {
-                break
-              }
-
-              actionData += new TextDecoder().decode(value)
-            }
-
-            if (isURLEncodedAction) {
-              const formData = formDataFromSearchQueryString(actionData)
-              bound = await decodeReply(formData, serverModuleMap)
-            } else {
-              bound = await decodeReply(actionData, serverModuleMap)
-            }
+            // Skip the fetch path
+            return
           }
         } else {
-          // Use react-server-dom-webpack/server.node which supports streaming
-          const {
-            decodeReply,
-            decodeReplyFromBusboy,
-            decodeAction,
-            decodeFormState,
-          } = require(`./react-server.node`)
+          let actionData = ''
 
-          if (isMultipartAction) {
-            if (isFetchAction) {
-              const busboy = require('busboy')
-              const bb = busboy({ headers: req.headers })
-              req.pipe(bb)
-
-              bound = await decodeReplyFromBusboy(bb, serverModuleMap)
-            } else {
-              // React doesn't yet publish a busboy version of decodeAction
-              // so we polyfill the parsing of FormData.
-              const UndiciRequest = require('next/dist/compiled/undici').Request
-              const fakeRequest = new UndiciRequest('http://localhost', {
-                method: 'POST',
-                headers: { 'Content-Type': req.headers['content-type'] },
-                body: nodeToWebReadableStream(req),
-                duplex: 'half',
-              })
-              const formData = await fakeRequest.formData()
-              const action = await decodeAction(formData, serverModuleMap)
-              const actionReturnedState = await action()
-              formState = await decodeFormState(actionReturnedState, formData)
-
-              // Skip the fetch path
-              return
+          const reader = webRequest.body.getReader()
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) {
+              break
             }
+
+            actionData += new TextDecoder().decode(value)
+          }
+
+          if (isURLEncodedAction) {
+            const formData = formDataFromSearchQueryString(actionData)
+            bound = await decodeReply(formData, serverModuleMap)
           } else {
-            const { parseBody } =
-              require('../api-utils/node/parse-body') as typeof import('../api-utils/node/parse-body')
-
-            let actionData
-            try {
-              actionData =
-                (await parseBody(req, serverActionsBodySizeLimit ?? '1mb')) ||
-                ''
-            } catch (e: any) {
-              if (e && (e as ApiError).statusCode === 413) {
-                // Exceeded the size limit
-                e.message =
-                  e.message +
-                  '\nTo configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/server-actions#size-limitation'
-              }
-              throw e
-            }
-
-            if (isURLEncodedAction) {
-              const formData = formDataFromSearchQueryString(actionData)
-              bound = await decodeReply(formData, serverModuleMap)
-            } else {
-              bound = await decodeReply(actionData, serverModuleMap)
-            }
+            bound = await decodeReply(actionData, serverModuleMap)
           }
         }
+      } else {
+        // Use react-server-dom-webpack/server.node which supports streaming
+        const {
+          decodeReply,
+          decodeReplyFromBusboy,
+          decodeAction,
+          decodeFormState,
+        } = require(`./react-server.node`)
 
-        // actions.js
-        // app/page.js
-        //   action worker1
-        //     appRender1
+        if (isMultipartAction) {
+          if (isFetchAction) {
+            const busboy = require('busboy')
+            const bb = busboy({ headers: req.headers })
+            req.pipe(bb)
 
-        // app/foo/page.js
-        //   action worker2
-        //     appRender
+            bound = await decodeReplyFromBusboy(bb, serverModuleMap)
+          } else {
+            // React doesn't yet publish a busboy version of decodeAction
+            // so we polyfill the parsing of FormData.
+            const UndiciRequest = require('next/dist/compiled/undici').Request
+            const fakeRequest = new UndiciRequest('http://localhost', {
+              method: 'POST',
+              headers: { 'Content-Type': req.headers['content-type'] },
+              body: nodeToWebReadableStream(req),
+              duplex: 'half',
+            })
+            const formData = await fakeRequest.formData()
+            const action = await decodeAction(formData, serverModuleMap)
+            const actionReturnedState = await action()
+            formState = await decodeFormState(actionReturnedState, formData)
 
-        // / -> fire action -> POST / -> appRender1 -> modId for the action file
-        // /foo -> fire action -> POST /foo -> appRender2 -> modId for the action file
-
-        const actionModId =
-          serverActionsManifest[
-            process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
-          ][actionId].workers[workerName]
-        const actionHandler =
-          ComponentMod.__next_app__.require(actionModId)[actionId]
-
-        const returnVal = await actionHandler.apply(null, bound)
-
-        // For form actions, we need to continue rendering the page.
-        if (isFetchAction) {
-          await addRevalidationHeader(res, {
-            staticGenerationStore,
-            requestStore,
-          })
-
-          actionResult = await generateFlight({
-            actionResult: Promise.resolve(returnVal),
-            // if the page was not revalidated, we can skip the rendering the flight tree
-            skipFlight: !staticGenerationStore.pathWasRevalidated,
-          })
-        }
-      })
-
-      return {
-        type: 'done',
-        result: actionResult,
-        formState,
-      }
-    } catch (err) {
-      if (isRedirectError(err)) {
-        const redirectUrl = getURLFromRedirectError(err)
-
-        // if it's a fetch action, we don't want to mess with the status code
-        // and we'll handle it on the client router
-        await addRevalidationHeader(res, {
-          staticGenerationStore,
-          requestStore,
-        })
-
-        if (isFetchAction) {
-          return {
-            type: 'done',
-            result: await createRedirectRenderResult(
-              req,
-              res,
-              redirectUrl,
-              staticGenerationStore
-            ),
+            // Skip the fetch path
+            return
           }
-        }
+        } else {
+          const { parseBody } =
+            require('../api-utils/node/parse-body') as typeof import('../api-utils/node/parse-body')
 
-        if (err.mutableCookies) {
-          const headers = new Headers()
-
-          // If there were mutable cookies set, we need to set them on the
-          // response.
-          if (appendMutableCookies(headers, err.mutableCookies)) {
-            res.setHeader('set-cookie', Array.from(headers.values()))
-          }
-        }
-
-        res.setHeader('Location', redirectUrl)
-        res.statusCode = 303
-        return {
-          type: 'done',
-          result: new RenderResult(''),
-        }
-      } else if (isNotFoundError(err)) {
-        res.statusCode = 404
-
-        await addRevalidationHeader(res, {
-          staticGenerationStore,
-          requestStore,
-        })
-
-        if (isFetchAction) {
-          const promise = Promise.reject(err)
+          let actionData
           try {
-            await promise
-          } catch {}
-          return {
-            type: 'done',
-            result: await generateFlight({
-              skipFlight: false,
-              actionResult: promise,
-              asNotFound: true,
-            }),
+            actionData =
+              (await parseBody(req, serverActionsBodySizeLimit ?? '1mb')) || ''
+          } catch (e: any) {
+            if (e && (e as ApiError).statusCode === 413) {
+              // Exceeded the size limit
+              e.message =
+                e.message +
+                '\nTo configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/server-actions#size-limitation'
+            }
+            throw e
+          }
+
+          if (isURLEncodedAction) {
+            const formData = formDataFromSearchQueryString(actionData)
+            bound = await decodeReply(formData, serverModuleMap)
+          } else {
+            bound = await decodeReply(actionData, serverModuleMap)
           }
         }
+      }
+
+      // actions.js
+      // app/page.js
+      //   action worker1
+      //     appRender1
+
+      // app/foo/page.js
+      //   action worker2
+      //     appRender
+
+      // / -> fire action -> POST / -> appRender1 -> modId for the action file
+      // /foo -> fire action -> POST /foo -> appRender2 -> modId for the action file
+
+      // Get all workers that include this action
+      const actionWorkers =
+        serverActionsManifest[
+          process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
+        ][actionId]
+
+      if (!actionWorkers) {
+        // When this happens, it could be a deployment skew where the action came
+        // from a different deployment. We'll just return a 404 with a message logged.
+        console.error(
+          'Failed to find Server Action "${actionId}". This request might be from an older or newer deployment.'
+        )
         return {
           type: 'not-found',
         }
       }
 
+      const actionModId = actionWorkers.workers[workerName]
+      const actionHandler =
+        ComponentMod.__next_app__.require(actionModId)[actionId]
+
+      const returnVal = await actionHandler.apply(null, bound)
+
+      // For form actions, we need to continue rendering the page.
       if (isFetchAction) {
-        res.statusCode = 500
-        await Promise.all(staticGenerationStore.pendingRevalidates || [])
+        await addRevalidationHeader(res, {
+          staticGenerationStore,
+          requestStore,
+        })
+
+        actionResult = await generateFlight({
+          actionResult: Promise.resolve(returnVal),
+          // if the page was not revalidated, we can skip the rendering the flight tree
+          skipFlight: !staticGenerationStore.pathWasRevalidated,
+        })
+      }
+    })
+
+    return {
+      type: 'done',
+      result: actionResult,
+      formState,
+    }
+  } catch (err) {
+    if (isRedirectError(err)) {
+      const redirectUrl = getURLFromRedirectError(err)
+
+      // if it's a fetch action, we don't want to mess with the status code
+      // and we'll handle it on the client router
+      await addRevalidationHeader(res, {
+        staticGenerationStore,
+        requestStore,
+      })
+
+      if (isFetchAction) {
+        return {
+          type: 'done',
+          result: await createRedirectRenderResult(
+            req,
+            res,
+            redirectUrl,
+            staticGenerationStore
+          ),
+        }
+      }
+
+      if (err.mutableCookies) {
+        const headers = new Headers()
+
+        // If there were mutable cookies set, we need to set them on the
+        // response.
+        if (appendMutableCookies(headers, err.mutableCookies)) {
+          res.setHeader('set-cookie', Array.from(headers.values()))
+        }
+      }
+
+      res.setHeader('Location', redirectUrl)
+      res.statusCode = 303
+      return {
+        type: 'done',
+        result: new RenderResult(''),
+      }
+    } else if (isNotFoundError(err)) {
+      res.statusCode = 404
+
+      await addRevalidationHeader(res, {
+        staticGenerationStore,
+        requestStore,
+      })
+
+      if (isFetchAction) {
         const promise = Promise.reject(err)
         try {
           await promise
         } catch {}
-
         return {
           type: 'done',
           result: await generateFlight({
+            skipFlight: false,
             actionResult: promise,
-            // if the page was not revalidated, we can skip the rendering the flight tree
-            skipFlight: !staticGenerationStore.pathWasRevalidated,
+            asNotFound: true,
           }),
         }
       }
-
-      throw err
+      return {
+        type: 'not-found',
+      }
     }
+
+    if (isFetchAction) {
+      res.statusCode = 500
+      await Promise.all(staticGenerationStore.pendingRevalidates || [])
+      const promise = Promise.reject(err)
+      try {
+        await promise
+      } catch {}
+
+      return {
+        type: 'done',
+        result: await generateFlight({
+          actionResult: promise,
+          // if the page was not revalidated, we can skip the rendering the flight tree
+          skipFlight: !staticGenerationStore.pathWasRevalidated,
+        }),
+      }
+    }
+
+    throw err
   }
 }


### PR DESCRIPTION
When there's a version skew, it might be possible that the Action's ID has changed and we're no longer able to locate it. By definition, that means we **should** return a 404 because it might have a different implementation now. Currently this throws a "cannot access workers of undefined" error which doesn't make sense.

Please review with whitespace ignored.