### PR TITLE
Early return for the disabled `@next/bundle-analyzer` plugin

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -1,22 +1,27 @@
-module.exports =
-  ({ enabled = true, openAnalyzer, analyzerMode } = {}) =>
-  (nextConfig = {}) => {
+module.exports = function makeBundleAnalyzer({
+  enabled = true,
+  openAnalyzer,
+  analyzerMode,
+} = {}) {
+  if (!enabled) {
+    const identity = (it) => it
+    return identity
+  }
+  return (nextConfig = {}) => {
     return Object.assign({}, nextConfig, {
       webpack(config, options) {
-        if (enabled) {
-          const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
-          config.plugins.push(
-            new BundleAnalyzerPlugin({
-              analyzerMode: analyzerMode || 'static',
-              openAnalyzer,
-              reportFilename: !options.nextRuntime
-                ? `./analyze/client.html`
-                : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${
-                    options.nextRuntime
-                  }.html`,
-            })
-          )
-        }
+        const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+        config.plugins.push(
+          new BundleAnalyzerPlugin({
+            analyzerMode: analyzerMode || 'static',
+            openAnalyzer,
+            reportFilename: !options.nextRuntime
+              ? `./analyze/client.html`
+              : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${
+                  options.nextRuntime
+                }.html`,
+          })
+        )
 
         if (typeof nextConfig.webpack === 'function') {
           return nextConfig.webpack(config, options)
@@ -25,3 +30,4 @@ module.exports =
       },
     })
   }
+}


### PR DESCRIPTION
### What?

`@next/bundle-analyzer` is introducing a custom webpack configuration even if disabled. Thus, we see this warning with `next@14`

![JPEG-1](https://github.com/vercel/next.js/assets/922234/da2dd915-8a3e-4dc8-a1b2-1fc7e46004e8)

### Why?

This is due to: https://github.com/vercel/next.js/blob/v14.0.1/packages/next-bundle-analyzer/index.js

### How?

Early return an `identity` function if the plugin is disabled.

