### PR TITLE
fix(next-core): correct assets url reference condition

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
@@ -23,23 +23,29 @@ use turbopack_binding::turbopack::{
 
 use crate::next_image::{module::BlurPlaceholderMode, StructuredImageModuleType};
 
-/// Returns a rule which applies the Next.js dynamic transform.
 pub fn get_next_image_rule() -> ModuleRule {
     ModuleRule::new(
-        ModuleRuleCondition::any(vec![
-            ModuleRuleCondition::ResourcePathEndsWith(".jpg".to_string()),
-            ModuleRuleCondition::ResourcePathEndsWith(".jpeg".to_string()),
-            ModuleRuleCondition::ResourcePathEndsWith(".png".to_string()),
-            ModuleRuleCondition::ResourcePathEndsWith(".apng".to_string()),
-            ModuleRuleCondition::ResourcePathEndsWith(".gif".to_string()),
-            ModuleRuleCondition::ResourcePathEndsWith(".svg".to_string()),
-            ModuleRuleCondition::ResourcePathEndsWith(".bmp".to_string()),
-            ModuleRuleCondition::ResourcePathEndsWith(".ico".to_string()),
-            // These images may not be encoded by turbopack depends on the feature availability
-            // As turbopack-image returns raw bytes if compile time codec support is not enabled:
-            // ref:https://github.com/vercel/turbo/pull/5967
-            ModuleRuleCondition::ResourcePathEndsWith(".webp".to_string()),
-            ModuleRuleCondition::ResourcePathEndsWith(".avif".to_string()),
+        ModuleRuleCondition::All(vec![
+            // avoid urlAssetReference to be affected by this rule, since urlAssetReference
+            // requires raw module to have its paths in the export
+            ModuleRuleCondition::not(ModuleRuleCondition::ReferenceType(ReferenceType::Url(
+                UrlReferenceSubType::Undefined,
+            ))),
+            ModuleRuleCondition::any(vec![
+                ModuleRuleCondition::ResourcePathEndsWith(".jpg".to_string()),
+                ModuleRuleCondition::ResourcePathEndsWith(".jpeg".to_string()),
+                ModuleRuleCondition::ResourcePathEndsWith(".png".to_string()),
+                ModuleRuleCondition::ResourcePathEndsWith(".apng".to_string()),
+                ModuleRuleCondition::ResourcePathEndsWith(".gif".to_string()),
+                ModuleRuleCondition::ResourcePathEndsWith(".svg".to_string()),
+                ModuleRuleCondition::ResourcePathEndsWith(".bmp".to_string()),
+                ModuleRuleCondition::ResourcePathEndsWith(".ico".to_string()),
+                // These images may not be encoded by turbopack depends on the feature availability
+                // As turbopack-image returns raw bytes if compile time codec support is not
+                // enabled: ref:https://github.com/vercel/turbo/pull/5967
+                ModuleRuleCondition::ResourcePathEndsWith(".webp".to_string()),
+                ModuleRuleCondition::ResourcePathEndsWith(".avif".to_string()),
+            ]),
         ]),
         vec![ModuleRuleEffect::ModuleType(ModuleType::Custom(
             Vc::upcast(StructuredImageModuleType::new(Value::new(
@@ -49,6 +55,7 @@ pub fn get_next_image_rule() -> ModuleRule {
     )
 }
 
+/// Returns a rule which applies the Next.js dynamic transform.
 pub(crate) fn module_rule_match_js_no_url() -> ModuleRuleCondition {
     ModuleRuleCondition::all(vec![
         ModuleRuleCondition::not(ModuleRuleCondition::ReferenceType(ReferenceType::Url(

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -3368,10 +3368,12 @@
       "app dir - metadata dynamic routes social image routes should support params as argument in dynamic routes",
       "app dir - metadata dynamic routes text routes should handle robots.[ext] dynamic routes",
       "app dir - metadata dynamic routes text routes should handle sitemap.[ext] dynamic routes",
-      "app dir - metadata dynamic routes text routes should not throw if client components are imported but not used"
+      "app dir - metadata dynamic routes text routes should not throw if client components are imported but not used",
+      "app dir - metadata dynamic routes should generate unique path for image routes under group routes",
+      "app dir - metadata dynamic routes social image routes should handle custom fonts in both edge and nodejs runtime"
     ],
     "failed": [
-      "app dir - metadata dynamic routes should error if the default export of dynamic image is missing"
+      "app dir - should error if the default export of dynamic image is missing"
     ],
     "pending": [],
     "flakey": [],
@@ -14880,15 +14882,16 @@
     "runtimeError": false
   },
   "test/integration/url/test/index.test.js": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "Handle new URL asset references in next dev should client-render the /ssg page",
       "Handle new URL asset references in next dev should client-render the /ssr page",
       "Handle new URL asset references in next dev should client-render the /static page",
       "Handle new URL asset references in next dev should render the /ssg page",
       "Handle new URL asset references in next dev should render the /ssr page",
       "Handle new URL asset references in next dev should render the /static page",
-      "Handle new URL asset references in next dev should respond on basename api",
+      "Handle new URL asset references in next dev should respond on basename api"
+    ],
+    "failed": [
       "Handle new URL asset references in next dev should respond on size api"
     ],
     "pending": [


### PR DESCRIPTION
### What

Corrects how urlassetreference reads its assets path to allow to resolve image assets correctly.

There is a test failure in the integration/url still, that involves probably larger refactoring so making this PR first to enable baseline, ensure further refactoring does not breaks anything.