### PR TITLE
Modify tailwindcss related dependency of `create-next-app`

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -209,9 +209,9 @@ export const installTemplate = async ({
   if (tailwind) {
     packageJson.devDependencies = {
       ...packageJson.devDependencies,
-      autoprefixer: '^10',
+      autoprefixer: '^10.0.1',
       postcss: '^8',
-      tailwindcss: '^3',
+      tailwindcss: '^3.3.0',
     }
   }
 


### PR DESCRIPTION
### What?
If the version of `autoprefixer` is 10.0.0 and the version of `tailwindcss` is less than 3.3.0, the error `RangeError: Maximum call stack size exceeded` occurs when you create with tailwindcss & typescript and run it.

### Why?
The exact reason is unknown, but it appears to be a compatibility issue. Also, currently configuring tailwindcss with ts makes the tailwind config file in ts, which is supported since tailwindcss version 3.3.0. (In js, it works even if you set the version of `autoprefixer` to 10.0.1 and lower the version of tailwindcss.)

### How?
Simply default the minimum version of `autoprefixer` to 10.0.1 and the minimum version of `tailwindcss` to 3.3.0.


