### PR TITLE
Increase build-native CI job timeout

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -228,7 +228,7 @@ jobs:
 
     name: stable - ${{ matrix.settings.target }} - node@16
     runs-on: ${{ matrix.settings.host }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       # https://github.com/actions/virtual-environments/issues/1187
       - name: tune linux network


### PR DESCRIPTION
This is currently timing out so this increases the timeout for Windows specifically