### PR TITLE
Fix: codemods.mdx Incorrect heading structure of next-og-import, meta…

### DIFF
--- a/docs/02-app/01-building-your-application/09-upgrading/01-codemods.mdx
+++ b/docs/02-app/01-building-your-application/09-upgrading/01-codemods.mdx
@@ -28,7 +28,7 @@ Replacing `<transform>` and `<path>` with appropriate values.
 
 #### Migrate `ImageResponse` imports
 
-#### `next-og-import`
+##### `next-og-import`
 
 ```bash filename="Terminal"
 npx @next/codemod@latest next-og-import .
@@ -50,7 +50,7 @@ import { ImageResponse } from 'next/og'
 
 #### Use `viewport` export
 
-#### `metadata-to-viewport-export`
+##### `metadata-to-viewport-export`
 
 ```bash filename="Terminal"
 npx @next/codemod@latest metadata-to-viewport-export .


### PR DESCRIPTION
### Fixing a bug

- Related issues linked using `fixes #57593`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### What?
These changes will fix the incorrect heading structure in `codemods.mdx`.

Closes NEXT-
Fixes #57593 


