### PR TITLE
Remove experimental flag from `serverActions.bodySizeLimit`

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/server-actions.mdx
+++ b/docs/02-app/02-api-reference/04-functions/server-actions.mdx
@@ -140,7 +140,7 @@ In both cases, the form is interactive before hydration occurs. Although Server 
 
 ## Size Limitation
 
-By default, the maximum size of the request body sent to a Server Action is 1MB, to prevent the consumption of excessive server resources in parsing large amounts of data.
+By default, the maximum size of the request body sent to a Server Action is 1mb, to prevent the consumption of excessive server resources in parsing large amounts of data.
 
 However, you can configure this limit using the `serverActions.bodySizeLimit` option. It can take the number of bytes or any string format supported by bytes, for example `1000`, `'500kb'` or `'3mb'`.
 

--- a/docs/02-app/02-api-reference/04-functions/server-actions.mdx
+++ b/docs/02-app/02-api-reference/04-functions/server-actions.mdx
@@ -146,10 +146,8 @@ However, you can configure this limit using the `serverActions.bodySizeLimit` op
 
 ```js filename="next.config.js"
 module.exports = {
-  experimental: {
-    serverActions: {
-      bodySizeLimit: '2mb',
-    },
+  serverActions: {
+    bodySizeLimit: '2mb',
   },
 }
 ```

--- a/docs/02-app/02-api-reference/04-functions/server-actions.mdx
+++ b/docs/02-app/02-api-reference/04-functions/server-actions.mdx
@@ -140,9 +140,9 @@ In both cases, the form is interactive before hydration occurs. Although Server 
 
 ## Size Limitation
 
-By default, the maximum size of the request body sent to a Server Action is 1mb, to prevent the consumption of excessive server resources in parsing large amounts of data.
+By default, the maximum size of the request body sent to a Server Action is `1mb`, to prevent the consumption of excessive server resources in parsing large amounts of data.
 
-However, you can configure this limit using the `serverActions.bodySizeLimit` option. It can take the number of bytes or any string format supported by bytes, for example `1000`, `'500kb'` or `'3mb'`.
+However, you can configure this limit using the `serverActions.bodySizeLimit` option. It can take the number of bits or any string format supported by bits, for example `1000`, `'500kb'` or `'3mb'`.
 
 ```js filename="next.config.js"
 module.exports = {

--- a/examples/next-forms/next.config.js
+++ b/examples/next-forms/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    serverActions: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/examples/with-fauna/next.config.js
+++ b/examples/with-fauna/next.config.js
@@ -1,7 +1,3 @@
-const nextConfig = {
-  experimental: {
-    serverActions: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/examples/with-stripe-typescript/next.config.js
+++ b/examples/with-stripe-typescript/next.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  experimental: {
-    serverActions: true,
-  },
-}
+module.exports = {}

--- a/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
@@ -158,7 +158,6 @@ async fn wrap_edge_page(
     //    let server_actions_body_size_limit =
     // &next_config.experimental.server_actions.body_size_limit;
     let server_actions_body_size_limit = next_config
-        .experimental
         .server_actions
         .as_ref()
         .and_then(|sa| sa.body_size_limit.as_ref());

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -94,6 +94,7 @@ pub struct NextConfig {
     pub dev_indicators: Option<DevIndicatorsConfig>,
     pub output: Option<OutputType>,
     pub analytics_id: Option<String>,
+    pub server_actions: Option<ServerActions>,
 
     ///
     #[serde(rename = "_originalRedirects")]
@@ -442,7 +443,6 @@ pub struct ExperimentalConfig {
     pub optimize_css: Option<serde_json::Value>,
     pub next_script_workers: Option<bool>,
     pub web_vitals_attribution: Option<Vec<String>>,
-    pub server_actions: Option<ServerActions>,
     pub sri: Option<SubResourceIntegrity>,
 
     // ---

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -417,8 +417,7 @@ export function getEdgeServerEntry(opts: {
     middlewareConfig: Buffer.from(
       JSON.stringify(opts.middlewareConfig || {})
     ).toString('base64'),
-    serverActionsBodySizeLimit:
-      opts.config.experimental.serverActions?.bodySizeLimit,
+    serverActionsBodySizeLimit: opts.config.serverActions?.bodySizeLimit,
   }
 
   return {

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -10,6 +10,7 @@ import type { DocumentType } from '../../shared/lib/utils'
 import type { BuildManifest } from '../../server/get-page-files'
 import type { RequestData } from '../../server/web/types'
 import type { NextConfigComplete } from '../../server/config-shared'
+import type { SizeLimit } from '../../../types'
 
 declare const incrementalCacheHandler: any
 // OPTIONAL_IMPORT:incrementalCacheHandler
@@ -23,7 +24,7 @@ const error500Mod = null
 declare const sriEnabled: boolean
 declare const isServerComponent: boolean
 declare const dev: boolean
-declare const serverActionsBodySizeLimit: any
+declare const serverActionsBodySizeLimit: SizeLimit
 declare const nextConfig: NextConfigComplete
 // INJECT:sriEnabled
 // INJECT:isServerComponent

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -488,8 +488,7 @@ export async function exportAppImpl(
     optimizeFonts: nextConfig.optimizeFonts as FontConfig,
     largePageDataBytes: nextConfig.experimental.largePageDataBytes,
     serverComponents: options.hasAppDir,
-    serverActionsBodySizeLimit:
-      nextConfig.experimental.serverActions?.bodySizeLimit,
+    serverActionsBodySizeLimit: nextConfig.serverActions?.bodySizeLimit,
     nextFontManifest: require(join(
       distDir,
       'server',

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -41,6 +41,7 @@ const supportedTurbopackNextConfigOptions = [
   'amp',
   'devIndicators',
   'analyticsId',
+  'serverActions',
 
   // Options that are ignored as they don't affect Turbopack
   'webpack',
@@ -78,7 +79,7 @@ const supportedTurbopackNextConfigOptions = [
   'experimental.logging.fullUrl',
   'experimental.scrollRestoration',
   'experimental.forceSwcTransforms',
-  'experimental.serverActions.bodySizeLimit',
+  // 'experimental.serverActions.bodySizeLimit',
   'experimental.memoryBasedWorkersCount',
   'experimental.clientRouterFilterRedirects',
   'experimental.webpackBuildWorker',

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -79,7 +79,6 @@ const supportedTurbopackNextConfigOptions = [
   'experimental.logging.fullUrl',
   'experimental.scrollRestoration',
   'experimental.forceSwcTransforms',
-  // 'experimental.serverActions.bodySizeLimit',
   'experimental.memoryBasedWorkersCount',
   'experimental.clientRouterFilterRedirects',
   'experimental.webpackBuildWorker',

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -429,8 +429,8 @@ export async function handleAction({
             const { ApiError } = require('../api-utils')
             throw new ApiError(
               413,
-              `Body exceeded ${serverActionsBodySizeLimit} limit.
-To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/server-actions#size-limitation`
+              `Body exceeded ${serverActionsBodySizeLimit} limit. ` +
+                'To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/functions/server-actions#size-limitation'
             )
           }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2091,7 +2091,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
               isRevalidate: isSSG,
               originalPathname: components.ComponentMod.originalPathname,
               serverActionsBodySizeLimit:
