### PR TITLE
docs: fix typo in errors/api-routes-static-export.mdx

### DIFF
--- a/errors/api-routes-static-export.mdx
+++ b/errors/api-routes-static-export.mdx
@@ -15,7 +15,7 @@ To resolve this issue, you have two main options:
 
 1. Use the `next build` command instead of `next export` if you're deploying your application on platforms that don't require `next export`. For example, [Vercel](https://vercel.com) is a popular hosting platform for Next.js applications that supports this feature.
 2. If you still need to use `next export`, make sure to remove any paths that use API routes from your `exportPathMap` in your `next.config.js` file.
-3. Consider [incrementally adopting the App Router](/docs/app/building-your-application/upgrading/app-router-migration), which supportes [Route Handlers](/docs/app/building-your-application/routing/route-handlers). These "API Routes" can be used to create endpoints that can be statically exported in your application.
+3. Consider [incrementally adopting the App Router](/docs/app/building-your-application/upgrading/app-router-migration), which supports [Route Handlers](/docs/app/building-your-application/routing/route-handlers). These "API Routes" can be used to create endpoints that can be statically exported in your application.
 
 ## Useful Links
 


### PR DESCRIPTION
`supportes -> supports`