### PR TITLE
ignore invalid server actions before decoding body

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -39,6 +39,37 @@ createNextDescribe(
       await check(() => browser.elementByCss('h1').text(), '3')
     })
 
+    it('should properly ignore malformed requests', async () => {
+      const res = await next.fetch('/server', {
+        method: 'POST',
+        body: 'data',
+        headers: {
+          'content-type': 'multipart/form-data',
+        },
+      })
+
+      expect(res.status).toBe(404)
+      await check(() => next.cliOutput, /Missing Server Action ID/)
+    })
+
+    it('should properly handle action IDs that cannot be found', async () => {
+      const res = await next.fetch('/server', {
+        method: 'POST',
+        body: 'data',
+        headers: {
+          'content-type': 'multipart/form-data',
+          'next-action': 'foo',
+        },
+      })
+
+      expect(res.status).toBe(404)
+
+      await check(
+        () => next.cliOutput,
+        /Failed to find Server Action "foo". This request might be from an older or newer deployment./
+      )
+    })
+
     it('should support headers and cookies', async () => {
       const browser = await next.browser('/header')
 


### PR DESCRIPTION
If an invalid action ID is provided, or we cannot find the associated ID in the build manifest, we should short-circuit the request before moving on to body parsing. 

[slack x-ref](https://vercel.slack.com/archives/C03S8ED1DKM/p1698595376350239)