### PR TITLE
Telemetry: add http.status_code tag for fetch responses

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -160,6 +160,444 @@ export function patchFetch({
   const { DynamicServerError } = serverHooks
   const originFetch: typeof fetch = (globalThis as any)._nextOriginalFetch
 
+  const internalFetch = async (
+    input: RequestInfo | URL,
+    init: RequestInit | undefined,
+    isInternal: boolean,
+    fetchUrl: string,
+    fetchStart: number
+  ): Promise<Response> => {
+    const staticGenerationStore: StaticGenerationStore =
+      staticGenerationAsyncStorage.getStore() ||
+      (fetch as any).__nextGetStaticStore?.()
+    const isRequestInput =
+      input &&
+      typeof input === 'object' &&
+      typeof (input as Request).method === 'string'
+
+    const getRequestMeta = (field: string) => {
+      let value = isRequestInput ? (input as any)[field] : null
+      return value || (init as any)?.[field]
+    }
+
+    // If the staticGenerationStore is not available, we can't do any
+    // special treatment of fetch, therefore fallback to the original
+    // fetch implementation.
+    if (
+      !staticGenerationStore ||
+      isInternal ||
+      staticGenerationStore.isDraftMode
+    ) {
+      return originFetch(input, init)
+    }
+
+    let revalidate: number | undefined | false = undefined
+    const getNextField = (field: 'revalidate' | 'tags') => {
+      return typeof init?.next?.[field] !== 'undefined'
+        ? init?.next?.[field]
+        : isRequestInput
+        ? (input as any).next?.[field]
+        : undefined
+    }
+    // RequestInit doesn't keep extra fields e.g. next so it's
+    // only available if init is used separate
+    let curRevalidate = getNextField('revalidate')
+    const tags: string[] = validateTags(
+      getNextField('tags') || [],
+      `fetch ${input.toString()}`
+    )
+
+    if (Array.isArray(tags)) {
+      if (!staticGenerationStore.tags) {
+        staticGenerationStore.tags = []
+      }
+      for (const tag of tags) {
+        if (!staticGenerationStore.tags.includes(tag)) {
+          staticGenerationStore.tags.push(tag)
+        }
+      }
+    }
+    const implicitTags = addImplicitTags(staticGenerationStore)
+
+    const isOnlyCache = staticGenerationStore.fetchCache === 'only-cache'
+    const isForceCache = staticGenerationStore.fetchCache === 'force-cache'
+    const isDefaultCache = staticGenerationStore.fetchCache === 'default-cache'
+    const isDefaultNoStore =
+      staticGenerationStore.fetchCache === 'default-no-store'
+    const isOnlyNoStore = staticGenerationStore.fetchCache === 'only-no-store'
+    const isForceNoStore = staticGenerationStore.fetchCache === 'force-no-store'
+
+    let _cache = getRequestMeta('cache')
+    let cacheReason = ''
+
+    if (typeof _cache === 'string' && typeof curRevalidate !== 'undefined') {
+      Log.warn(
+        `fetch for ${fetchUrl} on ${staticGenerationStore.urlPathname} specified "cache: ${_cache}" and "revalidate: ${curRevalidate}", only one should be specified.`
+      )
+      _cache = undefined
+    }
+
+    if (_cache === 'force-cache') {
+      curRevalidate = false
+    } else if (
+      _cache === 'no-cache' ||
+      _cache === 'no-store' ||
+      isForceNoStore ||
+      isOnlyNoStore
+    ) {
+      curRevalidate = 0
+    }
+
+    if (_cache === 'no-cache' || _cache === 'no-store') {
+      cacheReason = `cache: ${_cache}`
+    }
+
+    if (typeof curRevalidate === 'number' || curRevalidate === false) {
+      revalidate = curRevalidate
+    }
+
+    const _headers = getRequestMeta('headers')
+    const initHeaders: Headers =
+      typeof _headers?.get === 'function'
+        ? _headers
+        : new Headers(_headers || {})
+
+    const hasUnCacheableHeader =
+      initHeaders.get('authorization') || initHeaders.get('cookie')
+
+    const isUnCacheableMethod = !['get', 'head'].includes(
+      getRequestMeta('method')?.toLowerCase() || 'get'
+    )
+
+    // if there are authorized headers or a POST method and
+    // dynamic data usage was present above the tree we bail
+    // e.g. if cookies() is used before an authed/POST fetch
+    const autoNoCache =
+      (hasUnCacheableHeader || isUnCacheableMethod) &&
+      staticGenerationStore.revalidate === 0
+
+    if (isForceNoStore) {
+      cacheReason = 'fetchCache = force-no-store'
+    }
+
+    if (isOnlyNoStore) {
+      if (
+        _cache === 'force-cache' ||
+        (typeof revalidate !== 'undefined' &&
+          (revalidate === false || revalidate > 0))
+      ) {
+        throw new Error(
+          `cache: 'force-cache' used on fetch for ${fetchUrl} with 'export const fetchCache = 'only-no-store'`
+        )
+      }
+      cacheReason = 'fetchCache = only-no-store'
+    }
+
+    if (isOnlyCache && _cache === 'no-store') {
+      throw new Error(
+        `cache: 'no-store' used on fetch for ${fetchUrl} with 'export const fetchCache = 'only-cache'`
+      )
+    }
+
+    if (
+      isForceCache &&
+      (typeof curRevalidate === 'undefined' || curRevalidate === 0)
+    ) {
+      cacheReason = 'fetchCache = force-cache'
+      revalidate = false
+    }
+
+    if (typeof revalidate === 'undefined') {
+      if (isDefaultCache) {
+        revalidate = false
+        cacheReason = 'fetchCache = default-cache'
+      } else if (autoNoCache) {
+        revalidate = 0
+        cacheReason = 'auto no cache'
+      } else if (isDefaultNoStore) {
+        revalidate = 0
+        cacheReason = 'fetchCache = default-no-store'
+      } else {
+        cacheReason = 'auto cache'
+        revalidate =
+          typeof staticGenerationStore.revalidate === 'boolean' ||
+          typeof staticGenerationStore.revalidate === 'undefined'
+            ? false
+            : staticGenerationStore.revalidate
+      }
+    } else if (!cacheReason) {
+      cacheReason = `revalidate: ${revalidate}`
+    }
+
+    if (
+      // we don't consider autoNoCache to switch to dynamic during
+      // revalidate although if it occurs during build we do
+      !autoNoCache &&
+      (typeof staticGenerationStore.revalidate === 'undefined' ||
+        (typeof revalidate === 'number' &&
+          (staticGenerationStore.revalidate === false ||
+            (typeof staticGenerationStore.revalidate === 'number' &&
+              revalidate < staticGenerationStore.revalidate))))
+    ) {
+      // If enabled, we should bail out of static generation.
+      if (revalidate === 0) {
+        maybePostpone(staticGenerationStore, 'revalidate: 0')
+      }
+
+      staticGenerationStore.revalidate = revalidate
+    }
+
+    const isCacheableRevalidate =
+      (typeof revalidate === 'number' && revalidate > 0) || revalidate === false
+
+    let cacheKey: string | undefined
+    if (staticGenerationStore.incrementalCache && isCacheableRevalidate) {
+      try {
+        cacheKey = await staticGenerationStore.incrementalCache.fetchCacheKey(
+          fetchUrl,
+          isRequestInput ? (input as RequestInit) : init
+        )
+      } catch (err) {
+        console.error(`Failed to generate cache key for`, input)
+      }
+    }
+
+    const fetchIdx = staticGenerationStore.nextFetchId ?? 1
+    staticGenerationStore.nextFetchId = fetchIdx + 1
+
+    const normalizedRevalidate =
+      typeof revalidate !== 'number' ? CACHE_ONE_YEAR : revalidate
+
+    const doOriginalFetch = async (
+      isStale?: boolean,
+      cacheReasonOverride?: string
+    ) => {
+      const requestInputFields = [
+        'cache',
+        'credentials',
+        'headers',
+        'integrity',
+        'keepalive',
+        'method',
+        'mode',
+        'redirect',
+        'referrer',
+        'referrerPolicy',
+        'window',
+        'duplex',
+
+        // don't pass through signal when revalidating
+        ...(isStale ? [] : ['signal']),
+      ]
+
+      if (isRequestInput) {
+        const reqInput: Request = input as any
+        const reqOptions: RequestInit = {
+          body: (reqInput as any)._ogBody || reqInput.body,
+        }
+
+        for (const field of requestInputFields) {
+          // @ts-expect-error custom fields
+          reqOptions[field] = reqInput[field]
+        }
+        input = new Request(reqInput.url, reqOptions)
+      } else if (init) {
+        const initialInit = init
+        init = {
+          body: (init as any)._ogBody || init.body,
+        }
+        for (const field of requestInputFields) {
+          // @ts-expect-error custom fields
+          init[field] = initialInit[field]
+        }
+      }
+
+      // add metadata to init without editing the original
+      const clonedInit = {
+        ...init,
+        next: { ...init?.next, fetchType: 'origin', fetchIdx },
+      }
+
+      return originFetch(input, clonedInit).then(async (res) => {
+        if (!isStale) {
+          trackFetchMetric(staticGenerationStore, {
+            start: fetchStart,
+            url: fetchUrl,
+            cacheReason: cacheReasonOverride || cacheReason,
+            cacheStatus:
+              revalidate === 0 || cacheReasonOverride ? 'skip' : 'miss',
+            status: res.status,
+            method: clonedInit.method || 'GET',
+          })
+        }
+        if (
+          res.status === 200 &&
+          staticGenerationStore.incrementalCache &&
+          cacheKey &&
+          isCacheableRevalidate
+        ) {
+          const bodyBuffer = Buffer.from(await res.arrayBuffer())
+
+          try {
+            await staticGenerationStore.incrementalCache.set(
+              cacheKey,
+              {
+                kind: 'FETCH',
+                data: {
+                  headers: Object.fromEntries(res.headers.entries()),
+                  body: bodyBuffer.toString('base64'),
+                  status: res.status,
+                  url: res.url,
+                },
+                revalidate: normalizedRevalidate,
+              },
+              {
+                fetchCache: true,
+                revalidate,
+                fetchUrl,
+                fetchIdx,
+                tags,
+              }
+            )
+          } catch (err) {
+            console.warn(`Failed to set fetch cache`, input, err)
+          }
+
+          const response = new Response(bodyBuffer, {
+            headers: new Headers(res.headers),
+            status: res.status,
+          })
+          Object.defineProperty(response, 'url', { value: res.url })
+          return response
+        }
+        return res
+      })
+    }
+
+    let handleUnlock = () => Promise.resolve()
+    let cacheReasonOverride
+
+    if (cacheKey && staticGenerationStore.incrementalCache) {
+      handleUnlock = await staticGenerationStore.incrementalCache.lock(cacheKey)
+
+      const entry = staticGenerationStore.isOnDemandRevalidate
+        ? null
+        : await staticGenerationStore.incrementalCache.get(cacheKey, {
+            fetchCache: true,
+            revalidate,
+            fetchUrl,
+            fetchIdx,
+            tags,
+            softTags: implicitTags,
+          })
+
+      if (entry) {
+        await handleUnlock()
+      } else {
+        // in dev, incremental cache response will be null in case the browser adds `cache-control: no-cache` in the request headers
+        cacheReasonOverride = 'cache-control: no-cache (hard refresh)'
+      }
+
+      if (entry?.value && entry.value.kind === 'FETCH') {
+        // when stale and is revalidating we wait for fresh data
+        // so the revalidated entry has the updated data
+        if (!(staticGenerationStore.isRevalidate && entry.isStale)) {
+          if (entry.isStale) {
+            if (!staticGenerationStore.pendingRevalidates) {
+              staticGenerationStore.pendingRevalidates = []
+            }
+            staticGenerationStore.pendingRevalidates.push(
+              doOriginalFetch(true).catch(console.error)
+            )
+          }
+          const resData = entry.value.data
+
+          trackFetchMetric(staticGenerationStore, {
+            start: fetchStart,
+            url: fetchUrl,
+            cacheReason,
+            cacheStatus: 'hit',
+            status: resData.status || 200,
+            method: init?.method || 'GET',
+          })
+
+          const response = new Response(Buffer.from(resData.body, 'base64'), {
+            headers: resData.headers,
+            status: resData.status,
+          })
+          Object.defineProperty(response, 'url', {
+            value: entry.value.data.url,
+          })
+          return response
+        }
+      }
+    }
+
+    if (
+      staticGenerationStore.isStaticGeneration &&
+      init &&
+      typeof init === 'object'
+    ) {
+      const { cache } = init
+
+      // Delete `cache` property as Cloudflare Workers will throw an error
+      if (isEdgeRuntime) delete init.cache
+
+      if (cache === 'no-store') {
+        const dynamicUsageReason = `no-store fetch ${input}${
+          staticGenerationStore.urlPathname
+            ? ` ${staticGenerationStore.urlPathname}`
+            : ''
+        }`
+        const err = new DynamicServerError(dynamicUsageReason)
+        staticGenerationStore.dynamicUsageErr = err
+        staticGenerationStore.dynamicUsageStack = err.stack
+        staticGenerationStore.dynamicUsageDescription = dynamicUsageReason
+
+        // If enabled, we should bail out of static generation.
+        maybePostpone(staticGenerationStore, dynamicUsageReason)
+
+        // PPR is not enabled, or React postpone is not available, we
+        // should set the revalidate to 0.
+        staticGenerationStore.revalidate = 0
+      }
+
+      const hasNextConfig = 'next' in init
+      const { next = {} } = init
+      if (
+        typeof next.revalidate === 'number' &&
+        (typeof staticGenerationStore.revalidate === 'undefined' ||
+          (typeof staticGenerationStore.revalidate === 'number' &&
+            next.revalidate < staticGenerationStore.revalidate))
+      ) {
+        const forceDynamic = staticGenerationStore.forceDynamic
+
+        if (!forceDynamic && next.revalidate === 0) {
+          const dynamicUsageReason = `revalidate: 0 fetch ${input}${
+            staticGenerationStore.urlPathname
+              ? ` ${staticGenerationStore.urlPathname}`
+              : ''
+          }`
+          const err = new DynamicServerError(dynamicUsageReason)
+          staticGenerationStore.dynamicUsageErr = err
+          staticGenerationStore.dynamicUsageStack = err.stack
+          staticGenerationStore.dynamicUsageDescription = dynamicUsageReason
+
+          // If enabled, we should bail out of static generation.
+          maybePostpone(staticGenerationStore, dynamicUsageReason)
+        }
+
+        if (!forceDynamic || next.revalidate !== 0) {
+          staticGenerationStore.revalidate = next.revalidate
+        }
+      }
+
+      if (hasNextConfig) delete init.next
+    }
+
+    return doOriginalFetch(false, cacheReasonOverride).finally(handleUnlock)
+  }
+
   globalThis.fetch = async (
     input: RequestInfo | URL,
     init: RequestInit | undefined
@@ -193,449 +631,18 @@ export function patchFetch({
           'net.peer.port': url?.port || undefined,
         },
       },
-      async () => {
-        const staticGenerationStore: StaticGenerationStore =
-          staticGenerationAsyncStorage.getStore() ||
-          (fetch as any).__nextGetStaticStore?.()
-        const isRequestInput =
-          input &&
-          typeof input === 'object' &&
-          typeof (input as Request).method === 'string'
-
-        const getRequestMeta = (field: string) => {
-          let value = isRequestInput ? (input as any)[field] : null
-          return value || (init as any)?.[field]
-        }
-
-        // If the staticGenerationStore is not available, we can't do any
-        // special treatment of fetch, therefore fallback to the original
-        // fetch implementation.
-        if (
-          !staticGenerationStore ||
-          isInternal ||
-          staticGenerationStore.isDraftMode
-        ) {
-          return originFetch(input, init)
-        }
-
-        let revalidate: number | undefined | false = undefined
-        const getNextField = (field: 'revalidate' | 'tags') => {
-          return typeof init?.next?.[field] !== 'undefined'
-            ? init?.next?.[field]
-            : isRequestInput
-            ? (input as any).next?.[field]
-            : undefined
-        }
-        // RequestInit doesn't keep extra fields e.g. next so it's
-        // only available if init is used separate
-        let curRevalidate = getNextField('revalidate')
-        const tags: string[] = validateTags(
-          getNextField('tags') || [],
-          `fetch ${input.toString()}`
+      async (span) => {
+        const response = await internalFetch(
+          input,
+          init,
+          isInternal,
+          fetchUrl,
+          fetchStart
         )
-
-        if (Array.isArray(tags)) {
-          if (!staticGenerationStore.tags) {
-            staticGenerationStore.tags = []
-          }
-          for (const tag of tags) {
-            if (!staticGenerationStore.tags.includes(tag)) {
-              staticGenerationStore.tags.push(tag)
-            }
-          }
+        if (span) {
+          span.setAttribute('http.status_code', response.status)
         }
-        const implicitTags = addImplicitTags(staticGenerationStore)
-
-        const isOnlyCache = staticGenerationStore.fetchCache === 'only-cache'
-        const isForceCache = staticGenerationStore.fetchCache === 'force-cache'
-        const isDefaultCache =
-          staticGenerationStore.fetchCache === 'default-cache'
-        const isDefaultNoStore =
-          staticGenerationStore.fetchCache === 'default-no-store'
-        const isOnlyNoStore =
-          staticGenerationStore.fetchCache === 'only-no-store'
-        const isForceNoStore =
-          staticGenerationStore.fetchCache === 'force-no-store'
-
-        let _cache = getRequestMeta('cache')
-        let cacheReason = ''
-
-        if (
-          typeof _cache === 'string' &&
-          typeof curRevalidate !== 'undefined'
-        ) {
-          Log.warn(
-            `fetch for ${fetchUrl} on ${staticGenerationStore.urlPathname} specified "cache: ${_cache}" and "revalidate: ${curRevalidate}", only one should be specified.`
-          )
-          _cache = undefined
-        }
-
-        if (_cache === 'force-cache') {
-          curRevalidate = false
-        } else if (
-          _cache === 'no-cache' ||
-          _cache === 'no-store' ||
-          isForceNoStore ||
-          isOnlyNoStore
-        ) {
-          curRevalidate = 0
-        }
-
-        if (_cache === 'no-cache' || _cache === 'no-store') {
-          cacheReason = `cache: ${_cache}`
-        }
-
-        if (typeof curRevalidate === 'number' || curRevalidate === false) {
-          revalidate = curRevalidate
-        }
-
-        const _headers = getRequestMeta('headers')
-        const initHeaders: Headers =
-          typeof _headers?.get === 'function'
-            ? _headers
-            : new Headers(_headers || {})
-
-        const hasUnCacheableHeader =
-          initHeaders.get('authorization') || initHeaders.get('cookie')
-
-        const isUnCacheableMethod = !['get', 'head'].includes(
-          getRequestMeta('method')?.toLowerCase() || 'get'
-        )
-
-        // if there are authorized headers or a POST method and
-        // dynamic data usage was present above the tree we bail
-        // e.g. if cookies() is used before an authed/POST fetch
-        const autoNoCache =
-          (hasUnCacheableHeader || isUnCacheableMethod) &&
-          staticGenerationStore.revalidate === 0
-
-        if (isForceNoStore) {
-          cacheReason = 'fetchCache = force-no-store'
-        }
-
-        if (isOnlyNoStore) {
-          if (
-            _cache === 'force-cache' ||
-            (typeof revalidate !== 'undefined' &&
-              (revalidate === false || revalidate > 0))
-          ) {
-            throw new Error(
-              `cache: 'force-cache' used on fetch for ${fetchUrl} with 'export const fetchCache = 'only-no-store'`
-            )
-          }
-          cacheReason = 'fetchCache = only-no-store'
-        }
-
-        if (isOnlyCache && _cache === 'no-store') {
-          throw new Error(
-            `cache: 'no-store' used on fetch for ${fetchUrl} with 'export const fetchCache = 'only-cache'`
-          )
-        }
-
-        if (
-          isForceCache &&
-          (typeof curRevalidate === 'undefined' || curRevalidate === 0)
-        ) {
-          cacheReason = 'fetchCache = force-cache'
-          revalidate = false
-        }
-
-        if (typeof revalidate === 'undefined') {
-          if (isDefaultCache) {
-            revalidate = false
-            cacheReason = 'fetchCache = default-cache'
-          } else if (autoNoCache) {
-            revalidate = 0
-            cacheReason = 'auto no cache'
-          } else if (isDefaultNoStore) {
-            revalidate = 0
-            cacheReason = 'fetchCache = default-no-store'
-          } else {
-            cacheReason = 'auto cache'
-            revalidate =
-              typeof staticGenerationStore.revalidate === 'boolean' ||
-              typeof staticGenerationStore.revalidate === 'undefined'
-                ? false
-                : staticGenerationStore.revalidate
-          }
-        } else if (!cacheReason) {
-          cacheReason = `revalidate: ${revalidate}`
-        }
-
-        if (
-          // we don't consider autoNoCache to switch to dynamic during
-          // revalidate although if it occurs during build we do
-          !autoNoCache &&
-          (typeof staticGenerationStore.revalidate === 'undefined' ||
-            (typeof revalidate === 'number' &&
-              (staticGenerationStore.revalidate === false ||
-                (typeof staticGenerationStore.revalidate === 'number' &&
-                  revalidate < staticGenerationStore.revalidate))))
-        ) {
-          // If enabled, we should bail out of static generation.
-          if (revalidate === 0) {
-            maybePostpone(staticGenerationStore, 'revalidate: 0')
-          }
-
-          staticGenerationStore.revalidate = revalidate
-        }
-
-        const isCacheableRevalidate =
-          (typeof revalidate === 'number' && revalidate > 0) ||
-          revalidate === false
-
-        let cacheKey: string | undefined
-        if (staticGenerationStore.incrementalCache && isCacheableRevalidate) {
-          try {
-            cacheKey =
-              await staticGenerationStore.incrementalCache.fetchCacheKey(
-                fetchUrl,
-                isRequestInput ? (input as RequestInit) : init
-              )
-          } catch (err) {
-            console.error(`Failed to generate cache key for`, input)
-          }
-        }
-
-        const fetchIdx = staticGenerationStore.nextFetchId ?? 1
-        staticGenerationStore.nextFetchId = fetchIdx + 1
-
-        const normalizedRevalidate =
-          typeof revalidate !== 'number' ? CACHE_ONE_YEAR : revalidate
-
-        const doOriginalFetch = async (
-          isStale?: boolean,
-          cacheReasonOverride?: string
-        ) => {
-          const requestInputFields = [
-            'cache',
-            'credentials',
-            'headers',
-            'integrity',
-            'keepalive',
-            'method',
-            'mode',
-            'redirect',
-            'referrer',
-            'referrerPolicy',
-            'window',
-            'duplex',
-
-            // don't pass through signal when revalidating
-            ...(isStale ? [] : ['signal']),
-          ]
-
-          if (isRequestInput) {
-            const reqInput: Request = input as any
-            const reqOptions: RequestInit = {
-              body: (reqInput as any)._ogBody || reqInput.body,
-            }
-
-            for (const field of requestInputFields) {
-              // @ts-expect-error custom fields
-              reqOptions[field] = reqInput[field]
-            }
-            input = new Request(reqInput.url, reqOptions)
-          } else if (init) {
-            const initialInit = init
-            init = {
-              body: (init as any)._ogBody || init.body,
-            }
-            for (const field of requestInputFields) {
-              // @ts-expect-error custom fields
-              init[field] = initialInit[field]
-            }
-          }
-
-          // add metadata to init without editing the original
-          const clonedInit = {
-            ...init,
-            next: { ...init?.next, fetchType: 'origin', fetchIdx },
-          }
-
-          return originFetch(input, clonedInit).then(async (res) => {
-            if (!isStale) {
-              trackFetchMetric(staticGenerationStore, {
-                start: fetchStart,
-                url: fetchUrl,
-                cacheReason: cacheReasonOverride || cacheReason,
-                cacheStatus:
-                  revalidate === 0 || cacheReasonOverride ? 'skip' : 'miss',
-                status: res.status,
-                method: clonedInit.method || 'GET',
-              })
-            }
-            if (
-              res.status === 200 &&
-              staticGenerationStore.incrementalCache &&
-              cacheKey &&
-              isCacheableRevalidate
-            ) {
-              const bodyBuffer = Buffer.from(await res.arrayBuffer())
-
-              try {
-                await staticGenerationStore.incrementalCache.set(
-                  cacheKey,
-                  {
-                    kind: 'FETCH',
-                    data: {
-                      headers: Object.fromEntries(res.headers.entries()),
-                      body: bodyBuffer.toString('base64'),
-                      status: res.status,
-                      url: res.url,
-                    },
-                    revalidate: normalizedRevalidate,
-                  },
-                  {
-                    fetchCache: true,
-                    revalidate,
-                    fetchUrl,
-                    fetchIdx,
-                    tags,
-                  }
-                )
-              } catch (err) {
-                console.warn(`Failed to set fetch cache`, input, err)
-              }
-
-              const response = new Response(bodyBuffer, {
-                headers: new Headers(res.headers),
-                status: res.status,
-              })
-              Object.defineProperty(response, 'url', { value: res.url })
-              return response
-            }
-            return res
-          })
-        }
-
-        let handleUnlock = () => Promise.resolve()
-        let cacheReasonOverride
-
-        if (cacheKey && staticGenerationStore.incrementalCache) {
-          handleUnlock = await staticGenerationStore.incrementalCache.lock(
-            cacheKey
-          )
-
-          const entry = staticGenerationStore.isOnDemandRevalidate
-            ? null
-            : await staticGenerationStore.incrementalCache.get(cacheKey, {
-                fetchCache: true,
-                revalidate,
-                fetchUrl,
-                fetchIdx,
-                tags,
-                softTags: implicitTags,
-              })
-
-          if (entry) {
-            await handleUnlock()
-          } else {
-            // in dev, incremental cache response will be null in case the browser adds `cache-control: no-cache` in the request headers
-            cacheReasonOverride = 'cache-control: no-cache (hard refresh)'
-          }
-
-          if (entry?.value && entry.value.kind === 'FETCH') {
-            // when stale and is revalidating we wait for fresh data
-            // so the revalidated entry has the updated data
-            if (!(staticGenerationStore.isRevalidate && entry.isStale)) {
-              if (entry.isStale) {
-                if (!staticGenerationStore.pendingRevalidates) {
-                  staticGenerationStore.pendingRevalidates = []
-                }
-                staticGenerationStore.pendingRevalidates.push(
-                  doOriginalFetch(true).catch(console.error)
-                )
-              }
-              const resData = entry.value.data
-
-              trackFetchMetric(staticGenerationStore, {
-                start: fetchStart,
-                url: fetchUrl,
-                cacheReason,
-                cacheStatus: 'hit',
-                status: resData.status || 200,
-                method: init?.method || 'GET',
-              })
-
-              const response = new Response(
-                Buffer.from(resData.body, 'base64'),
-                {
-                  headers: resData.headers,
-                  status: resData.status,
-                }
-              )
-              Object.defineProperty(response, 'url', {
-                value: entry.value.data.url,
-              })
-              return response
-            }
-          }
-        }
-
-        if (
-          staticGenerationStore.isStaticGeneration &&
-          init &&
-          typeof init === 'object'
-        ) {
-          const { cache } = init
-
-          // Delete `cache` property as Cloudflare Workers will throw an error
-          if (isEdgeRuntime) delete init.cache
-
-          if (cache === 'no-store') {
-            const dynamicUsageReason = `no-store fetch ${input}${
-              staticGenerationStore.urlPathname
-                ? ` ${staticGenerationStore.urlPathname}`
-                : ''
-            }`
-            const err = new DynamicServerError(dynamicUsageReason)
-            staticGenerationStore.dynamicUsageErr = err
-            staticGenerationStore.dynamicUsageStack = err.stack
-            staticGenerationStore.dynamicUsageDescription = dynamicUsageReason
-
-            // If enabled, we should bail out of static generation.
-            maybePostpone(staticGenerationStore, dynamicUsageReason)
-
-            // PPR is not enabled, or React postpone is not available, we
-            // should set the revalidate to 0.
-            staticGenerationStore.revalidate = 0
-          }
-
-          const hasNextConfig = 'next' in init
-          const { next = {} } = init
-          if (
-            typeof next.revalidate === 'number' &&
-            (typeof staticGenerationStore.revalidate === 'undefined' ||
-              (typeof staticGenerationStore.revalidate === 'number' &&
-                next.revalidate < staticGenerationStore.revalidate))
-          ) {
-            const forceDynamic = staticGenerationStore.forceDynamic
-
-            if (!forceDynamic && next.revalidate === 0) {
-              const dynamicUsageReason = `revalidate: 0 fetch ${input}${
-                staticGenerationStore.urlPathname
-                  ? ` ${staticGenerationStore.urlPathname}`
-                  : ''
-              }`
-              const err = new DynamicServerError(dynamicUsageReason)
-              staticGenerationStore.dynamicUsageErr = err
-              staticGenerationStore.dynamicUsageStack = err.stack
-              staticGenerationStore.dynamicUsageDescription = dynamicUsageReason
-
-              // If enabled, we should bail out of static generation.
-              maybePostpone(staticGenerationStore, dynamicUsageReason)
-            }
-
-            if (!forceDynamic || next.revalidate !== 0) {
-              staticGenerationStore.revalidate = next.revalidate
-            }
-          }
-
-          if (hasNextConfig) delete init.next
-        }
-
-        return doOriginalFetch(false, cacheReasonOverride).finally(handleUnlock)
+        return response
       }
     )
   }

--- a/test/e2e/opentelemetry/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/opentelemetry.test.ts
@@ -120,6 +120,7 @@ createNextDescribe(
                   {
                     "attributes": {
                       "http.method": "GET",
+                      "http.status_code": 200,
                       "http.url": "https://vercel.com/",
                       "net.peer.name": "vercel.com",
                       "next.span_name": "fetch GET https://vercel.com/",


### PR DESCRIPTION
`http.status_code` is the [standard](https://github.com/open-telemetry/opentelemetry-js/blob/1c7d7a354281c720e7229d3d5498bbec8d3b2b8d/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts#L389) attribute for HTTP requests.