### PR TITLE
Adjust update-turbopack-test-manifest.yml to run once per day

### DIFF
--- a/.github/workflows/update-turbopack-test-manifest.yml
+++ b/.github/workflows/update-turbopack-test-manifest.yml
@@ -3,8 +3,8 @@ name: Update Turbopack test manifest
 
 on:
   schedule:
-    # Every hour
-    - cron: '0 * * * *'
+    # Every day at 9AM https://crontab.guru/#0_9_*_*_*
+    - cron: '0 9 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The workflow is creating and closing PRs ever hour, which is too much.