### PR TITLE
fail build if not using Next canary with PPR flag

### DIFF
--- a/errors/ppr-preview.mdx
+++ b/errors/ppr-preview.mdx
@@ -1,0 +1,15 @@
+---
+title: Partial Prerendering Preview in Next.js Canary
+---
+
+## Why This Error Occurred
+
+In your `next.config.js` you enabled `experimental.ppr` but you are not using the latest Next.js canary. To ensure you are experimenting with the latest version, we currently require the use of a canary release.
+
+## Possible Ways to Fix It
+
+- Install `next@canary` (e.g. `npm install next@canary`)
+
+## Useful Links
+
+- [Partial Prerendering Preview](/blog/next-14#partial-prerendering-preview)

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -256,8 +256,8 @@ function assignDefaults(
     result.experimental?.ppr &&
     !process.env.__NEXT_VERSION!.includes('canary')
   ) {
-    Log.warn(
-      `The experimental.ppr feature is present in your current version but we recommend using the latest canary version for the best experience.`
+    throw new Error(
+      `The experimental.ppr preview feature can only be enabled when using the latest canary version of Next.js. See more info here: https://nextjs.org/docs/messages/ppr-preview`
     )
   }
 


### PR DESCRIPTION
This is to ensure that folks experimenting with PPR are receiving the latest updates as the feature is actively being worked on. 