### PR TITLE
build: Update `swc_core` to `v0.86.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "serde",
  "smallvec",
@@ -3524,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "serde",
@@ -7635,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7667,7 +7667,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7708,7 +7708,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7725,7 +7725,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7755,7 +7755,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "base16",
  "hex",
@@ -7767,7 +7767,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7781,7 +7781,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7791,7 +7791,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "mimalloc",
 ]
@@ -7799,7 +7799,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7824,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7895,7 +7895,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7917,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7941,7 +7941,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7971,7 +7971,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7993,7 +7993,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8017,7 +8017,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8054,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8088,7 +8088,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "serde",
  "serde_json",
@@ -8099,7 +8099,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8122,7 +8122,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8139,7 +8139,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8155,7 +8155,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8175,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "serde",
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8205,7 +8205,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8240,7 +8240,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "serde",
@@ -8256,7 +8256,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8267,7 +8267,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231017.3#6ffb2e9cb5e18301fca7ccdc0b909deb04cd9fc4"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "serde",
  "smallvec",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.57.26"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6caf54b6448f05c25096a528c2a3b292e38fb59298c118edcf9da45ff05515"
+checksum = "be6c12f02a22c583432408b7726ed405c693964dd4d13e212f06b829a80c6a17"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -531,11 +531,11 @@ dependencies = [
  "once_cell",
  "serde",
  "serde-wasm-bindgen",
- "swc 0.266.26",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_transforms 0.224.19",
- "swc_ecma_visit 0.95.1",
+ "swc",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms",
+ "swc_ecma_visit",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -1301,19 +1301,24 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.29.6"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
+checksum = "9be934d936a0fbed5bcdc01042b770de1398bf79d0e192f49fa7faea0e99281e"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "matches",
  "phf",
- "proc-macro2",
- "quote",
  "smallvec",
- "syn 1.0.109",
+]
+
+[[package]]
+name = "cssparser-color"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556c099a61d85989d7af52b692e35a8d68a57e7df8c6d07563dc0778b3960c9f"
+dependencies = [
+ "cssparser",
 ]
 
 [[package]]
@@ -2848,14 +2853,15 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.46"
+version = "1.0.0-alpha.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfe5176488bc25fda36d65ef3570d378a7c48d5ae22a63c030b443e9943b8eb"
+checksum = "06476660ee1e593a2672e4a342a1289708fd9936dcdf3e74433ad078145e9e3d"
 dependencies = [
  "ahash 0.7.6",
  "bitflags 2.4.0",
  "const-str",
  "cssparser",
+ "cssparser-color",
  "dashmap",
  "data-encoding",
  "itertools",
@@ -2868,13 +2874,14 @@ dependencies = [
  "rayon",
  "serde",
  "smallvec",
+ "static-self",
 ]
 
 [[package]]
 name = "lightningcss-derive"
-version = "1.0.0-alpha.40"
+version = "1.0.0-alpha.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcce94c3a34f43e83e1f92a81eca61697c298149a56489bba1b02ebb93fa607"
+checksum = "8f02a09f0b79d31f1ee13ea55e2f7021037c6b72e0a3ab6c1cb0e9bd7ac8a295"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3008,13 +3015,13 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73de74452171e35ed9d82961e403b8b197dcf752b45a51072d83e4813d42d53"
+checksum = "03a14df3f7188cc868ed50d415ac9527660f761ce2c392b27dc8b18b33cd7525"
 dependencies = [
  "markdown",
  "serde",
- "swc_core 0.83.28",
+ "swc_core 0.85.8",
 ]
 
 [[package]]
@@ -3207,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.48.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1070d9027b5d1eb4e54d81c86dfd26fd1e1370916ce5881c498361799e9a14"
+checksum = "1ab7951af2a437aeb38e89975f331f09dcb247c21bd923ef3e7039b1bae841e2"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -3217,9 +3224,9 @@ dependencies = [
  "regex",
  "serde",
  "swc_cached",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_visit 0.95.1",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -3491,7 +3498,7 @@ version = "0.1.0"
 dependencies = [
  "pathdiff",
  "swc_core 0.86.1",
- "testing 0.35.0",
+ "testing",
 ]
 
 [[package]]
@@ -3510,14 +3517,14 @@ version = "0.1.0"
 dependencies = [
  "rustc-hash",
  "swc_core 0.86.1",
- "testing 0.35.0",
+ "testing",
  "tracing",
 ]
 
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "serde",
@@ -3800,9 +3807,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parcel_selectors"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1aa68e6c4bf7a49302b9c711c880c1cc2a7dc5c5184042cc724e4124e0d95f"
+checksum = "0f000cdd23df6cebe999cf2b02a3bf40d55758f74883d7fd43a33690565618c8"
 dependencies = [
  "bitflags 2.4.0",
  "cssparser",
@@ -3812,6 +3819,7 @@ dependencies = [
  "phf_codegen",
  "precomputed-hash",
  "smallvec",
+ "static-self",
 ]
 
 [[package]]
@@ -4442,11 +4450,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "438fc3e0d739395c34f7741aa7b8ff1e19b7c18139fb1b083600dd9e3a2a05df"
 dependencies = [
  "serde",
- "swc_atoms 0.6.0",
+ "swc_atoms",
  "swc_cached",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_visit 0.96.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -4585,11 +4593,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f2663c3a81f6d6d0cdb15c6505287f3baade5c36bcb324180e857e39e7d09d"
 dependencies = [
  "serde",
- "swc_atoms 0.6.0",
+ "swc_atoms",
  "swc_cached",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_visit 0.96.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -4813,12 +4821,6 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
-
-[[package]]
-name = "ryu-js"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
 name = "ryu-js"
@@ -5469,6 +5471,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "static-self"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2978fa810a31711d7162d0bb843df1f36d84e393e335ce31ec2c485b2464c44"
+dependencies = [
+ "smallvec",
+ "static-self-derive",
+]
+
+[[package]]
+name = "static-self-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc53c080b79432d9babd26457df68fb4b002cc7d2ce36a1a5195091cf9fecc14"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5576,44 +5599,44 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.75.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93b77bf37c113d7401b11d87ec48d264b6200c8167e647c9f2bf5f7368d2abf"
+checksum = "2efe2ad3cd5fe8868b2fa9d7b2619110313c19c3c304733651cd90d11b6e201a"
 dependencies = [
  "Inflector",
  "once_cell",
  "regex",
  "serde",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
 [[package]]
 name = "styled_jsx"
-version = "0.52.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d784207110496555ca76ee3a29bfea8fd24c2e8a7669ae1796bddd7f50e2b"
+checksum = "e77c71053b7d8f0334864053e883bc96a14fcbc97a97e8c10b3b4c1f0614762a"
 dependencies = [
  "easy-error",
  "lightningcss",
  "parcel_selectors",
  "serde",
- "swc_common 0.32.1",
+ "swc_common",
  "swc_css_ast",
  "swc_css_codegen",
  "swc_css_minifier",
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_minifier 0.187.20",
- "swc_ecma_parser 0.140.0",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
+ "swc_ecma_ast",
+ "swc_ecma_minifier",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_plugin_macro",
  "tracing",
 ]
@@ -5654,9 +5677,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.266.26"
+version = "0.269.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518128b65105b48a58bf81e718a915ad60daebb89ccdf966d11cc616bfd0fd28"
+checksum = "129ee8c5cb4b521004a19943440b9431c153b49ee7f727a1e76b26fabbb5c679"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -5675,77 +5698,30 @@ dependencies = [
  "serde",
  "serde_json",
  "sourcemap",
- "swc_atoms 0.5.9",
+ "swc_atoms",
  "swc_cached",
- "swc_common 0.32.1",
- "swc_config",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_codegen 0.145.5",
- "swc_ecma_ext_transforms 0.109.0",
- "swc_ecma_lints 0.88.6",
- "swc_ecma_loader 0.44.4",
- "swc_ecma_minifier 0.187.20",
- "swc_ecma_parser 0.140.0",
- "swc_ecma_preset_env 0.201.21",
- "swc_ecma_transforms 0.224.19",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_transforms_compat 0.159.11",
- "swc_ecma_transforms_optimization 0.193.19",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
- "swc_error_reporters 0.16.1",
- "swc_node_comments 0.19.1",
- "swc_plugin_proxy",
- "swc_plugin_runner",
- "swc_timer 0.20.1",
- "swc_visit",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "swc"
-version = "0.269.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129ee8c5cb4b521004a19943440b9431c153b49ee7f727a1e76b26fabbb5c679"
-dependencies = [
- "anyhow",
- "base64 0.13.1",
- "dashmap",
- "either",
- "indexmap 1.9.3",
- "jsonc-parser",
- "lru",
- "once_cell",
- "parking_lot",
- "pathdiff",
- "regex",
- "rustc-hash",
- "serde",
- "serde_json",
- "sourcemap",
- "swc_atoms 0.6.0",
- "swc_cached",
- "swc_common 0.33.0",
+ "swc_common",
  "swc_compiler_base",
  "swc_config",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_codegen 0.146.1",
- "swc_ecma_ext_transforms 0.110.4",
- "swc_ecma_lints 0.89.4",
- "swc_ecma_loader 0.45.0",
- "swc_ecma_minifier 0.189.1",
- "swc_ecma_parser 0.141.1",
- "swc_ecma_preset_env 0.203.1",
- "swc_ecma_transforms 0.226.1",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_transforms_compat 0.160.5",
- "swc_ecma_transforms_optimization 0.195.1",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
- "swc_error_reporters 0.17.0",
- "swc_node_comments 0.20.0",
- "swc_timer 0.21.0",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_ext_transforms",
+ "swc_ecma_lints",
+ "swc_ecma_loader",
+ "swc_ecma_minifier",
+ "swc_ecma_parser",
+ "swc_ecma_preset_env",
+ "swc_ecma_transforms",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_compat",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "swc_error_reporters",
+ "swc_node_comments",
+ "swc_plugin_proxy",
+ "swc_plugin_runner",
+ "swc_timer",
  "swc_visit",
  "tracing",
  "url",
@@ -5753,9 +5729,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.5.9"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f54563d7dcba626d4acfe14ed12def7ecc28e004debe3ecd2c3ee07cc47e449"
+checksum = "ebf7a12229f0c0efb654a6a0f8cbfd94fbd320a57c764857a82d8abe9342b450"
 dependencies = [
  "bytecheck",
  "once_cell",
@@ -5768,24 +5744,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_atoms"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf7a12229f0c0efb654a6a0f8cbfd94fbd320a57c764857a82d8abe9342b450"
-dependencies = [
- "once_cell",
- "rustc-hash",
- "serde",
- "string_cache",
- "string_cache_codegen",
- "triomphe",
-]
-
-[[package]]
 name = "swc_bundler"
-version = "0.220.20"
+version = "0.222.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1ddf4d7fc3c4da744561ca2a984f537888fe65ce9e8d2d207372e054c351e2"
+checksum = "1685da3c84410231f19d60cfedd273cdbe7bdfc306afb8c04445678577950530"
 dependencies = [
  "anyhow",
  "crc",
@@ -5798,17 +5760,17 @@ dependencies = [
  "radix_fmt",
  "rayon",
  "relative-path",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_codegen 0.145.5",
- "swc_ecma_loader 0.44.4",
- "swc_ecma_parser 0.140.0",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_transforms_optimization 0.193.19",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
- "swc_fast_graph 0.20.1",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_loader",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "swc_fast_graph",
  "swc_graph_analyzer",
  "tracing",
 ]
@@ -5829,9 +5791,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c84742fc22df1c293da5354c1cc8a5b45a045e9dc941005c1fd9cb4e9bdabc1"
+checksum = "490e199e25d2aa3fbef675524fa81408651f4e7178b51110470ddd1b3e3bbe75"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -5852,38 +5814,7 @@ dependencies = [
  "siphasher",
  "sourcemap",
  "string_cache",
- "swc_atoms 0.5.9",
- "swc_eq_ignore_macros",
- "swc_visit",
- "termcolor",
- "tracing",
- "unicode-width",
- "url",
-]
-
-[[package]]
-name = "swc_common"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490e199e25d2aa3fbef675524fa81408651f4e7178b51110470ddd1b3e3bbe75"
-dependencies = [
- "ahash 0.8.3",
- "ast_node",
- "atty",
- "better_scoped_tls",
- "cfg-if 1.0.0",
- "either",
- "from_variant",
- "new_debug_unreachable",
- "num-bigint",
- "once_cell",
- "parking_lot",
- "rustc-hash",
- "serde",
- "siphasher",
- "sourcemap",
- "string_cache",
- "swc_atoms 0.6.0",
+ "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",
  "termcolor",
@@ -5900,18 +5831,20 @@ checksum = "0de0359c44fa960798a80815ce10f25302fa05a1d477ee9c2ab74baa926a754a"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
+ "napi",
+ "napi-derive",
  "pathdiff",
  "serde",
  "sourcemap",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
+ "swc_atoms",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_codegen 0.146.1",
- "swc_ecma_minifier 0.189.1",
- "swc_ecma_parser 0.141.1",
- "swc_ecma_visit 0.96.0",
- "swc_timer 0.21.0",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_minifier",
+ "swc_ecma_parser",
+ "swc_ecma_visit",
+ "swc_timer",
 ]
 
 [[package]]
@@ -5941,43 +5874,17 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.83.28"
+version = "0.85.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e826020b0481212a0ba4f20d5c74bbe71b6cee6949583896788ca8d98039851"
+checksum = "f7dad3a255025c7ae04576ade40dfdeb03f2229159ea6b112ed180a206a9d5a0"
 dependencies = [
- "binding_macros",
- "swc 0.266.26",
- "swc_atoms 0.5.9",
- "swc_bundler",
- "swc_cached",
- "swc_common 0.32.1",
- "swc_css_ast",
- "swc_css_codegen",
- "swc_css_compat",
- "swc_css_modules",
- "swc_css_parser",
- "swc_css_utils",
- "swc_css_visit",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_codegen 0.145.5",
- "swc_ecma_loader 0.44.4",
- "swc_ecma_minifier 0.187.20",
- "swc_ecma_parser 0.140.0",
- "swc_ecma_preset_env 0.201.21",
- "swc_ecma_quote_macros 0.51.0",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_transforms_module 0.176.14",
- "swc_ecma_transforms_optimization 0.193.19",
- "swc_ecma_transforms_proposal 0.167.13",
- "swc_ecma_transforms_react 0.179.14",
- "swc_ecma_transforms_testing 0.136.5",
- "swc_ecma_transforms_typescript 0.183.18",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
- "swc_nodejs_common",
- "swc_plugin_proxy",
- "swc_plugin_runner",
- "testing 0.34.1",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_visit",
  "vergen",
 ]
 
@@ -5987,51 +5894,67 @@ version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c049be93138bf3f521dd42500301762fdd5f5d326e11de012588dcd8135ca"
 dependencies = [
- "swc 0.269.1",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_codegen 0.146.1",
- "swc_ecma_loader 0.45.0",
- "swc_ecma_parser 0.141.1",
- "swc_ecma_preset_env 0.203.1",
- "swc_ecma_quote_macros 0.52.1",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_transforms_module 0.177.5",
- "swc_ecma_transforms_react 0.180.5",
- "swc_ecma_transforms_testing 0.137.4",
- "swc_ecma_transforms_typescript 0.185.1",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
- "testing 0.35.0",
+ "binding_macros",
+ "swc",
+ "swc_atoms",
+ "swc_bundler",
+ "swc_cached",
+ "swc_common",
+ "swc_css_ast",
+ "swc_css_codegen",
+ "swc_css_compat",
+ "swc_css_modules",
+ "swc_css_parser",
+ "swc_css_utils",
+ "swc_css_visit",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_loader",
+ "swc_ecma_minifier",
+ "swc_ecma_parser",
+ "swc_ecma_preset_env",
+ "swc_ecma_quote_macros",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_module",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_transforms_proposal",
+ "swc_ecma_transforms_react",
+ "swc_ecma_transforms_testing",
+ "swc_ecma_transforms_typescript",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "swc_nodejs_common",
+ "swc_plugin_proxy",
+ "swc_plugin_runner",
+ "testing",
  "vergen",
 ]
 
 [[package]]
 name = "swc_css_ast"
-version = "0.139.1"
+version = "0.140.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab824eff88884673de1d6b84cdb5d3d71c0b903fcef62a3ec1f44f40477433f"
+checksum = "fa155c888b70f7a1bc1de995006bda7c4b2c501712d8a88a1d6d9406b04be359"
 dependencies = [
  "is-macro",
  "serde",
  "string_enum",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
+ "swc_atoms",
+ "swc_common",
 ]
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.149.1"
+version = "0.151.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef989abd4b9ccf3caf6a4ab0ceb9f9e7d6a27c08585a20a7fc7b9db6c73a341"
+checksum = "cd94d4f6b939a7643d29fd9322d87a0c6fd9488fd9a508472239e02abcfb3f29"
 dependencies = [
  "auto_impl",
  "bitflags 2.4.0",
  "rustc-hash",
  "serde",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
+ "swc_atoms",
+ "swc_common",
  "swc_css_ast",
  "swc_css_codegen_macros",
  "swc_css_utils",
@@ -6052,16 +5975,16 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.25.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ee1b2b77e7daaf389237ca2656df01cf8c1a6f2d9b158459921b202a661f8a"
+checksum = "b77d8336003883f2590b400bc103c735eaa32d0a16beb3bcc87bc93f9e28065a"
 dependencies = [
  "bitflags 2.4.0",
  "once_cell",
  "serde",
  "serde_json",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
+ "swc_atoms",
+ "swc_common",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -6069,13 +5992,13 @@ dependencies = [
 
 [[package]]
 name = "swc_css_minifier"
-version = "0.114.1"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21db6b6ef607d47d09a7e2fd0b8fd5ec29d05d1182f8d3d5eebef0f1b94c3f4d"
+checksum = "5861fcaa5a392d38a5f21f013a16c4e6f4b0f1dd2a0db8351f33588974169e63"
 dependencies = [
  "serde",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
+ "swc_atoms",
+ "swc_common",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -6083,14 +6006,14 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.27.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac80e62e3221cb2abc0edd33886c74c7d2a64ca3756adce0047527026dff71ca"
+checksum = "0c3c9990c49999331738343387696c6a8d7379af694c3bab4707d9b43f91921c"
 dependencies = [
  "rustc-hash",
  "serde",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
+ "swc_atoms",
+ "swc_common",
  "swc_css_ast",
  "swc_css_codegen",
  "swc_css_parser",
@@ -6099,29 +6022,29 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.148.1"
+version = "0.150.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02a3c11508487249aa571a908e673c540191de97d5139bb78ab03188dd57e26"
+checksum = "04bce69bb9c68681ea4467d7c02906fd01245e9838b70c92dad4512e7ad23b2d"
 dependencies = [
  "lexical",
  "serde",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
+ "swc_atoms",
+ "swc_common",
  "swc_css_ast",
 ]
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.151.1"
+version = "0.153.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274da87a8f0117ef86382b132812aa6a1b700b31c37ef95ce3bbde7e05f8c098"
+checksum = "440823e50ce60fb4ece4d7e241849f32344676726f66324adfd38e9762ca07fe"
 dependencies = [
  "once_cell",
  "preset_env_base",
  "serde",
  "serde_json",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
+ "swc_atoms",
+ "swc_common",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -6129,49 +6052,30 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.136.1"
+version = "0.137.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eead47672e3c832e2e3fc3e523490c4822d80a7fc8c50e87a66f9ab7003b517"
+checksum = "dc71e4976bb516112b6d9d3da37989256e0fc6da84e3fe65c049ea1871515069"
 dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
+ "swc_atoms",
+ "swc_common",
  "swc_css_ast",
  "swc_css_visit",
 ]
 
 [[package]]
 name = "swc_css_visit"
-version = "0.138.1"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f01449a09b8a87ab4bd2ea6cbaaf74e39f9bfba3842a2918e998c5f9b428a4"
+checksum = "c94eb9e33d88fa3315464660a89873ff021ab940f56902d9961a06f85bdd1886"
 dependencies = [
  "serde",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
+ "swc_atoms",
+ "swc_common",
  "swc_css_ast",
  "swc_visit",
-]
-
-[[package]]
-name = "swc_ecma_ast"
-version = "0.109.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e063a1614daed3ea8be56e5dd8edb17003409088d2fc9ce4aca3378879812607"
-dependencies = [
- "bitflags 2.4.0",
- "bytecheck",
- "is-macro",
- "num-bigint",
- "rkyv",
- "scoped-tls",
- "serde",
- "string_enum",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "unicode-id",
 ]
 
 [[package]]
@@ -6181,33 +6085,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cbbf9918976a7e7fbdb4f76fe659d08e291a8b56b524b424183fc67d1189679"
 dependencies = [
  "bitflags 2.4.0",
+ "bytecheck",
  "is-macro",
  "num-bigint",
+ "rkyv",
  "scoped-tls",
  "serde",
  "string_enum",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
+ "swc_atoms",
+ "swc_common",
  "unicode-id",
-]
-
-[[package]]
-name = "swc_ecma_codegen"
-version = "0.145.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547ed57b827ea4df3e2c27cea153482f8b2ce2d271ae30c456fbb2d5a5ecc19d"
-dependencies = [
- "memchr",
- "num-bigint",
- "once_cell",
- "rustc-hash",
- "serde",
- "sourcemap",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_codegen_macros",
- "tracing",
 ]
 
 [[package]]
@@ -6222,9 +6109,9 @@ dependencies = [
  "rustc-hash",
  "serde",
  "sourcemap",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -6248,13 +6135,13 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e86fbe39425c5135fbef3bd8ffbbb6d24f8d53942d21914cf765ff43d09be19"
 dependencies = [
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_ecma_compat_es2015",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6265,10 +6152,10 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ecceb5d816d6f416bff1c13aea1814e27f43a25551066c66c0fdbd834be67bf"
 dependencies = [
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
 ]
 
@@ -6284,16 +6171,16 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
+ "swc_atoms",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 0.110.0",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_transforms_classes 0.123.4",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6304,13 +6191,13 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145df6ac733548dae7f31aa21264e8609e5deb0f0a46019a3fc8e4a70c8cbf3a"
 dependencies = [
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_transforms_base 0.134.4",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6322,13 +6209,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11b1d15155a9d1608e49a8d67e134d6d03e43eaa3f0e2b5eae465d84288c85f5"
 dependencies = [
  "serde",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_transforms_base 0.134.4",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6340,14 +6227,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "047286ba45b3afb868452b947cef646ef66d410c269935f30d494d0489c2321c"
 dependencies = [
  "serde",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6358,12 +6245,12 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cbbafa9873cd396980b0dbb34304545191f630b822659e7de13eedaa4ec6e26"
 dependencies = [
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6375,12 +6262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a22db764b289d87676997d6a3c3c00e00fe965711940aedce93a09097b742c3"
 dependencies = [
  "serde",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6391,12 +6278,12 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7ded8f71201833cca75ff0eb490e5d9237e7e1808c9ca204e6e70da545829f"
 dependencies = [
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6407,15 +6294,15 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82e116ad390b63a72250b0624100f9f0052fa0a5053bb6cd78cd11ce1636575"
 dependencies = [
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_transforms_classes 0.123.4",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6426,27 +6313,13 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2546a901da8f8570c1964961eb6d49962dcf1b3b95791e8c5899b4f53c46283a"
 dependencies = [
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_ext_transforms"
-version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d995f94740b4cde4919e6e03d982230f755f49dac9dac52f0218254a1fd69f2b"
-dependencies = [
- "phf",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
 ]
 
 [[package]]
@@ -6456,31 +6329,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c47c85a90f01607fe136be5fb15cc5033e1eb0bbe16c89855bad5e0d0915159"
 dependencies = [
  "phf",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
-]
-
-[[package]]
-name = "swc_ecma_lints"
-version = "0.88.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300ae29c0fc98ed0364aa2fd4aa7702d6dc67d411dd4894e7e60d40e99c4ef19"
-dependencies = [
- "auto_impl",
- "dashmap",
- "parking_lot",
- "rayon",
- "regex",
- "serde",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_config",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -6495,33 +6348,12 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
+ "swc_atoms",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
-]
-
-[[package]]
-name = "swc_ecma_loader"
-version = "0.44.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2b3a3ec38fc9c691b787d32ac2aa5eb6871d1fe74ac4a10638fbd9b9bc407b"
-dependencies = [
- "anyhow",
- "dashmap",
- "lru",
- "normpath",
- "once_cell",
- "parking_lot",
- "path-clean",
- "pathdiff",
- "serde",
- "serde_json",
- "swc_cached",
- "swc_common 0.32.1",
- "tracing",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -6541,42 +6373,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_cached",
- "swc_common 0.33.0",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_minifier"
-version = "0.187.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8458b755f90a0152a8cbb48b299956ce388eb6d96aa333f9efe243776fefb9c9"
-dependencies = [
- "arrayvec",
- "indexmap 1.9.3",
- "num-bigint",
- "num_cpus",
- "once_cell",
- "parking_lot",
- "radix_fmt",
- "rayon",
- "regex",
- "rustc-hash",
- "ryu-js 0.2.2",
- "serde",
- "serde_json",
- "swc_atoms 0.5.9",
- "swc_cached",
- "swc_common 0.32.1",
- "swc_config",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_codegen 0.145.5",
- "swc_ecma_parser 0.140.0",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_transforms_optimization 0.193.19",
- "swc_ecma_usage_analyzer 0.19.0",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
- "swc_timer 0.20.1",
+ "swc_common",
  "tracing",
 ]
 
@@ -6593,45 +6390,26 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "radix_fmt",
+ "rayon",
  "regex",
  "rustc-hash",
- "ryu-js 1.0.0",
+ "ryu-js",
  "serde",
  "serde_json",
- "swc_atoms 0.6.0",
+ "swc_atoms",
  "swc_cached",
- "swc_common 0.33.0",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_codegen 0.146.1",
- "swc_ecma_parser 0.141.1",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_transforms_optimization 0.195.1",
- "swc_ecma_usage_analyzer 0.20.4",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
- "swc_timer 0.21.0",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_usage_analyzer",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "swc_timer",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_parser"
-version = "0.140.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c968599841fcecfdc2e490188ad93251897a1bb912882547e6889e14a368399"
-dependencies = [
- "either",
- "num-bigint",
- "num-traits",
- "serde",
- "smallvec",
- "smartstring",
- "stacker",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "tracing",
- "typed-arena",
 ]
 
 [[package]]
@@ -6647,36 +6425,11 @@ dependencies = [
  "smallvec",
  "smartstring",
  "stacker",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
  "tracing",
  "typed-arena",
-]
-
-[[package]]
-name = "swc_ecma_preset_env"
-version = "0.201.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aac45044af56b9be44aed5664238b6c1076c5a1c0bf4fd17ae83826f4b19ff1"
-dependencies = [
- "anyhow",
- "dashmap",
- "indexmap 1.9.3",
- "once_cell",
- "preset_env_base",
- "rustc-hash",
- "semver 1.0.18",
- "serde",
- "serde_json",
- "st-map",
- "string_enum",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_transforms 0.224.19",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
 ]
 
 [[package]]
@@ -6696,30 +6449,12 @@ dependencies = [
  "serde_json",
  "st-map",
  "string_enum",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_transforms 0.226.1",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
-]
-
-[[package]]
-name = "swc_ecma_quote_macros"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b028b0675ad45b79b163c70e192f25b59d72366a2864c5d369dce707a38a1597"
-dependencies = [
- "anyhow",
- "pmutil",
- "proc-macro2",
- "quote",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_parser 0.140.0",
- "swc_macros_common",
- "syn 2.0.32",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -6732,25 +6467,12 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_parser 0.141.1",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_macros_common",
  "syn 2.0.32",
-]
-
-[[package]]
-name = "swc_ecma_testing"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b776795afd44c8df3977391e239a8dedbe2139c5eeb1ea053c1e29314b6d8a7"
-dependencies = [
- "anyhow",
- "hex",
- "sha-1",
- "testing 0.34.1",
- "tracing",
 ]
 
 [[package]]
@@ -6762,28 +6484,8 @@ dependencies = [
  "anyhow",
  "hex",
  "sha-1",
- "testing 0.35.0",
+ "testing",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_transforms"
-version = "0.224.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f893871042dbe3eb3f9cb4fb878d24163fd0e568896d68f02a8952d2c9d9a5"
-dependencies = [
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_transforms_compat 0.159.11",
- "swc_ecma_transforms_module 0.176.14",
- "swc_ecma_transforms_optimization 0.193.19",
- "swc_ecma_transforms_proposal 0.167.13",
- "swc_ecma_transforms_react 0.179.14",
- "swc_ecma_transforms_typescript 0.183.18",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
 ]
 
 [[package]]
@@ -6792,42 +6494,18 @@ version = "0.226.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f989184c2b223d1c0d00e0c4abe2e60ce04c7cbc3be80fc28ef403799d7d00ae"
 dependencies = [
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_transforms_compat 0.160.5",
- "swc_ecma_transforms_module 0.177.5",
- "swc_ecma_transforms_optimization 0.195.1",
- "swc_ecma_transforms_proposal 0.168.7",
- "swc_ecma_transforms_react 0.180.5",
- "swc_ecma_transforms_typescript 0.185.1",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms_base"
-version = "0.133.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496e3957e19c22e61cd7ff020a87e1fe94c9334f4fa11267f08614fd5f85ba67"
-dependencies = [
- "better_scoped_tls",
- "bitflags 2.4.0",
- "indexmap 1.9.3",
- "once_cell",
- "phf",
- "rayon",
- "rustc-hash",
- "serde",
- "smallvec",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_parser 0.140.0",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
- "tracing",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_compat",
+ "swc_ecma_transforms_module",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_transforms_proposal",
+ "swc_ecma_transforms_react",
+ "swc_ecma_transforms_typescript",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -6841,30 +6519,17 @@ dependencies = [
  "indexmap 1.9.3",
  "once_cell",
  "phf",
+ "rayon",
  "rustc-hash",
  "serde",
  "smallvec",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_parser 0.141.1",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_transforms_classes"
-version = "0.122.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519ffccc874b8bb39db0fceec06c172b1d7a6e812ac6f4b0a000e5d3c295e495"
-dependencies = [
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
 ]
 
 [[package]]
@@ -6873,38 +6538,12 @@ version = "0.123.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abc1dd56c4f76505604c081ff540b3137da6098f0055515af7150e2f0d265af2"
 dependencies = [
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms_compat"
-version = "0.159.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bf11f8c486856ea9c8d24d84e5e8629afbd49919be519fddda67d3d440a9be"
-dependencies = [
- "arrayvec",
- "indexmap 1.9.3",
- "is-macro",
- "num-bigint",
- "rayon",
- "serde",
- "smallvec",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_config",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_transforms_classes 0.122.5",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
- "swc_trace_macro",
- "tracing",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -6917,12 +6556,13 @@ dependencies = [
  "indexmap 1.9.3",
  "is-macro",
  "num-bigint",
+ "rayon",
  "serde",
  "smallvec",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
+ "swc_atoms",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 0.110.0",
+ "swc_ecma_ast",
  "swc_ecma_compat_bugfixes",
  "swc_ecma_compat_common",
  "swc_ecma_compat_es2015",
@@ -6934,11 +6574,11 @@ dependencies = [
  "swc_ecma_compat_es2021",
  "swc_ecma_compat_es2022",
  "swc_ecma_compat_es3",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_transforms_classes 0.123.4",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6958,33 +6598,6 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.176.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5239cdd86eb8a99d04473dfaceb778ec080be9644ae9d53bc92b6967a3eea60b"
-dependencies = [
- "Inflector",
- "anyhow",
- "bitflags 2.4.0",
- "indexmap 1.9.3",
- "is-macro",
- "path-clean",
- "pathdiff",
- "regex",
- "serde",
- "swc_atoms 0.5.9",
- "swc_cached",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_loader 0.44.4",
- "swc_ecma_parser 0.140.0",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_transforms_module"
 version = "0.177.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7551406c42c22444cec84d35a19bfdc3d3030262a736b5bec06c8fc6c2f4a7bb"
@@ -6998,40 +6611,15 @@ dependencies = [
  "pathdiff",
  "regex",
  "serde",
- "swc_atoms 0.6.0",
+ "swc_atoms",
  "swc_cached",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_loader 0.45.0",
- "swc_ecma_parser 0.141.1",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_transforms_optimization"
-version = "0.193.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47028d59dbb4635f4881393f19644bc3f3808536c901551a73ed0a454160d077"
-dependencies = [
- "dashmap",
- "indexmap 1.9.3",
- "once_cell",
- "petgraph",
- "rayon",
- "rustc-hash",
- "serde_json",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_parser 0.140.0",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
- "swc_fast_graph 0.20.1",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_loader",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -7045,38 +6633,19 @@ dependencies = [
  "indexmap 1.9.3",
  "once_cell",
  "petgraph",
+ "rayon",
  "rustc-hash",
  "serde_json",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_parser 0.141.1",
- "swc_ecma_transforms_base 0.134.4",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
- "swc_fast_graph 0.21.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "swc_fast_graph",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_transforms_proposal"
-version = "0.167.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e896e6d01b1618f4f2061c6ab4c5f74e98b47d93f80bd81731243e880aa721a"
-dependencies = [
- "either",
- "rustc-hash",
- "serde",
- "smallvec",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_transforms_classes 0.122.5",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
 ]
 
 [[package]]
@@ -7089,39 +6658,14 @@ dependencies = [
  "rustc-hash",
  "serde",
  "smallvec",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_transforms_classes 0.123.4",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms_react"
-version = "0.179.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eff59ce7151b51e5eaf0c961cf3a264258f179abe5ca1de6d0c5843020784d"
-dependencies = [
- "base64 0.13.1",
- "dashmap",
- "indexmap 1.9.3",
- "once_cell",
- "rayon",
- "serde",
- "sha-1",
- "string_enum",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_config",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_parser 0.140.0",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -7134,44 +6678,19 @@ dependencies = [
  "dashmap",
  "indexmap 1.9.3",
  "once_cell",
+ "rayon",
  "serde",
  "sha-1",
  "string_enum",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
+ "swc_atoms",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_parser 0.141.1",
- "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms_testing"
-version = "0.136.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0636ec69f3de36ed0155a05e338b6ee294b115fafa15e13996f1ca7f2af6c3"
-dependencies = [
- "ansi_term",
- "anyhow",
- "base64 0.13.1",
- "hex",
- "serde",
- "serde_json",
- "sha-1",
- "sourcemap",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_codegen 0.145.5",
- "swc_ecma_parser 0.140.0",
- "swc_ecma_testing 0.21.1",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
- "tempfile",
- "testing 0.34.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -7188,33 +6707,16 @@ dependencies = [
  "serde_json",
  "sha-1",
  "sourcemap",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_codegen 0.146.1",
- "swc_ecma_parser 0.141.1",
- "swc_ecma_testing 0.22.0",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_testing",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tempfile",
- "testing 0.35.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms_typescript"
-version = "0.183.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705566ab5897223937008a759556d562044a195f2ee8597fa0d9b2af4ca32495"
-dependencies = [
- "ryu-js 0.2.2",
- "serde",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_transforms_base 0.133.5",
- "swc_ecma_transforms_react 0.179.14",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
+ "testing",
 ]
 
 [[package]]
@@ -7223,32 +6725,15 @@ version = "0.185.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "935b5d1dfe618b72c760edd5dfbb9f95d7e5dddfcf11f83a08e851682b0ab20f"
 dependencies = [
- "ryu-js 1.0.0",
+ "ryu-js",
  "serde",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_transforms_base 0.134.4",
- "swc_ecma_transforms_react 0.180.5",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
-]
-
-[[package]]
-name = "swc_ecma_usage_analyzer"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71dc9b35f1f137c72badbadb705a2325d161ff603224ab0e07e6834774ea281"
-dependencies = [
- "indexmap 1.9.3",
- "rustc-hash",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
- "swc_timer 0.20.1",
- "tracing",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_react",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -7259,32 +6744,13 @@ checksum = "d71bbc022658f28e9455c6199069d48dc54b487bc883343f4b265b0f4c44966e"
 dependencies = [
  "indexmap 1.9.3",
  "rustc-hash",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_utils 0.124.4",
- "swc_ecma_visit 0.96.0",
- "swc_timer 0.21.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "swc_timer",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_utils"
-version = "0.123.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6d6b59ebd31b25fe2692ff705c806961e7856de8b7e91fd0942328886cd315"
-dependencies = [
- "indexmap 1.9.3",
- "num_cpus",
- "once_cell",
- "rayon",
- "rustc-hash",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_visit 0.95.1",
- "tracing",
- "unicode-id",
 ]
 
 [[package]]
@@ -7296,28 +6762,14 @@ dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
  "once_cell",
+ "rayon",
  "rustc-hash",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
- "swc_ecma_visit 0.96.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
  "tracing",
  "unicode-id",
-]
-
-[[package]]
-name = "swc_ecma_visit"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2774848b306e17fa280c598ecb192cc2c72a1163942b02d48606514336e9e7c5"
-dependencies = [
- "num-bigint",
- "serde",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_visit",
- "tracing",
 ]
 
 [[package]]
@@ -7328,18 +6780,18 @@ checksum = "47081acd84cdb2d49d6340ed3204e17738b444da10a3e1dd1eb3d7c8e4d47091"
 dependencies = [
  "num-bigint",
  "serde",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
- "swc_ecma_ast 0.110.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_visit",
  "tracing",
 ]
 
 [[package]]
 name = "swc_emotion"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1a13c3241b2812f15e751687924b0458b55ca7c3576a752b939e954cb4b0ba"
+checksum = "43150c60e1fbb43010427afe474246189bc426c5ee833cc413b558a41f0836cd"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -7349,12 +6801,12 @@ dependencies = [
  "regex",
  "serde",
  "sourcemap",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_codegen 0.145.5",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -7373,19 +6825,6 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76b479ad1a69bec65b261354b8e2dec8ed0f9ed43c7b54ab053dc4923e1c90e"
-dependencies = [
- "anyhow",
- "miette",
- "once_cell",
- "parking_lot",
- "swc_common 0.32.1",
-]
-
-[[package]]
-name = "swc_error_reporters"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "015cbdf2b13ccc76eb12d1702a90fb9aae7b3cddacaf2c56a1b1a4a02f9fcd81"
@@ -7394,19 +6833,7 @@ dependencies = [
  "miette",
  "once_cell",
  "parking_lot",
- "swc_common 0.33.0",
-]
-
-[[package]]
-name = "swc_fast_graph"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f7297cdefdb54d8d09e0294c1aec3826825b1feefd0c25978365aa7f447a1c"
-dependencies = [
- "indexmap 1.9.3",
- "petgraph",
- "rustc-hash",
- "swc_common 0.32.1",
+ "swc_common",
 ]
 
 [[package]]
@@ -7418,19 +6845,19 @@ dependencies = [
  "indexmap 1.9.3",
  "petgraph",
  "rustc-hash",
- "swc_common 0.33.0",
+ "swc_common",
 ]
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20a18d45da54ba15698d5ce1f6a0a97684f4035922730393e98e47b44fc3573"
+checksum = "0f59cccef405565b041a8fa1fc2e7059856149f7fc658544c4bafd1a001ea483"
 dependencies = [
  "auto_impl",
  "petgraph",
- "swc_common 0.32.1",
- "swc_fast_graph 0.20.1",
+ "swc_common",
+ "swc_fast_graph",
  "tracing",
 ]
 
@@ -7448,24 +6875,13 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b9597573f1ab8bae72329eef550d214ced0955c7a4f1b6b4ae5e216219e710"
-dependencies = [
- "dashmap",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
-]
-
-[[package]]
-name = "swc_node_comments"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf250afa389a40c4856a250d63f5b1f8d46b513446299b72166c870c7641c365"
 dependencies = [
  "dashmap",
- "swc_atoms 0.6.0",
- "swc_common 0.33.0",
+ "swc_atoms",
+ "swc_common",
 ]
 
 [[package]]
@@ -7495,23 +6911,23 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76ccadcc63a459e096f332730b2d4e09548fc10e0be63df9f3bacecdf5332fe"
+checksum = "55e32ea3aeb4930d0b6fcf1f052d33a4bb115a9d58e32bf3baade3316ef6bdd3"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.102.1"
+version = "0.104.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5626614e11d835b3e8631a7dde4da044d143dc20fd8da3d7ab8d05aaf3cd6b"
+checksum = "86c58e6dfbcc59185e9c557d952f431c5140ed546cfebc053ad0b082c4a3e4e4"
 dependencies = [
  "anyhow",
  "enumset",
@@ -7520,8 +6936,8 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_plugin_proxy",
  "tokio",
  "tracing",
@@ -7533,28 +6949,19 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b74826cb88703713c9c081f5968324490eed925217813ffa1de22da711a80a9"
+checksum = "5dfcf5ebeb56cf35ddfcab86338ee9a776ccde2e27b44a63a2b41271572d9f8c"
 dependencies = [
  "once_cell",
  "regex",
  "serde",
  "serde_json",
- "swc_atoms 0.5.9",
- "swc_common 0.32.1",
- "swc_ecma_ast 0.109.1",
- "swc_ecma_utils 0.123.0",
- "swc_ecma_visit 0.95.1",
- "tracing",
-]
-
-[[package]]
-name = "swc_timer"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b740ce6b402ed04176bd28dc4f4f92c764fe0defe8437c2f3b6e1b5818b4e10c"
-dependencies = [
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -7728,26 +7135,6 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.34.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31f7f4a7baef94495386462c2a55caa0f0885b61b28c120f783132d14938ed"
-dependencies = [
- "ansi_term",
- "cargo_metadata",
- "difference",
- "once_cell",
- "pretty_assertions",
- "regex",
- "serde_json",
- "swc_common 0.32.1",
- "swc_error_reporters 0.16.1",
- "testing_macros",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "testing"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e149694212e0152671c616dc21e4029a0f39710085f32705b2fb07fda89e437f"
@@ -7759,8 +7146,8 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "serde_json",
- "swc_common 0.33.0",
- "swc_error_reporters 0.17.0",
+ "swc_common",
+ "swc_error_reporters",
  "testing_macros",
  "tracing",
  "tracing-subscriber",
@@ -8264,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8296,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -8308,7 +7695,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8323,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -8337,7 +7724,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8354,7 +7741,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -8384,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "base16",
  "hex",
@@ -8396,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -8410,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8420,7 +7807,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "mimalloc",
 ]
@@ -8428,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -8453,7 +7840,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8484,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -8492,10 +7879,10 @@ dependencies = [
  "node-file-trace",
  "styled_components",
  "styled_jsx",
- "swc_core 0.83.28",
+ "swc_core 0.86.1",
  "swc_emotion",
  "swc_relay",
- "testing 0.34.1",
+ "testing",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-bytes",
@@ -8524,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8533,7 +7920,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core 0.83.28",
+ "swc_core 0.86.1",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -8546,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -8570,7 +7957,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8588,7 +7975,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core 0.83.28",
+ "swc_core 0.86.1",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -8600,7 +7987,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8609,7 +7996,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "swc_core 0.83.28",
+ "swc_core 0.86.1",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -8622,7 +8009,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8630,7 +8017,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "swc_core 0.83.28",
+ "swc_core 0.86.1",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -8646,7 +8033,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8683,7 +8070,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8702,7 +8089,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "swc_core 0.83.28",
+ "swc_core 0.86.1",
  "tokio",
  "tracing",
  "turbo-tasks",
@@ -8717,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "serde",
  "serde_json",
@@ -8728,7 +8115,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8738,7 +8125,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core 0.83.28",
+ "swc_core 0.86.1",
  "swc_emotion",
  "swc_relay",
  "turbo-tasks",
@@ -8751,12 +8138,12 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "indoc",
  "serde",
- "swc_core 0.83.28",
+ "swc_core 0.86.1",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -8768,7 +8155,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8784,7 +8171,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8804,7 +8191,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "serde",
@@ -8819,7 +8206,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8834,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8869,7 +8256,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "serde",
@@ -8885,9 +8272,9 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
- "swc_core 0.83.28",
+ "swc_core 0.86.1",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbopack-core",
@@ -8896,7 +8283,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "serde",
  "smallvec",
@@ -3015,13 +3015,13 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a14df3f7188cc868ed50d415ac9527660f761ce2c392b27dc8b18b33cd7525"
+checksum = "7572e57307a72a93fed80bf5aaa0a81cca3a47d7faaf65af4f0d3ac4d84a1715"
 dependencies = [
  "markdown",
  "serde",
- "swc_core 0.85.8",
+ "swc_core",
 ]
 
 [[package]]
@@ -3430,7 +3430,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "swc_core 0.86.1",
+ "swc_core",
  "thiserror",
  "tracing",
  "turbo-tasks",
@@ -3497,7 +3497,7 @@ name = "next-transform-dynamic"
 version = "0.1.0"
 dependencies = [
  "pathdiff",
- "swc_core 0.86.1",
+ "swc_core",
  "testing",
 ]
 
@@ -3508,7 +3508,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "swc_core 0.86.1",
+ "swc_core",
 ]
 
 [[package]]
@@ -3516,7 +3516,7 @@ name = "next-transform-strip-page-exports"
 version = "0.1.0"
 dependencies = [
  "rustc-hash",
- "swc_core 0.86.1",
+ "swc_core",
  "testing",
  "tracing",
 ]
@@ -3524,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "serde",
@@ -5874,22 +5874,6 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.85.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7dad3a255025c7ae04576ade40dfdeb03f2229159ea6b112ed180a206a9d5a0"
-dependencies = [
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_visit",
- "vergen",
-]
-
-[[package]]
-name = "swc_core"
 version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c049be93138bf3f521dd42500301762fdd5f5d326e11de012588dcd8135ca"
@@ -7651,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7683,7 +7667,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7695,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7710,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7724,7 +7708,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7741,7 +7725,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7771,7 +7755,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "base16",
  "hex",
@@ -7783,7 +7767,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7797,7 +7781,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7807,7 +7791,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "mimalloc",
 ]
@@ -7815,7 +7799,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7840,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7871,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7879,7 +7863,7 @@ dependencies = [
  "node-file-trace",
  "styled_components",
  "styled_jsx",
- "swc_core 0.86.1",
+ "swc_core",
  "swc_emotion",
  "swc_relay",
  "testing",
@@ -7911,7 +7895,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7920,7 +7904,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core 0.86.1",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -7933,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7957,7 +7941,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7975,7 +7959,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core 0.86.1",
+ "swc_core",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -7987,7 +7971,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7996,7 +7980,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "swc_core 0.86.1",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -8009,7 +7993,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8017,7 +8001,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "swc_core 0.86.1",
+ "swc_core",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -8033,7 +8017,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8070,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8089,7 +8073,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "swc_core 0.86.1",
+ "swc_core",
  "tokio",
  "tracing",
  "turbo-tasks",
@@ -8104,7 +8088,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8115,7 +8099,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8125,7 +8109,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core 0.86.1",
+ "swc_core",
  "swc_emotion",
  "swc_relay",
  "turbo-tasks",
@@ -8138,12 +8122,12 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "indoc",
  "serde",
- "swc_core 0.86.1",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -8155,7 +8139,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8171,7 +8155,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8191,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "serde",
@@ -8206,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8221,7 +8205,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8256,7 +8240,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "serde",
@@ -8272,9 +8256,9 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
- "swc_core 0.86.1",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbopack-core",
@@ -8283,7 +8267,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#0e9f8fed0aa18449daa51ce87e015e7c15061cf6"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-85-1#6707236567432495605a996c0b46ddc339a92de0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8733,7 +8717,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "swc_core 0.86.1",
+ "swc_core",
  "tracing",
  "turbopack-binding",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,11 +531,11 @@ dependencies = [
  "once_cell",
  "serde",
  "serde-wasm-bindgen",
- "swc",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms",
- "swc_ecma_visit",
+ "swc 0.266.26",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_transforms 0.224.19",
+ "swc_ecma_visit 0.95.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -1474,10 +1474,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -3013,7 +3014,7 @@ checksum = "c73de74452171e35ed9d82961e403b8b197dcf752b45a51072d83e4813d42d53"
 dependencies = [
  "markdown",
  "serde",
- "swc_core",
+ "swc_core 0.83.28",
 ]
 
 [[package]]
@@ -3216,9 +3217,9 @@ dependencies = [
  "regex",
  "serde",
  "swc_cached",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_visit 0.95.1",
 ]
 
 [[package]]
@@ -3422,7 +3423,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "swc_core",
+ "swc_core 0.86.1",
  "thiserror",
  "tracing",
  "turbo-tasks",
@@ -3489,8 +3490,8 @@ name = "next-transform-dynamic"
 version = "0.1.0"
 dependencies = [
  "pathdiff",
- "swc_core",
- "testing",
+ "swc_core 0.86.1",
+ "testing 0.35.0",
 ]
 
 [[package]]
@@ -3500,7 +3501,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "swc_core",
+ "swc_core 0.86.1",
 ]
 
 [[package]]
@@ -3508,8 +3509,8 @@ name = "next-transform-strip-page-exports"
 version = "0.1.0"
 dependencies = [
  "rustc-hash",
- "swc_core",
- "testing",
+ "swc_core 0.86.1",
+ "testing 0.35.0",
  "tracing",
 ]
 
@@ -4106,6 +4107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4430,16 +4437,16 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc14dca06a6d0f4796dde331bf9ae17fcb93b9f2d8c8fca8bdc0bd28ff2bd07"
+checksum = "438fc3e0d739395c34f7741aa7b8ff1e19b7c18139fb1b083600dd9e3a2a05df"
 dependencies = [
  "serde",
- "swc_atoms",
+ "swc_atoms 0.6.0",
  "swc_cached",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_visit 0.96.0",
 ]
 
 [[package]]
@@ -4573,16 +4580,16 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b0da70a7bee5f2d9cdb94977225dac1d64946ec65aa2b30386a0a1f5bc5006"
+checksum = "77f2663c3a81f6d6d0cdb15c6505287f3baade5c36bcb324180e857e39e7d09d"
 dependencies = [
  "serde",
- "swc_atoms",
+ "swc_atoms 0.6.0",
  "swc_cached",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_visit 0.96.0",
 ]
 
 [[package]]
@@ -4814,6 +4821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4950d85bc52415f8432144c97c4791bd0c4f7954de32a7270ee9cccd3c22b12b"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4995,16 +5008,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.26",
+ "time 0.3.30",
  "url",
  "uuid",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
@@ -5041,9 +5054,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5126,7 +5139,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.26",
+ "time 0.3.30",
 ]
 
 [[package]]
@@ -5209,7 +5222,7 @@ checksum = "970538704756fd0bb4ec8cb89f80674afb661e7c0fe716f9ba5be57717742300"
 dependencies = [
  "const_format",
  "is_debug",
- "time 0.3.26",
+ "time 0.3.30",
  "tzdb",
 ]
 
@@ -5571,11 +5584,11 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
  "tracing",
 ]
 
@@ -5589,18 +5602,18 @@ dependencies = [
  "lightningcss",
  "parcel_selectors",
  "serde",
- "swc_common",
+ "swc_common 0.32.1",
  "swc_css_ast",
  "swc_css_codegen",
  "swc_css_minifier",
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast",
- "swc_ecma_minifier",
- "swc_ecma_parser",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_minifier 0.187.20",
+ "swc_ecma_parser 0.140.0",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
  "swc_plugin_macro",
  "tracing",
 ]
@@ -5662,29 +5675,77 @@ dependencies = [
  "serde",
  "serde_json",
  "sourcemap",
- "swc_atoms",
+ "swc_atoms 0.5.9",
  "swc_cached",
- "swc_common",
+ "swc_common 0.32.1",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_ext_transforms",
- "swc_ecma_lints",
- "swc_ecma_loader",
- "swc_ecma_minifier",
- "swc_ecma_parser",
- "swc_ecma_preset_env",
- "swc_ecma_transforms",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_compat",
- "swc_ecma_transforms_optimization",
- "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_error_reporters",
- "swc_node_comments",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_codegen 0.145.5",
+ "swc_ecma_ext_transforms 0.109.0",
+ "swc_ecma_lints 0.88.6",
+ "swc_ecma_loader 0.44.4",
+ "swc_ecma_minifier 0.187.20",
+ "swc_ecma_parser 0.140.0",
+ "swc_ecma_preset_env 0.201.21",
+ "swc_ecma_transforms 0.224.19",
+ "swc_ecma_transforms_base 0.133.5",
+ "swc_ecma_transforms_compat 0.159.11",
+ "swc_ecma_transforms_optimization 0.193.19",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+ "swc_error_reporters 0.16.1",
+ "swc_node_comments 0.19.1",
  "swc_plugin_proxy",
  "swc_plugin_runner",
- "swc_timer",
+ "swc_timer 0.20.1",
+ "swc_visit",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "swc"
+version = "0.269.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129ee8c5cb4b521004a19943440b9431c153b49ee7f727a1e76b26fabbb5c679"
+dependencies = [
+ "anyhow",
+ "base64 0.13.1",
+ "dashmap",
+ "either",
+ "indexmap 1.9.3",
+ "jsonc-parser",
+ "lru",
+ "once_cell",
+ "parking_lot",
+ "pathdiff",
+ "regex",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sourcemap",
+ "swc_atoms 0.6.0",
+ "swc_cached",
+ "swc_common 0.33.0",
+ "swc_compiler_base",
+ "swc_config",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_codegen 0.146.1",
+ "swc_ecma_ext_transforms 0.110.4",
+ "swc_ecma_lints 0.89.4",
+ "swc_ecma_loader 0.45.0",
+ "swc_ecma_minifier 0.189.1",
+ "swc_ecma_parser 0.141.1",
+ "swc_ecma_preset_env 0.203.1",
+ "swc_ecma_transforms 0.226.1",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_compat 0.160.5",
+ "swc_ecma_transforms_optimization 0.195.1",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_error_reporters 0.17.0",
+ "swc_node_comments 0.20.0",
+ "swc_timer 0.21.0",
  "swc_visit",
  "tracing",
  "url",
@@ -5699,6 +5760,20 @@ dependencies = [
  "bytecheck",
  "once_cell",
  "rkyv",
+ "rustc-hash",
+ "serde",
+ "string_cache",
+ "string_cache_codegen",
+ "triomphe",
+]
+
+[[package]]
+name = "swc_atoms"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf7a12229f0c0efb654a6a0f8cbfd94fbd320a57c764857a82d8abe9342b450"
+dependencies = [
+ "once_cell",
  "rustc-hash",
  "serde",
  "string_cache",
@@ -5723,17 +5798,17 @@ dependencies = [
  "radix_fmt",
  "rayon",
  "relative-path",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_loader",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_optimization",
- "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_fast_graph",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_codegen 0.145.5",
+ "swc_ecma_loader 0.44.4",
+ "swc_ecma_parser 0.140.0",
+ "swc_ecma_transforms_base 0.133.5",
+ "swc_ecma_transforms_optimization 0.193.19",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+ "swc_fast_graph 0.20.1",
  "swc_graph_analyzer",
  "tracing",
 ]
@@ -5777,13 +5852,66 @@ dependencies = [
  "siphasher",
  "sourcemap",
  "string_cache",
- "swc_atoms",
+ "swc_atoms 0.5.9",
  "swc_eq_ignore_macros",
  "swc_visit",
  "termcolor",
  "tracing",
  "unicode-width",
  "url",
+]
+
+[[package]]
+name = "swc_common"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490e199e25d2aa3fbef675524fa81408651f4e7178b51110470ddd1b3e3bbe75"
+dependencies = [
+ "ahash 0.8.3",
+ "ast_node",
+ "atty",
+ "better_scoped_tls",
+ "cfg-if 1.0.0",
+ "either",
+ "from_variant",
+ "new_debug_unreachable",
+ "num-bigint",
+ "once_cell",
+ "parking_lot",
+ "rustc-hash",
+ "serde",
+ "siphasher",
+ "sourcemap",
+ "string_cache",
+ "swc_atoms 0.6.0",
+ "swc_eq_ignore_macros",
+ "swc_visit",
+ "termcolor",
+ "tracing",
+ "unicode-width",
+ "url",
+]
+
+[[package]]
+name = "swc_compiler_base"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de0359c44fa960798a80815ce10f25302fa05a1d477ee9c2ab74baa926a754a"
+dependencies = [
+ "anyhow",
+ "base64 0.13.1",
+ "pathdiff",
+ "serde",
+ "sourcemap",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_config",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_codegen 0.146.1",
+ "swc_ecma_minifier 0.189.1",
+ "swc_ecma_parser 0.141.1",
+ "swc_ecma_visit 0.96.0",
+ "swc_timer 0.21.0",
 ]
 
 [[package]]
@@ -5818,11 +5946,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e826020b0481212a0ba4f20d5c74bbe71b6cee6949583896788ca8d98039851"
 dependencies = [
  "binding_macros",
- "swc",
- "swc_atoms",
+ "swc 0.266.26",
+ "swc_atoms 0.5.9",
  "swc_bundler",
  "swc_cached",
- "swc_common",
+ "swc_common 0.32.1",
  "swc_css_ast",
  "swc_css_codegen",
  "swc_css_compat",
@@ -5830,26 +5958,52 @@ dependencies = [
  "swc_css_parser",
  "swc_css_utils",
  "swc_css_visit",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_loader",
- "swc_ecma_minifier",
- "swc_ecma_parser",
- "swc_ecma_preset_env",
- "swc_ecma_quote_macros",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_module",
- "swc_ecma_transforms_optimization",
- "swc_ecma_transforms_proposal",
- "swc_ecma_transforms_react",
- "swc_ecma_transforms_testing",
- "swc_ecma_transforms_typescript",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_codegen 0.145.5",
+ "swc_ecma_loader 0.44.4",
+ "swc_ecma_minifier 0.187.20",
+ "swc_ecma_parser 0.140.0",
+ "swc_ecma_preset_env 0.201.21",
+ "swc_ecma_quote_macros 0.51.0",
+ "swc_ecma_transforms_base 0.133.5",
+ "swc_ecma_transforms_module 0.176.14",
+ "swc_ecma_transforms_optimization 0.193.19",
+ "swc_ecma_transforms_proposal 0.167.13",
+ "swc_ecma_transforms_react 0.179.14",
+ "swc_ecma_transforms_testing 0.136.5",
+ "swc_ecma_transforms_typescript 0.183.18",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
  "swc_nodejs_common",
  "swc_plugin_proxy",
  "swc_plugin_runner",
- "testing",
+ "testing 0.34.1",
+ "vergen",
+]
+
+[[package]]
+name = "swc_core"
+version = "0.86.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40c049be93138bf3f521dd42500301762fdd5f5d326e11de012588dcd8135ca"
+dependencies = [
+ "swc 0.269.1",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_codegen 0.146.1",
+ "swc_ecma_loader 0.45.0",
+ "swc_ecma_parser 0.141.1",
+ "swc_ecma_preset_env 0.203.1",
+ "swc_ecma_quote_macros 0.52.1",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_module 0.177.5",
+ "swc_ecma_transforms_react 0.180.5",
+ "swc_ecma_transforms_testing 0.137.4",
+ "swc_ecma_transforms_typescript 0.185.1",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "testing 0.35.0",
  "vergen",
 ]
 
@@ -5862,8 +6016,8 @@ dependencies = [
  "is-macro",
  "serde",
  "string_enum",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
 ]
 
 [[package]]
@@ -5876,8 +6030,8 @@ dependencies = [
  "bitflags 2.4.0",
  "rustc-hash",
  "serde",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
  "swc_css_ast",
  "swc_css_codegen_macros",
  "swc_css_utils",
@@ -5906,8 +6060,8 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -5920,8 +6074,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21db6b6ef607d47d09a7e2fd0b8fd5ec29d05d1182f8d3d5eebef0f1b94c3f4d"
 dependencies = [
  "serde",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -5935,8 +6089,8 @@ checksum = "ac80e62e3221cb2abc0edd33886c74c7d2a64ca3756adce0047527026dff71ca"
 dependencies = [
  "rustc-hash",
  "serde",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
  "swc_css_ast",
  "swc_css_codegen",
  "swc_css_parser",
@@ -5951,8 +6105,8 @@ checksum = "b02a3c11508487249aa571a908e673c540191de97d5139bb78ab03188dd57e26"
 dependencies = [
  "lexical",
  "serde",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
  "swc_css_ast",
 ]
 
@@ -5966,8 +6120,8 @@ dependencies = [
  "preset_env_base",
  "serde",
  "serde_json",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -5982,8 +6136,8 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
  "swc_css_ast",
  "swc_css_visit",
 ]
@@ -5995,8 +6149,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83f01449a09b8a87ab4bd2ea6cbaaf74e39f9bfba3842a2918e998c5f9b428a4"
 dependencies = [
  "serde",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
  "swc_css_ast",
  "swc_visit",
 ]
@@ -6015,8 +6169,25 @@ dependencies = [
  "scoped-tls",
  "serde",
  "string_enum",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_ast"
+version = "0.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbbf9918976a7e7fbdb4f76fe659d08e291a8b56b524b424183fc67d1189679"
+dependencies = [
+ "bitflags 2.4.0",
+ "is-macro",
+ "num-bigint",
+ "scoped-tls",
+ "serde",
+ "string_enum",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
  "unicode-id",
 ]
 
@@ -6032,9 +6203,28 @@ dependencies = [
  "rustc-hash",
  "serde",
  "sourcemap",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_codegen_macros",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_codegen"
+version = "0.146.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fba119c76654599b71099a0150094f5790f00db63aab6cda1790e731f42c98f"
+dependencies = [
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "sourcemap",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -6053,17 +6243,224 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_compat_bugfixes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e86fbe39425c5135fbef3bd8ffbbb6d24f8d53942d21914cf765ff43d09be19"
+dependencies = [
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_compat_es2015",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_common"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ecceb5d816d6f416bff1c13aea1814e27f43a25551066c66c0fdbd834be67bf"
+dependencies = [
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_trace_macro",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2015"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000318f4ef8ad1b1e417120b630530a453165b9c6f85052010ce28d01e078e15"
+dependencies = [
+ "arrayvec",
+ "indexmap 1.9.3",
+ "is-macro",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_config",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_compat_common",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_classes 0.123.4",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2016"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145df6ac733548dae7f31aa21264e8609e5deb0f0a46019a3fc8e4a70c8cbf3a"
+dependencies = [
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2017"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11b1d15155a9d1608e49a8d67e134d6d03e43eaa3f0e2b5eae465d84288c85f5"
+dependencies = [
+ "serde",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2018"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "047286ba45b3afb868452b947cef646ef66d410c269935f30d494d0489c2321c"
+dependencies = [
+ "serde",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_compat_common",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2019"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cbbafa9873cd396980b0dbb34304545191f630b822659e7de13eedaa4ec6e26"
+dependencies = [
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2020"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a22db764b289d87676997d6a3c3c00e00fe965711940aedce93a09097b742c3"
+dependencies = [
+ "serde",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2021"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7ded8f71201833cca75ff0eb490e5d9237e7e1808c9ca204e6e70da545829f"
+dependencies = [
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2022"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82e116ad390b63a72250b0624100f9f0052fa0a5053bb6cd78cd11ce1636575"
+dependencies = [
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_compat_common",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_classes 0.123.4",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es3"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2546a901da8f8570c1964961eb6d49962dcf1b3b95791e8c5899b4f53c46283a"
+dependencies = [
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
 name = "swc_ecma_ext_transforms"
 version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d995f94740b4cde4919e6e03d982230f755f49dac9dac52f0218254a1fd69f2b"
 dependencies = [
  "phf",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+]
+
+[[package]]
+name = "swc_ecma_ext_transforms"
+version = "0.110.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c47c85a90f01607fe136be5fb15cc5033e1eb0bbe16c89855bad5e0d0915159"
+dependencies = [
+ "phf",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
 ]
 
 [[package]]
@@ -6078,12 +6475,32 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+]
+
+[[package]]
+name = "swc_ecma_lints"
+version = "0.89.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09ea9e797559ccdf30db36403d3a2097e3c750c86c576b001b2dfc24c244265"
+dependencies = [
+ "auto_impl",
+ "dashmap",
+ "parking_lot",
+ "rayon",
+ "regex",
+ "serde",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_config",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
 ]
 
 [[package]]
@@ -6103,7 +6520,28 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_cached",
- "swc_common",
+ "swc_common 0.32.1",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_loader"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7fe06d942fe20a5a81cc14f4a53e64a5efdc851fa895a869224b2d41df73276"
+dependencies = [
+ "anyhow",
+ "dashmap",
+ "lru",
+ "normpath",
+ "once_cell",
+ "parking_lot",
+ "path-clean",
+ "pathdiff",
+ "serde",
+ "serde_json",
+ "swc_cached",
+ "swc_common 0.33.0",
  "tracing",
 ]
 
@@ -6123,22 +6561,56 @@ dependencies = [
  "rayon",
  "regex",
  "rustc-hash",
- "ryu-js",
+ "ryu-js 0.2.2",
  "serde",
  "serde_json",
- "swc_atoms",
+ "swc_atoms 0.5.9",
  "swc_cached",
- "swc_common",
+ "swc_common 0.32.1",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_optimization",
- "swc_ecma_usage_analyzer",
- "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_timer",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_codegen 0.145.5",
+ "swc_ecma_parser 0.140.0",
+ "swc_ecma_transforms_base 0.133.5",
+ "swc_ecma_transforms_optimization 0.193.19",
+ "swc_ecma_usage_analyzer 0.19.0",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+ "swc_timer 0.20.1",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_minifier"
+version = "0.189.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57524e1f80b1facd4332aea354365a42772addc484a571130173f4512a18c902"
+dependencies = [
+ "arrayvec",
+ "indexmap 1.9.3",
+ "num-bigint",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "radix_fmt",
+ "regex",
+ "rustc-hash",
+ "ryu-js 1.0.0",
+ "serde",
+ "serde_json",
+ "swc_atoms 0.6.0",
+ "swc_cached",
+ "swc_common 0.33.0",
+ "swc_config",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_codegen 0.146.1",
+ "swc_ecma_parser 0.141.1",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_optimization 0.195.1",
+ "swc_ecma_usage_analyzer 0.20.4",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_timer 0.21.0",
  "tracing",
 ]
 
@@ -6155,9 +6627,29 @@ dependencies = [
  "smallvec",
  "smartstring",
  "stacker",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "tracing",
+ "typed-arena",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "0.141.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26e535c623db7beb04ba8ebfa821c287b72a23f9fb523990b54db6c1355c990"
+dependencies = [
+ "either",
+ "num-bigint",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "smartstring",
+ "stacker",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
  "tracing",
  "typed-arena",
 ]
@@ -6179,12 +6671,37 @@ dependencies = [
  "serde_json",
  "st-map",
  "string_enum",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_transforms 0.224.19",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+]
+
+[[package]]
+name = "swc_ecma_preset_env"
+version = "0.203.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc6a6b74e0136460cf3938a873d158e02ac226c22ee8c1c002c91672cfbaeda"
+dependencies = [
+ "anyhow",
+ "dashmap",
+ "indexmap 1.9.3",
+ "once_cell",
+ "preset_env_base",
+ "rustc-hash",
+ "semver 1.0.18",
+ "serde",
+ "serde_json",
+ "st-map",
+ "string_enum",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_transforms 0.226.1",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
 ]
 
 [[package]]
@@ -6197,10 +6714,28 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_parser 0.140.0",
+ "swc_macros_common",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "swc_ecma_quote_macros"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687e5944bd1ccf5729104c2ed11c182b1f679d18d620980da442bfe326391ddf"
+dependencies = [
+ "anyhow",
+ "pmutil",
+ "proc-macro2",
+ "quote",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_parser 0.141.1",
  "swc_macros_common",
  "syn 2.0.32",
 ]
@@ -6214,7 +6749,20 @@ dependencies = [
  "anyhow",
  "hex",
  "sha-1",
- "testing",
+ "testing 0.34.1",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_testing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c456e2c330c0049f77780cd412e61d9c9d0ae7ff9b6c0e4f8262270b7c718e"
+dependencies = [
+ "anyhow",
+ "hex",
+ "sha-1",
+ "testing 0.35.0",
  "tracing",
 ]
 
@@ -6224,18 +6772,38 @@ version = "0.224.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66f893871042dbe3eb3f9cb4fb878d24163fd0e568896d68f02a8952d2c9d9a5"
 dependencies = [
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_compat",
- "swc_ecma_transforms_module",
- "swc_ecma_transforms_optimization",
- "swc_ecma_transforms_proposal",
- "swc_ecma_transforms_react",
- "swc_ecma_transforms_typescript",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_transforms_base 0.133.5",
+ "swc_ecma_transforms_compat 0.159.11",
+ "swc_ecma_transforms_module 0.176.14",
+ "swc_ecma_transforms_optimization 0.193.19",
+ "swc_ecma_transforms_proposal 0.167.13",
+ "swc_ecma_transforms_react 0.179.14",
+ "swc_ecma_transforms_typescript 0.183.18",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+]
+
+[[package]]
+name = "swc_ecma_transforms"
+version = "0.226.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f989184c2b223d1c0d00e0c4abe2e60ce04c7cbc3be80fc28ef403799d7d00ae"
+dependencies = [
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_compat 0.160.5",
+ "swc_ecma_transforms_module 0.177.5",
+ "swc_ecma_transforms_optimization 0.195.1",
+ "swc_ecma_transforms_proposal 0.168.7",
+ "swc_ecma_transforms_react 0.180.5",
+ "swc_ecma_transforms_typescript 0.185.1",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
 ]
 
 [[package]]
@@ -6253,12 +6821,35 @@ dependencies = [
  "rustc-hash",
  "serde",
  "smallvec",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_parser 0.140.0",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "0.134.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d30c5aa540b6516875d507d3dc2ca7edf77a30fe9e070868ccd2d90b85a3a3"
+dependencies = [
+ "better_scoped_tls",
+ "bitflags 2.4.0",
+ "indexmap 1.9.3",
+ "once_cell",
+ "phf",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_parser 0.141.1",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
  "tracing",
 ]
 
@@ -6268,12 +6859,26 @@ version = "0.122.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519ffccc874b8bb39db0fceec06c172b1d7a6e812ac6f4b0a000e5d3c295e495"
 dependencies = [
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_transforms_base 0.133.5",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+]
+
+[[package]]
+name = "swc_ecma_transforms_classes"
+version = "0.123.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc1dd56c4f76505604c081ff540b3137da6098f0055515af7150e2f0d265af2"
+dependencies = [
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
 ]
 
 [[package]]
@@ -6289,15 +6894,51 @@ dependencies = [
  "rayon",
  "serde",
  "smallvec",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_classes",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_transforms_base 0.133.5",
+ "swc_ecma_transforms_classes 0.122.5",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_compat"
+version = "0.160.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413a57c78f02d51af95100928ce62af0c832169ad38c73e46c77015cbe3785f9"
+dependencies = [
+ "arrayvec",
+ "indexmap 1.9.3",
+ "is-macro",
+ "num-bigint",
+ "serde",
+ "smallvec",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_config",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_compat_bugfixes",
+ "swc_ecma_compat_common",
+ "swc_ecma_compat_es2015",
+ "swc_ecma_compat_es2016",
+ "swc_ecma_compat_es2017",
+ "swc_ecma_compat_es2018",
+ "swc_ecma_compat_es2019",
+ "swc_ecma_compat_es2020",
+ "swc_ecma_compat_es2021",
+ "swc_ecma_compat_es2022",
+ "swc_ecma_compat_es3",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_classes 0.123.4",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6330,15 +6971,42 @@ dependencies = [
  "pathdiff",
  "regex",
  "serde",
- "swc_atoms",
+ "swc_atoms 0.5.9",
  "swc_cached",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_loader",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_loader 0.44.4",
+ "swc_ecma_parser 0.140.0",
+ "swc_ecma_transforms_base 0.133.5",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_module"
+version = "0.177.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7551406c42c22444cec84d35a19bfdc3d3030262a736b5bec06c8fc6c2f4a7bb"
+dependencies = [
+ "Inflector",
+ "anyhow",
+ "bitflags 2.4.0",
+ "indexmap 1.9.3",
+ "is-macro",
+ "path-clean",
+ "pathdiff",
+ "regex",
+ "serde",
+ "swc_atoms 0.6.0",
+ "swc_cached",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_loader 0.45.0",
+ "swc_ecma_parser 0.141.1",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
  "tracing",
 ]
 
@@ -6355,15 +7023,39 @@ dependencies = [
  "rayon",
  "rustc-hash",
  "serde_json",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_parser 0.140.0",
+ "swc_ecma_transforms_base 0.133.5",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_fast_graph",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+ "swc_fast_graph 0.20.1",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_optimization"
+version = "0.195.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6de1cd412b1bf59f1c71f61c6399a89faab1f2a99657cffcf889cde5cce09f"
+dependencies = [
+ "dashmap",
+ "indexmap 1.9.3",
+ "once_cell",
+ "petgraph",
+ "rustc-hash",
+ "serde_json",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_parser 0.141.1",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_fast_graph 0.21.0",
  "tracing",
 ]
 
@@ -6377,14 +7069,34 @@ dependencies = [
  "rustc-hash",
  "serde",
  "smallvec",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_classes",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_transforms_base 0.133.5",
+ "swc_ecma_transforms_classes 0.122.5",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+]
+
+[[package]]
+name = "swc_ecma_transforms_proposal"
+version = "0.168.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67728d832bdb7d7ff44f8bfb93830df7ec1e3fe516c3022525949b92f822d8c8"
+dependencies = [
+ "either",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_classes 0.123.4",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
 ]
 
 [[package]]
@@ -6401,15 +7113,39 @@ dependencies = [
  "serde",
  "sha-1",
  "string_enum",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_parser 0.140.0",
+ "swc_ecma_transforms_base 0.133.5",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+]
+
+[[package]]
+name = "swc_ecma_transforms_react"
+version = "0.180.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417f343e75a3c0c0df0504651947c012b4f8de1519d14c9e7cc7fb847326ced8"
+dependencies = [
+ "base64 0.13.1",
+ "dashmap",
+ "indexmap 1.9.3",
+ "once_cell",
+ "serde",
+ "sha-1",
+ "string_enum",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_config",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_parser 0.141.1",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
 ]
 
 [[package]]
@@ -6426,16 +7162,42 @@ dependencies = [
  "serde_json",
  "sha-1",
  "sourcemap",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
- "swc_ecma_testing",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_codegen 0.145.5",
+ "swc_ecma_parser 0.140.0",
+ "swc_ecma_testing 0.21.1",
+ "swc_ecma_transforms_base 0.133.5",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
  "tempfile",
- "testing",
+ "testing 0.34.1",
+]
+
+[[package]]
+name = "swc_ecma_transforms_testing"
+version = "0.137.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06b02eb5f5972cc9000aedf436aefdd1723d6f7235fc829eb1a2f29fcff38f86"
+dependencies = [
+ "ansi_term",
+ "anyhow",
+ "base64 0.13.1",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha-1",
+ "sourcemap",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_codegen 0.146.1",
+ "swc_ecma_parser 0.141.1",
+ "swc_ecma_testing 0.22.0",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "tempfile",
+ "testing 0.35.0",
 ]
 
 [[package]]
@@ -6444,15 +7206,32 @@ version = "0.183.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "705566ab5897223937008a759556d562044a195f2ee8597fa0d9b2af4ca32495"
 dependencies = [
- "ryu-js",
+ "ryu-js 0.2.2",
  "serde",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_react",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_transforms_base 0.133.5",
+ "swc_ecma_transforms_react 0.179.14",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+]
+
+[[package]]
+name = "swc_ecma_transforms_typescript"
+version = "0.185.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "935b5d1dfe618b72c760edd5dfbb9f95d7e5dddfcf11f83a08e851682b0ab20f"
+dependencies = [
+ "ryu-js 1.0.0",
+ "serde",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_transforms_base 0.134.4",
+ "swc_ecma_transforms_react 0.180.5",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
 ]
 
 [[package]]
@@ -6463,12 +7242,29 @@ checksum = "d71dc9b35f1f137c72badbadb705a2325d161ff603224ab0e07e6834774ea281"
 dependencies = [
  "indexmap 1.9.3",
  "rustc-hash",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_timer",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
+ "swc_timer 0.20.1",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_usage_analyzer"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71bbc022658f28e9455c6199069d48dc54b487bc883343f4b265b0f4c44966e"
+dependencies = [
+ "indexmap 1.9.3",
+ "rustc-hash",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_utils 0.124.4",
+ "swc_ecma_visit 0.96.0",
+ "swc_timer 0.21.0",
  "tracing",
 ]
 
@@ -6483,10 +7279,28 @@ dependencies = [
  "once_cell",
  "rayon",
  "rustc-hash",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_visit 0.95.1",
+ "tracing",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "0.124.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5dd053e9a21c433504664d7083869c9d02394eb5141b101c81067067536471"
+dependencies = [
+ "indexmap 1.9.3",
+ "num_cpus",
+ "once_cell",
+ "rustc-hash",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
+ "swc_ecma_visit 0.96.0",
  "tracing",
  "unicode-id",
 ]
@@ -6499,9 +7313,24 @@ checksum = "2774848b306e17fa280c598ecb192cc2c72a1163942b02d48606514336e9e7c5"
 dependencies = [
  "num-bigint",
  "serde",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47081acd84cdb2d49d6340ed3204e17738b444da10a3e1dd1eb3d7c8e4d47091"
+dependencies = [
+ "num-bigint",
+ "serde",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
+ "swc_ecma_ast 0.110.0",
  "swc_visit",
  "tracing",
 ]
@@ -6520,12 +7349,12 @@ dependencies = [
  "regex",
  "serde",
  "sourcemap",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_codegen 0.145.5",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6552,7 +7381,20 @@ dependencies = [
  "miette",
  "once_cell",
  "parking_lot",
- "swc_common",
+ "swc_common 0.32.1",
+]
+
+[[package]]
+name = "swc_error_reporters"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015cbdf2b13ccc76eb12d1702a90fb9aae7b3cddacaf2c56a1b1a4a02f9fcd81"
+dependencies = [
+ "anyhow",
+ "miette",
+ "once_cell",
+ "parking_lot",
+ "swc_common 0.33.0",
 ]
 
 [[package]]
@@ -6564,7 +7406,19 @@ dependencies = [
  "indexmap 1.9.3",
  "petgraph",
  "rustc-hash",
- "swc_common",
+ "swc_common 0.32.1",
+]
+
+[[package]]
+name = "swc_fast_graph"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97e69e9617913611e39284cf724a412ab7fc6081708d0ef2820855774da5357"
+dependencies = [
+ "indexmap 1.9.3",
+ "petgraph",
+ "rustc-hash",
+ "swc_common 0.33.0",
 ]
 
 [[package]]
@@ -6575,8 +7429,8 @@ checksum = "d20a18d45da54ba15698d5ce1f6a0a97684f4035922730393e98e47b44fc3573"
 dependencies = [
  "auto_impl",
  "petgraph",
- "swc_common",
- "swc_fast_graph",
+ "swc_common 0.32.1",
+ "swc_fast_graph 0.20.1",
  "tracing",
 ]
 
@@ -6599,8 +7453,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b9597573f1ab8bae72329eef550d214ced0955c7a4f1b6b4ae5e216219e710"
 dependencies = [
  "dashmap",
- "swc_atoms",
- "swc_common",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+]
+
+[[package]]
+name = "swc_node_comments"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf250afa389a40c4856a250d63f5b1f8d46b513446299b72166c870c7641c365"
+dependencies = [
+ "dashmap",
+ "swc_atoms 0.6.0",
+ "swc_common 0.33.0",
 ]
 
 [[package]]
@@ -6636,8 +7501,8 @@ checksum = "a76ccadcc63a459e096f332730b2d4e09548fc10e0be63df9f3bacecdf5332fe"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6655,8 +7520,8 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
  "swc_plugin_proxy",
  "tokio",
  "tracing",
@@ -6676,11 +7541,11 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_atoms 0.5.9",
+ "swc_common 0.32.1",
+ "swc_ecma_ast 0.109.1",
+ "swc_ecma_utils 0.123.0",
+ "swc_ecma_visit 0.95.1",
  "tracing",
 ]
 
@@ -6689,6 +7554,15 @@ name = "swc_timer"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b740ce6b402ed04176bd28dc4f4f92c764fe0defe8437c2f3b6e1b5818b4e10c"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "swc_timer"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a6e150f91760ccaca6f6b797b95ffb00bbc245a71311c483b84a7bc700e9c4"
 dependencies = [
  "tracing",
 ]
@@ -6865,8 +7739,28 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "serde_json",
- "swc_common",
- "swc_error_reporters",
+ "swc_common 0.32.1",
+ "swc_error_reporters 0.16.1",
+ "testing_macros",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "testing"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e149694212e0152671c616dc21e4029a0f39710085f32705b2fb07fda89e437f"
+dependencies = [
+ "ansi_term",
+ "cargo_metadata",
+ "difference",
+ "once_cell",
+ "pretty_assertions",
+ "regex",
+ "serde_json",
+ "swc_common 0.33.0",
+ "swc_error_reporters 0.17.0",
  "testing_macros",
  "tracing",
  "tracing-subscriber",
@@ -6962,24 +7856,25 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79d09ac6b08c1ab3906a2f7cc2e81a0e27c7ae89c63812df75e52bef0751e07"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
  "num_threads",
+ "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.12",
+ "time-macros 0.2.15",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
@@ -6993,9 +7888,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c65469ed6b3a4809d987a41eb1dc918e9bc1d92211cbad7ae82931846f7451"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -7597,10 +8492,10 @@ dependencies = [
  "node-file-trace",
  "styled_components",
  "styled_jsx",
- "swc_core",
+ "swc_core 0.83.28",
  "swc_emotion",
  "swc_relay",
- "testing",
+ "testing 0.34.1",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-bytes",
@@ -7638,7 +8533,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core",
+ "swc_core 0.83.28",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -7693,7 +8588,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core",
+ "swc_core 0.83.28",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -7714,7 +8609,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "swc_core",
+ "swc_core 0.83.28",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -7735,7 +8630,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "swc_core",
+ "swc_core 0.83.28",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -7807,7 +8702,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "swc_core",
+ "swc_core 0.83.28",
  "tokio",
  "tracing",
  "turbo-tasks",
@@ -7843,7 +8738,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core",
+ "swc_core 0.83.28",
  "swc_emotion",
  "swc_relay",
  "turbo-tasks",
@@ -7861,7 +8756,7 @@ dependencies = [
  "anyhow",
  "indoc",
  "serde",
- "swc_core",
+ "swc_core 0.83.28",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -7992,7 +8887,7 @@ name = "turbopack-swc-utils"
 version = "0.1.0"
 source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231013.3#1e7c4b84f11561db5c6c671480e55e6cc8d9f481"
 dependencies = [
- "swc_core",
+ "swc_core 0.83.28",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbopack-core",
@@ -8241,7 +9136,7 @@ dependencies = [
  "getset",
  "rustversion",
  "thiserror",
- "time 0.3.26",
+ "time 0.3.30",
 ]
 
 [[package]]
@@ -8451,7 +9346,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "swc_core",
+ "swc_core 0.86.1",
  "tracing",
  "turbopack-binding",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ next-transform-dynamic = { path = "packages/next-swc/crates/next-transform-dynam
 next-transform-strip-page-exports = { path = "packages/next-swc/crates/next-transform-strip-page-exports" }
 
 # SWC crates
-swc_core = { version = "0.85.7", features = [
+swc_core = { version = "0.86.1", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ swc_core = { version = "0.86.1", features = [
 testing = { version = "0.35.0" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-85-1" } # last tag: "turbopack-231013.3"
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231017.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-85-1" } # last tag: "turbopack-231013.3"
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231017.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-85-1" } # last tag: "turbopack-231013.3"
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231017.3" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ next-transform-dynamic = { path = "packages/next-swc/crates/next-transform-dynam
 next-transform-strip-page-exports = { path = "packages/next-swc/crates/next-transform-strip-page-exports" }
 
 # SWC crates
-swc_core = { version = "0.83.28", features = [
+swc_core = { version = "0.85.7", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
-testing = { version = "0.34.1" }
+testing = { version = "0.35.0" }
 
 # Turbo crates
 turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231013.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ swc_core = { version = "0.86.1", features = [
 testing = { version = "0.35.0" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231013.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-85-1" } # last tag: "turbopack-231013.3"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231013.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-85-1" } # last tag: "turbopack-231013.3"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231013.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-85-1" } # last tag: "turbopack-231013.3"
 
 # General Deps
 

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -33,8 +33,8 @@ turbopack-binding = { workspace = true, features = [
   "__swc_transform_modularize_imports",
   "__swc_transform_relay",
 ] }
-react_remove_properties = "0.3.0"
-remove_console = "0.4.0"
+react_remove_properties = "0.4.0"
+remove_console = "0.5.0"
 
 [dev-dependencies]
 turbopack-binding = { workspace = true, features = [

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -33,8 +33,8 @@ turbopack-binding = { workspace = true, features = [
   "__swc_transform_modularize_imports",
   "__swc_transform_relay",
 ] }
-react_remove_properties = "0.4.0"
-remove_console = "0.5.0"
+react_remove_properties = "0.5.0"
+remove_console = "0.6.0"
 
 [dev-dependencies]
 turbopack-binding = { workspace = true, features = [

--- a/packages/next-swc/crates/core/src/cjs_optimizer.rs
+++ b/packages/next-swc/crates/core/src/cjs_optimizer.rs
@@ -233,7 +233,7 @@ impl VisitMut for CjsOptimizer {
                                         self.data.imports.insert(
                                             key,
                                             ImportRecord {
-                                                module_specifier: v.value.clone().into(),
+                                                module_specifier: v.value.clone(),
                                             },
                                         );
                                     }

--- a/packages/next-swc/crates/core/src/optimize_server_react.rs
+++ b/packages/next-swc/crates/core/src/optimize_server_react.rs
@@ -68,7 +68,7 @@ impl Fold for OptimizeServerReact {
             new_items.push(item.clone().fold_with(self));
 
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)) = &item {
-                if import_decl.src.value.to_string() != "react" {
+                if import_decl.src.value != "react" {
                     continue;
                 }
                 for specifier in &import_decl.specifiers {
@@ -119,9 +119,7 @@ impl Fold for OptimizeServerReact {
                         if &f.to_id() == react_ident {
                             if let MemberProp::Ident(i) = &member.prop {
                                 // Remove `React.useEffect` and `React.useLayoutEffect` calls
-                                if i.sym.to_string() == "useEffect"
-                                    || i.sym.to_string() == "useLayoutEffect"
-                                {
+                                if i.sym == "useEffect" || i.sym == "useLayoutEffect" {
                                     return Expr::Lit(Lit::Null(Null { span: DUMMY_SP }));
                                 }
                             }

--- a/packages/next-swc/crates/core/src/page_config.rs
+++ b/packages/next-swc/crates/core/src/page_config.rs
@@ -77,7 +77,7 @@ impl Fold for PageConfig {
             for decl in &var_decl.decls {
                 let mut is_config = false;
                 if let Pat::Ident(ident) = &decl.name {
-                    if &ident.id.sym == CONFIG_KEY {
+                    if ident.id.sym == CONFIG_KEY {
                         is_config = true;
                     }
                 }
@@ -151,14 +151,14 @@ impl Fold for PageConfig {
         match &specifier.exported {
             Some(ident) => {
                 if let ModuleExportName::Ident(ident) = ident {
-                    if &ident.sym == CONFIG_KEY {
+                    if ident.sym == CONFIG_KEY {
                         self.handle_error("Config cannot be re-exported.", specifier.span)
                     }
                 }
             }
             None => {
                 if let ModuleExportName::Ident(ident) = &specifier.orig {
-                    if &ident.sym == CONFIG_KEY {
+                    if ident.sym == CONFIG_KEY {
                         self.handle_error("Config cannot be re-exported.", specifier.span)
                     }
                 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -191,7 +191,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231013.3",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -191,7 +191,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231017.3",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -191,7 +191,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,8 +1061,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -26800,9 +26800,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,8 +1061,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231017.3
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231017.3(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -26800,9 +26800,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?6707236567432495605a996c0b46ddc339a92de0'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231017.3(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231017.3}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231017.3'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,8 +1061,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231013.3
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231013.3(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -26800,9 +26800,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231013.3(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231013.3}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231013.3'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0e9f8fed0aa18449daa51ce87e015e7c15061cf6'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

Update SWC crates, to apply bugfixes.

### Why?

We adjusted the mangling option to make it identical with `swcMinify: false` with https://github.com/vercel/next.js/pull/56281, and it revealed some bugs of the name mangler of the SWC minifier.

### How?


 - Fixes #56550
 - Fixes #56614

 - Turbopack counterpart: https://github.com/vercel/turbo/pull/6171

### Other Turbopack Changes

* https://github.com/vercel/turbo/pull/6177 <!-- Tim Neutkens - Add support for FreeVarReference::Error  -->
* https://github.com/vercel/turbo/pull/6180 <!-- Tobias Koppers - fix chunk loading in build runtime  -->
* https://github.com/vercel/turbo/pull/6191 <!-- Justin Ridgewell - Deduplicate referenced_output_assets  -->
* https://github.com/vercel/turbo/pull/6171 <!-- Donny/강동윤 - build: Update `swc_core` to `v0.86.1`  -->

Closes WEB-1775