### PR TITLE
fix(next-core): adjust og alias

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -605,10 +605,7 @@ async fn insert_next_server_special_aliases(
 
     import_map.insert_exact_alias(
         "@vercel/og",
-        external_if_node(
-            project_path,
-            "next/dist/server/web/spec-extension/image-response",
-        ),
+        external_if_node(project_path, "next/dist/server/og/image-response"),
     );
 
     Ok(())


### PR DESCRIPTION
### What?

minor adjustment to the alias to reflect latest changes: 

https://github.com/vercel/next.js/blob/9c87ea5a3d45c64da220e1013a4fe802935b2b31/packages/next/src/server/web/spec-extension/image-response.ts#L3

Closes WEB-1861