### PR TITLE
Apply react-server transform and valication to middleware

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -461,8 +461,8 @@ export default async function getBaseWebpackConfig(
 
   const swcLoaderForMiddlewareLayer = useSWCLoader
     ? getSwcLoader({
-        serverComponents: false,
-        isReactServerLayer: false,
+        serverComponents: true,
+        isReactServerLayer: true,
       })
     : // When using Babel, we will have to use SWC to do the optimization
       // for middleware to tree shake the unused default optimized imports like "next/server".
@@ -470,8 +470,8 @@ export default async function getBaseWebpackConfig(
       // acceptable as Babel will not be recommended.
       [
         getSwcLoader({
-          serverComponents: false,
-          isReactServerLayer: false,
+          serverComponents: true,
+          isReactServerLayer: true,
         }),
         getBabelLoader(),
       ]

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -154,12 +154,9 @@ const WEBPACK_LAYERS = {
       WEBPACK_LAYERS_NAMES.actionBrowser,
       WEBPACK_LAYERS_NAMES.appMetadataRoute,
       WEBPACK_LAYERS_NAMES.appRouteHandler,
-    ],
-    nonClientServerTarget: [
-      // plus middleware and pages api
       WEBPACK_LAYERS_NAMES.middleware,
-      WEBPACK_LAYERS_NAMES.api,
     ],
+    nonClientServerTarget: [WEBPACK_LAYERS_NAMES.api],
     app: [
       WEBPACK_LAYERS_NAMES.reactServerComponents,
       WEBPACK_LAYERS_NAMES.actionBrowser,

--- a/test/e2e/module-layer/index.test.ts
+++ b/test/e2e/module-layer/index.test.ts
@@ -5,7 +5,7 @@ createNextDescribe(
   {
     files: __dirname,
   },
-  ({ next, isNextStart }) => {
+  ({ next, isNextStart, isNextDev }) => {
     function runTests() {
       it('should render routes marked with restriction marks without errors', async () => {
         const routes = [
@@ -75,7 +75,7 @@ createNextDescribe(
         await next.patchFile(
           middlewareFile,
           middlewareContent
-            .replace("import 'server-only'", "// import 'server-only'")
+            // .replace("import 'server-only'", "// import 'server-only'")
             .replace("// import './lib/mixed-lib'", "import './lib/mixed-lib'")
         )
 
@@ -95,7 +95,11 @@ createNextDescribe(
         await next.patchFile(middlewareFile, middlewareContent)
         // await next.patchFile(pagesApiFile, pagesApiContent)
       })
-      runTests()
+
+      it('should error when import client-only in middleware', async () => {
+        const { status } = await next.fetch('/')
+        expect(status).toBe(500)
+      })
     })
     describe('with server-only in server targets', () => {
       runTests()

--- a/test/e2e/module-layer/index.test.ts
+++ b/test/e2e/module-layer/index.test.ts
@@ -1,4 +1,5 @@
 import { createNextDescribe } from 'e2e-utils'
+import { getRedboxSource, hasRedbox } from 'next-test-utils'
 
 createNextDescribe(
   'module layer',
@@ -60,49 +61,60 @@ createNextDescribe(
       }
     }
 
-    describe('no server-only in server targets', () => {
-      const middlewareFile = 'middleware.js'
-      // const pagesApiFile = 'pages/api/hello.js'
-      let middlewareContent = ''
-      // let pagesApiContent = ''
-
-      beforeAll(async () => {
-        await next.stop()
-
-        middlewareContent = await next.readFile(middlewareFile)
-        // pagesApiContent = await next.readFile(pagesApiFile)
-
-        await next.patchFile(
-          middlewareFile,
-          middlewareContent
-            // .replace("import 'server-only'", "// import 'server-only'")
-            .replace("// import './lib/mixed-lib'", "import './lib/mixed-lib'")
-        )
-
-        // await next.patchFile(
-        //   pagesApiFile,
-        //   pagesApiContent
-        //     .replace("import 'server-only'", "// import 'server-only'")
-        //     .replace(
-        //       "// import '../../lib/mixed-lib'",
-        //       "import '../../lib/mixed-lib'"
-        //     )
-        // )
-
-        await next.start()
-      })
-      afterAll(async () => {
-        await next.patchFile(middlewareFile, middlewareContent)
-        // await next.patchFile(pagesApiFile, pagesApiContent)
-      })
-
-      it('should error when import client-only in middleware', async () => {
-        const { status } = await next.fetch('/')
-        expect(status).toBe(500)
-      })
-    })
     describe('with server-only in server targets', () => {
       runTests()
     })
+
+    // Should error for using mixed (with client-only) in server targets
+    if (isNextDev) {
+      describe('no server-only in server targets', () => {
+        const middlewareFile = 'middleware.js'
+        // const pagesApiFile = 'pages/api/hello.js'
+        let middlewareContent = ''
+        // let pagesApiContent = ''
+
+        beforeAll(async () => {
+          await next.stop()
+
+          middlewareContent = await next.readFile(middlewareFile)
+          // pagesApiContent = await next.readFile(pagesApiFile)
+
+          await next.patchFile(
+            middlewareFile,
+            middlewareContent
+              // .replace("import 'server-only'", "// import 'server-only'")
+              .replace(
+                "// import './lib/mixed-lib'",
+                "import './lib/mixed-lib'"
+              )
+          )
+
+          // await next.patchFile(
+          //   pagesApiFile,
+          //   pagesApiContent
+          //     .replace("import 'server-only'", "// import 'server-only'")
+          //     .replace(
+          //       "// import '../../lib/mixed-lib'",
+          //       "import '../../lib/mixed-lib'"
+          //     )
+          // )
+
+          await next.start()
+        })
+        afterAll(async () => {
+          await next.patchFile(middlewareFile, middlewareContent)
+          // await next.patchFile(pagesApiFile, pagesApiContent)
+        })
+
+        it('should error when import client-only in middleware', async () => {
+          const browser = await next.browser('/')
+
+          expect(await hasRedbox(browser, true)).toBe(true)
+          expect(await getRedboxSource(browser)).toContain(
+            `You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.`
+          )
+        })
+      })
+    }
   }
 )


### PR DESCRIPTION
Apply `react-server` resolving and server components invalid APIs checking to middleware. We want to limit the react usage in in middleware as so far it's not aimed for rendering purpose. 

Another invalid case could be: if you're doing react SSR with `renderToString` in middleware it should be disallowed. Imaging it could send the rendered html code to client and you display it in browser. But it might require hydration so it can be broken.

This PR will only let you import `react-server` export condition packages.