### PR TITLE
memoize `useParams`

### DIFF
--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -172,13 +172,13 @@ export function useParams<T extends Params = Params>(): T {
 
   return useMemo(() => {
     // When it's under app router
-    if (globalLayoutRouter) {
+    if (globalLayoutRouter?.tree) {
       return getSelectedParams(globalLayoutRouter.tree) as T
     }
 
     // When it's under client side pages router
     return pathParams as T
-  }, [globalLayoutRouter, pathParams])
+  }, [globalLayoutRouter?.tree, pathParams])
 }
 
 // TODO-APP: handle parallel routes

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -170,13 +170,15 @@ export function useParams<T extends Params = Params>(): T {
   const globalLayoutRouter = useContext(GlobalLayoutRouterContext)
   const pathParams = useContext(PathParamsContext)
 
-  // When it's under app router
-  if (globalLayoutRouter) {
-    return getSelectedParams(globalLayoutRouter.tree) as T
-  }
+  return useMemo(() => {
+    // When it's under app router
+    if (globalLayoutRouter) {
+      return getSelectedParams(globalLayoutRouter.tree) as T
+    }
 
-  // When it's under client side pages router
-  return pathParams as T
+    // When it's under client side pages router
+    return pathParams as T
+  }, [globalLayoutRouter, pathParams])
 }
 
 // TODO-APP: handle parallel routes

--- a/test/e2e/app-dir/navigation/app/search-params/[foo]/page.js
+++ b/test/e2e/app-dir/navigation/app/search-params/[foo]/page.js
@@ -1,0 +1,30 @@
+'use client'
+import { useParams, useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { useEffect } from 'react'
+
+export default function Page() {
+  const params = useParams()
+  const router = useRouter()
+  const [count, setCount] = useState(0)
+  useEffect(() => {
+    console.log('params changed')
+  }, [params])
+  return (
+    <div>
+      <button
+        id="rerender-button"
+        onClick={() => setCount((count) => count + 1)}
+      >
+        Re-Render {count}
+      </button>
+
+      <button
+        id="change-params-button"
+        onClick={() => router.push('/search-params/bar')}
+      >
+        Change Params
+      </button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -55,41 +55,52 @@ createNextDescribe(
         }, 'success')
       })
 
-      it.only('should keep a stable ref to useParams between renders', async () => {
-        const browser = await next.browser('/search-params/foo')
+      describe('useParams identity between renders', () => {
+        async function runTests(page: string) {
+          const browser = await next.browser(page)
 
-        await check(
-          async () => JSON.stringify(await browser.log()),
-          /params changed/
-        )
-
-        let outputIndex = (await browser.log()).length
-
-        await browser.elementById('rerender-button').click()
-        await browser.elementById('rerender-button').click()
-        await browser.elementById('rerender-button').click()
-
-        await check(async () => {
-          return browser.elementById('rerender-button').text()
-        }, 'Re-Render 3')
-
-        await check(async () => {
-          const logs = await browser.log()
-          return JSON.stringify(logs.slice(outputIndex)).includes(
-            'params changed'
+          await check(
+            async () => JSON.stringify(await browser.log()),
+            /params changed/
           )
-            ? 'fail'
-            : 'success'
-        }, 'success')
 
-        outputIndex = (await browser.log()).length
+          let outputIndex = (await browser.log()).length
 
-        await browser.elementById('change-params-button').click()
+          await browser.elementById('rerender-button').click()
+          await browser.elementById('rerender-button').click()
+          await browser.elementById('rerender-button').click()
 
-        await check(
-          async () => JSON.stringify((await browser.log()).slice(outputIndex)),
-          /params changed/
-        )
+          await check(async () => {
+            return browser.elementById('rerender-button').text()
+          }, 'Re-Render 3')
+
+          await check(async () => {
+            const logs = await browser.log()
+            return JSON.stringify(logs.slice(outputIndex)).includes(
+              'params changed'
+            )
+              ? 'fail'
+              : 'success'
+          }, 'success')
+
+          outputIndex = (await browser.log()).length
+
+          await browser.elementById('change-params-button').click()
+
+          await check(
+            async () =>
+              JSON.stringify((await browser.log()).slice(outputIndex)),
+            /params changed/
+          )
+        }
+
+        it('should be equal in app', async () => {
+          await runTests('/search-params/foo')
+        })
+
+        it('should be stable in pages', async () => {
+          await runTests('/search-params-pages/foo')
+        })
       })
     })
 

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -94,7 +94,7 @@ createNextDescribe(
           )
         }
 
-        it('should be equal in app', async () => {
+        it('should be stable in app', async () => {
           await runTests('/search-params/foo')
         })
 

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -54,6 +54,43 @@ createNextDescribe(
             : JSON.stringify(requests)
         }, 'success')
       })
+
+      it.only('should keep a stable ref to useParams between renders', async () => {
+        const browser = await next.browser('/search-params/foo')
+
+        await check(
+          async () => JSON.stringify(await browser.log()),
+          /params changed/
+        )
+
+        let outputIndex = (await browser.log()).length
+
+        await browser.elementById('rerender-button').click()
+        await browser.elementById('rerender-button').click()
+        await browser.elementById('rerender-button').click()
+
+        await check(async () => {
+          return browser.elementById('rerender-button').text()
+        }, 'Re-Render 3')
+
+        await check(async () => {
+          const logs = await browser.log()
+          return JSON.stringify(logs.slice(outputIndex)).includes(
+            'params changed'
+          )
+            ? 'fail'
+            : 'success'
+        }, 'success')
+
+        outputIndex = (await browser.log()).length
+
+        await browser.elementById('change-params-button').click()
+
+        await check(
+          async () => JSON.stringify((await browser.log()).slice(outputIndex)),
+          /params changed/
+        )
+      })
     })
 
     describe('hash', () => {

--- a/test/e2e/app-dir/navigation/pages/search-params-pages/[foo]/index.js
+++ b/test/e2e/app-dir/navigation/pages/search-params-pages/[foo]/index.js
@@ -1,0 +1,29 @@
+import { useParams, useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { useEffect } from 'react'
+
+export default function Page() {
+  const params = useParams()
+  const router = useRouter()
+  const [count, setCount] = useState(0)
+  useEffect(() => {
+    console.log('params changed')
+  }, [params])
+  return (
+    <div>
+      <button
+        id="rerender-button"
+        onClick={() => setCount((count) => count + 1)}
+      >
+        Re-Render {count}
+      </button>
+
+      <button
+        id="change-params-button"
+        onClick={() => router.push('/search-params-pages/bar')}
+      >
+        Change Params
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
`useParams` is not referentially equal between renders which can lead to unexpected behavior when used as a dep. 
This memoizes the response from `useParams` similar to `useSearchParams`.

[slack x-ref](https://vercel.slack.com/archives/C04DUD7EB1B/p1697145987740229)
