### PR TITLE
Ensure rewrites are included in build manifest when using Turbopack

### DIFF
--- a/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
@@ -20,12 +20,36 @@ import { spans } from './profiling-plugin'
 
 type DeepMutable<T> = { -readonly [P in keyof T]: DeepMutable<T[P]> }
 
-export type ClientBuildManifest = Record<string, string[]>
+export type ClientBuildManifest = {
+  [key: string]: string[]
+}
 
 // Add the runtime ssg manifest file as a lazy-loaded file dependency.
 // We also stub this file out for development mode (when it is not
 // generated).
 export const srcEmptySsgManifest = `self.__SSG_MANIFEST=new Set;self.__SSG_MANIFEST_CB&&self.__SSG_MANIFEST_CB()`
+
+function normalizeRewrite(item: {
+  source: string
+  destination: string
+  has?: any
+}): CustomRoutes['rewrites']['beforeFiles'][0] {
+  return {
+    has: item.has,
+    source: item.source,
+    destination: item.destination,
+  }
+}
+
+export function normalizeRewritesForBuildManifest(
+  rewrites: CustomRoutes['rewrites']
+): CustomRoutes['rewrites'] {
+  return {
+    afterFiles: rewrites.afterFiles?.map((item) => normalizeRewrite(item)),
+    beforeFiles: rewrites.beforeFiles?.map((item) => normalizeRewrite(item)),
+    fallback: rewrites.fallback?.map((item) => normalizeRewrite(item)),
+  }
+}
 
 // This function takes the asset map generated in BuildManifestPlugin and creates a
 // reduced version to send to the client.
@@ -40,27 +64,9 @@ function generateClientManifest(
     'NextJsBuildManifest-generateClientManifest'
   )
 
-  const normalizeRewrite = (item: {
-    source: string
-    destination: string
-    has?: any
-  }) => {
-    return {
-      has: item.has,
-      source: item.source,
-      destination: item.destination,
-    }
-  }
-
   return genClientManifestSpan?.traceFn(() => {
     const clientManifest: ClientBuildManifest = {
-      __rewrites: {
-        afterFiles: rewrites.afterFiles?.map((item) => normalizeRewrite(item)),
-        beforeFiles: rewrites.beforeFiles?.map((item) =>
-          normalizeRewrite(item)
-        ),
-        fallback: rewrites.fallback?.map((item) => normalizeRewrite(item)),
-      } as any,
+      __rewrites: normalizeRewritesForBuildManifest(rewrites) as any,
     }
     const appDependencies = new Set(assetMap.pages['/_app'])
     const sortedPageKeys = getSortedRoutes(Object.keys(assetMap.pages))

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -98,7 +98,11 @@ import {
 } from 'next/dist/compiled/@next/react-dev-overlay/dist/middleware'
 import { mkdir, readFile, writeFile, rename, unlink } from 'fs/promises'
 import { PageNotFoundError } from '../../../shared/lib/utils'
-import { srcEmptySsgManifest } from '../../../build/webpack/plugins/build-manifest-plugin'
+import {
+  type ClientBuildManifest,
+  normalizeRewritesForBuildManifest,
+  srcEmptySsgManifest,
+} from '../../../build/webpack/plugins/build-manifest-plugin'
 import { devPageFiles } from '../../../build/webpack/plugins/next-types-plugin/shared'
 import type { LazyRenderServerInstance } from '../router-server'
 import { pathToRegexp } from 'next/dist/compiled/path-to-regexp'
@@ -710,7 +714,9 @@ async function startWatcher(opts: SetupOpts) {
       }
     }
 
-    async function writeBuildManifest(): Promise<void> {
+    async function writeBuildManifest(
+      rewrites: SetupOpts['fsChecker']['rewrites']
+    ): Promise<void> {
       const buildManifest = mergeBuildManifests(buildManifests.values())
       const buildManifestPath = path.join(distDir, BUILD_MANIFEST)
       deleteCache(buildManifestPath)
@@ -718,8 +724,11 @@ async function startWatcher(opts: SetupOpts) {
         buildManifestPath,
         JSON.stringify(buildManifest, null, 2)
       )
-      const content = {
-        __rewrites: { afterFiles: [], beforeFiles: [], fallback: [] },
+
+      const content: ClientBuildManifest = {
+        __rewrites: rewrites
+          ? (normalizeRewritesForBuildManifest(rewrites) as any)
+          : { afterFiles: [], beforeFiles: [], fallback: [] },
         ...Object.fromEntries(
           [...curEntries.keys()].map((pathname) => [
             pathname,
@@ -1035,7 +1044,7 @@ async function startWatcher(opts: SetupOpts) {
       )
     )
     await currentEntriesHandling
-    await writeBuildManifest()
+    await writeBuildManifest(opts.fsChecker.rewrites)
     await writeAppBuildManifest()
     await writeFallbackBuildManifest()
     await writePagesManifest()
@@ -1204,7 +1213,7 @@ async function startWatcher(opts: SetupOpts) {
           await loadBuildManifest('_error')
           await loadPagesManifest('_error')
 
-          await writeBuildManifest()
+          await writeBuildManifest(opts.fsChecker.rewrites)
           await writeFallbackBuildManifest()
           await writePagesManifest()
           await writeMiddlewareManifest()
@@ -1318,7 +1327,7 @@ async function startWatcher(opts: SetupOpts) {
               middlewareManifests.delete(page)
             }
 
-            await writeBuildManifest()
+            await writeBuildManifest(opts.fsChecker.rewrites)
             await writeFallbackBuildManifest()
             await writePagesManifest()
             await writeMiddlewareManifest()
@@ -1379,7 +1388,7 @@ async function startWatcher(opts: SetupOpts) {
             await loadActionManifest(page)
 
             await writeAppBuildManifest()
-            await writeBuildManifest()
+            await writeBuildManifest(opts.fsChecker.rewrites)
             await writeAppPathsManifest()
             await writeMiddlewareManifest()
             await writeActionManifest()


### PR DESCRIPTION
The build manifest when using webpack includes the rewrites config so that the Pages Router can correctly match the path. The manifest for Turbopack was missing these properties which caused a bunch of the middleware tests to fail. This PR reuses the function to generate rewrites from build-manifest-plugin.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
