### PR TITLE
Use W3C trace context headers to support OTEL trace propagation

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -712,7 +712,6 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     const traceState =
       typeof traceStateHeader === 'string' ? traceStateHeader : undefined
 
-    console.log('DEBUG', { traceParent, traceState })
     return getTracer().trace(
       BaseServerSpan.handleRequest,
       {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -701,7 +701,6 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     parsedUrl?: NextUrlWithParsedQuery
   ): Promise<void> {
     await this.prepare()
-
     const method = req.method.toUpperCase()
 
     // Extract the w3c trace context headers and pass them to tracer

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -210,8 +210,6 @@ class NextTracerImpl implements NextTracer {
             options: { ...fnOrOptions },
           }
 
-    console.log('DEBUG - TRACING!!!', { options: options, fn: fn, args })
-
     if (
       (!NextVanillaSpanAllowlist.includes(type) &&
         process.env.NEXT_OTEL_VERBOSE !== '1') ||

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -48,8 +48,8 @@ type TracerSpanOptions = Omit<SpanOptions, 'attributes'> & {
   attributes?: Partial<Record<AttributeNames, AttributeValue | undefined>>
   hideSpan?: boolean
   reqHeaderTraceContext?: {
-    traceParent: string | undefined
-    traceState: string | undefined
+    traceParent?: string
+    traceState?: string
   }
 }
 


### PR DESCRIPTION
### Adding propagation to OTEL tracing
Implements OTEL propagation https://opentelemetry.io/docs/instrumentation/js/propagation/ for API route handler traces by extracting the W3C trace context headers https://www.w3.org/TR/trace-context/ from the request and using them to create the context for the active span.

I spent some time trying to figure out how best to test this but I wasn't sure. Would appreciate a pointer to existing tests for the tracer or any advice on testing this.

I followed the doc here https://github.com/vercel/next.js/blob/canary/contributing/core/developing-using-local-app.md and was able to confirm the header values are being used to create the context through logging, but have not been able to do a more thorough test end-to-end to confirm that the generated API route spans are parented correctly. I wanted to deploy a testing app to Vercel that uses my local Next.js build so I could double check that the headers are being used in the generated traces, but I ran into some problems getting the app to build correctly with my local version of Next.js. I asked in Discord here https://discord.com/channels/752553802359505017/1007476603422527558/threads/1162417878507737228 and someone has been helping out but I still haven't yet been able to deploy it. If the reviewer has any advice on the `Error: No Next.js version could be detected in your project. Make sure `"next"` is installed in "dependencies" or "devDependencies"` error I'm getting there it would be appreciated (more context in Discord). 

*I was not able to find a checklist in the PR template for this that is a great match for this since it's not exactly a bug or a feature. Please let me know if anything should be added or expanded here

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
