### PR TITLE
chore: fix typo in jsDoc

### DIFF
--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -87,7 +87,7 @@ export type Redirect =
     }
 
 /**
- * `Page` type, use it as a guide to create `pages`.
+ * `NextPage` type, use it as a guide to create `pages`.
  */
 export type NextPage<Props = {}, InitialProps = Props> = NextComponentType<
   NextPageContext,


### PR DESCRIPTION
The type name is `NextPage` but in the jsDoc comment it's referred to as `Page`