### PR TITLE
Update runner for e2e deploy tests

### DIFF
--- a/.github/workflows/test_e2e_deploy.yml
+++ b/.github/workflows/test_e2e_deploy.yml
@@ -9,7 +9,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - 'self-hosted'
+      - 'linux'
+      - 'x64'
+      - 'metal'
+
     env:
       VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
       VERCEL_TEST_TEAM: vtest314-next-e2e-tests


### PR DESCRIPTION
This attempts to fix our tests timing out from an obscure lost connection to runner message


![CleanShot 2023-10-19 at 16 29 50@2x](https://github.com/vercel/next.js/assets/22380829/594b21c4-4df9-418b-afbb-5e290020d25d)
