### PR TITLE
Add `isRedirectError` export in `navigation`

### DIFF
--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -251,4 +251,4 @@ export {
   permanentRedirect,
   RedirectType,
 } from './redirect'
-export { notFound } from './not-found'
+export { notFound, isNotFoundError } from './not-found'

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -245,5 +245,10 @@ export function useSelectedLayoutSegment(
   return selectedLayoutSegments[0]
 }
 
-export { redirect, permanentRedirect, RedirectType } from './redirect'
+export {
+  redirect,
+  isRedirectError,
+  permanentRedirect,
+  RedirectType,
+} from './redirect'
 export { notFound } from './not-found'


### PR DESCRIPTION
## What

This PR adds the `isRedirectError` utility to the navigation exports. 

## Why

For API routes or Actions that rely on errors for control flow, it's difficult to handle Next.js's internal errors that come from `redirect`.

As an example, imagine you have a login API route. If the form body doesn't have a username or password, you might throw an error that indicates a bad request. If there is a user already logged in, you might want to `redirect` them to their home page. But differentiating between the two errors right now is difficult outside of importing this helper via:

```tsx
import { isRedirectError } from "next/dist/client/components/redirect";
```

Lifting the export into `next/navigation` allows for a more stable import.
