### PR TITLE
chore(next/image): remove deprecation of `onLoadingComplete` temporarily

### DIFF
--- a/packages/next/src/shared/lib/get-img-props.ts
+++ b/packages/next/src/shared/lib/get-img-props.ts
@@ -38,10 +38,6 @@ export type ImageProps = Omit<
   placeholder?: PlaceholderValue
   blurDataURL?: string
   unoptimized?: boolean
-  /**
-   * @deprecated Use `onLoad` instead.
-   * @see https://nextjs.org/docs/app/api-reference/components/image#onload
-   */
   onLoadingComplete?: OnLoadingComplete
   /**
    * @deprecated Use `fill` prop instead of `layout="fill"` or change import to `next/legacy/image`.
@@ -525,12 +521,6 @@ export function getImgProps(
             `\nRead more: https://nextjs.org/docs/messages/next-image-missing-loader-width`
         )
       }
-    }
-
-    if (onLoadingComplete) {
-      warnOnce(
-        `Image with src "${src}" is using deprecated "onLoadingComplete" property. Please use the "onLoad" property instead.`
-      )
     }
 
     for (const [legacyKey, legacyValue] of Object.entries({

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -357,15 +357,6 @@ function runTests(mode) {
       () => browser.eval(`document.getElementById("msg9").textContent`),
       'loaded 1 img9 with dimensions 400x400'
     )
-
-    if (mode === 'dev') {
-      const warnings = (await browser.log('browser'))
-        .map((log) => log.message)
-        .join('\n')
-      expect(warnings).toMatch(
-        /Image with src "(.*)" is using deprecated "onLoadingComplete" property/gm
-      )
-    }
   })
 
   it('should callback native onLoad with sythetic event', async () => {

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -358,15 +358,6 @@ function runTests(mode) {
       () => browser.eval(`document.getElementById("msg9").textContent`),
       'loaded 1 img9 with dimensions 400x400'
     )
-
-    if (mode === 'dev') {
-      const warnings = (await browser.log('browser'))
-        .map((log) => log.message)
-        .join('\n')
-      expect(warnings).toMatch(
-        /Image with src "(.*)" is using deprecated "onLoadingComplete" property/gm
-      )
-    }
   })
 
   it('should callback native onLoad with sythetic event', async () => {


### PR DESCRIPTION
- Temporary revert of #56944 