### PR TITLE
perf: fix server trace file logic 

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -288,7 +288,6 @@ export async function collectBuildTraces({
               // this is being handled outside of next-server
               '**/next/dist/server/image-optimizer.js',
               '**/node_modules/sharp/**/*',
-              '**/next/dist/compiled/edge-runtime/**/*',
             ]
           : []),
 

--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -289,7 +289,6 @@ export async function collectBuildTraces({
               '**/next/dist/server/image-optimizer.js',
               '**/node_modules/sharp/**/*',
               '**/next/dist/compiled/edge-runtime/**/*',
-              '**/next/dist/server/web/sandbox/**/*',
             ]
           : []),
 

--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -25,6 +25,7 @@ import { nodeFileTrace } from 'next/dist/compiled/@vercel/nft'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import isError from '../lib/is-error'
+import type { NodeFileTraceReasons } from '@vercel/nft'
 
 const debug = debugOriginal('next:build:build-traces')
 
@@ -33,7 +34,7 @@ const cachedIgnoreFiles = new Map<string, boolean>()
 function shouldIgnore(
   file: string,
   serverIgnoreFn: (file: string) => boolean,
-  reasons: Map<string, { parents: Set<string> }>
+  reasons: NodeFileTraceReasons
 ) {
   if (cachedIgnoreFiles.has(file)) {
     return cachedIgnoreFiles.get(file)
@@ -45,7 +46,7 @@ function shouldIgnore(
   }
 
   const reason = reasons.get(file)
-  if (!reason || reason.parents.size === 0) {
+  if (!reason || reason.parents.size === 0 || reason.type.includes('initial')) {
     cachedIgnoreFiles.set(file, false)
     return false
   }

--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -392,7 +392,6 @@ export async function collectBuildTraces({
           fileList.add(file)
         }
 
-        console.log('reasons', reasons)
         const parentFilesMap = getFilesMapFromReasons(fileList, reasons)
 
         for (const [entries, tracedFiles] of [


### PR DESCRIPTION
This PR fixes an issue caused by a previous change in the handling of NFT files that broke the handling of ignored files, which caused an increase in the size of the final lambdas when deployed on Vercel.

The problem is that when moving the check for the handling of ignored files, we didn't check if the parents in the dependency graph were ignored. We would correctly remove `foo.js` but not files imported by `foo.js`.

This also adds more files to be removed + fixes some misc files being imported as well.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
