### PR TITLE
remove legacy handling for suspense option of next/dynamic

### DIFF
--- a/packages/next-swc/crates/next-transform-dynamic/src/lib.rs
+++ b/packages/next-swc/crates/next-transform-dynamic/src/lib.rs
@@ -326,7 +326,6 @@ impl Fold for NextDynamicPatcher {
                         })))];
 
                     let mut has_ssr_false = false;
-                    let mut has_suspense = false;
 
                     if expr.args.len() == 2 {
                         if let Expr::Object(ObjectLit {
@@ -359,15 +358,6 @@ impl Fold for NextDynamicPatcher {
                                                 has_ssr_false = true
                                             }
                                         }
-                                        if sym == "suspense" {
-                                            if let Some(Lit::Bool(Bool {
-                                                value: true,
-                                                span: _,
-                                            })) = value.as_lit()
-                                            {
-                                                has_suspense = true
-                                            }
-                                        }
                                     }
                                 }
                             }
@@ -375,17 +365,10 @@ impl Fold for NextDynamicPatcher {
                         }
                     }
 
-                    // Don't strip the `loader` argument if suspense is true
-                    // See https://github.com/vercel/next.js/issues/36636 for background.
-
                     // Also don't strip the `loader` argument for server components (both
                     // server/client layers), since they're aliased to a
                     // React.lazy implementation.
-                    if has_ssr_false
-                        && !has_suspense
-                        && self.is_server_compiler
-                        && !self.is_react_server_layer
-                    {
+                    if has_ssr_false && self.is_server_compiler && !self.is_react_server_layer {
                         expr.args[0] = Lit::Null(Null { span: DUMMY_SP }).as_arg();
                     }
 


### PR DESCRIPTION
This part was removed before but added in back during the merging of turbopack and legacy `next-swc` changes. Remove them again