### PR TITLE
Leverage defineEnv for all environment variables in Turbopack

### DIFF
--- a/packages/next-swc/crates/next-api/src/project.rs
+++ b/packages/next-swc/crates/next-api/src/project.rs
@@ -475,7 +475,6 @@ impl Project {
     #[turbo_tasks::function]
     pub(super) async fn client_compile_time_info(&self) -> Result<Vc<CompileTimeInfo>> {
         Ok(get_client_compile_time_info(
-            self.mode,
             self.browserslist_query.clone(),
             self.define_env.client(),
         ))
@@ -485,11 +484,9 @@ impl Project {
     pub(super) async fn server_compile_time_info(self: Vc<Self>) -> Result<Vc<CompileTimeInfo>> {
         let this = self.await?;
         Ok(get_server_compile_time_info(
-            this.mode,
             self.env(),
             self.server_addr(),
             this.define_env.nodejs(),
-            self.next_config(),
         ))
     }
 
@@ -497,7 +494,6 @@ impl Project {
     pub(super) async fn edge_compile_time_info(self: Vc<Self>) -> Result<Vc<CompileTimeInfo>> {
         let this = self.await?;
         Ok(get_edge_compile_time_info(
-            this.mode,
             self.project_path(),
             self.server_addr(),
             this.define_env.nodejs(),

--- a/packages/next-swc/crates/next-api/src/project.rs
+++ b/packages/next-swc/crates/next-api/src/project.rs
@@ -496,7 +496,7 @@ impl Project {
         Ok(get_edge_compile_time_info(
             self.project_path(),
             self.server_addr(),
-            this.define_env.nodejs(),
+            this.define_env.edge(),
         ))
     }
 

--- a/packages/next-swc/crates/next-build/src/next_build.rs
+++ b/packages/next-swc/crates/next-build/src/next_build.rs
@@ -134,16 +134,11 @@ pub(crate) async fn next_build(options: TransientInstance<BuildOptions>) -> Resu
 
     let client_define_env = Vc::cell(options.define_env.client.iter().cloned().collect());
     let client_compile_time_info =
-        get_client_compile_time_info(mode, browserslist_query, client_define_env);
+        get_client_compile_time_info(browserslist_query, client_define_env);
 
     let server_define_env = Vc::cell(options.define_env.nodejs.iter().cloned().collect());
-    let server_compile_time_info = get_server_compile_time_info(
-        mode,
-        env,
-        ServerAddr::empty(),
-        server_define_env,
-        next_config,
-    );
+    let server_compile_time_info =
+        get_server_compile_time_info(env, ServerAddr::empty(), server_define_env);
 
     // TODO(alexkirsz) Pages should build their own routes, outside of a FS.
     let next_router_fs = Vc::upcast::<Box<dyn FileSystem>>(VirtualFileSystem::new());

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -69,7 +69,14 @@ fn defines(define_env: &IndexMap<String, String>) -> CompileTimeDefines {
     for (k, v) in define_env {
         defines
             .entry(k.split('.').map(|s| s.to_string()).collect::<Vec<String>>())
-            .or_insert_with(|| CompileTimeDefineValue::JSON(v.clone()));
+            .or_insert_with(|| {
+                let val = serde_json::from_str(v);
+                match val {
+                    Ok(serde_json::Value::Bool(v)) => CompileTimeDefineValue::Bool(v),
+                    Ok(serde_json::Value::String(v)) => CompileTimeDefineValue::String(v),
+                    _ => CompileTimeDefineValue::JSON(v.clone()),
+                }
+            });
     }
 
     CompileTimeDefines(defines)

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -38,7 +38,14 @@ fn defines(define_env: &IndexMap<String, String>) -> CompileTimeDefines {
     for (k, v) in define_env {
         defines
             .entry(k.split('.').map(|s| s.to_string()).collect::<Vec<String>>())
-            .or_insert_with(|| CompileTimeDefineValue::JSON(v.clone()));
+            .or_insert_with(|| {
+                let val = serde_json::from_str(v);
+                match val {
+                    Ok(serde_json::Value::Bool(v)) => CompileTimeDefineValue::Bool(v),
+                    Ok(serde_json::Value::String(v)) => CompileTimeDefineValue::String(v),
+                    _ => CompileTimeDefineValue::JSON(v.clone()),
+                }
+            });
     }
 
     CompileTimeDefines(defines)

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -339,6 +339,20 @@ pub async fn get_next_server_import_map(
             );
             import_map.insert_exact_alias("react-server-dom-webpack/server.node", mapping);
             import_map.insert_exact_alias("react-server-dom-turbopack/server.node", mapping);
+            import_map.insert_exact_alias(
+                "react-dom",
+                request_to_import_mapping(
+                    project_path,
+                    &format!("next/dist/compiled/react-dom{react_flavor}"),
+                ),
+            );
+            import_map.insert_wildcard_alias(
+                "react-dom/",
+                request_to_import_mapping(
+                    project_path,
+                    &format!("next/dist/compiled/react-dom{react_flavor}/*"),
+                ),
+            );
         }
         ServerContextType::Middleware => {}
     }

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -198,7 +198,14 @@ fn defines(define_env: &IndexMap<String, String>) -> CompileTimeDefines {
     for (k, v) in define_env {
         defines
             .entry(k.split('.').map(|s| s.to_string()).collect::<Vec<String>>())
-            .or_insert_with(|| CompileTimeDefineValue::JSON(v.clone()));
+            .or_insert_with(|| {
+                let val = serde_json::from_str(v);
+                match val {
+                    Ok(serde_json::Value::Bool(v)) => CompileTimeDefineValue::Bool(v),
+                    Ok(serde_json::Value::String(v)) => CompileTimeDefineValue::String(v),
+                    _ => CompileTimeDefineValue::JSON(v.clone()),
+                }
+            });
     }
 
     CompileTimeDefines(defines)

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1043,6 +1043,7 @@ export default async function build(
           root,
           distDir: config.distDir,
           defineEnv: createDefineEnv({
+            isTurbopack: turboNextBuild,
             allowedRevalidateHeaderKeys:
               config.experimental.allowedRevalidateHeaderKeys,
             clientRouterFilters: NextBuildContext.clientRouterFilters,

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -420,6 +420,7 @@ export interface DefineEnv {
 }
 
 export function createDefineEnv({
+  isTurbopack,
   allowedRevalidateHeaderKeys,
   clientRouterFilters,
   config,
@@ -442,6 +443,7 @@ export function createDefineEnv({
   for (const variant of Object.keys(defineEnv) as (keyof typeof defineEnv)[]) {
     defineEnv[variant] = rustifyEnv(
       getDefineEnv({
+        isTurbopack,
         allowedRevalidateHeaderKeys,
         clientRouterFilters,
         config,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1948,6 +1948,7 @@ export default async function getBaseWebpackConfig(
           ...(isClient && { process: [require.resolve('process')] }),
         }),
       getDefineEnvPlugin({
+        isTurbopack: false,
         allowedRevalidateHeaderKeys,
         clientRouterFilters,
         config,

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -15,6 +15,7 @@ function errorIfEnvConflicted(config: NextConfigComplete, key: string) {
 }
 
 export interface DefineEnvPluginOptions {
+  isTurbopack: boolean
   allowedRevalidateHeaderKeys: string[] | undefined
   clientRouterFilters?: {
     staticFilter: ReturnType<
@@ -38,6 +39,7 @@ export interface DefineEnvPluginOptions {
 }
 
 export function getDefineEnv({
+  isTurbopack,
   allowedRevalidateHeaderKeys,
   clientRouterFilters,
   config,
@@ -85,7 +87,8 @@ export function getDefineEnv({
             process.env.NEXT_EDGE_RUNTIME_PROVIDER || 'edge-runtime'
           ),
         }),
-    'process.turbopack': JSON.stringify(false),
+    'process.turbopack': JSON.stringify(isTurbopack),
+    'process.env.TURBOPACK': JSON.stringify(isTurbopack),
     // TODO: enforce `NODE_ENV` on `process.env`, and add a test:
     'process.env.NODE_ENV': JSON.stringify(dev ? 'development' : 'production'),
     'process.env.NEXT_RUNTIME': JSON.stringify(
@@ -212,7 +215,6 @@ export function getDefineEnv({
           'global.GENTLY': JSON.stringify(false),
         }
       : undefined),
-    'process.env.TURBOPACK': JSON.stringify(false),
     ...(isNodeOrEdgeCompilation
       ? {
           'process.env.__NEXT_EXPERIMENTAL_REACT': JSON.stringify(

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -92,7 +92,7 @@ export function getDefineEnv({
     // TODO: enforce `NODE_ENV` on `process.env`, and add a test:
     'process.env.NODE_ENV': JSON.stringify(dev ? 'development' : 'production'),
     'process.env.NEXT_RUNTIME': JSON.stringify(
-      isEdgeServer ? 'edge' : isNodeServer ? 'nodejs' : undefined
+      isEdgeServer ? 'edge' : isNodeServer ? 'nodejs' : ''
     ),
     'process.env.NEXT_MINIMAL': JSON.stringify(''),
     'process.env.__NEXT_ACTIONS_DEPLOYMENT_ID': JSON.stringify(

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -67,6 +67,8 @@ const supportedTurbopackNextConfigOptions = [
   'experimental.deploymentId',
 
   // Experimental options that don't affect compilation
+  'experimental.ppr',
+  'experimental.taint',
   'experimental.proxyTimeout',
   'experimental.caseSensitiveRoutes',
   'experimental.workerThreads',

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -237,6 +237,7 @@ async function startWatcher(opts: SetupOpts) {
       watch: true,
       env: process.env as Record<string, string>,
       defineEnv: createDefineEnv({
+        isTurbopack: true,
         allowedRevalidateHeaderKeys: undefined,
         clientRouterFilters: undefined,
         config: nextConfig,
@@ -1878,6 +1879,7 @@ async function startWatcher(opts: SetupOpts) {
 
           await hotReloader.turbopackProject.update({
             defineEnv: createDefineEnv({
+              isTurbopack: true,
               allowedRevalidateHeaderKeys: undefined,
               clientRouterFilters,
               config: nextConfig,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1945,6 +1945,7 @@ async function startWatcher(opts: SetupOpts) {
                 plugin.definitions.__NEXT_DEFINE_ENV
               ) {
                 const newDefine = getDefineEnv({
+                  isTurbopack: false,
                   allowedRevalidateHeaderKeys: undefined,
                   clientRouterFilters,
                   config: nextConfig,

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -176,6 +176,7 @@ describe('next.rs api', () => {
       watch: true,
       serverAddr: `127.0.0.1:3000`,
       defineEnv: createDefineEnv({
+        isTurbopack: true,
         allowedRevalidateHeaderKeys: undefined,
         clientRouterFilters: undefined,
         config: nextConfig,

--- a/test/integration/amphtml-custom-validator/test/index.test.js
+++ b/test/integration/amphtml-custom-validator/test/index.test.js
@@ -14,38 +14,45 @@ let app
 let appPort
 const appDir = join(__dirname, '../')
 
-describe('AMP Custom Validator', () => {
-  ;(process.env.TURBOPACK ? describe.skip : describe)('production mode', () => {
-    it('should build and start successfully', async () => {
-      const { code } = await nextBuild(appDir)
-      expect(code).toBe(0)
+// Turbopack does not support AMP rendering.
+;(process.env.TURBOPACK ? describe.skip : describe)(
+  'AMP Custom Validator',
+  () => {
+    ;(process.env.TURBOPACK ? describe.skip : describe)(
+      'production mode',
+      () => {
+        it('should build and start successfully', async () => {
+          const { code } = await nextBuild(appDir)
+          expect(code).toBe(0)
 
-      appPort = await findPort()
-      app = await nextStart(appDir, appPort)
+          appPort = await findPort()
+          app = await nextStart(appDir, appPort)
 
-      const html = await renderViaHTTP(appPort, '/')
-      await killApp(app)
+          const html = await renderViaHTTP(appPort, '/')
+          await killApp(app)
 
-      expect(html).toContain('Hello from AMP')
-    })
-  })
+          expect(html).toContain('Hello from AMP')
+        })
+      }
+    )
 
-  describe('development mode', () => {
-    it('should run in dev mode successfully', async () => {
-      let stderr = ''
+    describe('development mode', () => {
+      it('should run in dev mode successfully', async () => {
+        let stderr = ''
 
-      appPort = await findPort()
-      app = await launchApp(appDir, appPort, {
-        onStderr(msg) {
-          stderr += msg || ''
-        },
+        appPort = await findPort()
+        app = await launchApp(appDir, appPort, {
+          onStderr(msg) {
+            stderr += msg || ''
+          },
+        })
+
+        const html = await renderViaHTTP(appPort, '/')
+        await killApp(app)
+
+        expect(stderr).not.toContain('error')
+        expect(html).toContain('Hello from AMP')
       })
-
-      const html = await renderViaHTTP(appPort, '/')
-      await killApp(app)
-
-      expect(stderr).not.toContain('error')
-      expect(html).toContain('Hello from AMP')
     })
-  })
-})
+  }
+)


### PR DESCRIPTION
This ensures all `process.env` replacement comes from define-env in Next.js, instead of also applying it partially on the Rust side.
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
