### PR TITLE
Filter out CSS files from middleware files and client reference chunks

### DIFF
--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -865,6 +865,7 @@ impl AppEndpoint {
                             async move {
                                 Ok(node_root_value
                                     .get_path_to(&*file.ident().path().await?)
+                                    .filter(|path| path.ends_with(".js"))
                                     .map(|path| path.to_string()))
                             }
                         }
@@ -882,6 +883,7 @@ impl AppEndpoint {
                         async move {
                             Ok(node_root_value
                                 .get_path_to(&*file.ident().path().await?)
+                                .filter(|path| path.ends_with(".js"))
                                 .map(|path| path.to_string()))
                         }
                     })

--- a/packages/next-swc/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/packages/next-swc/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -160,6 +160,9 @@ impl ClientReferenceManifest {
                         .iter()
                         .filter_map(|chunk_path| client_relative_path.get_path_to(chunk_path))
                         .map(ToString::to_string)
+                        // It's possible that a chunk also emits CSS files, that will
+                        // be handled separatedly.
+                        .filter(|path| path.ends_with(".js"))
                         .collect::<Vec<_>>();
 
                     let ssr_chunks_paths = ssr_chunks


### PR DESCRIPTION
There could be CSS files emitted in these chunks so both manifests need to filter them out. This fixes `app dir - css css support chunks should bundle css resources into chunks`.