### PR TITLE
Revert  "Drop ipc server headers filters (#56226)"

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -12,6 +12,7 @@ import type { NextUrlWithParsedQuery } from '../../request-meta'
 import url from 'url'
 import setupDebug from 'next/dist/compiled/debug'
 import { getCloneableBody } from '../../body-streams'
+import { filterReqHeaders, ipcForbiddenHeaders } from '../server-ipc/utils'
 import { stringifyQuery } from '../../server-route-utils'
 import { formatHostname } from '../format-hostname'
 import { toNodeOutgoingHttpHeaders } from '../../web/utils'
@@ -457,7 +458,7 @@ export function getResolveRoutes(
               const { res: mockedRes } = await createRequestResponseMocks({
                 url: req.url || '/',
                 method: req.method || 'GET',
-                headers: invokeHeaders,
+                headers: filterReqHeaders(invokeHeaders, ipcForbiddenHeaders),
                 resWriter(chunk) {
                   readableController.enqueue(Buffer.from(chunk))
                   return true
@@ -560,7 +561,7 @@ export function getResolveRoutes(
             delete middlewareHeaders['x-middleware-next']
 
             for (const [key, value] of Object.entries({
-              ...middlewareHeaders,
+              ...filterReqHeaders(middlewareHeaders, ipcForbiddenHeaders),
             })) {
               if (
                 [

--- a/packages/next/src/server/lib/server-ipc/invoke-request.ts
+++ b/packages/next/src/server/lib/server-ipc/invoke-request.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage } from 'http'
 import type { Readable } from 'stream'
+import { filterReqHeaders, ipcForbiddenHeaders } from './utils'
 
 export const invokeRequest = async (
   targetUrl: string,
@@ -10,10 +11,13 @@ export const invokeRequest = async (
   },
   readableBody?: Readable | ReadableStream
 ) => {
-  const invokeHeaders = {
-    'cache-control': '',
-    ...requestInit.headers,
-  }
+  const invokeHeaders = filterReqHeaders(
+    {
+      'cache-control': '',
+      ...requestInit.headers,
+    },
+    ipcForbiddenHeaders
+  ) as IncomingMessage['headers']
 
   return await fetch(targetUrl, {
     headers: invokeHeaders as any as Headers,

--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -1,4 +1,4 @@
-export const actionsForbiddenHeaders = [
+export const ipcForbiddenHeaders = [
   'accept-encoding',
   'keepalive',
   'keep-alive',
@@ -8,7 +8,10 @@ export const actionsForbiddenHeaders = [
   'connection',
   // marked as unsupported by undici: https://github.com/nodejs/undici/blob/c83b084879fa0bb8e0469d31ec61428ac68160d5/lib/core/request.js#L354
   'expect',
-  // action specific
+]
+
+export const actionsForbiddenHeaders = [
+  ...ipcForbiddenHeaders,
   'content-length',
 ]
 

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -93,6 +93,7 @@ import { nodeFs } from './lib/node-fs-methods'
 import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { invokeRequest } from './lib/server-ipc/invoke-request'
 import { pipeReadable } from './pipe-readable'
+import { filterReqHeaders, ipcForbiddenHeaders } from './lib/server-ipc/utils'
 import { createRequestResponseMocks } from './lib/mock-request'
 import { NEXT_RSC_UNION_QUERY } from '../client/components/app-router-headers'
 import { signalFromNodeResponse } from './web/spec-extension/adapters/next-request'
@@ -549,12 +550,13 @@ export default class NextNodeServer extends BaseServer {
               signal: signalFromNodeResponse(res.originalResponse),
             }
           )
-          const nodeOutgoingHttpHeaders = toNodeOutgoingHttpHeaders(
-            invokeRes.headers
+          const filteredResHeaders = filterReqHeaders(
+            toNodeOutgoingHttpHeaders(invokeRes.headers),
+            ipcForbiddenHeaders
           )
 
-          for (const key of Object.keys(nodeOutgoingHttpHeaders)) {
-            newRes.setHeader(key, nodeOutgoingHttpHeaders[key] || '')
+          for (const key of Object.keys(filteredResHeaders)) {
+            newRes.setHeader(key, filteredResHeaders[key] || '')
           }
           newRes.statusCode = invokeRes.status || 200
 


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/issues/56038#issuecomment-1762855556
x-ref: https://github.com/vercel/next.js/issues/56038#issuecomment-1746864558

http header `connection` could still fail the image requests while running next build