### PR TITLE
feat(turbopack): initial import.meta.url support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "serde",
  "smallvec",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "serde",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7671,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7683,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7698,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7712,7 +7712,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7729,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7759,7 +7759,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "base16",
  "hex",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7785,7 +7785,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7795,7 +7795,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "mimalloc",
 ]
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7828,7 +7828,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7859,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7899,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7945,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7975,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8021,7 +8021,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8058,7 +8058,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8092,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "serde",
  "serde_json",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8143,7 +8143,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8179,7 +8179,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "serde",
@@ -8194,7 +8194,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8209,7 +8209,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8244,7 +8244,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "serde",
@@ -8260,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8271,7 +8271,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231102.2#102d4ea5dbb6f1a9332bd15bb604740774bcf1d7"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ swc_core = { version = "0.86.10", features = [
 testing = { version = "0.35.0" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231026.5" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231102.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231026.5" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231102.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231026.5" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231102.2" }
 
 # General Deps
 

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -3317,10 +3317,11 @@
       "app dir - metadata dynamic routes text routes should not throw if client components are imported but not used",
       "app dir - metadata dynamic routes social image routes should fill params into routes groups url of static images",
       "app dir - metadata dynamic routes social image routes should support params as argument in dynamic routes",
-      "app dir - metadata dynamic routes should generate unique path for image routes under group routes"
+      "app dir - metadata dynamic routes should generate unique path for image routes under group routes",
+      "app dir - metadata dynamic routes social image routes should handle custom fonts in both edge and nodejs runtime"
     ],
     "failed": [
-      "app dir - metadata dynamic routes social image routes should handle custom fonts in both edge and nodejs runtime"
+      "app dir - should error if the default export of dynamic image is missing"
     ],
     "pending": [],
     "flakey": [],


### PR DESCRIPTION
### What

This PR bumps up turbopack to support initial `import.meta.url` as static global (outside of new URL() ctor). Enables some of vercel/og supports.