### PR TITLE
Skip packing compression in tests

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -190,13 +190,17 @@ module.exports = (actionInfo) => {
               }
             }
 
-            const { stdout } = await execa('pnpm', ['pack'], {
-              cwd: pkgPath,
-              env: {
-                ...process.env,
-                COREPACK_ENABLE_STRICT: '0',
-              },
-            })
+            const { stdout } = await execa(
+              'pnpm',
+              ['pack', '--pack-gzip-level=0'],
+              {
+                cwd: pkgPath,
+                env: {
+                  ...process.env,
+                  COREPACK_ENABLE_STRICT: '0',
+                },
+              }
+            )
 
             return Promise.all([
               fs.rename(path.resolve(pkgPath, stdout.trim()), packedPkgPath),


### PR DESCRIPTION
I saw that you guys updated to `pnpm@8`, which means you are able to use [this flag](https://github.com/pnpm/pnpm/pull/6406) that I added into `pnpm` when I was digging into next speed improvements.

Especially when running in `dev` move the longest thing is packing our packages that are later installed in the isolated test environment. It can be sped up by a lot if you skip the compression because we don't care about the sizes in our tests.

You can see the speed improvement by running [test tracing](https://github.com/vercel/next.js/pull/44046):
```
pnpm build && NEXT_TEST_TRACE=1  pnpm test-dev test/e2e/test-utils-tests/basic/basic.test.ts && pnpm node scripts/trace-to-tree.mjs test/.trace/trace
```

When I measured the impact half-year ago it should speed up each test run by ~4 seconds.

I tried to do this myself, but I was not able to get the test suite to run (even on `canary`).
Also testing doc is outdated, the example commands use non-existent tests.
The issue was that `next build` running in the test got stuck and never finished.