-                this.nextConfig.experimental.serverActions?.bodySizeLimit,
+                this.nextConfig.serverActions?.bodySizeLimit,
             }
           : {}),
         isDataReq,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -306,13 +306,6 @@ export interface ExperimentalConfig {
    */
   taint?: boolean
 
-  serverActions?: {
-    /**
-     * Allows adjusting body parser size limit for server actions.
-     */
-    bodySizeLimit?: SizeLimit
-  }
-
   /**
    * enables the minification of server code.
    */
@@ -670,6 +663,13 @@ export interface NextConfig extends Record<string, any> {
     fetches?: {
       fullUrl?: boolean
     }
+  }
+
+  serverActions?: {
+    /**
+     * Allows adjusting body parser size limit for server actions.
+     */
+    bodySizeLimit?: SizeLimit
   }
 
   /**

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -490,15 +490,11 @@ function assignDefaults(
     result.output = 'standalone'
   }
 
-  if (
-    typeof result.experimental?.serverActions?.bodySizeLimit !== 'undefined'
-  ) {
-    const value = parseInt(
-      result.experimental.serverActions?.bodySizeLimit.toString()
-    )
+  if (typeof result.serverActions?.bodySizeLimit !== 'undefined') {
+    const value = parseInt(result.serverActions?.bodySizeLimit.toString())
     if (isNaN(value) || value < 1) {
       throw new Error(
-        'Server Actions Size Limit must be a valid number or filesize format lager than 1MB: https://nextjs.org/docs/app/api-reference/server-actions#size-limitation'
+        'Server Actions Size Limit must be a valid number or filesize format lager than 1MB: https://nextjs.org/docs/app/api-reference/functions/server-actions#size-limitation'
       )
     }
   }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -494,7 +494,7 @@ function assignDefaults(
     const value = parseInt(result.serverActions?.bodySizeLimit.toString())
     if (isNaN(value) || value < 1) {
       throw new Error(
-        'Server Actions Size Limit must be a valid number or filesize format lager than 1MB: https://nextjs.org/docs/app/api-reference/functions/server-actions#size-limitation'
+        'Server Actions Size Limit must be a valid number or filesize format lager than 1mb: https://nextjs.org/docs/app/api-reference/functions/server-actions#size-limitation'
       )
     }
   }

--- a/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
+++ b/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
@@ -2,7 +2,7 @@ import { createNextDescribe } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 const CONFIG_ERROR =
-  'Server Actions Size Limit must be a valid number or filesize format lager than 1MB'
+  'Server Actions Size Limit must be a valid number or filesize format lager than 1mb'
 
 createNextDescribe(
   'app-dir action size limit invalid config',

--- a/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
+++ b/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
@@ -26,9 +26,7 @@ createNextDescribe(
         'next.config.js',
         `
       module.exports = {
-        experimental: {
-          serverActions: { bodySizeLimit: -3000 }
-        },
+        serverActions: { bodySizeLimit: -3000 }
       }
       `
       )
@@ -44,9 +42,7 @@ createNextDescribe(
         'next.config.js',
         `
       module.exports = {
-        experimental: {
-          serverActions: { bodySizeLimit: 'testmb' }
-        },
+        serverActions: { bodySizeLimit: 'testmb' }
       }
       `
       )
@@ -62,9 +58,7 @@ createNextDescribe(
         'next.config.js',
         `
       module.exports = {
-        experimental: {
-          serverActions: { bodySizeLimit: '-3000mb' }
-        },
+        serverActions: { bodySizeLimit: '-3000mb' }
       }
       `
       )
@@ -81,9 +75,7 @@ createNextDescribe(
           'next.config.js',
           `
       module.exports = {
-        experimental: {
-          serverActions: { bodySizeLimit: '1.5mb' }
-        },
+        serverActions: { bodySizeLimit: '1.5mb' }
       }
       `
         )


### PR DESCRIPTION
Since the Server Actions became stable, the following config for `bodySizeLimit` should also be removed from the `experimental` section.

This PR added the `serverActions` option to the next config for the current `bodySizeLimit` and further additions.
Also, modified text on docs from `bytes` to `bits` and `MB` to `mb`.

Extends #57145 #57433