### PR TITLE
Fix trace ignore handling

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -233,7 +233,7 @@ export async function collectBuildTraces({
           })
         }
       }
-      const ignores = [
+      const serverIgnores = [
         '**/*.d.ts',
         '**/*.map',
         isStandalone ? null : '**/next/dist/compiled/jest-worker/**/*',
@@ -241,6 +241,8 @@ export async function collectBuildTraces({
         '**/node_modules/webpack5/**/*',
         '**/next/dist/server/lib/squoosh/**/*.wasm',
         '**/next/dist/server/lib/route-resolver*',
+        '**/next/dist/pages/**/*',
+
         ...(ciEnvironment.hasNextSupport
           ? [
               // only ignore image-optimizer code when
@@ -261,12 +263,12 @@ export async function collectBuildTraces({
         ...(config.experimental.outputFileTracingIgnores || []),
       ].filter(nonNullable)
 
-      const ignoreFn = (pathname: string) => {
+      const serverIgnoreFn = (pathname: string) => {
         if (path.isAbsolute(pathname) && !pathname.startsWith(root)) {
           return true
         }
 
-        return isMatch(pathname, ignores, {
+        return isMatch(pathname, serverIgnores, {
           contains: true,
           dot: true,
         })
@@ -321,7 +323,7 @@ export async function collectBuildTraces({
           [minimalServerTracedFiles, minimalFiles],
         ] as [Set<string>, string[]][]) {
           for (const file of files) {
-            if (!ignoreFn(path.join(traceContext, file))) {
+            if (!serverIgnoreFn(path.join(traceContext, file))) {
               addToTracedFiles(traceContext, file, set)
             }
           }
@@ -336,7 +338,6 @@ export async function collectBuildTraces({
         const result = await nodeFileTrace(chunksToTrace, {
           base: outputFileTracingRoot,
           processCwd: dir,
-          ignore: ignoreFn,
           mixedModules: true,
         })
         const reasons = result.reasons
@@ -360,12 +361,7 @@ export async function collectBuildTraces({
             for (const curFile of curFiles || []) {
               const filePath = path.join(outputFileTracingRoot, curFile)
 
-              if (
-                !isMatch(filePath, '**/next/dist/pages/**/*', {
-                  dot: true,
-                  contains: true,
-                })
-              ) {
+              if (!serverIgnoreFn(filePath)) {
                 tracedFiles.add(
                   path.relative(distDir, filePath).replace(/\\/g, '/')
                 )


### PR DESCRIPTION
This ensures we separate our ignore handling for next-server runtime entries and `.next/server` chunks. When these were combined our ignores caused modules that should were actually needed by user code to be excluded. 

Verified patch against the provided minimal repros

![CleanShot 2023-10-10 at 11 56 36@2x](https://github.com/vercel/next.js/assets/22380829/1dd83996-fa95-462a-98ed-485ce6c4d3f5)

![CleanShot 2023-10-10 at 12 01 08@2x](https://github.com/vercel/next.js/assets/22380829/c17c6147-0e3e-422b-bf2d-5fedfd6827ef)


x-ref: https://github.com/vercel/next.js/pull/56048#discussion_r1345651964
Fixes: https://github.com/vercel/next.js/issues/56357