### PR TITLE
Fix: Build compilation warning when using middlewar

### DIFF
--- a/packages/next/src/shared/lib/router/utils/app-paths.ts
+++ b/packages/next/src/shared/lib/router/utils/app-paths.ts
@@ -1,6 +1,5 @@
 import { ensureLeadingSlash } from '../../page-path/ensure-leading-slash'
 import { isGroupSegment } from '../../segment'
-import { parse, format } from 'url'
 
 /**
  * Normalizes an app route so it represents the actual request path. Essentially
@@ -70,12 +69,12 @@ export function normalizeRscURL(url: string) {
  * @param url the url to normalize
  */
 export function normalizePostponedURL(url: string) {
-  const parsed = parse(url)
-  let { pathname } = parsed
+  const parsed = new URL(url)
+  const { pathname } = parsed
   if (pathname && pathname.startsWith('/_next/postponed')) {
-    pathname = pathname.substring('/_next/postponed'.length) || '/'
+    parsed.pathname = pathname.substring('/_next/postponed'.length) || '/'
 
-    return format({ ...parsed, pathname })
+    return parsed.toString()
   }
 
   return url


### PR DESCRIPTION
### Fixing a bug

- Related issues linked using `fixes #57533`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### What?

If there is a `middleware.js` or `middleware.ts` file in Next.JS 14, running `next build` shows the following warning:

```
./node_modules/next/dist/esm/shared/lib/router/utils/app-paths.js
A Node.js module is loaded ('url' at line 3) which is not supported in the Edge Runtime.
Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime

Import trace for requested module:
./node_modules/next/dist/esm/shared/lib/router/utils/app-paths.js
```
This PR will remove the warning.

Closes NEXT-
Fixes #57533 
