### PR TITLE
fix(next-swc): update the server actions link

### DIFF
--- a/packages/next-swc/crates/core/src/server_actions.rs
+++ b/packages/next-swc/crates/core/src/server_actions.rs
@@ -1455,7 +1455,7 @@ fn remove_server_directive_index_in_module(
                                 handler
                                     .struct_span_err(
                                         *span,
-                                        "To use Server Actions, please enable the feature flag in your Next.js config. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching/forms-and-mutations#convention",
+                                        "To use Server Actions, please enable the feature flag in your Next.js config. Read more: https://nextjs.org/docs/app/api-reference/functions/server-actions#convention",
                                     )
                                     .emit()
                             });
@@ -1554,7 +1554,7 @@ fn remove_server_directive_index_in_fn(
                             handler
                                 .struct_span_err(
                                     *span,
-                                    "To use Server Actions, please enable the feature flag in your Next.js config. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching/forms-and-mutations#convention",
+                                    "To use Server Actions, please enable the feature flag in your Next.js config. Read more: https://nextjs.org/docs/app/api-reference/functions/server-actions#convention",
                                 )
                                 .emit()
                         });


### PR DESCRIPTION
### What?
Update the error message for missing experimental server action configuration to point to the proper docs

### Why?

On the previous link, I couldn't find any reference to the cited `convention`. 

### How?

string replacement
