### PR TITLE
Reduce FS access for incremental cache

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1267,6 +1267,8 @@ export async function buildAppStaticPaths({
   const incrementalCache = new IncrementalCache({
     fs: nodeFs,
     dev: true,
+    // Enabled both for build as we're only writing this cache, not reading it.
+    pagesDir: true,
     appDir: true,
     flushToDisk: isrFlushToDisk,
     serverDistDir: path.join(distDir, 'server'),

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -69,8 +69,8 @@ import { nodeFs } from '../server/lib/node-fs-methods'
 import * as ciEnvironment from '../telemetry/ci-info'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import { denormalizeAppPagePath } from '../shared/lib/page-path/denormalize-app-path'
-import { AppRouteRouteModule } from '../server/future/route-modules/app-route/module.compiled'
 import { RouteKind } from '../server/future/route-kind'
+import { isAppRouteRouteModule } from '../server/future/route-modules/checks'
 
 export type ROUTER_TYPE = 'pages' | 'app'
 
@@ -1508,7 +1508,7 @@ export async function isPageStatic({
         const { tree, staticGenerationAsyncStorage, serverHooks } = ComponentMod
 
         const generateParams: GenerateParams =
-          routeModule && AppRouteRouteModule.is(routeModule)
+          routeModule && isAppRouteRouteModule(routeModule)
             ? [
                 {
                   config: {

--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -1,14 +1,17 @@
+import type { NextEnabledDirectories } from '../../server/base-server'
+
 import path from 'path'
-import fs from 'fs'
 import { IncrementalCache } from '../../server/lib/incremental-cache'
 import { hasNextSupport } from '../../telemetry/ci-info'
+import { nodeFs } from '../../server/lib/node-fs-methods'
 
 export function createIncrementalCache(
   incrementalCacheHandlerPath: string | undefined,
   isrMemoryCacheSize: number | undefined,
   fetchCacheKeyPrefix: string | undefined,
   distDir: string,
-  dir: string
+  dir: string,
+  enabledDirectories: NextEnabledDirectories
 ) {
   // Custom cache handler overrides.
   let CacheHandler: any
@@ -37,13 +40,9 @@ export function createIncrementalCache(
       },
       notFoundRoutes: [],
     }),
-    fs: {
-      readFile: fs.promises.readFile,
-      readFileSync: fs.readFileSync,
-      writeFile: (f, d) => fs.promises.writeFile(f, d),
-      mkdir: (d) => fs.promises.mkdir(d, { recursive: true }),
-      stat: (f) => fs.promises.stat(f),
-    },
+    fs: nodeFs,
+    pagesDir: enabledDirectories.pages,
+    appDir: enabledDirectories.app,
     serverDistDir: path.join(distDir, 'server'),
     CurCacheHandler: CacheHandler,
     minimalMode: hasNextSupport,

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -215,6 +215,8 @@ export async function exportAppImpl(
   // attempt to load global env values so they are available in next.config.js
   span.traceChild('load-dotenv').traceFn(() => loadEnvConfig(dir, false, Log))
 
+  const { enabledDirectories } = options
+
   const nextConfig =
     options.nextConfig ||
     (await span
@@ -444,7 +446,7 @@ export async function exportAppImpl(
   }
 
   let serverActionsManifest
-  if (options.hasAppDir) {
+  if (enabledDirectories.app) {
     serverActionsManifest = require(join(
       distDir,
       SERVER_DIRECTORY,
@@ -487,15 +489,15 @@ export async function exportAppImpl(
     nextScriptWorkers: nextConfig.experimental.nextScriptWorkers,
     optimizeFonts: nextConfig.optimizeFonts as FontConfig,
     largePageDataBytes: nextConfig.experimental.largePageDataBytes,
-    serverComponents: options.hasAppDir,
     serverActions: nextConfig.experimental.serverActions,
+    serverComponents: enabledDirectories.app,
     nextFontManifest: require(join(
       distDir,
       'server',
       `${NEXT_FONT_MANIFEST}.json`
     )),
     images: nextConfig.images,
-    ...(options.hasAppDir
+    ...(enabledDirectories.app
       ? {
           serverActionsManifest,
         }
@@ -698,6 +700,7 @@ export async function exportAppImpl(
           incrementalCacheHandlerPath:
             nextConfig.experimental.incrementalCacheHandlerPath,
           enableExperimentalReact: needsExperimentalReact(nextConfig),
+          enabledDirectories,
         })
       })
 

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -8,6 +8,7 @@ import type { FontConfig } from '../server/font-utils'
 import type { ExportPathMap, NextConfigComplete } from '../server/config-shared'
 import type { Span } from '../trace'
 import type { Revalidate } from '../server/lib/revalidate'
+import type { NextEnabledDirectories } from '../server/base-server'
 
 export interface AmpValidation {
   page: string
@@ -58,6 +59,7 @@ export interface ExportPageInput {
   fetchCacheKeyPrefix?: string
   nextConfigOutput?: NextConfigComplete['output']
   enableExperimentalReact?: boolean
+  enabledDirectories: NextEnabledDirectories
 }
 
 export type ExportedPageFile = {
@@ -98,7 +100,7 @@ export type ExportWorker = (
 
 export interface ExportAppOptions {
   outdir: string
-  hasAppDir: boolean
+  enabledDirectories: NextEnabledDirectories
   silent?: boolean
   threads?: number
   debugOutput?: boolean

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -64,6 +64,7 @@ async function exportPageImpl(
     enableExperimentalReact,
     ampValidatorPath,
     trailingSlash,
+    enabledDirectories,
   } = input
 
   if (enableExperimentalReact) {
@@ -221,7 +222,8 @@ async function exportPageImpl(
             isrMemoryCacheSize,
             fetchCacheKeyPrefix,
             distDir,
-            dir
+            dir,
+            enabledDirectories
           )
         : undefined
 

--- a/packages/next/src/server/app-render/strip-flight-headers.ts
+++ b/packages/next/src/server/app-render/strip-flight-headers.ts
@@ -1,0 +1,14 @@
+import type { IncomingHttpHeaders } from 'node:http'
+
+import { FLIGHT_PARAMETERS } from '../../client/components/app-router-headers'
+
+/**
+ * Removes the flight headers from the request.
+ *
+ * @param req the request to strip the headers from
+ */
+export function stripFlightHeaders(headers: IncomingHttpHeaders) {
+  for (const [header] of FLIGHT_PARAMETERS) {
+    delete headers[header.toLowerCase()]
+  }
+}

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -32,15 +32,11 @@ import type {
 } from '../build'
 import type { ClientReferenceManifest } from '../build/webpack/plugins/flight-manifest-plugin'
 import type { NextFontManifest } from '../build/webpack/plugins/next-font-manifest-plugin'
-import type { PagesRouteModule } from './future/route-modules/pages/module'
 import type { AppPageRouteModule } from './future/route-modules/app-page/module'
 import type { NodeNextRequest, NodeNextResponse } from './base-http/node'
 import type { WebNextRequest, WebNextResponse } from './base-http/web'
 import type { PagesAPIRouteMatch } from './future/route-matches/pages-api-route-match'
-import type {
-  AppRouteRouteHandlerContext,
-  AppRouteRouteModule,
-} from './future/route-modules/app-route/module'
+import type { AppRouteRouteHandlerContext } from './future/route-modules/app-route/module'
 import type { Server as HTTPServer } from 'http'
 import type { ImageConfigComplete } from '../shared/lib/image-config'
 import type { MiddlewareMatcher } from '../build/analysis/get-page-static-info'
@@ -105,7 +101,6 @@ import { getTracer, SpanKind } from './lib/trace/tracer'
 import { BaseServerSpan } from './lib/trace/constants'
 import { I18NProvider } from './future/helpers/i18n-provider'
 import { sendResponse } from './send-response'
-import { RouteKind } from './future/route-kind'
 import { handleInternalServerErrorResponse } from './future/route-modules/helpers/response-handlers'
 import {
   fromNodeOutgoingHttpHeaders,
@@ -128,6 +123,12 @@ import { stripInternalHeaders } from './internal-utils'
 import { RSCPathnameNormalizer } from './future/normalizers/request/rsc'
 import { PostponedPathnameNormalizer } from './future/normalizers/request/postponed'
 import type { TLSSocket } from 'tls'
+import { stripFlightHeaders } from './app-render/strip-flight-headers'
+import {
+  isAppPageRouteModule,
+  isAppRouteRouteModule,
+  isPagesRouteModule,
+} from './future/route-modules/checks'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -297,6 +298,11 @@ type ResponsePayload = {
   revalidate?: Revalidate
 }
 
+export type NextEnabledDirectories = {
+  readonly pages: boolean
+  readonly app: boolean
+}
+
 export default abstract class Server<ServerOptions extends Options = Options> {
   public readonly hostname?: string
   public readonly fetchHostname?: string
@@ -307,7 +313,6 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   protected readonly distDir: string
   protected readonly publicDir: string
   protected readonly hasStaticDir: boolean
-  protected readonly hasAppDir: boolean
   protected readonly pagesManifest?: PagesManifest
   protected readonly appPathsManifest?: PagesManifest
   protected readonly buildId: string
@@ -321,10 +326,12 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
   protected abstract getPublicDir(): string
   protected abstract getHasStaticDir(): boolean
-  protected abstract getHasAppDir(dev: boolean): boolean
   protected abstract getPagesManifest(): PagesManifest | undefined
   protected abstract getAppPathsManifest(): PagesManifest | undefined
   protected abstract getBuildId(): string
+
+  protected readonly enabledDirectories: NextEnabledDirectories
+  protected abstract getEnabledDirectories(dev: boolean): NextEnabledDirectories
 
   protected abstract findPageComponents(params: {
     page: string
@@ -461,16 +468,14 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     this[minimalModeKey] =
       minimalMode || !!process.env.NEXT_PRIVATE_MINIMAL_MODE
 
-    this.hasAppDir = this.getHasAppDir(dev)
+    this.enabledDirectories = this.getEnabledDirectories(dev)
 
     this.normalizers = {
       postponed: new PostponedPathnameNormalizer(
-        this.hasAppDir && this.nextConfig.experimental.ppr
+        this.enabledDirectories.app && this.nextConfig.experimental.ppr
       ),
-      rsc: new RSCPathnameNormalizer(this.hasAppDir),
+      rsc: new RSCPathnameNormalizer(this.enabledDirectories.app),
     }
-
-    const serverComponents = this.hasAppDir
 
     this.nextFontManifest = this.getNextFontManifest()
 
@@ -503,7 +508,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         this.nextConfig.experimental.disableOptimizedLoading,
       domainLocales: this.nextConfig.i18n?.domains,
       distDir: this.distDir,
-      serverComponents,
+      serverComponents: this.enabledDirectories.app,
       enableTainting: this.nextConfig.experimental.taint,
       crossOrigin: this.nextConfig.crossOrigin
         ? this.nextConfig.crossOrigin
@@ -734,7 +739,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     )
 
     // If the app directory is enabled, then add the app matchers and handlers.
-    if (this.hasAppDir) {
+    if (this.enabledDirectories.app) {
       // Match app pages under `app/`.
       matchers.push(
         new AppPageRouteMatcherProvider(this.distDir, manifestLoader)
@@ -934,7 +939,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       // TODO: merge handling with x-invoke-path
       if (useMatchedPathHeader) {
         try {
-          if (this.hasAppDir) {
+          if (this.enabledDirectories.app) {
             // ensure /index path is normalized for prerender
             // in minimal mode
             if (req.url.match(/^\/index($|\?)/)) {
@@ -1389,7 +1394,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     finished = await this.handleNextDataRequest(req, res, url)
     if (finished) return true
 
-    if (this.minimalMode && this.hasAppDir) {
+    if (this.minimalMode && this.enabledDirectories.app) {
       finished = await this.handleRSCRequest(req, res, url)
       if (finished) return true
 
@@ -1931,7 +1936,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
       // We don't clear RSC headers in development since SSG doesn't apply
       // These headers are cleared for SSG as we need to always generate the
-      // full RSC response for ISR
+      // full RSC response for ISR.
       if (
         !this.renderOpts.dev &&
         !isPreviewMode &&
@@ -1941,14 +1946,14 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         if (!this.minimalMode) {
           isDataReq = true
         }
-        // strip header so we generate HTML still
+
+        // Strip the flight headers so that we generate both the RSC and HTML
+        // for the request.
         if (
           !isEdgeRuntime(opts.runtime) ||
           (this.serverOptions as any).webServerConfig
         ) {
-          for (const param of FLIGHT_PARAMETERS) {
-            delete req.headers[param.toString().toLowerCase()]
-          }
+          stripFlightHeaders(req.headers)
         }
       }
     }
@@ -2072,6 +2077,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           | 'https',
       })
 
+    const { routeModule } = components
+
     type Renderer = (
       postponed: string | undefined
     ) => Promise<ResponseCacheEntry | null>
@@ -2141,141 +2148,138 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       // served by the server.
       let result: RenderResult
 
-      if (components.routeModule?.definition.kind === RouteKind.APP_ROUTE) {
-        const routeModule = components.routeModule as AppRouteRouteModule
-
-        const context: AppRouteRouteHandlerContext = {
-          params: opts.params,
-          prerenderManifest,
-          renderOpts: {
-            // App Route's cannot postpone, so don't enable it.
-            ppr: false,
-            originalPathname: components.ComponentMod.originalPathname,
-            supportsDynamicHTML,
-            incrementalCache,
-            isRevalidate: isSSG,
-          },
-        }
-
-        try {
-          const request = NextRequestAdapter.fromBaseNextRequest(
-            req,
-            signalFromNodeResponse((res as NodeNextResponse).originalResponse)
-          )
-
-          const response = await routeModule.handle(request, context)
-
-          ;(req as any).fetchMetrics = (context.renderOpts as any).fetchMetrics
-
-          const cacheTags = (context.renderOpts as any).fetchTags
-
-          // If the request is for a static response, we can cache it so long
-          // as it's not edge.
-          if (isSSG && process.env.NEXT_RUNTIME !== 'edge') {
-            const blob = await response.blob()
-
-            // Copy the headers from the response.
-            headers = toNodeOutgoingHttpHeaders(response.headers)
-
-            if (cacheTags) {
-              headers[NEXT_CACHE_TAGS_HEADER] = cacheTags
-            }
-
-            if (!headers['content-type'] && blob.type) {
-              headers['content-type'] = blob.type
-            }
-
-            const revalidate = context.renderOpts.store?.revalidate ?? false
-
-            // Create the cache entry for the response.
-            const cacheEntry: ResponseCacheEntry = {
-              value: {
-                kind: 'ROUTE',
-                status: response.status,
-                body: Buffer.from(await blob.arrayBuffer()),
-                headers,
-              },
-              revalidate,
-            }
-
-            return cacheEntry
-          }
-
-          // Send the response now that we have copied it into the cache.
-          await sendResponse(req, res, response, context.renderOpts.waitUntil)
-          return null
-        } catch (err) {
-          // If this is during static generation, throw the error again.
-          if (isSSG) throw err
-
-          Log.error(err)
-
-          // Otherwise, send a 500 response.
-          await sendResponse(req, res, handleInternalServerErrorResponse())
-
-          return null
-        }
-      }
-      // If we've matched a page while not in edge where the module exports a
-      // `routeModule`, then we should be able to render it using the provided
-      // `render` method.
-      else if (components.routeModule?.definition.kind === RouteKind.PAGES) {
-        const module = components.routeModule as PagesRouteModule
-
-        // Due to the way we pass data by mutating `renderOpts`, we can't extend
-        // the object here but only updating its `clientReferenceManifest` and
-        // `nextFontManifest` properties.
-        // https://github.com/vercel/next.js/blob/df7cbd904c3bd85f399d1ce90680c0ecf92d2752/packages/next/server/render.tsx#L947-L952
-        renderOpts.nextFontManifest = this.nextFontManifest
-        renderOpts.clientReferenceManifest = components.clientReferenceManifest
-
-        // Call the built-in render method on the module.
-        result = await module.render(
-          (req as NodeNextRequest).originalRequest ?? (req as WebNextRequest),
-          (res as NodeNextResponse).originalResponse ??
-            (res as WebNextResponse),
-          { page: pathname, params: opts.params, query, renderOpts }
-        )
-      } else if (
-        components.routeModule?.definition.kind === RouteKind.APP_PAGE
-      ) {
-        if (isAppPrefetch && process.env.NODE_ENV === 'production') {
-          try {
-            const prefetchRsc = await this.getPrefetchRsc(resolvedUrlPathname)
-            if (prefetchRsc) {
-              res.setHeader(
-                'cache-control',
-                'private, no-cache, no-store, max-age=0, must-revalidate'
-              )
-              res.setHeader('content-type', RSC_CONTENT_TYPE_HEADER)
-              res.body(prefetchRsc).send()
-              return null
-            }
-          } catch {
-            // We fallback to invoking the function if prefetch data is not
-            // available.
-          }
-        }
-
-        const module = components.routeModule as AppPageRouteModule
-
-        // Due to the way we pass data by mutating `renderOpts`, we can't extend the
-        // object here but only updating its `nextFontManifest` field.
-        // https://github.com/vercel/next.js/blob/df7cbd904c3bd85f399d1ce90680c0ecf92d2752/packages/next/server/render.tsx#L947-L952
-        renderOpts.nextFontManifest = this.nextFontManifest
-
-        // Call the built-in render method on the module.
-        result = await module.render(
-          (req as NodeNextRequest).originalRequest ?? (req as WebNextRequest),
-          (res as NodeNextResponse).originalResponse ??
-            (res as WebNextResponse),
-          {
-            page: is404Page ? '/404' : pathname,
+      if (routeModule) {
+        if (isAppRouteRouteModule(routeModule)) {
+          const context: AppRouteRouteHandlerContext = {
             params: opts.params,
-            query,
-            renderOpts,
+            prerenderManifest,
+            renderOpts: {
+              // App Route's cannot postpone, so don't enable it.
+              ppr: false,
+              originalPathname: components.ComponentMod.originalPathname,
+              supportsDynamicHTML,
+              incrementalCache,
+              isRevalidate: isSSG,
+            },
           }
-        )
+
+          try {
+            const request = NextRequestAdapter.fromBaseNextRequest(
+              req,
+              signalFromNodeResponse((res as NodeNextResponse).originalResponse)
+            )
+
+            const response = await routeModule.handle(request, context)
+
+            ;(req as any).fetchMetrics = (
+              context.renderOpts as any
+            ).fetchMetrics
+
+            const cacheTags = (context.renderOpts as any).fetchTags
+
+            // If the request is for a static response, we can cache it so long
+            // as it's not edge.
+            if (isSSG && process.env.NEXT_RUNTIME !== 'edge') {
+              const blob = await response.blob()
+
+              // Copy the headers from the response.
+              headers = toNodeOutgoingHttpHeaders(response.headers)
+
+              if (cacheTags) {
+                headers[NEXT_CACHE_TAGS_HEADER] = cacheTags
+              }
+
+              if (!headers['content-type'] && blob.type) {
+                headers['content-type'] = blob.type
+              }
+
+              const revalidate = context.renderOpts.store?.revalidate ?? false
+
+              // Create the cache entry for the response.
+              const cacheEntry: ResponseCacheEntry = {
+                value: {
+                  kind: 'ROUTE',
+                  status: response.status,
+                  body: Buffer.from(await blob.arrayBuffer()),
+                  headers,
+                },
+                revalidate,
+              }
+
+              return cacheEntry
+            }
+
+            // Send the response now that we have copied it into the cache.
+            await sendResponse(req, res, response, context.renderOpts.waitUntil)
+            return null
+          } catch (err) {
+            // If this is during static generation, throw the error again.
+            if (isSSG) throw err
+
+            Log.error(err)
+
+            // Otherwise, send a 500 response.
+            await sendResponse(req, res, handleInternalServerErrorResponse())
+
+            return null
+          }
+        } else if (isPagesRouteModule(routeModule)) {
+          // Due to the way we pass data by mutating `renderOpts`, we can't extend
+          // the object here but only updating its `clientReferenceManifest` and
+          // `nextFontManifest` properties.
+          // https://github.com/vercel/next.js/blob/df7cbd904c3bd85f399d1ce90680c0ecf92d2752/packages/next/server/render.tsx#L947-L952
+          renderOpts.nextFontManifest = this.nextFontManifest
+          renderOpts.clientReferenceManifest =
+            components.clientReferenceManifest
+
+          // Call the built-in render method on the module.
+          result = await routeModule.render(
+            (req as NodeNextRequest).originalRequest ?? (req as WebNextRequest),
+            (res as NodeNextResponse).originalResponse ??
+              (res as WebNextResponse),
+            { page: pathname, params: opts.params, query, renderOpts }
+          )
+        } else if (isAppPageRouteModule(routeModule)) {
+          if (isAppPrefetch && process.env.NODE_ENV === 'production') {
+            try {
+              const prefetchRsc = await this.getPrefetchRsc(resolvedUrlPathname)
+              if (prefetchRsc) {
+                res.setHeader(
+                  'cache-control',
+                  'private, no-cache, no-store, max-age=0, must-revalidate'
+                )
+                res.setHeader('content-type', RSC_CONTENT_TYPE_HEADER)
+                res.body(prefetchRsc).send()
+                return null
+              }
+            } catch {
+              // We fallback to invoking the function if prefetch data is not
+              // available.
+            }
+          }
+
+          const module = components.routeModule as AppPageRouteModule
+
+          // Due to the way we pass data by mutating `renderOpts`, we can't extend the
+          // object here but only updating its `nextFontManifest` field.
+          // https://github.com/vercel/next.js/blob/df7cbd904c3bd85f399d1ce90680c0ecf92d2752/packages/next/server/render.tsx#L947-L952
+          renderOpts.nextFontManifest = this.nextFontManifest
+
+          // Call the built-in render method on the module.
+          result = await module.render(
+            (req as NodeNextRequest).originalRequest ?? (req as WebNextRequest),
+            (res as NodeNextResponse).originalResponse ??
+              (res as WebNextResponse),
+            {
+              page: is404Page ? '/404' : pathname,
+              params: opts.params,
+              query,
+              renderOpts,
+            }
+          )
+        } else {
+          throw new Error('Invariant: Unknown route module type')
+        }
       } else {
         // If we didn't match a page, we should fallback to using the legacy
         // render method.
@@ -2516,6 +2520,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         }
       },
       {
+        routeKind: routeModule?.definition.kind,
         incrementalCache,
         isOnDemandRevalidate: isOnDemandRevalidate,
         isPrefetch: req.headers.purpose === 'prefetch',
@@ -2798,7 +2803,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
   // map the route to the actual bundle name
   protected getOriginalAppPaths(route: string) {
-    if (this.hasAppDir) {
+    if (this.enabledDirectories.app) {
       const originalAppPath = this.appPathRoutes?.[route]
 
       if (!originalAppPath) {
@@ -3102,7 +3107,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       let using404Page = false
 
       if (is404) {
-        if (this.hasAppDir) {
+        if (this.enabledDirectories.app) {
           // Use the not-found entry in app directory
           result = await this.findPageComponents({
             page: this.renderOpts.dev ? '/not-found' : '/_not-found',

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -508,7 +508,7 @@ export default class DevServer extends Server {
   }
 
   protected getAppPathsManifest(): PagesManifest | undefined {
-    if (!this.hasAppDir) return undefined
+    if (!this.enabledDirectories.app) return undefined
 
     return (
       NodeManifestLoader.require(

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -14,9 +14,7 @@ import { setHttpClientAndAgentOptions } from '../setup-http-agent-env'
 import type { IncrementalCache } from '../lib/incremental-cache'
 import * as serverHooks from '../../client/components/hooks-server-context'
 import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
-
-const { AppRouteRouteModule } =
-  require('../future/route-modules/app-route/module.compiled') as typeof import('../future/route-modules/app-route/module')
+import { isAppRouteRouteModule } from '../future/route-modules/checks'
 
 type RuntimeConfig = {
   configFileName: string
@@ -88,7 +86,7 @@ export async function loadStaticPaths({
   if (isAppPath) {
     const { routeModule } = components
     const generateParams: GenerateParams =
-      routeModule && AppRouteRouteModule.is(routeModule)
+      routeModule && isAppRouteRouteModule(routeModule)
         ? [
             {
               config: {

--- a/packages/next/src/server/future/route-modules/app-route/module.ts
+++ b/packages/next/src/server/future/route-modules/app-route/module.ts
@@ -32,7 +32,6 @@ import * as Log from '../../../../build/output/log'
 import { autoImplementMethods } from './helpers/auto-implement-methods'
 import { getNonStaticMethods } from './helpers/get-non-static-methods'
 import { appendMutableCookies } from '../../../web/spec-extension/adapters/request-cookies'
-import { RouteKind } from '../../route-kind'
 import { parsedUrlQueryToParams } from './helpers/parsed-url-query-to-params'
 
 import * as serverHooks from '../../../../client/components/hooks-server-context'
@@ -161,10 +160,6 @@ export class AppRouteRouteModule extends RouteModule<
   private readonly methods: Record<HTTP_METHOD, AppRouteHandlerFn>
   private readonly nonStaticMethods: ReadonlyArray<HTTP_METHOD> | false
   private readonly dynamic: AppRouteUserlandModule['dynamic']
-
-  public static is(route: RouteModule): route is AppRouteRouteModule {
-    return route.definition.kind === RouteKind.APP_ROUTE
-  }
 
   constructor({
     userland,

--- a/packages/next/src/server/future/route-modules/checks.ts
+++ b/packages/next/src/server/future/route-modules/checks.ts
@@ -1,0 +1,32 @@
+import type { AppRouteRouteModule } from './app-route/module'
+import type { AppPageRouteModule } from './app-page/module'
+import type { PagesRouteModule } from './pages/module'
+import type { PagesAPIRouteModule } from './pages-api/module'
+
+import type { RouteModule } from './route-module'
+
+import { RouteKind } from '../route-kind'
+
+export function isAppRouteRouteModule(
+  routeModule: RouteModule
+): routeModule is AppRouteRouteModule {
+  return routeModule.definition.kind === RouteKind.APP_ROUTE
+}
+
+export function isAppPageRouteModule(
+  routeModule: RouteModule
+): routeModule is AppPageRouteModule {
+  return routeModule.definition.kind === RouteKind.APP_PAGE
+}
+
+export function isPagesRouteModule(
+  routeModule: RouteModule
+): routeModule is PagesRouteModule {
+  return routeModule.definition.kind === RouteKind.PAGES
+}
+
+export function isPagesAPIRouteModule(
+  routeModule: RouteModule
+): routeModule is PagesAPIRouteModule {
+  return routeModule.definition.kind === RouteKind.PAGES_API
+}

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -1,7 +1,10 @@
 import type { RouteMetadata } from '../../../export/routes/types'
 import type { CacheHandler, CacheHandlerContext, CacheHandlerValue } from './'
 import type { CacheFs } from '../../../shared/lib/utils'
-import type { CachedFetchValue } from '../../response-cache'
+import type {
+  CachedFetchValue,
+  IncrementalCacheKindHint,
+} from '../../response-cache'
 
 import LRUCache from 'next/dist/compiled/lru-cache'
 import path from '../../../shared/lib/isomorphic/path'
@@ -27,6 +30,7 @@ export default class FileSystemCache implements CacheHandler {
   private flushToDisk?: FileSystemCacheContext['flushToDisk']
   private serverDistDir: FileSystemCacheContext['serverDistDir']
   private appDir: boolean
+  private pagesDir: boolean
   private tagsManifestPath?: string
   private revalidatedTags: string[]
 
@@ -35,6 +39,7 @@ export default class FileSystemCache implements CacheHandler {
     this.flushToDisk = ctx.flushToDisk
     this.serverDistDir = ctx.serverDistDir
     this.appDir = !!ctx._appDir
+    this.pagesDir = !!ctx._pagesDir
     this.revalidatedTags = ctx.revalidatedTags
 
     if (ctx.maxMemoryCacheSize && !memoryCache) {
@@ -111,11 +116,11 @@ export default class FileSystemCache implements CacheHandler {
     {
       tags,
       softTags,
-      fetchCache,
+      kindHint,
     }: {
       tags?: string[]
       softTags?: string[]
-      fetchCache?: boolean
+      kindHint?: IncrementalCacheKindHint
     } = {}
   ) {
     let data = memoryCache?.get(key)
@@ -123,10 +128,7 @@ export default class FileSystemCache implements CacheHandler {
     // let's check the disk for seed data
     if (!data && process.env.NEXT_RUNTIME !== 'edge') {
       try {
-        const { filePath } = await this.getFsPath({
-          pathname: `${key}.body`,
-          appDir: true,
-        })
+        const filePath = this.getFilePath(`${key}.body`, 'app')
         const fileData = await this.fs.readFile(filePath)
         const { mtime } = await this.fs.stat(filePath)
 
@@ -149,14 +151,22 @@ export default class FileSystemCache implements CacheHandler {
       }
 
       try {
-        const { filePath, isAppPath } = await this.getFsPath({
-          pathname: fetchCache ? key : `${key}.html`,
-          fetchCache,
-        })
+        // Determine the file kind if we didn't know it already.
+        let kind = kindHint
+        if (!kind) {
+          kind = this.detectFileKind(`${key}.html`)
+        }
+
+        const isAppPath = kind === 'app'
+        const filePath = this.getFilePath(
+          kind === 'fetch' ? key : `${key}.html`,
+          kind
+        )
+
         const fileData = await this.fs.readFile(filePath, 'utf8')
         const { mtime } = await this.fs.stat(filePath)
 
-        if (fetchCache) {
+        if (kind === 'fetch') {
           const lastModified = mtime.getTime()
           const parsedData: CachedFetchValue = JSON.parse(fileData)
           data = {
@@ -177,22 +187,12 @@ export default class FileSystemCache implements CacheHandler {
         } else {
           const pageData = isAppPath
             ? await this.fs.readFile(
-                (
-                  await this.getFsPath({
-                    pathname: `${key}.rsc`,
-                    appDir: true,
-                  })
-                ).filePath,
+                this.getFilePath(`${key}.rsc`, 'app'),
                 'utf8'
               )
             : JSON.parse(
                 await this.fs.readFile(
-                  (
-                    await this.getFsPath({
-                      pathname: `${key}.json`,
-                      appDir: false,
-                    })
-                  ).filePath,
+                  this.getFilePath(`${key}.json`, 'pages'),
                   'utf8'
                 )
               )
@@ -299,10 +299,7 @@ export default class FileSystemCache implements CacheHandler {
     if (!this.flushToDisk) return
 
     if (data?.kind === 'ROUTE') {
-      const { filePath } = await this.getFsPath({
-        pathname: `${key}.body`,
-        appDir: true,
-      })
+      const filePath = this.getFilePath(`${key}.body`, 'app')
       await this.fs.mkdir(path.dirname(filePath))
       await this.fs.writeFile(filePath, data.body)
 
@@ -321,20 +318,18 @@ export default class FileSystemCache implements CacheHandler {
 
     if (data?.kind === 'PAGE') {
       const isAppPath = typeof data.pageData === 'string'
-      const { filePath: htmlPath } = await this.getFsPath({
-        pathname: `${key}.html`,
-        appDir: isAppPath,
-      })
+      const htmlPath = this.getFilePath(
+        `${key}.html`,
+        isAppPath ? 'app' : 'pages'
+      )
       await this.fs.mkdir(path.dirname(htmlPath))
       await this.fs.writeFile(htmlPath, data.html)
 
       await this.fs.writeFile(
-        (
-          await this.getFsPath({
-            pathname: `${key}.${isAppPath ? 'rsc' : 'json'}`,
-            appDir: isAppPath,
-          })
-        ).filePath,
+        this.getFilePath(
+          `${key}.${isAppPath ? 'rsc' : 'json'}`,
+          isAppPath ? 'app' : 'pages'
+        ),
         isAppPath ? data.pageData : JSON.stringify(data.pageData)
       )
 
@@ -351,10 +346,7 @@ export default class FileSystemCache implements CacheHandler {
         )
       }
     } else if (data?.kind === 'FETCH') {
-      const { filePath } = await this.getFsPath({
-        pathname: key,
-        fetchCache: true,
-      })
+      const filePath = this.getFilePath(key, 'fetch')
       await this.fs.mkdir(path.dirname(filePath))
       await this.fs.writeFile(
         filePath,
@@ -366,51 +358,61 @@ export default class FileSystemCache implements CacheHandler {
     }
   }
 
-  private async getFsPath({
-    pathname,
-    appDir,
-    fetchCache,
-  }: {
-    pathname: string
-    appDir?: boolean
-    fetchCache?: boolean
-  }): Promise<{
-    filePath: string
-    isAppPath: boolean
-  }> {
-    if (fetchCache) {
-      // we store in .next/cache/fetch-cache so it can be persisted
-      // across deploys
-      return {
-        filePath: path.join(
+  private detectFileKind(pathname: string) {
+    if (!this.appDir && !this.pagesDir) {
+      throw new Error(
+        "Invariant: Can't determine file path kind, no page directory enabled"
+      )
+    }
+
+    // If app directory isn't enabled, then assume it's pages and avoid the fs
+    // hit.
+    if (!this.appDir && this.pagesDir) {
+      return 'pages'
+    }
+    // Otherwise assume it's a pages file if the pages directory isn't enabled.
+    else if (this.appDir && !this.pagesDir) {
+      return 'app'
+    }
+
+    // If both are enabled, we need to test each in order, starting with
+    // `pages`.
+    let filePath = this.getFilePath(pathname, 'pages')
+    if (this.fs.existsSync(filePath)) {
+      return 'pages'
+    }
+
+    filePath = this.getFilePath(pathname, 'app')
+    if (this.fs.existsSync(filePath)) {
+      return 'app'
+    }
+
+    throw new Error(
+      `Invariant: Unable to determine file path kind for ${pathname}`
+    )
+  }
+
+  private getFilePath(
+    pathname: string,
+    kind: 'app' | 'fetch' | 'pages'
+  ): string {
+    switch (kind) {
+      case 'fetch':
+        // we store in .next/cache/fetch-cache so it can be persisted
+        // across deploys
+        return path.join(
           this.serverDistDir,
           '..',
           'cache',
           'fetch-cache',
           pathname
-        ),
-        isAppPath: false,
-      }
-    }
-    let isAppPath = false
-    let filePath = path.join(this.serverDistDir, 'pages', pathname)
-
-    if (!this.appDir || appDir === false)
-      return {
-        filePath,
-        isAppPath,
-      }
-    try {
-      await this.fs.readFile(filePath)
-      return {
-        filePath,
-        isAppPath,
-      }
-    } catch (err) {
-      return {
-        filePath: path.join(this.serverDistDir, 'app', pathname),
-        isAppPath: true,
-      }
+        )
+      case 'pages':
+        return path.join(this.serverDistDir, 'pages', pathname)
+      case 'app':
+        return path.join(this.serverDistDir, 'app', pathname)
+      default:
+        throw new Error("Invariant: Can't determine file path kind")
     }
   }
 }

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -3,7 +3,10 @@ import type { PrerenderManifest } from '../../../build'
 import type {
   IncrementalCacheValue,
   IncrementalCacheEntry,
+  IncrementalCache as IncrementalCacheType,
+  IncrementalCacheKindHint,
 } from '../../response-cache'
+
 import FetchCache from './fetch-cache'
 import FileSystemCache from './file-system-cache'
 import path from '../../../shared/lib/isomorphic/path'
@@ -30,6 +33,7 @@ export interface CacheHandlerContext {
   prerenderManifest?: PrerenderManifest
   revalidatedTags: string[]
   _appDir: boolean
+  _pagesDir: boolean
   _requestHeaders: IncrementalCache['requestHeaders']
 }
 
@@ -57,7 +61,7 @@ export class CacheHandler {
   public async revalidateTag(_tag: string): Promise<void> {}
 }
 
-export class IncrementalCache {
+export class IncrementalCache implements IncrementalCacheType {
   dev?: boolean
   cacheHandler?: CacheHandler
   prerenderManifest: PrerenderManifest
@@ -75,6 +79,7 @@ export class IncrementalCache {
     fs,
     dev,
     appDir,
+    pagesDir,
     flushToDisk,
     fetchCache,
     minimalMode,
@@ -90,6 +95,7 @@ export class IncrementalCache {
     fs?: CacheFs
     dev: boolean
     appDir?: boolean
+    pagesDir?: boolean
     fetchCache?: boolean
     minimalMode?: boolean
     serverDistDir?: string
@@ -165,6 +171,7 @@ export class IncrementalCache {
         serverDistDir,
         revalidatedTags,
         maxMemoryCacheSize,
+        _pagesDir: !!pagesDir,
         _appDir: !!appDir,
         _requestHeaders: requestHeaders,
         fetchCacheKeyPrefix,
@@ -397,7 +404,7 @@ export class IncrementalCache {
   async get(
     cacheKey: string,
     ctx: {
-      fetchCache?: boolean
+      kindHint?: IncrementalCacheKindHint
       revalidate?: number | false
       fetchUrl?: string
       fetchIdx?: number
@@ -425,12 +432,13 @@ export class IncrementalCache {
     // so that getStaticProps is always called for easier debugging
     if (
       this.dev &&
-      (!ctx.fetchCache || this.requestHeaders['cache-control'] === 'no-cache')
+      (ctx.kindHint !== 'fetch' ||
+        this.requestHeaders['cache-control'] === 'no-cache')
     ) {
       return null
     }
 
-    cacheKey = this._getPathname(cacheKey, ctx.fetchCache)
+    cacheKey = this._getPathname(cacheKey, ctx.kindHint === 'fetch')
     let entry: IncrementalCacheEntry | null = null
     let revalidate = ctx.revalidate
 
@@ -479,7 +487,7 @@ export class IncrementalCache {
       revalidateAfter = this.calculateRevalidate(
         cacheKey,
         cacheData?.lastModified || Date.now(),
-        this.dev && !ctx.fetchCache
+        this.dev && ctx.kindHint !== 'fetch'
       )
       isStale =
         revalidateAfter !== false && revalidateAfter < Date.now()

--- a/packages/next/src/server/lib/node-fs-methods.ts
+++ b/packages/next/src/server/lib/node-fs-methods.ts
@@ -1,10 +1,12 @@
-import _fs from 'fs'
 import type { CacheFs } from '../../shared/lib/utils'
 
+import fs from 'fs'
+
 export const nodeFs: CacheFs = {
-  readFile: _fs.promises.readFile,
-  readFileSync: _fs.readFileSync,
-  writeFile: (f, d) => _fs.promises.writeFile(f, d),
-  mkdir: (dir) => _fs.promises.mkdir(dir, { recursive: true }),
-  stat: (f) => _fs.promises.stat(f),
+  existsSync: fs.existsSync,
+  readFile: fs.promises.readFile,
+  readFileSync: fs.readFileSync,
+  writeFile: (f, d) => fs.promises.writeFile(f, d),
+  mkdir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
+  stat: (f) => fs.promises.stat(f),
 }

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -522,7 +522,7 @@ export function patchFetch({
           const entry = staticGenerationStore.isOnDemandRevalidate
             ? null
             : await staticGenerationStore.incrementalCache.get(cacheKey, {
-                fetchCache: true,
+                kindHint: 'fetch',
                 revalidate,
                 fetchUrl,
                 fetchIdx,

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -1,6 +1,7 @@
 import type { OutgoingHttpHeaders } from 'http'
 import type RenderResult from '../render-result'
 import type { Revalidate } from '../lib/revalidate'
+import type { RouteKind } from '../../server/future/route-kind'
 
 export interface ResponseCacheBase {
   get(
@@ -10,6 +11,12 @@ export interface ResponseCacheBase {
       isOnDemandRevalidate?: boolean
       isPrefetch?: boolean
       incrementalCache: IncrementalCache
+      /**
+       * This is a hint to the cache to help it determine what kind of route
+       * this is so it knows where to look up the cache entry from. If not
+       * provided it will test the filesystem to check.
+       */
+      routeKind?: RouteKind
     }
   ): Promise<ResponseCacheEntry | null>
 }
@@ -120,10 +127,18 @@ export type IncrementalCacheItem = {
   isMiss?: boolean
 } | null
 
+export type IncrementalCacheKindHint = 'app' | 'pages' | 'fetch'
+
 export interface IncrementalCache {
   get: (
     key: string,
-    ctx?: { fetchCache?: boolean }
+    ctx?: {
+      /**
+       * The kind of cache entry to get. If not provided it will try to
+       * determine the kind from the filesystem.
+       */
+      kindHint?: IncrementalCacheKindHint
+    }
   ) => Promise<IncrementalCacheItem>
   set: (
     key: string,

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -62,7 +62,8 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
       dev,
       requestHeaders,
       requestProtocol: 'https',
-      appDir: this.hasAppDir,
+      pagesDir: this.enabledDirectories.pages,
+      appDir: this.enabledDirectories.app,
       allowedRevalidateHeaderKeys:
         this.nextConfig.experimental.allowedRevalidateHeaderKeys,
       minimalMode: this.minimalMode,
@@ -87,8 +88,11 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
     return this.serverOptions.webServerConfig.extendRenderOpts.buildId
   }
 
-  protected getHasAppDir() {
-    return this.serverOptions.webServerConfig.pagesType === 'app'
+  protected getEnabledDirectories() {
+    return {
+      app: this.serverOptions.webServerConfig.pagesType === 'app',
+      pages: this.serverOptions.webServerConfig.pagesType === 'pages',
+    }
   }
 
   protected getPagesManifest() {

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -107,7 +107,7 @@ export function unstable_cache<T extends Callback>(
             store?.isOnDemandRevalidate || incrementalCache.isOnDemandRevalidate
           ) &&
           (await incrementalCache?.get(cacheKey, {
-            fetchCache: true,
+            kindHint: 'fetch',
             revalidate: options.revalidate,
             tags,
             softTags: implicitTags,

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -448,6 +448,7 @@ export class MiddlewareNotFoundError extends Error {
 }
 
 export interface CacheFs {
+  existsSync: typeof fs.existsSync
   readFile: typeof fs.promises.readFile
   readFileSync: typeof fs.readFileSync
   writeFile(f: string, d: any): Promise<void>

--- a/test/unit/incremental-cache/file-system-cache.test.ts
+++ b/test/unit/incremental-cache/file-system-cache.test.ts
@@ -9,6 +9,7 @@ describe('FileSystemCache', () => {
   it('set image route', async () => {
     const fsCache = new FileSystemCache({
       _appDir: true,
+      _pagesDir: true,
       _requestHeaders: {},
       flushToDisk: true,
       fs: nodeFs,


### PR DESCRIPTION
This passes down the route kind information to the incrememntal cache so it no longer needs to test some files existing in order to validate if the file exists or not for a route.
