### PR TITLE
update turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "serde",
  "smallvec",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "serde",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7671,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7683,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7698,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7712,7 +7712,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7729,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7759,7 +7759,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "base16",
  "hex",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7785,7 +7785,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7795,7 +7795,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "mimalloc",
 ]
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7828,7 +7828,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7859,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7899,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7945,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7975,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8021,7 +8021,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8058,7 +8058,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8092,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "serde",
  "serde_json",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8143,7 +8143,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8179,7 +8179,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "serde",
@@ -8194,7 +8194,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8209,7 +8209,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8244,7 +8244,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "serde",
@@ -8260,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8271,7 +8271,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231026.5#633766b9ceb1493449dbdbebe56e52552f72e980"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231106.2#f903ed554b255ba9227c726a3953fe8673c10945"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5021,9 +5021,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
@@ -5060,9 +5060,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ swc_core = { version = "0.86.10", features = [
 testing = { version = "0.35.0" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231026.5" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231106.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231026.5" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231106.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231026.5" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231106.2" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-api/src/dynamic_imports.rs
+++ b/packages/next-swc/crates/next-api/src/dynamic_imports.rs
@@ -202,8 +202,8 @@ async fn build_dynamic_imports_map_for_module(
             )),
             Request::parse(Value::new(Pattern::Constant(import.to_string()))),
             Value::new(EcmaScriptModulesReferenceSubType::Undefined),
-            None,
             IssueSeverity::Error.cell(),
+            None,
         )
         .first_module()
         .await?;

--- a/packages/next-swc/crates/next-api/src/pages.rs
+++ b/packages/next-swc/crates/next-api/src/pages.rs
@@ -545,8 +545,8 @@ impl PageEndpoint {
                 "next/dist/client/next-dev-turbopack.js".to_string(),
             ))),
             Value::new(EcmaScriptModulesReferenceSubType::Undefined),
-            None,
             IssueSeverity::Error.cell(),
+            None,
         )
         .first_module()
         .await?

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -73,8 +73,8 @@ pub async fn get_swc_ecma_transform_plugin_impl(
             project_path,
             request,
             resolve_options,
-            None,
             IssueSeverity::Error.cell(),
+            None,
         )
         .await?;
         let Some(plugin_module) = *plugin_wasm_module_resolve_result.first_module().await? else {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -193,7 +193,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231026.5",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231106.2",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,8 +1061,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231026.5
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231026.5(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231106.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231106.2(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -24642,9 +24642,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231026.5(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231026.5}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231026.5'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231106.2(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231106.2}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231106.2'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
* https://github.com/vercel/turbo/pull/6325 <!-- OJ Kwon - build(cargo): skip external build script with rust-analyzer  -->
* https://github.com/vercel/turbo/pull/6318 <!-- OJ Kwon - feat(turbopack-ecmascript): calculate import.meta.url as an absolute path  -->
* https://github.com/vercel/turbo/pull/6359 <!-- Will Binns-Smith - Turbopack: Defer calculating source positions until needed  -->
* https://github.com/vercel/turbo/pull/6274 <!-- Tobias Koppers - add backtrace for trait calls  -->
* https://github.com/vercel/turbo/pull/6305 <!-- Tobias Koppers - Triple chunk size heuristic  -->
* https://github.com/vercel/turbo/pull/6304 <!-- Tobias Koppers - improve resolving performance  -->