### PR TITLE
[.next/trace] Add tags for webpack build worker

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1070,6 +1070,11 @@ export default async function build(
       // has a custom webpack config and disable the build worker by default.
       const useBuildWorker =
         config.experimental.webpackBuildWorker || !config.webpack
+      nextBuildSpan.setAttribute(
+        'has-custom-webpack-config',
+        String(!!config.webpack)
+      )
+      nextBuildSpan.setAttribute('use-build-worker', String(useBuildWorker))
 
       if (
         config.webpack &&


### PR DESCRIPTION
This PR adds a tag to the `next-build` span to identify whether the build is using the webpack build workers and/or has a custom webpack config which can be used during debugging traces.

![Screenshot 2023-10-31 at 8 11 37 AM](https://github.com/vercel/next.js/assets/7355009/6ef028e0-36d6-4d0d-a9a8-bf40bde3d19c)
