### PR TITLE
build(package): clean up next-swc* pkg properties

### DIFF
--- a/packages/next-swc/crates/napi/npm/linux-arm64-gnu/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-gnu/package.json
@@ -19,9 +19,6 @@
   "files": [
     "next-swc.linux-arm64-gnu.node"
   ],
-  "libc": [
-    "glibc"
-  ],
   "license": "MIT",
   "engines": {
     "node": ">= 10"

--- a/packages/next-swc/crates/napi/npm/linux-arm64-musl/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-musl/package.json
@@ -19,9 +19,6 @@
   "files": [
     "next-swc.linux-arm64-musl.node"
   ],
-  "libc": [
-    "musl"
-  ],
   "license": "MIT",
   "engines": {
     "node": ">= 10"

--- a/packages/next-swc/crates/napi/npm/linux-x64-gnu/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-x64-gnu/package.json
@@ -19,9 +19,6 @@
   "files": [
     "next-swc.linux-x64-gnu.node"
   ],
-  "libc": [
-    "glibc"
-  ],
   "license": "MIT",
   "engines": {
     "node": ">= 10"

--- a/packages/next-swc/crates/napi/npm/linux-x64-musl/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-x64-musl/package.json
@@ -19,9 +19,6 @@
   "files": [
     "next-swc.linux-x64-musl.node"
   ],
-  "libc": [
-    "musl"
-  ],
   "license": "MIT",
   "engines": {
     "node": ">= 10"


### PR DESCRIPTION
### What

Minor updates to the pkg manifest to remove duplicated property definition.