### PR TITLE
Turbopack: fix over-invalidation of node.js assets

### DIFF
--- a/packages/next/src/client/dev/dev-build-watcher.ts
+++ b/packages/next/src/client/dev/dev-build-watcher.ts
@@ -95,6 +95,7 @@ export default function initializeBuildWatcher(
         break
       case HMR_ACTIONS_SENT_TO_BROWSER.BUILT:
       case HMR_ACTIONS_SENT_TO_BROWSER.SYNC:
+      case HMR_ACTIONS_SENT_TO_BROWSER.FINISH_BUILDING:
         hide()
         break
     }

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -17,6 +17,7 @@ export const enum HMR_ACTIONS_SENT_TO_BROWSER {
   SYNC = 'sync',
   BUILT = 'built',
   BUILDING = 'building',
+  FINISH_BUILDING = 'finishBuilding',
   DEV_PAGES_MANIFEST_UPDATE = 'devPagesManifestUpdate',
   TURBOPACK_MESSAGE = 'turbopack-message',
   SERVER_ERROR = 'serverError',
@@ -35,6 +36,10 @@ export interface TurbopackMessageAction {
 
 interface BuildingAction {
   action: HMR_ACTIONS_SENT_TO_BROWSER.BUILDING
+}
+
+interface FinishBuildingAction {
+  action: HMR_ACTIONS_SENT_TO_BROWSER.FINISH_BUILDING
 }
 
 interface SyncAction {
@@ -95,6 +100,7 @@ export type HMR_ACTION_TYPES =
   | TurbopackMessageAction
   | TurbopackConnectedAction
   | BuildingAction
+  | FinishBuildingAction
   | SyncAction
   | BuiltAction
   | AddedPageAction

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -374,7 +374,7 @@ async function startWatcher(opts: SetupOpts) {
         if (p.endsWith('.map')) continue
         let key = `${id}:${p}`
         const previousHash = serverPathState.get(key)
-        if (previousHash !== contentHash) {
+        if (previousHash && previousHash !== contentHash) {
           hasChange = true
           serverPathState.set(key, contentHash)
         }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1265,8 +1265,8 @@ async function startWatcher(opts: SetupOpts) {
         let page = definition?.pathname ?? inputPage
 
         if (page === '/_error') {
+          let finishBuilding = startBuilding(page)
           try {
-            startBuilding(page)
             if (globalEntries.app) {
               const writtenEndpoint = await processResult(
                 '_app',
@@ -1305,7 +1305,7 @@ async function startWatcher(opts: SetupOpts) {
             await writeMiddlewareManifest()
             await writeLoadableManifest()
           } finally {
-            finishBuilding(page)
+            finishBuilding()
           }
           return
         }
@@ -1327,7 +1327,6 @@ async function startWatcher(opts: SetupOpts) {
           throw new PageNotFoundError(`route not found ${page}`)
         }
 
-        let buildingKey = page
         let suffix
         switch (route.type) {
           case 'app-page':
@@ -1344,10 +1343,10 @@ async function startWatcher(opts: SetupOpts) {
             throw new Error('Unexpected route type ' + route.type)
         }
 
-        buildingKey = `${page}${
+        const buildingKey = `${page}${
           !page.endsWith('/') && suffix.length > 0 ? '/' : ''
         }${suffix}`
-        let finishBuilding: (() => {}) | undefined = undefined
+        let finishBuilding: (() => void) | undefined = undefined
 
         try {
           switch (route.type) {
@@ -1515,11 +1514,13 @@ async function startWatcher(opts: SetupOpts) {
               break
             }
             default: {
-              throw new Error(`unknown route type ${route.type} for ${page}`)
+              throw new Error(
+                `unknown route type ${(route as any).type} for ${page}`
+              )
             }
           }
         } finally {
-          if (finishBuilding) finishBuilding(buildingKey)
+          if (finishBuilding) finishBuilding()
         }
       },
     }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -382,6 +382,13 @@ async function startWatcher(opts: SetupOpts) {
           hasChange = true
           serverPathState.set(key, contentHash)
           serverPathState.set(p, contentHash)
+        } else {
+          if (!localHash) {
+            serverPathState.set(key, contentHash)
+          }
+          if (!globaHash) {
+            serverPathState.set(p, contentHash)
+          }
         }
       }
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -373,10 +373,15 @@ async function startWatcher(opts: SetupOpts) {
         // We ignore source maps
         if (p.endsWith('.map')) continue
         let key = `${id}:${p}`
-        const previousHash = serverPathState.get(key)
-        if (previousHash && previousHash !== contentHash) {
+        const localHash = serverPathState.get(key)
+        const globaHash = serverPathState.get(p)
+        if (
+          (localHash && localHash !== contentHash) ||
+          (globaHash && globaHash !== contentHash)
+        ) {
           hasChange = true
           serverPathState.set(key, contentHash)
+          serverPathState.set(p, contentHash)
         }
       }
 

--- a/test/integration/build-indicator/test/index.test.js
+++ b/test/integration/build-indicator/test/index.test.js
@@ -20,7 +20,7 @@ const installCheckVisible = (browser) => {
         watcherDiv.querySelector('div').className.indexOf('visible') > -1
       )
       if (window.showedBuilder) clearInterval(window.checkInterval)
-    }, 50)
+    }, 5)
   })()`)
 }
 


### PR DESCRIPTION
### What?

* no need to clear require cache when assets where not used previously
* make build status reporting more consistent
* report build status to client side for build indicator

### Why?

### How?


Closes WEB-1826