### PR TITLE
fix static worker restart behavior

### DIFF
--- a/test/production/app-dir/worker-restart/app/bad-page/page.js
+++ b/test/production/app-dir/worker-restart/app/bad-page/page.js
@@ -1,0 +1,11 @@
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 11000))
+
+  return {
+    title: 'Test',
+  }
+}
+
+export default function Page() {
+  return <div>Hello World</div>
+}

--- a/test/production/app-dir/worker-restart/app/layout.js
+++ b/test/production/app-dir/worker-restart/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/worker-restart/app/page.js
+++ b/test/production/app-dir/worker-restart/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Root Page</div>
+}

--- a/test/production/app-dir/worker-restart/next.config.js
+++ b/test/production/app-dir/worker-restart/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  staticPageGenerationTimeout: 10,
+}

--- a/test/production/app-dir/worker-restart/worker-restart.test.ts
+++ b/test/production/app-dir/worker-restart/worker-restart.test.ts
@@ -1,0 +1,21 @@
+import { nextBuild } from 'next-test-utils'
+
+describe('worker-restart', () => {
+  it('should properly exhaust all restart attempts and not fail with any worker errors', async () => {
+    const { stdout, stderr } = await nextBuild(__dirname, [], {
+      stdout: true,
+      stderr: true,
+    })
+
+    const output = stdout + stderr
+    expect(output).toContain(
+      'Restarted static page generation for /bad-page because it took more than 10 seconds'
+    )
+    expect(output).toContain(
+      'Static page generation for /bad-page is still timing out after 3 attempts'
+    )
+    expect(output).not.toContain(
+      'Error: Farm is ended, no more calls can be done to it'
+    )
+  })
+})


### PR DESCRIPTION
In [55841](https://github.com/vercel/next.js/pull/55841), this file was reworked to improve type safety and readability, but it changed the behavior of how we were invoking methods on the worker. Specifically, when a restart occurred, this timeout wrapping function was referencing an already ended worker, resulting in a "Farm is ended, no more calls can be done to it" build error.

This PR ensures that we're fetching the method from the current `this._worker` at the time of invocation, not at the time of method creation.

[Slack x-ref](https://vercel.slack.com/archives/C04KC8A53T7/p1697064752635179?thread_ts=1696952142.759769&cid=C04KC8A53T7)