### PR TITLE
[Traces] Serialize trace info across workers to preserve .next/trace with webpackBuildWorker

### DIFF
--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -357,7 +357,9 @@ export async function workerMain(workerData: {
     PHASE_PRODUCTION_BUILD,
     NextBuildContext.dir!
   )
-  NextBuildContext.nextBuildSpan = trace('next-build')
+  NextBuildContext.nextBuildSpan = trace(
+    `worker-main-${workerData.compilerName}`
+  )
 
   const result = await webpackBuildImpl(workerData.compilerName)
   const { entriesTrace, chunksTrace } = result.buildTraceContext ?? {}
@@ -375,5 +377,6 @@ export async function workerMain(workerData: {
     const entryNameFilesMap = chunksTrace.entryNameFilesMap
     result.buildTraceContext!.chunksTrace!.entryNameFilesMap = entryNameFilesMap
   }
+  NextBuildContext.nextBuildSpan.stop()
   return { ...result, debugTraceEvents: getTraceEvents() }
 }

--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -6,7 +6,7 @@ import { Worker } from 'next/dist/compiled/jest-worker'
 import origDebug from 'next/dist/compiled/debug'
 import type { ChildProcess } from 'child_process'
 import path from 'path'
-import { exportTraceState, recordTracesFromWorker } from '../../trace'
+import { exportTraceState, recordTraceEvents } from '../../trace'
 
 const debug = origDebug('next:build:webpack-build')
 
@@ -84,10 +84,14 @@ async function webpackBuildWithWorker(
     const curResult = await worker.workerMain({
       buildContext: prunedBuildContext,
       compilerName,
-      traceState: exportTraceState(),
+      traceState: {
+        ...exportTraceState(),
+        defaultParentSpanId: nextBuildSpan?.id,
+        shouldSaveTraceEvents: true,
+      },
     })
     if (nextBuildSpan && curResult.debugTraceEvents) {
-      recordTracesFromWorker(nextBuildSpan, curResult.debugTraceEvents)
+      recordTraceEvents(curResult.debugTraceEvents)
     }
     // destroy worker so it's not sticking around using memory
     await worker.end()

--- a/packages/next/src/trace/index.ts
+++ b/packages/next/src/trace/index.ts
@@ -1,12 +1,25 @@
 import {
   trace,
+  exportTraceState,
   flushAllTraces,
   getTraceEvents,
+  initializeTraceState,
+  recordTracesFromWorker,
   Span,
   SpanStatus,
 } from './trace'
 import { setGlobal } from './shared'
-import type { SpanId, TraceEvent } from './types'
+import type { SpanId, TraceEvent, TraceState } from './types'
 
-export { trace, flushAllTraces, getTraceEvents, Span, setGlobal, SpanStatus }
-export type { SpanId, TraceEvent }
+export {
+  trace,
+  exportTraceState,
+  flushAllTraces,
+  getTraceEvents,
+  initializeTraceState,
+  recordTracesFromWorker,
+  Span,
+  setGlobal,
+  SpanStatus,
+}
+export type { SpanId, TraceEvent, TraceState }

--- a/packages/next/src/trace/index.ts
+++ b/packages/next/src/trace/index.ts
@@ -1,6 +1,12 @@
-import { trace, flushAllTraces, Span, SpanStatus } from './trace'
-import type { SpanId } from './shared'
+import {
+  trace,
+  flushAllTraces,
+  getTraceEvents,
+  Span,
+  SpanStatus,
+} from './trace'
 import { setGlobal } from './shared'
+import type { SpanId, TraceEvent } from './types'
 
-export { trace, flushAllTraces, Span, setGlobal, SpanStatus }
-export type { SpanId }
+export { trace, flushAllTraces, getTraceEvents, Span, setGlobal, SpanStatus }
+export type { SpanId, TraceEvent }

--- a/packages/next/src/trace/index.ts
+++ b/packages/next/src/trace/index.ts
@@ -4,7 +4,7 @@ import {
   flushAllTraces,
   getTraceEvents,
   initializeTraceState,
-  recordTracesFromWorker,
+  recordTraceEvents,
   Span,
   SpanStatus,
 } from './trace'
@@ -17,7 +17,7 @@ export {
   flushAllTraces,
   getTraceEvents,
   initializeTraceState,
-  recordTracesFromWorker,
+  recordTraceEvents,
   Span,
   setGlobal,
   SpanStatus,

--- a/packages/next/src/trace/report/index.test.ts
+++ b/packages/next/src/trace/report/index.test.ts
@@ -23,9 +23,15 @@ describe('Trace Reporter', () => {
   describe('Multireporter', () => {
     it('should keep track of all the trace events', () => {
       reporter.report(TRACE_EVENT)
+      reporter.report(WEBPACK_INVALIDATED_EVENT)
       const traceEvents = reporter.getTraceEvents()
-      expect(traceEvents.length).toEqual(1)
-      expect(traceEvents[0].name).toEqual('test-span')
+      expect(traceEvents.length).toEqual(2)
+      const firstEvent = traceEvents[0]
+      expect(firstEvent.name).toEqual('test-span')
+      expect(firstEvent.id).toEqual(127)
+      const secondEvent = traceEvents[1]
+      expect(secondEvent.name).toEqual('webpack-invalidated')
+      expect(secondEvent.id).toEqual(112)
     })
   })
 
@@ -40,6 +46,8 @@ describe('Trace Reporter', () => {
       const traces = JSON.parse(await readFile(traceFilename, 'utf-8'))
       expect(traces.length).toEqual(1)
       expect(traces[0].name).toEqual('test-span')
+      expect(traces[0].id).toEqual(127)
+      expect(traces[0].duration).toEqual(321)
     })
   })
 

--- a/packages/next/src/trace/report/index.test.ts
+++ b/packages/next/src/trace/report/index.test.ts
@@ -48,6 +48,7 @@ describe('Trace Reporter', () => {
       expect(traces[0].name).toEqual('test-span')
       expect(traces[0].id).toEqual(127)
       expect(traces[0].duration).toEqual(321)
+      expect(traces[0].traceId).toBeDefined()
     })
   })
 

--- a/packages/next/src/trace/report/index.test.ts
+++ b/packages/next/src/trace/report/index.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, readFile } from 'fs/promises'
+import { reporter } from '.'
+import { setGlobal } from '../shared'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const TRACE_EVENT = {
+  name: 'test-span',
+  duration: 321,
+  timestamp: Date.now(),
+  id: 127,
+  startTime: Date.now(),
+}
+const WEBPACK_INVALIDATED_EVENT = {
+  name: 'webpack-invalidated',
+  duration: 100,
+  timestamp: Date.now(),
+  id: 112,
+  startTime: Date.now(),
+}
+
+describe('Trace Reporter', () => {
+  describe('Multireporter', () => {
+    it('should keep track of all the trace events', () => {
+      reporter.report(TRACE_EVENT)
+      const traceEvents = reporter.getTraceEvents()
+      expect(traceEvents.length).toEqual(1)
+      expect(traceEvents[0].name).toEqual('test-span')
+    })
+  })
+
+  describe('JSON reporter', () => {
+    it('should write the trace events to JSON file', async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), 'json-reporter'))
+      setGlobal('distDir', tmpDir)
+      setGlobal('phase', 'anything')
+      reporter.report(TRACE_EVENT)
+      await reporter.flushAll()
+      const traceFilename = join(tmpDir, 'trace')
+      const traces = JSON.parse(await readFile(traceFilename, 'utf-8'))
+      expect(traces.length).toEqual(1)
+      expect(traces[0].name).toEqual('test-span')
+    })
+  })
+
+  describe('Telemetry reporter', () => {
+    it('should record telemetry event', async () => {
+      const recordMock = jest.fn()
+      const telemetryMock = {
+        record: recordMock,
+      }
+      setGlobal('telemetry', telemetryMock)
+      // This should be ignored.
+      reporter.report(TRACE_EVENT)
+      expect(recordMock).toBeCalledTimes(0)
+      reporter.report(WEBPACK_INVALIDATED_EVENT)
+      expect(recordMock).toBeCalledTimes(1)
+      expect(recordMock).toHaveBeenCalledWith({
+        eventName: 'WEBPACK_INVALIDATED',
+        payload: {
+          durationInMicroseconds: 100,
+        },
+      })
+    })
+  })
+})

