### PR TITLE
Use async-retry for font fetching as runtime dependency

### DIFF
--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -20,8 +20,10 @@
     "ncc-fontkit": "ncc build ./fontkit.js -o dist/fontkit"
   },
   "devDependencies": {
+    "@types/async-retry": "1.4.2",
     "@types/fontkit": "2.0.0",
     "@vercel/ncc": "0.34.0",
+    "async-retry": "1.3.3",
     "fontkit": "2.0.2"
   }
 }

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -23,7 +23,9 @@
     "@types/async-retry": "1.4.2",
     "@types/fontkit": "2.0.0",
     "@vercel/ncc": "0.34.0",
-    "async-retry": "1.3.3",
     "fontkit": "2.0.2"
+  },
+  "dependencies": {
+    "async-retry": "1.3.3"
   }
 }

--- a/packages/font/src/google/fetch-css-from-google-fonts.ts
+++ b/packages/font/src/google/fetch-css-from-google-fonts.ts
@@ -2,22 +2,7 @@
 import fetch from 'next/dist/compiled/node-fetch'
 import { nextFontError } from '../next-font-error'
 import { getProxyAgent } from './get-proxy-agent'
-
-async function retry<T>(fn: () => Promise<T>, attempts: number): Promise<T> {
-  let cnt = attempts
-  while (true) {
-    try {
-      return await fn()
-    } catch (err) {
-      cnt--
-      if (cnt <= 0) throw err
-      console.error(
-        (err as Error).message + `\n\nRetrying ${attempts - cnt}/3...`
-      )
-      await new Promise((resolve) => setTimeout(resolve, 100))
-    }
-  }
-}
+import { retry } from './retry'
 
 /**
  * Fetches the CSS containing the @font-face declarations from Google Fonts.

--- a/packages/font/src/google/retry.ts
+++ b/packages/font/src/google/retry.ts
@@ -8,9 +8,7 @@ export async function retry<T>(
   return await asyncRetry(fn, {
     retries,
     onRetry(e, attempt) {
-      console.error(
-        (e as Error).message + `\n\nRetrying ${attempt}/${retries}...`
-      )
+      console.error(e.message + `\n\nRetrying ${attempt}/${retries}...`)
     },
     minTimeout: 100,
   })

--- a/packages/font/src/google/retry.ts
+++ b/packages/font/src/google/retry.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import asyncRetry from 'async-retry'
+
+export async function retry<T>(
+  fn: asyncRetry.RetryFunction<T>,
+  retries: number
+) {
+  return await asyncRetry(fn, {
+    retries,
+    onRetry(e, attempt) {
+      console.error(
+        (e as Error).message + `\n\nRetrying ${attempt}/${retries}...`
+      )
+    },
+    minTimeout: 100,
+  })
+}

--- a/packages/font/src/google/retry.ts
+++ b/packages/font/src/google/retry.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import asyncRetry from 'async-retry'
 
 export async function retry<T>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,6 +782,10 @@ importers:
         version: 7.24.0
 
   packages/font:
+    dependencies:
+      async-retry:
+        specifier: 1.3.3
+        version: 1.3.3
     devDependencies:
       '@types/async-retry':
         specifier: 1.4.2
@@ -792,9 +796,6 @@ importers:
       '@vercel/ncc':
         specifier: 0.34.0
         version: 0.34.0
-      async-retry:
-        specifier: 1.3.3
-        version: 1.3.3
       fontkit:
         specifier: 2.0.2
         version: 2.0.2
@@ -7965,7 +7966,7 @@ packages:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
     dependencies:
       retry: 0.13.1
-    dev: true
+    dev: false
 
   /async-sema@3.0.0:
     resolution: {integrity: sha512-zyCMBDl4m71feawrxYcVbHxv/UUkqm4nKJiLu3+l9lfiQha6jQ/9dxhrXLnzzBXVFqCTDwiUkZOz9XFbdEGQsg==}
@@ -21442,7 +21443,6 @@ packages:
   /retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
-    dev: true
 
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,12 +783,18 @@ importers:
 
   packages/font:
     devDependencies:
+      '@types/async-retry':
+        specifier: 1.4.2
+        version: 1.4.2
       '@types/fontkit':
         specifier: 2.0.0
         version: 2.0.0
       '@vercel/ncc':
         specifier: 0.34.0
         version: 0.34.0
+      async-retry:
+        specifier: 1.3.3
+        version: 1.3.3
       fontkit:
         specifier: 2.0.2
         version: 2.0.2
@@ -7953,6 +7959,12 @@ packages:
     resolution: {integrity: sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==}
     dependencies:
       retry: 0.12.0
+    dev: true
+
+  /async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+    dependencies:
+      retry: 0.13.1
     dev: true
 
   /async-sema@3.0.0:
@@ -21423,7 +21435,7 @@ packages:
     dev: true
 
   /retry@0.12.0:
-    resolution: {integrity: sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=}
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
     dev: true
 


### PR DESCRIPTION
Restores PR #56583 by reverting PR #57154 , with moving `async-retry` from devDependencies to dependencies.

see. https://github.com/vercel/next.js/pull/56583#issuecomment-1775699450

