### PR TITLE
codemods: migrate viewport related metadata export to viewport export 

### DIFF
--- a/docs/02-app/01-building-your-application/09-upgrading/01-codemods.mdx
+++ b/docs/02-app/01-building-your-application/09-upgrading/01-codemods.mdx
@@ -48,6 +48,41 @@ Transform into:
 import { ImageResponse } from 'next/og'
 ```
 
+#### Use `viewport` export
+
+#### `metadata-to-viewport-export`
+
+```bash filename="Terminal"
+npx @next/codemod@latest metadata-to-viewport-export .
+```
+
+This codemod migrates certain viewport metadata to `viewport` export.
+
+For example:
+
+```js
+export const metadata = {
+  title: 'My App',
+  themeColor: 'dark',
+  viewport: {
+    width: 1,
+  },
+}
+```
+
+Transforms into:
+
+```js
+export const metadata = {
+  title: 'My App',
+}
+
+export const viewport = {
+  width: 1,
+  themeColor: 'dark',
+}
+```
+
 ### 13.2
 
 #### Use Built-in Font

--- a/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-empty.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-empty.input.tsx
@@ -1,0 +1,1 @@
+export const metadata = {}

--- a/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-empty.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-empty.output.tsx
@@ -1,0 +1,1 @@
+export const metadata = {}

--- a/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-with-viewport.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-with-viewport.input.tsx
@@ -1,0 +1,5 @@
+export const metadata = {
+  viewport: {
+    width: 'device-width'
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-with-viewport.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-with-viewport.output.tsx
@@ -1,0 +1,5 @@
+export const metadata = {}
+
+export const viewport = {
+  width: 'device-width'
+};

--- a/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-without-mixed.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-without-mixed.input.tsx
@@ -1,0 +1,7 @@
+export const metadata = {
+  themeColor: '#000000',
+  colorScheme: 'dark',
+  viewport: {
+    width: 'device-width',
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-without-mixed.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-without-mixed.output.tsx
@@ -1,0 +1,7 @@
+export const metadata = {}
+
+export const viewport = {
+  width: 'device-width',
+  colorScheme: 'dark',
+  themeColor: '#000000'
+};

--- a/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-without-viewport.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-without-viewport.input.tsx
@@ -1,0 +1,3 @@
+export const metadata = {
+  title: 'My page'
+}

--- a/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-without-viewport.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/metadata-to-viewport-export/metadata-without-viewport.output.tsx
@@ -1,0 +1,3 @@
+export const metadata = {
+  title: 'My page'
+}

--- a/packages/next-codemod/transforms/__tests__/metadata-to-viewport-export.test.js
+++ b/packages/next-codemod/transforms/__tests__/metadata-to-viewport-export.test.js
@@ -1,0 +1,16 @@
+/* global jest */
+jest.autoMockOff()
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+const { readdirSync } = require('fs')
+const { join } = require('path')
+
+const fixtureDir = 'metadata-to-viewport-export'
+const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir)
+const fixtures = readdirSync(fixtureDirPath)
+  .filter(file => file.endsWith('.input.tsx'))
+  .map(file => file.replace('.input.tsx', ''))
+
+for (const fixture of fixtures) {
+  const prefix = `${fixtureDir}/${fixture}`;
+  defineTest(__dirname, fixtureDir,  null, prefix, { parser: 'tsx' });
+}

--- a/packages/next-codemod/transforms/metadata-to-viewport-export.ts
+++ b/packages/next-codemod/transforms/metadata-to-viewport-export.ts
@@ -1,0 +1,85 @@
+import type { API, FileInfo } from 'jscodeshift'
+
+export default function transformer(file: FileInfo, api: API) {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  // Find the metadata export
+  const metadataExport = root.find(j.ExportNamedDeclaration, {
+    declaration: {
+      type: 'VariableDeclaration',
+      declarations: [
+        {
+          id: { name: 'metadata' },
+        },
+      ],
+    },
+  })
+
+  if (metadataExport.size() !== 1) {
+    return
+  }
+
+  const metadataObject = metadataExport.find(j.ObjectExpression).get(0).node
+  if (!metadataObject) {
+    console.error('Could not find metadata object')
+    return
+  }
+
+  let metadataProperties = metadataObject.properties
+  let viewportProperties
+
+  const viewport = metadataProperties.find(
+    (prop) => prop.key.name === 'viewport'
+  )
+  if (viewport) {
+    viewportProperties = viewport.value.properties
+    metadataProperties = metadataProperties.filter(
+      (prop) => prop.key.name !== 'viewport'
+    )
+  } else {
+    viewportProperties = []
+  }
+
+  const colorScheme = metadataProperties.find(
+    (prop) => prop.key.name === 'colorScheme'
+  )
+  if (colorScheme) {
+    viewportProperties.push(colorScheme)
+    metadataProperties = metadataProperties.filter(
+      (prop) => prop.key.name !== 'colorScheme'
+    )
+  }
+
+  const themeColor = metadataProperties.find(
+    (prop) => prop.key.name === 'themeColor'
+  )
+  if (themeColor) {
+    viewportProperties.push(themeColor)
+    metadataProperties = metadataProperties.filter(
+      (prop) => prop.key.name !== 'themeColor'
+    )
+  }
+
+  // Update the metadata export
+  metadataExport
+    .find(j.ObjectExpression)
+    .replaceWith(j.objectExpression(metadataProperties))
+
+  // Create the new viewport object
+  const viewportExport = j.exportNamedDeclaration(
+    j.variableDeclaration('const', [
+      j.variableDeclarator(
+        j.identifier('viewport'),
+        j.objectExpression(viewportProperties)
+      ),
+    ])
+  )
+
+  // Append the viewport export to the body of the program
+  if (viewportProperties.length) {
+    root.get().node.program.body.push(viewportExport)
+  }
+
+  return root.toSource()
+}


### PR DESCRIPTION
This PR adds the codemods transforming certain fields from `metadata` export to `viewport` export, will still preserve rest metadata export properties. We don't cover `generateMetadata` to `generateViewport` as there might be more complex logic inside the function which is hard to apply the codemods rules.

TLDR: Codemods for #57302 