### PR TITLE
Fix typos

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/10-third-party-libraries.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/10-third-party-libraries.mdx
@@ -88,7 +88,7 @@ export default function MyApp({ Component, pageProps }) {
 
 </PagesOnly>
 
-To load Google Tag Manager for a single route, include the comopnent in your page file:
+To load Google Tag Manager for a single route, include the component in your page file:
 
 <AppOnly>
 
@@ -238,9 +238,9 @@ docs](https://developers.google.com/maps/documentation/embed/embedding-map).
 | `width`           | Optional | Width of the embed. Defaults to `auto`.                                                             |
 | `style`           | Optional | Pass styles to the iframe.                                                                          |
 | `allowfullscreen` | Optional | Property to allow certain map parts to go full screen.                                              |
-| `loading`         | Optional | Defaults to lazy. Consider changing if you know your embed will be above-the-fold.                  |
+| `loading`         | Optional | Defaults to lazy. Consider changing if you know your embed will be above the fold.                  |
 | `q`               | Optional | Defines map marker location. _This may be required depending on the map mode_.                      |
-| `center`          | Optional | Defines center of the map view.                                                                     |
+| `center`          | Optional | Defines the center of the map view.                                                                     |
 | `zoom`            | Optional | Sets initial zoom level of the map.                                                                 |
 | `maptype`         | Optional | Defines type of map tiles to load.                                                                  |
 | `language`        | Optional | Defines the language to use for UI elements and for the display of labels on map tiles.             |


### PR DESCRIPTION
- `comopnent` → `component`
- `above-the-fold` → `above the fold`
- `Defines center (…)` → `Defines the center (…)`