### PR TITLE
ensure experimental warning shows up when using PPR

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -790,6 +790,7 @@ export const defaultConfig: NextConfig = {
     typedRoutes: false,
     instrumentationHook: false,
     bundlePagesExternals: false,
+    ppr: false,
   },
 }
 

--- a/test/e2e/app-dir/ppr/ppr.test.ts
+++ b/test/e2e/app-dir/ppr/ppr.test.ts
@@ -7,6 +7,10 @@ createNextDescribe(
     skipDeployment: true,
   },
   ({ next, isNextDev, isNextStart }) => {
+    it('should indicate the feature is experimental', () => {
+      expect(next.cliOutput).toContain('Experiments (use at your own risk)')
+      expect(next.cliOutput).toContain('ppr')
+    })
     if (isNextStart) {
       describe('build output', () => {
         it('correctly marks pages as being partially prerendered in the build output', () => {


### PR DESCRIPTION
Fixes a bug where when `config.experimental.ppr` was set, we didn't show the proper warning indicator that the feature is experimental. 