### PR TITLE
fix(turbopack): don't emit issues when parsing the segment config for non js files

### DIFF
--- a/packages/next-swc/crates/next-core/src/app_segment_config.rs
+++ b/packages/next-swc/crates/next-core/src/app_segment_config.rs
@@ -211,6 +211,16 @@ pub async fn parse_segment_config_from_source(
 ) -> Result<Vc<NextSegmentConfig>> {
     let path = source.ident().path().await?;
 
+    // Don't try parsing if it's not a javascript file, otherwise it will emit an
+    // issue causing the build to "fail".
+    if !(path.path.ends_with(".js")
+        || path.path.ends_with(".jsx")
+        || path.path.ends_with(".ts")
+        || path.path.ends_with(".tsx"))
+    {
+        return Ok(Default::default());
+    }
+
     let result = &*parse(
         source,
         turbo_tasks::Value::new(


### PR DESCRIPTION
### Why?

Calling `parse` will emit issues with error severity, causing the build to get marked as failed


Closes WEB-1869