### PR TITLE
docs: Fix grammar in Dynamic Rendering section

### DIFF
--- a/docs/02-app/01-building-your-application/03-rendering/01-server-components.mdx
+++ b/docs/02-app/01-building-your-application/03-rendering/01-server-components.mdx
@@ -78,7 +78,7 @@ Dynamic rendering is useful when a route has data that is personalized to the us
 
 > **Dynamic Routes with Cached Data**
 >
-> In most websites, routes are not fully static or fully dynamic - it's a spectrum. For example, you can have e-commerce page that uses cached product data that's revalidated at an interval, but also has uncached, personalized customer data.
+> In most websites, routes are not fully static or fully dynamic - it's a spectrum. For example, you can have an e-commerce page that uses cached product data that's revalidated at an interval, but also has uncached, personalized customer data.
 >
 > In Next.js, you can have dynamically rendered routes that have both cached and uncached data. This is because the RSC Payload and data are cached separately. This allows you to opt into dynamic rendering without worrying about the performance impact of fetching all the data at request time.
 >


### PR DESCRIPTION
This PR fixes a minor grammar issue in the `Dynamic Routes with Cached Data` section under https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering.