### PR TITLE
Add Next.js 14 codemods to CLI output.

### DIFF
--- a/packages/next-codemod/bin/cli.ts
+++ b/packages/next-codemod/bin/cli.ts
@@ -136,6 +136,14 @@ const TRANSFORMER_INQUIRER_CHOICES = [
     value: 'new-link',
   },
   {
+    name: 'next-og-import: Transforms imports from `next/server` to `next/og` for usage of Dynamic OG Image Generation.',
+    value: 'next-og-import',
+  },
+  {
+    name: 'metadata-to-viewport-export: Migrates certain viewport related metadata from the `metadata` export to a new `viewport` export.',
+    value: 'metadata-to-viewport-export',
+  },
+  {
     name: 'next-image-to-legacy-image: safely migrate Next.js 10, 11, 12 applications importing `next/image` to the renamed `next/legacy/image` import in Next.js 13',
     value: 'next-image-to-legacy-image',
   },


### PR DESCRIPTION
Following the documentation:

```
▲  commerce/ npx @next/codemod@latest next-og-import .
Invalid transform choice, pick one of:
- name-default-component
- add-missing-react-import
- withamp-to-config
- url-to-withrouter
- cra-to-next
- new-link
- next-image-to-legacy-image
- next-image-experimental
- built-in-next-font
```