### PR TITLE
Implement for EDGE_UNSUPPORTED_NODE_APIS in Turbopack

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use indexmap::IndexMap;
+use indexmap::{indexmap, IndexMap};
 use turbo_tasks::{Value, Vc};
 use turbopack_binding::{
     turbo::{tasks_env::EnvMap, tasks_fs::FileSystemPath},
@@ -65,36 +65,36 @@ async fn next_edge_free_vars(
     project_path: Vc<FileSystemPath>,
     define_env: Vc<EnvMap>,
 ) -> Result<Vc<FreeVarReferences>> {
-    let error_message = "A Node.js API is used which is not supported in the Edge Runtime. Learn more: https://nextjs.org/docs/api-reference/edge-runtime".to_string();
+    let node_api_error = FreeVarReference::Error("A Node.js API is used which is not supported in the Edge Runtime. Learn more: https://nextjs.org/docs/api-reference/edge-runtime".to_string());
 
     let unsupported_runtime_apis = match mode {
         NextMode::Build => {
-            (
+            Ok(indexmap! {
                 // Mirrors warnForUnsupportedApi in middleware-plugin.ts
-                clearImmediate = FreeVarReference::Error(error_message.clone()),
-                setImmediate = FreeVarReference::Error(error_message.clone()),
-                BroadcastChannel = FreeVarReference::Error(error_message.clone()),
-                ByteLengthQueuingStrategy = FreeVarReference::Error(error_message.clone()),
-                CompressionStream = FreeVarReference::Error(error_message.clone()),
-                CountQueuingStrategy = FreeVarReference::Error(error_message.clone()),
-                DecompressionStream = FreeVarReference::Error(error_message.clone()),
-                DomException = FreeVarReference::Error(error_message.clone()),
-                MessageChannel = FreeVarReference::Error(error_message.clone()),
-                MessageEvent = FreeVarReference::Error(error_message.clone()),
-                MessagePort = FreeVarReference::Error(error_message.clone()),
-                ReadableByteStreamController = FreeVarReference::Error(error_message.clone()),
-                ReadableStreamBYOBRequest = FreeVarReference::Error(error_message.clone()),
-                ReadableStreamDefaultController = FreeVarReference::Error(error_message.clone()),
-                TransformStreamDefaultController = FreeVarReference::Error(error_message.clone()),
-                WritableStreamDefaultController = FreeVarReference::Error(error_message.clone()),
+                "clearImmediate" => node_api_error.clone(),
+                "setImmediate" => node_api_error.clone(),
+                "BroadcastChannel" => node_api_error.clone(),
+                "ByteLengthQueuingStrategy" => node_api_error.clone(),
+                "CompressionStream" => node_api_error.clone(),
+                "CountQueuingStrategy" => node_api_error.clone(),
+                "DecompressionStream" => node_api_error.clone(),
+                "DomException" => node_api_error.clone(),
+                "MessageChannel" => node_api_error.clone(),
+                "MessageEvent" => node_api_error.clone(),
+                "MessagePort" => node_api_error.clone(),
+                "ReadableByteStreamController" => node_api_error.clone(),
+                "ReadableStreamBYOBRequest" => node_api_error.clone(),
+                "ReadableStreamDefaultController" => node_api_error.clone(),
+                "TransformStreamDefaultController" => node_api_error.clone(),
+                "WritableStreamDefaultController" => node_api_error.clone(),
                 // TODO: Implement warnForUnsupportedProcessApi from
                 // middleware-plugin.ts That function implements
                 // a check for `process.something` where `something` could be
                 // anything in the process object except for `process.env` as that is
                 // excluded.
-            )
+            })
         }
-        NextMode::Development => (),
+        NextMode::Development => Ok(()),
     };
     Ok(free_var_references!(
         ..defines(mode, &*define_env.await?).into_iter(),

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -90,7 +90,7 @@ async fn next_edge_free_vars(
                 // TODO: Implement warnForUnsupportedProcessApi from
                 // middleware-plugin.ts That function implements
                 // a check for `process.something` where `something` could be
-                // anything in the process object except for `env` as that is
+                // anything in the process object except for `process.env` as that is
                 // excluded.
             )
         }
@@ -108,7 +108,7 @@ async fn next_edge_free_vars(
             lookup_path: Some(project_path),
             export: Some("default".to_string()),
         },
-        // ..unsupported_runtime_apis
+        ..unsupported_runtime_apis
     ))
     .cell()
 }

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -65,6 +65,8 @@ async fn next_edge_free_vars(
     project_path: Vc<FileSystemPath>,
     define_env: Vc<EnvMap>,
 ) -> Result<Vc<FreeVarReferences>> {
+    // let error_message = "A Node.js API is used which is not supported in the Edge Runtime. Learn more: https://nextjs.org/docs/api-reference/edge-runtime".to_string();
+
     Ok(free_var_references!(
         ..defines(mode, &*define_env.await?).into_iter(),
         Buffer = FreeVarReference::EcmaScriptModule {
@@ -77,6 +79,28 @@ async fn next_edge_free_vars(
             lookup_path: Some(project_path),
             export: Some("default".to_string()),
         },
+        // TODO: These are production build only currently in webpack.
+        // See warnForUnsupportedApi in middleware-plugin.ts
+        // clearImmediate = FreeVarReference::Error(error_message.clone()),
+        // setImmediate = FreeVarReference::Error(error_message.clone()),
+        // BroadcastChannel = FreeVarReference::Error(error_message.clone()),
+        // ByteLengthQueuingStrategy = FreeVarReference::Error(error_message.clone()),
+        // CompressionStream = FreeVarReference::Error(error_message.clone()),
+        // CountQueuingStrategy = FreeVarReference::Error(error_message.clone()),
+        // DecompressionStream = FreeVarReference::Error(error_message.clone()),
+        // DomException = FreeVarReference::Error(error_message.clone()),
+        // MessageChannel = FreeVarReference::Error(error_message.clone()),
+        // MessageEvent = FreeVarReference::Error(error_message.clone()),
+        // MessagePort = FreeVarReference::Error(error_message.clone()),
+        // ReadableByteStreamController = FreeVarReference::Error(error_message.clone()),
+        // ReadableStreamBYOBRequest = FreeVarReference::Error(error_message.clone()),
+        // ReadableStreamDefaultController = FreeVarReference::Error(error_message.clone()),
+        // TransformStreamDefaultController = FreeVarReference::Error(error_message.clone()),
+        // WritableStreamDefaultController = FreeVarReference::Error(error_message.clone()),
+
+        // TODO: Implement warnForUnsupportedProcessApi from middleware-plugin.ts
+        // That function implements a check for `process.something` where `something` could be
+        // anything in the process object except for `env` as that is excluded.
     )
     .cell())
 }

--- a/packages/next/src/shared/lib/constants.ts
+++ b/packages/next/src/shared/lib/constants.ts
@@ -126,6 +126,7 @@ export const RSC_MODULE_TYPES = {
 // https://nextjs.org/docs/api-reference/edge-runtime
 // with
 // https://nodejs.org/docs/latest/api/globals.html
+// Keep in sync with packages/next-swc/crates/next-core/src/next_edge/context.rs
 export const EDGE_UNSUPPORTED_NODE_APIS = [
   'clearImmediate',
   'setImmediate',


### PR DESCRIPTION
Depends on https://github.com/vercel/turbo/pull/6177.

This implements `warnForUnsupportedApi` from `middleware-plugin.ts`, however after implementing I noticed that this feature is only enable in production builds so commented it out for now.

Update: found a way to only apply it for builds so it's fine to land when Turbopack is upgraded.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
