### PR TITLE
Update unrelated mdx tests with turbopack

### DIFF
--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -1,6 +1,10 @@
 import { createNextDescribe } from 'e2e-utils'
 
-for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
+for (const type of [
+  'with-mdx-rs',
+  // only mdx-rs should work with turbopack
+  ...(process.env.TURBOPACK ? [] : ['without-mdx-rs']),
+]) {
   createNextDescribe(
     `mdx ${type}`,
     {


### PR DESCRIPTION
The non-mdxrs version of the plugin isn't expected to work with turbopack so this skips it in that mode