### PR TITLE
fix relative path shown in styled-components example code

### DIFF
--- a/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
+++ b/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
@@ -196,7 +196,7 @@ export default function StyledComponentsRegistry({ children }) {
 Wrap the `children` of the root layout with the style registry component:
 
 ```tsx filename="app/layout.tsx" switcher
-import StyledComponentsRegistry from './lib/registry'
+import StyledComponentsRegistry from '../lib/registry'
 
 export default function RootLayout({
   children,
@@ -214,7 +214,7 @@ export default function RootLayout({
 ```
 
 ```jsx filename="app/layout.js" switcher
-import StyledComponentsRegistry from './lib/registry'
+import StyledComponentsRegistry from '../lib/registry'
 
 export default function RootLayout({ children }) {
   return (


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

This PR fixes the example code shown for `styled-components`, as seen [here](https://nextjs.org/docs/app/building-your-application/styling/css-in-js#styled-components)

Example suggests to add new file to `lib/registry.tsx`. Later, the next example code suggests to import `registry.tsx` by referencing a non-existent path.

Assuming both `lib/registry.tsx` and `app/layout.tsx` files are under `src` folder, then the correct import path from `app.layout.tsx` to `lib/registry.tsx` would be `../lib/registry.tsx`.

This change makes examples more copy-paste friendly.