### PR TITLE
Revert "chore: reduce `fs-extra` usage in `scripts/`"

### DIFF
--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -5,7 +5,7 @@ const path = require('path')
 const execa = require('execa')
 const { Sema } = require('async-sema')
 const { execSync } = require('child_process')
-const fs = require('fs')
+const { readJson, readdir } = require('fs-extra')
 
 const cwd = process.cwd()
 
@@ -38,7 +38,7 @@ const cwd = process.cwd()
   }
 
   const packagesDir = path.join(cwd, 'packages')
-  const packageDirs = fs.readdirSync(packagesDir)
+  const packageDirs = await readdir(packagesDir)
   const publishSema = new Sema(2)
 
   const publish = async (pkg, retry = 0) => {
@@ -88,11 +88,8 @@ const cwd = process.cwd()
 
   await Promise.allSettled(
     packageDirs.map(async (packageDir) => {
-      const pkgJson = JSON.parse(
-        await fs.promises.readFile(
-          path.join(packagesDir, packageDir, 'package.json'),
-          'utf-8'
-        )
+      const pkgJson = await readJson(
+        path.join(packagesDir, packageDir, 'package.json')
       )
 
       if (pkgJson.private) {

--- a/scripts/setup-wasm.mjs
+++ b/scripts/setup-wasm.mjs
@@ -1,6 +1,6 @@
 import path from 'path'
-import fs from 'fs'
-import { copy } from 'fs-extra'
+import { readFile, writeFile } from 'fs/promises'
+import { copy, pathExists } from 'fs-extra'
 ;(async function () {
   try {
     let wasmDir = path.join(process.cwd(), 'packages/next-swc/crates/wasm')
@@ -8,16 +8,16 @@ import { copy } from 'fs-extra'
 
     // CI restores artifact at pkg-${wasmTarget}
     // This only runs locally
-    let folderName = fs.existsSync(path.join(wasmDir, 'pkg'))
+    let folderName = (await pathExists(path.join(wasmDir, 'pkg')))
       ? 'pkg'
       : `pkg-${wasmTarget}`
 
     let wasmPkg = JSON.parse(
-      fs.readFileSync(path.join(wasmDir, `${folderName}/package.json`))
+      await readFile(path.join(wasmDir, `${folderName}/package.json`))
     )
     wasmPkg.name = `@next/swc-wasm-${wasmTarget}`
 
-    fs.writeFileSync(
+    await writeFile(
       path.join(wasmDir, `${folderName}/package.json`),
       JSON.stringify(wasmPkg, null, 2)
     )

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 const path = require('path')
-const fsp = require('fs/promises')
+const { readJson, writeJson } = require('fs-extra')
 const execa = require('execa')
 
 /** @type {any} */
@@ -52,9 +52,7 @@ Or, run this command with no arguments to use the most recently published versio
   }
 
   const cwd = process.cwd()
-  const pkgJson = JSON.parse(
-    await fsp.readFile(path.join(cwd, 'package.json'), 'utf-8')
-  )
+  const pkgJson = await readJson(path.join(cwd, 'package.json'))
   const devDependencies = pkgJson.devDependencies
   const baseVersionStr = devDependencies[
     useExperimental ? 'react-experimental-builtin' : 'react-builtin'
@@ -92,10 +90,7 @@ Or, run this command with no arguments to use the most recently published versio
       )
     }
   }
-  await fsp.writeFile(
-    path.join(cwd, 'package.json'),
-    JSON.stringify(pkgJson, null, 2)
-  )
+  await writeJson(path.join(cwd, 'package.json'), pkgJson, { spaces: 2 })
   console.log('Successfully updated React dependencies in package.json.\n')
 
   // Install the updated dependencies and build the vendored React files.


### PR DESCRIPTION
Reverts vercel/next.js#56917 since its failing on windows

```
❌ packages/font/src/google/get-font-axes.test.ts output:
packages/font/src/google/get-font-axes.test.ts failed to pass within 0 retries
IS_RETRY=undefined RECORD_REPLAY=undefined HEADLESS=true TRACE_PLAYWRIGHT=true NEXT_TELEMETRY_DISABLED=1 CI= CIRCLECI= GITHUB_ACTIONS= CONTINUOUS_INTEGRATION= RUN_ID= BUILD_NUMBER= JEST_JUNIT_OUTPUT_NAME=packages_font_src_google_get-font-axes.test.ts JEST_SUITE_NAME=dev:unit:packages/font/src/google/get-font-axes.test.ts D:\a\1\s\node_modules\.bin\jest.CMD '--runInBand' '--forceExit' '--verbose' '--silent' 'packages/font/src/google/get-font-axes.test.ts'
   Downloading swc package @next/swc-win32-x64-msvc...
node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[Error: EPERM: operation not permitted, rename 'C:\Users\VssAdministrator\AppData\Local\next-swc\swc-win32-x64-msvc-13.5.6-canary.3.tgz.temp-1697574492235' -> 'C:\Users\VssAdministrator\AppData\Local\next-swc\swc-win32-x64-msvc-13.5.6-canary.3.tgz'] {
  errno: -4048,
  code: 'EPERM',
  syscall: 'rename',
  path: 'C:\\Users\\VssAdministrator\\AppData\\Local\\next-swc\\swc-win32-x64-msvc-13.5.6-canary.3.tgz.temp-1697574492235',
  dest: 'C:\\Users\\VssAdministrator\\AppData\\Local\\next-swc\\swc-win32-x64-msvc-13.5.6-canary.3.tgz'
}
```

https://dev.azure.com/nextjs/next.js/_build/results?buildId=70758&view=logs&j=8af7cf9c-43a1-584d-6f5c-57bad8880974&t=7ae70e63-3625-50f4-6764-5b3e72b4bd7a