### PR TITLE
docs: note that sitemap fn return value can be a promise

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/sitemap.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/sitemap.mdx
@@ -32,7 +32,7 @@ Add or generate a `sitemap.xml` file that matches the [Sitemaps XML format](http
 
 ## Generate a Sitemap
 
-Add a `sitemap.js` or `sitemap.ts` file that returns [`Sitemap`](#sitemap-return-type).
+Add a `sitemap.js` or `sitemap.ts` file that returns [`Sitemap` or `Promise<Sitemap>`](#sitemap-return-type).
 
 ```ts filename="app/sitemap.ts" switcher
 import { MetadataRoute } from 'next'


### PR DESCRIPTION
### What?

Change the docs about the default export function for `app/sitemap.ts` return value from `` `Sitemap` `` to `` `Sitemap` | `Promise<Sitemap>` ``.

### Why?

Because it can be a promise, but I wasn't sure of that until I experimented. I would also very much like it to always allow an async function so I wanted to make it officially documented so it can't be taken away!

### How?

Using my keyboard to type the letters.