### PR TITLE
[docs] fix next.config.mjs using commonjs in the example

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/index.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/index.mdx
@@ -34,7 +34,7 @@ export default nextConfig
 You can also use a function:
 
 ```js filename="next.config.mjs"
-module.exports = (phase, { defaultConfig }) => {
+export default (phase, { defaultConfig }) => {
   /**
    * @type {import('next').NextConfig}
    */


### PR DESCRIPTION
make sure `next.config.mjs` uses `export` instead of `module.exports`