### PR TITLE
improve next-image-proxy test

### DIFF
--- a/test/e2e/app-dir/next-image/next-image-proxy.test.ts
+++ b/test/e2e/app-dir/next-image/next-image-proxy.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { findPort } from 'next-test-utils'
+import { findPort, check } from 'next-test-utils'
 import https from 'https'
 import httpProxy from 'http-proxy'
 import fs from 'fs'
@@ -40,7 +40,7 @@ createNextDescribe(
       })
 
       proxy.on('error', (err) => {
-        console.warn('Failed to proxy', err)
+        throw new Error('Failed to proxy: ' + err.message)
       })
 
       await new Promise<void>((resolve) => {
@@ -50,6 +50,7 @@ createNextDescribe(
 
     it('loads images without any errors', async () => {
       let failCount = 0
+      let fulfilledCount = 0
 
       const browser = await webdriver(`https://localhost:${proxyPort}`, '/', {
         ignoreHTTPSErrors: true,
@@ -66,6 +67,8 @@ createNextDescribe(
               console.log(`Request failed: ${url}`)
               failCount++
             }
+
+            fulfilledCount++
           })
         },
       })
@@ -77,10 +80,15 @@ createNextDescribe(
         '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90'
       )
 
-      expect(failCount).toBe(0)
+      await check(() => {
+        // we expect 3 images to load and for none of them to have errors
+        if (fulfilledCount === 3 && failCount === 0) {
+          return 'success'
+        }
+      }, 'success')
     })
 
-    afterAll(async () => {
+    afterAll(() => {
       proxyServer.close()
     })
   }


### PR DESCRIPTION
This fixes a warning where the test server was exiting before all the proxy requests finished. This also throws an error to fail the test if any of the proxied requests aren't fulfilled. 

[slack x-ref](https://vercel.slack.com/archives/C04DUD7EB1B/p1697465502593889?thread_ts=1697143786.511779&cid=C04DUD7EB1B)