### PR TITLE
Fix logging removed experiments in start logs

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -277,7 +277,6 @@ export interface ExperimentalConfig {
 
   /**
    * Generate Route types and enable type checking for Link and Router.push, etc.
-   * This option requires `appDir` to be enabled first.
    * @see https://nextjs.org/docs/app/api-reference/next-config-js/typedRoutes
    */
   typedRoutes?: boolean

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1084,8 +1084,9 @@ export function getEnabledExperimentalFeatures(
       userNextConfigExperimental
     ) as (keyof ExperimentalConfig)[]) {
       if (
+        featureName in defaultConfig.experimental &&
         userNextConfigExperimental[featureName] !==
-        defaultConfig.experimental[featureName]
+          defaultConfig.experimental[featureName]
       ) {
         enabledExperiments.push(featureName)
       }

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -171,7 +171,7 @@ describe('Config Experimental Warning', () => {
     expect(stdout).toMatch(' · instrumentationHook')
   })
 
-  it.only('should show unrecognized experimental features in warning but not in start log experiments section', async () => {
+  it('should show unrecognized experimental features in warning but not in start log experiments section', async () => {
     configFile.write(`
       module.exports = {
         experimental: {

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -8,7 +8,9 @@ import {
   File,
   nextBuild,
   nextStart,
+  check,
 } from 'next-test-utils'
+import stripAnsi from 'strip-ansi'
 
 const appDir = join(__dirname, '..')
 const configFile = new File(join(appDir, '/next.config.js'))
@@ -107,8 +109,8 @@ describe('Config Experimental Warning', () => {
     `)
 
     const stdout = await collectStdoutFromDev(appDir)
-    expect(stdout).not.toMatch(' - Experiments (use at your own risk):')
-    expect(stdout).not.toMatch(' · workerThreads')
+    expect(stdout).not.toContain(' - Experiments (use at your own risk):')
+    expect(stdout).not.toContain(' · workerThreads')
   })
 
   it('should show warning with config from object with experimental and multiple keys', async () => {
@@ -122,9 +124,9 @@ describe('Config Experimental Warning', () => {
     `)
 
     const stdout = await collectStdoutFromDev(appDir)
-    expect(stdout).toMatch(' - Experiments (use at your own risk):')
-    expect(stdout).toMatch(' · workerThreads')
-    expect(stdout).toMatch(' · scrollRestoration')
+    expect(stdout).toContain(' - Experiments (use at your own risk):')
+    expect(stdout).toContain(' · workerThreads')
+    expect(stdout).toContain(' · scrollRestoration')
   })
 
   it('should not show next app info in next start', async () => {
@@ -167,5 +169,37 @@ describe('Config Experimental Warning', () => {
     expect(stdout).toMatch(' · workerThreads')
     expect(stdout).toMatch(' · scrollRestoration')
     expect(stdout).toMatch(' · instrumentationHook')
+  })
+
+  it.only('should show unrecognized experimental features in warning but not in start log experiments section', async () => {
+    configFile.write(`
+      module.exports = {
+        experimental: {
+          appDir: true
+        }
+      }
+    `)
+
+    await collectStdoutFromBuild(appDir)
+    const port = await findPort()
+    let stdout = ''
+    let stderr = ''
+    app = await nextStart(appDir, port, {
+      onStdout(msg) {
+        stdout += msg
+      },
+      onStderr(msg) {
+        stderr += msg
+      },
+    })
+
+    await check(() => {
+      const cliOutput = stripAnsi(stdout)
+      const cliOutputErr = stripAnsi(stderr)
+      expect(cliOutput).not.toContain(' - Experiments (use at your own risk):')
+      expect(cliOutputErr).toContain(
+        `Unrecognized key(s) in object: 'appDir' at "experimental"`
+      )
+    })
   })
 })


### PR DESCRIPTION
Do not log the removed experiments in the start server logs, for instance `experimental.appDir` should get warned as unexpected option but it's not the valid experiment anymore