### PR TITLE
Revert "Increase build-native CI job timeout (#57314)"

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -228,7 +228,7 @@ jobs:
 
     name: stable - ${{ matrix.settings.target }} - node@16
     runs-on: ${{ matrix.settings.host }}
-    timeout-minutes: 45
+    timeout-minutes: 30
     steps:
       # https://github.com/actions/virtual-environments/issues/1187
       - name: tune linux network


### PR DESCRIPTION
This reverts commit 003ec7a15b56accd86fa85931735dc089b727e06.

Re-adding this as a safe guard as the stalling was a real issue