### PR TITLE
Fix incorrect normalizing in minimal mode

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -989,8 +989,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
             addRequestMeta(req, 'postponed', postponed)
           }
 
-          matchedPath = this.normalize(matchedPath)
-          const normalizedUrlPath = this.normalize(parsedUrl.pathname)
+          matchedPath = this.stripNextDataPath(matchedPath, false)
+          const normalizedUrlPath = this.stripNextDataPath(urlPathname)
 
           // Perform locale detection and normalization.
           const localeAnalysisResult = this.i18nProvider?.analyze(matchedPath, {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -958,6 +958,15 @@ export default abstract class Server<ServerOptions extends Options = Options> {
             'http://localhost'
           )
 
+          if (this.normalizers.rsc.match(matchedPath)) {
+            matchedPath = this.normalizers.rsc.normalize(matchedPath, true)
+          } else if (this.normalizers.postponed.match(matchedPath)) {
+            matchedPath = this.normalizers.postponed.normalize(
+              matchedPath,
+              true
+            )
+          }
+
           const { pathname: urlPathname } = new URL(req.url, 'http://localhost')
 
           // For ISR  the URL is normalized to the prerenderPath so if


### PR DESCRIPTION
This reverts an extra change in https://github.com/vercel/next.js/commit/3fa9f31ce15edb4e98b5a2d358411ad31015a60d causing normalizing to be incorrect and route params to not parse properly with i18n. 

This unblocks https://github.com/vercel/vercel/pull/10799