### PR TITLE
add better logs around worker restarts

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1207,6 +1207,7 @@ export default async function build(
 
         return new Worker(staticWorkerPath, {
           timeout: timeout * 1000,
+          logger: Log,
           onRestart: (method, [arg], attempts) => {
             if (method === 'exportPage') {
               const pagePath = arg.path

--- a/test/production/app-dir/worker-restart/worker-restart.test.ts
+++ b/test/production/app-dir/worker-restart/worker-restart.test.ts
@@ -9,6 +9,12 @@ describe('worker-restart', () => {
 
     const output = stdout + stderr
     expect(output).toContain(
+      'Sending SIGTERM signal to static worker due to timeout of 10 seconds. Subsequent errors may be a result of the worker exiting.'
+    )
+    expect(output).toContain(
+      'Static worker exited with code: null and signal: SIGTERM'
+    )
+    expect(output).toContain(
       'Restarted static page generation for /bad-page because it took more than 10 seconds'
     )
     expect(output).toContain(


### PR DESCRIPTION
We currently log when a worker is restarted but not when we send the kill signal, which can create a delta in logs of cryptic errors while the worker is exiting. This explicitly logs when we're terminating the static worker prior to a restart, and also adds an optional logger fn so that we pretty-print the messages. 

[slack x-ref](https://vercel.slack.com/archives/C061DJBG8PN/p1697491350970269)