### PR TITLE
interception routes: fix interception for dynamic routes

### DIFF
--- a/packages/next/src/lib/create-client-router-filter.ts
+++ b/packages/next/src/lib/create-client-router-filter.ts
@@ -4,6 +4,10 @@ import { isDynamicRoute } from '../shared/lib/router/utils'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import type { Redirect } from './load-custom-routes'
 import { tryToParsePath } from './try-to-parse-path'
+import {
+  extractInterceptionRouteInformation,
+  isInterceptionRouteAppPath,
+} from '../server/future/helpers/interception-routes'
 
 export function createClientRouterFilter(
   paths: string[],
@@ -16,8 +20,12 @@ export function createClientRouterFilter(
   const staticPaths = new Set<string>()
   const dynamicPaths = new Set<string>()
 
-  for (const path of paths) {
+  for (let path of paths) {
     if (isDynamicRoute(path)) {
+      if (isInterceptionRouteAppPath(path)) {
+        path = extractInterceptionRouteInformation(path).interceptedRoute
+      }
+
       let subPath = ''
       const pathParts = path.split('/')
 

--- a/packages/next/src/shared/lib/router/utils/is-dynamic.ts
+++ b/packages/next/src/shared/lib/router/utils/is-dynamic.ts
@@ -1,6 +1,15 @@
+import {
+  extractInterceptionRouteInformation,
+  isInterceptionRouteAppPath,
+} from '../../../../server/future/helpers/interception-routes'
+
 // Identify /[param]/ in route string
 const TEST_ROUTE = /\/\[[^/]+?\](?=\/|$)/
 
 export function isDynamicRoute(route: string): boolean {
+  if (isInterceptionRouteAppPath(route)) {
+    route = extractInterceptionRouteInformation(route).interceptedRoute
+  }
+
   return TEST_ROUTE.test(route)
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/@modal/(.)[id]/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/@modal/(.)[id]/page.js
@@ -1,0 +1,8 @@
+export default function Page({ params: { id } }) {
+  return (
+    <div>
+      <h2>intercepting-siblings</h2>
+      <p id="intercepted-sibling">{id}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/@modal/default.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/@modal/default.js
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <div>default</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/[id]/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/[id]/page.js
@@ -1,0 +1,8 @@
+export default function Page({ params: { id } }) {
+  return (
+    <div>
+      <h2>main slot</h2>
+      <p id="main-slot">{id}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/layout.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/layout.js
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+
+export default function Layout({ children, modal }) {
+  return (
+    <div>
+      <h1>intercepting-siblings</h1>
+      <div style={{ border: '1px solid black', padding: '1rem' }}>
+        {children}
+      </div>
+      <hr />
+      <div style={{ border: '1px solid black', padding: '1rem' }}>{modal}</div>
+      <h1>links</h1>
+      <ul>
+        <li>
+          <Link href="/intercepting-siblings">/intercepting-siblings</Link>
+        </li>
+        <li>
+          <Link href="/intercepting-siblings/1">/intercepting-siblings/1</Link>
+        </li>
+        <li>
+          <Link href="/intercepting-siblings/2">/intercepting-siblings/2</Link>
+        </li>
+        <li>
+          <Link href="/intercepting-siblings/3">/intercepting-siblings/3</Link>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>main page</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -751,6 +751,42 @@ createNextDescribe(
           'intercepted'
         )
       })
+
+      it('should support intercepting local dynamic sibling routes', async () => {
+        const browser = await next.browser('/intercepting-siblings')
+
+        await check(
+          () =>
+            browser
+              .elementByCss('[href="/intercepting-siblings/1"]')
+              .click()
+              .waitForElementByCss('#intercepted-sibling')
+              .text(),
+          '1'
+        )
+        await check(
+          () =>
+            browser
+              .elementByCss('[href="/intercepting-siblings/2"]')
+              .click()
+              .waitForElementByCss('#intercepted-sibling')
+              .text(),
+          '2'
+        )
+        await check(
+          () =>
+            browser
+              .elementByCss('[href="/intercepting-siblings/3"]')
+              .click()
+              .waitForElementByCss('#intercepted-sibling')
+              .text(),
+          '3'
+        )
+
+        await next.browser('/intercepting-siblings/1')
+
+        await check(() => browser.waitForElementByCss('#main-slot').text(), '1')
+      })
     })
   }
 )


### PR DESCRIPTION
This PR fixes the bug in which interception routes of the form `(.)[param]` would not intercept navigations.

The bug happened because we would not create a dynamic route matcher for the intercepted route, so we would never match the correct dynamic route when hitting the server, falling back to the base one. 

The fix consists of fixing the logic that checks for a dynamic route so that it checks the correct path when handling an interception route.

There's probably a better fix here, advice welcome

fixes #52533


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
