### PR TITLE
Update flakey build trace case

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -406,11 +406,10 @@ export async function collectBuildTraces({
               return await fs.readFile(p, 'utf8')
             } catch (e) {
               if (isError(e) && (e.code === 'ENOENT' || e.code === 'EISDIR')) {
-                // handle temporary internal webpack files
-                if (p.match(/static[/\\]media/)) {
-                  return ''
-                }
-                return null
+                // since tracing runs in parallel with static generation server
+                // files might be removed from that step so tolerate ENOENT
+                // errors gracefully
+                return ''
               }
               throw e
             }


### PR DESCRIPTION
This updates to tolerate ENOENT during build tracing as this can expectedly occur since we run static optimization in parallel to the tracing which static generation can remove server files and replace them with their HTML files. 

x-ref: https://github.com/vercel/next.js/actions/runs/6581290033/job/17880939489?pr=57088