### PR TITLE
Fix SSG query with experimental-compile

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -941,7 +941,7 @@ export default async function build(
                 ? path.relative(distDir, incrementalCacheHandlerPath)
                 : undefined,
 
-              isExperimentalCompile: true,
+              isExperimentalCompile: isCompile,
             },
           },
           appDir: dir,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -688,7 +688,8 @@ export default class NextNodeServer extends BaseServer {
         return {
           components,
           query: {
-            ...(components.getStaticProps
+            ...(!this.renderOpts.isExperimentalCompile &&
+            components.getStaticProps
               ? ({
                   amp: query.amp,
                   __nextDataReq: query.__nextDataReq,

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -199,7 +199,7 @@ export class NextServer {
         )).config
 
         // @ts-expect-error internal field
-        config.experimental.isExperimentalConfig =
+        config.experimental.isExperimentalCompile =
           serializedConfig.experimental.isExperimentalCompile
       } catch (_) {
         // if distDir is customized we don't know until we

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -14,6 +14,16 @@ createNextDescribe(
       : undefined,
   },
   ({ next, isNextDev: isDev, isNextStart, isNextDeploy }) => {
+    if (process.env.NEXT_EXPERIMENTAL_COMPILE) {
+      it('should provide query for getStaticProps page correctly', async () => {
+        const res = await next.fetch('/ssg?hello=world')
+        expect(res.status).toBe(200)
+
+        const $ = cheerio.load(await res.text())
+        expect(JSON.parse($('#query').text())).toEqual({ hello: 'world' })
+      })
+    }
+
     if (isNextStart && !process.env.NEXT_EXPERIMENTAL_COMPILE) {
       it('should not have loader generated function for edge runtime', async () => {
         expect(

--- a/test/e2e/app-dir/app/pages/ssg.js
+++ b/test/e2e/app-dir/app/pages/ssg.js
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router'
+
+export default function Page(props) {
+  return (
+    <>
+      <p>hello from ssg</p>
+      <p id="query">{JSON.stringify(useRouter().query)}</p>
+    </>
+  )
+}
+
+export function getStaticProps() {
+  return {
+    props: {},
+  }
+}


### PR DESCRIPTION
Ensures query isn't omitted when using experimental compile mode with SSG pages as it skips the isReady delay that is normally done with prerendering. 