### PR TITLE
Optimize client entry module by tracking individual imported names from the client boundary

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-client-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-client-entry-loader.ts
@@ -21,14 +21,15 @@ export default function transformSource(this: any) {
     // Filter out CSS files in the SSR compilation
     .filter(([request]) => (isServer ? !regexCSS.test(request) : true))
     .map(([request, imports]) => {
-      if (imports[0] === '*') {
+      const uniqueImports = new Set(imports)
+
+      if (uniqueImports.has('*')) {
         return `import(/* webpackMode: "eager" */ ${JSON.stringify(request)})`
       }
 
-      const uniqueImports = [...new Set(imports)]
-      return `import(/* webpackMode: "eager" *//* webpackExports: [${uniqueImports
-        .map((i) => JSON.stringify(i))
-        .join(', ')}] */ ${JSON.stringify(request)})`
+      return `import(/* webpackMode: "eager", webpackExports: ${JSON.stringify([
+        ...uniqueImports,
+      ])} */ ${JSON.stringify(request)})`
     })
     .join(';\n')
 

--- a/packages/next/src/build/webpack/loaders/next-flight-client-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-client-entry-loader.ts
@@ -25,7 +25,8 @@ export default function transformSource(this: any) {
         return `import(/* webpackMode: "eager" */ ${JSON.stringify(request)})`
       }
 
-      return `import(/* webpackMode: "eager" *//* webpackExports: [${imports
+      const uniqueImports = [...new Set(imports)]
+      return `import(/* webpackMode: "eager" *//* webpackExports: [${uniqueImports
         .map((i) => JSON.stringify(i))
         .join(', ')}] */ ${JSON.stringify(request)})`
     })

--- a/packages/next/src/build/webpack/loaders/next-flight-client-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-client-entry-loader.ts
@@ -23,7 +23,7 @@ export default function transformSource(this: any) {
     .map(([request, imports]) => {
       const uniqueImports = new Set(imports)
 
-      if (uniqueImports.has('*')) {
+      if (uniqueImports.has('*') || uniqueImports.size === 0) {
         return `import(/* webpackMode: "eager" */ ${JSON.stringify(request)})`
       }
 

--- a/packages/next/src/build/webpack/loaders/next-flight-client-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-client-entry-loader.ts
@@ -2,11 +2,11 @@ import { RSC_MODULE_TYPES } from '../../../shared/lib/constants'
 import { getModuleBuildInfo } from './get-module-build-info'
 import { regexCSS } from './utils'
 
-export type ClientComponentImports = string[]
+export type ClientComponentImports = Record<string, string[]>
 export type CssImports = Record<string, string[]>
 
 export type NextFlightClientEntryLoaderOptions = {
-  modules: ClientComponentImports
+  modules: string
   /** This is transmitted as a string to `getOptions` */
   server: boolean | 'true' | 'false'
 }
@@ -15,19 +15,20 @@ export default function transformSource(this: any) {
   let { modules, server }: NextFlightClientEntryLoaderOptions =
     this.getOptions()
   const isServer = server === 'true'
+  const clientImports = JSON.parse(modules) as [string, string[]][]
 
-  if (!Array.isArray(modules)) {
-    modules = modules ? [modules] : []
-  }
-
-  const requests = modules as string[]
-  const code = requests
+  const code = clientImports
     // Filter out CSS files in the SSR compilation
-    .filter((request) => (isServer ? !regexCSS.test(request) : true))
-    .map(
-      (request) =>
-        `import(/* webpackMode: "eager" */ ${JSON.stringify(request)})`
-    )
+    .filter(([request]) => (isServer ? !regexCSS.test(request) : true))
+    .map(([request, imports]) => {
+      if (imports[0] === '*') {
+        return `import(/* webpackMode: "eager" */ ${JSON.stringify(request)})`
+      }
+
+      return `import(/* webpackMode: "eager" *//* webpackExports: [${imports
+        .map((i) => JSON.stringify(i))
+        .join(', ')}] */ ${JSON.stringify(request)})`
+    })
     .join(';\n')
 
   const buildInfo = getModuleBuildInfo(this._module)

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -624,10 +624,10 @@ export class FlightClientEntryPlugin {
       if (isClientComponentEntryModule(mod)) {
         clientComponentImports[modRequest] =
           clientComponentImports[modRequest] || []
-        // Add all imported ids to the client component entry.
-        for (const id of ids) {
-          clientComponentImports[modRequest].push(id)
-        }
+
+        // Add the imported id to the list of ids for the given module.
+        clientComponentImports[modRequest].push(ids[0] || '*')
+
         return
       }
 
@@ -661,7 +661,7 @@ export class FlightClientEntryPlugin {
         .forEach((connection: any) => {
           filterClientComponents(
             connection.resolvedModule,
-            connection.dependency?.ids || []
+            connection.dependency?.ids || ['*']
           )
         })
     }

--- a/test/e2e/app-dir/rsc-client-entry/app/client.js
+++ b/test/e2e/app-dir/rsc-client-entry/app/client.js
@@ -1,0 +1,9 @@
+'use client'
+
+export function Foo() {
+  return <h2>Foo</h2>
+}
+
+export function ThisComponentIsNotUsedAtAll() {
+  return <h2>secret internal do not use otherwise you will be fired</h2>
+}

--- a/test/e2e/app-dir/rsc-client-entry/app/layout.js
+++ b/test/e2e/app-dir/rsc-client-entry/app/layout.js
@@ -1,0 +1,10 @@
+export default function AppLayout({ children }) {
+  return (
+    <html>
+      <head>
+        <title>RSC</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/rsc-client-entry/app/page.js
+++ b/test/e2e/app-dir/rsc-client-entry/app/page.js
@@ -1,0 +1,10 @@
+import { Foo as FooRenamed } from './client'
+
+export default function Page() {
+  return (
+    <>
+      <h1>hi</h1>
+      <FooRenamed />
+    </>
+  )
+}

--- a/test/e2e/app-dir/rsc-client-entry/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-client-entry/rsc-basic.test.ts
@@ -1,0 +1,30 @@
+import { createNextDescribe } from 'e2e-utils'
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+createNextDescribe(
+  'app dir - rsc client entry',
+  {
+    files: __dirname,
+  },
+  ({ next, isNextDev, isTurbopack }) => {
+    if (!isNextDev && !isTurbopack) {
+      it('should not include client modules that are not imported in the client bundle', async () => {
+        const files = await fs.readdir(
+          join(next.testDir, '.next', 'static', 'chunks', 'app')
+        )
+        const pageFile = files.find((file) => file.startsWith('page-'))
+        const pageBundle = await next.readFile(
+          join('.next', 'static', 'chunks', 'app', pageFile)
+        )
+
+        expect(pageBundle).not.toContain(
+          'secret internal do not use otherwise you will be fired'
+        )
+      })
+    } else {
+      // Noop test
+      it('should ', () => {})
+    }
+  }
+)


### PR DESCRIPTION
Previously, we're collecting all client module imports from the server layer and then create the client entry module with these imports (`import(/* webpackMode: "eager" */ importPath)`). Since that's a separate module graph, Webpack will just keep everything in the bundle.

That means if you only import one value from it (`import { Foo } from './client-module'`), the entire `./client-module` will be included in the client bundle.

This PR adds the tracking for actual imported names too, and create the client entry imports with the `/* webpackExports */` comment so Webpack knows which exports are needed and can tree-shake the unused ones. In certain cases this can reduce the size of the client bundle quite a lot.