### PR TITLE
Trigger canary release nightly

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -1,4 +1,8 @@
 on:
+  schedule:
+    # run every day at 23:15
+    - cron: '15 23 * * *'
+
   workflow_dispatch:
     inputs:
       releaseType:
@@ -38,7 +42,7 @@ jobs:
       # canary next-swc binaries in the monorepo
       NEXT_SKIP_NATIVE_POSTINSTALL: 1
 
-    environment: release-${{ github.event.inputs.releaseType }}
+    environment: release-${{ github.event.inputs.releaseType || 'canary' }}
     steps:
       - name: Setup node
         uses: actions/setup-node@v3
@@ -73,6 +77,6 @@ jobs:
 
       - run: pnpm run build
 
-      - run: node ./scripts/start-release.js --release-type ${{ github.event.inputs.releaseType }} --semver-type ${{ github.event.inputs.semverType }}
+      - run: node ./scripts/start-release.js --release-type ${{ github.event.inputs.releaseType || 'canary' }} --semver-type ${{ github.event.inputs.semverType }}
         env:
           RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/56755 this updates to trigger at least one canary nightly before we run our E2E deploy tests. 