### PR TITLE
OpenTelemetry: propagate a configured context(s) to root requests

### DIFF
--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -174,6 +174,9 @@ class NextTracerImpl implements NextTracer {
   }
 
   public withPropagatedContext<T>(req: BaseNextRequest, fn: () => T): T {
+    if (context.active() !== ROOT_CONTEXT) {
+      return fn()
+    }
     const remoteContext = propagation.extract(ROOT_CONTEXT, req.headers)
     return context.with(remoteContext, fn)
   }

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -236,7 +236,9 @@ class NextTracerImpl implements NextTracer {
     let isRootSpan = false
 
     if (!spanContext) {
-      spanContext = api.ROOT_CONTEXT
+      spanContext = ROOT_CONTEXT
+      isRootSpan = true
+    } else if (trace.getSpanContext(spanContext)?.isRemote) {
       isRootSpan = true
     }
 
@@ -248,7 +250,7 @@ class NextTracerImpl implements NextTracer {
       ...options.attributes,
     }
 
-    return api.context.with(spanContext.setValue(rootSpanIdKey, spanId), () =>
+    return context.with(spanContext.setValue(rootSpanIdKey, spanId), () =>
       this.getTracerInstance().startActiveSpan(
         spanName,
         options,

--- a/test/e2e/opentelemetry/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/opentelemetry.test.ts
@@ -3,6 +3,11 @@ import { check } from 'next-test-utils'
 
 import { SavedSpan, traceFile } from './constants'
 
+const EXTERNAL = {
+  traceId: 'ee75cd9e534ff5e9ed78b4a0c706f0f2',
+  spanId: '0f6a325411bdc432',
+} as const
+
 createNextDescribe(
   'opentelemetry',
   {
@@ -33,8 +38,12 @@ createNextDescribe(
       delete span.links
       delete span.events
       delete span.timestamp
-      delete span.traceId
-      span.parentId = span.parentId === undefined ? undefined : '[parent-id]'
+      span.traceId =
+        span.traceId === EXTERNAL.traceId ? span.traceId : '[trace-id]'
+      span.parentId =
+        span.parentId === undefined || span.parentId === EXTERNAL.spanId
+          ? span.parentId
+          : '[parent-id]'
       return span
     }
     const sanitizeSpans = (spans: SavedSpan[]) => {
@@ -71,286 +80,376 @@ createNextDescribe(
       await cleanTraces()
     })
 
-    // turbopack does not support experimental.instrumentationHook
-    ;(process.env.TURBOPACK ? describe.skip : describe)('app router', () => {
-      it('should handle RSC with fetch', async () => {
-        await next.fetch('/app/param/rsc-fetch')
+    for (const env of [
+      {
+        name: 'root context',
+        fetchInit: undefined,
+        span: {
+          traceId: '[trace-id]',
+          rootParentId: undefined,
+        },
+      },
+      {
+        name: 'incoming context propagation',
+        fetchInit: {
+          headers: {
+            traceparent: `00-${EXTERNAL.traceId}-${EXTERNAL.spanId}-01`,
+          },
+        },
+        span: {
+          traceId: EXTERNAL.traceId,
+          rootParentId: EXTERNAL.spanId,
+        },
+      },
+    ]) {
+      // turbopack does not support experimental.instrumentationHook
+      ;(process.env.TURBOPACK ? describe.skip : describe)(env.name, () => {
+        describe('app router', () => {
+          it('should handle RSC with fetch', async () => {
+            await next.fetch('/app/param/rsc-fetch', env.fetchInit)
 
-        await check(async () => {
-          expect(await getSanitizedTraces(1)).toMatchInlineSnapshot(`
-            [
-              {
-                "attributes": {
-                  "http.method": "GET",
-                  "http.url": "https://vercel.com/",
-                  "net.peer.name": "vercel.com",
-                  "next.span_name": "fetch GET https://vercel.com/",
-                  "next.span_type": "AppRender.fetch",
-                },
-                "kind": 2,
-                "name": "fetch GET https://vercel.com/",
-                "parentId": "[parent-id]",
-                "status": {
-                  "code": 0,
-                },
-              },
-              {
-                "attributes": {
-                  "next.route": "/app/[param]/rsc-fetch",
-                  "next.span_name": "render route (app) /app/[param]/rsc-fetch",
-                  "next.span_type": "AppRender.getBodyResult",
-                },
-                "kind": 0,
-                "name": "render route (app) /app/[param]/rsc-fetch",
-                "parentId": "[parent-id]",
-                "status": {
-                  "code": 0,
-                },
-              },
-              {
-                "attributes": {
-                  "http.method": "GET",
-                  "http.route": "/app/[param]/rsc-fetch",
-                  "http.status_code": 200,
-                  "http.target": "/app/param/rsc-fetch",
-                  "next.route": "/app/[param]/rsc-fetch",
-                  "next.span_name": "GET /app/[param]/rsc-fetch",
-                  "next.span_type": "BaseServer.handleRequest",
-                },
-                "kind": 1,
-                "name": "GET /app/[param]/rsc-fetch",
-                "parentId": undefined,
-                "status": {
-                  "code": 0,
-                },
-              },
-              {
-                "attributes": {
-                  "next.page": "/app/[param]/layout",
-                  "next.span_name": "generateMetadata /app/[param]/layout",
-                  "next.span_type": "ResolveMetadata.generateMetadata",
-                },
-                "kind": 0,
-                "name": "generateMetadata /app/[param]/layout",
-                "parentId": "[parent-id]",
-                "status": {
-                  "code": 0,
-                },
-              },
-              {
-                "attributes": {
-                  "next.page": "/app/[param]/rsc-fetch/page",
-                  "next.span_name": "generateMetadata /app/[param]/rsc-fetch/page",
-                  "next.span_type": "ResolveMetadata.generateMetadata",
-                },
-                "kind": 0,
-                "name": "generateMetadata /app/[param]/rsc-fetch/page",
-                "parentId": "[parent-id]",
-                "status": {
-                  "code": 0,
-                },
-              },
-            ]
-          `)
-          return 'success'
-        }, 'success')
+            await check(async () => {
+              const numberOfRootTraces =
+                env.span.rootParentId === undefined ? 1 : 0
+              const traces = await getSanitizedTraces(numberOfRootTraces)
+              if (traces.length < 5) {
+                return `not enough traces, expected 5, but got ${traces.length}`
+              }
+              expect(traces).toMatchInlineSnapshot(`
+                [
+                  {
+                    "attributes": {
+                      "http.method": "GET",
+                      "http.url": "https://vercel.com/",
+                      "net.peer.name": "vercel.com",
+                      "next.span_name": "fetch GET https://vercel.com/",
+                      "next.span_type": "AppRender.fetch",
+                    },
+                    "kind": 2,
+                    "name": "fetch GET https://vercel.com/",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.route": "/app/[param]/rsc-fetch",
+                      "next.span_name": "render route (app) /app/[param]/rsc-fetch",
+                      "next.span_type": "AppRender.getBodyResult",
+                    },
+                    "kind": 0,
+                    "name": "render route (app) /app/[param]/rsc-fetch",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "http.method": "GET",
+                      "http.route": "/app/[param]/rsc-fetch",
+                      "http.status_code": 200,
+                      "http.target": "/app/param/rsc-fetch",
+                      "next.route": "/app/[param]/rsc-fetch",
+                      "next.span_name": "GET /app/[param]/rsc-fetch",
+                      "next.span_type": "BaseServer.handleRequest",
+                    },
+                    "kind": 1,
+                    "name": "GET /app/[param]/rsc-fetch",
+                    "parentId": ${
+                      env.span.rootParentId
+                        ? `"${env.span.rootParentId}"`
+                        : undefined
+                    },
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.page": "/app/[param]/layout",
+                      "next.span_name": "generateMetadata /app/[param]/layout",
+                      "next.span_type": "ResolveMetadata.generateMetadata",
+                    },
+                    "kind": 0,
+                    "name": "generateMetadata /app/[param]/layout",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.page": "/app/[param]/rsc-fetch/page",
+                      "next.span_name": "generateMetadata /app/[param]/rsc-fetch/page",
+                      "next.span_type": "ResolveMetadata.generateMetadata",
+                    },
+                    "kind": 0,
+                    "name": "generateMetadata /app/[param]/rsc-fetch/page",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                ]
+              `)
+              return 'success'
+            }, 'success')
+          })
+
+          it('should handle route handlers in app router', async () => {
+            await next.fetch('/api/app/param/data', env.fetchInit)
+
+            await check(async () => {
+              const numberOfRootTraces =
+                env.span.rootParentId === undefined ? 1 : 0
+              const traces = await getSanitizedTraces(numberOfRootTraces)
+              if (traces.length < 2) {
+                return `not enough traces, expected 2, but got ${traces.length}`
+              }
+              expect(traces).toMatchInlineSnapshot(`
+                [
+                  {
+                    "attributes": {
+                      "next.route": "/api/app/[param]/data/route",
+                      "next.span_name": "executing api route (app) /api/app/[param]/data/route",
+                      "next.span_type": "AppRouteRouteHandlers.runHandler",
+                    },
+                    "kind": 0,
+                    "name": "executing api route (app) /api/app/[param]/data/route",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "http.method": "GET",
+                      "http.route": "/api/app/[param]/data/route",
+                      "http.status_code": 200,
+                      "http.target": "/api/app/param/data",
+                      "next.route": "/api/app/[param]/data/route",
+                      "next.span_name": "GET /api/app/[param]/data/route",
+                      "next.span_type": "BaseServer.handleRequest",
+                    },
+                    "kind": 1,
+                    "name": "GET /api/app/[param]/data/route",
+                    "parentId": ${
+                      env.span.rootParentId
+                        ? `"${env.span.rootParentId}"`
+                        : undefined
+                    },
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                ]
+              `)
+              return 'success'
+            }, 'success')
+          })
+        })
+
+        describe('pages', () => {
+          it('should handle getServerSideProps', async () => {
+            await next.fetch('/pages/param/getServerSideProps', env.fetchInit)
+
+            await check(async () => {
+              const numberOfRootTraces =
+                env.span.rootParentId === undefined ? 1 : 0
+              const traces = await getSanitizedTraces(numberOfRootTraces)
+              if (traces.length < 3) {
+                return `not enough traces, expected 3, but got ${traces.length}`
+              }
+              expect(traces).toMatchInlineSnapshot(`
+                [
+                  {
+                    "attributes": {
+                      "http.method": "GET",
+                      "http.route": "/pages/[param]/getServerSideProps",
+                      "http.status_code": 200,
+                      "http.target": "/pages/param/getServerSideProps",
+                      "next.route": "/pages/[param]/getServerSideProps",
+                      "next.span_name": "GET /pages/[param]/getServerSideProps",
+                      "next.span_type": "BaseServer.handleRequest",
+                    },
+                    "kind": 1,
+                    "name": "GET /pages/[param]/getServerSideProps",
+                    "parentId": ${
+                      env.span.rootParentId
+                        ? `"${env.span.rootParentId}"`
+                        : undefined
+                    },
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.route": "/pages/[param]/getServerSideProps",
+                      "next.span_name": "getServerSideProps /pages/[param]/getServerSideProps",
+                      "next.span_type": "Render.getServerSideProps",
+                    },
+                    "kind": 0,
+                    "name": "getServerSideProps /pages/[param]/getServerSideProps",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.route": "/pages/[param]/getServerSideProps",
+                      "next.span_name": "render route (pages) /pages/[param]/getServerSideProps",
+                      "next.span_type": "Render.renderDocument",
+                    },
+                    "kind": 0,
+                    "name": "render route (pages) /pages/[param]/getServerSideProps",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                ]
+              `)
+              return 'success'
+            }, 'success')
+          })
+
+          it("should handle getStaticProps when fallback: 'blocking'", async () => {
+            const v = env.span.rootParentId ? '2' : ''
+            await next.fetch(`/pages/param/getStaticProps${v}`, env.fetchInit)
+
+            await check(async () => {
+              const numberOfRootTraces =
+                env.span.rootParentId === undefined ? 1 : 0
+              const traces = await getSanitizedTraces(numberOfRootTraces)
+              if (traces.length < 3) {
+                return `not enough traces, expected 3, but got ${traces.length}`
+              }
+              expect(traces).toMatchInlineSnapshot(`
+                [
+                  {
+                    "attributes": {
+                      "http.method": "GET",
+                      "http.route": "/pages/[param]/getStaticProps${v}",
+                      "http.status_code": 200,
+                      "http.target": "/pages/param/getStaticProps${v}",
+                      "next.route": "/pages/[param]/getStaticProps${v}",
+                      "next.span_name": "GET /pages/[param]/getStaticProps${v}",
+                      "next.span_type": "BaseServer.handleRequest",
+                    },
+                    "kind": 1,
+                    "name": "GET /pages/[param]/getStaticProps${v}",
+                    "parentId": ${
+                      env.span.rootParentId
+                        ? `"${env.span.rootParentId}"`
+                        : undefined
+                    },
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.route": "/pages/[param]/getStaticProps${v}",
+                      "next.span_name": "getStaticProps /pages/[param]/getStaticProps${v}",
+                      "next.span_type": "Render.getStaticProps",
+                    },
+                    "kind": 0,
+                    "name": "getStaticProps /pages/[param]/getStaticProps${v}",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.route": "/pages/[param]/getStaticProps${v}",
+                      "next.span_name": "render route (pages) /pages/[param]/getStaticProps${v}",
+                      "next.span_type": "Render.renderDocument",
+                    },
+                    "kind": 0,
+                    "name": "render route (pages) /pages/[param]/getStaticProps${v}",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                ]
+              `)
+              return 'success'
+            }, 'success')
+          })
+
+          it('should handle api routes in pages', async () => {
+            await next.fetch('/api/pages/param/basic', env.fetchInit)
+
+            await check(async () => {
+              const numberOfRootTraces =
+                env.span.rootParentId === undefined ? 1 : 0
+              const traces = await getSanitizedTraces(numberOfRootTraces)
+              if (traces.length < 2) {
+                return `not enough traces, expected 2, but got ${traces.length}`
+              }
+              expect(traces).toMatchInlineSnapshot(`
+                [
+                  {
+                    "attributes": {
+                      "http.method": "GET",
+                      "http.route": "/api/pages/[param]/basic",
+                      "http.status_code": 200,
+                      "http.target": "/api/pages/param/basic",
+                      "next.route": "/api/pages/[param]/basic",
+                      "next.span_name": "GET /api/pages/[param]/basic",
+                      "next.span_type": "BaseServer.handleRequest",
+                    },
+                    "kind": 1,
+                    "name": "GET /api/pages/[param]/basic",
+                    "parentId": ${
+                      env.span.rootParentId
+                        ? `"${env.span.rootParentId}"`
+                        : undefined
+                    },
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.span_name": "executing api route (pages) /api/pages/[param]/basic",
+                      "next.span_type": "Node.runHandler",
+                    },
+                    "kind": 0,
+                    "name": "executing api route (pages) /api/pages/[param]/basic",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                ]
+              `)
+              return 'success'
+            }, 'success')
+          })
+        })
       })
-
-      it('should handle route handlers in app router', async () => {
-        await next.fetch('/api/app/param/data')
-
-        await check(async () => {
-          expect(await getSanitizedTraces(1)).toMatchInlineSnapshot(`
-            [
-              {
-                "attributes": {
-                  "next.route": "/api/app/[param]/data/route",
-                  "next.span_name": "executing api route (app) /api/app/[param]/data/route",
-                  "next.span_type": "AppRouteRouteHandlers.runHandler",
-                },
-                "kind": 0,
-                "name": "executing api route (app) /api/app/[param]/data/route",
-                "parentId": "[parent-id]",
-                "status": {
-                  "code": 0,
-                },
-              },
-              {
-                "attributes": {
-                  "http.method": "GET",
-                  "http.route": "/api/app/[param]/data/route",
-                  "http.status_code": 200,
-                  "http.target": "/api/app/param/data",
-                  "next.route": "/api/app/[param]/data/route",
-                  "next.span_name": "GET /api/app/[param]/data/route",
-                  "next.span_type": "BaseServer.handleRequest",
-                },
-                "kind": 1,
-                "name": "GET /api/app/[param]/data/route",
-                "parentId": undefined,
-                "status": {
-                  "code": 0,
-                },
-              },
-            ]
-          `)
-          return 'success'
-        }, 'success')
-      })
-    })
-
-    // turbopack does not support experimental.instrumentationHook
-    ;(process.env.TURBOPACK ? describe.skip : describe)('pages', () => {
-      it('should handle getServerSideProps', async () => {
-        await next.fetch('/pages/param/getServerSideProps')
-
-        await check(async () => {
-          expect(await getSanitizedTraces(1)).toMatchInlineSnapshot(`
-            [
-              {
-                "attributes": {
-                  "http.method": "GET",
-                  "http.route": "/pages/[param]/getServerSideProps",
-                  "http.status_code": 200,
-                  "http.target": "/pages/param/getServerSideProps",
-                  "next.route": "/pages/[param]/getServerSideProps",
-                  "next.span_name": "GET /pages/[param]/getServerSideProps",
-                  "next.span_type": "BaseServer.handleRequest",
-                },
-                "kind": 1,
-                "name": "GET /pages/[param]/getServerSideProps",
-                "parentId": undefined,
-                "status": {
-                  "code": 0,
-                },
-              },
-              {
-                "attributes": {
-                  "next.route": "/pages/[param]/getServerSideProps",
-                  "next.span_name": "getServerSideProps /pages/[param]/getServerSideProps",
-                  "next.span_type": "Render.getServerSideProps",
-                },
-                "kind": 0,
-                "name": "getServerSideProps /pages/[param]/getServerSideProps",
-                "parentId": "[parent-id]",
-                "status": {
-                  "code": 0,
-                },
-              },
-              {
-                "attributes": {
-                  "next.route": "/pages/[param]/getServerSideProps",
-                  "next.span_name": "render route (pages) /pages/[param]/getServerSideProps",
-                  "next.span_type": "Render.renderDocument",
-                },
-                "kind": 0,
-                "name": "render route (pages) /pages/[param]/getServerSideProps",
-                "parentId": "[parent-id]",
-                "status": {
-                  "code": 0,
-                },
-              },
-            ]
-          `)
-          return 'success'
-        }, 'success')
-      })
-
-      it("should handle getStaticProps when fallback: 'blocking'", async () => {
-        await next.fetch('/pages/param/getStaticProps')
-
-        await check(async () => {
-          expect(await getSanitizedTraces(1)).toMatchInlineSnapshot(`
-            [
-              {
-                "attributes": {
-                  "http.method": "GET",
-                  "http.route": "/pages/[param]/getStaticProps",
-                  "http.status_code": 200,
-                  "http.target": "/pages/param/getStaticProps",
-                  "next.route": "/pages/[param]/getStaticProps",
-                  "next.span_name": "GET /pages/[param]/getStaticProps",
-                  "next.span_type": "BaseServer.handleRequest",
-                },
-                "kind": 1,
-                "name": "GET /pages/[param]/getStaticProps",
-                "parentId": undefined,
-                "status": {
-                  "code": 0,
-                },
-              },
-              {
-                "attributes": {
-                  "next.route": "/pages/[param]/getStaticProps",
-                  "next.span_name": "getStaticProps /pages/[param]/getStaticProps",
-                  "next.span_type": "Render.getStaticProps",
-                },
-                "kind": 0,
-                "name": "getStaticProps /pages/[param]/getStaticProps",
-                "parentId": "[parent-id]",
-                "status": {
-                  "code": 0,
-                },
-              },
-              {
-                "attributes": {
-                  "next.route": "/pages/[param]/getStaticProps",
-                  "next.span_name": "render route (pages) /pages/[param]/getStaticProps",
-                  "next.span_type": "Render.renderDocument",
-                },
-                "kind": 0,
-                "name": "render route (pages) /pages/[param]/getStaticProps",
-                "parentId": "[parent-id]",
-                "status": {
-                  "code": 0,
-                },
-              },
-            ]
-          `)
-          return 'success'
-        }, 'success')
-      })
-
-      it('should handle api routes in pages', async () => {
-        await next.fetch('/api/pages/param/basic')
-
-        await check(async () => {
-          expect(await getSanitizedTraces(1)).toMatchInlineSnapshot(`
-            [
-              {
-                "attributes": {
-                  "http.method": "GET",
-                  "http.route": "/api/pages/[param]/basic",
-                  "http.status_code": 200,
-                  "http.target": "/api/pages/param/basic",
-                  "next.route": "/api/pages/[param]/basic",
-                  "next.span_name": "GET /api/pages/[param]/basic",
-                  "next.span_type": "BaseServer.handleRequest",
-                },
-                "kind": 1,
-                "name": "GET /api/pages/[param]/basic",
-                "parentId": undefined,
-                "status": {
-                  "code": 0,
-                },
-              },
-              {
-                "attributes": {
-                  "next.span_name": "executing api route (pages) /api/pages/[param]/basic",
-                  "next.span_type": "Node.runHandler",
-                },
-                "kind": 0,
-                "name": "executing api route (pages) /api/pages/[param]/basic",
-                "parentId": "[parent-id]",
-                "status": {
-                  "code": 0,
-                },
-              },
-            ]
-          `)
-          return 'success'
-        }, 'success')
-      })
-    })
+    }
   }
 )

--- a/test/e2e/opentelemetry/pages/pages/[param]/getStaticProps2.tsx
+++ b/test/e2e/opentelemetry/pages/pages/[param]/getStaticProps2.tsx
@@ -1,0 +1,17 @@
+export default function Page() {
+  return <div>Page</div>
+}
+
+export function getStaticProps() {
+  return {
+    props: {},
+  }
+}
+
+// We don't want to render in build time
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}


### PR DESCRIPTION
Implement OTEL propagation according to the OpenTelemetry API per https://opentelemetry.io/docs/specs/otel/context/api-propagators/. Any configured propagator should work with this API, including `W3CTraceContextPropagator` (https://www.w3.org/TR/trace-context/).

Alternative to the https://github.com/vercel/next.js/pull/56891.

/cc @sfirrin