### PR TITLE
codemod: migrate ImageResponse imports

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-og-import/mixed-import.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-og-import/mixed-import.input.tsx
@@ -1,0 +1,6 @@
+import { ImageResponse, NextResponse } from "next/server";
+
+export {
+  ImageResponse,
+  NextResponse
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-og-import/mixed-import.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-og-import/mixed-import.output.tsx
@@ -1,0 +1,7 @@
+import { ImageResponse } from "next/og";
+import { NextResponse } from "next/server";
+
+export {
+  ImageResponse,
+  NextResponse
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-og-import/next-server-only-import.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-og-import/next-server-only-import.input.tsx
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export {
+  NextResponse
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-og-import/next-server-only-import.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-og-import/next-server-only-import.output.tsx
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export {
+  NextResponse
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-og-import/og-only-import.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-og-import/og-only-import.input.tsx
@@ -1,0 +1,5 @@
+import { ImageResponse } from "next/server";
+
+export {
+  ImageResponse
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-og-import/og-only-import.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-og-import/og-only-import.output.tsx
@@ -1,0 +1,5 @@
+import { ImageResponse } from "next/og";
+
+export {
+  ImageResponse
+}

--- a/packages/next-codemod/transforms/__tests__/next-og-import.test.js
+++ b/packages/next-codemod/transforms/__tests__/next-og-import.test.js
@@ -1,0 +1,16 @@
+/* global jest */
+jest.autoMockOff()
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+const { readdirSync } = require('fs')
+const { join } = require('path')
+
+const fixtureDir = 'next-og-import'
+const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir)
+const fixtures = readdirSync(fixtureDirPath)
+  .filter(file => file.endsWith('.input.tsx'))
+  .map(file => file.replace('.input.tsx', ''))
+
+for (const fixture of fixtures) {
+  const prefix = `${fixtureDir}/${fixture}`;
+  defineTest(__dirname, fixtureDir,  null, prefix, { parser: 'tsx' });
+}

--- a/packages/next-codemod/transforms/next-og-import.ts
+++ b/packages/next-codemod/transforms/next-og-import.ts
@@ -1,0 +1,51 @@
+import type { API, FileInfo } from 'jscodeshift'
+
+const importToChange = 'ImageResponse'
+
+export default function transformer(file: FileInfo, api: API) {
+  const j = api.jscodeshift
+
+  // Find import declarations that match the pattern
+  file.source = j(file.source)
+    .find(j.ImportDeclaration, {
+      source: {
+        value: 'next/server',
+      },
+    })
+    .forEach((path) => {
+      const importSpecifiers = path.node.specifiers
+      const importNamesToChange = importSpecifiers.filter(
+        (specifier) => specifier.local.name === importToChange
+      )
+      const importsNamesRemained = importSpecifiers.filter(
+        (specifier) => specifier.local.name !== importToChange
+      )
+
+      // If the import includes the specified import name, create a new import for it from 'next/og'
+
+      if (importNamesToChange.length > 0) {
+        // Replace the original import with the remaining specifiers
+        // path.node.specifiers = remainingSpecifiers
+        const newImportStatement = j.importDeclaration(
+          importNamesToChange,
+          j.stringLiteral('next/og')
+        )
+        path.insertBefore(newImportStatement)
+      }
+      if (importsNamesRemained.length > 0) {
+        const remainingSpecifiers = importSpecifiers.filter(
+          (specifier) => specifier.local.name !== importToChange
+        )
+
+        const nextServerRemainImportsStatement = j.importDeclaration(
+          remainingSpecifiers,
+          j.stringLiteral('next/server')
+        )
+        path.insertBefore(nextServerRemainImportsStatement)
+      }
+      j(path).remove()
+    })
+    .toSource()
+
+  return file.source
+}


### PR DESCRIPTION
Adding codemod for #56662 for easier migration of `ImageResponse` from `"next/server"` to `"next/og"`