### PR TITLE
fix(docs): correct unintended word

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/06-lazy-loading.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/06-lazy-loading.mdx
@@ -57,7 +57,7 @@ export default function ClientComponentExample() {
 
 ### Skipping SSR
 
-When using `React.lazy()` and Suspense, Client Components will be pre-rendered (SSR) by default.
+When using `dynamic()`, Client Components will be pre-rendered (SSR) by default.
 
 If you want to disable pre-rendering for a Client Component, you can use the `ssr` option set to `false`:
 


### PR DESCRIPTION
### What?

[Read the context first](https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading#skipping-ssr)

The section is about how to skip SSR for lazy loaded components using `dynamic()`. The current sentence `When using React.lazy() and Suspense, Client Components will be pre-rendered (SSR) by default.`. but the context and code snippet is talking about `dynamic()`