### PR TITLE
Docs: Add missing description field

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/optimizePackageImports.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/optimizePackageImports.mdx
@@ -1,6 +1,6 @@
 ---
 title: optimizePackageImports
-description:
+description: API Reference for optmizedPackageImports Next.js Config Option
 ---
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}


### PR DESCRIPTION
Fixing error in next-site due to empty description field. 