### PR TITLE
[Traces] Await the flush of the trace write stream to make sure trace file is written

### DIFF
--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -174,7 +174,7 @@ export default {
           const phase = traceGlobals.get('phase')
           // Only end writeStream when manually flushing in production
           if (phase !== PHASE_DEVELOPMENT_SERVER) {
-            writeStream.end()
+            return writeStream.end()
           }
         })
       : undefined,


### PR DESCRIPTION
This PR fixes an issue where sometimes the `.next/trace` file would not be written at the end of a build. The process was not waiting for the write stream to be flushed before closing, losing the contents of the trace, which was especially visible when using `experimental-compile`.