### PR TITLE
Reduce max header length emitted

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -751,6 +751,7 @@ async function renderToHTMLOrFlightImpl(
         const renderStream = await renderer.render(content, {
           onError: htmlRendererErrorHandler,
           onHeaders: onHeaders,
+          maxHeadersLength: 1000,
           nonce,
           bootstrapScripts: [bootstrapScript],
           formState,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -751,7 +751,7 @@ async function renderToHTMLOrFlightImpl(
         const renderStream = await renderer.render(content, {
           onError: htmlRendererErrorHandler,
           onHeaders: onHeaders,
-          maxHeadersLength: 1000,
+          maxHeadersLength: 600,
           nonce,
           bootstrapScripts: [bootstrapScript],
           formState,

--- a/packages/next/src/server/app-render/static/static-renderer.ts
+++ b/packages/next/src/server/app-render/static/static-renderer.ts
@@ -1,6 +1,7 @@
 type StreamOptions = {
   onError?: (error: Error) => void
   onHeaders?: (headers: Headers) => void
+  maxHeadersLength?: number
   nonce?: string
   bootstrapScripts?: {
     src: string


### PR DESCRIPTION
Seems like the default 2000 limit is getting hit. Start more conservative while investigating why. Picked half to start.
