### PR TITLE
Turbopack: avoid crashing when server actions can't parse the file

### DIFF
--- a/packages/next-swc/crates/next-api/src/server_actions.rs
+++ b/packages/next-swc/crates/next-api/src/server_actions.rs
@@ -240,10 +240,8 @@ async fn parse_actions(module: Vc<Box<dyn Module>>) -> Result<Vc<OptionActionMap
         comments, program, ..
     } = &*ecmascript_asset.parse().await?
     else {
-        bail!(
-            "failed to parse action module '{id}'",
-            id = module.ident().to_string().await?
-        );
+        // The file might be be parse-able, but this is reported separately.
+        return Ok(OptionActionMap::none());
     };
 
     let Some(actions) = parse_server_actions(program, comments.clone()) else {


### PR DESCRIPTION
Introducting syntax errors in files throws an error in the server actions parsing, which hides the actual syntax error reported

Closes WEB-1858