### PR TITLE
fix(turbopack): make layout in group not cause a 404

### DIFF
--- a/test/e2e/app-dir/parallel-routes-and-interception/app/(group)/layout.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/(group)/layout.js
@@ -1,0 +1,3 @@
+export default function Layout({ children }) {
+  return children
+}


### PR DESCRIPTION
### What?

Given the structure:
`/page.js`
`/(group)/layout.js`

Going to `/` would 404

Closes WEB-1878