### PR TITLE
Docs: fix grammatical issue in "Data Fetching Patterns" section

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/02-patterns.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/02-patterns.mdx
@@ -137,7 +137,7 @@ This will prevent the whole route from being blocked by data fetching, and the u
 >
 > An alternative approach to prevent waterfalls is to fetch data globally, at the root of your application, but this will block rendering for all route segments beneath it until the data has finished loading. This can be described as "all or nothing" data fetching. Either you have the entire data for your page or application, or none.
 >
-> Any fetch requests with `await` will block rendering and data fetching for the entire tree beneath it, unless they are wrapped in a `<Suspense>` boundary or `loading.js` is used. Another alternative is use [parallel data fetching](#parallel-data-fetching) or the [preload pattern](#preloading-data).
+> Any fetch requests with `await` will block rendering and data fetching for the entire tree beneath it, unless they are wrapped in a `<Suspense>` boundary or `loading.js` is used. Another alternative is to use [parallel data fetching](#parallel-data-fetching) or the [preload pattern](#preloading-data).
 
 #### Parallel Data Fetching
 


### PR DESCRIPTION
## Description

This PR addresses a minor grammatical issue in the Next.js documentation. It corrects the use of the word "is" and replaces it with "is to" to ensure clarity and correctness.

Before:
```markdown
Any fetch requests with `await` will block rendering and data fetching for the entire tree beneath it, unless they are wrapped in a `<Suspense>` boundary or `loading.js` is used. Another alternative is use [parallel data fetching](#parallel-data-fetching) or the [preload pattern](#preloading-data).
```


After:
```markdown
Any fetch requests with `await` will block rendering and data fetching for the entire tree beneath it, unless they are wrapped in a `<Suspense>` boundary or `loading.js` is used. Another alternative is to use [parallel data fetching](#parallel-data-fetching) or the [preload pattern](#preloading-data).
```

This change improves the readability and correctness of the documentation.

## Checklist

- [x] I have tested the changes to ensure they are correct and do not introduce new issues.
- [x] I have followed the Next.js documentation contribution guidelines.
- [x] I have made a concise and clear commit message: "docs: fix a grammatical problem."

Thank you for reviewing and merging this PR.