### PR TITLE
Ensure unstable_cache revalidate option enables ISR

### DIFF
--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -31,14 +31,19 @@ export function unstable_cache<T extends Callback>(
       staticGenerationAsyncStorage?.getStore()
 
     if (store && typeof options.revalidate === 'number') {
+      // Revalidate 0 is a special case, it means opt-out of static generation.
       if (options.revalidate === 0) {
         maybePostpone(store, 'revalidate: 0')
+        // Set during dynamic rendering
         store.revalidate = 0
+        // If revalidate was already set in the store before we should check if the new value is lower, set it to the lowest of the two.
       } else if (typeof store.revalidate === 'number') {
-        // Only set revalidate if it is lower than the previously set value
         if (store.revalidate > options.revalidate) {
           store.revalidate = options.revalidate
         }
+        // All other cases we set the value from the option.
+      } else {
+        store.revalidate = options.revalidate
       }
     }
 

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -1,3 +1,4 @@
+import { maybePostpone } from '../../../client/components/maybe-postpone'
 import type {
   StaticGenerationStore,
   StaticGenerationAsyncStorage,
@@ -30,13 +31,14 @@ export function unstable_cache<T extends Callback>(
       staticGenerationAsyncStorage?.getStore()
 
     if (store && typeof options.revalidate === 'number') {
-      // Only set revalidate if it is lower than the previously set value
-      if (
-        typeof store.revalidate !== 'number' ||
-        (typeof store.revalidate === 'number' &&
-          store.revalidate > options.revalidate)
-      ) {
-        store.revalidate = options.revalidate
+      if (options.revalidate === 0) {
+        maybePostpone(store, 'revalidate: 0')
+        store.revalidate = 0
+      } else if (typeof store.revalidate === 'number') {
+        // Only set revalidate if it is lower than the previously set value
+        if (store.revalidate > options.revalidate) {
+          store.revalidate = options.revalidate
+        }
       }
     }
 

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -29,6 +29,17 @@ export function unstable_cache<T extends Callback>(
     const store: undefined | StaticGenerationStore =
       staticGenerationAsyncStorage?.getStore()
 
+    if (store && typeof options.revalidate === 'number') {
+      // Only set revalidate if it is lower than the previously set value
+      if (
+        typeof store.revalidate !== 'number' ||
+        (typeof store.revalidate === 'number' &&
+          store.revalidate > options.revalidate)
+      ) {
+        store.revalidate = options.revalidate
+      }
+    }
+
     const incrementalCache:
       | import('../../lib/incremental-cache').IncrementalCache
       | undefined =


### PR DESCRIPTION
Noticed that if you use `unstable_cache` it did not opt-in to ISR even though fetch() does opt-in. This ensures the prerender-manifest holds the revalidate value.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