--- a/packages/next/src/trace/report/index.test.ts
+++ b/packages/next/src/trace/report/index.test.ts
@@ -20,21 +20,6 @@ const WEBPACK_INVALIDATED_EVENT = {
 }
 
 describe('Trace Reporter', () => {
-  describe('Multireporter', () => {
-    it('should keep track of all the trace events', () => {
-      reporter.report(TRACE_EVENT)
-      reporter.report(WEBPACK_INVALIDATED_EVENT)
-      const traceEvents = reporter.getTraceEvents()
-      expect(traceEvents.length).toEqual(2)
-      const firstEvent = traceEvents[0]
-      expect(firstEvent.name).toEqual('test-span')
-      expect(firstEvent.id).toEqual(127)
-      const secondEvent = traceEvents[1]
-      expect(secondEvent.name).toEqual('webpack-invalidated')
-      expect(secondEvent.id).toEqual(112)
-    })
-  })
-
   describe('JSON reporter', () => {
     it('should write the trace events to JSON file', async () => {
       const tmpDir = await mkdtemp(join(tmpdir(), 'json-reporter'))

--- a/packages/next/src/trace/report/index.ts
+++ b/packages/next/src/trace/report/index.ts
@@ -4,7 +4,6 @@ import reportToJson from './to-json'
 import type { Reporter } from './types'
 
 class MultiReporter implements Reporter {
-  private events: TraceEvent[] = []
   private reporters: Reporter[] = []
 
   constructor(reporters: Reporter[]) {
@@ -15,16 +14,7 @@ class MultiReporter implements Reporter {
     await Promise.all(this.reporters.map((reporter) => reporter.flushAll()))
   }
 
-  getTraceEvents() {
-    return this.events
-  }
-
-  clearTraceEvents() {
-    this.events = []
-  }
-
   report(event: TraceEvent) {
-    this.events.push(event)
     this.reporters.forEach((reporter) => reporter.report(event))
   }
 }

--- a/packages/next/src/trace/report/index.ts
+++ b/packages/next/src/trace/report/index.ts
@@ -1,6 +1,6 @@
+import type { TraceEvent } from '../types'
 import reportToTelemetry from './to-telemetry'
 import reportToJson from './to-json'
-import type { TraceEvent } from '../types'
 import type { Reporter } from './types'
 
 class MultiReporter implements Reporter {

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -140,7 +140,10 @@ const reportToLocalHost = (event: TraceEvent) => {
     })
   }
 
-  batch.report(event)
+  batch.report({
+    ...event,
+    traceId,
+  })
 }
 
 export default {

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -3,6 +3,7 @@ import { traceGlobals } from '../shared'
 import fs from 'fs'
 import path from 'path'
 import { PHASE_DEVELOPMENT_SERVER } from '../../shared/lib/constants'
+import type { TraceEvent } from '../types'
 
 const localEndpoint = {
   serviceName: 'nextjs',
@@ -10,16 +11,8 @@ const localEndpoint = {
   port: 9411,
 }
 
-type Event = {
-  traceId: string
-  parentId?: number
-  name: string
-  id: number
-  timestamp: number
-  duration: number
+type Event = TraceEvent & {
   localEndpoint?: typeof localEndpoint
-  tags?: Object
-  startTime?: number
 }
 
 // Batch events as zipkin allows for multiple events to be sent in one go
@@ -116,15 +109,7 @@ class RotatingWriteStream {
   }
 }
 
-const reportToLocalHost = (
-  name: string,
-  duration: number,
-  timestamp: number,
-  id: number,
-  parentId?: number,
-  attrs?: Object,
-  startTime?: number
-) => {
+const reportToLocalHost = (event: TraceEvent) => {
   const distDir = traceGlobals.get('distDir')
   const phase = traceGlobals.get('phase')
   if (!distDir || !phase) {
@@ -136,7 +121,7 @@ const reportToLocalHost = (
   }
 
   if (!batch) {
-    batch = batcher(async (events) => {
+    batch = batcher(async (events: TraceEvent[]) => {
       if (!writeStream) {
         await fs.promises.mkdir(distDir, { recursive: true })
         const file = path.join(distDir, 'trace')
@@ -155,16 +140,7 @@ const reportToLocalHost = (
     })
   }
 
-  batch.report({
-    traceId,
-    parentId,
-    name,
-    id,
-    timestamp,
-    duration,
-    tags: attrs,
-    startTime,
-  })
+  batch.report(event)
 }
 
 export default {

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -174,7 +174,7 @@ export default {
           const phase = traceGlobals.get('phase')
           // Only end writeStream when manually flushing in production
           if (phase !== PHASE_DEVELOPMENT_SERVER) {
-            writeStream.end()
+            return writeStream.end()
           }
         })
       : undefined,

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -121,7 +121,7 @@ const reportToLocalHost = (event: TraceEvent) => {
   }
 
   if (!batch) {
-    batch = batcher(async (events: TraceEvent[]) => {
+    batch = batcher(async (events: Event[]) => {
       if (!writeStream) {
         await fs.promises.mkdir(distDir, { recursive: true })
         const file = path.join(distDir, 'trace')

--- a/packages/next/src/trace/report/to-telemetry.ts
+++ b/packages/next/src/trace/report/to-telemetry.ts
@@ -1,5 +1,6 @@
 import type { Telemetry } from '../../telemetry/storage'
 import { traceGlobals } from '../shared'
+import type { TraceEvent } from '../types'
 
 const TRACE_EVENT_ACCESSLIST = new Map(
   Object.entries({
@@ -7,8 +8,8 @@ const TRACE_EVENT_ACCESSLIST = new Map(
   })
 )
 
-const reportToTelemetry = (spanName: string, duration: number) => {
-  const eventName = TRACE_EVENT_ACCESSLIST.get(spanName)
+const reportToTelemetry = ({ name, duration }: TraceEvent) => {
+  const eventName = TRACE_EVENT_ACCESSLIST.get(name)
   if (!eventName) {
     return
   }

--- a/packages/next/src/trace/report/types.ts
+++ b/packages/next/src/trace/report/types.ts
@@ -1,0 +1,6 @@
+import type { TraceEvent } from '../types'
+
+export type Reporter = {
+  flushAll: () => Promise<void> | void
+  report: (event: TraceEvent) => void
+}

--- a/packages/next/src/trace/shared.ts
+++ b/packages/next/src/trace/shared.ts
@@ -1,5 +1,3 @@
-export type SpanId = number
-
 let _traceGlobals: Map<any, any> = (global as any)._traceGlobals
 
 if (!_traceGlobals) {

--- a/packages/next/src/trace/trace.test.ts
+++ b/packages/next/src/trace/trace.test.ts
@@ -1,0 +1,62 @@
+import { reporter } from './report'
+import {
+  clearTraceEvents,
+  exportTraceState,
+  getTraceEvents,
+  initializeTraceState,
+  recordTracesFromWorker,
+  trace,
+} from './trace'
+import type { TraceEvent, TraceState } from './types'
+
+describe('Trace', () => {
+  beforeEach(() => {
+    initializeTraceState({
+      lastId: 0,
+    })
+    clearTraceEvents()
+  })
+
+  describe('Tracer', () => {
+    it('traces a block of code', async () => {
+      const root = trace('root-span')
+      root.traceChild('child-span').traceFn(() => null)
+      await root.traceChild('async-child-span').traceAsyncFn(async () => {
+        const delayedPromise = new Promise((resolve) => {
+          setTimeout(resolve, 100)
+        })
+        await delayedPromise
+      })
+      root.stop()
+      const traceEvents = reporter.getTraceEvents()
+      expect(traceEvents.length).toEqual(3)
+    })
+  })
+
+  describe('Worker', () => {
+    it('exports and initializes trace state', () => {
+      const root = trace('root-span')
+      expect(root.id).toEqual(1)
+      const traceState = exportTraceState()
+      expect(traceState.lastId).toEqual(1)
+      initializeTraceState({
+        lastId: 101,
+      })
+      const span = trace('another-span')
+      expect(span.id).toEqual(102)
+    })
+
+    it('trace data is serializable to a worker', async () => {
+      const root = trace('root-span')
+      root.traceChild('child-span').traceFn(() => null)
+      root.stop()
+      const traceEvents = getTraceEvents()
+      expect(traceEvents.length).toEqual(2)
+      // This is a proxy check to make sure the object would be serializable
+      // to a worker. It will fail if the data contains some unserializable
+      // objects like BigInt.
+      const clone = JSON.parse(JSON.stringify(traceEvents))
+      expect(clone).toEqual(traceEvents)
+    })
+  })
+})

--- a/packages/next/src/trace/trace.ts
+++ b/packages/next/src/trace/trace.ts
@@ -7,6 +7,9 @@ const getId = () => {
   count++
   return count
 }
+let defaultParentSpanId: SpanId | undefined
+let shouldSaveTraceEvents: boolean | undefined
+let savedTraceEvents: TraceEvent[] = []
 
 // eslint typescript has a bug with TS enums
 /* eslint-disable no-shadow */
@@ -40,7 +43,7 @@ export class Span {
     attrs?: Object
   }) {
     this.name = name
-    this.parentId = parentId
+    this.parentId = parentId ?? defaultParentSpanId
     this.duration = null
     this.attrs = attrs ? { ...attrs } : {}
     this.status = SpanStatus.Started
@@ -66,7 +69,7 @@ export class Span {
       throw new Error(`Duration is too long to express as float64: ${duration}`)
     }
     const timestamp = this._start / NUM_OF_MICROSEC_IN_NANOSEC
-    reporter.report({
+    const traceEvent: TraceEvent = {
       name: this.name,
       duration: Number(duration),
       timestamp: Number(timestamp),
@@ -74,7 +77,11 @@ export class Span {
       parentId: this.parentId,
       tags: this.attrs,
       startTime: this.now,
-    })
+    }
+    reporter.report(traceEvent)
+    if (shouldSaveTraceEvents) {
+      savedTraceEvents.push(traceEvent)
+    }
   }
 
   traceChild(name: string, attrs?: Object) {
@@ -122,22 +129,36 @@ export const trace = (
   return new Span({ name, parentId, attrs })
 }
 
-export function recordTracesFromWorker(parentSpan: Span, events: TraceEvent[]) {
+export const flushAllTraces = () => reporter.flushAll()
+
+// This code supports workers by serializing the state of tracers when the
+// worker is initialized, and serializing the trace events from the worker back
+// to the main process to record when the worker is complete.
+export const exportTraceState = (): TraceState => ({
+  defaultParentSpanId,
+  lastId: count,
+  shouldSaveTraceEvents,
+})
+export const initializeTraceState = (state: TraceState) => {
+  count = state.lastId
+  defaultParentSpanId = state.defaultParentSpanId
+  shouldSaveTraceEvents = state.shouldSaveTraceEvents
+}
+
+export function getTraceEvents(): TraceEvent[] {
+  return savedTraceEvents
+}
+
+export function recordTraceEvents(events: TraceEvent[]) {
   for (const traceEvent of events) {
-    const startTime = BigInt(traceEvent.startTime! * 1000)
-    parentSpan.manualTraceChild(
-      traceEvent.name,
-      startTime,
-      BigInt(traceEvent.startTime! * 1000 + traceEvent.duration * 1000),
-      traceEvent.tags
-    )
+    reporter.report(traceEvent)
+    if (traceEvent.id > count) {
+      count = traceEvent.id + 1
+    }
+  }
+  if (shouldSaveTraceEvents) {
+    savedTraceEvents.push(...events)
   }
 }
 
-export const flushAllTraces = () => reporter.flushAll()
-export const clearTraceEvents = () => reporter.clearTraceEvents()
-export const getTraceEvents = () => reporter.getTraceEvents()
-export const exportTraceState = (): TraceState => ({ lastId: count })
-export const initializeTraceState = (state: TraceState) => {
-  count = state.lastId
-}
+export const clearTraceEvents = () => (savedTraceEvents = [])

--- a/packages/next/src/trace/types.ts
+++ b/packages/next/src/trace/types.ts
@@ -1,0 +1,16 @@
+export type SpanId = number
+
+export interface TraceState {
+  lastId: number
+}
+
+export type TraceEvent = {
+  traceId?: string
+  parentId?: SpanId
+  name: string
+  id: SpanId
+  timestamp: number
+  duration: number
+  tags?: Object
+  startTime?: number
+}

--- a/packages/next/src/trace/types.ts
+++ b/packages/next/src/trace/types.ts
@@ -2,6 +2,8 @@ export type SpanId = number
 
 export interface TraceState {
   lastId: number
+  defaultParentSpanId?: SpanId
+  shouldSaveTraceEvents?: boolean
 }
 
 export type TraceEvent = {

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -17,7 +17,8 @@ module.exports = {
           : []),
         {
           source: '/to-websocket',
-          destination: 'http://localhost:62765/_next/webpack-hmr?page=/about',
+          destination:
+            'http://localhost:__EXTERNAL_PORT__/_next/webpack-hmr?page=/about',
         },
         {
           source: '/websocket-to-page',
@@ -93,7 +94,7 @@ module.exports = {
         },
         {
           source: '/proxy-me/:path*',
-          destination: 'http://localhost:62765/:path*',
+          destination: 'http://localhost:__EXTERNAL_PORT__/:path*',
         },
         {
           source: '/api-hello',

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -17,8 +17,7 @@ module.exports = {
           : []),
         {
           source: '/to-websocket',
-          destination:
-            'http://localhost:__EXTERNAL_PORT__/_next/webpack-hmr?page=/about',
+          destination: 'http://localhost:62765/_next/webpack-hmr?page=/about',
         },
         {
           source: '/websocket-to-page',
@@ -94,7 +93,7 @@ module.exports = {
         },
         {
           source: '/proxy-me/:path*',
-          destination: 'http://localhost:__EXTERNAL_PORT__/:path*',
+          destination: 'http://localhost:62765/:path*',
         },
         {
           source: '/api-hello',


### PR DESCRIPTION
This PR sets up the webpack build workers (`webpackBuildWorker: true`) to serialize debug trace information across the worker boundary so that it can appear in the final `.next/trace` file at the end of the build.

Currently, when `webpackBuildWorker` is turned on, all traces that appear under the webpack compilation are lost. After this PR, they will appear in the trace file just like when the workers are not enabled.