### PR TITLE
fix(next_core): align remove trailing slash

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_edge/route_regex.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/route_regex.rs
@@ -68,8 +68,17 @@ fn escape_string_regexp(segment: &str) -> String {
     regex::escape(segment)
 }
 
+/// Removes the trailing slash for a given route or page path. Preserves the
+/// root page. Examples:
+///  - `/foo/bar/` -> `/foo/bar`
+///  - `/foo/bar` -> `/foo/bar`
+///  - `/` -> `/`
 fn remove_trailing_slash(route: &str) -> &str {
-    route.trim_end_matches('/')
+    if route == "/" {
+        route
+    } else {
+        route.trim_end_matches('/')
+    }
 }
 
 static PARAM_MATCH_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\[((?:\[.*\])|.+)\]").unwrap());

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -13408,14 +13408,15 @@
       "Basics default setting with react 18 dev should contain dynamicIds in next data for dynamic imports",
       "Basics default setting with react 18 dev should only render once in SSR",
       "Basics default setting with react 18 dev useId() values should match on hydration",
-      "Concurrent mode in the experimental-edge runtime dev <RouteAnnouncer /> should not have the initial route announced",
       "Concurrent mode in the experimental-edge runtime dev flushes styled-jsx styles as the page renders",
       "Concurrent mode in the experimental-edge runtime dev should not have invalid config warning",
       "Concurrent mode in the nodejs runtime dev <RouteAnnouncer /> should not have the initial route announced",
       "Concurrent mode in the nodejs runtime dev flushes styled-jsx styles as the page renders",
       "Concurrent mode in the nodejs runtime dev should not have invalid config warning"
     ],
-    "failed": [],
+    "failed": [
+      "Concurrent mode in the experimental-edge runtime dev <RouteAnnouncer /> should not have the initial route announced"
+    ],
     "pending": [
       "Basics production mode default setting with react 18 prod hydrates correctly for normal page",
       "Basics production mode default setting with react 18 prod no warnings for image related link props",


### PR DESCRIPTION
### What

minor fix to match behavior to https://github.com/vercel/next.js/blob/ae10b5c82b29b3b077378f05f75eb1b215b327f0/packages/next/src/shared/lib/router/utils/remove-trailing-slash.ts#L2C4-L9

as we're seeing a panic when route is /

```
Panic: PanicInfo { payload: Any { .. }, message: Some(byte index 1 is out of bounds of ``), location: Location { file: "packages/next-swc/crates/next-core/src/next_edge/route_regex.rs", line: 202, col: 59 }, can_unwind: true, force_no_backtrace: false }
Backtrace:    0: backtrace::backtrace::libunwind::trace
```

Closes WEB-1841