### PR TITLE
chore: revert back to moving files w/ `fs-extra`

### DIFF
--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -2,7 +2,7 @@ import os from 'os'
 import path from 'path'
 import execa from 'execa'
 import fs from 'fs'
-import fsp from 'fs/promises'
+import { move } from 'fs-extra'
 ;(async function () {
   if (process.env.NEXT_SKIP_NATIVE_POSTINSTALL) {
     console.log(
@@ -71,8 +71,7 @@ import fsp from 'fs/promises'
         const from = path.join(tmpdir, 'node_modules/@next', pkg)
         const to = path.join(cwd, 'node_modules/@next', pkg)
         // overwriting by removing the target first
-        await fsp.rm(to, { recursive: true, force: true })
-        return fsp.rename(from, to)
+        return move(from, to, { overwrite: true })
       })
     )
     fs.rmSync(tmpdir, { recursive: true, force: true })


### PR DESCRIPTION
Follows #56917, revert back to moving files using `fs-extra`. This should help with the flaky `fs.rename` operation on Windows.

cc @styfle 