### PR TITLE
Fix root not found page not loading beforeInteractive scripts in dev

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -160,6 +160,7 @@ async function createTreeCodeFromPath(
     metadataResolver,
     pageExtensions,
     basePath,
+    loaderContext,
   }: {
     page: string
     resolveDir: DirResolver
@@ -178,8 +179,11 @@ async function createTreeCodeFromPath(
   rootLayout: string | undefined
   globalError: string | undefined
 }> {
+  const isDev = loaderContext.mode === 'development'
+  const notFoundRoute = isDev ? '/not-found' : '/_not-found'
+
   const splittedPath = pagePath.split(/[\\/]/)
-  const isNotFoundRoute = page === '/_not-found'
+  const isNotFoundRoute = page === notFoundRoute
   const isDefaultNotFound = isAppBuiltinNotFoundPage(pagePath)
   const appDirPrefix = isDefaultNotFound ? APP_DIR_ALIAS : splittedPath[0]
   const hasRootNotFound = await resolver(

--- a/test/e2e/app-dir/not-found/before-interactive-scripts-loaded/app/layout.tsx
+++ b/test/e2e/app-dir/not-found/before-interactive-scripts-loaded/app/layout.tsx
@@ -1,0 +1,16 @@
+import Script from 'next/script'
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>
+        {children}
+
+        <Script id="beforeInteractiveScript" strategy="beforeInteractive">
+          {`window.__BEFORE_INTERACTIVE_CONTENT = "loaded"`}
+        </Script>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/not-found/before-interactive-scripts-loaded/app/not-found.tsx
+++ b/test/e2e/app-dir/not-found/before-interactive-scripts-loaded/app/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <div></div>
+}

--- a/test/e2e/app-dir/not-found/before-interactive-scripts-loaded/app/page.tsx
+++ b/test/e2e/app-dir/not-found/before-interactive-scripts-loaded/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div></div>
+}

--- a/test/e2e/app-dir/not-found/before-interactive-scripts-loaded/index.test.ts
+++ b/test/e2e/app-dir/not-found/before-interactive-scripts-loaded/index.test.ts
@@ -1,0 +1,20 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'app dir - not-found - before interactive scripts loaded',
+  {
+    files: __dirname,
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should include before interactive scripts defined in RootLayout', async () => {
+      const browser = await next.browser('/non-existent')
+
+      const scriptContent = await browser.eval(
+        'window.__BEFORE_INTERACTIVE_CONTENT'
+      )
+
+      expect(scriptContent).toBe('loaded')
+    })
+  }
+)


### PR DESCRIPTION
There's an issue when running the app in development with the root not found page not including beforeInteractive scripts.

The main issue is that `appBoostrap` is being called before `initialize` thus `self.__next_s` is `undefined`.

Some work was done previously that fixed this issue from happening in production: https://github.com/vercel/next.js/commit/594f3d1fc0b917b4438cc72bbe284792a7dedda6

The problem is that page in development is equal to /not-found instead of /_not-found so that change is not being applied. I tested it by checking against /not-found instead and the script was added properly.

My proposed solution checks if we are in development and if we do we compare page against `/not-found` instead of `/_not-found`.

This change fixes the beforeInteractive scripts in the root not-found page.

Fixes #56556 
