### PR TITLE
Bump packages version to match canary versions

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
       "registry": "https://registry.npmjs.org/"
     }
   },
-  "version": "13.5.6-canary.8"
+  "version": "13.5.7-canary.8"
 }

--- a/packages/create-next-app/package.json
+++ b/packages/create-next-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-next-app",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "keywords": [
     "react",
     "next",

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-next",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "description": "ESLint configuration used by Next.js.",
   "main": "index.js",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "homepage": "https://nextjs.org/docs/app/building-your-application/configuring/eslint#eslint-config",
   "dependencies": {
-    "@next/eslint-plugin-next": "13.5.6-canary.8",
+    "@next/eslint-plugin-next": "13.5.7-canary.8",
     "@rushstack/eslint-patch": "^1.3.3",
     "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
     "eslint-import-resolver-node": "^0.3.6",

--- a/packages/eslint-plugin-next/package.json
+++ b/packages/eslint-plugin-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/eslint-plugin-next",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "description": "ESLint plugin for Next.js.",
   "main": "dist/index.js",
   "license": "MIT",

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/font",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/font"

--- a/packages/next-bundle-analyzer/package.json
+++ b/packages/next-bundle-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/bundle-analyzer",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "MIT",

--- a/packages/next-codemod/package.json
+++ b/packages/next-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/codemod",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/next-env/package.json
+++ b/packages/next-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/env",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "keywords": [
     "react",
     "next",

--- a/packages/next-mdx/package.json
+++ b/packages/next-mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/mdx",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "main": "index.js",
   "license": "MIT",
   "repository": {

--- a/packages/next-plugin-storybook/package.json
+++ b/packages/next-plugin-storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/plugin-storybook",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/next-plugin-storybook"

--- a/packages/next-polyfill-module/package.json
+++ b/packages/next-polyfill-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/polyfill-module",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "description": "A standard library polyfill for ES Modules supporting browsers (Edge 16+, Firefox 60+, Chrome 61+, Safari 10.1+)",
   "main": "dist/polyfill-module.js",
   "license": "MIT",

--- a/packages/next-polyfill-nomodule/package.json
+++ b/packages/next-polyfill-nomodule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/polyfill-nomodule",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "description": "A polyfill for non-dead, nomodule browsers.",
   "main": "dist/polyfill-nomodule.js",
   "license": "MIT",

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/swc",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "private": true,
   "scripts": {
     "clean": "node ../../scripts/rm.mjs native",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "description": "The React Framework",
   "main": "./dist/server/next.js",
   "license": "MIT",
@@ -92,7 +92,7 @@
     ]
   },
   "dependencies": {
-    "@next/env": "13.5.6-canary.8",
+    "@next/env": "13.5.7-canary.8",
     "@swc/helpers": "0.5.2",
     "busboy": "1.6.0",
     "caniuse-lite": "^1.0.30001406",
@@ -146,11 +146,11 @@
     "@mswjs/interceptors": "0.23.0",
     "@napi-rs/cli": "2.16.2",
     "@napi-rs/triples": "1.1.0",
-    "@next/polyfill-module": "13.5.6-canary.8",
-    "@next/polyfill-nomodule": "13.5.6-canary.8",
-    "@next/react-dev-overlay": "13.5.6-canary.8",
-    "@next/react-refresh-utils": "13.5.6-canary.8",
-    "@next/swc": "13.5.6-canary.8",
+    "@next/polyfill-module": "13.5.7-canary.8",
+    "@next/polyfill-nomodule": "13.5.7-canary.8",
+    "@next/react-dev-overlay": "13.5.7-canary.8",
+    "@next/react-refresh-utils": "13.5.7-canary.8",
+    "@next/swc": "13.5.7-canary.8",
     "@opentelemetry/api": "1.4.1",
     "@playwright/test": "^1.35.1",
     "@taskr/clear": "1.1.0",

--- a/packages/react-dev-overlay/package.json
+++ b/packages/react-dev-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/react-dev-overlay",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "description": "A development-only overlay for developing React applications.",
   "repository": {
     "url": "vercel/next.js",

--- a/packages/react-refresh-utils/package.json
+++ b/packages/react-refresh-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/react-refresh-utils",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "description": "An experimental package providing utilities for React Refresh.",
   "repository": {
     "url": "vercel/next.js",

--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/third-parties",
-  "version": "13.5.6-canary.8",
+  "version": "13.5.7-canary.8",
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/third-parties"
@@ -22,7 +22,7 @@
     "third-party-capital": "1.0.20"
   },
   "devDependencies": {
-    "next": "13.5.6-canary.8",
+    "next": "13.5.7-canary.8",
     "outdent": "0.8.0",
     "prettier": "2.5.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -738,7 +738,7 @@ importers:
   packages/eslint-config-next:
     dependencies:
       '@next/eslint-plugin-next':
-        specifier: 13.5.6-canary.8
+        specifier: 13.5.7-canary.8
         version: link:../eslint-plugin-next
       '@rushstack/eslint-patch':
         specifier: ^1.3.3
@@ -799,7 +799,7 @@ importers:
   packages/next:
     dependencies:
       '@next/env':
-        specifier: 13.5.6-canary.8
+        specifier: 13.5.7-canary.8
         version: link:../next-env
       '@swc/helpers':
         specifier: 0.5.2
@@ -923,19 +923,19 @@ importers:
         specifier: 1.1.0
         version: 1.1.0
       '@next/polyfill-module':
-        specifier: 13.5.6-canary.8
+        specifier: 13.5.7-canary.8
         version: link:../next-polyfill-module
       '@next/polyfill-nomodule':
-        specifier: 13.5.6-canary.8
+        specifier: 13.5.7-canary.8
         version: link:../next-polyfill-nomodule
       '@next/react-dev-overlay':
-        specifier: 13.5.6-canary.8
+        specifier: 13.5.7-canary.8
         version: link:../react-dev-overlay
       '@next/react-refresh-utils':
-        specifier: 13.5.6-canary.8
+        specifier: 13.5.7-canary.8
         version: link:../react-refresh-utils
       '@next/swc':
-        specifier: 13.5.6-canary.8
+        specifier: 13.5.7-canary.8
         version: link:../next-swc
       '@opentelemetry/api':
         specifier: 1.4.1
@@ -1586,7 +1586,7 @@ importers:
         version: 1.0.20
     devDependencies:
       next:
-        specifier: 13.5.6-canary.8
+        specifier: 13.5.7-canary.8
         version: link:../next
       outdent:
         specifier: 0.8.0


### PR DESCRIPTION
We released 13.5.6 as stable patch, need to bump the canary version higher than stable to match the semantics