### PR TITLE
Make example more generic - avoid hard coding localhost, port, etc...

### DIFF
--- a/examples/with-redux/lib/redux/slices/counterSlice/fetchIdentityCount.ts
+++ b/examples/with-redux/lib/redux/slices/counterSlice/fetchIdentityCount.ts
@@ -1,7 +1,7 @@
 export const fetchIdentityCount = async (
   amount = 1
 ): Promise<{ data: number }> => {
-  const response = await fetch('http://localhost:3000/api/identity-count', {
+  const response = await fetch(`http://${$window.location.hostname}:3000/api/identity-count`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ amount }),

--- a/examples/with-redux/lib/redux/slices/counterSlice/fetchIdentityCount.ts
+++ b/examples/with-redux/lib/redux/slices/counterSlice/fetchIdentityCount.ts
@@ -1,7 +1,7 @@
 export const fetchIdentityCount = async (
   amount = 1
 ): Promise<{ data: number }> => {
-  const response = await fetch(`http://${$window.location.hostname}:3000/api/identity-count`, {
+  const response = await fetch(`/api/identity-count`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ amount }),


### PR DESCRIPTION
### What?

Switch to using ${window.location.hostname} instead of hardcoding localhost for the with-redux example

### Why?

workaround for CORS issue when accessing the local site via `127.0.0.1:3000` instead of `localhost:3000`

### How?

Switched to a templated string instead of a hard coded one, and referencing `window.location.hostname` instead of a hardcoded `localhost`