### PR TITLE
Fix no-store/revalidate 0 inside of unstable_cache

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -311,7 +311,11 @@ export function patchFetch({
         }
 
         if (isOnlyNoStore) {
-          if (_cache === 'force-cache' || revalidate === 0) {
+          if (
+            _cache === 'force-cache' ||
+            (typeof revalidate !== 'undefined' &&
+              (revalidate === false || revalidate > 0))
+          ) {
             throw new Error(
               `cache: 'force-cache' used on fetch for ${fetchUrl} with 'export const fetchCache = 'only-no-store'`
             )

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -51,7 +51,9 @@ export function unstable_cache<T extends Callback>(
     return staticGenerationAsyncStorage.run(
       {
         ...store,
-        fetchCache: 'only-no-store',
+        // force any nested fetches to bypass cache so they revalidate
+        // when the unstable_cache call is revalidated
+        fetchCache: 'force-no-store',
         urlPathname: store?.urlPathname || '/',
         isUnstableCacheCallback: true,
         isStaticGeneration: store?.isStaticGeneration === true,

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/revalidate-360/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/revalidate-360/page.js
@@ -22,10 +22,29 @@ export default async function Page() {
       const fetchedRandom = await fetch(
         'https://next-data-api-endpoint.vercel.app/api/random'
       ).then((res) => res.json())
+
+      const fetchedRandomNoStore = await fetch(
+        'https://next-data-api-endpoint.vercel.app/api/random',
+        {
+          cache: 'no-store',
+        }
+      ).then((res) => res.json())
+
+      const fetchedRandomRevalidateZero = await fetch(
+        'https://next-data-api-endpoint.vercel.app/api/random',
+        {
+          next: {
+            revalidate: 0,
+          },
+        }
+      ).then((res) => res.json())
+
       return {
         now: Date.now(),
         random: Math.random(),
         fetchedRandom,
+        fetchedRandomNoStore,
+        fetchedRandomRevalidateZero,
       }
     },
     ['random'],


### PR DESCRIPTION
This ensures we don't unexpectedly error when a fetch attempts to cache inside of `unstable_cache`, this also ensures `only-on-store` doesn't unexpectedly error when `revalidate: 0` is set. 