### PR TITLE
refactor: Swap `swc_css` out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "serde",
  "smallvec",
@@ -611,31 +611,6 @@ checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
-]
-
-[[package]]
-name = "browserslist-rs"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bda9b4595376bf255f68dafb5dcc5b0e2842b38dc2a7b52c4e0bfe9fd1c651"
-dependencies = [
- "ahash 0.8.6",
- "anyhow",
- "chrono",
- "either",
- "getrandom",
- "itertools",
- "js-sys",
- "nom",
- "once_cell",
- "quote",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "string_cache",
- "string_cache_codegen",
- "thiserror",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1331,6 +1306,7 @@ dependencies = [
  "dtoa-short",
  "itoa",
  "phf 0.11.2",
+ "serde",
  "smallvec",
 ]
 
@@ -3249,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b7185e6577ae96612f3ad16f77e26631f1a3227a7baff75c2113e336a28111"
+checksum = "b938c4ffaa1180f64186fd52f51dac5998e68c8c29f3ce4a0da952b873ebe021"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -3563,7 +3539,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "serde",
@@ -3857,6 +3833,7 @@ dependencies = [
  "phf 0.10.1",
  "phf_codegen",
  "precomputed-hash",
+ "serde",
  "smallvec",
  "static-self",
 ]
@@ -4221,7 +4198,7 @@ checksum = "3277c43d5ab99ddc71f4a301686c50a1a155339feb0cbe41492aabc211ef474f"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
- "browserslist-rs 0.13.0",
+ "browserslist-rs",
  "dashmap",
  "from_variant",
  "once_cell",
@@ -5680,9 +5657,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.82.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e27c25eeaa8ddea7f9094187417251cdedcd6e31a97404c964f724bf5fbaf0"
+checksum = "97aa75a37e4afde897446c920d4569ff18fbf32d2f8f3d9d0f109da674a9cb15"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -5698,13 +5675,14 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.59.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7aa926750af235c32342376eaf5f997595b381f4202908e40a71bf3708c284"
+checksum = "0d5d705b3f746558b25d9badb4e2af0d106688880a7a7efd7cc41b4af7d42fd4"
 dependencies = [
  "easy-error",
  "lightningcss",
  "parcel_selectors",
+ "preset_env_base",
  "serde",
  "swc_common",
  "swc_css_ast",
@@ -5963,13 +5941,6 @@ dependencies = [
  "swc_bundler",
  "swc_cached",
  "swc_common",
- "swc_css_ast",
- "swc_css_codegen",
- "swc_css_compat",
- "swc_css_modules",
- "swc_css_parser",
- "swc_css_utils",
- "swc_css_visit",
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_loader",
@@ -6000,7 +5971,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24e33aed6900a6478ec9bffa7cdf5249ea79b55fcc86b34872212800086504fa"
 dependencies = [
  "is-macro",
- "serde",
  "string_enum",
  "swc_atoms",
  "swc_common",
@@ -6037,49 +6007,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_css_compat"
-version = "0.27.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f82fd2fc69fb5898111ef25a2dd74f68dc4f043a25b4a4ceca7db67322e4a83"
-dependencies = [
- "bitflags 2.4.0",
- "once_cell",
- "serde",
- "serde_json",
- "swc_atoms",
- "swc_common",
- "swc_css_ast",
- "swc_css_utils",
- "swc_css_visit",
-]
-
-[[package]]
 name = "swc_css_minifier"
-version = "0.116.9"
+version = "0.116.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe9803a0b7562ac8e0baebca15fc228fdd3dbc3c88d4fc5e85545b5f1f9597f"
+checksum = "f758a030c634a2dfd78c44ebefbb64c9155e086a72d15784ad3ee91c1fa66485"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
  "swc_css_ast",
  "swc_css_utils",
- "swc_css_visit",
-]
-
-[[package]]
-name = "swc_css_modules"
-version = "0.29.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcf9dc1c339724167d9bbeec6176e4785d0996babc9def04786c724626dee69"
-dependencies = [
- "rustc-hash",
- "serde",
- "swc_atoms",
- "swc_common",
- "swc_css_ast",
- "swc_css_codegen",
- "swc_css_parser",
  "swc_css_visit",
 ]
 
@@ -6098,9 +6035,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.153.10"
+version = "0.153.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28769f899a6c6dc208221c0272b58576b6c8cbe8988395efae913eeba5e4834e"
+checksum = "18ee513d43dca0debd04de9f2df55292778f982ec27d02bc503203bb644e409d"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -6856,9 +6793,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d123bc6ff6aff8724f43542964ee726801fc205137bbf0de7f822a2f8b15f204"
+checksum = "708a605ff7a722d169e800dbbb0328a82db38811d3b07cbb8ca87db27d7b3e9c"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -7016,9 +6953,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffdcdf1fd127262323ba54a1ab97a6dc0f5ba937e5d3fca8aa79935ded1a151"
+checksum = "9a144781f2f2de3e7ccc22f7381a7f24383ac36168a4afefdbb029f78c1aa973"
 dependencies = [
  "once_cell",
  "regex",
@@ -7709,7 +7646,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7741,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7753,7 +7690,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7768,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7782,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7799,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7829,7 +7766,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "base16",
  "hex",
@@ -7841,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7855,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7865,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "mimalloc",
 ]
@@ -7873,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7898,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7929,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7969,7 +7906,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7992,7 +7929,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -8016,13 +7953,13 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
  "auto-hash-map",
- "browserslist-rs 0.12.4",
+ "browserslist-rs",
  "futures",
  "indexmap 1.9.3",
  "lazy_static",
@@ -8046,15 +7983,19 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "async-trait",
  "indexmap 1.9.3",
  "indoc",
+ "lightningcss",
  "once_cell",
+ "parcel_selectors",
+ "parcel_sourcemap",
  "regex",
  "serde",
+ "smallvec",
  "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -8068,7 +8009,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8092,7 +8033,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8129,7 +8070,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8163,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "serde",
  "serde_json",
@@ -8174,7 +8115,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8197,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8214,7 +8155,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8230,7 +8171,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8250,7 +8191,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "serde",
@@ -8265,7 +8206,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8280,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8315,7 +8256,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "serde",
@@ -8331,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8342,7 +8283,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231109.2#0bd3879d6b969daa15a6edd3f065204fae3e5ce8"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swap-css#0412a5f72d36d00a68db27215d18baa1972f519b"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,8 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.49"
-source = "git+https://github.com/kdy1/lightningcss.git?branch=derive-unsafe#67b54837359da576b94c6cb8a73837fa6b41605a"
+version = "1.0.0-alpha.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2999490cc10a59ad8a87d731791a5d438d2d025e3f137aa7d4c23e1827985b0"
 dependencies = [
  "ahash 0.7.6",
  "bitflags 2.4.0",
@@ -2893,7 +2894,8 @@ dependencies = [
 [[package]]
 name = "lightningcss-derive"
 version = "1.0.0-alpha.42"
-source = "git+https://github.com/kdy1/lightningcss.git?branch=derive-unsafe#67b54837359da576b94c6cb8a73837fa6b41605a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f02a09f0b79d31f1ee13ea55e2f7021037c6b72e0a3ab6c1cb0e9bd7ac8a295"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3823,8 +3825,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parcel_selectors"
-version = "0.26.3"
-source = "git+https://github.com/kdy1/lightningcss.git?branch=derive-unsafe#67b54837359da576b94c6cb8a73837fa6b41605a"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d74befe2d076330d9a58bf9ca2da424568724ab278adf15fb5718253133887"
 dependencies = [
  "bitflags 2.4.0",
  "cssparser",
@@ -5529,8 +5532,9 @@ dependencies = [
 
 [[package]]
 name = "static-self"
-version = "0.1.0"
-source = "git+https://github.com/kdy1/lightningcss.git?branch=derive-unsafe#67b54837359da576b94c6cb8a73837fa6b41605a"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "253e76c8c993a7b1b201b0539228b334582153cd4364292822d2c30776d469c7"
 dependencies = [
  "smallvec",
  "static-self-derive",
@@ -5538,8 +5542,9 @@ dependencies = [
 
 [[package]]
 name = "static-self-derive"
-version = "0.1.0"
-source = "git+https://github.com/kdy1/lightningcss.git?branch=derive-unsafe#67b54837359da576b94c6cb8a73837fa6b41605a"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5268c96d4b907c558a9a52d8492522d6c7b559651a5e1d8f2d551e461b9425d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2868,8 +2868,7 @@ dependencies = [
 [[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06476660ee1e593a2672e4a342a1289708fd9936dcdf3e74433ad078145e9e3d"
+source = "git+https://github.com/kdy1/lightningcss.git?branch=derive-unsafe#67b54837359da576b94c6cb8a73837fa6b41605a"
 dependencies = [
  "ahash 0.7.6",
  "bitflags 2.4.0",
@@ -2894,8 +2893,7 @@ dependencies = [
 [[package]]
 name = "lightningcss-derive"
 version = "1.0.0-alpha.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f02a09f0b79d31f1ee13ea55e2f7021037c6b72e0a3ab6c1cb0e9bd7ac8a295"
+source = "git+https://github.com/kdy1/lightningcss.git?branch=derive-unsafe#67b54837359da576b94c6cb8a73837fa6b41605a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3826,8 +3824,7 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 [[package]]
 name = "parcel_selectors"
 version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f000cdd23df6cebe999cf2b02a3bf40d55758f74883d7fd43a33690565618c8"
+source = "git+https://github.com/kdy1/lightningcss.git?branch=derive-unsafe#67b54837359da576b94c6cb8a73837fa6b41605a"
 dependencies = [
  "bitflags 2.4.0",
  "cssparser",
@@ -5533,8 +5530,7 @@ dependencies = [
 [[package]]
 name = "static-self"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2978fa810a31711d7162d0bb843df1f36d84e393e335ce31ec2c485b2464c44"
+source = "git+https://github.com/kdy1/lightningcss.git?branch=derive-unsafe#67b54837359da576b94c6cb8a73837fa6b41605a"
 dependencies = [
  "smallvec",
  "static-self-derive",
@@ -5543,8 +5539,7 @@ dependencies = [
 [[package]]
 name = "static-self-derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc53c080b79432d9babd26457df68fb4b002cc7d2ce36a1a5195091cf9fecc14"
+source = "git+https://github.com/kdy1/lightningcss.git?branch=derive-unsafe#67b54837359da576b94c6cb8a73837fa6b41605a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.60.40"
+version = "0.60.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc6d576fb61191dccafc3c5c69fcfe579606c6e64b71f3b57865040a8eff6ad"
+checksum = "6fdde7535e3cb901527bb60f69b10958215f8dafde044f2c57fd9fd7cb02e49b"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -636,6 +636,27 @@ dependencies = [
  "string_cache_codegen",
  "thiserror",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "browserslist-rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33066f72a558361eeb1077b0aff0f1dce1ac75bdc20b38a642f155f767b2824"
+dependencies = [
+ "ahash 0.8.6",
+ "anyhow",
+ "chrono",
+ "either",
+ "itertools",
+ "nom",
+ "once_cell",
+ "quote",
+ "serde",
+ "serde_json",
+ "string_cache",
+ "string_cache_codegen",
+ "thiserror",
 ]
 
 [[package]]
@@ -1309,7 +1330,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.10.1",
+ "phf 0.11.2",
  "smallvec",
 ]
 
@@ -2250,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "hstr"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f8eaaa1bccc114f3ed94b7b66f0195cbf48151402d3efc27f7f6e362042416"
+checksum = "de90d3db62411eb62eddabe402d706ac4970f7ac8d088c05f11069cad9be9857"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
@@ -4194,13 +4215,13 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "preset_env_base"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a83fddb10b466da126eaf6bf444c878141f691b23c2de6004bf1ef83c38e8e6"
+checksum = "3277c43d5ab99ddc71f4a301686c50a1a155339feb0cbe41492aabc211ef474f"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
- "browserslist-rs",
+ "browserslist-rs 0.13.0",
  "dashmap",
  "from_variant",
  "once_cell",
@@ -4505,9 +4526,9 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40e33698331c12e20b0163444c2dffc109122a5ef8abfffa5c9aaaccbb3f383"
+checksum = "c179dadcf9e31539e9af8a709153adafa4cf9f907c4df20a4b52a80718bd884d"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -4648,9 +4669,9 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4804169f67ce1ac6064588a5256ccd876082ffdf083c34e4114447e4d98d210e"
+checksum = "4bb68d00d948a7ffa1dc16aee64cc45640ca8ed9afe14e109d5a1f1d8e4db65e"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5737,9 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.269.35"
+version = "0.269.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fa4c765e8d643246054b4f4ad83bcf9cb7a7715e094c3f54c5c51754901c24"
+checksum = "05849a2ce200bb82aec323cb672d9ecb9e9029316e3d44a0a7d510572d5e5501"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -5789,9 +5810,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad769aeefe4cf20c3ec29e714c91870fa89307faa4280a644c4c65b5cc692"
+checksum = "b8a9e1b6d97f27b6abe5571f8fe3bdbd2fa987299fc2126450c7cde6214896ef"
 dependencies = [
  "bytecheck",
  "hstr",
@@ -5803,9 +5824,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.222.31"
+version = "0.222.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8e4c2e870949ef919693a16a7bae57e30b75bec662e0e40bba131b5884c3fb"
+checksum = "cdab096f62e461d4524ddf65978e69393db703356a97f4b558f2a4f212a1b7dd"
 dependencies = [
  "anyhow",
  "crc",
@@ -5849,9 +5870,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.33.5"
+version = "0.33.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b33eb74d42276b5f37ac78ed470dd206ece8a2687cfe3a681444f66c29a061f"
+checksum = "49fba1ce1d44f142b9e8212a6360fc7818e2c99c7f5ebe8b4fa4061c5764e48e"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
@@ -5883,9 +5904,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.3.37"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5aa27756be34b2dcba6e632ac35e1416aefaef7aa1cf9e32c54bdd482a8b5ab"
+checksum = "4ccb251385a0ab21b4470b2e9088c3d992f4cb3c9a3a80a46ee802e4f6b22dbb"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -5932,9 +5953,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.86.40"
+version = "0.86.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22da79427085d5ba7ea5ec14f104f8af66bf479655475cd901d292e87b7b3a73"
+checksum = "f718c699aac95c69bad3ba5e81e554407c4195ff339e61b96686abab4bfed40c"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5974,9 +5995,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.140.6"
+version = "0.140.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec6ea3b519c6e44a16f680036f5faadcfd31d6bdad0762f19d4f15c2e6d013a"
+checksum = "24e33aed6900a6478ec9bffa7cdf5249ea79b55fcc86b34872212800086504fa"
 dependencies = [
  "is-macro",
  "serde",
@@ -5987,9 +6008,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.151.9"
+version = "0.151.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b313c0ca16ddb367288d17dd77d491c7c6ad62eb297448a0ce0ae1c3767592"
+checksum = "71a04ac7b5672d740340ae09a6bcedad753d45ae9d4ec3b935617c20dce90094"
 dependencies = [
  "auto_impl",
  "bitflags 2.4.0",
@@ -6017,9 +6038,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.27.9"
+version = "0.27.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8448e5731f3d2d2d91b28f11ca2c1ff0d92e7f8f687e3bba20857b0b85abc2fb"
+checksum = "4f82fd2fc69fb5898111ef25a2dd74f68dc4f043a25b4a4ceca7db67322e4a83"
 dependencies = [
  "bitflags 2.4.0",
  "once_cell",
@@ -6048,9 +6069,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.29.10"
+version = "0.29.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064878840d63575702f64e4f22e7c7866e5d61e3aa026237d5acd7f3b6ce547e"
+checksum = "3fcf9dc1c339724167d9bbeec6176e4785d0996babc9def04786c724626dee69"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -6064,9 +6085,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.150.9"
+version = "0.150.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ae34661b2c08cb60947e05735d8d6db255b5ee2484d2ebdbc5d7de0f14b121"
+checksum = "5a3a21dc7405cbb2f7c923e0759bc3ab4a561780b638e9e79c96675341fd89d0"
 dependencies = [
  "lexical",
  "serde",
@@ -6094,9 +6115,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.137.6"
+version = "0.137.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e64f7d7de2158bbedd12b309089f8bb94ce60fc45dde37fa0447da8b6fa624"
+checksum = "24fec9a00252d393ca43383109f38a68d64c326ca967b40ec35499ef0c57a7dc"
 dependencies = [
  "once_cell",
  "serde",
@@ -6109,9 +6130,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.139.6"
+version = "0.139.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1b09ebb933e50d23d5d583e783bf35c678b7ad7072a6d5f8f47e72aceeb6b5"
+checksum = "5f4827e116e4e417a5f7f995ef3e2ef83ddef034418667c5e1ed169f072053c2"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6122,9 +6143,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.110.6"
+version = "0.110.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f902ec313c3c442bfbb5e999326582fccfb83b7db6c171819495b485f4057f01"
+checksum = "4cefcc1c71bf00e48da7b65801d1fccf7eed2b7fa1fc5c4848ed09801bfe2403"
 dependencies = [
  "bitflags 2.4.0",
  "bytecheck",
@@ -6142,9 +6163,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.146.16"
+version = "0.146.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c8efbcee4acb346c15e6d9470f47b94053a3d61f1677d5b7d677c8a79e6a6f"
+checksum = "c45a0beb1293372354b57bbafa06bf5ca6c3fab4bfd157b54d65db96612232eb"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -6174,9 +6195,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.1.24"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7475da4769ed5be961cd86a4cb0a0629ff55d11ff044a366732a64e02119d3cb"
+checksum = "5521b96f87e13fd10f2a7c3bf4f8f80ed2cc3a532a4c9b6625a724d8e3083e85"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6191,9 +6212,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "0.1.16"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ea85927ab506fb1f42a9c0c2cac73d8f0a4a28f2ec7aace836aba0ebfd62f6"
+checksum = "c1889c73fde0612659b59359a0f4e42be73b623cba895fd88957b60471559d04"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6204,9 +6225,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.1.24"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0904f4a35212c021e40745c6aa71b44c0bb2827ecdd836e4064d34db5cc6437"
+checksum = "ea1c8835b35efa6b3264cf3330e5ecd3abde691e3037fac724fe73cf26fb4a9f"
 dependencies = [
  "arrayvec",
  "indexmap 1.9.3",
@@ -6230,9 +6251,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.1.22"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587dad924fc00d268899771ae942a84c87c493dadc1a024d831eb464dcf330f9"
+checksum = "58265ca3e2bbeefe595c3a77cbca10d44d877cf006429529ee6a7245122a7f84"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6247,9 +6268,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.1.22"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bf1d18316b202f2a75dcd364f49c3bd6406d58f1c2cf308388c782773bbc66"
+checksum = "590e3ea46d074bd8ebd57d0f45d3c8dcbafacf18e58704abd034ebcf73f120ad"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6265,9 +6286,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.1.22"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62266ecd18493c9440413731606ca8d46f76d32a1df3474f20b5863a6175c9bc"
+checksum = "8e8ba03ae7d980a7a09c425b8be7ef56775f7ee703cceee82cf6f6712899cfe6"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6284,9 +6305,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.1.22"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49646a589d7c4594b452b4133e833060fe894efc16929bdb6b7040261601e845"
+checksum = "7c034b8ea66e47552fafdef3d904c53597761c91ca51174c2576c04706e38687"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6300,9 +6321,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.1.21"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53da0baf19e324757527733d3b37615bfebc2d136ee3d989c0e930c5636e090"
+checksum = "5d43af0631e13dbfccf67c42105b3e07dfc620d43226128c3a0cd478b57e87de"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6318,9 +6339,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.1.20"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c67a4db9e67f6ff3afc5629091cf672703966d69956dcdd88aa3e859f992008"
+checksum = "4623f933fea8df5e8d8be0d511b9c441c30f0601f9161b6a6660fc0f6a54aea9"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6334,9 +6355,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.1.22"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088b968df343c7d2d5dc05dbe72124a7745126c0febe4ce201eeb0f78c10c3be"
+checksum = "9e041d062041ca30fea5cb0f9c590edff6e99f3fc117c0470f12dbe5abe5412d"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6353,9 +6374,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.1.21"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54548c16bc5198c152ab61cb62167f2c883f96cae8ec3346182f7e05235598d8"
+checksum = "6102f7c0c339ed21d5be4a197332ec9b4886d0b28fd4ca15905a9ce6eec4ea83"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6368,9 +6389,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.110.19"
+version = "0.110.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4b20acb54ee2c48784efa3f27995c648a6f44cb58c166e0538b92075c54e10"
+checksum = "04c4614dca2e8561024be8906f9a095777ad1f39a3b2b426111b96c03465af8d"
 dependencies = [
  "phf 0.10.1",
  "swc_atoms",
@@ -6382,9 +6403,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.89.22"
+version = "0.89.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c3900597328e9e84f903dd1ba0c5d1c82a304b4ac60fa71891f221c15d0cfb"
+checksum = "c783cf4cf1a5887de0e7b5fc25fab6f7bdcf7268eca671fe2fb4ff654e6b1006"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -6402,9 +6423,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.45.6"
+version = "0.45.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a550d167cef210e34ea7ad223a3243969257c3fe0efcdbe605b390065afc4a3"
+checksum = "cc83806e30310943718eef1209c388f375417bcc3e499df8820c189d92ecf05f"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6423,9 +6444,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.189.32"
+version = "0.189.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b07fc3067a5ed6ded17b4133765b1cde0a8e8a1c30c39388e0b864e97ad27"
+checksum = "1d50fedc759df341016d49a100b389cb6c1b7574e4cc65367487d5d3afc22e9e"
 dependencies = [
  "arrayvec",
  "indexmap 1.9.3",
@@ -6458,9 +6479,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.141.14"
+version = "0.141.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17e2c91d688f8853ed6be8ba5ee3bdec2230b60a58b22338f3174792646c9c8"
+checksum = "acfad502c2e0579e09e216da1c627d583fdbc6c8a08f2c8bd0160f9119d4246d"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -6480,9 +6501,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.203.29"
+version = "0.203.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b8ca7733d321438e15eee673bc435cacdd4b92fd71e0b441a5cd72b0ba5d35"
+checksum = "652c066e316cd2acf9bc39a151456188925a5f01e5bb00018b9bf468ee0fd734"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6505,9 +6526,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.52.14"
+version = "0.52.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725e83abdb92bac059ea9a90e41710e28dc8a892141bf79a2ca836c5c562d3d8"
+checksum = "51c6de18105523ee7c930178406cd324c272ae21bc549e53593105b345969e18"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -6523,9 +6544,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.22.7"
+version = "0.22.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea1698f37105c753803166f415569edcf34a2b82f41c9aee125d5462af40d13"
+checksum = "62dc3d273ef4f7fe39b670b7f1fdd2dd33518f5de987e7f7fe9d1b44e650e891"
 dependencies = [
  "anyhow",
  "hex",
@@ -6536,9 +6557,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.226.29"
+version = "0.226.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529ea35a5ad6ee8add3ef15380a8e5e5a1da4cfd04e0d070f2efc4c8c2266823"
+checksum = "5b020aef371703583047e8e41468c17790e5f3caf9cf1cb53b7fb91d7a8d8a70"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6556,9 +6577,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.134.22"
+version = "0.134.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b27038edff04dc41a41b1976670df93470a4a88c1dc5b17e996326978b76e8c"
+checksum = "1cea2778aaa7152bacc2877ce900a78f815c64630102ec8d824a8ec543ac5ef5"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -6580,9 +6601,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.123.23"
+version = "0.123.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e8bf4894b46f56b37657c942529d3478224260e576ab38c641c508b805d0bb"
+checksum = "75a2a98541dffaffbfecb6aaccf8d910c8e9e54576a785e431d8eb2d2c56b80a"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6594,9 +6615,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.160.28"
+version = "0.160.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407f66ce3dd22fd2bcc00876d2007aefa73183e39bbca6e19da2a083235b001a"
+checksum = "2be5f5f7b7e62cd94ae24f51bf42fc33a25a3ea5a401e3da313538bfa682bdf7"
 dependencies = [
  "arrayvec",
  "indexmap 1.9.3",
@@ -6644,9 +6665,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.177.30"
+version = "0.177.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a7827f522465f597d1dfd93ec8b3e389799c3d351058d0f4a272bce15c1e1a"
+checksum = "ee2323576600e67365ba75f6db9fa38d18d2227921cd5cec907a2bc5f3e8a51b"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -6671,9 +6692,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.195.29"
+version = "0.195.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a1cce15248d51fd3a1b4c8a638fda8e67ffab269a6ea2a53fb3e6a05d1ff2"
+checksum = "eb488266e2ed474b1315fee62396217fc62a505adfe4a29a65aa9985026e9d24"
 dependencies = [
  "dashmap",
  "indexmap 1.9.3",
@@ -6696,9 +6717,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.168.30"
+version = "0.168.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42afc0f6df25e37c46241fe86619a561ece47bb75317ff540da04ceba81ed707"
+checksum = "fa5d747160aca89b0496d0f3e5a3c7961e6f31d3b4f75a1ab52e050d894d0e12"
 dependencies = [
  "either",
  "rustc-hash",
@@ -6716,9 +6737,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.180.31"
+version = "0.180.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7ccd4ed6b3272dff18fb088b3030215c3dd1fdc44b0b3cac96dfcd459b67af"
+checksum = "21876e623cb894ca2d020c29003c8e5f619e7d345f6188eb53e39c2ce6dea783"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
@@ -6741,9 +6762,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.137.24"
+version = "0.137.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3929c8c9820a4277b801ac796f03deddc25134bd2e34a6973a00828c87aa8bdc"
+checksum = "1633020e7f46dd994e1f39c9365b852f25384cab56e527cbde645ba6742dba65"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -6767,9 +6788,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.185.28"
+version = "0.185.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74cfc6095f0e141595aa12845d6d2f93a73108c7eacc88f0e4dd472b74e41e58"
+checksum = "e64b6cf5505e05f4a3a9ef2fcb13bcd5147e16ce642a8a06f76270eb5a240434"
 dependencies = [
  "ryu-js",
  "serde",
@@ -6784,9 +6805,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.20.20"
+version = "0.20.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab9cbafaf2d28e1b45bad1e07bf97ab230f2cdc7cb4d494908b432f79cd1b"
+checksum = "e5fd3bb4cdb8813a7045eb569388386ab9a13317f5bef4a334cfe2e7018bbc29"
 dependencies = [
  "indexmap 1.9.3",
  "rustc-hash",
@@ -6801,9 +6822,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.124.19"
+version = "0.124.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055737e1189b2bac57aac998699b339ab839945058134ed28b7611c950e34071"
+checksum = "10584648054df1b174b0ce48070f1567996141c2549906eebd12467019752c00"
 dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
@@ -6820,9 +6841,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.96.6"
+version = "0.96.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c97d88354947ba36b21b355fccb75b5fba2a2db36f00bf8327a6728257662e4f"
+checksum = "21305b130986e771206c9f447c8040f9b3be47c9fbbb1f659904e223b8e1c007"
 dependencies = [
  "num-bigint",
  "serde",
@@ -6871,9 +6892,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.17.5"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbfad2ff99154d20b5dd9246290f162114c836cfe8532d8d0d4c116f49ee6ce"
+checksum = "4a80f674bef7baf65c979f684bbe9fa8f4e275e3b61589b62d6dc260331a102b"
 dependencies = [
  "anyhow",
  "miette",
@@ -6884,9 +6905,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.21.5"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175c7dced501083242106790d72119bebe84233bc24c26b59a70172967dc8231"
+checksum = "392047ce047ab6f9c02ef17e7e19627c0050fe6dbb0bccd2350a92664a859c62"
 dependencies = [
  "indexmap 1.9.3",
  "petgraph",
@@ -6896,9 +6917,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.22.7"
+version = "0.22.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7090c8d9faba1e3ff6ed8f88662ac89ce410cb70f87e940fe29a06099a07c83"
+checksum = "ebb1843242b0ee38517116da75576e13bcdcc8e08af288537e8745d480c31cfc"
 dependencies = [
  "auto_impl",
  "petgraph",
@@ -6921,9 +6942,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.20.5"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d8f8597eeb98dbcc7571af50bfa664d68b192a0e07c7b52643a3bfa720806"
+checksum = "249c6c5935bcea54025c5c767f33d89d650293288837b50113ac9c437e546450"
 dependencies = [
  "dashmap",
  "swc_atoms",
@@ -6957,9 +6978,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.39.6"
+version = "0.39.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2004e74d75a7bbbf5d6b89f2348e000825cb7eaf87d51966793729aa1bc56690"
+checksum = "e73aa3453e0026b009f35462b77f7dbc2e1b9a91cd92fae6f517802f3b6f4561"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -6971,9 +6992,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.104.14"
+version = "0.104.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1604548ed056f29dcc3dafa6dd131ac00fc752f4fc812a02ac34a448133a4e6"
+checksum = "b1ef2eb955ba87377bda7b17b7bb511b62d3c8e7b56c9481598f7821438df5e0"
 dependencies = [
  "anyhow",
  "enumset",
@@ -7013,9 +7034,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90c333bce29a3bc3ee694976cce0b08927f0939c494bb0e1650bfce3dba214"
+checksum = "388d9d8a67d907c9a5f69250a32134b80fa01c2c03b7fbfcdbb9e8d4ed18b3ed"
 dependencies = [
  "tracing",
 ]
@@ -7181,9 +7202,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.35.7"
+version = "0.35.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272f2b6de45b9ad1444af11a54077d9b2ec439357c44086da60ad8369db1b87e"
+checksum = "94fa85c2c4605cd16c3b358b125a23b36e01fe04a0ef687d22df97baa4b25fa8"
 dependencies = [
  "ansi_term",
  "cargo_metadata",
@@ -8001,7 +8022,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "auto-hash-map",
- "browserslist-rs",
+ "browserslist-rs 0.12.4",
  "futures",
  "indexmap 1.9.3",
  "lazy_static",
@@ -8343,7 +8364,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,3 +132,8 @@ url = "2.2.2"
 urlencoding = "2.1.2"
 webbrowser = "0.8.7"
 dhat = { version = "0.3.2" }
+
+
+[patch.crates-io]
+lightningcss = { git = "https://github.com/kdy1/lightningcss.git", branch = "derive-unsafe"}
+parcel_selectors = { git = "https://github.com/kdy1/lightningcss.git", branch = "derive-unsafe" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,3 @@ urlencoding = "2.1.2"
 webbrowser = "0.8.7"
 dhat = { version = "0.3.2" }
 
-
-[patch.crates-io]
-lightningcss = { git = "https://github.com/kdy1/lightningcss.git", branch = "derive-unsafe"}
-parcel_selectors = { git = "https://github.com/kdy1/lightningcss.git", branch = "derive-unsafe" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ next-transform-dynamic = { path = "packages/next-swc/crates/next-transform-dynam
 next-transform-strip-page-exports = { path = "packages/next-swc/crates/next-transform-strip-page-exports" }
 
 # SWC crates
-  swc_core = { version = "0.86.40", features = [
+  swc_core = { version = "0.86.60", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
-testing = { version = "0.35.7" }
+testing = { version = "0.35.10" }
 
 # Turbo crates
 turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231109.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ next-transform-strip-page-exports = { path = "packages/next-swc/crates/next-tran
 testing = { version = "0.35.10" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231109.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swap-css" } # last tag: "turbopack-231109.2"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231109.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swap-css" } # last tag: "turbopack-231109.2"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231109.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swap-css" } # last tag: "turbopack-231109.2"
 
 # General Deps
 

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -35,8 +35,8 @@ turbopack-binding = { workspace = true, features = [
   "__swc_transform_modularize_imports",
   "__swc_transform_relay",
 ] }
-react_remove_properties = "0.10.0"
-remove_console = "0.11.0"
+react_remove_properties = "0.11.0"
+remove_console = "0.12.0"
 
 [dev-dependencies]
 turbopack-binding = { workspace = true, features = [

--- a/packages/next-swc/crates/napi/src/next_api/utils.rs
+++ b/packages/next-swc/crates/napi/src/next_api/utils.rs
@@ -13,7 +13,7 @@ use turbopack_binding::{
     turbopack::core::{
         diagnostics::{Diagnostic, DiagnosticContextExt, PlainDiagnostic},
         error::PrettyPrintError,
-        issue::{IssueDescriptionExt, PlainIssue, PlainIssueSource, PlainSource},
+        issue::{IssueDescriptionExt, PlainIssue, PlainIssueSource, PlainSource, StyledString},
         source_pos::SourcePos,
     },
 };
@@ -101,7 +101,7 @@ pub struct NapiIssue {
     pub category: String,
     pub file_path: String,
     pub title: String,
-    pub description: String,
+    pub description: serde_json::Value,
     pub detail: String,
     pub source: Option<NapiIssueSource>,
     pub documentation_link: String,
@@ -111,7 +111,8 @@ pub struct NapiIssue {
 impl From<&PlainIssue> for NapiIssue {
     fn from(issue: &PlainIssue) -> Self {
         Self {
-            description: issue.description.clone(),
+            description: serde_json::to_value(Into::<NapiStyledString>::into(&issue.description))
+                .unwrap(),
             category: issue.category.clone(),
             file_path: issue.file_path.clone(),
             detail: issue.detail.clone(),
@@ -124,6 +125,38 @@ impl From<&PlainIssue> for NapiIssue {
                 .iter()
                 .map(|issue| (&**issue).into())
                 .collect(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum NapiStyledString {
+    Line { value: Vec<NapiStyledString> },
+    Stack { value: Vec<NapiStyledString> },
+    Text { value: String },
+    Code { value: String },
+    Strong { value: String },
+}
+
+impl From<&StyledString> for NapiStyledString {
+    fn from(value: &StyledString) -> Self {
+        match value {
+            StyledString::Line(parts) => NapiStyledString::Line {
+                value: parts.iter().map(|p| p.into()).collect(),
+            },
+            StyledString::Stack(parts) => NapiStyledString::Stack {
+                value: parts.iter().map(|p| p.into()).collect(),
+            },
+            StyledString::Text(string) => NapiStyledString::Text {
+                value: string.clone(),
+            },
+            StyledString::Code(string) => NapiStyledString::Code {
+                value: string.clone(),
+            },
+            StyledString::Strong(string) => NapiStyledString::Strong {
+                value: string.clone(),
+            },
         }
     }
 }

--- a/packages/next-swc/crates/next-core/src/app_segment_config.rs
+++ b/packages/next-swc/crates/next-core/src/app_segment_config.rs
@@ -13,7 +13,7 @@ use turbopack_binding::turbopack::{
     core::{
         file_source::FileSource,
         ident::AssetIdent,
-        issue::{Issue, IssueExt, IssueSeverity, IssueSource, OptionIssueSource},
+        issue::{Issue, IssueExt, IssueSeverity, IssueSource, OptionIssueSource, StyledString},
         source::Source,
     },
     ecmascript::{
@@ -178,12 +178,13 @@ impl Issue for NextSegmentConfigParsingIssue {
     }
 
     #[turbo_tasks::function]
-    fn description(&self) -> Vc<String> {
-        Vc::cell(
+    fn description(&self) -> Vc<StyledString> {
+        StyledString::Text(
             "The exported configuration object in a source file need to have a very specific \
              format from which some properties can be statically parsed at compiled-time."
                 .to_string(),
         )
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/packages/next-swc/crates/next-core/src/app_structure.rs
+++ b/packages/next-swc/crates/next-core/src/app_structure.rs
@@ -13,7 +13,7 @@ use turbo_tasks::{
 };
 use turbopack_binding::{
     turbo::tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPath},
-    turbopack::core::issue::{Issue, IssueExt, IssueSeverity},
+    turbopack::core::issue::{Issue, IssueExt, IssueSeverity, StyledString},
 };
 
 use crate::{
@@ -468,11 +468,12 @@ fn conflict_issue(
 
     DirectoryTreeIssue {
         app_dir,
-        message: Vc::cell(format!(
+        message: StyledString::Text(format!(
             "Conflicting {} at {}: {a} at {value_a} and {b} at {value_b}",
             item_names,
             e.key(),
-        )),
+        ))
+        .cell(),
         severity: IssueSeverity::Error.cell(),
     }
     .cell()
@@ -781,11 +782,12 @@ async fn directory_tree_to_loader_tree(
                 // TODO: improve error message to have the full paths
                 DirectoryTreeIssue {
                     app_dir,
-                    message: Vc::cell(format!(
+                    message: StyledString::Text(format!(
                         "You cannot have two parallel pages that resolve to the same path. Route \
                          {} has multiple matches in {}",
                         for_app_path, app_page
-                    )),
+                    ))
+                    .cell(),
                     severity: IssueSeverity::Error.cell(),
                 }
                 .cell()
@@ -1127,7 +1129,7 @@ pub async fn get_global_metadata(
 struct DirectoryTreeIssue {
     pub severity: Vc<IssueSeverity>,
     pub app_dir: Vc<FileSystemPath>,
-    pub message: Vc<String>,
+    pub message: Vc<StyledString>,
 }
 
 #[turbo_tasks::value_impl]
@@ -1155,7 +1157,7 @@ impl Issue for DirectoryTreeIssue {
     }
 
     #[turbo_tasks::function]
-    fn description(&self) -> Vc<String> {
+    fn description(&self) -> Vc<StyledString> {
         self.message
     }
 }

--- a/packages/next-swc/crates/next-core/src/babel.rs
+++ b/packages/next-swc/crates/next-core/src/babel.rs
@@ -4,7 +4,7 @@ use turbopack_binding::{
     turbo::tasks_fs::{FileSystemEntryType, FileSystemPath},
     turbopack::{
         core::{
-            issue::{Issue, IssueExt, IssueSeverity},
+            issue::{Issue, IssueExt, IssueSeverity, StyledString},
             resolve::{parse::Request, pattern::Pattern, resolve},
         },
         node::transforms::webpack::WebpackLoaderItem,
@@ -77,10 +77,11 @@ pub async fn maybe_add_babel_loader(
                             "Unable to resolve babel-loader, but a babel config is present"
                                 .to_owned(),
                         ),
-                        description: Vc::cell(
+                        description: StyledString::Text(
                             "Make sure babel-loader is installed via your package manager."
                                 .to_owned(),
-                        ),
+                        )
+                        .cell(),
                         severity: IssueSeverity::Fatal.cell(),
                     }
                     .cell()
@@ -143,7 +144,7 @@ pub async fn is_babel_loader_available(project_path: Vc<FileSystemPath>) -> Resu
 struct BabelIssue {
     path: Vc<FileSystemPath>,
     title: Vc<String>,
-    description: Vc<String>,
+    description: Vc<StyledString>,
     severity: Vc<IssueSeverity>,
 }
 
@@ -170,7 +171,7 @@ impl Issue for BabelIssue {
     }
 
     #[turbo_tasks::function]
-    fn description(&self) -> Vc<String> {
+    fn description(&self) -> Vc<StyledString> {
         self.description
     }
 }

--- a/packages/next-swc/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -77,6 +77,8 @@ impl ProcessCss for CssClientReferenceModule {
             bail!("CSS client reference client module must be CSS processable");
         };
 
+        dbg!("imp.get_css_with_placeholder");
+
         Ok(imp.get_css_with_placeholder())
     }
 
@@ -89,6 +91,8 @@ impl ProcessCss for CssClientReferenceModule {
         else {
             bail!("CSS client reference client module must be CSS processable");
         };
+
+        dbg!("imp.finalize_css");
 
         Ok(imp.finalize_css(chunking_context))
     }

--- a/packages/next-swc/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -3,10 +3,14 @@ use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
     core::{
         asset::{Asset, AssetContent},
+        chunk::ChunkingContext,
         ident::AssetIdent,
         module::Module,
     },
-    turbopack::css::{chunk::CssChunkPlaceable, ParseCss, ParseCssResult},
+    turbopack::css::{
+        chunk::CssChunkPlaceable, CssWithPlaceholderResult, FinalCssResult, ParseCss,
+        ParseCssResult, ProcessCss,
+    },
 };
 
 /// A [`CssClientReferenceModule`] is a marker module used to indicate which
@@ -61,5 +65,31 @@ impl ParseCss for CssClientReferenceModule {
         };
 
         Ok(parse_css.parse_css())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ProcessCss for CssClientReferenceModule {
+    #[turbo_tasks::function]
+    async fn get_css_with_placeholder(&self) -> Result<Vc<CssWithPlaceholderResult>> {
+        let Some(imp) = Vc::try_resolve_sidecast::<Box<dyn ProcessCss>>(self.client_module).await?
+        else {
+            bail!("CSS client reference client module must be CSS processable");
+        };
+
+        Ok(imp.get_css_with_placeholder())
+    }
+
+    #[turbo_tasks::function]
+    async fn finalize_css(
+        &self,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Result<Vc<FinalCssResult>> {
+        let Some(imp) = Vc::try_resolve_sidecast::<Box<dyn ProcessCss>>(self.client_module).await?
+        else {
+            bail!("CSS client reference client module must be CSS processable");
+        };
+
+        Ok(imp.finalize_css(chunking_context))
     }
 }

--- a/packages/next-swc/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -77,8 +77,6 @@ impl ProcessCss for CssClientReferenceModule {
             bail!("CSS client reference client module must be CSS processable");
         };
 
-        dbg!("imp.get_css_with_placeholder");
-
         Ok(imp.get_css_with_placeholder())
     }
 
@@ -91,8 +89,6 @@ impl ProcessCss for CssClientReferenceModule {
         else {
             bail!("CSS client reference client module must be CSS processable");
         };
-
-        dbg!("imp.finalize_css");
 
         Ok(imp.finalize_css(chunking_context))
     }

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -12,7 +12,7 @@ use turbopack_binding::{
             context::AssetContext,
             file_source::FileSource,
             ident::AssetIdent,
-            issue::{Issue, IssueDescriptionExt, IssueExt, IssueSeverity},
+            issue::{Issue, IssueDescriptionExt, IssueExt, IssueSeverity, StyledString},
             reference_type::{EntryReferenceSubType, InnerAssets, ReferenceType},
             resolve::{
                 find_context_file,
@@ -967,7 +967,7 @@ impl Issue for OutdatedConfigIssue {
     }
 
     #[turbo_tasks::function]
-    fn description(&self) -> Vc<String> {
-        Vc::cell(self.description.to_string())
+    fn description(&self) -> Vc<StyledString> {
+        StyledString::Text(self.description.to_string()).cell()
     }
 }

--- a/packages/next-swc/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/font_fallback.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use turbo_tasks::{trace::TraceRawVcs, Vc};
 use turbopack_binding::{
     turbo::tasks_fs::FileSystemPath,
-    turbopack::core::issue::{IssueExt, IssueSeverity},
+    turbopack::core::issue::{IssueExt, IssueSeverity, StyledString},
 };
 
 use super::options::NextFontGoogleOptions;
@@ -86,7 +86,10 @@ pub(super) async fn get_font_fallback(
                             "Failed to find font override values for font `{}`",
                             &options.font_family,
                         )),
-                        description: Vc::cell("Skipping generating a fallback font.".to_owned()),
+                        description: StyledString::Text(
+                            "Skipping generating a fallback font.".to_owned(),
+                        )
+                        .cell(),
                         severity: IssueSeverity::Warning.cell(),
                     }
                     .cell()

--- a/packages/next-swc/crates/next-core/src/next_font/issue.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/issue.rs
@@ -1,14 +1,14 @@
 use turbo_tasks::Vc;
 use turbopack_binding::{
     turbo::tasks_fs::FileSystemPath,
-    turbopack::core::issue::{Issue, IssueSeverity},
+    turbopack::core::issue::{Issue, IssueSeverity, StyledString},
 };
 
 #[turbo_tasks::value(shared)]
 pub(crate) struct NextFontIssue {
     pub(crate) path: Vc<FileSystemPath>,
     pub(crate) title: Vc<String>,
-    pub(crate) description: Vc<String>,
+    pub(crate) description: Vc<StyledString>,
     pub(crate) severity: Vc<IssueSeverity>,
 }
 
@@ -35,7 +35,7 @@ impl Issue for NextFontIssue {
     }
 
     #[turbo_tasks::function]
-    fn description(&self) -> Vc<String> {
+    fn description(&self) -> Vc<StyledString> {
         self.description
     }
 }

--- a/packages/next-swc/crates/next-core/src/next_font/local/stylesheet.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/local/stylesheet.rs
@@ -59,7 +59,7 @@ pub(super) async fn build_font_face_definitions(
             }}
         "#,
             *scoped_font_family.await?,
-            &font.path,
+            &font.path.replace("/index.ts/", "/"),
             ext_to_format(&font.ext)?,
             options.display,
             &font

--- a/packages/next-swc/crates/next-core/src/next_font/local/stylesheet.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/local/stylesheet.rs
@@ -59,7 +59,7 @@ pub(super) async fn build_font_face_definitions(
             }}
         "#,
             *scoped_font_family.await?,
-            &font.path.replace("/index.ts/", "/"),
+            &font.path,
             ext_to_format(&font.ext)?,
             options.display,
             &font

--- a/packages/next-swc/crates/next-core/src/util.rs
+++ b/packages/next-swc/crates/next-core/src/util.rs
@@ -12,7 +12,7 @@ use turbopack_binding::{
             asset::AssetContent,
             environment::{ServerAddr, ServerInfo},
             ident::AssetIdent,
-            issue::{Issue, IssueExt, IssueSeverity},
+            issue::{Issue, IssueExt, IssueSeverity, StyledString},
             module::Module,
             source::Source,
             virtual_source::VirtualSource,
@@ -191,12 +191,13 @@ impl Issue for NextSourceConfigParsingIssue {
     }
 
     #[turbo_tasks::function]
-    fn description(&self) -> Vc<String> {
-        Vc::cell(
+    fn description(&self) -> Vc<StyledString> {
+        StyledString::Text(
             "The exported configuration object in a source file need to have a very specific \
              format from which some properties can be statically parsed at compiled-time."
                 .to_string(),
         )
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -193,7 +193,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231109.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0412a5f72d36d00a68db27215d18baa1972f519b",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -473,12 +473,34 @@ export interface TurboEngineOptions {
   memoryLimit?: number
 }
 
+export type StyledString =
+  | {
+      type: 'text'
+      value: string
+    }
+  | {
+      type: 'code'
+      value: string
+    }
+  | {
+      type: 'strong'
+      value: string
+    }
+  | {
+      type: 'stack'
+      value: StyledString[]
+    }
+  | {
+      type: 'line'
+      value: StyledString[]
+    }
+
 export interface Issue {
   severity: string
   category: string
   filePath: string
   title: string
-  description: string
+  description: StyledString
   detail: string
   source?: {
     source: {

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -6,6 +6,7 @@ import type {
   WrittenEndpoint,
   Issue,
   Project,
+  StyledString,
 } from '../../../build/swc'
 import type { Socket } from 'net'
 import type { FilesystemDynamicRoute } from './filesystem'
@@ -126,6 +127,7 @@ import type { ActionManifest } from '../../../build/webpack/plugins/flight-clien
 import { denormalizePagePath } from '../../../shared/lib/page-path/denormalize-page-path'
 import type { LoadableManifest } from '../../load-components'
 import { generateRandomActionKeyRaw } from '../../app-render/action-encryption-utils'
+import { bold, green, red } from '../../../lib/picocolors'
 
 const wsServer = new ws.Server({ noServer: true })
 
@@ -285,44 +287,52 @@ async function startWatcher(opts: SetupOpts) {
     function formatIssue(issue: Issue) {
       const { filePath, title, description, source, detail } = issue
       let formattedTitle = title.replace(/\n/g, '\n    ')
-      let message = ''
 
       let formattedFilePath = filePath
         .replace('[project]/', '')
         .replaceAll('/./', '/')
         .replace('\\\\?\\', '')
 
+      let message
+
       if (source) {
         if (source.range) {
-          const { start, end } = source.range
+          const { start } = source.range
           message = `${issue.severity} - ${formattedFilePath}:${
             start.line + 1
-          }:${start.column}  ${formattedTitle}`
-
-          if (source.source.content) {
-            const {
-              codeFrameColumns,
-            } = require('next/dist/compiled/babel/code-frame')
-            message +=
-              '\n\n' +
-              codeFrameColumns(
-                source.source.content,
-                {
-                  start: { line: start.line + 1, column: start.column + 1 },
-                  end: { line: end.line + 1, column: end.column + 1 },
-                },
-                { forceColor: true }
-              )
-          }
+          }:${start.column}`
         } else {
           message = `${issue.severity} - ${formattedFilePath}  ${formattedTitle}`
         }
       } else {
         message = `${formattedTitle}`
       }
-      if (description) {
-        message += `\n${description.replace(/\n/g, '\n    ')}`
+
+      if (source?.range && source.source.content) {
+        const { start, end } = source.range
+        const {
+          codeFrameColumns,
+        } = require('next/dist/compiled/babel/code-frame')
+
+        message +=
+          '\n\n' +
+          codeFrameColumns(
+            source.source.content,
+            {
+              start: { line: start.line + 1, column: start.column + 1 },
+              end: { line: end.line + 1, column: end.column + 1 },
+            },
+            { forceColor: true }
+          )
       }
+
+      if (description) {
+        message += `\n${renderStyledStringToErrorAnsi(description).replace(
+          /\n/g,
+          '\n    '
+        )}`
+      }
+
       if (detail) {
         message += `\n${detail.replace(/\n/g, '\n    ')}`
       }
@@ -2489,3 +2499,29 @@ export async function setupDevBundler(opts: SetupOpts) {
 }
 
 export type DevBundler = Awaited<ReturnType<typeof setupDevBundler>>
+
+function renderStyledStringToErrorAnsi(string: StyledString): string {
+  switch (string.type) {
+    case 'text':
+      return string.value
+    case 'strong':
+      return bold(red(string.value))
+    case 'code':
+      return green(string.value)
+    case 'line': {
+      let line = ''
+      for (const styled of string.value) {
+        line += renderStyledStringToErrorAnsi(styled)
+      }
+      return line + '\n'
+    }
+    case 'stack':
+      let stack = ''
+      for (const styled of string.value) {
+        stack += renderStyledStringToErrorAnsi(styled) + '\n'
+      }
+      return stack + '\n'
+    default:
+      throw new Error('Unknown StyledString type', string)
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1065,8 +1065,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231109.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231109.2(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0412a5f72d36d00a68db27215d18baa1972f519b
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0412a5f72d36d00a68db27215d18baa1972f519b(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -24646,9 +24646,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231109.2(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231109.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231109.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0412a5f72d36d00a68db27215d18baa1972f519b(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0412a5f72d36d00a68db27215d18baa1972f519b}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?0412a5f72d36d00a68db27215d18baa1972f519b'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

Use `lightningcss` instead

### Why?

For matainenance

### How?

Closes NEXT-
Fixes #

Turbopack counterpart: https://github.com/vercel/turbo/pull/5737

Closes WEB-1842