### PR TITLE
doc: CSP middleware stop passing request headers to response

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/15-content-security-policy.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/15-content-security-policy.mdx
@@ -53,22 +53,18 @@ export function middleware(request: NextRequest) {
     frame-ancestors 'none';
     block-all-mixed-content;
     upgrade-insecure-requests;
-`
+`.replace(/\s{2,}/g, ' ').trim() // Replace newline characters and spaces
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', nonce)
-  requestHeaders.set(
-    'Content-Security-Policy',
-    // Replace newline characters and spaces
-    cspHeader.replace(/\s{2,}/g, ' ').trim()
-  )
+  requestHeaders.set('Content-Security-Policy', cspHeader)
 
-  return NextResponse.next({
-    headers: requestHeaders,
-    request: {
-      headers: requestHeaders,
-    },
-  })
+  // Create response and set request headers
+  const response = NextResponse.next({ request: { headers: requestHeaders } })
+  // Now update the response headers
+  response.headers.set("content-security-policy", contentSecurityPolicy)
+
+  return response
 }
 ```
 

--- a/docs/02-app/01-building-your-application/07-configuring/15-content-security-policy.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/15-content-security-policy.mdx
@@ -53,7 +53,9 @@ export function middleware(request: NextRequest) {
     frame-ancestors 'none';
     block-all-mixed-content;
     upgrade-insecure-requests;
-`.replace(/\s{2,}/g, ' ').trim() // Replace newline characters and spaces
+`
+    .replace(/\s{2,}/g, ' ')
+    .trim() // Replace newline characters and spaces
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', nonce)
@@ -62,7 +64,7 @@ export function middleware(request: NextRequest) {
   // Create response and set request headers
   const response = NextResponse.next({ request: { headers: requestHeaders } })
   // Now update the response headers
-  response.headers.set("content-security-policy", contentSecurityPolicy)
+  response.headers.set('content-security-policy', contentSecurityPolicy)
 
   return response
 }
@@ -86,21 +88,19 @@ export function middleware(request) {
     block-all-mixed-content;
     upgrade-insecure-requests;
 `
+    .replace(/\s{2,}/g, ' ')
+    .trim() // Replace newline characters and spaces
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', nonce)
-  requestHeaders.set(
-    'Content-Security-Policy',
-    // Replace newline characters and spaces
-    cspHeader.replace(/\s{2,}/g, ' ').trim()
-  )
+  requestHeaders.set('Content-Security-Policy', cspHeader)
 
-  return NextResponse.next({
-    headers: requestHeaders,
-    request: {
-      headers: requestHeaders,
-    },
-  })
+  // Create response and set request headers
+  const response = NextResponse.next({ request: { headers: requestHeaders } })
+  // Now update the response headers
+  response.headers.set('content-security-policy', contentSecurityPolicy)
+
+  return response
 }
 ```
 


### PR DESCRIPTION
Because not all request headers should be returned in the response, we shouldn't blindly recommend passing all request headers into the modified Response

## For Contributors

### Improving Documentation

- ✅ Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- ✅ Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide


### What?

The way the documentation suggests adding headers will result in all request headers being returned on the response.

This results in things like `user-agent` being a response header.

### Why?

This potentially could be a security problem. Although the larger issue is the wrong headers being sent back.

### How?

Simply modify the MDX