### PR TITLE
Ensure cache soft tags are correct

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1387,6 +1387,7 @@ export default async function build(
           async () =>
             hasCustomErrorPage &&
             pagesStaticWorkers.isPageStatic({
+              dir,
               page: '/_error',
               distDir,
               configFileName,
@@ -1586,6 +1587,7 @@ export default async function build(
                               ? appStaticWorkers
                               : pagesStaticWorkers
                           )!.isPageStatic({
+                            dir,
                             page,
                             originalAppPath,
                             distDir,

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1216,6 +1216,7 @@ export const collectGenerateParams = async (
 }
 
 export async function buildAppStaticPaths({
+  dir,
   page,
   distDir,
   configFileName,
@@ -1229,6 +1230,7 @@ export async function buildAppStaticPaths({
   serverHooks,
   ppr,
 }: {
+  dir: string
   page: string
   configFileName: string
   generateParams: GenerateParams
@@ -1252,7 +1254,9 @@ export async function buildAppStaticPaths({
   let CacheHandler: any
 
   if (incrementalCacheHandlerPath) {
-    CacheHandler = require(incrementalCacheHandlerPath)
+    CacheHandler = require(path.isAbsolute(incrementalCacheHandlerPath)
+      ? incrementalCacheHandlerPath
+      : path.join(dir, incrementalCacheHandlerPath))
     CacheHandler = CacheHandler.default || CacheHandler
   }
 
@@ -1379,6 +1383,7 @@ export async function buildAppStaticPaths({
 }
 
 export async function isPageStatic({
+  dir,
   page,
   distDir,
   configFileName,
@@ -1396,6 +1401,7 @@ export async function isPageStatic({
   incrementalCacheHandlerPath,
   ppr,
 }: {
+  dir: string
   page: string
   distDir: string
   configFileName: string
@@ -1565,6 +1571,7 @@ export async function isPageStatic({
             fallback: prerenderFallback,
             encodedPaths: encodedPrerenderRoutes,
           } = await buildAppStaticPaths({
+            dir,
             page,
             serverHooks,
             staticGenerationAsyncStorage,

--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -7,12 +7,15 @@ export function createIncrementalCache(
   incrementalCacheHandlerPath: string | undefined,
   isrMemoryCacheSize: number | undefined,
   fetchCacheKeyPrefix: string | undefined,
-  distDir: string
+  distDir: string,
+  dir: string
 ) {
   // Custom cache handler overrides.
   let CacheHandler: any
   if (incrementalCacheHandlerPath) {
-    CacheHandler = require(incrementalCacheHandlerPath)
+    CacheHandler = require(path.isAbsolute(incrementalCacheHandlerPath)
+      ? incrementalCacheHandlerPath
+      : path.join(dir, incrementalCacheHandlerPath))
     CacheHandler = CacheHandler.default || CacheHandler
   }
 

--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -41,7 +41,7 @@ export function createIncrementalCache(
       readFile: fs.promises.readFile,
       readFileSync: fs.readFileSync,
       writeFile: (f, d) => fs.promises.writeFile(f, d),
-      mkdir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
+      mkdir: (d) => fs.promises.mkdir(d, { recursive: true }),
       stat: (f) => fs.promises.stat(f),
     },
     serverDistDir: path.join(distDir, 'server'),

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -674,6 +674,7 @@ export async function exportAppImpl(
 
       const result = await pageExportSpan.traceAsyncFn(async () => {
         return await exportPage({
+          dir,
           path,
           pathMap,
           distDir,

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -35,6 +35,7 @@ type PathMap = ExportPathMap[keyof ExportPathMap]
 
 export interface ExportPageInput {
   path: string
+  dir: string
   pathMap: PathMap
   distDir: string
   outDir: string

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -45,6 +45,7 @@ async function exportPageImpl(
   fileWriter: FileWriter
 ): Promise<ExportRouteResult | undefined> {
   const {
+    dir,
     path,
     pathMap,
     distDir,
@@ -219,7 +220,8 @@ async function exportPageImpl(
             incrementalCacheHandlerPath,
             isrMemoryCacheSize,
             fetchCacheKeyPrefix,
-            distDir
+            distDir,
+            dir
           )
         : undefined
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1048,6 +1048,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
   query,
   renderOpts
 ) => {
+  // TODO: this includes query string, should it?
   const pathname = validateURL(req.url)
 
   return RequestAsyncStorageWrapper.wrap(

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -656,6 +656,7 @@ export default class DevServer extends Server {
 
       try {
         const pathsResult = await staticPathsWorker.loadStaticPaths({
+          dir: this.dir,
           distDir: this.distDir,
           pathname,
           config: {

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -28,6 +28,7 @@ type RuntimeConfig = {
 // side-effects aren't relied on in dev that will break
 // during a production build
 export async function loadStaticPaths({
+  dir,
   distDir,
   pathname,
   config,
@@ -43,6 +44,7 @@ export async function loadStaticPaths({
   incrementalCacheHandlerPath,
   ppr,
 }: {
+  dir: string
   distDir: string
   pathname: string
   config: RuntimeConfig
@@ -101,6 +103,7 @@ export async function loadStaticPaths({
         : await collectGenerateParams(components.ComponentMod.tree)
 
     return await buildAppStaticPaths({
+      dir,
       page: pathname,
       generateParams,
       configFileName: config.configFileName,

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -92,7 +92,9 @@ export function addImplicitTags(staticGenerationStore: StaticGenerationStore) {
   }
 
   if (urlPathname) {
-    const tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${urlPathname}`
+    const parsedPathname = new URL(urlPathname, 'http://n').pathname
+
+    const tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${parsedPathname}`
     if (!staticGenerationStore.tags?.includes(tag)) {
       staticGenerationStore.tags.push(tag)
     }

--- a/test/production/standalone-mode/required-server-files/app/ssr/[slug]/page.js
+++ b/test/production/standalone-mode/required-server-files/app/ssr/[slug]/page.js
@@ -6,6 +6,7 @@ export default async function Page({ params }) {
     {
       next: {
         tags: ['ssr-page'],
+        revalidate: 3,
       },
     }
   ).then((res) => res.text())

--- a/test/production/standalone-mode/required-server-files/cache-handler.js
+++ b/test/production/standalone-mode/required-server-files/cache-handler.js
@@ -5,13 +5,17 @@ module.exports = class CacheHandler {
     console.log('initialized custom cache-handler')
   }
 
-  async get(key) {
-    console.log('cache-handler get', key)
+  async get(key, ctx) {
+    console.log('cache-handler get', key, ctx)
+
+    if (ctx.softTags?.some((tag) => tag.includes('?'))) {
+      throw new Error(`invalid soft tag found should only be pathname`)
+    }
     return cache.get(key)
   }
 
-  async set(key, data) {
-    console.log('cache-handler set', key)
+  async set(key, data, ctx) {
+    console.log('cache-handler set', key, ctx)
     cache.set(key, {
       value: data,
       lastModified: Date.now(),

--- a/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
@@ -30,6 +30,7 @@ describe('required server files app router', () => {
       files: {
         app: new FileRef(join(__dirname, 'app')),
         lib: new FileRef(join(__dirname, 'lib')),
+        'cache-handler.js': new FileRef(join(__dirname, 'cache-handler.js')),
         'middleware.js': new FileRef(join(__dirname, 'middleware.js')),
         'data.txt': new FileRef(join(__dirname, 'data.txt')),
         '.env': new FileRef(join(__dirname, '.env')),
@@ -37,6 +38,9 @@ describe('required server files app router', () => {
         '.env.production': new FileRef(join(__dirname, '.env.production')),
       },
       nextConfig: {
+        experimental: {
+          incrementalCacheHandlerPath: './cache-handler.js',
+        },
         eslint: {
           ignoreDuringBuilds: true,
         },
@@ -86,6 +90,7 @@ describe('required server files app router', () => {
         cwd: next.testDir,
       }
     )
+    appPort = `http://127.0.0.1:${appPort}`
   }
 
   beforeAll(async () => {
@@ -192,6 +197,26 @@ describe('required server files app router', () => {
       const res = await fetchViaHTTP(appPort, path, undefined, {
         redirect: 'manual',
       })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('x-next-cache-tags')).toBeFalsy()
+    }
+  })
+
+  it('should not send invalid soft tags to cache handler', async () => {
+    for (const path of [
+      '/ssr/first',
+      '/ssr/second',
+      '/api/ssr/first',
+      '/api/ssr/second',
+    ]) {
+      const res = await fetchViaHTTP(
+        appPort,
+        path,
+        { hello: 'world' },
+        {
+          redirect: 'manual',
+        }
+      )
       expect(res.status).toBe(200)
       expect(res.headers.get('x-next-cache-tags')).toBeFalsy()
     }


### PR DESCRIPTION
We noticed that our internal soft tags were unexpectedly including the query string for SSR routes which causes the URL soft tag to not match correctly so this ensures we properly normalize the value to just the pathname and not include the query. 