### PR TITLE
Refactor swc options

### DIFF
--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -47,8 +47,7 @@ use turbopack_binding::swc::{
             SyntaxContext,
         },
         ecma::{
-            ast::EsVersion, atoms::JsWord, parser::parse_file_as_module,
-            transforms::base::pass::noop, visit::Fold,
+            ast::EsVersion, parser::parse_file_as_module, transforms::base::pass::noop, visit::Fold,
         },
     },
     custom_transform::modularize_imports,
@@ -94,10 +93,7 @@ pub struct TransformOptions {
     pub is_development: bool,
 
     #[serde(default)]
-    pub is_server: bool,
-
-    #[serde(default)]
-    pub bundle_target: JsWord,
+    pub is_server_compiler: bool,
 
     #[serde(default)]
     pub server_components: Option<react_server_components::Config>,
@@ -198,7 +194,6 @@ where
                     config.clone(),
                     comments.clone(),
                     opts.app_dir.clone(),
-                    opts.bundle_target.clone()
                 )),
             _ => Either::Right(noop()),
         },
@@ -230,7 +225,7 @@ where
         amp_attributes::amp_attributes(),
         next_dynamic(
             opts.is_development,
-            opts.is_server,
+            opts.is_server_compiler,
             match &opts.server_components {
                 Some(config) if config.truthy() => match config {
                     // Always enable the Server Components mode for both

--- a/packages/next-swc/crates/core/src/react_server_components.rs
+++ b/packages/next-swc/crates/core/src/react_server_components.rs
@@ -37,11 +37,11 @@ impl Config {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Options {
-    pub is_server: bool,
+    pub is_react_server_layer: bool,
 }
 
 struct ReactServerComponents<C: Comments> {
-    is_server: bool,
+    is_react_server_layer: bool,
     filepath: String,
     app_dir: Option<PathBuf>,
     comments: C,
@@ -50,7 +50,6 @@ struct ReactServerComponents<C: Comments> {
     invalid_client_imports: Vec<JsWord>,
     invalid_server_react_apis: Vec<JsWord>,
     invalid_server_react_dom_apis: Vec<JsWord>,
-    bundle_target: String,
 }
 
 struct ModuleImports {
@@ -66,11 +65,11 @@ impl<C: Comments> VisitMut for ReactServerComponents<C> {
             self.collect_top_level_directives_and_imports(module);
         let is_cjs = contains_cjs(module);
 
-        if self.is_server {
+        if self.is_react_server_layer {
             if is_client_entry {
                 self.to_module_ref(module, is_cjs);
                 return;
-            } else if self.bundle_target == "server" {
+            } else {
                 // Only assert server graph if file's bundle target is "server", e.g.
                 // * server components pages
                 // * pages bundles on SSR layer
@@ -83,7 +82,7 @@ impl<C: Comments> VisitMut for ReactServerComponents<C> {
             // and bundle target is "client" e.g.
             // * client components pages
             // * pages bundles on browser layer
-            if !is_action_file && self.bundle_target == "client" {
+            if !is_action_file {
                 self.assert_client_graph(&imports);
                 self.assert_invalid_api(module, true);
             }
@@ -139,7 +138,7 @@ impl<C: Comments> ReactServerComponents<C> {
                                             if is_action_file {
                                                 panic_both_directives(expr_stmt.span)
                                             }
-                                        } else if self.bundle_target != "default" {
+                                        } else {
                                             HANDLER.with(|handler| {
                                                 handler
                                                     .struct_span_err(
@@ -588,17 +587,15 @@ pub fn server_components<C: Comments>(
     config: Config,
     comments: C,
     app_dir: Option<PathBuf>,
-    bundle_target: JsWord,
 ) -> impl Fold + VisitMut {
-    let is_server: bool = match &config {
-        Config::WithOptions(x) => x.is_server,
-        _ => true,
+    let is_react_server_layer: bool = match &config {
+        Config::WithOptions(x) => x.is_react_server_layer,
+        _ => false,
     };
     as_folder(ReactServerComponents {
-        is_server,
+        is_react_server_layer,
         comments,
         filepath: filename.to_string(),
-        bundle_target: bundle_target.to_string(),
         app_dir,
         export_names: vec![],
         invalid_server_imports: vec![

--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -24,7 +24,7 @@ use turbopack_binding::swc::core::{
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Config {
-    pub is_server: bool,
+    pub is_react_server_layer: bool,
     pub enabled: bool,
 }
 
@@ -141,7 +141,7 @@ impl<C: Comments> ServerActions<C> {
                     self.config.enabled,
                 );
 
-                if is_action_fn && !self.config.is_server {
+                if is_action_fn && !self.config.is_react_server_layer {
                     HANDLER.with(|handler| {
                         handler
                             .struct_span_err(
@@ -1029,7 +1029,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
 
             stmt.visit_mut_with(self);
 
-            if self.config.is_server || !self.in_action_file {
+            if self.config.is_react_server_layer || !self.in_action_file {
                 new.push(stmt);
                 new.extend(self.annotations.drain(..).map(ModuleItem::Stmt));
                 new.append(&mut self.extra_items);
@@ -1041,7 +1041,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             // If it's compiled in the client layer, each export field needs to be
             // wrapped by a reference creation call.
             let create_ref_ident = private_ident!("createServerReference");
-            if !self.config.is_server {
+            if !self.config.is_react_server_layer {
                 // import { createServerReference } from
                 // 'private-next-rsc-action-client-wrapper'
                 // createServerReference("action_id")
@@ -1066,7 +1066,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             for (id, export_name) in self.exported_idents.iter() {
                 let ident = Ident::new(id.0.clone(), DUMMY_SP.with_ctxt(id.1));
 
-                if !self.config.is_server {
+                if !self.config.is_react_server_layer {
                     let action_id = generate_action_id(&self.file_name, export_name);
 
                     if export_name == "default" {
@@ -1123,7 +1123,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                 }
             }
 
-            if self.config.is_server {
+            if self.config.is_react_server_layer {
                 new.append(&mut self.extra_items);
 
                 // Ensure that the exports are valid by appending a check
@@ -1219,7 +1219,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             })));
 
             // Encryption and decryption only happens on the server layer.
-            if self.config.is_server {
+            if self.config.is_react_server_layer {
                 // import { encryptActionBoundArgs, decryptActionBoundArgs } from
                 // 'private-next-rsc-action-encryption'
                 new.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {

--- a/packages/next-swc/crates/core/tests/errors.rs
+++ b/packages/next-swc/crates/core/tests/errors.rs
@@ -94,7 +94,9 @@ fn react_server_components_server_graph_errors(input: PathBuf) {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/layout.js")),
                 next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options { is_server: true },
+                    next_swc::react_server_components::Options {
+                        is_react_server_layer: true,
+                    },
                 ),
                 tr.comments.as_ref().clone(),
                 None,
@@ -119,7 +121,9 @@ fn react_server_components_client_graph_errors(input: PathBuf) {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/page.js")),
                 next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options { is_server: false },
+                    next_swc::react_server_components::Options {
+                        is_react_server_layer: false,
+                    },
                 ),
                 tr.comments.as_ref().clone(),
                 None,
@@ -166,16 +170,17 @@ fn react_server_actions_server_errors(input: PathBuf) {
                 server_components(
                     FileName::Real(PathBuf::from("/app/item.js")),
                     next_swc::react_server_components::Config::WithOptions(
-                        next_swc::react_server_components::Options { is_server: true },
+                        next_swc::react_server_components::Options {
+                            is_react_server_layer: true
+                        },
                     ),
                     tr.comments.as_ref().clone(),
                     None,
-                    String::from("default").into(),
                 ),
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
                     server_actions::Config {
-                        is_server: true,
+                        is_react_server_layer: true,
                         enabled: true
                     },
                     tr.comments.as_ref().clone(),
@@ -202,7 +207,9 @@ fn react_server_actions_client_errors(input: PathBuf) {
                 server_components(
                     FileName::Real(PathBuf::from("/app/item.js")),
                     next_swc::react_server_components::Config::WithOptions(
-                        next_swc::react_server_components::Options { is_server: false },
+                        next_swc::react_server_components::Options {
+                            is_react_server_layer: false
+                        },
                     ),
                     tr.comments.as_ref().clone(),
                     None,
@@ -211,7 +218,7 @@ fn react_server_actions_client_errors(input: PathBuf) {
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
                     server_actions::Config {
-                        is_server: false,
+                        is_react_server_layer: false,
                         enabled: true
                     },
                     tr.comments.as_ref().clone(),

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -285,11 +285,12 @@ fn react_server_components_server_graph_fixture(input: PathBuf) {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options { is_server: true },
+                    next_swc::react_server_components::Options {
+                        is_react_server_layer: true,
+                    },
                 ),
                 tr.comments.as_ref().clone(),
                 None,
-                String::from("default").into(),
             )
         },
         &input,
@@ -307,11 +308,12 @@ fn react_server_components_no_checks_server_graph_fixture(input: PathBuf) {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options { is_server: true },
+                    next_swc::react_server_components::Options {
+                        is_react_server_layer: true,
+                    },
                 ),
                 tr.comments.as_ref().clone(),
                 None,
-                String::from("default").into(),
             )
         },
         &input,
@@ -329,11 +331,12 @@ fn react_server_components_client_graph_fixture(input: PathBuf) {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options { is_server: false },
+                    next_swc::react_server_components::Options {
+                        is_react_server_layer: false,
+                    },
                 ),
                 tr.comments.as_ref().clone(),
                 None,
-                String::from("default").into(),
             )
         },
         &input,
@@ -351,11 +354,12 @@ fn react_server_components_no_checks_client_graph_fixture(input: PathBuf) {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options { is_server: false },
+                    next_swc::react_server_components::Options {
+                        is_react_server_layer: false,
+                    },
                 ),
                 tr.comments.as_ref().clone(),
                 None,
-                String::from("default").into(),
             )
         },
         &input,
@@ -392,7 +396,7 @@ fn server_actions_server_fixture(input: PathBuf) {
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
                     server_actions::Config {
-                        is_server: true,
+                        is_react_server_layer: true,
                         enabled: true
                     },
                     _tr.comments.as_ref().clone(),
@@ -416,7 +420,7 @@ fn server_actions_client_fixture(input: PathBuf) {
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
                     server_actions::Config {
-                        is_server: false,
+                        is_react_server_layer: false,
                         enabled: true
                     },
                     _tr.comments.as_ref().clone(),

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/output-server.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/output-server.js
@@ -5,7 +5,7 @@ const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hell
             "some-file.js -> " + "../components/hello"
         ]
     },
-    loading: ()=><p >...</p>
+    loading: ()=><p>...</p>
 });
 const DynamicClientOnlyComponent = dynamic(null, {
     loadableGenerated: {
@@ -15,7 +15,7 @@ const DynamicClientOnlyComponent = dynamic(null, {
     },
     ssr: false
 });
-const DynamicClientOnlyComponentWithSuspense = dynamic(null, {
+const DynamicClientOnlyComponentWithSuspense = dynamic(()=>import('../components/hello'), {
     loadableGenerated: {
         modules: [
             "some-file.js -> " + "../components/hello"

--- a/packages/next-swc/crates/core/tests/full.rs
+++ b/packages/next-swc/crates/core/tests/full.rs
@@ -64,7 +64,7 @@ fn test(input: &Path, minify: bool) {
                 pages_dir: None,
                 is_page_file: false,
                 is_development: true,
-                is_server: false,
+                is_server_compiler: false,
                 server_components: None,
                 styled_components: Some(assert_json("{}")),
                 styled_jsx: Some(assert_json("{}")),
@@ -81,7 +81,6 @@ fn test(input: &Path, minify: bool) {
                 auto_modularize_imports: None,
                 optimize_barrel_exports: None,
                 optimize_server_react: None,
-                bundle_target: String::from("default").into(),
             };
 
             let unresolved_mark = Mark::new();

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -24,14 +24,14 @@ use crate::mode::NextMode;
 
 /// Returns a rule which applies the Next.js dynamic transform.
 pub async fn get_next_dynamic_transform_rule(
-    is_server: bool,
-    is_server_components: bool,
+    is_server_compiler: bool,
+    is_react_server_layer: bool,
     pages_dir: Option<Vc<FileSystemPath>>,
     mode: NextMode,
 ) -> Result<ModuleRule> {
     let dynamic_transform = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextJsDynamic {
-        is_server,
-        is_server_components,
+        is_server_compiler,
+        is_react_server_layer,
         pages_dir: match pages_dir {
             None => None,
             Some(path) => Some(path.await?.path.clone().into()),
@@ -48,8 +48,8 @@ pub async fn get_next_dynamic_transform_rule(
 
 #[derive(Debug)]
 struct NextJsDynamic {
-    is_server: bool,
-    is_server_components: bool,
+    is_server_compiler: bool,
+    is_react_server_layer: bool,
     pages_dir: Option<PathBuf>,
     mode: NextMode,
 }
@@ -63,8 +63,8 @@ impl CustomTransformer for NextJsDynamic {
                 NextMode::Development => true,
                 NextMode::Build => false,
             },
-            self.is_server,
-            self.is_server_components,
+            self.is_server_compiler,
+            self.is_react_server_layer,
             NextDynamicMode::Webpack,
             FileName::Real(ctx.file_path_str.into()),
             self.pages_dir.clone(),

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -42,7 +42,7 @@ impl CustomTransformer for NextServerActions {
         let mut actions = server_actions(
             &FileName::Real(ctx.file_path_str.into()),
             Config {
-                is_server: matches!(self.transform, ActionsTransform::Server),
+                is_react_server_layer: matches!(self.transform, ActionsTransform::Server),
                 enabled: true,
             },
             ctx.comments.clone(),

--- a/packages/next-swc/crates/next-transform-dynamic/src/lib.rs
+++ b/packages/next-swc/crates/next-transform-dynamic/src/lib.rs
@@ -26,16 +26,16 @@ use swc_core::{
 /// with current loadable manifest, which causes hydration errors.
 pub fn next_dynamic(
     is_development: bool,
-    is_server: bool,
-    is_server_components: bool,
+    is_server_compiler: bool,
+    is_react_server_layer: bool,
     mode: NextDynamicMode,
     filename: FileName,
     pages_dir: Option<PathBuf>,
 ) -> impl Fold {
     NextDynamicPatcher {
         is_development,
-        is_server,
-        is_server_components,
+        is_server_compiler,
+        is_react_server_layer,
         pages_dir,
         filename,
         dynamic_bindings: vec![],
@@ -79,8 +79,8 @@ pub enum NextDynamicMode {
 #[derive(Debug)]
 struct NextDynamicPatcher {
     is_development: bool,
-    is_server: bool,
-    is_server_components: bool,
+    is_server_compiler: bool,
+    is_react_server_layer: bool,
     pages_dir: Option<PathBuf>,
     filename: FileName,
     dynamic_bindings: Vec<Id>,
@@ -228,7 +228,7 @@ impl Fold for NextDynamicPatcher {
                         span: DUMMY_SP,
                         props: match &mut self.state {
                             NextDynamicPatcherState::Webpack => {
-                                if self.is_development || self.is_server {
+                                if self.is_development || self.is_server_compiler {
                                     module_id_options(quote!(
                                         "$left + $right" as Expr,
                                         left: Expr = format!(
@@ -249,7 +249,7 @@ impl Fold for NextDynamicPatcher {
                                 let id_ident =
                                     private_ident!(dynamically_imported_specifier_span, "id");
 
-                                match (self.is_development, self.is_server) {
+                                match (self.is_development, self.is_server_compiler) {
                                     (true, true) => {
                                         let chunks_ident = private_ident!(
                                             dynamically_imported_specifier_span,
@@ -383,8 +383,8 @@ impl Fold for NextDynamicPatcher {
                     // React.lazy implementation.
                     if has_ssr_false
                         && !has_suspense
-                        && self.is_server
-                        && !self.is_server_components
+                        && self.is_server_compiler
+                        && !self.is_react_server_layer
                     {
                         expr.args[0] = Lit::Null(Null { span: DUMMY_SP }).as_arg();
                     }

--- a/packages/next-swc/crates/next-transform-dynamic/tests/fixture.rs
+++ b/packages/next-swc/crates/next-transform-dynamic/tests/fixture.rs
@@ -100,8 +100,8 @@ fn next_dynamic_fixture_run(
     input: &Path,
     output: &str,
     is_development: bool,
-    is_server: bool,
-    is_server_components: bool,
+    is_server_compiler: bool,
+    is_react_server_layer: bool,
     mode: NextDynamicMode,
 ) {
     let output = input.parent().unwrap().join(output);
@@ -110,8 +110,8 @@ fn next_dynamic_fixture_run(
         &|_tr| {
             next_dynamic(
                 is_development,
-                is_server,
-                is_server_components,
+                is_server_compiler,
+                is_react_server_layer,
                 mode.clone(),
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 Some("/some-project/src".into()),

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -61,7 +61,7 @@ const SERVER_ACTION_DIRECTIVE = 'use server'
 export type RSCModuleType = 'server' | 'client'
 export function getRSCModuleInformation(
   source: string,
-  isServerLayer: boolean
+  isReactServerLayer: boolean
 ): RSCMeta {
   const actionsJson = source.match(ACTION_MODULE_LABEL)
   const actions = actionsJson
@@ -70,7 +70,7 @@ export function getRSCModuleInformation(
   const clientInfoMatch = source.match(CLIENT_MODULE_LABEL)
   const isClientRef = !!clientInfoMatch
 
-  if (!isServerLayer) {
+  if (!isReactServerLayer) {
     return {
       type: RSC_MODULE_TYPES.client,
       actions,

--- a/packages/next/src/build/jest/jest.ts
+++ b/packages/next/src/build/jest/jest.ts
@@ -65,7 +65,7 @@ export default function nextJest(options: { dir?: string } = {}) {
       let resolvedBaseUrl
       let isEsmProject = false
       let pagesDir: string | undefined
-      let hasServerComponents: boolean | undefined
+      let serverComponents: boolean | undefined
 
       if (options.dir) {
         const resolvedDir = resolve(options.dir)
@@ -74,7 +74,7 @@ export default function nextJest(options: { dir?: string } = {}) {
 
         nextConfig = await getConfig(resolvedDir)
         const findPagesDirResult = findPagesDir(resolvedDir)
-        hasServerComponents = !!findPagesDirResult.appDir
+        serverComponents = !!findPagesDirResult.appDir
         pagesDir = findPagesDirResult.pagesDir
         setUpEnv(resolvedDir)
         // TODO: revisit when bug in SWC is fixed that strips `.css`
@@ -103,7 +103,7 @@ export default function nextJest(options: { dir?: string } = {}) {
         compilerOptions: nextConfig?.compiler,
         jsConfig,
         resolvedBaseUrl,
-        hasServerComponents,
+        serverComponents,
         isEsmProject,
         pagesDir,
       }

--- a/packages/next/src/build/swc/jest-transformer.ts
+++ b/packages/next/src/build/swc/jest-transformer.ts
@@ -42,7 +42,7 @@ export interface JestTransformerConfig extends TransformerConfig {
   jsConfig: any
   resolvedBaseUrl?: string
   pagesDir?: string
-  hasServerComponents?: boolean
+  serverComponents?: boolean
   isEsmProject: boolean
   modularizeImports?: NextConfig['modularizeImports']
   swcPlugins: ExperimentalConfig['swcPlugins']
@@ -91,7 +91,7 @@ const createTransformer: TransformerCreator<
       jsConfig: inputOptions?.jsConfig,
       resolvedBaseUrl: inputOptions?.resolvedBaseUrl,
       pagesDir: inputOptions?.pagesDir,
-      hasServerComponents: inputOptions?.hasServerComponents,
+      serverComponents: inputOptions?.serverComponents,
       modularizeImports: inputOptions?.modularizeImports,
       swcPlugins: inputOptions?.swcPlugins,
       compilerOptions: inputOptions?.compilerOptions,

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -5,8 +5,6 @@ import type {
   StyledComponentsConfig,
 } from '../../server/config-shared'
 
-export type BundleType = 'client' | 'server' | 'default'
-
 const nextDistPath =
   /(next[\\/]dist[\\/]shared[\\/]lib)|(next[\\/]dist[\\/]client)|(next[\\/]dist[\\/]pages)/
 

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -45,8 +45,7 @@ function getBaseSWCOptions({
   swcCacheDir,
   serverComponents,
   isReactServerLayer,
-}: // bundleTarget,
-{
+}: {
   filename: string
   jest?: boolean
   development: boolean
@@ -57,7 +56,6 @@ function getBaseSWCOptions({
   swcPlugins: ExperimentalConfig['swcPlugins']
   resolvedBaseUrl?: string
   jsConfig: any
-  // bundleTarget: BundleType
   swcCacheDir?: string
   serverComponents?: boolean
   isReactServerLayer?: boolean
@@ -263,6 +261,7 @@ export function getJestSWCOptions({
   jsConfig: any
   resolvedBaseUrl?: string
   pagesDir?: string
+  serverComponents?: boolean
 }) {
   let baseOptions = getBaseSWCOptions({
     filename,
@@ -274,8 +273,11 @@ export function getJestSWCOptions({
     swcPlugins,
     compilerOptions,
     jsConfig,
-    isReactServerLayer: false,
     resolvedBaseUrl,
+    // Don't apply server layer transformations for Jest
+    isReactServerLayer: false,
+    // Disable server / client graph assertions for Jest
+    serverComponents: false,
   })
 
   const isNextDist = nextDistPath.test(filename)

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -43,10 +43,10 @@ function getBaseSWCOptions({
   resolvedBaseUrl,
   jsConfig,
   swcCacheDir,
-  isServerLayer,
-  bundleTarget,
-  hasServerComponents,
-}: {
+  serverComponents,
+  isReactServerLayer,
+}: // bundleTarget,
+{
   filename: string
   jest?: boolean
   development: boolean
@@ -57,10 +57,10 @@ function getBaseSWCOptions({
   swcPlugins: ExperimentalConfig['swcPlugins']
   resolvedBaseUrl?: string
   jsConfig: any
-  bundleTarget: BundleType
+  // bundleTarget: BundleType
   swcCacheDir?: string
-  isServerLayer?: boolean
-  hasServerComponents?: boolean
+  serverComponents?: boolean
+  isReactServerLayer?: boolean
 }) {
   const parserConfig = getParserOptions({ filename, jsConfig })
   const paths = jsConfig?.compilerOptions?.paths
@@ -108,7 +108,7 @@ function getBaseSWCOptions({
         react: {
           importSource:
             jsConfig?.compilerOptions?.jsxImportSource ??
-            (compilerOptions?.emotion && !isServerLayer
+            (compilerOptions?.emotion && !isReactServerLayer
               ? '@emotion/react'
               : 'react'),
           runtime: 'automatic',
@@ -167,7 +167,7 @@ function getBaseSWCOptions({
     // Always transform styled-jsx and error when `client-only` condition is triggered
     styledJsx: {},
     // Disable css-in-js libs (without client-only integration) transform on server layer for server components
-    ...(!isServerLayer && {
+    ...(!isReactServerLayer && {
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       emotion: getEmotionOptions(compilerOptions?.emotion, development),
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -177,15 +177,20 @@ function getBaseSWCOptions({
       ),
     }),
     serverComponents:
-      hasServerComponents && !jest ? { isServer: !!isServerLayer } : undefined,
-    serverActions:
-      hasServerComponents && !jest
+      serverComponents && !jest
         ? {
-            enabled: true,
-            isServer: !!isServerLayer,
+            isReactServerLayer: !!isReactServerLayer,
           }
         : undefined,
-    bundleTarget,
+    serverActions:
+      serverComponents && !jest
+        ? {
+            // always enable server actions
+            // TODO: remove this option
+            enabled: true,
+            isReactServerLayer: !!isReactServerLayer,
+          }
+        : undefined,
   }
 }
 
@@ -248,7 +253,6 @@ export function getJestSWCOptions({
   jsConfig,
   resolvedBaseUrl,
   pagesDir,
-  hasServerComponents,
 }: {
   isServer: boolean
   filename: string
@@ -259,7 +263,6 @@ export function getJestSWCOptions({
   jsConfig: any
   resolvedBaseUrl?: string
   pagesDir?: string
-  hasServerComponents?: boolean
 }) {
   let baseOptions = getBaseSWCOptions({
     filename,
@@ -271,12 +274,8 @@ export function getJestSWCOptions({
     swcPlugins,
     compilerOptions,
     jsConfig,
-    hasServerComponents,
+    isReactServerLayer: false,
     resolvedBaseUrl,
-    // Don't apply server layer transformations for Jest
-    isServerLayer: false,
-    // Disable server / client graph assertions for Jest
-    bundleTarget: 'default',
   })
 
   const isNextDist = nextDistPath.test(filename)
@@ -315,9 +314,8 @@ export function getLoaderSWCOptions({
   supportedBrowsers,
   swcCacheDir,
   relativeFilePathFromRoot,
-  hasServerComponents,
-  isServerLayer,
-  bundleTarget,
+  serverComponents,
+  isReactServerLayer,
 }: // This is not passed yet as "paths" resolving is handled by webpack currently.
 // resolvedBaseUrl,
 {
@@ -339,9 +337,8 @@ export function getLoaderSWCOptions({
   supportedBrowsers: string[] | undefined
   swcCacheDir: string
   relativeFilePathFromRoot: string
-  bundleTarget: BundleType
-  hasServerComponents?: boolean
-  isServerLayer: boolean
+  serverComponents?: boolean
+  isReactServerLayer?: boolean
 }) {
   let baseOptions: any = getBaseSWCOptions({
     filename,
@@ -354,9 +351,8 @@ export function getLoaderSWCOptions({
     jsConfig,
     // resolvedBaseUrl,
     swcCacheDir,
-    hasServerComponents,
-    isServerLayer,
-    bundleTarget,
+    isReactServerLayer,
+    serverComponents,
   })
   baseOptions.fontLoaders = {
     fontLoaders: [
@@ -405,7 +401,7 @@ export function getLoaderSWCOptions({
       disableNextSsg: true,
       disablePageConfig: true,
       isDevelopment: development,
-      isServer,
+      isServerCompiler: isServer,
       pagesDir,
       appDir,
       isPageFile,
@@ -429,7 +425,7 @@ export function getLoaderSWCOptions({
         : {}),
       disableNextSsg: !isPageFile,
       isDevelopment: development,
-      isServer,
+      isServerCompiler: isServer,
       pagesDir,
       appDir,
       isPageFile,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -431,7 +431,10 @@ export default async function getBaseWebpackConfig(
 
   const defaultLoaders = {
     babel: useSWCLoader
-      ? getSwcLoader({ isReactServerLayer: false })
+      ? getSwcLoader({
+          serverComponents: true,
+          isReactServerLayer: false,
+        })
       : getBabelLoader(),
   }
 
@@ -492,7 +495,7 @@ export default async function getBaseWebpackConfig(
         ? [
             getSwcLoader({
               isReactServerLayer: false,
-              serverComponents: hasAppDir,
+              serverComponents: true,
             }),
           ]
         : // When using Babel, we will have to add the SWC loader

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -390,7 +390,6 @@ export default async function getBaseWebpackConfig(
         pagesDir,
         cwd: dir,
         development: dev,
-        hasServerComponents: hasAppDir,
         hasReactRefresh: dev && isClient,
         hasJsxRuntime: true,
       },
@@ -398,12 +397,7 @@ export default async function getBaseWebpackConfig(
   }
 
   let swcTraceProfilingInitialized = false
-  const getSwcLoader = (
-    extraOptions: Partial<SWCLoaderOptions> & {
-      bundleTarget: SWCLoaderOptions['bundleTarget']
-      isServerLayer: SWCLoaderOptions['isServerLayer']
-    }
-  ) => {
+  const getSwcLoader = (extraOptions: Partial<SWCLoaderOptions>) => {
     if (
       config?.experimental?.swcTraceProfiling &&
       !swcTraceProfilingInitialized
@@ -426,7 +420,6 @@ export default async function getBaseWebpackConfig(
         pagesDir,
         appDir,
         hasReactRefresh: dev && isClient,
-        hasServerComponents: true,
         nextConfig: config,
         jsConfig,
         supportedBrowsers,
@@ -438,28 +431,35 @@ export default async function getBaseWebpackConfig(
 
   const defaultLoaders = {
     babel: useSWCLoader
-      ? getSwcLoader({ bundleTarget: 'client', isServerLayer: false })
+      ? getSwcLoader({ isReactServerLayer: false })
       : getBabelLoader(),
   }
 
   const swcLoaderForServerLayer = hasAppDir
     ? useSWCLoader
-      ? [getSwcLoader({ isServerLayer: true, bundleTarget: 'server' })]
+      ? [
+          getSwcLoader({
+            isReactServerLayer: true,
+            serverComponents: true,
+          }),
+        ]
       : // When using Babel, we will have to add the SWC loader
         // as an additional pass to handle RSC correctly.
         // This will cause some performance overhead but
         // acceptable as Babel will not be recommended.
         [
-          getSwcLoader({ isServerLayer: true, bundleTarget: 'server' }),
+          getSwcLoader({
+            isReactServerLayer: true,
+            serverComponents: true,
+          }),
           getBabelLoader(),
         ]
     : []
 
   const swcLoaderForMiddlewareLayer = useSWCLoader
     ? getSwcLoader({
-        isServerLayer: false,
-        hasServerComponents: false,
-        bundleTarget: 'default',
+        serverComponents: false,
+        isReactServerLayer: false,
       })
     : // When using Babel, we will have to use SWC to do the optimization
       // for middleware to tree shake the unused default optimized imports like "next/server".
@@ -467,9 +467,8 @@ export default async function getBaseWebpackConfig(
       // acceptable as Babel will not be recommended.
       [
         getSwcLoader({
-          isServerLayer: false,
-          hasServerComponents: false,
-          bundleTarget: 'default',
+          serverComponents: false,
+          isReactServerLayer: false,
         }),
         getBabelLoader(),
       ]
@@ -492,9 +491,8 @@ export default async function getBaseWebpackConfig(
       ? useSWCLoader
         ? [
             getSwcLoader({
-              hasServerComponents: hasAppDir,
-              isServerLayer: false,
-              bundleTarget: 'client',
+              isReactServerLayer: false,
+              serverComponents: hasAppDir,
             }),
           ]
         : // When using Babel, we will have to add the SWC loader
@@ -503,8 +501,8 @@ export default async function getBaseWebpackConfig(
           // acceptable as Babel will not be recommended.
           [
             getSwcLoader({
-              isServerLayer: false,
-              bundleTarget: 'client',
+              isReactServerLayer: false,
+              serverComponents: false,
             }),
             getBabelLoader(),
           ]
@@ -517,9 +515,8 @@ export default async function getBaseWebpackConfig(
   const loaderForAPIRoutes =
     hasAppDir && useSWCLoader
       ? getSwcLoader({
-          isServerLayer: false,
-          bundleTarget: 'default',
-          hasServerComponents: false,
+          serverComponents: false,
+          isReactServerLayer: false,
         })
       : defaultLoaders.babel
 
@@ -1671,12 +1668,11 @@ export default async function getBaseWebpackConfig(
         ? (() => {
             // Even though require.cache is server only we have to clear assets from both compilations
             // This is because the client compilation generates the build manifest that's used on the server side
-            const {
-              NextJsRequireCacheHotReloader,
-            } = require('./webpack/plugins/nextjs-require-cache-hot-reloader')
-            const devPlugins = [
+            const { NextJsRequireCacheHotReloader } =
+              require('./webpack/plugins/nextjs-require-cache-hot-reloader') as typeof import('./webpack/plugins/nextjs-require-cache-hot-reloader')
+            const devPlugins: any[] = [
               new NextJsRequireCacheHotReloader({
-                hasServerComponents: hasAppDir,
+                serverComponents: hasAppDir,
               }),
             ]
 

--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -42,9 +42,8 @@ export interface SWCLoaderOptions {
   jsConfig: any
   supportedBrowsers: string[] | undefined
   swcCacheDir: string
-  bundleTarget: BundleType
-  hasServerComponents?: boolean
-  isServerLayer: boolean
+  serverComponents?: boolean
+  isReactServerLayer?: boolean
 }
 
 async function loaderTransform(
@@ -68,9 +67,9 @@ async function loaderTransform(
     jsConfig,
     supportedBrowsers,
     swcCacheDir,
-    hasServerComponents,
-    isServerLayer,
-    bundleTarget,
+    serverComponents,
+    isReactServerLayer,
+    // bundleTarget,
   } = loaderOptions
   const isPageFile = filename.startsWith(pagesDir)
   const relativeFilePathFromRoot = path.relative(rootDir, filename)
@@ -92,9 +91,9 @@ async function loaderTransform(
     supportedBrowsers,
     swcCacheDir,
     relativeFilePathFromRoot,
-    hasServerComponents,
-    isServerLayer,
-    bundleTarget,
+    serverComponents,
+    isReactServerLayer,
+    // bundleTarget,
   })
 
   const programmaticOptions = {

--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -28,7 +28,7 @@ DEALINGS IN THE SOFTWARE.
 
 import type { NextConfig } from '../../../../types'
 import { isWasm, transform } from '../../swc'
-import { type BundleType, getLoaderSWCOptions } from '../../swc/options'
+import { getLoaderSWCOptions } from '../../swc/options'
 import path, { isAbsolute } from 'path'
 
 export interface SWCLoaderOptions {

--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -69,7 +69,6 @@ async function loaderTransform(
     swcCacheDir,
     serverComponents,
     isReactServerLayer,
-    // bundleTarget,
   } = loaderOptions
   const isPageFile = filename.startsWith(pagesDir)
   const relativeFilePathFromRoot = path.relative(rootDir, filename)
@@ -93,7 +92,6 @@ async function loaderTransform(
     relativeFilePathFromRoot,
     serverComponents,
     isReactServerLayer,
-    // bundleTarget,
   })
 
   const programmaticOptions = {

--- a/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
+++ b/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
@@ -69,10 +69,10 @@ const PLUGIN_NAME = 'NextJsRequireCacheHotReloader'
 // This plugin flushes require.cache after emitting the files. Providing 'hot reloading' of server files.
 export class NextJsRequireCacheHotReloader implements WebpackPluginInstance {
   prevAssets: any = null
-  hasServerComponents: boolean
+  serverComponents: boolean
 
-  constructor(opts: { hasServerComponents: boolean }) {
-    this.hasServerComponents = opts.hasServerComponents
+  constructor(opts: { serverComponents: boolean }) {
+    this.serverComponents = opts.serverComponents
   }
 
   apply(compiler: Compiler) {


### PR DESCRIPTION
* Rename swc option `is_server` to `is_server_compiler`
* Rename swc plugin `config.is_server` to `config.is_react_server_layer`
* Remove unused `bundle_target`, which could be covered by composing `is_server_compiler` and `is_react_server_layer`