### PR TITLE
add failing tests on parallel routes catchall

### DIFF
--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall-slot-only/@slot/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall-slot-only/@slot/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'slot catchall'
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall-slot-only/@slot/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall-slot-only/@slot/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'root slot'
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall-slot-only/foo/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall-slot-only/foo/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'foo'
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall-slot-only/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall-slot-only/layout.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+
+export default function Layout({ children, slot }) {
+  return (
+    <div>
+      <div>Main content</div>
+      <div id="main">{children}</div>
+      <div>
+        Slot content:
+        <div id="slot-content">{slot}</div>
+      </div>
+
+      <div>
+        {/* /foo exists only as @children slot and should be rendered using [...catchAll] for the @slot slot */}
+        <Link href="/parallel-catchall-slot-only/foo">foo only children</Link>
+      </div>
+      <div>
+        {/* /bar doesn't exist as @children slot */}
+        <Link href="/parallel-catchall-slot-only/bar">not existing bar</Link>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall-slot-only/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-catchall-slot-only/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <div>Page</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -339,6 +339,41 @@ createNextDescribe(
         )
       })
 
+      describe('on soft navigation', () => {
+        it('should apply the catch-all slot to the parallel route that has only the children slot', async () => {
+          const browser = await next.browser('/parallel-catchall-slot-only')
+
+          await browser
+            .elementByCss('[href="/parallel-catchall-slot-only/foo"]')
+            .click()
+          await check(() => browser.waitForElementByCss('#main').text(), 'foo')
+          await check(
+            () => browser.waitForElementByCss('#slot-content').text(),
+            'slot catchall'
+          )
+        })
+      })
+
+      describe('on hard navigation', () => {
+        it('should apply the catch-all slot to the parallel route that has only the children slot', async () => {
+          const browser = await next.browser('/parallel-catchall-slot-only/foo')
+
+          await check(() => browser.waitForElementByCss('#main').text(), 'foo')
+          await check(
+            () => browser.waitForElementByCss('#slot-content').text(),
+            'slot catchall'
+          )
+        })
+      })
+
+      it('should throw a 404 when no children slot available', async () => {
+        const browser = await next.browser('/parallel-catchall-slot-only/bar')
+
+        expect(await browser.elementByCss('body').text()).toMatch(
+          /This page could not be found/
+        )
+      })
+
       it('should navigate with a link with prefetch=false', async () => {
         const browser = await next.browser('/parallel-prefetch-false')
 


### PR DESCRIPTION
I have added failed tests related to issue https://github.com/vercel/next.js/issues/48719.

In the current implementation of Next.js, when utilising parallel routes, the usage of [...catchall] route segments necessitates the inclusion of a catchall route segment within every slot associated with the layout branch.

For example, with the following structure:
```
app/
├── layout.tsx
├── a/
│   └── page.tsx
├── b/
│   └── page.tsx
└── @slot/
    ├── a/
    │   └── page.tsx
    └── [...catchall]/
        └── page.tsx
```
```tsx
// app/layout.tsx

import { SomeComponent } from "some-component";

export default function RootLayout({ children, slot }) {
  return (
    <html>
      <head />
      <body>
        <SomeComponent foo={slot} />
        <main>{children}</main>
      </body>
    </html>
  );
}
```
- navigating to the path `/a` , we would have both `@children` and `@slot` defined
- navigating to the path `/b` , only `@children` is defined and `@slot/[...catchall]/page.tsx` is not taken into account, so this will result in a 404

Personally, I find it counterintuitive and doing it this way makes it much more complicated to manage the slots of the parallel routes.


This [codesandbox](https://codesandbox.io/p/sandbox/interesting-glade-fykc54) is a practical example of one of the most problematic use cases I have come across.
Suppose we have a header in the root layout, and this header internally has a subheader that should be different for each page. However, this subheader is optional. For example, I have 50 pages in total, and on 20 of them I need to display a subheader, while on the other 30 the subheader must not exist (it can be a component that returns null). The way Next.js works now, what I should do is create 30 pages inside the `@subheader` slot, all of which return null.

Currently catchall is of no help because it cannot intercept such 30 pages, and `default.tsx` is also unusable because it only works on hard-navigation, while on soft-navigation the previously existing slot is preserved.

Apart from the documentation of parallel routes, I have not been able to find more in-depth or formalised specifications, so I would like to open a discussion with these questions:
- Is the parallel routes architecture final or is it still a WIP?
- Is what I have presented above something that can actually be implemented, perhaps even listening to other feedback from the community?

@leerob @feedthejim @timneutkens