### PR TITLE
Correcting an error that occurred in Bun when running the server. Und…

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -1,6 +1,9 @@
-if (performance.getEntriesByName('next-start').length === 0) {
-  performance.mark('next-start')
+if(performance.getEntriesByName !== undefined) {
+  if (performance.getEntriesByName('next-start').length === 0) {
+    performance.mark('next-start')
+  }
 }
+
 import '../next'
 import '../node-polyfill-fetch'
 import '../require-hook'


### PR DESCRIPTION
# Error Output:
```
bun --bun run dev                                                                             
$ next dev                                                                                                       
80 |     }                                                                                                       
81 |     return newObj;                                                                                          
82 | }                                                                                                           
83 | if (performance != undefined)                                                                               
84 | {                                                                                                           
85 |    if (performance.getEntriesByName("next-start").length === 0) {                                           
        ^                                                                                                        
TypeError: performance.getEntriesByName is not a function. (In 'performance.getEntriesByName("next-start")', 'per
formance.getEntriesByName' is undefined)                                                                         
      at /home/satoshi/Documents/bomjs-shop/node_modules/next/dist/server/lib/start-server.js:85:5
      at globalThis (/home/satoshi/Documents/bomjs-shop/node_modules/next/dist/server/lib/start-server.js:288:5)

```
# How i fix it?
I simply set it to only execute if when is different from `undefined`, and yes, it worked.