### PR TITLE
chore: reword in tree-view

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -680,7 +680,11 @@ export async function printTreeView(
   print(
     textTable(
       [
-        usedSymbols.has('○') && ['○', '(Static)', 'prerendered as static HTML'],
+        usedSymbols.has('○') && [
+          '○',
+          '(Static)',
+          'prerendered as static content',
+        ],
         usedSymbols.has('●') && [
           '●',
           '(SSG)',


### PR DESCRIPTION
### What?

Minor change to use the word `content` instead of `HTML` in the build output tree-view legend.

### Why?

The `○` symbol is also used for statically pre-rendered Route Handlers, which might not return HTML, so just clarifying the wording.

[Slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1698844583794019)