### PR TITLE
turbopack: Fix Server Actions in Edge runtime

### DIFF
--- a/packages/next-swc/crates/next-api/src/server_actions.rs
+++ b/packages/next-swc/crates/next-api/src/server_actions.rs
@@ -95,17 +95,14 @@ async fn build_server_actions_loader(
         for (hash_id, name) in &*actions_map.await? {
             writedoc!(
                 contents,
-                "
-                \x20 '{hash_id}': (...args) => import('{module_name}')
-                    .then(mod => (0, mod['{name}'])(...args)),\n
-                ",
+                "  '{hash_id}': (...args) => (0, require('{module_name}')['{name}'])(...args),",
             )?;
         }
         import_map.insert(module_name, module.1);
     }
     write!(contents, "}});")?;
 
-    let output_path = node_root.join(format!("server/app{page_name}/actions.ts"));
+    let output_path = node_root.join(format!("server/app{page_name}/actions.js"));
     let file = File::from(contents.build());
     let source = VirtualSource::new(output_path, AssetContent::file(file.into()));
     let module = asset_context.process(

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -2211,7 +2211,6 @@
       "app-dir action handling fetch actions should revalidate when cookies.set is called",
       "app-dir action handling fetch actions should revalidate when cookies.set is called in a client action",
       "app-dir action handling fetch actions should store revalidation data in the prefetch cache",
-      "app-dir action handling should bundle external libraries if they are on the action layer",
       "app-dir action handling should handle basic actions correctly",
       "app-dir action handling should not block navigation events while a server action is in flight",
       "app-dir action handling should only submit action once when resubmitting an action after navigation",
@@ -2223,14 +2222,16 @@
       "app-dir action handling should support headers in client imported actions",
       "app-dir action handling should support hoc auth wrappers",
       "app-dir action handling should support importing actions in client components",
-      "app-dir action handling should support importing the same action module instance in both server and action layers",
       "app-dir action handling should support next/dynamic with ssr: false",
       "app-dir action handling should support notFound",
       "app-dir action handling should support notFound (javascript disabled)",
       "app-dir action handling should support setting cookies in route handlers with the correct overrides",
       "app-dir action handling should support uploading files"
     ],
-    "failed": [],
+    "failed": [
+      "app-dir action handling should support importing the same action module instance in both server and action layers",
+      "app-dir action handling should bundle external libraries if they are on the action layer"
+    ],
     "pending": [
       "app-dir action handling fetch actions should handle revalidateTag + redirect"
     ],

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -2192,7 +2192,12 @@
   },
   "test/e2e/app-dir/actions/app-action.test.ts": {
     "passed": [
+      "app-dir action handling Edge SSR should allow cookie and header async storages",
+      "app-dir action handling Edge SSR should handle basic actions correctly",
       "app-dir action handling Edge SSR should handle redirect to a relative URL in a single pass",
+      "app-dir action handling Edge SSR should handle regular redirects",
+      "app-dir action handling Edge SSR should handle unicode search params",
+      "app-dir action handling Edge SSR should return error response for hoc auth wrappers in edge runtime",
       "app-dir action handling HMR should support updating the action",
       "app-dir action handling encryption should send encrypted values from the closed over closure",
       "app-dir action handling fetch actions should handle a fetch action initiated from a static page",
@@ -2206,6 +2211,7 @@
       "app-dir action handling fetch actions should revalidate when cookies.set is called",
       "app-dir action handling fetch actions should revalidate when cookies.set is called in a client action",
       "app-dir action handling fetch actions should store revalidation data in the prefetch cache",
+      "app-dir action handling should bundle external libraries if they are on the action layer",
       "app-dir action handling should handle basic actions correctly",
       "app-dir action handling should not block navigation events while a server action is in flight",
       "app-dir action handling should only submit action once when resubmitting an action after navigation",
@@ -2217,21 +2223,14 @@
       "app-dir action handling should support headers in client imported actions",
       "app-dir action handling should support hoc auth wrappers",
       "app-dir action handling should support importing actions in client components",
+      "app-dir action handling should support importing the same action module instance in both server and action layers",
       "app-dir action handling should support next/dynamic with ssr: false",
       "app-dir action handling should support notFound",
       "app-dir action handling should support notFound (javascript disabled)",
       "app-dir action handling should support setting cookies in route handlers with the correct overrides",
       "app-dir action handling should support uploading files"
     ],
-    "failed": [
-      "app-dir action handling Edge SSR should allow cookie and header async storages",
-      "app-dir action handling Edge SSR should handle basic actions correctly",
-      "app-dir action handling Edge SSR should handle regular redirects",
-      "app-dir action handling Edge SSR should handle unicode search params",
-      "app-dir action handling Edge SSR should return error response for hoc auth wrappers in edge runtime",
-      "app-dir action handling should bundle external libraries if they are on the action layer",
-      "app-dir action handling should support importing the same action module instance in both server and action layers"
-    ],
+    "failed": [],
     "pending": [
       "app-dir action handling fetch actions should handle revalidateTag + redirect"
     ],


### PR DESCRIPTION
### What?

Changes Server Actions to use a lazy `require()` statement instead of a lazy dynamic `import()`, to fix SA in the Edge runtime.

### Why?

The Edge runtime has a restriction that it's not allowed to lazy load more files. The problem is that dynamic `import()` does exactly that, it defers importing those files until the call time. `require()` doesn't have this issue, because the chunks it would load are included instead of deferred.

### How?

Just needed to modify the actions loader entry point… after hours of trying to get the action loader to evaluate in the node runtime and then import the actions in the edge runtime.


Closes WEB-1874