### PR TITLE
allow bypassing client-side routing on link component

### DIFF
--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -571,6 +571,10 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
         return
       }
 
+      if (nativeBehavior) {
+        return
+      }
+
       // Prefetch the URL.
       prefetch(
         router,
@@ -672,6 +676,10 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
           return
         }
 
+        if (nativeBehavior) {
+          return;
+        }
+
         prefetch(
           router,
           href,
@@ -707,6 +715,10 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
 
         if (!prefetchEnabled && isAppRouter) {
           return
+        }
+
+        if (nativeBehavior) {
+          return;
         }
 
         prefetch(

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -365,6 +365,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
         onMouseEnter: true,
         onTouchStart: true,
         legacyBehavior: true,
+        nativeBehavior: true,
       } as const
       const optionalProps: LinkPropsOptional[] = Object.keys(
         optionalPropsGuard
@@ -406,7 +407,8 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
           key === 'shallow' ||
           key === 'passHref' ||
           key === 'prefetch' ||
-          key === 'legacyBehavior'
+          key === 'legacyBehavior' ||
+          key === 'nativeBehavior'
         ) {
           if (props[key] != null && valType !== 'boolean') {
             throw createPropError({

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -88,6 +88,11 @@ type InternalLinkProps = {
    */
   legacyBehavior?: boolean
   /**
+   * Enable native behavior - bypass the client-side navigation
+   * @defaultValue `false`
+   */
+  nativeBehavior?: boolean;
+  /**
    * Optional event handler for when the mouse pointer is moved onto Link
    */
   onMouseEnter?: React.MouseEventHandler<HTMLAnchorElement>
@@ -277,6 +282,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       onMouseEnter: onMouseEnterProp,
       onTouchStart: onTouchStartProp,
       legacyBehavior = false,
+      nativeBehavior = false,
       ...restProps
     } = props
 
@@ -623,6 +629,10 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
 
         if (e.defaultPrevented) {
           return
+        }
+
+        if (nativeBehavior) {
+          return;
         }
 
         linkClicked(


### PR DESCRIPTION
Add ability to disable client-side navigation at next/link component level

Use case :
In some cases, it may be wanted to disable client-side navigation on certain internal links :
- When a classic page refresh is faster than client-side navigation
- When you want to force the page to refresh

Why not replace `<Link/>` with a simple `<a>` tag?
We could actually replace next/link with simple `<a>` tags. But this has several disadvantages:
- Unable to differentiate between internal/external links
- Difficult migration: the native `<a>` and `<Link />` do not have the same signature (passHref / LegacyBehavior etc…)

Adding a “nativeBehavior” property allows to keep next/link for all internal links, and have fine management of client-side navigation. You can also switch from one to the other very easily