### PR TITLE
Turbopack: avoid sending serverComponentChanges with errors

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1492,6 +1492,11 @@ async function startWatcher(opts: SetupOpts) {
               )
 
               changeSubscription(page, route.rscEndpoint, (_page, change) => {
+                if (change.issues.some((issue) => issue.severity === 'error')) {
+                  // Ignore any updates that has errors
+                  // There will be another update without errors eventually
+                  return
+                }
                 switch (change.type) {
                   case ServerClientChangeType.Server:
                   case ServerClientChangeType.Both:


### PR DESCRIPTION
We don't want to send the serverComponentChanges event until the compilation is free of errors.

Closes WEB-1859