### PR TITLE
fix(docs): default `serverActions.bodySizeLimit` is `1mb` not `1MB`

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/server-actions.mdx
+++ b/docs/02-app/02-api-reference/04-functions/server-actions.mdx
@@ -142,7 +142,7 @@ In both cases, the form is interactive before hydration occurs. Although Server 
 
 By default, the maximum size of the request body sent to a Server Action is `1mb`, to prevent the consumption of excessive server resources in parsing large amounts of data.
 
-However, you can configure this limit using the `serverActions.bodySizeLimit` option. It can take the number of bits or any string format supported by bits, for example `1000`, `'500kb'` or `'3mb'`.
+However, you can configure this limit using the `serverActions.bodySizeLimit` option. It can take the number of bits or any string format supported by file size format, for example `1000`, `'500kb'` or `'3mb'`.
 
 ```js filename="next.config.js"
 module.exports = {

--- a/docs/02-app/02-api-reference/04-functions/server-actions.mdx
+++ b/docs/02-app/02-api-reference/04-functions/server-actions.mdx
@@ -140,9 +140,9 @@ In both cases, the form is interactive before hydration occurs. Although Server 
 
 ## Size Limitation
 
-By default, the maximum size of the request body sent to a Server Action is 1MB, to prevent the consumption of excessive server resources in parsing large amounts of data.
+By default, the maximum size of the request body sent to a Server Action is `1mb`, to prevent the consumption of excessive server resources in parsing large amounts of data.
 
-However, you can configure this limit using the `serverActions.bodySizeLimit` option. It can take the number of bytes or any string format supported by bytes, for example `1000`, `'500kb'` or `'3mb'`.
+However, you can configure this limit using the `serverActions.bodySizeLimit` option. It can take the number of bits or any string format supported by bits, for example `1000`, `'500kb'` or `'3mb'`.
 
 ```js filename="next.config.js"
 module.exports = {


### PR DESCRIPTION
This PR fixes bytes to bits on explaining serverActions bodySizeLimit.

https://github.com/vercel/next.js/blob/ccac12f69faabc1f52c7d558495ba75fb4cd2a7c/packages/next/src/server/app-render/action-handler.ts#L425

Partial fix from #57661