### PR TITLE
fix(i18n): match domain in hostname instead of equalization

### DIFF
--- a/docs/03-pages/01-building-your-application/01-routing/08-internationalization.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/08-internationalization.mdx
@@ -100,8 +100,8 @@ module.exports = {
 
     domains: [
       {
-        // Note: subdomains must be included in the domain value to be matched
-        // e.g. www.example.com should be used if that is the expected hostname
+        // Domain is checked if it is included in the hostname.
+        // For instance, if the domain is "example.com," it will also match "www.example.com."
         domain: 'example.com',
         defaultLocale: 'en-US',
       },

--- a/packages/next/src/server/future/helpers/i18n-provider.test.ts
+++ b/packages/next/src/server/future/helpers/i18n-provider.test.ts
@@ -65,6 +65,10 @@ describe('I18NProvider', () => {
       domain: 'example.fr',
       defaultLocale: 'fr',
     })
+    expect(provider.detectDomainLocale('www.example.fr')).toEqual({
+      domain: 'example.fr',
+      defaultLocale: 'fr',
+    })
     expect(provider.detectDomainLocale('example.de')).toBeUndefined()
   })
 

--- a/packages/next/src/server/future/helpers/i18n-provider.ts
+++ b/packages/next/src/server/future/helpers/i18n-provider.ts
@@ -83,7 +83,7 @@ export class I18NProvider {
       const domainLocale = this.lowerCaseDomains[i]
       if (
         // We assume that the hostname is already lowercased.
-        domainLocale.hostname === hostname ||
+        hostname.includes(domainLocale.hostname) ||
         // Configuration validation ensures that the locale is not repeated in
         // other domains locales.
         domainLocale.locales?.some((locale) => locale === detectedLocale)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #56926

-->

### What?
Match domain in hostname instead of equalization

### Why?
To be able match also subdomains.

### How?

Fixes #56926
