### PR TITLE
docs: clarify `src` + Middleware

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/06-src-directory.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/06-src-directory.mdx
@@ -29,4 +29,5 @@ To use the `src` directory, move the `app` Router folder or `pages` Router folde
 > - `.env.*` files should remain in the root of your project.
 > - `src/app` or `src/pages` will be ignored if `app` or `pages` are present in the root directory.
 > - If you're using `src`, you'll probably also move other application folders such as `/components` or `/lib`.
+> - If you're using `src` and Middleware move the `middleware.ts` or `.js` file to `src` as well.
 > - If you're using Tailwind CSS, you'll need to add the `/src` prefix to the `tailwind.config.js` file in the [content section](https://tailwindcss.com/docs/content-configuration).


### PR DESCRIPTION
### What? Why?

https://nextjs.org/docs/app/building-your-application/routing/middleware#convention already mentions this, making it consistent.

### How?

Add it to the good-to-know section

Closes #57923