### PR TITLE
Update app-icons.mdx: icon and apple-icon need to be in the root route segment as well

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/app-icons.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/app-icons.mdx
@@ -22,8 +22,8 @@ Next.js will evaluate the file and automatically add the appropriate tags to you
 | File convention             | Supported file types                    | Valid locations |
 | --------------------------- | --------------------------------------- | --------------- |
 | [`favicon`](#favicon)       | `.ico`                                  | `app/`          |
-| [`icon`](#icon)             | `.ico`, `.jpg`, `.jpeg`, `.png`, `.svg` | `app/**/*`      |
-| [`apple-icon`](#apple-icon) | `.jpg`, `.jpeg`, `.png`                 | `app/**/*`      |
+| [`icon`](#icon)             | `.ico`, `.jpg`, `.jpeg`, `.png`, `.svg` | `app/`      |
+| [`apple-icon`](#apple-icon) | `.jpg`, `.jpeg`, `.png`                 | `app/`      |
 
 ### `favicon`
 
@@ -35,7 +35,7 @@ Add a `favicon.ico` image file to the root `/app` route segment.
 
 ### `icon`
 
-Add an `icon.(ico|jpg|jpeg|png|svg)` image file.
+Add an `icon.(ico|jpg|jpeg|png|svg)` image file to the root `/app` route segment.
 
 ```html filename="<head> output"
 <link
@@ -48,7 +48,7 @@ Add an `icon.(ico|jpg|jpeg|png|svg)` image file.
 
 ### `apple-icon`
 
-Add an `apple-icon.(jpg|jpeg|png)` image file.
+Add an `apple-icon.(jpg|jpeg|png)` image file to the root `/app` route segment.
 
 ```html filename="<head> output"
 <link
@@ -62,7 +62,6 @@ Add an `apple-icon.(jpg|jpeg|png)` image file.
 > **Good to know**
 >
 > - You can set multiple icons by adding a number suffix to the file name. For example, `icon1.png`, `icon2.png`, etc. Numbered files will sort lexically.
-> - Favicons can only be set in the root `/app` segment. If you need more granularity, you can use [`icon`](#icon).
 > - The appropriate `<link>` tags and attributes such as `rel`, `href`, `type`, and `sizes` are determined by the icon type and metadata of the evaluated file.
 >   - For example, a 32 by 32px `.png` file will have `type="image/png"` and `sizes="32x32"` attributes.
 > - `sizes="any"` is added to `favicon.ico` output to [avoid a browser bug](https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs) where an `.ico` icon is favored over `.svg`.


### PR DESCRIPTION
The docs suggest that `icon` files can be place in other folders than the root route segment.  However, that does not work.

See also https://github.com/vercel/next.js/issues/52579
