### PR TITLE
perf: fix tracing for routes

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -269,11 +269,19 @@ export async function collectBuildTraces({
           })
         }
       }
-      const serverIgnores = [
+
+      const sharedIgnores = [
         '**/*.d.ts',
         '**/*.map',
         '**/next/dist/compiled/next-server/**/*.dev.js',
         '**/node_modules/react{,-dom,-dom-server-turbopack}/**/*.development.js',
+
+        ...additionalIgnores,
+        ...(config.experimental.outputFileTracingIgnores || []),
+      ]
+
+      const serverIgnores = [
+        ...sharedIgnores,
         isStandalone ? null : '**/next/dist/compiled/jest-worker/**/*',
         '**/next/dist/compiled/webpack/(bundle4|bundle5).js',
         '**/node_modules/webpack5/**/*',
@@ -294,32 +302,32 @@ export async function collectBuildTraces({
           ? ['**/next/dist/compiled/@ampproject/toolbox-optimizer/**/*']
           : []),
 
-        ...additionalIgnores,
-
         ...(isStandalone ? [] : TRACE_IGNORES),
-
-        ...(config.experimental.outputFileTracingIgnores || []),
       ].filter(nonNullable)
 
       const minimalServerIgnores = [
         ...serverIgnores,
         '**/next/dist/compiled/edge-runtime/**/*',
         '**/next/dist/server/web/sandbox/**/*',
+        '**/next/dist/server/post-process.js',
       ]
 
-      const serverIgnoreFn = (minimal: boolean) => (pathname: string) => {
+      const routesIgnores = [
+        ...sharedIgnores,
+        '**/next/dist/compiled/next-server/**/*',
+        '**/next/dist/server/optimize-amp.js',
+        '**/next/dist/server/post-process.js',
+      ]
+
+      const makeIgnoreFn = (ignores: string[]) => (pathname: string) => {
         if (path.isAbsolute(pathname) && !pathname.startsWith(root)) {
           return true
         }
 
-        return isMatch(
-          pathname,
-          minimal ? minimalServerIgnores : serverIgnores,
-          {
-            contains: true,
-            dot: true,
-          }
-        )
+        return isMatch(pathname, ignores, {
+          contains: true,
+          dot: true,
+        })
       }
       const traceContext = path.join(nextServerEntry, '..', '..')
       const serverTracedFiles = new Set<string>()
@@ -372,9 +380,11 @@ export async function collectBuildTraces({
         ] as [Set<string>, string[]][]) {
           for (const file of files) {
             if (
-              !serverIgnoreFn(set === minimalServerTracedFiles)(
-                path.join(traceContext, file)
-              )
+              !makeIgnoreFn(
+                set === minimalServerTracedFiles
+                  ? minimalServerIgnores
+                  : serverIgnores
+              )(path.join(traceContext, file))
             ) {
               addToTracedFiles(traceContext, file, set)
             }
@@ -433,14 +443,13 @@ export async function collectBuildTraces({
         })
         const reasons = result.reasons
         const fileList = result.fileList
-
         for (const file of result.esmFileList) {
           fileList.add(file)
         }
 
         const parentFilesMap = getFilesMapFromReasons(fileList, reasons)
-        const cachedIgnoreFiles = new Map<string, boolean>()
-        const cachedIgnoreFilesMinimal = new Map<string, boolean>()
+        const cachedLookupIgnore = new Map<string, boolean>()
+        const cachedLookupIgnoreMinimal = new Map<string, boolean>()
 
         for (const [entries, tracedFiles] of [
           [serverEntries, serverTracedFiles],
@@ -458,11 +467,15 @@ export async function collectBuildTraces({
               if (
                 !shouldIgnore(
                   curFile,
-                  serverIgnoreFn(tracedFiles === minimalServerTracedFiles),
+                  makeIgnoreFn(
+                    tracedFiles === minimalServerTracedFiles
+                      ? minimalServerIgnores
+                      : serverIgnores
+                  ),
                   reasons,
                   tracedFiles === minimalServerTracedFiles
-                    ? cachedIgnoreFilesMinimal
-                    : cachedIgnoreFiles
+                    ? cachedLookupIgnoreMinimal
+                    : cachedLookupIgnore
                 )
               ) {
                 tracedFiles.add(
@@ -474,6 +487,8 @@ export async function collectBuildTraces({
         }
 
         const { entryNameFilesMap } = buildTraceContext?.chunksTrace || {}
+
+        const cachedLookupIgnoreRoutes = new Map<string, boolean>()
 
         await Promise.all(
           [
@@ -514,14 +529,21 @@ export async function collectBuildTraces({
                 path.relative(outputFileTracingRoot, file)
               )
               for (const curFile of curFiles || []) {
-                curTracedFiles.add(
-                  path
-                    .relative(
-                      traceOutputDir,
-                      path.join(outputFileTracingRoot, curFile)
-                    )
+                if (
+                  !shouldIgnore(
+                    curFile,
+                    makeIgnoreFn(routesIgnores),
+                    reasons,
+                    cachedLookupIgnoreRoutes
+                  )
+                ) {
+                  // console.log(`tracing ${curFile} for route ${route}`)
+                  const filePath = path.join(outputFileTracingRoot, curFile)
+                  const outputFile = path
+                    .relative(traceOutputDir, filePath)
                     .replace(/\\/g, '/')
-                )
+                  curTracedFiles.add(outputFile)
+                }
               }
             }
 
@@ -556,7 +578,7 @@ export async function collectBuildTraces({
 
         for (const item of await fs.readdir(contextDir)) {
           const itemPath = path.relative(root, path.join(contextDir, item))
-          if (!serverIgnoreFn(false)(itemPath)) {
+          if (!makeIgnoreFn(serverIgnores)(itemPath)) {
             addToTracedFiles(root, itemPath, serverTracedFiles)
             addToTracedFiles(root, itemPath, minimalServerTracedFiles)
           }

--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -537,7 +537,6 @@ export async function collectBuildTraces({
                     cachedLookupIgnoreRoutes
                   )
                 ) {
-                  // console.log(`tracing ${curFile} for route ${route}`)
                   const filePath = path.join(outputFileTracingRoot, curFile)
                   const outputFile = path
                     .relative(traceOutputDir, filePath)


### PR DESCRIPTION
follow up to #56898 where I noticed that we don't apply any filtering to the trace files for the user routes, resulting in files that would need to be filtered like `caniuse` not being filtered out correctly. This fixes that.

A lambda in my test project goes from `2.7MB` to `1.4MB`

followup: add some snapshot tests

before
```
Serverless function size info
Serverless Function's pages: _not-found.js, index.js
Large Dependencies                                                     Uncompressed size  Compressed size
node_modules/.pnpm/next@13.5.6-canary.1_react-dom@18.2.0_react@18.2.0            4.61 MB          1.35 MB
node_modules/.pnpm/caniuse-lite@1.0.30001517                                   909.73 KB        327.14 KB
node_modules/.pnpm/react-dom@18.2.0_react@18.2.0                               546.21 KB        138.87 KB

All dependencies                                                                 3.66 MB          2.01 MB
Serverless Function's page: favicon.ico.js
Large Dependencies                                                     Uncompressed size  Compressed size
node_modules/.pnpm/next@13.5.6-canary.1_react-dom@18.2.0_react@18.2.0            6.71 MB          2.05 MB
node_modules/.pnpm/caniuse-lite@1.0.30001517                                   909.73 KB        327.14 KB
node_modules/.pnpm/react-dom@18.2.0_react@18.2.0                               546.21 KB        138.87 KB

All dependencies                                                                 5.78 MB          2.71 MB
Serverless Function's page: api/hello-world.js
Large Dependencies                                                     Uncompressed size  Compressed size
node_modules/.pnpm/next@13.5.6-canary.1_react-dom@18.2.0_react@18.2.0            4.61 MB          1.35 MB
node_modules/.pnpm/caniuse-lite@1.0.30001517                                   909.73 KB        327.14 KB
node_modules/.pnpm/react-dom@18.2.0_react@18.2.0                               546.21 KB        138.87 KB

All dependencies                                                                 3.65 MB          2.01 MB
```

after

```
Large Dependencies                                                                          Uncompressed size  Compressed size
node_modules/.pnpm/file+next-canary+next-13.5.6-canary.1.tgz_react-dom@18.2.0_react@18.2.0            2.87 MB         844.1 KB

All dependencies                                                                                    341.31 KB        992.45 KB
Serverless Function's page: favicon.ico.js
Large Dependencies                                                                          Uncompressed size  Compressed size
node_modules/.pnpm/file+next-canary+next-13.5.6-canary.1.tgz_react-dom@18.2.0_react@18.2.0            4.97 MB          1.52 MB

All dependencies                                                                                      2.45 MB          1.67 MB
Serverless Function's page: api/hello-world.js
Large Dependencies                                                                          Uncompressed size  Compressed size
node_modules/.pnpm/file+next-canary+next-13.5.6-canary.1.tgz_react-dom@18.2.0_react@18.2.0            2.87 MB         844.1 KB

All dependencies                                                                                    328.64 KB        989.23 KB
````


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
