### PR TITLE
Use compiled async-retry for font fetching

### DIFF
--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -20,8 +20,10 @@
     "ncc-fontkit": "ncc build ./fontkit.js -o dist/fontkit"
   },
   "devDependencies": {
+    "@types/async-retry": "1.4.2",
     "@types/fontkit": "2.0.0",
     "@vercel/ncc": "0.34.0",
+    "async-retry": "1.3.3",
     "fontkit": "2.0.2"
   }
 }

--- a/packages/font/src/google/fetch-css-from-google-fonts.ts
+++ b/packages/font/src/google/fetch-css-from-google-fonts.ts
@@ -2,22 +2,7 @@
 import fetch from 'next/dist/compiled/node-fetch'
 import { nextFontError } from '../next-font-error'
 import { getProxyAgent } from './get-proxy-agent'
-
-async function retry<T>(fn: () => Promise<T>, attempts: number): Promise<T> {
-  let cnt = attempts
-  while (true) {
-    try {
-      return await fn()
-    } catch (err) {
-      cnt--
-      if (cnt <= 0) throw err
-      console.error(
-        (err as Error).message + `\n\nRetrying ${attempts - cnt}/3...`
-      )
-      await new Promise((resolve) => setTimeout(resolve, 100))
-    }
-  }
-}
+import { retry } from './retry'
 
 /**
  * Fetches the CSS containing the @font-face declarations from Google Fonts.

--- a/packages/font/src/google/retry.ts
+++ b/packages/font/src/google/retry.ts
@@ -8,9 +8,7 @@ export async function retry<T>(
   return await asyncRetry(fn, {
     retries,
     onRetry(e, attempt) {
-      console.error(
-        (e as Error).message + `\n\nRetrying ${attempt}/${retries}...`
-      )
+      console.error(e.message + `\n\nRetrying ${attempt}/${retries}...`)
     },
     minTimeout: 100,
   })

--- a/packages/font/src/google/retry.ts
+++ b/packages/font/src/google/retry.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import asyncRetry from 'async-retry'
+
+export async function retry<T>(
+  fn: asyncRetry.RetryFunction<T>,
+  retries: number
+) {
+  return await asyncRetry(fn, {
+    retries,
+    onRetry(e, attempt) {
+      console.error(
+        (e as Error).message + `\n\nRetrying ${attempt}/${retries}...`
+      )
+    },
+    minTimeout: 100,
+  })
+}

--- a/packages/font/src/google/retry.ts
+++ b/packages/font/src/google/retry.ts
@@ -1,5 +1,5 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import asyncRetry from 'async-retry'
+// @ts-ignore
+import asyncRetry from 'next/dist/compiled/async-retry'
 
 export async function retry<T>(
   fn: asyncRetry.RetryFunction<T>,
@@ -7,7 +7,7 @@ export async function retry<T>(
 ) {
   return await asyncRetry(fn, {
     retries,
-    onRetry(e, attempt) {
+    onRetry(e: Error, attempt: number) {
       console.error(e.message + `\n\nRetrying ${attempt}/${retries}...`)
     },
     minTimeout: 100,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,12 +783,18 @@ importers:
 
   packages/font:
     devDependencies:
+      '@types/async-retry':
+        specifier: 1.4.2
+        version: 1.4.2
       '@types/fontkit':
         specifier: 2.0.0
         version: 2.0.0
       '@vercel/ncc':
         specifier: 0.34.0
         version: 0.34.0
+      async-retry:
+        specifier: 1.3.3
+        version: 1.3.3
       fontkit:
         specifier: 2.0.2
         version: 2.0.2
@@ -7953,6 +7959,12 @@ packages:
     resolution: {integrity: sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==}
     dependencies:
       retry: 0.12.0
+    dev: true
+
+  /async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+    dependencies:
+      retry: 0.13.1
     dev: true
 
   /async-sema@3.0.0:
@@ -21423,7 +21435,7 @@ packages:
     dev: true
 
   /retry@0.12.0:
-    resolution: {integrity: sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=}
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
     dev: true
 


### PR DESCRIPTION
Restores PR #56583 by reverting PR #57154 , with using `next/dist/compiled/async-retry` .

see. https://github.com/vercel/next.js/pull/56583#issuecomment-1775699450

