### PR TITLE
[Docs] Make example of passing down a Server Action more clear

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/server-actions.mdx
+++ b/docs/02-app/02-api-reference/04-functions/server-actions.mdx
@@ -76,9 +76,9 @@ In some cases, you might want to pass down a Server Action to a Client Component
 ```jsx filename="app/client-component.jsx"
 'use client'
 
-export default function ClientComponent({ myAction }) {
+export default function ClientComponent({ updateItem }) {
   return (
-    <form action={myAction}>
+    <form action={updateItem}>
       <input type="text" name="name" />
       <button type="submit">Update Item</button>
     </form>


### PR DESCRIPTION
Currently the example shows that we pass down `updateItem`. But in the client component the prop is called `myAction`.

### What?
Change the prop name in the documentation here: https://nextjs.org/docs/app/api-reference/functions/server-actions#props

### Why?
Currently the example can't work like it is shown since the prop names mismatch.