### PR TITLE
feat: introduce `future.fallbackNodePolyfills`

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/future.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/future.mdx
@@ -1,0 +1,12 @@
+---
+title: future
+description: Future flags that can be enabled in your Next.js app to opt-in to new features earlier.
+---
+
+## `fallbackNodePolyfills`
+
+For historical reasons, Next.js falls back to polyfill some popular Node.js modules in the browser. This is for compatibility reasons with libraries that are meant to run on Node.js but are used in browser context. This is can however cause an increases of the client bundle size. By setting `future.fallbackNodePolyfills` to `false`, Next.js will no longer polyfill Node.js modules in the browser and will instead throw an error during development/build.
+
+The full list of polyfills is accessible here: [webpack/webpack#ModuleNotoundError.js#L13-L42](https://github.com/webpack/webpack/blob/2a0536cf510768111a3a6dceeb14cb79b9f59273/lib/ModuleNotFoundError.js#L13-L42)
+
+In new projects, we recommend setting `future.fallbackNodePolyfills` to `false` to avoid the extra bundle size.

--- a/packages/create-next-app/templates/app-tw/js/next.config.js
+++ b/packages/create-next-app/templates/app-tw/js/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  future: {
+    fallbackNodePolyfills: false,
+  },
+}
 
 module.exports = nextConfig

--- a/packages/create-next-app/templates/app-tw/ts/next.config.js
+++ b/packages/create-next-app/templates/app-tw/ts/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  future: {
+    fallbackNodePolyfills: false,
+  },
+}
 
 module.exports = nextConfig

--- a/packages/create-next-app/templates/app/js/next.config.js
+++ b/packages/create-next-app/templates/app/js/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  future: {
+    fallbackNodePolyfills: false,
+  },
+}
 
 module.exports = nextConfig

--- a/packages/create-next-app/templates/app/ts/next.config.js
+++ b/packages/create-next-app/templates/app/ts/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  future: {
+    fallbackNodePolyfills: false,
+  },
+}
 
 module.exports = nextConfig

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1807,7 +1807,7 @@ export default async function getBaseWebpackConfig(
               {
                 resolve: {
                   fallback:
-                    config.experimental.fallbackNodePolyfills === false
+                    config.future.fallbackNodePolyfills === false
                       ? {
                           assert: false,
                           buffer: false,

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -114,7 +114,7 @@ const supportedTurbopackNextConfigOptions = [
   // 'experimental.allowedRevalidateHeaderKeys',
   // 'experimental.bundlePagesExternals',
   // 'experimental.extensionAlias',
-  // 'experimental.fallbackNodePolyfills',
+  // 'future.fallbackNodePolyfills',
 
   // 'experimental.sri.algorithm',
   // 'experimental.swcTraceProfiling',

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -257,7 +257,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         extensionAlias: z.record(z.string(), z.any()).optional(),
         externalDir: z.boolean().optional(),
         externalMiddlewareRewritesResolve: z.boolean().optional(),
-        fallbackNodePolyfills: z.literal(false).optional(),
         fetchCacheKeyPrefix: z.string().optional(),
         forceSwcTransforms: z.boolean().optional(),
         fullySpecified: z.boolean().optional(),
@@ -381,6 +380,11 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         })
       )
       .returns(z.union([zExportMap, z.promise(zExportMap)]))
+      .optional(),
+    future: z
+      .strictObject({
+        fallbackNodePolyfills: z.literal(false).optional(),
+      })
       .optional(),
     generateBuildId: z
       .function()

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -776,7 +776,7 @@ export const defaultConfig: NextConfig = {
     bundlePagesExternals: false,
   },
   future: {
-    fallbackNodePolyfills: false,
+    fallbackNodePolyfills: undefined,
   },
 }
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -665,6 +665,8 @@ export interface NextConfig extends Record<string, any> {
      * If set to `false`, webpack won't fall back to polyfill Node.js modules in the browser
      * Full list of old polyfills is accessible here:
      * [webpack/webpack#ModuleNotoundError.js#L13-L42](https://github.com/webpack/webpack/blob/2a0536cf510768111a3a6dceeb14cb79b9f59273/lib/ModuleNotFoundError.js#L13-L42)
+     *
+     * @see https://nextjs.org/docs/pages/api-reference/next-config-js/future#fallbacknodepolyfills
      */
     fallbackNodePolyfills?: false
   }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -224,12 +224,6 @@ export interface ExperimentalConfig {
 
   swcPlugins?: Array<[string, Record<string, unknown>]>
   largePageDataBytes?: number
-  /**
-   * If set to `false`, webpack won't fall back to polyfill Node.js modules in the browser
-   * Full list of old polyfills is accessible here:
-   * [webpack/webpack#ModuleNotoundError.js#L13-L42](https://github.com/webpack/webpack/blob/2a0536cf510768111a3a6dceeb14cb79b9f59273/lib/ModuleNotFoundError.js#L13-L42)
-   */
-  fallbackNodePolyfills?: false
   sri?: {
     algorithm?: SubresourceIntegrityAlgorithm
   }
@@ -666,6 +660,14 @@ export interface NextConfig extends Record<string, any> {
    * Enable experimental features. Note that all experimental features are subject to breaking changes in the future.
    */
   experimental?: ExperimentalConfig
+  future?: {
+    /**
+     * If set to `false`, webpack won't fall back to polyfill Node.js modules in the browser
+     * Full list of old polyfills is accessible here:
+     * [webpack/webpack#ModuleNotoundError.js#L13-L42](https://github.com/webpack/webpack/blob/2a0536cf510768111a3a6dceeb14cb79b9f59273/lib/ModuleNotFoundError.js#L13-L42)
+     */
+    fallbackNodePolyfills?: false
+  }
 }
 
 export const defaultConfig: NextConfig = {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -773,6 +773,9 @@ export const defaultConfig: NextConfig = {
     instrumentationHook: false,
     bundlePagesExternals: false,
   },
+  future: {
+    fallbackNodePolyfills: false,
+  },
 }
 
 export async function normalizeConfig(phase: string, config: any) {

--- a/test/production/disable-fallback-polyfills/index.test.ts
+++ b/test/production/disable-fallback-polyfills/index.test.ts
@@ -41,7 +41,7 @@ describe('Disable fallback polyfills', () => {
     await next.patchFile(
       'next.config.js',
       `module.exports = {
-        experimental: {
+        future: {
           fallbackNodePolyfills: false
         }
       }`


### PR DESCRIPTION
### What?

When set to `false`, stop polyfilling Node.js modules in the browser.

To not break libraries that rely on this currently, we introduce it as opted-out for now, but add it to the default CNA templates. (Note: The flag can be removed if you rely on misconfigured packages that use these modules in a browser context.)

### Why?

More iterative version of https://github.com/vercel/next.js/pull/57080#issuecomment-1771823931

### How?

move `experimental.fallbackNodePolyfills` to `future.fallbackNodePolyfills` and document it.
