### PR TITLE
Revert Update parallelizing tasks with webpackBuildWorker config

### DIFF
--- a/packages/next/src/build/build-context.ts
+++ b/packages/next/src/build/build-context.ts
@@ -5,6 +5,7 @@ import type { __ApiPreviewProps } from '../server/api-utils'
 import type { NextConfigComplete } from '../server/config-shared'
 import type { Span } from '../trace'
 import type getBaseWebpackConfig from './webpack-config'
+import type { PagesManifest } from './webpack/plugins/pages-manifest-plugin'
 import type { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
 
 // A layer for storing data that is used by plugins to communicate with each
@@ -47,6 +48,12 @@ export function getPluginState() {
 export const NextBuildContext: Partial<{
   compilerIdx?: number
   pluginState: Record<string, any>
+  serializedPagesManifestEntries: {
+    edgeServerPages?: PagesManifest
+    nodeServerPages?: PagesManifest
+    edgeServerAppPaths?: PagesManifest
+    nodeServerAppPaths?: PagesManifest
+  }
   // core fields
   dir: string
   buildId: string

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -26,6 +26,7 @@ import { WEBPACK_LAYERS } from '../../lib/constants'
 import { TraceEntryPointsPlugin } from '../webpack/plugins/next-trace-entrypoints-plugin'
 import type { BuildTraceContext } from '../webpack/plugins/next-trace-entrypoints-plugin'
 import type { UnwrapPromise } from '../../lib/coalesced-function'
+import * as pagesPluginModule from '../webpack/plugins/pages-manifest-plugin'
 
 import origDebug from 'next/dist/compiled/debug'
 
@@ -59,6 +60,7 @@ export async function webpackBuildImpl(
   duration: number
   pluginState: any
   buildTraceContext?: BuildTraceContext
+  serializedPagesManifestEntries?: (typeof NextBuildContext)['serializedPagesManifestEntries']
 }> {
   let result: CompilerResult | null = {
     warnings: [],
@@ -323,6 +325,12 @@ export async function webpackBuildImpl(
       duration: webpackBuildEnd[0],
       buildTraceContext: traceEntryPointsPlugin?.buildTraceContext,
       pluginState: getPluginState(),
+      serializedPagesManifestEntries: {
+        edgeServerPages: pagesPluginModule.edgeServerPages,
+        edgeServerAppPaths: pagesPluginModule.edgeServerAppPaths,
+        nodeServerPages: pagesPluginModule.nodeServerPages,
+        nodeServerAppPaths: pagesPluginModule.nodeServerAppPaths,
+      },
     }
   }
 }
@@ -337,6 +345,16 @@ export async function workerMain(workerData: {
 
   // Resume plugin state
   resumePluginState(NextBuildContext.pluginState)
+
+  // restore module scope maps for flight plugins
+  const { serializedPagesManifestEntries } = NextBuildContext
+
+  for (const key of Object.keys(serializedPagesManifestEntries || {})) {
+    Object.assign(
+      (pagesPluginModule as any)[key],
+      (serializedPagesManifestEntries as any)?.[key]
+    )
+  }
 
   /// load the config because it's not serializable
   NextBuildContext.config = await loadConfig(
@@ -353,12 +371,17 @@ export async function workerMain(workerData: {
       result.buildTraceContext!.entriesTrace!.depModArray = depModArray
     }
     if (entryNameMap) {
-      const entryEntries = entryNameMap
-      result.buildTraceContext!.entriesTrace!.entryNameMap = entryEntries
+      const entryEntries = Array.from(entryNameMap?.entries() ?? [])
+      // @ts-expect-error
+      result.buildTraceContext.entriesTrace.entryNameMap = entryEntries
     }
   }
   if (chunksTrace?.entryNameFilesMap) {
-    const entryNameFilesMap = chunksTrace.entryNameFilesMap
+    const entryNameFilesMap = Array.from(
+      chunksTrace.entryNameFilesMap.entries() ?? []
+    )
+
+    // @ts-expect-error
     result.buildTraceContext!.chunksTrace!.entryNameFilesMap = entryNameFilesMap
   }
   return result

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2021,9 +2021,8 @@ export default async function getBaseWebpackConfig(
       isNodeOrEdgeCompilation &&
         new PagesManifestPlugin({
           dev,
-          appDirEnabled: hasAppDir,
           isEdgeRuntime: isEdgeServer,
-          distDir: !dev ? distDir : undefined,
+          appDirEnabled: hasAppDir,
         }),
       // MiddlewarePlugin should be after DefinePlugin so  NEXT_PUBLIC_*
       // replacement is done before its process.env.* handling

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -118,12 +118,12 @@ export interface BuildTraceContext {
     appDir: string
     outputPath: string
     depModArray: string[]
-    entryNameMap: Record<string, string>
+    entryNameMap: Map<string, string>
   }
   chunksTrace?: {
     action: TurbotraceAction
     outputPath: string
-    entryNameFilesMap: Record<string, Array<string>>
+    entryNameFilesMap: Map<string, Array<string>>
   }
 }
 
@@ -222,7 +222,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
           logLevel: this.turbotrace?.logLevel,
         },
         outputPath,
-        entryNameFilesMap: Object.fromEntries(entryNameFilesMap),
+        entryNameFilesMap,
       }
 
       for (const [entrypoint, entryFiles] of entryFilesMap) {
@@ -434,7 +434,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
               },
               appDir: this.rootDir,
               depModArray: Array.from(depModMap.keys()),
-              entryNameMap: Object.fromEntries(entryNameMap),
+              entryNameMap,
               outputPath: compilation.outputOptions.path!,
             }
 

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -89,7 +89,7 @@ export class Worker<T extends object = object, Args extends any[] = any[]> {
 
           poolWorker._child.once('exit', (code, signal) => {
             // log unexpected exit if .end() wasn't called
-            if ((code || (signal && signal !== 'SIGINT')) && this._worker) {
+            if ((code || signal) && this._worker) {
               console.error(
                 `Static worker unexpectedly exited with code: ${code} and signal: ${signal}`
               )


### PR DESCRIPTION
This reverts the parallelizing which was being experimented with to speed up the total build time although the main goal of this config is reduce memory usage and to avoid OOMs which parallelizing goes against since it will require more memory. 