### PR TITLE
feat(cna): standardize viewport sizing

### DIFF
--- a/packages/create-next-app/templates/app-tw/js/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/js/app/globals.css
@@ -2,6 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
+/**
+ * Ensure the viewport is always filled.
+ */
+html,
+body,
+#__next,
+main {
+  width: 100%;
+  min-height: 100vh;
+}
+
 :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;

--- a/packages/create-next-app/templates/app-tw/js/app/page.js
+++ b/packages/create-next-app/templates/app-tw/js/app/page.js
@@ -2,7 +2,7 @@ import Image from 'next/image'
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+    <main className="flex flex-col items-center justify-between gap-8 p-24">
       <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm lg:flex">
         <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
           Get started by editing&nbsp;

--- a/packages/create-next-app/templates/app-tw/ts/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/ts/app/globals.css
@@ -2,6 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
+/**
+ * Ensure the viewport is always filled.
+ */
+html,
+body,
+#__next,
+main {
+  width: 100%;
+  min-height: 100vh;
+}
+
 :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;

--- a/packages/create-next-app/templates/app-tw/ts/app/page.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/page.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+    <main className="flex flex-col items-center justify-between gap-8 p-24">
       <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm lg:flex">
         <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
           Get started by editing&nbsp;

--- a/packages/create-next-app/templates/app/js/app/globals.css
+++ b/packages/create-next-app/templates/app/js/app/globals.css
@@ -1,3 +1,14 @@
+/**
+ * Ensure the viewport is always filled.
+ */
+html,
+body,
+#__next,
+main {
+  width: 100%;
+  min-height: 100vh;
+}
+
 :root {
   --max-width: 1100px;
   --border-radius: 12px;

--- a/packages/create-next-app/templates/app/ts/app/globals.css
+++ b/packages/create-next-app/templates/app/ts/app/globals.css
@@ -1,3 +1,14 @@
+/**
+ * Ensure the viewport is always filled.
+ */
+html,
+body,
+#__next,
+main {
+  width: 100%;
+  min-height: 100vh;
+}
+
 :root {
   --max-width: 1100px;
   --border-radius: 12px;

--- a/packages/create-next-app/templates/default-tw/js/pages/index.js
+++ b/packages/create-next-app/templates/default-tw/js/pages/index.js
@@ -6,7 +6,7 @@ const inter = Inter({ subsets: ['latin'] })
 export default function Home() {
   return (
     <main
-      className={`flex min-h-screen flex-col items-center justify-between p-24 ${inter.className}`}
+      className={`flex flex-col items-center justify-between gap-8 p-24 ${inter.className}`}
     >
       <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm lg:flex">
         <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">

--- a/packages/create-next-app/templates/default-tw/js/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/js/styles/globals.css
@@ -2,6 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
+/**
+ * Ensure the viewport is always filled.
+ */
+html,
+body,
+#__next,
+main {
+  width: 100%;
+  min-height: 100vh;
+}
+
 :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;

--- a/packages/create-next-app/templates/default-tw/ts/pages/index.tsx
+++ b/packages/create-next-app/templates/default-tw/ts/pages/index.tsx
@@ -6,7 +6,7 @@ const inter = Inter({ subsets: ['latin'] })
 export default function Home() {
   return (
     <main
-      className={`flex min-h-screen flex-col items-center justify-between p-24 ${inter.className}`}
+      className={`flex flex-col items-center justify-between gap-8 p-24 ${inter.className}`}
     >
       <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm lg:flex">
         <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">

--- a/packages/create-next-app/templates/default-tw/ts/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/ts/styles/globals.css
@@ -2,6 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
+/**
+ * Ensure the viewport is always filled.
+ */
+html,
+body,
+#__next,
+main {
+  width: 100%;
+  min-height: 100vh;
+}
+
 :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;

--- a/packages/create-next-app/templates/default/js/styles/globals.css
+++ b/packages/create-next-app/templates/default/js/styles/globals.css
@@ -1,3 +1,14 @@
+/**
+ * Ensure the viewport is always filled.
+ */
+html,
+body,
+#__next,
+main {
+  width: 100%;
+  min-height: 100vh;
+}
+
 :root {
   --max-width: 1100px;
   --border-radius: 12px;

--- a/packages/create-next-app/templates/default/ts/styles/globals.css
+++ b/packages/create-next-app/templates/default/ts/styles/globals.css
@@ -1,3 +1,14 @@
+/**
+ * Ensure the viewport is always filled.
+ */
+html,
+body,
+#__next,
+main {
+  width: 100%;
+  min-height: 100vh;
+}
+
 :root {
   --max-width: 1100px;
   --border-radius: 12px;


### PR DESCRIPTION
Original fix from #28096 was overwritten in #43482.

### Goal

Our goal is to set the starter pages up so that they behave predictably with respect to viewport size. The rule is:

**The page container should be *at least as tall* as the viewport.** 

In CSS:

```css
/** <html> and <body> are always page containers. */
html,
body,
/** #__next wraps rendered pages. */
#__next,
/** Pages should wrap content with <main> in order to fill the viewport. */
main {
  width: 100%;
  min-height: 100vh;
}
```

See:
  - https://twitter.com/rauchg/status/1716226300602655119
  - https://twitter.com/ctjlewis/status/1716227338835489027

Discussion regarding units (Jhey - is `svh` preferable to `vh` here?):

> @rauchg: Isn’t 100dvh what you’d most likely want now?

> @ctjlewis: i think using dynamic could cause the viewport to resize as you scroll. we just want to properly size the viewport to be “at least as tall as the device screen,” so “min-height: 100vh” is the canonical approach i usually use.

> @jh3y: Totally right 🤙 The dynamic unit will adapt as UA UI resizes and tucks away on devices (where applicable). Using a min of 100svh is sometimes a safe option depending on if any sticky header/nav/footer elements exist.

cc @jh3y @leerob @rauchg 

---

The template logic strayed far from grace with #46927: Rather than utilizing the default template for files common to all templates, the same CSS update had to be applied *8 times* here. 

**This is a big mistake** - the default-override template pattern is meant to prevent duplicate copies of template files from diverging over time, a problem that was originally devastating for AWS Amplify CLI (https://github.com/aws-amplify/amplify-cli/pull/7219), which is why I brought the pattern here via #42012.  I'm owning the oversight though because I missed it somehow when I reviewed Balázs's rewrite. **Be _especially_ careful updating template files that touch starter logic/config while this redundancy exists!**

I may tack on a massive simplification of the templating logic ad hoc to this PR, unless we think it's ready to rapid-merge or something in which case I'd just do it in a separate one. In general though it would be better to not push 12 changes to update two core files.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
