### PR TITLE
Fix relative metadata url resolving on windows

### DIFF
--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -66,7 +66,7 @@ function resolveUrl(
 
   // Handle relative or absolute paths
   const basePath = metadataBase.pathname || ''
-  const joinedPath = path.join(basePath, url)
+  const joinedPath = path.posix.join(basePath, url)
 
   return new URL(joinedPath, metadataBase)
 }


### PR DESCRIPTION
x-ref: https://dev.azure.com/nextjs/next.js/_build/results?buildId=71544&view=logs&j=8af7cf9c-43a1-584d-6f5c-57bad8880974&t=7ae70e63-3625-50f4-6764-5b3e72b4bd7a

We need to use poxis join for url pathname

```
- Expected  - 1
+ Received  + 1
  Object {
    "itunes": Object {
-     "appArgument": "http://test.com/base/test/native/app",
+     "appArgument": "d:\\test\\native\\app",
    },
    "metadataBase": "http://test.com/base",
  }
  210 |       ]
  211 |       const metadata = await accumulateMetadata(metadataItems)
> 212 |       expect(mapUrlsToStrings(metadata)).toMatchObject(
      |                                          ^
  213 |         mapUrlsToStrings({
  214 |           metadataBase: new URL('http://test.com/base'),
  215 |           itunes: {

```