### PR TITLE
typo in 03-environment-variables.mdx

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/03-environment-variables.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/03-environment-variables.mdx
@@ -158,7 +158,7 @@ export default function Component() {
 
 **Good to know:**
 
-- You can run code on server startup using the `[register` function](/docs/app/building-your-application/optimizing/instrumentation).
+- You can run code on server startup using the [`register` function](/docs/app/building-your-application/optimizing/instrumentation).
 - We do not recommend using the [runtimeConfig](/docs/pages/api-reference/next-config-js/runtime-configuration) option, as this does not work with the standalone output mode. Instead, we recommend [incrementally adopting](/docs/app/building-your-application/upgrading/app-router-migration) the App Router.
 
 ## Default Environment Variables


### PR DESCRIPTION
### What?

typo in documentation

### Why?

In the environment variables page, https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#runtime-environment-variables 

![image](https://github.com/vercel/next.js/assets/2212144/099bcdf9-f068-4dde-85e5-b270b5049f5a)
