### PR TITLE
fix(next-export): CORS errors due to wrong `crossorigin` default value

### DIFF
--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -483,7 +483,8 @@ export async function exportAppImpl(
     disableOptimizedLoading: nextConfig.experimental.disableOptimizedLoading,
     // Exported pages do not currently support dynamic HTML.
     supportsDynamicHTML: false,
-    crossOrigin: nextConfig.crossOrigin || '',
+    crossOrigin:
+      nextConfig.crossOrigin === false ? undefined : nextConfig.crossOrigin,
     optimizeCss: nextConfig.experimental.optimizeCss,
     nextConfigOutput: nextConfig.output,
     nextScriptWorkers: nextConfig.experimental.nextScriptWorkers,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -532,9 +532,10 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       distDir: this.distDir,
       serverComponents: this.enabledDirectories.app,
       enableTainting: this.nextConfig.experimental.taint,
-      crossOrigin: this.nextConfig.crossOrigin
-        ? this.nextConfig.crossOrigin
-        : undefined,
+      crossOrigin:
+        this.nextConfig.crossOrigin === false
+          ? undefined
+          : this.nextConfig.crossOrigin,
       largePageDataBytes: this.nextConfig.experimental.largePageDataBytes,
       // Only the `publicRuntimeConfig` key is exposed to the client side
       // It'll be rendered as part of __NEXT_DATA__ on the client side


### PR DESCRIPTION
If `corsOrigin` is not specified in nextConfig it become `false` and in the following code

```
crossOrigin: nextConfig.crossOrigin || '',
```
It fallback to empty string `''` , but this is wrong since the default value should be `undefined` otherwise we are forcing the client to use ALWAYS **CORS** for assets as you can see from the [MDN Official `crossorigin` spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin)

some `crossorigin` values can be:

- `anonymous`: Request uses CORS headers and credentials flag is set to 'same-origin'. There is no exchange of user credentials via cookies, client-side TLS certificates or HTTP authentication, unless destination is the same origin.
- `""`:  Setting the attribute name to an empty value, like crossorigin or crossorigin="", is the same as anonymous.

> **By default (that is, when the attribute is not specified), CORS is not used at all. The user agent will not ask for permission for full access to the resource and in the case of a cross-origin request, certain limitations will be applied based on the type of element concerned:**

You can see the **Current vs. Expected behavior** in the [issue](https://github.com/vercel/next.js/issues/57931)

Fixes #57931