### PR TITLE
test(turbopack): update test manifest

### DIFF
--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -3078,10 +3078,10 @@
     "runtimeError": false
   },
   "test/e2e/app-dir/emotion-js/index.test.ts": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "app dir - emotion-js should render emotion-js css with compiler.emotion option correctly"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What

Enabling test from https://github.com/vercel/next.js/pull/57300. There may be some other test cases passing by fix, but this is the known direct offending test can be enabled.

Closes WEB-1847