### PR TITLE
perf: remove the capsize font definition from the pages runtime

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -219,14 +219,6 @@ export async function collectBuildTraces({
                 paths: [require.resolve('next/dist/server/require-hook')],
               })
             )),
-        require.resolve('next/dist/compiled/next-server/app-page.runtime.prod'),
-        require.resolve(
-          'next/dist/compiled/next-server/app-route.runtime.prod'
-        ),
-        require.resolve('next/dist/compiled/next-server/pages.runtime.prod'),
-        require.resolve(
-          'next/dist/compiled/next-server/pages-api.runtime.prod'
-        ),
       ]
 
       const { incrementalCacheHandlerPath } = config.experimental
@@ -271,30 +263,21 @@ export async function collectBuildTraces({
       }
 
       const sharedIgnores = [
-        '**/*.d.ts',
-        '**/*.map',
         '**/next/dist/compiled/next-server/**/*.dev.js',
         '**/node_modules/react{,-dom,-dom-server-turbopack}/**/*.development.js',
-
-        ...additionalIgnores,
-        ...(config.experimental.outputFileTracingIgnores || []),
-      ]
-
-      const serverIgnores = [
-        ...sharedIgnores,
         isStandalone ? null : '**/next/dist/compiled/jest-worker/**/*',
         '**/next/dist/compiled/webpack/(bundle4|bundle5).js',
         '**/node_modules/webpack5/**/*',
         '**/next/dist/server/lib/squoosh/**/*.wasm',
         '**/next/dist/server/lib/route-resolver*',
+        'next/dist/compiled/@next/react-dev-overlay/dist/**/*',
+        'next/dist/compiled/semver/semver/**/*.js',
         '**/next/dist/pages/**/*',
-
         ...(ciEnvironment.hasNextSupport
           ? [
               // only ignore image-optimizer code when
               // this is being handled outside of next-server
               '**/next/dist/server/image-optimizer.js',
-              '**/node_modules/sharp/**/*',
             ]
           : []),
 
@@ -303,6 +286,16 @@ export async function collectBuildTraces({
           : []),
 
         ...(isStandalone ? [] : TRACE_IGNORES),
+        ...additionalIgnores,
+        ...(config.experimental.outputFileTracingIgnores || []),
+      ]
+
+      const serverIgnores = [
+        ...sharedIgnores,
+        '**/*.d.ts',
+        '**/*.map',
+
+        ...(ciEnvironment.hasNextSupport ? ['**/node_modules/sharp/**/*'] : []),
       ].filter(nonNullable)
 
       const minimalServerIgnores = [
@@ -314,10 +307,9 @@ export async function collectBuildTraces({
 
       const routesIgnores = [
         ...sharedIgnores,
-        '**/next/dist/compiled/next-server/**/*',
         '**/next/dist/server/optimize-amp.js',
         '**/next/dist/server/post-process.js',
-      ]
+      ].filter(nonNullable)
 
       const makeIgnoreFn = (ignores: string[]) => (pathname: string) => {
         if (path.isAbsolute(pathname) && !pathname.startsWith(root)) {

--- a/packages/next/src/server/font-utils.ts
+++ b/packages/next/src/server/font-utils.ts
@@ -49,20 +49,6 @@ export async function getFontDefinitionFromNetwork(
   return result
 }
 
-export function getFontDefinitionFromManifest(
-  url: string,
-  manifest: FontManifest
-): string {
-  return (
-    manifest.find((font) => {
-      if (font && font.url === url) {
-        return true
-      }
-      return false
-    })?.content || ''
-  )
-}
-
 function parseGoogleFontName(css: string): Array<string> {
   const regex = /font-family: ([^;]*)/g
   const matches = css.matchAll(regex)

--- a/packages/next/src/server/lib/server-ipc/request-utils.ts
+++ b/packages/next/src/server/lib/server-ipc/request-utils.ts
@@ -20,7 +20,10 @@ export const deserializeErr = (serializedErr: any) => {
   err.name = serializedErr.name
   ;(err as any).digest = serializedErr.digest
 
-  if (process.env.NEXT_RUNTIME !== 'edge') {
+  if (
+    process.env.NODE_ENV === 'development' &&
+    process.env.NEXT_RUNTIME !== 'edge'
+  ) {
     const { decorateServerError } =
       require('next/dist/compiled/@next/react-dev-overlay/dist/middleware') as typeof import('next/dist/compiled/@next/react-dev-overlay/dist/middleware')
     decorateServerError(err, serializedErr.source || 'server')

--- a/packages/next/src/server/post-process.ts
+++ b/packages/next/src/server/post-process.ts
@@ -210,15 +210,17 @@ async function postProcessHTML(
     process.env.NEXT_RUNTIME !== 'edge' && renderOpts.optimizeFonts
       ? async (html: string) => {
           const getFontDefinition = (url: string) => {
-            if (renderOpts.fontManifest) {
-              const { getFontDefinitionFromManifest } =
-                require('./font-utils') as typeof import('./font-utils')
-              return getFontDefinitionFromManifest!(
-                url,
-                renderOpts.fontManifest
-              )
+            if (!renderOpts.fontManifest) {
+              return ''
             }
-            return ''
+            return (
+              renderOpts.fontManifest.find((font) => {
+                if (font && font.url === url) {
+                  return true
+                }
+                return false
+              })?.content || ''
+            )
           }
           return await processHTML(
             html,

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -5,10 +5,10 @@ import type {
 } from '../../../build/webpack/plugins/middleware-plugin'
 import type { UnwrapPromise } from '../../../lib/coalesced-function'
 import { AsyncLocalStorage } from 'async_hooks'
-import {
-  decorateServerError,
-  getServerError,
-} from 'next/dist/compiled/@next/react-dev-overlay/dist/middleware'
+// import {
+//   decorateServerError,
+//   getServerError,
+// } from 'next/dist/compiled/@next/react-dev-overlay/dist/middleware'
 import {
   COMPILER_NAMES,
   EDGE_UNSUPPORTED_NODE_APIS,
@@ -30,6 +30,18 @@ interface ModuleContext {
   runtime: EdgeRuntime
   paths: Map<string, string>
   warnedEvals: Set<string>
+}
+
+let getServerError: typeof import('next/dist/compiled/@next/react-dev-overlay/dist/middleware').getServerError
+let decorateServerError: typeof import('next/dist/compiled/@next/react-dev-overlay/dist/middleware').decorateServerError
+
+if (process.env.NODE_ENV === 'development') {
+  const middleware = require('next/dist/compiled/@next/react-dev-overlay/dist/middleware')
+  getServerError = middleware.getServerError
+  decorateServerError = middleware.decorateServerError
+} else {
+  getServerError = (error: Error, _: string) => error
+  decorateServerError = (error: Error, _: string) => error
 }
 
 /**

--- a/packages/next/src/server/web/sandbox/sandbox.ts
+++ b/packages/next/src/server/web/sandbox/sandbox.ts
@@ -1,7 +1,6 @@
 import type { NodejsRequestData, FetchEventResult, RequestData } from '../types'
 import type { EdgeFunctionDefinition } from '../../../build/webpack/plugins/middleware-plugin'
 import type { EdgeRuntime } from 'next/dist/compiled/edge-runtime'
-import { getServerError } from 'next/dist/compiled/@next/react-dev-overlay/dist/middleware'
 import { getModuleContext } from './context'
 import { requestToBodyStream } from '../../body-streams'
 import { NEXT_RSC_UNION_QUERY } from '../../../client/components/app-router-headers'
@@ -30,19 +29,26 @@ type RunnerFn = (params: {
  * tagged with `edge-server` so they can properly be rendered in dev.
  */
 function withTaggedErrors(fn: RunnerFn): RunnerFn {
-  return (params) =>
-    fn(params)
-      .then((result) => ({
-        ...result,
-        waitUntil: result?.waitUntil?.catch((error) => {
-          // TODO: used COMPILER_NAMES.edgeServer instead. Verify that it does not increase the runtime size.
+  if (process.env.NODE_ENV === 'development') {
+    const { getServerError } =
+      require('next/dist/compiled/@next/react-dev-overlay/dist/middleware') as typeof import('next/dist/compiled/@next/react-dev-overlay/dist/middleware')
+
+    return (params) =>
+      fn(params)
+        .then((result) => ({
+          ...result,
+          waitUntil: result?.waitUntil?.catch((error) => {
+            // TODO: used COMPILER_NAMES.edgeServer instead. Verify that it does not increase the runtime size.
+            throw getServerError(error, 'edge-server')
+          }),
+        }))
+        .catch((error) => {
+          // TODO: used COMPILER_NAMES.edgeServer instead
           throw getServerError(error, 'edge-server')
-        }),
-      }))
-      .catch((error) => {
-        // TODO: used COMPILER_NAMES.edgeServer instead
-        throw getServerError(error, 'edge-server')
-      })
+        })
+  }
+
+  return fn
 }
 
 export async function getRuntimeContext(params: {


### PR DESCRIPTION
This PR removes the `next/dist/server/capsize-font-metrics.json` from the pages runtime, a 300KB file that was unused during render. This was compiled in the runtime because we were importing from `font-utils`. I just changed it to inline the util method.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
