### PR TITLE
Add node-pty to externals list

### DIFF
--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -30,6 +30,7 @@
   "mongoose",
   "next-mdx-remote",
   "next-seo",
+  "node-pty",
   "payload",
   "pg",
   "playwright",


### PR DESCRIPTION
This is a native module so exteranlize it by default