### PR TITLE
fix: bool types of middleware, redirect and rewrite

### DIFF
--- a/packages/next/src/lib/load-custom-routes.ts
+++ b/packages/next/src/lib/load-custom-routes.ts
@@ -21,8 +21,8 @@ export type RouteHas =
 export type Rewrite = {
   source: string
   destination: string
-  basePath?: false
-  locale?: false
+  basePath?: boolean
+  locale?: boolean
   has?: RouteHas[]
   missing?: RouteHas[]
 
@@ -34,8 +34,8 @@ export type Rewrite = {
 
 export type Header = {
   source: string
-  basePath?: false
-  locale?: false
+  basePath?: boolean
+  locale?: boolean
   headers: Array<{ key: string; value: string }>
   has?: RouteHas[]
   missing?: RouteHas[]
@@ -50,8 +50,8 @@ export type Header = {
 export type Redirect = {
   source: string
   destination: string
-  basePath?: false
-  locale?: false
+  basePath?: boolean
+  locale?: boolean
   has?: RouteHas[]
   missing?: RouteHas[]
 
@@ -72,7 +72,7 @@ export type Redirect = {
 
 export type Middleware = {
   source: string
-  locale?: false
+  locale?: boolean
   has?: RouteHas[]
   missing?: RouteHas[]
 }


### PR DESCRIPTION
### What?

Fix types of boolean properties in custom routes types.

### Why?

When configuring for example `basePath: false` the linter throws an error that the type `boolean` does not match the type `false` 
