### PR TITLE
docs: fix typo in examples/with-quill-js/README.md

### DIFF
--- a/examples/with-quill-js/README.md
+++ b/examples/with-quill-js/README.md
@@ -2,7 +2,7 @@
 
 [Quill](https://quilljs.com/) is powerful rich text editor. This example uses [react-quill](https://github.com/zenoamaro/react-quill) to integrate Quill with Next.js.
 
-Quill does not suppport SSR, so it's only loaded and rendered in the browser.
+Quill does not support SSR, so it's only loaded and rendered in the browser.
 
 ## Deploy your own
 


### PR DESCRIPTION
`suppport -> support`