### PR TITLE
fix(bundle-analyzer): generate files with `.json` extension with `anayzerMode` is set to `json`

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -5,15 +5,16 @@ module.exports =
       webpack(config, options) {
         if (enabled) {
           const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+          const fileExtension = analyzerMode === 'json' ? '.json' : '.html'
           config.plugins.push(
             new BundleAnalyzerPlugin({
               analyzerMode: analyzerMode || 'static',
               openAnalyzer,
               reportFilename: !options.nextRuntime
-                ? `./analyze/client.html`
+                ? `./analyze/client${fileExtension}`
                 : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${
                     options.nextRuntime
-                  }.html`,
+                  }${fileExtension}`,
             })
           )
         }


### PR DESCRIPTION
fixes: #58040 

This PR changes the file extension of the files generated by `@next/bundle-analyzer` to `.json` when `analyzerMode: 'json'` is set.