### PR TITLE
Update & Repair LRUCache importation on NextJS Rate Limit API example

### DIFF
--- a/examples/api-routes-rate-limit/package.json
+++ b/examples/api-routes-rate-limit/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "lru-cache": "^7.12.0",
+    "lru-cache": "^10.0.1",
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/api-routes-rate-limit/utils/rate-limit.ts
+++ b/examples/api-routes-rate-limit/utils/rate-limit.ts
@@ -1,5 +1,5 @@
 import type { NextApiResponse } from 'next'
-import LRU from 'lru-cache'
+import { LRUCache } from 'lru-cache'
 
 type Options = {
   uniqueTokenPerInterval?: number


### PR DESCRIPTION
- Fixes LRUCache versioning from legacy v7 to v10
- Fixes import statement for LRUCache v10 to deconstruct from package

---
- [X] I have tested the changes to ensure they are correct and do not introduce new issues.
- [X] I have followed the Next.js documentation contribution guidelines.
- [X] I have made a concise and clear commit message: "Update & Repair LRUCache importation on NextJS Rate Limit API example."