### PR TITLE
perf: memory usage tweaks

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -6,6 +6,7 @@ import {
   RESTART_EXIT_CODE,
   checkNodeDebugType,
   getDebugPort,
+  getMaxOldSpaceSize,
   getNodeOptionsWithoutInspect,
   getPort,
   printAndExit,
@@ -33,6 +34,7 @@ import {
   getReservedPortExplanation,
   isPortIsReserved,
 } from '../lib/helpers/get-reserved-port'
+import os from 'os'
 
 let dir: string
 let child: undefined | ReturnType<typeof fork>
@@ -232,6 +234,16 @@ const nextDev: CliCommand = async (args) => {
 
       let NODE_OPTIONS = getNodeOptionsWithoutInspect()
       let nodeDebugType = checkNodeDebugType()
+
+      const maxOldSpaceSize = getMaxOldSpaceSize()
+
+      if (!maxOldSpaceSize && !process.env.NEXT_DISABLE_MEM_OVERRIDE) {
+        const totalMem = os.totalmem()
+        const totalMemInMB = Math.floor(totalMem / 1024 / 1024)
+        NODE_OPTIONS = `${NODE_OPTIONS} --max-old-space-size=${Math.floor(
+          totalMemInMB * 0.5
+        )}`
+      }
 
       if (nodeDebugType) {
         NODE_OPTIONS = `${NODE_OPTIONS} --${nodeDebugType}=${

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -20,7 +20,7 @@ import { formatHostname } from './format-hostname'
 import { initialize } from './router-server'
 import { CONFIG_FILES } from '../../shared/lib/constants'
 import { getStartServerInfo, logStartInfo } from './app-info-log'
-
+import v8 from 'v8'
 const debug = setupDebug('next:start-server')
 
 export interface StartServerOptions {
@@ -136,6 +136,18 @@ export async function startServer({
       res.end('Internal Server Error')
       Log.error(`Failed to handle request for ${req.url}`)
       console.error(err)
+    } finally {
+      if (isDev) {
+        if (
+          v8.getHeapStatistics().used_heap_size >
+          0.8 * v8.getHeapStatistics().heap_size_limit
+        ) {
+          Log.warn(
+            `Server is approaching the used memory threshold, restarting...`
+          )
+          process.exit(RESTART_EXIT_CODE)
+        }
+      }
     }
   }
 

--- a/packages/next/src/server/lib/utils.ts
+++ b/packages/next/src/server/lib/utils.ts
@@ -62,3 +62,11 @@ export function checkNodeDebugType() {
 
   return nodeDebugType
 }
+
+export function getMaxOldSpaceSize() {
+  const maxOldSpaceSize = process.env.NODE_OPTIONS?.match(
+    /--max-old-space-size=(\d+)/
+  )?.[1]
+
+  return maxOldSpaceSize ? parseInt(maxOldSpaceSize, 10) : undefined
+}


### PR DESCRIPTION
This PR does two things:
- bring back the logic to restart the dev server when approaching 80% of the heap limits
- add some logic to increase the default Node.js memory usage to 50% of the available RAM

Tested manually

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
