### PR TITLE
Upgrade edge-runtime/cookies

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -135,7 +135,7 @@
     "@babel/traverse": "7.18.0",
     "@babel/types": "7.18.0",
     "@capsizecss/metrics": "1.1.0",
-    "@edge-runtime/cookies": "4.0.1",
+    "@edge-runtime/cookies": "4.0.2",
     "@edge-runtime/ponyfill": "2.4.1",
     "@edge-runtime/primitives": "4.0.2",
     "@hapi/accept": "5.0.2",

--- a/packages/next/src/compiled/@edge-runtime/cookies/package.json
+++ b/packages/next/src/compiled/@edge-runtime/cookies/package.json
@@ -1,1 +1,1 @@
-{"name":"@edge-runtime/cookies","version":"4.0.1","main":"./index.js","license":"MPL-2.0"}
+{"name":"@edge-runtime/cookies","version":"4.0.2","main":"./index.js","license":"MPL-2.0"}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -893,8 +893,8 @@ importers:
         specifier: 1.1.0
         version: 1.1.0
       '@edge-runtime/cookies':
-        specifier: 4.0.1
-        version: 4.0.1
+        specifier: 4.0.2
+        version: 4.0.2
       '@edge-runtime/ponyfill':
         specifier: 2.4.1
         version: 2.4.1
@@ -5045,8 +5045,8 @@ packages:
     resolution: {integrity: sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew==}
     dev: true
 
-  /@edge-runtime/cookies@4.0.1:
-    resolution: {integrity: sha512-QIZ1lz6rAF8rTrFdGkljedUaZpXbGIWmRdbA+kwm15ddFfryyekYwI3luFKB33KDcXRHrBi6WdMuyQN19CS6pg==}
+  /@edge-runtime/cookies@4.0.2:
+    resolution: {integrity: sha512-BphVamVz/yt9FN1b60ZXp+iTJVRLUHI0POxKYZG3gn+RsP+M0phqS87Z9JnDn2YOsPx9SRhhrN9AB7yhpexNEw==}
     engines: {node: '>=16'}
     dev: true
 
@@ -6723,8 +6723,8 @@ packages:
     resolution: {integrity: sha512-XQr74QaLeMiqhStEhLn1im9EOMnkypp7MZOwQhGzqp2Weu5eQJbpPxWxixxlYRKWPOmJjsk6qYfYH9kq43yc2w==}
     dev: true
 
-  /@next/react-refresh-utils@13.5.4(react-refresh@0.12.0)(webpack@5.86.0):
-    resolution: {integrity: sha512-Y2bFd17Gn5Wh1gT/P/xTlApmipdrD0JdTdMwhi8G2wD2qj8p7SZbci1kp7zp+utWVp8PFQD6kHAIBrJS9/iEQQ==}
+  /@next/react-refresh-utils@13.5.5(react-refresh@0.12.0)(webpack@5.86.0):
+    resolution: {integrity: sha512-8lvKW22vbWnloufUverqDOsmesoqBPxnX2rUAZuZ+e7240BqvXvhuWd9XWbwFXZ7bgR1FWU/5NYpGK/b2rT5vw==}
     peerDependencies:
       react-refresh: 0.12.0
       webpack: 5.86.0
@@ -26794,7 +26794,7 @@ packages:
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:
-      '@next/react-refresh-utils': 13.5.4(react-refresh@0.12.0)(webpack@5.86.0)
+      '@next/react-refresh-utils': 13.5.5(react-refresh@0.12.0)(webpack@5.86.0)
       '@types/node': 20.2.5
     transitivePeerDependencies:
       - react-refresh


### PR DESCRIPTION
### What
This partially reverts #56856 which removed a `Headers#getSetCookie` polyfill too early. 

### Why

This method is available in Node.js 18.16+ versions, but we did not require users to upgrade so this was a breaking change, thus considered a bug.

### How

Upgrading `@edge-runtime/cookies`. See the changelog here: https://github.com/vercel/edge-runtime/releases/tag/%40edge-runtime%2Fcookies%404.0.2

Fixes #56949