### PR TITLE
Output cache tags in standalone mode

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2438,7 +2438,12 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     } else if (cachedData.kind === 'ROUTE') {
       const headers = { ...cachedData.headers }
 
-      if (!(this.minimalMode && isSSG)) {
+      if (
+        !(
+          (this.minimalMode || this.nextConfig.output === 'standalone') &&
+          isSSG
+        )
+      ) {
         delete headers[NEXT_CACHE_TAGS_HEADER]
       }
 
@@ -2454,7 +2459,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     } else {
       if (isAppPath) {
         if (
-          this.minimalMode &&
+          (this.minimalMode || this.nextConfig.output === 'standalone') &&
           isSSG &&
           cachedData.headers?.[NEXT_CACHE_TAGS_HEADER]
         ) {


### PR DESCRIPTION
## For Contributors

### Adding a feature

Implements https://github.com/vercel/next.js/discussions/57263

This PR presents one option to implement the above discussion. Would also be happy to discuss other options to expose the Cache Tags as I think it would be a valuable addition to users running Next.js behind a CDN.