### PR TITLE
update turbopack and add HMR test case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "serde",
  "smallvec",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "serde",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7671,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7683,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7698,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7712,7 +7712,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7729,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7759,7 +7759,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "base16",
  "hex",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7785,7 +7785,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7795,7 +7795,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "mimalloc",
 ]
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7828,7 +7828,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7859,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7899,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7945,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7975,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8021,7 +8021,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8058,7 +8058,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8092,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "serde",
  "serde_json",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8143,7 +8143,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8179,7 +8179,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "serde",
@@ -8194,7 +8194,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8209,7 +8209,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8244,7 +8244,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "serde",
@@ -8260,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8271,7 +8271,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231023.1#61d5adf61b08e68e5a76e7d776ba9d6f8694de94"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "serde",
  "smallvec",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "serde",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7671,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7683,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7698,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7712,7 +7712,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7729,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7759,7 +7759,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "base16",
  "hex",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7785,7 +7785,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7795,7 +7795,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "mimalloc",
 ]
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7828,7 +7828,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7859,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7899,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7945,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7975,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8021,7 +8021,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8058,7 +8058,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8092,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "serde",
  "serde_json",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8143,7 +8143,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8179,7 +8179,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "serde",
@@ -8194,7 +8194,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8209,7 +8209,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8244,7 +8244,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "serde",
@@ -8260,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8271,7 +8271,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.1#834b2acebb22cfdd33ec39b5273e6106088b435d"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231024.2#546c9867a8d6ec2fdc52f246e8cdc7d9363ec3fb"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ swc_core = { version = "0.86.10", features = [
 testing = { version = "0.35.0" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231023.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231024.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231023.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231024.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231023.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231024.1" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ swc_core = { version = "0.86.10", features = [
 testing = { version = "0.35.0" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231024.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231024.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231024.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231024.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231024.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231024.2" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -193,7 +193,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231023.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -193,7 +193,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.2",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,8 +1061,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.2(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -24947,9 +24947,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.2(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.2}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.2'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,8 +1061,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231023.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231023.1(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -24947,9 +24947,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231023.1(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231023.1}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231023.1'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231024.1'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -561,4 +561,55 @@ describe('next.rs api', () => {
         }
       })
   }
+
+  it('should allow to make many HMR updates', async () => {
+    console.log('start')
+    await new Promise((r) => setTimeout(r, 1000))
+    const entrypointsSubscribtion = project.entrypointsSubscribe()
+    const entrypoints: TurbopackResult<Entrypoints> = (
+      await entrypointsSubscribtion.next()
+    ).value
+    const route = entrypoints.routes.get('/')
+    entrypointsSubscribtion.return()
+
+    if (route.type !== 'page') throw new Error('unknown route type')
+    await route.htmlEndpoint.writeToDisk()
+
+    const result = await project.hmrIdentifiersSubscribe().next()
+    expect(result.done).toBe(false)
+    const identifiers = result.value.identifiers
+
+    const subscriptions = identifiers.map((identifier) =>
+      project.hmrEvents(identifier)
+    )
+    await Promise.all(
+      subscriptions.map(async (subscription) => {
+        const result = await subscription.next()
+        expect(result.done).toBe(false)
+        expect(result.value).toHaveProperty('resource', expect.toBeObject())
+        expect(result.value).toHaveProperty('type', 'issues')
+        expect(result.value).toHaveProperty('diagnostics', expect.toBeEmpty())
+      })
+    )
+    const merged = raceIterators(subscriptions)
+
+    const file = 'pages/index.js'
+    let currentContent = await next.readFile(file)
+    let nextContent = pagesIndexCode('hello world2')
+
+    for (let i = 0; i < 1000; i++) {
+      await next.patchFileFast(file, nextContent)
+      const content = currentContent
+      currentContent = nextContent
+      nextContent = content
+
+      while (true) {
+        const { value, done } = await merged.next()
+        expect(done).toBe(false)
+        if (value.type === 'partial') {
+          break
+        }
+      }
+    }
+  })
 })

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -597,7 +597,8 @@ describe('next.rs api', () => {
     let currentContent = await next.readFile(file)
     let nextContent = pagesIndexCode('hello world2')
 
-    for (let i = 0; i < 1000; i++) {
+    const count = process.env.CI ? 300 : 1000
+    for (let i = 0; i < count; i++) {
       await next.patchFileFast(file, nextContent)
       const content = currentContent
       currentContent = nextContent
@@ -611,5 +612,5 @@ describe('next.rs api', () => {
         }
       }
     }
-  })
+  }, 300000)
 })

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -465,6 +465,10 @@ export class NextInstance {
       await this.handleDevWatchDelayAfterChange(filename)
     }
   }
+  public async patchFileFast(filename: string, content: string) {
+    const outputPath = path.join(this.testDir, filename)
+    await fs.writeFile(outputPath, content)
+  }
   public async renameFile(filename: string, newFilename: string) {
     await this.handleDevWatchDelayBeforeChange(filename)
 


### PR DESCRIPTION
### What?

adds a test case for HMR, which is fixed by the turbopack update

### Why?

### How?

### Turbopack Changes

* https://github.com/vercel/turbo/pull/6245 <!-- Justin Ridgewell - Parallelize `chunk_content` walk  -->
* https://github.com/vercel/turbo/pull/6212 <!-- Will Binns-Smith - Turbopack: don't consider any unanalyzable spawn expression `node`  -->
* https://github.com/vercel/turbo/pull/6255 <!-- Maia Teegarden - Padamaia/small docs changes  -->
* https://github.com/vercel/turbo/pull/6259 <!-- Tobias Koppers - disable lazy children removal  -->
* https://github.com/vercel/turbo/pull/6261 <!-- Will Binns-Smith - Turbopack: apply queued updates to aggregation context  -->
* https://github.com/vercel/turbo/pull/6260 <!-- Will Binns-Smith - Turbopack: add a simple `require` implementation at runtime for CJS checks  -->

Closes WEB-1836