### PR TITLE
Update CNA tests to avoid publish conflict

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -8,7 +8,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import { cyan, bold } from 'picocolors'
 import { Sema } from 'async-sema'
-import { version } from '../package.json'
+import pkg from '../package.json'
 
 import { GetTemplateFileArgs, InstallTemplateArgs } from './types'
 
@@ -167,6 +167,9 @@ export const installTemplate = async ({
     }
   }
 
+  /** Copy the version from package.json or override for tests. */
+  const version = process.env.NEXT_PRIVATE_TEST_VERSION ?? pkg.version
+
   /** Create a package.json for the new project and write it to disk. */
   const packageJson: any = {
     name: appName,
@@ -184,7 +187,7 @@ export const installTemplate = async ({
     dependencies: {
       react: '^18',
       'react-dom': '^18',
-      next: process.env.NEXT_PRIVATE_TEST_VERSION ?? version,
+      next: version,
     },
     devDependencies: {},
   }

--- a/test/integration/create-next-app/templates-app.test.ts
+++ b/test/integration/create-next-app/templates-app.test.ts
@@ -54,10 +54,13 @@ let testVersion
 describe('create-next-app --app', () => {
   beforeAll(async () => {
     if (testVersion) return
-    const span = new Span({ name: 'parent' })
-    testVersion = (
-      await createNextInstall({ onlyPackages: true, parentSpan: span })
-    ).get('next')
+    // TODO: investigate moving this post publish or create deployed
+    // tarballs to avoid these failing while a publish is in progress
+    testVersion = 'canary'
+    // const span = new Span({ name: 'parent' })
+    // testVersion = (
+    //   await createNextInstall({ onlyPackages: true, parentSpan: span })
+    // ).get('next')
   })
 
   it('should create TS appDir projects with --ts', async () => {

--- a/test/integration/create-next-app/templates-app.test.ts
+++ b/test/integration/create-next-app/templates-app.test.ts
@@ -13,12 +13,12 @@ import {
   shouldBeTemplateProject,
   spawnExitPromise,
 } from './lib/utils'
-import { Span } from 'next/dist/trace'
+//import { Span } from 'next/dist/trace'
 
 import { useTempDir } from '../../lib/use-temp-dir'
 import { fetchViaHTTP, findPort, killApp, launchApp } from 'next-test-utils'
 import resolveFrom from 'resolve-from'
-import { createNextInstall } from '../../lib/create-next-install'
+//import { createNextInstall } from '../../lib/create-next-install'
 
 const startsWithoutError = async (
   appDir: string,

--- a/test/integration/create-next-app/templates-pages.test.ts
+++ b/test/integration/create-next-app/templates-pages.test.ts
@@ -62,10 +62,13 @@ let testVersion
 
 describe('create-next-app templates', () => {
   beforeAll(async () => {
-    const span = new Span({ name: 'parent' })
-    testVersion = (
-      await createNextInstall({ onlyPackages: true, parentSpan: span })
-    ).get('next')
+    // TODO: investigate moving this post publish or create deployed
+    // tarballs to avoid these failing while a publish is in progress
+    testVersion = 'canary'
+    // const span = new Span({ name: 'parent' })
+    // testVersion = (
+    //   await createNextInstall({ onlyPackages: true, parentSpan: span })
+    // ).get('next')
   })
 
   it('should prompt user to choose if --ts or --js is not provided', async () => {

--- a/test/integration/create-next-app/templates-pages.test.ts
+++ b/test/integration/create-next-app/templates-pages.test.ts
@@ -15,7 +15,7 @@ import {
   shouldBeTypescriptProject,
   spawnExitPromise,
 } from './lib/utils'
-import { Span } from 'next/dist/trace'
+//import { Span } from 'next/dist/trace'
 
 import { useTempDir } from '../../lib/use-temp-dir'
 import {
@@ -26,7 +26,7 @@ import {
   launchApp,
 } from 'next-test-utils'
 import resolveFrom from 'resolve-from'
-import { createNextInstall } from '../../lib/create-next-install'
+//import { createNextInstall } from '../../lib/create-next-install'
 import ansiEscapes from 'ansi-escapes'
 
 const startsWithoutError = async (


### PR DESCRIPTION
This avoids testing against latest exact canary version as this causes these tests to fail while the publish is still in progress. As a follow-up we can investigate moving this post publish or packing/deploying tarballs to use. 