### PR TITLE
Add @highlight-run/node to externals list

### DIFF
--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -2,6 +2,7 @@
   "@aws-sdk/client-s3",
   "@aws-sdk/s3-presigned-post",
   "@blockfrost/blockfrost-js",
+  "@highlight-run/node",
   "@libsql/client",
   "@jpg-store/lucid-cardano",
   "@mikro-orm/core",


### PR DESCRIPTION
This is a native module that uses node.js features, so it should be externalized by default.
Related to #52091

cc @deltaepsilon