### PR TITLE
refactor: simplify swc loaders configuration

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -380,7 +380,8 @@ export default async function getBaseWebpackConfig(
     loggedIgnoredCompilerOptions = true
   }
 
-  const getBabelLoader = () => {
+  const babelLoader = (function getBabelLoader() {
+    if (useSWCLoader) return undefined
     return {
       loader: require.resolve('./babel/loader/index'),
       options: {
@@ -394,7 +395,7 @@ export default async function getBaseWebpackConfig(
         hasJsxRuntime: true,
       },
     }
-  }
+  })()
 
   let swcTraceProfilingInitialized = false
   const getSwcLoader = (extraOptions: Partial<SWCLoaderOptions>) => {
@@ -429,52 +430,37 @@ export default async function getBaseWebpackConfig(
     }
   }
 
+  const swcServerLayerLoader = getSwcLoader({
+    serverComponents: true,
+    isReactServerLayer: true,
+  })
+  const swcClientLayerLoader = getSwcLoader({
+    serverComponents: true,
+    isReactServerLayer: false,
+  })
+
   const defaultLoaders = {
-    babel: useSWCLoader
-      ? getSwcLoader({
-          serverComponents: true,
-          isReactServerLayer: false,
-        })
-      : getBabelLoader(),
+    babel: useSWCLoader ? swcClientLayerLoader : babelLoader!,
   }
 
   const swcLoaderForServerLayer = hasAppDir
-    ? useSWCLoader
-      ? [
-          getSwcLoader({
-            isReactServerLayer: true,
-            serverComponents: true,
-          }),
-        ]
-      : // When using Babel, we will have to add the SWC loader
+    ? [
+        // When using Babel, we will have to add the SWC loader
         // as an additional pass to handle RSC correctly.
         // This will cause some performance overhead but
         // acceptable as Babel will not be recommended.
-        [
-          getSwcLoader({
-            isReactServerLayer: true,
-            serverComponents: true,
-          }),
-          getBabelLoader(),
-        ]
+        swcServerLayerLoader,
+        babelLoader,
+      ].filter(Boolean)
     : []
 
   const swcLoaderForMiddlewareLayer = useSWCLoader
-    ? getSwcLoader({
-        serverComponents: true,
-        isReactServerLayer: true,
-      })
+    ? swcServerLayerLoader
     : // When using Babel, we will have to use SWC to do the optimization
       // for middleware to tree shake the unused default optimized imports like "next/server".
       // This will cause some performance overhead but
       // acceptable as Babel will not be recommended.
-      [
-        getSwcLoader({
-          serverComponents: true,
-          isReactServerLayer: true,
-        }),
-        getBabelLoader(),
-      ]
+      [swcServerLayerLoader, babelLoader]
 
   // client components layers: SSR + browser
   const swcLoaderForClientLayer = [
@@ -491,37 +477,21 @@ export default async function getBaseWebpackConfig(
       loader: 'next-flight-client-module-loader',
     },
     ...(hasAppDir
-      ? useSWCLoader
-        ? [
-            getSwcLoader({
-              isReactServerLayer: false,
-              serverComponents: true,
-            }),
-          ]
-        : // When using Babel, we will have to add the SWC loader
+      ? [
+          // When using Babel, we will have to add the SWC loader
           // as an additional pass to handle RSC correctly.
           // This will cause some performance overhead but
           // acceptable as Babel will not be recommended.
-          [
-            getSwcLoader({
-              isReactServerLayer: false,
-              serverComponents: false,
-            }),
-            getBabelLoader(),
-          ]
+          swcClientLayerLoader,
+          babelLoader,
+        ].filter(Boolean)
       : []),
   ]
 
   // Loader for API routes needs to be differently configured as it shouldn't
   // have RSC transpiler enabled, so syntax checks such as invalid imports won't
   // be performed.
-  const loaderForAPIRoutes =
-    hasAppDir && useSWCLoader
-      ? getSwcLoader({
-          serverComponents: false,
-          isReactServerLayer: false,
-        })
-      : defaultLoaders.babel
+  const loaderForAPIRoutes = [swcServerLayerLoader, babelLoader].filter(Boolean)
 
   const pageExtensions = config.pageExtensions
 

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -491,7 +491,13 @@ export default async function getBaseWebpackConfig(
   // Loader for API routes needs to be differently configured as it shouldn't
   // have RSC transpiler enabled, so syntax checks such as invalid imports won't
   // be performed.
-  const loaderForAPIRoutes = [swcServerLayerLoader, babelLoader].filter(Boolean)
+  const loaderForAPIRoutes =
+    hasAppDir && useSWCLoader
+      ? getSwcLoader({
+          serverComponents: false,
+          isReactServerLayer: false,
+        })
+      : defaultLoaders.babel
 
   const pageExtensions = config.pageExtensions
 


### PR DESCRIPTION
Reduce the times that we re-create loaders, down to 3 loaders:
* swc loader for server layer 
* swc loader for client layer
* babel loader

This change let us only create some loaders for once, and make the code easier to read.
`babelLoader` will only available when babel config is enabled, so we use filters to skip it when it's empty.