### PR TITLE
chore: bump `@edge-runtime/cookies`

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -137,7 +137,7 @@
     "@babel/traverse": "7.22.5",
     "@babel/types": "7.22.5",
     "@capsizecss/metrics": "1.1.0",
-    "@edge-runtime/cookies": "4.0.1",
+    "@edge-runtime/cookies": "4.0.2",
     "@edge-runtime/ponyfill": "2.4.1",
     "@edge-runtime/primitives": "4.0.2",
     "@hapi/accept": "5.0.2",

--- a/packages/next/src/compiled/@edge-runtime/cookies/index.js
+++ b/packages/next/src/compiled/@edge-runtime/cookies/index.js
@@ -28,6 +28,87 @@ __export(src_exports, {
 });
 module.exports = __toCommonJS(src_exports);
 
+
+/**
+ * @source https://github.com/nfriedly/set-cookie-parser/blob/master/lib/set-cookie.js
+ *
+ * Set-Cookie header field-values are sometimes comma joined in one string. This splits them without choking on commas
+ * that are within a single set-cookie field-value, such as in the Expires portion.
+ * This is uncommon, but explicitly allowed - see https://tools.ietf.org/html/rfc2616#section-4.2
+ * Node.js does this for every header *except* set-cookie - see https://github.com/nodejs/node/blob/d5e363b77ebaf1caf67cd7528224b651c86815c1/lib/_http_incoming.js#L128
+ * React Native's fetch does this for *every* header, including set-cookie.
+ *
+ * Based on: https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
+ * Credits to: https://github.com/tomball for original and https://github.com/chrusart for JavaScript implementation
+ */
+function splitCookiesString(cookiesString) {
+  if (!cookiesString) return []
+  var cookiesStrings = []
+  var pos = 0
+  var start
+  var ch
+  var lastComma
+  var nextStart
+  var cookiesSeparatorFound
+
+  function skipWhitespace() {
+    while (pos < cookiesString.length && /\s/.test(cookiesString.charAt(pos))) {
+      pos += 1
+    }
+    return pos < cookiesString.length
+  }
+
+  function notSpecialChar() {
+    ch = cookiesString.charAt(pos)
+
+    return ch !== '=' && ch !== ';' && ch !== ','
+  }
+
+  while (pos < cookiesString.length) {
+    start = pos
+    cookiesSeparatorFound = false
+
+    while (skipWhitespace()) {
+      ch = cookiesString.charAt(pos)
+      if (ch === ',') {
+        // ',' is a cookie separator if we have later first '=', not ';' or ','
+        lastComma = pos
+        pos += 1
+
+        skipWhitespace()
+        nextStart = pos
+
+        while (pos < cookiesString.length && notSpecialChar()) {
+          pos += 1
+        }
+
+        // currently special character
+        if (pos < cookiesString.length && cookiesString.charAt(pos) === '=') {
+          // we found cookies separator
+          cookiesSeparatorFound = true
+          // pos is inside the next cookie, so back up and return it.
+          pos = nextStart
+          cookiesStrings.push(cookiesString.substring(start, lastComma))
+          start = pos
+        } else {
+          // in param ',' or param separator ';',
+          // we continue from that comma
+          pos = lastComma + 1
+        }
+      } else {
+        pos += 1
+      }
+    }
+
+    if (!cookiesSeparatorFound || pos >= cookiesString.length) {
+      cookiesStrings.push(cookiesString.substring(start, cookiesString.length))
+    }
+  }
+
+  return cookiesStrings
+}
+
+
 // src/serialize.ts
 function stringifyCookie(c) {
   var _a;
@@ -197,7 +278,14 @@ var ResponseCookies = class {
     /** @internal */
     this._parsed = /* @__PURE__ */ new Map();
     this._headers = responseHeaders;
-    const cookieStrings = responseHeaders.getSetCookie();
+    const setCookie = responseHeaders.getSetCookie?.()
+    responseHeaders.get('set-cookie') ?? []
+
+    const cookieStrings = Array.isArray(setCookie)
+      ? setCookie
+      : // TODO: remove splitCookiesString when `getSetCookie` adoption is high enough in Node.js
+        // https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie#browser_compatibility
+        splitCookiesString(setCookie)
     for (const cookieString of cookieStrings) {
       const parsed = parseSetCookie(cookieString);
       if (parsed)

--- a/packages/next/src/compiled/@edge-runtime/cookies/index.js
+++ b/packages/next/src/compiled/@edge-runtime/cookies/index.js
@@ -28,87 +28,6 @@ __export(src_exports, {
 });
 module.exports = __toCommonJS(src_exports);
 
-
-/**
- * @source https://github.com/nfriedly/set-cookie-parser/blob/master/lib/set-cookie.js
- *
- * Set-Cookie header field-values are sometimes comma joined in one string. This splits them without choking on commas
- * that are within a single set-cookie field-value, such as in the Expires portion.
- * This is uncommon, but explicitly allowed - see https://tools.ietf.org/html/rfc2616#section-4.2
- * Node.js does this for every header *except* set-cookie - see https://github.com/nodejs/node/blob/d5e363b77ebaf1caf67cd7528224b651c86815c1/lib/_http_incoming.js#L128
- * React Native's fetch does this for *every* header, including set-cookie.
- *
- * Based on: https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
- * Credits to: https://github.com/tomball for original and https://github.com/chrusart for JavaScript implementation
- */
-function splitCookiesString(cookiesString) {
-  if (!cookiesString) return []
-  var cookiesStrings = []
-  var pos = 0
-  var start
-  var ch
-  var lastComma
-  var nextStart
-  var cookiesSeparatorFound
-
-  function skipWhitespace() {
-    while (pos < cookiesString.length && /\s/.test(cookiesString.charAt(pos))) {
-      pos += 1
-    }
-    return pos < cookiesString.length
-  }
-
-  function notSpecialChar() {
-    ch = cookiesString.charAt(pos)
-
-    return ch !== '=' && ch !== ';' && ch !== ','
-  }
-
-  while (pos < cookiesString.length) {
-    start = pos
-    cookiesSeparatorFound = false
-
-    while (skipWhitespace()) {
-      ch = cookiesString.charAt(pos)
-      if (ch === ',') {
-        // ',' is a cookie separator if we have later first '=', not ';' or ','
-        lastComma = pos
-        pos += 1
-
-        skipWhitespace()
-        nextStart = pos
-
-        while (pos < cookiesString.length && notSpecialChar()) {
-          pos += 1
-        }
-
-        // currently special character
-        if (pos < cookiesString.length && cookiesString.charAt(pos) === '=') {
-          // we found cookies separator
-          cookiesSeparatorFound = true
-          // pos is inside the next cookie, so back up and return it.
-          pos = nextStart
-          cookiesStrings.push(cookiesString.substring(start, lastComma))
-          start = pos
-        } else {
-          // in param ',' or param separator ';',
-          // we continue from that comma
-          pos = lastComma + 1
-        }
-      } else {
-        pos += 1
-      }
-    }
-
-    if (!cookiesSeparatorFound || pos >= cookiesString.length) {
-      cookiesStrings.push(cookiesString.substring(start, cookiesString.length))
-    }
-  }
-
-  return cookiesStrings
-}
-
-
 // src/serialize.ts
 function stringifyCookie(c) {
   var _a;
@@ -191,6 +110,57 @@ var PRIORITY = ["low", "medium", "high"];
 function parsePriority(string) {
   string = string.toLowerCase();
   return PRIORITY.includes(string) ? string : void 0;
+}
+function splitCookiesString(cookiesString) {
+  if (!cookiesString)
+    return [];
+  var cookiesStrings = [];
+  var pos = 0;
+  var start;
+  var ch;
+  var lastComma;
+  var nextStart;
+  var cookiesSeparatorFound;
+  function skipWhitespace() {
+    while (pos < cookiesString.length && /\s/.test(cookiesString.charAt(pos))) {
+      pos += 1;
+    }
+    return pos < cookiesString.length;
+  }
+  function notSpecialChar() {
+    ch = cookiesString.charAt(pos);
+    return ch !== "=" && ch !== ";" && ch !== ",";
+  }
+  while (pos < cookiesString.length) {
+    start = pos;
+    cookiesSeparatorFound = false;
+    while (skipWhitespace()) {
+      ch = cookiesString.charAt(pos);
+      if (ch === ",") {
+        lastComma = pos;
+        pos += 1;
+        skipWhitespace();
+        nextStart = pos;
+        while (pos < cookiesString.length && notSpecialChar()) {
+          pos += 1;
+        }
+        if (pos < cookiesString.length && cookiesString.charAt(pos) === "=") {
+          cookiesSeparatorFound = true;
+          pos = nextStart;
+          cookiesStrings.push(cookiesString.substring(start, lastComma));
+          start = pos;
+        } else {
+          pos = lastComma + 1;
+        }
+      } else {
+        pos += 1;
+      }
+    }
+    if (!cookiesSeparatorFound || pos >= cookiesString.length) {
+      cookiesStrings.push(cookiesString.substring(start, cookiesString.length));
+    }
+  }
+  return cookiesStrings;
 }
 
 // src/request-cookies.ts
@@ -277,15 +247,10 @@ var ResponseCookies = class {
   constructor(responseHeaders) {
     /** @internal */
     this._parsed = /* @__PURE__ */ new Map();
+    var _a, _b, _c;
     this._headers = responseHeaders;
-    const setCookie = responseHeaders.getSetCookie?.()
-    responseHeaders.get('set-cookie') ?? []
-
-    const cookieStrings = Array.isArray(setCookie)
-      ? setCookie
-      : // TODO: remove splitCookiesString when `getSetCookie` adoption is high enough in Node.js
-        // https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie#browser_compatibility
-        splitCookiesString(setCookie)
+    const setCookie = (_c = (_b = (_a = responseHeaders.getSetCookie) == null ? void 0 : _a.call(responseHeaders)) != null ? _b : responseHeaders.get("set-cookie")) != null ? _c : [];
+    const cookieStrings = Array.isArray(setCookie) ? setCookie : splitCookiesString(setCookie);
     for (const cookieString of cookieStrings) {
       const parsed = parseSetCookie(cookieString);
       if (parsed)

--- a/packages/next/src/compiled/@edge-runtime/cookies/package.json
+++ b/packages/next/src/compiled/@edge-runtime/cookies/package.json
@@ -1,1 +1,1 @@
-{"name":"@edge-runtime/cookies","version":"4.0.1","main":"./index.js","license":"MPL-2.0"}
+{"name":"@edge-runtime/cookies","version":"4.0.2","main":"./index.js","license":"MPL-2.0"}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,8 +896,8 @@ importers:
         specifier: 1.1.0
         version: 1.1.0
       '@edge-runtime/cookies':
-        specifier: 4.0.1
-        version: 4.0.1
+        specifier: 4.0.2
+        version: 4.0.2
       '@edge-runtime/ponyfill':
         specifier: 2.4.1
         version: 2.4.1
@@ -3448,8 +3448,8 @@ packages:
     resolution: {integrity: sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew==}
     dev: true
 
-  /@edge-runtime/cookies@4.0.1:
-    resolution: {integrity: sha512-QIZ1lz6rAF8rTrFdGkljedUaZpXbGIWmRdbA+kwm15ddFfryyekYwI3luFKB33KDcXRHrBi6WdMuyQN19CS6pg==}
+  /@edge-runtime/cookies@4.0.2:
+    resolution: {integrity: sha512-BphVamVz/yt9FN1b60ZXp+iTJVRLUHI0POxKYZG3gn+RsP+M0phqS87Z9JnDn2YOsPx9SRhhrN9AB7yhpexNEw==}
     engines: {node: '>=16'}
     dev: true
 


### PR DESCRIPTION
### What?

Same as #57021, but opened against the `canary` branch.

### Why?

Addressing https://github.com/vercel/next.js/pull/57080#discussion_r1366189356

### How?

updated the `@edge-runtime/cookies` package and ran pre-compilation
