### PR TITLE
Fix Google Tag Manager URL in Third Party Libraries documentation

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/10-third-party-libraries.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/10-third-party-libraries.mdx
@@ -30,7 +30,7 @@ All supported third-party libraries from Google can be imported from `@next/thir
 ### Google Tag Manager
 
 The `GoogleTagManager` component can be used to instantiate a [Google Tag
-Manager](https://developers.google.com/maps/documentation/embed/embedding-map) container to your
+Manager](https://developers.google.com/tag-platform/tag-manager) container to your
 page. By default, it fetches the original inline script after hydration occurs on the page.
 
 <AppOnly>


### PR DESCRIPTION
## Description

Updating the URL for the Google Tag Manager in the Next.js documentation for [Third Party Libraries](https://nextjs.org/docs/pages/building-your-application/optimizing/third-party-libraries).

We were using https://developers.google.com/maps/documentation/embed/embedding-map, which redirected to the documentation for embedding Google Maps.

## Implementation

- Replacing https://developers.google.com/maps/documentation/embed/embedding-map by https://developers.google.com/tag-platform/tag-manager