### PR TITLE
feat: add `logging` prop to the config schema

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -357,12 +357,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             memoryLimit: z.number().int().optional(),
           })
           .optional(),
-        logging: z
-          .object({
-            level: z.literal('verbose').optional(),
-            fullUrl: z.boolean().optional(),
-          })
-          .optional(),
         serverMinification: z.boolean().optional(),
         serverSourceMaps: z.boolean().optional(),
         bundlePagesExternals: z.boolean().optional(),
@@ -458,6 +452,15 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         path: z.string().optional(),
       })
       .optional(),
+    logging: z
+			.object({
+				fetches: z
+					.object({
+						fullUrl: z.boolean().optional(),
+					})
+					.optional(),
+			})
+			.optional(),
     modularizeImports: z
       .record(
         z.string(),


### PR DESCRIPTION
This PR aims to fix the warning that started with next@14
```
> next dev

   ▲ Next.js 14.0.0
   - Local:        http://localhost:3000
   - Environments: .env.local

 ⚠ Invalid next.config.js options detected: 
 ⚠     Unrecognized key(s) in object: 'logging'
 ⚠ See more info here: https://nextjs.org/docs/messages/invalid-next-config
```