### PR TITLE
tweak stats action to pull in runtime sizes

### DIFF
--- a/.github/actions/next-stats-action/src/run/collect-diffs.js
+++ b/.github/actions/next-stats-action/src/run/collect-diffs.js
@@ -39,15 +39,16 @@ module.exports = async function collectDiffs(
         })
       )
 
+      logger('Tracking the following files:')
+      logger(curFiles)
+
       for (let file of curFiles) {
         const absPath = path.join(statsAppDir, file)
 
         const diffDest = path.join(diffingDir, file)
+        logger('Copying', absPath, 'to', diffDest)
         await fs.cp(absPath, diffDest, { recursive: true, force: true })
       }
-
-      logger('Tracking the following files:')
-      logger(curFiles)
 
       if (curFiles.length > 0) {
         const prettierPath = path.join(

--- a/.github/actions/next-stats-action/src/run/collect-diffs.js
+++ b/.github/actions/next-stats-action/src/run/collect-diffs.js
@@ -51,15 +51,13 @@ module.exports = async function collectDiffs(
       }
 
       if (curFiles.length > 0) {
-        const filesInDiffingDir = await fs.readdir(diffingDir)
-        logger('Files in diffingDir:', filesInDiffingDir)
         const prettierPath = path.join(
           __dirname,
           '../../node_modules/.bin/prettier'
         )
         await exec(
           `cd "${process.env.LOCAL_STATS ? process.cwd() : diffingDir}" && ` +
-            `${prettierPath} --write ${curFiles
+            `${prettierPath} --write --no-error-on-unmatched-pattern ${curFiles
               .map((f) => path.join(diffingDir, f))
               .join(' ')}`
         )

--- a/.github/actions/next-stats-action/src/run/collect-diffs.js
+++ b/.github/actions/next-stats-action/src/run/collect-diffs.js
@@ -46,7 +46,6 @@ module.exports = async function collectDiffs(
         const absPath = path.join(statsAppDir, file)
 
         const diffDest = path.join(diffingDir, file)
-        logger('Copying', absPath, 'to', diffDest)
         await fs.cp(absPath, diffDest, { recursive: true, force: true })
       }
 

--- a/.github/actions/next-stats-action/src/run/collect-diffs.js
+++ b/.github/actions/next-stats-action/src/run/collect-diffs.js
@@ -51,6 +51,8 @@ module.exports = async function collectDiffs(
       }
 
       if (curFiles.length > 0) {
+        const filesInDiffingDir = await fs.readdir(diffingDir)
+        logger('Files in diffingDir:', filesInDiffingDir)
         const prettierPath = path.join(
           __dirname,
           '../../node_modules/.bin/prettier'

--- a/.github/actions/next-stats-action/src/run/collect-diffs.js
+++ b/.github/actions/next-stats-action/src/run/collect-diffs.js
@@ -46,6 +46,9 @@ module.exports = async function collectDiffs(
         await fs.cp(absPath, diffDest, { recursive: true, force: true })
       }
 
+      logger('Tracking the following files:')
+      logger(curFiles)
+
       if (curFiles.length > 0) {
         const prettierPath = path.join(
           __dirname,

--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -38,7 +38,7 @@ const clientGlobs = [
   },
   {
     name: 'Next Runtimes',
-    globs: ['../../node_modules/next/dist/compiled/next-server/**/*.js'],
+    globs: ['node_modules/next/dist/compiled/next-server/**/*.js'],
   },
 ]
 


### PR DESCRIPTION
This wasn't working previously so updated the glob & script to properly track changes to our bundled next runtimes

Should now be appended to the bottom of the PR stats action, eg:
![CleanShot 2023-11-03 at 13 49 58@2x](https://github.com/vercel/next.js/assets/1939140/54319a42-5a32-4e39-90c2-6ec07442ec73)
