### PR TITLE
Remove extra CI step and lock Node.js version

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -61,7 +61,7 @@ on:
 env:
   NAPI_CLI_VERSION: 2.14.7
   TURBO_VERSION: 1.10.9
-  NODE_LTS_VERSION: 20
+  NODE_LTS_VERSION: 20.9.0
   TEST_CONCURRENCY: 8
   # disable backtrace for test snapshots
   RUST_BACKTRACE: 0

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -165,8 +165,6 @@ jobs:
       - run: git checkout .
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
-      - run: pnpm store path
-
       - run: pnpm install
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 


### PR DESCRIPTION
Seems this command is causing intermittent issues and we don't actually need this information so removes it