### PR TITLE
fix: no-before-interactive-script-outside-document lint error in the app directory with code and tests.

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-before-interactive-script-outside-document.ts
+++ b/packages/eslint-plugin-next/src/rules/no-before-interactive-script-outside-document.ts
@@ -9,6 +9,16 @@ const startsWithUsingCorrectSeparators = (str: string, start: string) =>
     str.startsWith(start.replace(/\//g, sep))
   )
 
+const trimBeforePath = (fullPath: string, paths: string[]): string => {
+  for (const pathItem of paths) {
+    const index = fullPath.indexOf(pathItem)
+    if (index !== -1) {
+      return fullPath.substring(index)
+    }
+  }
+  return fullPath
+}
+
 export = defineRule({
   meta: {
     docs: {
@@ -32,17 +42,15 @@ export = defineRule({
       JSXOpeningElement(node) {
         let pathname = context.getFilename()
 
-        if (startsWithUsingCorrectSeparators(pathname, 'src/')) {
-          pathname = pathname.slice(4)
-        } else if (startsWithUsingCorrectSeparators(pathname, '/src/')) {
-          pathname = pathname.slice(5)
-        }
+        pathname = trimBeforePath(pathname, [
+          'pages',
+          'src/pages',
+          'app',
+          'src/app',
+        ])
 
         // This rule shouldn't fire in `app/`
-        if (
-          startsWithUsingCorrectSeparators(pathname, 'app/') ||
-          startsWithUsingCorrectSeparators(pathname, '/app/')
-        ) {
+        if (startsWithUsingCorrectSeparators(pathname, 'app/')) {
           return
         }
 

--- a/test/unit/eslint-plugin-next/no-before-interactive-script-outside-document.test.ts
+++ b/test/unit/eslint-plugin-next/no-before-interactive-script-outside-document.test.ts
@@ -161,6 +161,51 @@ ruleTester.run('no-before-interactive-script-outside-document', rule, {
           ></Script>
         );
       }`,
+      filename: 'vercel/next/eslint/somewhat/app/inner_app/layout.tsx',
+    },
+    {
+      code: `
+      import Script from "next/script";
+
+      export default function Index() {
+        return (
+          <Script
+            id="scriptBeforeInteractive"
+            src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js?a=scriptBeforeInteractive"
+            strategy="beforeInteractive"
+          ></Script>
+        );
+      }`,
+      filename: 'vercel/next/eslint/src/app/inner_app/layout.tsx',
+    },
+    {
+      code: `
+      import Script from "next/script";
+
+      export default function Index() {
+        return (
+          <Script
+            id="scriptBeforeInteractive"
+            src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js?a=scriptBeforeInteractive"
+            strategy="beforeInteractive"
+          ></Script>
+        );
+      }`,
+      filename: 'next/src/app/inner_app/layout.tsx',
+    },
+    {
+      code: `
+      import Script from "next/script";
+
+      export default function Index() {
+        return (
+          <Script
+            id="scriptBeforeInteractive"
+            src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js?a=scriptBeforeInteractive"
+            strategy="beforeInteractive"
+          ></Script>
+        );
+      }`,
       filename: 'src/app/deep/randomFile.tsx',
     },
     {


### PR DESCRIPTION
### Why?
Even though there was code that branched for the app directory, I encountered a lint error "no-before-script-outside-document-test.ts" in my appdir layout. This problem occurred when the entire path was used as the pathname, and I was able to identify this issue when logging with context.getFilename.

### What?
To resolve the above error, I trimmed any paths from the filePath that were not suitable for the next directory and branched for the app directory.


### Fixing a bug

- #56778 
- Tests added.
- [Link to CodeSandbox Error](https://codesandbox.io/p/sandbox/busy-varahamihira-72h4sq)



