### PR TITLE
Don't terminate PPR renders with dynamicUsageErr

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -195,7 +195,10 @@ export async function createComponentTree({
     }
   }
 
-  if (staticGenerationStore?.dynamicUsageErr) {
+  if (
+    staticGenerationStore?.dynamicUsageErr &&
+    !staticGenerationStore.experimental.ppr
+  ) {
     throw staticGenerationStore.dynamicUsageErr
   }
 


### PR DESCRIPTION
We track dynamicUsageErr in patch-fetch usually and then abort the whole prerender if that happens. With PPR we use maybePostpone and not that so we should just not abort when we use ppr.