### PR TITLE
58274: Call ipcServer.close() when build is done to avoid hanging.

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1302,1021 +1302,1107 @@ export default async function build(
 
       let incrementalCacheIpcPort
       let incrementalCacheIpcValidationKey
+      let incrementalCacheIpcServer
 
-      if (config.experimental.staticWorkerRequestDeduping) {
-        let CacheHandler
-        if (incrementalCacheHandlerPath) {
-          CacheHandler = require(path.isAbsolute(incrementalCacheHandlerPath)
-            ? incrementalCacheHandlerPath
-            : path.join(dir, incrementalCacheHandlerPath))
-          CacheHandler = CacheHandler.default || CacheHandler
-        }
-
-        const cacheInitialization = await initializeIncrementalCache({
-          fs: nodeFs,
-          dev: false,
-          pagesDir: true,
-          appDir: true,
-          fetchCache: true,
-          flushToDisk: config.experimental.isrFlushToDisk,
-          serverDistDir: path.join(distDir, 'server'),
-          fetchCacheKeyPrefix: config.experimental.fetchCacheKeyPrefix,
-          maxMemoryCacheSize: config.experimental.isrMemoryCacheSize,
-          getPrerenderManifest: () => ({
-            version: -1 as any, // letting us know this doesn't conform to spec
-            routes: {},
-            dynamicRoutes: {},
-            notFoundRoutes: [],
-            preview: null as any, // `preview` is special case read in next-dev-server
-          }),
-          requestHeaders: {},
-          CurCacheHandler: CacheHandler,
-          minimalMode: ciEnvironment.hasNextSupport,
-          allowedRevalidateHeaderKeys:
-            config.experimental.allowedRevalidateHeaderKeys,
-          experimental: { ppr: config.experimental.ppr === true },
-        })
-
-        incrementalCacheIpcPort = cacheInitialization.ipcPort
-        incrementalCacheIpcValidationKey = cacheInitialization.ipcValidationKey
-      }
-
-      const pagesStaticWorkers = createStaticWorker(
-        incrementalCacheIpcPort,
-        incrementalCacheIpcValidationKey
-      )
-      const appStaticWorkers = appDir
-        ? createStaticWorker(
-            incrementalCacheIpcPort,
-            incrementalCacheIpcValidationKey
-          )
-        : undefined
-
-      const analysisBegin = process.hrtime()
-      const staticCheckSpan = nextBuildSpan.traceChild('static-check')
-
-      const functionsConfigManifest = {} as Record<string, Record<string, any>>
-      const {
-        customAppGetInitialProps,
-        namedExports,
-        isNextImageImported,
-        hasSsrAmpPages,
-        hasNonStaticErrorPage,
-      } = await staticCheckSpan.traceAsyncFn(async () => {
-        if (isCompile) {
-          return {
-            customAppGetInitialProps: false,
-            namedExports: [],
-            isNextImageImported: true,
-            hasSsrAmpPages: !!pagesDir,
-            hasNonStaticErrorPage: true,
+      try {
+        if (config.experimental.staticWorkerRequestDeduping) {
+          let CacheHandler
+          if (incrementalCacheHandlerPath) {
+            CacheHandler = require(path.isAbsolute(incrementalCacheHandlerPath)
+              ? incrementalCacheHandlerPath
+              : path.join(dir, incrementalCacheHandlerPath))
+            CacheHandler = CacheHandler.default || CacheHandler
           }
+
+          const cacheInitialization = await initializeIncrementalCache({
+            fs: nodeFs,
+            dev: false,
+            pagesDir: true,
+            appDir: true,
+            fetchCache: true,
+            flushToDisk: config.experimental.isrFlushToDisk,
+            serverDistDir: path.join(distDir, 'server'),
+            fetchCacheKeyPrefix: config.experimental.fetchCacheKeyPrefix,
+            maxMemoryCacheSize: config.experimental.isrMemoryCacheSize,
+            getPrerenderManifest: () => ({
+              version: -1 as any, // letting us know this doesn't conform to spec
+              routes: {},
+              dynamicRoutes: {},
+              notFoundRoutes: [],
+              preview: null as any, // `preview` is special case read in next-dev-server
+            }),
+            requestHeaders: {},
+            CurCacheHandler: CacheHandler,
+            minimalMode: ciEnvironment.hasNextSupport,
+            allowedRevalidateHeaderKeys:
+              config.experimental.allowedRevalidateHeaderKeys,
+            experimental: { ppr: config.experimental.ppr === true },
+          })
+
+          incrementalCacheIpcPort = cacheInitialization.ipcPort
+          incrementalCacheIpcValidationKey =
+            cacheInitialization.ipcValidationKey
+          incrementalCacheIpcServer = cacheInitialization.ipcServer
         }
 
-        const { configFileName, publicRuntimeConfig, serverRuntimeConfig } =
-          config
-        const runtimeEnvConfig = { publicRuntimeConfig, serverRuntimeConfig }
-
-        const nonStaticErrorPageSpan = staticCheckSpan.traceChild(
-          'check-static-error-page'
+        const pagesStaticWorkers = createStaticWorker(
+          incrementalCacheIpcPort,
+          incrementalCacheIpcValidationKey
         )
-        const errorPageHasCustomGetInitialProps =
-          nonStaticErrorPageSpan.traceAsyncFn(
+        const appStaticWorkers = appDir
+          ? createStaticWorker(
+              incrementalCacheIpcPort,
+              incrementalCacheIpcValidationKey
+            )
+          : undefined
+
+        const analysisBegin = process.hrtime()
+        const staticCheckSpan = nextBuildSpan.traceChild('static-check')
+
+        const functionsConfigManifest = {} as Record<
+          string,
+          Record<string, any>
+        >
+        const {
+          customAppGetInitialProps,
+          namedExports,
+          isNextImageImported,
+          hasSsrAmpPages,
+          hasNonStaticErrorPage,
+        } = await staticCheckSpan.traceAsyncFn(async () => {
+          if (isCompile) {
+            return {
+              customAppGetInitialProps: false,
+              namedExports: [],
+              isNextImageImported: true,
+              hasSsrAmpPages: !!pagesDir,
+              hasNonStaticErrorPage: true,
+            }
+          }
+
+          const { configFileName, publicRuntimeConfig, serverRuntimeConfig } =
+            config
+          const runtimeEnvConfig = { publicRuntimeConfig, serverRuntimeConfig }
+
+          const nonStaticErrorPageSpan = staticCheckSpan.traceChild(
+            'check-static-error-page'
+          )
+          const errorPageHasCustomGetInitialProps =
+            nonStaticErrorPageSpan.traceAsyncFn(
+              async () =>
+                hasCustomErrorPage &&
+                (await pagesStaticWorkers.hasCustomGetInitialProps(
+                  '/_error',
+                  distDir,
+                  runtimeEnvConfig,
+                  false
+                ))
+            )
+
+          const errorPageStaticResult = nonStaticErrorPageSpan.traceAsyncFn(
             async () =>
               hasCustomErrorPage &&
-              (await pagesStaticWorkers.hasCustomGetInitialProps(
-                '/_error',
+              pagesStaticWorkers.isPageStatic({
+                dir,
+                page: '/_error',
                 distDir,
+                configFileName,
                 runtimeEnvConfig,
-                false
-              ))
+                httpAgentOptions: config.httpAgentOptions,
+                locales: config.i18n?.locales,
+                defaultLocale: config.i18n?.defaultLocale,
+                nextConfigOutput: config.output,
+                ppr: config.experimental.ppr === true,
+              })
           )
 
-        const errorPageStaticResult = nonStaticErrorPageSpan.traceAsyncFn(
-          async () =>
-            hasCustomErrorPage &&
-            pagesStaticWorkers.isPageStatic({
-              dir,
-              page: '/_error',
+          const appPageToCheck = '/_app'
+
+          const customAppGetInitialPropsPromise =
+            pagesStaticWorkers.hasCustomGetInitialProps(
+              appPageToCheck,
               distDir,
-              configFileName,
               runtimeEnvConfig,
-              httpAgentOptions: config.httpAgentOptions,
-              locales: config.i18n?.locales,
-              defaultLocale: config.i18n?.defaultLocale,
-              nextConfigOutput: config.output,
-              ppr: config.experimental.ppr === true,
-            })
-        )
+              true
+            )
 
-        const appPageToCheck = '/_app'
-
-        const customAppGetInitialPropsPromise =
-          pagesStaticWorkers.hasCustomGetInitialProps(
+          const namedExportsPromise = pagesStaticWorkers.getDefinedNamedExports(
             appPageToCheck,
             distDir,
-            runtimeEnvConfig,
-            true
+            runtimeEnvConfig
           )
 
-        const namedExportsPromise = pagesStaticWorkers.getDefinedNamedExports(
-          appPageToCheck,
-          distDir,
-          runtimeEnvConfig
-        )
+          // eslint-disable-next-line @typescript-eslint/no-shadow
+          let isNextImageImported: boolean | undefined
+          // eslint-disable-next-line @typescript-eslint/no-shadow
+          let hasSsrAmpPages = false
 
-        // eslint-disable-next-line @typescript-eslint/no-shadow
-        let isNextImageImported: boolean | undefined
-        // eslint-disable-next-line @typescript-eslint/no-shadow
-        let hasSsrAmpPages = false
+          const computedManifestData = await computeFromManifest(
+            { build: buildManifest, app: appBuildManifest },
+            distDir,
+            config.experimental.gzipSize
+          )
 
-        const computedManifestData = await computeFromManifest(
-          { build: buildManifest, app: appBuildManifest },
-          distDir,
-          config.experimental.gzipSize
-        )
+          const middlewareManifest: MiddlewareManifest = require(path.join(
+            distDir,
+            SERVER_DIRECTORY,
+            MIDDLEWARE_MANIFEST
+          ))
 
-        const middlewareManifest: MiddlewareManifest = require(path.join(
-          distDir,
-          SERVER_DIRECTORY,
-          MIDDLEWARE_MANIFEST
-        ))
-
-        const actionManifest = appDir
-          ? (require(path.join(
-              distDir,
-              SERVER_DIRECTORY,
-              SERVER_REFERENCE_MANIFEST + '.json'
-            )) as ActionManifest)
-          : null
-        const entriesWithAction = actionManifest ? new Set() : null
-        if (actionManifest && entriesWithAction) {
-          for (const id in actionManifest.node) {
-            for (const entry in actionManifest.node[id].workers) {
-              entriesWithAction.add(entry)
+          const actionManifest = appDir
+            ? (require(path.join(
+                distDir,
+                SERVER_DIRECTORY,
+                SERVER_REFERENCE_MANIFEST + '.json'
+              )) as ActionManifest)
+            : null
+          const entriesWithAction = actionManifest ? new Set() : null
+          if (actionManifest && entriesWithAction) {
+            for (const id in actionManifest.node) {
+              for (const entry in actionManifest.node[id].workers) {
+                entriesWithAction.add(entry)
+              }
+            }
+            for (const id in actionManifest.edge) {
+              for (const entry in actionManifest.edge[id].workers) {
+                entriesWithAction.add(entry)
+              }
             }
           }
-          for (const id in actionManifest.edge) {
-            for (const entry in actionManifest.edge[id].workers) {
-              entriesWithAction.add(entry)
+
+          for (const key of Object.keys(middlewareManifest?.functions)) {
+            if (key.startsWith('/api')) {
+              edgeRuntimePagesCount++
             }
           }
-        }
 
-        for (const key of Object.keys(middlewareManifest?.functions)) {
-          if (key.startsWith('/api')) {
-            edgeRuntimePagesCount++
-          }
-        }
+          await Promise.all(
+            Object.entries(pageKeys)
+              .reduce<Array<{ pageType: keyof typeof pageKeys; page: string }>>(
+                (acc, [key, files]) => {
+                  if (!files) {
+                    return acc
+                  }
 
-        await Promise.all(
-          Object.entries(pageKeys)
-            .reduce<Array<{ pageType: keyof typeof pageKeys; page: string }>>(
-              (acc, [key, files]) => {
-                if (!files) {
+                  const pageType = key as keyof typeof pageKeys
+
+                  for (const page of files) {
+                    acc.push({ pageType, page })
+                  }
+
                   return acc
-                }
+                },
+                []
+              )
+              .map(({ pageType, page }) => {
+                const checkPageSpan = staticCheckSpan.traceChild('check-page', {
+                  page,
+                })
+                return checkPageSpan.traceAsyncFn(async () => {
+                  const actualPage = normalizePagePath(page)
+                  const [size, totalSize] = await getJsPageSizeInKb(
+                    pageType,
+                    actualPage,
+                    distDir,
+                    buildManifest,
+                    appBuildManifest,
+                    config.experimental.gzipSize,
+                    computedManifestData
+                  )
 
-                const pageType = key as keyof typeof pageKeys
+                  let isPPR = false
+                  let isSSG = false
+                  let isStatic = false
+                  let isServerComponent = false
+                  let isHybridAmp = false
+                  let ssgPageRoutes: string[] | null = null
+                  let pagePath = ''
 
-                for (const page of files) {
-                  acc.push({ pageType, page })
-                }
+                  if (pageType === 'pages') {
+                    pagePath =
+                      pagesPaths.find((p) => {
+                        p = normalizePathSep(p)
+                        return (
+                          p.startsWith(actualPage + '.') ||
+                          p.startsWith(actualPage + '/index.')
+                        )
+                      }) || ''
+                  }
+                  let originalAppPath: string | undefined
 
-                return acc
-              },
-              []
-            )
-            .map(({ pageType, page }) => {
-              const checkPageSpan = staticCheckSpan.traceChild('check-page', {
-                page,
-              })
-              return checkPageSpan.traceAsyncFn(async () => {
-                const actualPage = normalizePagePath(page)
-                const [size, totalSize] = await getJsPageSizeInKb(
-                  pageType,
-                  actualPage,
-                  distDir,
-                  buildManifest,
-                  appBuildManifest,
-                  config.experimental.gzipSize,
-                  computedManifestData
-                )
-
-                let isPPR = false
-                let isSSG = false
-                let isStatic = false
-                let isServerComponent = false
-                let isHybridAmp = false
-                let ssgPageRoutes: string[] | null = null
-                let pagePath = ''
-
-                if (pageType === 'pages') {
-                  pagePath =
-                    pagesPaths.find((p) => {
-                      p = normalizePathSep(p)
-                      return (
-                        p.startsWith(actualPage + '.') ||
-                        p.startsWith(actualPage + '/index.')
-                      )
-                    }) || ''
-                }
-                let originalAppPath: string | undefined
-
-                if (pageType === 'app' && mappedAppPages) {
-                  for (const [originalPath, normalizedPath] of Object.entries(
-                    appPathRoutes
-                  )) {
-                    if (normalizedPath === page) {
-                      pagePath = mappedAppPages[originalPath].replace(
-                        /^private-next-app-dir/,
-                        ''
-                      )
-                      originalAppPath = originalPath
-                      break
+                  if (pageType === 'app' && mappedAppPages) {
+                    for (const [originalPath, normalizedPath] of Object.entries(
+                      appPathRoutes
+                    )) {
+                      if (normalizedPath === page) {
+                        pagePath = mappedAppPages[originalPath].replace(
+                          /^private-next-app-dir/,
+                          ''
+                        )
+                        originalAppPath = originalPath
+                        break
+                      }
                     }
                   }
-                }
 
-                const pageFilePath = isAppBuiltinNotFoundPage(pagePath)
-                  ? require.resolve(
-                      'next/dist/client/components/not-found-error'
-                    )
-                  : path.join(
-                      (pageType === 'pages' ? pagesDir : appDir) || '',
-                      pagePath
-                    )
-
-                const staticInfo = pagePath
-                  ? await getPageStaticInfo({
-                      pageFilePath,
-                      nextConfig: config,
-                      pageType,
-                    })
-                  : undefined
-
-                if (staticInfo?.extraConfig) {
-                  functionsConfigManifest[page] = staticInfo.extraConfig
-                }
-
-                const pageRuntime = middlewareManifest.functions[
-                  originalAppPath || page
-                ]
-                  ? 'edge'
-                  : staticInfo?.runtime
-
-                if (!isCompile) {
-                  isServerComponent =
-                    pageType === 'app' &&
-                    staticInfo?.rsc !== RSC_MODULE_TYPES.client
-
-                  if (pageType === 'app' || !isReservedPage(page)) {
-                    try {
-                      let edgeInfo: any
-
-                      if (isEdgeRuntime(pageRuntime)) {
-                        if (pageType === 'app') {
-                          edgeRuntimeAppCount++
-                        } else {
-                          edgeRuntimePagesCount++
-                        }
-
-                        const manifestKey =
-                          pageType === 'pages' ? page : originalAppPath || ''
-
-                        edgeInfo = middlewareManifest.functions[manifestKey]
-                      }
-
-                      let isPageStaticSpan =
-                        checkPageSpan.traceChild('is-page-static')
-                      let workerResult = await isPageStaticSpan.traceAsyncFn(
-                        () => {
-                          return (
-                            pageType === 'app'
-                              ? appStaticWorkers
-                              : pagesStaticWorkers
-                          )!.isPageStatic({
-                            dir,
-                            page,
-                            originalAppPath,
-                            distDir,
-                            configFileName,
-                            runtimeEnvConfig,
-                            httpAgentOptions: config.httpAgentOptions,
-                            locales: config.i18n?.locales,
-                            defaultLocale: config.i18n?.defaultLocale,
-                            parentId: isPageStaticSpan.id,
-                            pageRuntime,
-                            edgeInfo,
-                            pageType,
-                            incrementalCacheHandlerPath:
-                              config.experimental.incrementalCacheHandlerPath,
-                            isrFlushToDisk: config.experimental.isrFlushToDisk,
-                            maxMemoryCacheSize:
-                              config.experimental.isrMemoryCacheSize,
-                            nextConfigOutput: config.output,
-                            ppr: config.experimental.ppr === true,
-                          })
-                        }
+                  const pageFilePath = isAppBuiltinNotFoundPage(pagePath)
+                    ? require.resolve(
+                        'next/dist/client/components/not-found-error'
+                      )
+                    : path.join(
+                        (pageType === 'pages' ? pagesDir : appDir) || '',
+                        pagePath
                       )
 
-                      if (pageType === 'app' && originalAppPath) {
-                        appNormalizedPaths.set(originalAppPath, page)
-                        // TODO-APP: handle prerendering with edge
+                  const staticInfo = pagePath
+                    ? await getPageStaticInfo({
+                        pageFilePath,
+                        nextConfig: config,
+                        pageType,
+                      })
+                    : undefined
+
+                  if (staticInfo?.extraConfig) {
+                    functionsConfigManifest[page] = staticInfo.extraConfig
+                  }
+
+                  const pageRuntime = middlewareManifest.functions[
+                    originalAppPath || page
+                  ]
+                    ? 'edge'
+                    : staticInfo?.runtime
+
+                  if (!isCompile) {
+                    isServerComponent =
+                      pageType === 'app' &&
+                      staticInfo?.rsc !== RSC_MODULE_TYPES.client
+
+                    if (pageType === 'app' || !isReservedPage(page)) {
+                      try {
+                        let edgeInfo: any
+
                         if (isEdgeRuntime(pageRuntime)) {
-                          isStatic = false
-                          isSSG = false
-
-                          Log.warnOnce(
-                            `Using edge runtime on a page currently disables static generation for that page`
-                          )
-                        } else {
-                          // If this route can be partially pre-rendered, then
-                          // mark it as such and mark it that it can be
-                          // generated server-side.
-                          if (workerResult.isPPR) {
-                            isPPR = workerResult.isPPR
-                            isSSG = true
-                            isStatic = true
-
-                            appStaticPaths.set(originalAppPath, [])
-                            appStaticPathsEncoded.set(originalAppPath, [])
+                          if (pageType === 'app') {
+                            edgeRuntimeAppCount++
+                          } else {
+                            edgeRuntimePagesCount++
                           }
 
-                          if (
-                            workerResult.encodedPrerenderRoutes &&
-                            workerResult.prerenderRoutes
-                          ) {
-                            appStaticPaths.set(
+                          const manifestKey =
+                            pageType === 'pages' ? page : originalAppPath || ''
+
+                          edgeInfo = middlewareManifest.functions[manifestKey]
+                        }
+
+                        let isPageStaticSpan =
+                          checkPageSpan.traceChild('is-page-static')
+                        let workerResult = await isPageStaticSpan.traceAsyncFn(
+                          () => {
+                            return (
+                              pageType === 'app'
+                                ? appStaticWorkers
+                                : pagesStaticWorkers
+                            )!.isPageStatic({
+                              dir,
+                              page,
                               originalAppPath,
-                              workerResult.prerenderRoutes
-                            )
-                            appStaticPathsEncoded.set(
-                              originalAppPath,
-                              workerResult.encodedPrerenderRoutes
-                            )
-                            ssgPageRoutes = workerResult.prerenderRoutes
-                            isSSG = true
+                              distDir,
+                              configFileName,
+                              runtimeEnvConfig,
+                              httpAgentOptions: config.httpAgentOptions,
+                              locales: config.i18n?.locales,
+                              defaultLocale: config.i18n?.defaultLocale,
+                              parentId: isPageStaticSpan.id,
+                              pageRuntime,
+                              edgeInfo,
+                              pageType,
+                              incrementalCacheHandlerPath:
+                                config.experimental.incrementalCacheHandlerPath,
+                              isrFlushToDisk:
+                                config.experimental.isrFlushToDisk,
+                              maxMemoryCacheSize:
+                                config.experimental.isrMemoryCacheSize,
+                              nextConfigOutput: config.output,
+                              ppr: config.experimental.ppr === true,
+                            })
                           }
+                        )
 
-                          const appConfig = workerResult.appConfig || {}
-                          if (appConfig.revalidate !== 0) {
-                            const isDynamic = isDynamicRoute(page)
-                            const hasGenerateStaticParams =
-                              !!workerResult.prerenderRoutes?.length
+                        if (pageType === 'app' && originalAppPath) {
+                          appNormalizedPaths.set(originalAppPath, page)
+                          // TODO-APP: handle prerendering with edge
+                          if (isEdgeRuntime(pageRuntime)) {
+                            isStatic = false
+                            isSSG = false
 
-                            if (
-                              config.output === 'export' &&
-                              isDynamic &&
-                              !hasGenerateStaticParams
-                            ) {
-                              throw new Error(
-                                `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
-                              )
-                            }
-
-                            if (
-                              // Mark the app as static if:
-                              // - It has no dynamic param
-                              // - It doesn't have generateStaticParams but `dynamic` is set to
-                              //   `error` or `force-static`
-                              !isDynamic
-                            ) {
-                              appStaticPaths.set(originalAppPath, [page])
-                              appStaticPathsEncoded.set(originalAppPath, [page])
+                            Log.warnOnce(
+                              `Using edge runtime on a page currently disables static generation for that page`
+                            )
+                          } else {
+                            // If this route can be partially pre-rendered, then
+                            // mark it as such and mark it that it can be
+                            // generated server-side.
+                            if (workerResult.isPPR) {
+                              isPPR = workerResult.isPPR
+                              isSSG = true
                               isStatic = true
-                            } else if (
-                              isDynamic &&
-                              !hasGenerateStaticParams &&
-                              (appConfig.dynamic === 'error' ||
-                                appConfig.dynamic === 'force-static')
-                            ) {
+
                               appStaticPaths.set(originalAppPath, [])
                               appStaticPathsEncoded.set(originalAppPath, [])
-                              isStatic = true
-                              isPPR = false
+                            }
+
+                            if (
+                              workerResult.encodedPrerenderRoutes &&
+                              workerResult.prerenderRoutes
+                            ) {
+                              appStaticPaths.set(
+                                originalAppPath,
+                                workerResult.prerenderRoutes
+                              )
+                              appStaticPathsEncoded.set(
+                                originalAppPath,
+                                workerResult.encodedPrerenderRoutes
+                              )
+                              ssgPageRoutes = workerResult.prerenderRoutes
+                              isSSG = true
+                            }
+
+                            const appConfig = workerResult.appConfig || {}
+                            if (appConfig.revalidate !== 0) {
+                              const isDynamic = isDynamicRoute(page)
+                              const hasGenerateStaticParams =
+                                !!workerResult.prerenderRoutes?.length
+
+                              if (
+                                config.output === 'export' &&
+                                isDynamic &&
+                                !hasGenerateStaticParams
+                              ) {
+                                throw new Error(
+                                  `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
+                                )
+                              }
+
+                              if (
+                                // Mark the app as static if:
+                                // - It has no dynamic param
+                                // - It doesn't have generateStaticParams but `dynamic` is set to
+                                //   `error` or `force-static`
+                                !isDynamic
+                              ) {
+                                appStaticPaths.set(originalAppPath, [page])
+                                appStaticPathsEncoded.set(originalAppPath, [
+                                  page,
+                                ])
+                                isStatic = true
+                              } else if (
+                                isDynamic &&
+                                !hasGenerateStaticParams &&
+                                (appConfig.dynamic === 'error' ||
+                                  appConfig.dynamic === 'force-static')
+                              ) {
+                                appStaticPaths.set(originalAppPath, [])
+                                appStaticPathsEncoded.set(originalAppPath, [])
+                                isStatic = true
+                                isPPR = false
+                              }
+                            }
+
+                            if (workerResult.prerenderFallback) {
+                              // whether or not to allow requests for paths not
+                              // returned from generateStaticParams
+                              appDynamicParamPaths.add(originalAppPath)
+                            }
+                            appDefaultConfigs.set(originalAppPath, appConfig)
+
+                            // Only generate the app prefetch rsc if the route is
+                            // an app page.
+                            if (
+                              !isStatic &&
+                              !isAppRouteRoute(originalAppPath) &&
+                              !isDynamicRoute(originalAppPath) &&
+                              !isPPR
+                            ) {
+                              appPrefetchPaths.set(originalAppPath, page)
+                            }
+                          }
+                        } else {
+                          if (isEdgeRuntime(pageRuntime)) {
+                            if (workerResult.hasStaticProps) {
+                              console.warn(
+                                `"getStaticProps" is not yet supported fully with "experimental-edge", detected on ${page}`
+                              )
+                            }
+                            // TODO: add handling for statically rendering edge
+                            // pages and allow edge with Prerender outputs
+                            workerResult.isStatic = false
+                            workerResult.hasStaticProps = false
+                          }
+
+                          if (
+                            workerResult.isStatic === false &&
+                            (workerResult.isHybridAmp || workerResult.isAmpOnly)
+                          ) {
+                            hasSsrAmpPages = true
+                          }
+
+                          if (workerResult.isHybridAmp) {
+                            isHybridAmp = true
+                            hybridAmpPages.add(page)
+                          }
+
+                          if (workerResult.isNextImageImported) {
+                            isNextImageImported = true
+                          }
+
+                          if (workerResult.hasStaticProps) {
+                            ssgPages.add(page)
+                            isSSG = true
+
+                            if (
+                              workerResult.prerenderRoutes &&
+                              workerResult.encodedPrerenderRoutes
+                            ) {
+                              additionalSsgPaths.set(
+                                page,
+                                workerResult.prerenderRoutes
+                              )
+                              additionalSsgPathsEncoded.set(
+                                page,
+                                workerResult.encodedPrerenderRoutes
+                              )
+                              ssgPageRoutes = workerResult.prerenderRoutes
+                            }
+
+                            if (workerResult.prerenderFallback === 'blocking') {
+                              ssgBlockingFallbackPages.add(page)
+                            } else if (
+                              workerResult.prerenderFallback === true
+                            ) {
+                              ssgStaticFallbackPages.add(page)
+                            }
+                          } else if (workerResult.hasServerProps) {
+                            serverPropsPages.add(page)
+                          } else if (
+                            workerResult.isStatic &&
+                            !isServerComponent &&
+                            (await customAppGetInitialPropsPromise) === false
+                          ) {
+                            staticPages.add(page)
+                            isStatic = true
+                          } else if (isServerComponent) {
+                            // This is a static server component page that doesn't have
+                            // gSP or gSSP. We still treat it as a SSG page.
+                            ssgPages.add(page)
+                            isSSG = true
+                          }
+
+                          if (hasPages404 && page === '/404') {
+                            if (
+                              !workerResult.isStatic &&
+                              !workerResult.hasStaticProps
+                            ) {
+                              throw new Error(
+                                `\`pages/404\` ${STATIC_STATUS_PAGE_GET_INITIAL_PROPS_ERROR}`
+                              )
+                            }
+                            // we need to ensure the 404 lambda is present since we use
+                            // it when _app has getInitialProps
+                            if (
+                              (await customAppGetInitialPropsPromise) &&
+                              !workerResult.hasStaticProps
+                            ) {
+                              staticPages.delete(page)
                             }
                           }
 
-                          if (workerResult.prerenderFallback) {
-                            // whether or not to allow requests for paths not
-                            // returned from generateStaticParams
-                            appDynamicParamPaths.add(originalAppPath)
-                          }
-                          appDefaultConfigs.set(originalAppPath, appConfig)
-
-                          // Only generate the app prefetch rsc if the route is
-                          // an app page.
                           if (
-                            !isStatic &&
-                            !isAppRouteRoute(originalAppPath) &&
-                            !isDynamicRoute(originalAppPath) &&
-                            !isPPR
-                          ) {
-                            appPrefetchPaths.set(originalAppPath, page)
-                          }
-                        }
-                      } else {
-                        if (isEdgeRuntime(pageRuntime)) {
-                          if (workerResult.hasStaticProps) {
-                            console.warn(
-                              `"getStaticProps" is not yet supported fully with "experimental-edge", detected on ${page}`
-                            )
-                          }
-                          // TODO: add handling for statically rendering edge
-                          // pages and allow edge with Prerender outputs
-                          workerResult.isStatic = false
-                          workerResult.hasStaticProps = false
-                        }
-
-                        if (
-                          workerResult.isStatic === false &&
-                          (workerResult.isHybridAmp || workerResult.isAmpOnly)
-                        ) {
-                          hasSsrAmpPages = true
-                        }
-
-                        if (workerResult.isHybridAmp) {
-                          isHybridAmp = true
-                          hybridAmpPages.add(page)
-                        }
-
-                        if (workerResult.isNextImageImported) {
-                          isNextImageImported = true
-                        }
-
-                        if (workerResult.hasStaticProps) {
-                          ssgPages.add(page)
-                          isSSG = true
-
-                          if (
-                            workerResult.prerenderRoutes &&
-                            workerResult.encodedPrerenderRoutes
-                          ) {
-                            additionalSsgPaths.set(
-                              page,
-                              workerResult.prerenderRoutes
-                            )
-                            additionalSsgPathsEncoded.set(
-                              page,
-                              workerResult.encodedPrerenderRoutes
-                            )
-                            ssgPageRoutes = workerResult.prerenderRoutes
-                          }
-
-                          if (workerResult.prerenderFallback === 'blocking') {
-                            ssgBlockingFallbackPages.add(page)
-                          } else if (workerResult.prerenderFallback === true) {
-                            ssgStaticFallbackPages.add(page)
-                          }
-                        } else if (workerResult.hasServerProps) {
-                          serverPropsPages.add(page)
-                        } else if (
-                          workerResult.isStatic &&
-                          !isServerComponent &&
-                          (await customAppGetInitialPropsPromise) === false
-                        ) {
-                          staticPages.add(page)
-                          isStatic = true
-                        } else if (isServerComponent) {
-                          // This is a static server component page that doesn't have
-                          // gSP or gSSP. We still treat it as a SSG page.
-                          ssgPages.add(page)
-                          isSSG = true
-                        }
-
-                        if (hasPages404 && page === '/404') {
-                          if (
+                            STATIC_STATUS_PAGES.includes(page) &&
                             !workerResult.isStatic &&
                             !workerResult.hasStaticProps
                           ) {
                             throw new Error(
-                              `\`pages/404\` ${STATIC_STATUS_PAGE_GET_INITIAL_PROPS_ERROR}`
+                              `\`pages${page}\` ${STATIC_STATUS_PAGE_GET_INITIAL_PROPS_ERROR}`
                             )
                           }
-                          // we need to ensure the 404 lambda is present since we use
-                          // it when _app has getInitialProps
-                          if (
-                            (await customAppGetInitialPropsPromise) &&
-                            !workerResult.hasStaticProps
-                          ) {
-                            staticPages.delete(page)
-                          }
                         }
-
+                      } catch (err) {
                         if (
-                          STATIC_STATUS_PAGES.includes(page) &&
-                          !workerResult.isStatic &&
-                          !workerResult.hasStaticProps
-                        ) {
-                          throw new Error(
-                            `\`pages${page}\` ${STATIC_STATUS_PAGE_GET_INITIAL_PROPS_ERROR}`
-                          )
+                          !isError(err) ||
+                          err.message !== 'INVALID_DEFAULT_EXPORT'
+                        )
+                          throw err
+                        invalidPages.add(page)
+                      }
+                    }
+
+                    if (pageType === 'app') {
+                      if (isSSG || isStatic) {
+                        staticAppPagesCount++
+                      } else {
+                        serverAppPagesCount++
+                      }
+                    }
+                  }
+
+                  pageInfos.set(page, {
+                    size,
+                    totalSize,
+                    isStatic,
+                    isSSG,
+                    isPPR,
+                    isHybridAmp,
+                    ssgPageRoutes,
+                    initialRevalidateSeconds: false,
+                    runtime: pageRuntime,
+                    pageDuration: undefined,
+                    ssgPageDurations: undefined,
+                    hasEmptyPrelude: undefined,
+                  })
+                })
+              })
+          )
+
+          const errorPageResult = await errorPageStaticResult
+          const nonStaticErrorPage =
+            (await errorPageHasCustomGetInitialProps) ||
+            (errorPageResult && errorPageResult.hasServerProps)
+
+          const returnValue = {
+            customAppGetInitialProps: await customAppGetInitialPropsPromise,
+            namedExports: await namedExportsPromise,
+            isNextImageImported,
+            hasSsrAmpPages,
+            hasNonStaticErrorPage: nonStaticErrorPage,
+          }
+
+          return returnValue
+        })
+
+        if (postCompileSpinner) postCompileSpinner.stopAndPersist()
+
+        if (customAppGetInitialProps) {
+          console.warn(
+            bold(yellow(`Warning: `)) +
+              yellow(
+                `You have opted-out of Automatic Static Optimization due to \`getInitialProps\` in \`pages/_app\`. This does not opt-out pages with \`getStaticProps\``
+              )
+          )
+          console.warn(
+            'Read more: https://nextjs.org/docs/messages/opt-out-auto-static-optimization\n'
+          )
+        }
+
+        if (!hasSsrAmpPages) {
+          requiredServerFiles.ignore.push(
+            path.relative(
+              dir,
+              path.join(
+                path.dirname(
+                  require.resolve(
+                    'next/dist/compiled/@ampproject/toolbox-optimizer'
+                  )
+                ),
+                '**/*'
+              )
+            )
+          )
+        }
+
+        if (Object.keys(functionsConfigManifest).length > 0) {
+          const manifest: {
+            version: number
+            functions: Record<string, Record<string, string | number>>
+          } = {
+            version: 1,
+            functions: functionsConfigManifest,
+          }
+
+          await fs.writeFile(
+            path.join(distDir, SERVER_DIRECTORY, FUNCTIONS_CONFIG_MANIFEST),
+            formatManifest(manifest),
+            'utf8'
+          )
+        }
+
+        if (!isGenerate && config.outputFileTracing && !buildTracesPromise) {
+          buildTracesPromise = collectBuildTraces({
+            dir,
+            config,
+            distDir,
+            pageKeys,
+            pageInfos: Object.entries(pageInfos),
+            staticPages: [...staticPages],
+            nextBuildSpan,
+            hasSsrAmpPages,
+            buildTraceContext,
+            outputFileTracingRoot,
+          }).catch((err) => {
+            console.error(err)
+            process.exit(1)
+          })
+        }
+
+        if (serverPropsPages.size > 0 || ssgPages.size > 0) {
+          // We update the routes manifest after the build with the
+          // data routes since we can't determine these until after build
+          routesManifest.dataRoutes = getSortedRoutes([
+            ...serverPropsPages,
+            ...ssgPages,
+          ]).map((page) => {
+            return buildDataRoute(page, buildId)
+          })
+
+          await fs.writeFile(
+            routesManifestPath,
+            formatManifest(routesManifest),
+            'utf8'
+          )
+        }
+
+        // Since custom _app.js can wrap the 404 page we have to opt-out of static optimization if it has getInitialProps
+        // Only export the static 404 when there is no /_error present
+        const useStaticPages404 =
+          !customAppGetInitialProps && (!hasNonStaticErrorPage || hasPages404)
+
+        if (invalidPages.size > 0) {
+          const err = new Error(
+            `Build optimization failed: found page${
+              invalidPages.size === 1 ? '' : 's'
+            } without a React Component as default export in \n${[
+              ...invalidPages,
+            ]
+              .map((pg) => `pages${pg}`)
+              .join(
+                '\n'
+              )}\n\nSee https://nextjs.org/docs/messages/page-without-valid-component for more info.\n`
+          ) as NextError
+          err.code = 'BUILD_OPTIMIZATION_FAILED'
+          throw err
+        }
+
+        await writeBuildId(distDir, buildId)
+
+        if (config.experimental.optimizeCss) {
+          const globOrig =
+            require('next/dist/compiled/glob') as typeof import('next/dist/compiled/glob')
+
+          const cssFilePaths = await new Promise<string[]>(
+            (resolve, reject) => {
+              globOrig(
+                '**/*.css',
+                { cwd: path.join(distDir, 'static') },
+                (err, files) => {
+                  if (err) {
+                    return reject(err)
+                  }
+                  resolve(files)
+                }
+              )
+            }
+          )
+
+          requiredServerFiles.files.push(
+            ...cssFilePaths.map((filePath) =>
+              path.join(config.distDir, 'static', filePath)
+            )
+          )
+        }
+
+        const features: EventBuildFeatureUsage[] = [
+          {
+            featureName: 'experimental/optimizeCss',
+            invocationCount: config.experimental.optimizeCss ? 1 : 0,
+          },
+          {
+            featureName: 'experimental/nextScriptWorkers',
+            invocationCount: config.experimental.nextScriptWorkers ? 1 : 0,
+          },
+          {
+            featureName: 'optimizeFonts',
+            invocationCount: config.optimizeFonts ? 1 : 0,
+          },
+        ]
+        telemetry.record(
+          features.map((feature) => {
+            return {
+              eventName: EVENT_BUILD_FEATURE_USAGE,
+              payload: feature,
+            }
+          })
+        )
+
+        await fs.writeFile(
+          path.join(distDir, SERVER_FILES_MANIFEST),
+          formatManifest(requiredServerFiles),
+          'utf8'
+        )
+
+        const middlewareManifest: MiddlewareManifest = JSON.parse(
+          await fs.readFile(
+            path.join(distDir, SERVER_DIRECTORY, MIDDLEWARE_MANIFEST),
+            'utf8'
+          )
+        )
+
+        const finalPrerenderRoutes: { [route: string]: SsgRoute } = {}
+        const finalDynamicRoutes: PrerenderManifest['dynamicRoutes'] = {}
+        const tbdPrerenderRoutes: string[] = []
+        let ssgNotFoundPaths: string[] = []
+
+        const { i18n } = config
+
+        const usedStaticStatusPages = STATIC_STATUS_PAGES.filter(
+          (page) =>
+            mappedPages[page] &&
+            mappedPages[page].startsWith('private-next-pages')
+        )
+        usedStaticStatusPages.forEach((page) => {
+          if (!ssgPages.has(page) && !customAppGetInitialProps) {
+            staticPages.add(page)
+          }
+        })
+
+        const hasPages500 = usedStaticStatusPages.includes('/500')
+        const useDefaultStatic500 =
+          !hasPages500 && !hasNonStaticErrorPage && !customAppGetInitialProps
+
+        const combinedPages = [...staticPages, ...ssgPages]
+        const isApp404Static = appStaticPaths.has('/_not-found')
+        const hasStaticApp404 = hasApp404 && isApp404Static
+
+        // we need to trigger automatic exporting when we have
+        // - static 404/500
+        // - getStaticProps paths
+        // - experimental app is enabled
+        if (
+          !isCompile &&
+          (combinedPages.length > 0 ||
+            useStaticPages404 ||
+            useDefaultStatic500 ||
+            appDir)
+        ) {
+          const staticGenerationSpan =
+            nextBuildSpan.traceChild('static-generation')
+          await staticGenerationSpan.traceAsyncFn(async () => {
+            detectConflictingPaths(
+              [
+                ...combinedPages,
+                ...pageKeys.pages.filter(
+                  (page) => !combinedPages.includes(page)
+                ),
+              ],
+              ssgPages,
+              additionalSsgPaths
+            )
+            const exportApp: ExportAppWorker = require('../export').default
+
+            const exportConfig: NextConfigComplete = {
+              ...config,
+              // Default map will be the collection of automatic statically exported
+              // pages and incremental pages.
+              // n.b. we cannot handle this above in combinedPages because the dynamic
+              // page must be in the `pages` array, but not in the mapping.
+              exportPathMap: (defaultMap: ExportPathMap) => {
+                // Dynamically routed pages should be prerendered to be used as
+                // a client-side skeleton (fallback) while data is being fetched.
+                // This ensures the end-user never sees a 500 or slow response from the
+                // server.
+                //
+                // Note: prerendering disables automatic static optimization.
+                ssgPages.forEach((page) => {
+                  if (isDynamicRoute(page)) {
+                    tbdPrerenderRoutes.push(page)
+
+                    if (ssgStaticFallbackPages.has(page)) {
+                      // Override the rendering for the dynamic page to be treated as a
+                      // fallback render.
+                      if (i18n) {
+                        defaultMap[`/${i18n.defaultLocale}${page}`] = {
+                          page,
+                          query: { __nextFallback: 'true' },
+                        }
+                      } else {
+                        defaultMap[page] = {
+                          page,
+                          query: { __nextFallback: 'true' },
                         }
                       }
-                    } catch (err) {
-                      if (
-                        !isError(err) ||
-                        err.message !== 'INVALID_DEFAULT_EXPORT'
-                      )
-                        throw err
-                      invalidPages.add(page)
-                    }
-                  }
-
-                  if (pageType === 'app') {
-                    if (isSSG || isStatic) {
-                      staticAppPagesCount++
                     } else {
-                      serverAppPagesCount++
+                      // Remove dynamically routed pages from the default path map when
+                      // fallback behavior is disabled.
+                      delete defaultMap[page]
                     }
-                  }
-                }
-
-                pageInfos.set(page, {
-                  size,
-                  totalSize,
-                  isStatic,
-                  isSSG,
-                  isPPR,
-                  isHybridAmp,
-                  ssgPageRoutes,
-                  initialRevalidateSeconds: false,
-                  runtime: pageRuntime,
-                  pageDuration: undefined,
-                  ssgPageDurations: undefined,
-                  hasEmptyPrelude: undefined,
-                })
-              })
-            })
-        )
-
-        const errorPageResult = await errorPageStaticResult
-        const nonStaticErrorPage =
-          (await errorPageHasCustomGetInitialProps) ||
-          (errorPageResult && errorPageResult.hasServerProps)
-
-        const returnValue = {
-          customAppGetInitialProps: await customAppGetInitialPropsPromise,
-          namedExports: await namedExportsPromise,
-          isNextImageImported,
-          hasSsrAmpPages,
-          hasNonStaticErrorPage: nonStaticErrorPage,
-        }
-
-        return returnValue
-      })
-
-      if (postCompileSpinner) postCompileSpinner.stopAndPersist()
-
-      if (customAppGetInitialProps) {
-        console.warn(
-          bold(yellow(`Warning: `)) +
-            yellow(
-              `You have opted-out of Automatic Static Optimization due to \`getInitialProps\` in \`pages/_app\`. This does not opt-out pages with \`getStaticProps\``
-            )
-        )
-        console.warn(
-          'Read more: https://nextjs.org/docs/messages/opt-out-auto-static-optimization\n'
-        )
-      }
-
-      if (!hasSsrAmpPages) {
-        requiredServerFiles.ignore.push(
-          path.relative(
-            dir,
-            path.join(
-              path.dirname(
-                require.resolve(
-                  'next/dist/compiled/@ampproject/toolbox-optimizer'
-                )
-              ),
-              '**/*'
-            )
-          )
-        )
-      }
-
-      if (Object.keys(functionsConfigManifest).length > 0) {
-        const manifest: {
-          version: number
-          functions: Record<string, Record<string, string | number>>
-        } = {
-          version: 1,
-          functions: functionsConfigManifest,
-        }
-
-        await fs.writeFile(
-          path.join(distDir, SERVER_DIRECTORY, FUNCTIONS_CONFIG_MANIFEST),
-          formatManifest(manifest),
-          'utf8'
-        )
-      }
-
-      if (!isGenerate && config.outputFileTracing && !buildTracesPromise) {
-        buildTracesPromise = collectBuildTraces({
-          dir,
-          config,
-          distDir,
-          pageKeys,
-          pageInfos: Object.entries(pageInfos),
-          staticPages: [...staticPages],
-          nextBuildSpan,
-          hasSsrAmpPages,
-          buildTraceContext,
-          outputFileTracingRoot,
-        }).catch((err) => {
-          console.error(err)
-          process.exit(1)
-        })
-      }
-
-      if (serverPropsPages.size > 0 || ssgPages.size > 0) {
-        // We update the routes manifest after the build with the
-        // data routes since we can't determine these until after build
-        routesManifest.dataRoutes = getSortedRoutes([
-          ...serverPropsPages,
-          ...ssgPages,
-        ]).map((page) => {
-          return buildDataRoute(page, buildId)
-        })
-
-        await fs.writeFile(
-          routesManifestPath,
-          formatManifest(routesManifest),
-          'utf8'
-        )
-      }
-
-      // Since custom _app.js can wrap the 404 page we have to opt-out of static optimization if it has getInitialProps
-      // Only export the static 404 when there is no /_error present
-      const useStaticPages404 =
-        !customAppGetInitialProps && (!hasNonStaticErrorPage || hasPages404)
-
-      if (invalidPages.size > 0) {
-        const err = new Error(
-          `Build optimization failed: found page${
-            invalidPages.size === 1 ? '' : 's'
-          } without a React Component as default export in \n${[...invalidPages]
-            .map((pg) => `pages${pg}`)
-            .join(
-              '\n'
-            )}\n\nSee https://nextjs.org/docs/messages/page-without-valid-component for more info.\n`
-        ) as NextError
-        err.code = 'BUILD_OPTIMIZATION_FAILED'
-        throw err
-      }
-
-      await writeBuildId(distDir, buildId)
-
-      if (config.experimental.optimizeCss) {
-        const globOrig =
-          require('next/dist/compiled/glob') as typeof import('next/dist/compiled/glob')
-
-        const cssFilePaths = await new Promise<string[]>((resolve, reject) => {
-          globOrig(
-            '**/*.css',
-            { cwd: path.join(distDir, 'static') },
-            (err, files) => {
-              if (err) {
-                return reject(err)
-              }
-              resolve(files)
-            }
-          )
-        })
-
-        requiredServerFiles.files.push(
-          ...cssFilePaths.map((filePath) =>
-            path.join(config.distDir, 'static', filePath)
-          )
-        )
-      }
-
-      const features: EventBuildFeatureUsage[] = [
-        {
-          featureName: 'experimental/optimizeCss',
-          invocationCount: config.experimental.optimizeCss ? 1 : 0,
-        },
-        {
-          featureName: 'experimental/nextScriptWorkers',
-          invocationCount: config.experimental.nextScriptWorkers ? 1 : 0,
-        },
-        {
-          featureName: 'optimizeFonts',
-          invocationCount: config.optimizeFonts ? 1 : 0,
-        },
-      ]
-      telemetry.record(
-        features.map((feature) => {
-          return {
-            eventName: EVENT_BUILD_FEATURE_USAGE,
-            payload: feature,
-          }
-        })
-      )
-
-      await fs.writeFile(
-        path.join(distDir, SERVER_FILES_MANIFEST),
-        formatManifest(requiredServerFiles),
-        'utf8'
-      )
-
-      const middlewareManifest: MiddlewareManifest = JSON.parse(
-        await fs.readFile(
-          path.join(distDir, SERVER_DIRECTORY, MIDDLEWARE_MANIFEST),
-          'utf8'
-        )
-      )
-
-      const finalPrerenderRoutes: { [route: string]: SsgRoute } = {}
-      const finalDynamicRoutes: PrerenderManifest['dynamicRoutes'] = {}
-      const tbdPrerenderRoutes: string[] = []
-      let ssgNotFoundPaths: string[] = []
-
-      const { i18n } = config
-
-      const usedStaticStatusPages = STATIC_STATUS_PAGES.filter(
-        (page) =>
-          mappedPages[page] &&
-          mappedPages[page].startsWith('private-next-pages')
-      )
-      usedStaticStatusPages.forEach((page) => {
-        if (!ssgPages.has(page) && !customAppGetInitialProps) {
-          staticPages.add(page)
-        }
-      })
-
-      const hasPages500 = usedStaticStatusPages.includes('/500')
-      const useDefaultStatic500 =
-        !hasPages500 && !hasNonStaticErrorPage && !customAppGetInitialProps
-
-      const combinedPages = [...staticPages, ...ssgPages]
-      const isApp404Static = appStaticPaths.has('/_not-found')
-      const hasStaticApp404 = hasApp404 && isApp404Static
-
-      // we need to trigger automatic exporting when we have
-      // - static 404/500
-      // - getStaticProps paths
-      // - experimental app is enabled
-      if (
-        !isCompile &&
-        (combinedPages.length > 0 ||
-          useStaticPages404 ||
-          useDefaultStatic500 ||
-          appDir)
-      ) {
-        const staticGenerationSpan =
-          nextBuildSpan.traceChild('static-generation')
-        await staticGenerationSpan.traceAsyncFn(async () => {
-          detectConflictingPaths(
-            [
-              ...combinedPages,
-              ...pageKeys.pages.filter((page) => !combinedPages.includes(page)),
-            ],
-            ssgPages,
-            additionalSsgPaths
-          )
-          const exportApp: ExportAppWorker = require('../export').default
-
-          const exportConfig: NextConfigComplete = {
-            ...config,
-            // Default map will be the collection of automatic statically exported
-            // pages and incremental pages.
-            // n.b. we cannot handle this above in combinedPages because the dynamic
-            // page must be in the `pages` array, but not in the mapping.
-            exportPathMap: (defaultMap: ExportPathMap) => {
-              // Dynamically routed pages should be prerendered to be used as
-              // a client-side skeleton (fallback) while data is being fetched.
-              // This ensures the end-user never sees a 500 or slow response from the
-              // server.
-              //
-              // Note: prerendering disables automatic static optimization.
-              ssgPages.forEach((page) => {
-                if (isDynamicRoute(page)) {
-                  tbdPrerenderRoutes.push(page)
-
-                  if (ssgStaticFallbackPages.has(page)) {
-                    // Override the rendering for the dynamic page to be treated as a
-                    // fallback render.
-                    if (i18n) {
-                      defaultMap[`/${i18n.defaultLocale}${page}`] = {
-                        page,
-                        query: { __nextFallback: 'true' },
-                      }
-                    } else {
-                      defaultMap[page] = {
-                        page,
-                        query: { __nextFallback: 'true' },
-                      }
-                    }
-                  } else {
-                    // Remove dynamically routed pages from the default path map when
-                    // fallback behavior is disabled.
-                    delete defaultMap[page]
-                  }
-                }
-              })
-
-              // Append the "well-known" routes we should prerender for, e.g. blog
-              // post slugs.
-              additionalSsgPaths.forEach((routes, page) => {
-                const encodedRoutes = additionalSsgPathsEncoded.get(page)
-
-                routes.forEach((route, routeIdx) => {
-                  defaultMap[route] = {
-                    page,
-                    query: { __nextSsgPath: encodedRoutes?.[routeIdx] },
                   }
                 })
-              })
 
-              if (useStaticPages404) {
-                defaultMap['/404'] = {
-                  page: hasPages404 ? '/404' : '/_error',
+                // Append the "well-known" routes we should prerender for, e.g. blog
+                // post slugs.
+                additionalSsgPaths.forEach((routes, page) => {
+                  const encodedRoutes = additionalSsgPathsEncoded.get(page)
+
+                  routes.forEach((route, routeIdx) => {
+                    defaultMap[route] = {
+                      page,
+                      query: { __nextSsgPath: encodedRoutes?.[routeIdx] },
+                    }
+                  })
+                })
+
+                if (useStaticPages404) {
+                  defaultMap['/404'] = {
+                    page: hasPages404 ? '/404' : '/_error',
+                  }
                 }
-              }
 
-              if (useDefaultStatic500) {
-                defaultMap['/500'] = {
-                  page: '/_error',
+                if (useDefaultStatic500) {
+                  defaultMap['/500'] = {
+                    page: '/_error',
+                  }
                 }
-              }
 
-              // TODO: output manifest specific to app paths and their
-              // revalidate periods and dynamicParams settings
-              appStaticPaths.forEach((routes, originalAppPath) => {
-                const encodedRoutes = appStaticPathsEncoded.get(originalAppPath)
-                const appConfig = appDefaultConfigs.get(originalAppPath) || {}
+                // TODO: output manifest specific to app paths and their
+                // revalidate periods and dynamicParams settings
+                appStaticPaths.forEach((routes, originalAppPath) => {
+                  const encodedRoutes =
+                    appStaticPathsEncoded.get(originalAppPath)
+                  const appConfig = appDefaultConfigs.get(originalAppPath) || {}
 
-                routes.forEach((route, routeIdx) => {
-                  defaultMap[route] = {
+                  routes.forEach((route, routeIdx) => {
+                    defaultMap[route] = {
+                      page: originalAppPath,
+                      query: { __nextSsgPath: encodedRoutes?.[routeIdx] },
+                      _isDynamicError: appConfig.dynamic === 'error',
+                      _isAppDir: true,
+                    }
+                  })
+                })
+
+                // Ensure we don't generate explicit app prefetches while in PPR.
+                if (config.experimental.ppr && appPrefetchPaths.size > 0) {
+                  throw new Error(
+                    "Invariant: explicit app prefetches shouldn't generated with PPR"
+                  )
+                }
+
+                for (const [originalAppPath, page] of appPrefetchPaths) {
+                  defaultMap[page] = {
                     page: originalAppPath,
-                    query: { __nextSsgPath: encodedRoutes?.[routeIdx] },
-                    _isDynamicError: appConfig.dynamic === 'error',
+                    query: {},
                     _isAppDir: true,
+                    _isAppPrefetch: true,
                   }
-                })
-              })
-
-              // Ensure we don't generate explicit app prefetches while in PPR.
-              if (config.experimental.ppr && appPrefetchPaths.size > 0) {
-                throw new Error(
-                  "Invariant: explicit app prefetches shouldn't generated with PPR"
-                )
-              }
-
-              for (const [originalAppPath, page] of appPrefetchPaths) {
-                defaultMap[page] = {
-                  page: originalAppPath,
-                  query: {},
-                  _isAppDir: true,
-                  _isAppPrefetch: true,
                 }
+
+                if (i18n) {
+                  for (const page of [
+                    ...staticPages,
+                    ...ssgPages,
+                    ...(useStaticPages404 ? ['/404'] : []),
+                    ...(useDefaultStatic500 ? ['/500'] : []),
+                  ]) {
+                    const isSsg = ssgPages.has(page)
+                    const isDynamic = isDynamicRoute(page)
+                    const isFallback = isSsg && ssgStaticFallbackPages.has(page)
+
+                    for (const locale of i18n.locales) {
+                      // skip fallback generation for SSG pages without fallback mode
+                      if (isSsg && isDynamic && !isFallback) continue
+                      const outputPath = `/${locale}${page === '/' ? '' : page}`
+
+                      defaultMap[outputPath] = {
+                        page: defaultMap[page]?.page || page,
+                        query: {
+                          __nextLocale: locale,
+                          __nextFallback: isFallback ? 'true' : undefined,
+                        },
+                      }
+                    }
+
+                    if (isSsg) {
+                      // remove non-locale prefixed variant from defaultMap
+                      delete defaultMap[page]
+                    }
+                  }
+                }
+                return defaultMap
+              },
+            }
+
+            const exportOptions: ExportAppOptions = {
+              nextConfig: exportConfig,
+              enabledDirectories,
+              silent: false,
+              buildExport: true,
+              debugOutput,
+              threads: config.experimental.cpus,
+              pages: combinedPages,
+              outdir: path.join(distDir, 'export'),
+              statusMessage: 'Generating static pages',
+              // The worker already explicitly binds `this` to each of the
+              // exposed methods.
+              exportAppPageWorker: appStaticWorkers?.exportPage,
+              exportPageWorker: pagesStaticWorkers?.exportPage,
+              endWorker: async () => {
+                await pagesStaticWorkers.end()
+                await appStaticWorkers?.end()
+              },
+            }
+
+            const exportResult = await exportApp(
+              dir,
+              exportOptions,
+              nextBuildSpan
+            )
+
+            // If there was no result, there's nothing more to do.
+            if (!exportResult) return
+
+            ssgNotFoundPaths = Array.from(exportResult.ssgNotFoundPaths)
+
+            // remove server bundles that were exported
+            for (const page of staticPages) {
+              const serverBundle = getPagePath(page, distDir, undefined, false)
+              await fs.unlink(serverBundle)
+            }
+
+            for (const [originalAppPath, routes] of appStaticPaths) {
+              const page = appNormalizedPaths.get(originalAppPath) || ''
+              const appConfig = appDefaultConfigs.get(originalAppPath) || {}
+              let hasDynamicData =
+                appConfig.revalidate === 0 ||
+                exportResult.byPath.get(page)?.revalidate === 0
+
+              if (hasDynamicData && pageInfos.get(page)?.isStatic) {
+                // if the page was marked as being static, but it contains dynamic data
+                // (ie, in the case of a static generation bailout), then it should be marked dynamic
+                pageInfos.set(page, {
+                  ...(pageInfos.get(page) as PageInfo),
+                  isStatic: false,
+                  isSSG: false,
+                })
               }
 
-              if (i18n) {
-                for (const page of [
-                  ...staticPages,
-                  ...ssgPages,
-                  ...(useStaticPages404 ? ['/404'] : []),
-                  ...(useDefaultStatic500 ? ['/500'] : []),
-                ]) {
-                  const isSsg = ssgPages.has(page)
-                  const isDynamic = isDynamicRoute(page)
-                  const isFallback = isSsg && ssgStaticFallbackPages.has(page)
+              const isRouteHandler = isAppRouteRoute(originalAppPath)
 
-                  for (const locale of i18n.locales) {
-                    // skip fallback generation for SSG pages without fallback mode
-                    if (isSsg && isDynamic && !isFallback) continue
-                    const outputPath = `/${locale}${page === '/' ? '' : page}`
+              // When this is an app page and PPR is enabled, the route supports
+              // partial pre-rendering.
+              const experimentalPPR =
+                !isRouteHandler && config.experimental.ppr === true
+                  ? true
+                  : undefined
 
-                    defaultMap[outputPath] = {
-                      page: defaultMap[page]?.page || page,
-                      query: {
-                        __nextLocale: locale,
-                        __nextFallback: isFallback ? 'true' : undefined,
-                      },
+              // this flag is used to selectively bypass the static cache and invoke the lambda directly
+              // to enable server actions on static routes
+              const bypassFor: RouteHas[] = [
+                { type: 'header', key: ACTION },
+                {
+                  type: 'header',
+                  key: 'content-type',
+                  value: 'multipart/form-data',
+                },
+              ]
+
+              routes.forEach((route) => {
+                if (isDynamicRoute(page) && route === page) return
+                if (route === '/_not-found') return
+
+                const {
+                  revalidate = appConfig.revalidate ?? false,
+                  metadata = {},
+                  hasEmptyPrelude,
+                  hasPostponed,
+                } = exportResult.byPath.get(route) ?? {}
+
+                pageInfos.set(route, {
+                  ...(pageInfos.get(route) as PageInfo),
+                  hasPostponed,
+                  hasEmptyPrelude,
+                })
+
+                // update the page (eg /blog/[slug]) to also have the postpone metadata
+                pageInfos.set(page, {
+                  ...(pageInfos.get(page) as PageInfo),
+                  hasPostponed,
+                  hasEmptyPrelude,
+                })
+
+                if (revalidate !== 0) {
+                  const normalizedRoute = normalizePagePath(route)
+
+                  let dataRoute: string | null
+                  if (isRouteHandler) {
+                    dataRoute = null
+                  } else {
+                    dataRoute = path.posix.join(
+                      `${normalizedRoute}${RSC_SUFFIX}`
+                    )
+                  }
+
+                  let prefetchDataRoute: string | null | undefined
+                  if (experimentalPPR) {
+                    prefetchDataRoute = path.posix.join(
+                      `${normalizedRoute}${RSC_PREFETCH_SUFFIX}`
+                    )
+                  }
+
+                  const routeMeta: Partial<SsgRoute> = {}
+
+                  if (metadata.status !== 200) {
+                    routeMeta.initialStatus = metadata.status
+                  }
+
+                  const exportHeaders = metadata.headers
+                  const headerKeys = Object.keys(exportHeaders || {})
+
+                  if (exportHeaders && headerKeys.length) {
+                    routeMeta.initialHeaders = {}
+
+                    // normalize header values as initialHeaders
+                    // must be Record<string, string>
+                    for (const key of headerKeys) {
+                      let value = exportHeaders[key]
+
+                      if (Array.isArray(value)) {
+                        if (key === 'set-cookie') {
+                          value = value.join(',')
+                        } else {
+                          value = value[value.length - 1]
+                        }
+                      }
+
+                      if (typeof value === 'string') {
+                        routeMeta.initialHeaders[key] = value
+                      }
                     }
                   }
 
-                  if (isSsg) {
-                    // remove non-locale prefixed variant from defaultMap
-                    delete defaultMap[page]
+                  finalPrerenderRoutes[route] = {
+                    ...routeMeta,
+                    experimentalPPR,
+                    experimentalBypassFor: bypassFor,
+                    initialRevalidateSeconds: revalidate,
+                    srcRoute: page,
+                    dataRoute,
+                    prefetchDataRoute,
                   }
-                }
-              }
-              return defaultMap
-            },
-          }
-
-          const exportOptions: ExportAppOptions = {
-            nextConfig: exportConfig,
-            enabledDirectories,
-            silent: false,
-            buildExport: true,
-            debugOutput,
-            threads: config.experimental.cpus,
-            pages: combinedPages,
-            outdir: path.join(distDir, 'export'),
-            statusMessage: 'Generating static pages',
-            // The worker already explicitly binds `this` to each of the
-            // exposed methods.
-            exportAppPageWorker: appStaticWorkers?.exportPage,
-            exportPageWorker: pagesStaticWorkers?.exportPage,
-            endWorker: async () => {
-              await pagesStaticWorkers.end()
-              await appStaticWorkers?.end()
-            },
-          }
-
-          const exportResult = await exportApp(
-            dir,
-            exportOptions,
-            nextBuildSpan
-          )
-
-          // If there was no result, there's nothing more to do.
-          if (!exportResult) return
-
-          ssgNotFoundPaths = Array.from(exportResult.ssgNotFoundPaths)
-
-          // remove server bundles that were exported
-          for (const page of staticPages) {
-            const serverBundle = getPagePath(page, distDir, undefined, false)
-            await fs.unlink(serverBundle)
-          }
-
-          for (const [originalAppPath, routes] of appStaticPaths) {
-            const page = appNormalizedPaths.get(originalAppPath) || ''
-            const appConfig = appDefaultConfigs.get(originalAppPath) || {}
-            let hasDynamicData =
-              appConfig.revalidate === 0 ||
-              exportResult.byPath.get(page)?.revalidate === 0
-
-            if (hasDynamicData && pageInfos.get(page)?.isStatic) {
-              // if the page was marked as being static, but it contains dynamic data
-              // (ie, in the case of a static generation bailout), then it should be marked dynamic
-              pageInfos.set(page, {
-                ...(pageInfos.get(page) as PageInfo),
-                isStatic: false,
-                isSSG: false,
-              })
-            }
-
-            const isRouteHandler = isAppRouteRoute(originalAppPath)
-
-            // When this is an app page and PPR is enabled, the route supports
-            // partial pre-rendering.
-            const experimentalPPR =
-              !isRouteHandler && config.experimental.ppr === true
-                ? true
-                : undefined
-
-            // this flag is used to selectively bypass the static cache and invoke the lambda directly
-            // to enable server actions on static routes
-            const bypassFor: RouteHas[] = [
-              { type: 'header', key: ACTION },
-              {
-                type: 'header',
-                key: 'content-type',
-                value: 'multipart/form-data',
-              },
-            ]
-
-            routes.forEach((route) => {
-              if (isDynamicRoute(page) && route === page) return
-              if (route === '/_not-found') return
-
-              const {
-                revalidate = appConfig.revalidate ?? false,
-                metadata = {},
-                hasEmptyPrelude,
-                hasPostponed,
-              } = exportResult.byPath.get(route) ?? {}
-
-              pageInfos.set(route, {
-                ...(pageInfos.get(route) as PageInfo),
-                hasPostponed,
-                hasEmptyPrelude,
-              })
-
-              // update the page (eg /blog/[slug]) to also have the postpone metadata
-              pageInfos.set(page, {
-                ...(pageInfos.get(page) as PageInfo),
-                hasPostponed,
-                hasEmptyPrelude,
-              })
-
-              if (revalidate !== 0) {
-                const normalizedRoute = normalizePagePath(route)
-
-                let dataRoute: string | null
-                if (isRouteHandler) {
-                  dataRoute = null
                 } else {
-                  dataRoute = path.posix.join(`${normalizedRoute}${RSC_SUFFIX}`)
+                  hasDynamicData = true
+                  // we might have determined during prerendering that this page
+                  // used dynamic data
+                  pageInfos.set(route, {
+                    ...(pageInfos.get(route) as PageInfo),
+                    isSSG: false,
+                    isStatic: false,
+                  })
                 }
+              })
+
+              if (!hasDynamicData && isDynamicRoute(originalAppPath)) {
+                const normalizedRoute = normalizePagePath(page)
+                const dataRoute = path.posix.join(
+                  `${normalizedRoute}${RSC_SUFFIX}`
+                )
 
                 let prefetchDataRoute: string | null | undefined
                 if (experimentalPPR) {
@@ -2325,330 +2411,288 @@ export default async function build(
                   )
                 }
 
-                const routeMeta: Partial<SsgRoute> = {}
+                pageInfos.set(page, {
+                  ...(pageInfos.get(page) as PageInfo),
+                  isDynamicAppRoute: true,
+                  // if PPR is turned on and the route contains a dynamic segment,
+                  // we assume it'll be partially prerendered
+                  hasPostponed: experimentalPPR,
+                })
 
-                if (metadata.status !== 200) {
-                  routeMeta.initialStatus = metadata.status
-                }
-
-                const exportHeaders = metadata.headers
-                const headerKeys = Object.keys(exportHeaders || {})
-
-                if (exportHeaders && headerKeys.length) {
-                  routeMeta.initialHeaders = {}
-
-                  // normalize header values as initialHeaders
-                  // must be Record<string, string>
-                  for (const key of headerKeys) {
-                    let value = exportHeaders[key]
-
-                    if (Array.isArray(value)) {
-                      if (key === 'set-cookie') {
-                        value = value.join(',')
-                      } else {
-                        value = value[value.length - 1]
-                      }
-                    }
-
-                    if (typeof value === 'string') {
-                      routeMeta.initialHeaders[key] = value
-                    }
-                  }
-                }
-
-                finalPrerenderRoutes[route] = {
-                  ...routeMeta,
+                // TODO: create a separate manifest to allow enforcing
+                // dynamicParams for non-static paths?
+                finalDynamicRoutes[page] = {
                   experimentalPPR,
                   experimentalBypassFor: bypassFor,
-                  initialRevalidateSeconds: revalidate,
-                  srcRoute: page,
+                  routeRegex: normalizeRouteRegex(
+                    getNamedRouteRegex(page, false).re.source
+                  ),
                   dataRoute,
-                  prefetchDataRoute,
-                }
-              } else {
-                hasDynamicData = true
-                // we might have determined during prerendering that this page
-                // used dynamic data
-                pageInfos.set(route, {
-                  ...(pageInfos.get(route) as PageInfo),
-                  isSSG: false,
-                  isStatic: false,
-                })
-              }
-            })
-
-            if (!hasDynamicData && isDynamicRoute(originalAppPath)) {
-              const normalizedRoute = normalizePagePath(page)
-              const dataRoute = path.posix.join(
-                `${normalizedRoute}${RSC_SUFFIX}`
-              )
-
-              let prefetchDataRoute: string | null | undefined
-              if (experimentalPPR) {
-                prefetchDataRoute = path.posix.join(
-                  `${normalizedRoute}${RSC_PREFETCH_SUFFIX}`
-                )
-              }
-
-              pageInfos.set(page, {
-                ...(pageInfos.get(page) as PageInfo),
-                isDynamicAppRoute: true,
-                // if PPR is turned on and the route contains a dynamic segment,
-                // we assume it'll be partially prerendered
-                hasPostponed: experimentalPPR,
-              })
-
-              // TODO: create a separate manifest to allow enforcing
-              // dynamicParams for non-static paths?
-              finalDynamicRoutes[page] = {
-                experimentalPPR,
-                experimentalBypassFor: bypassFor,
-                routeRegex: normalizeRouteRegex(
-                  getNamedRouteRegex(page, false).re.source
-                ),
-                dataRoute,
-                // if dynamicParams are enabled treat as fallback:
-                // 'blocking' if not it's fallback: false
-                fallback: appDynamicParamPaths.has(originalAppPath)
-                  ? null
-                  : false,
-                dataRouteRegex: isRouteHandler
-                  ? null
-                  : normalizeRouteRegex(
-                      getNamedRouteRegex(
-                        dataRoute.replace(/\.rsc$/, ''),
-                        false
-                      ).re.source.replace(/\(\?:\\\/\)\?\$$/, '\\.rsc$')
-                    ),
-                prefetchDataRoute,
-                prefetchDataRouteRegex:
-                  isRouteHandler || !prefetchDataRoute
-                    ? undefined
+                  // if dynamicParams are enabled treat as fallback:
+                  // 'blocking' if not it's fallback: false
+                  fallback: appDynamicParamPaths.has(originalAppPath)
+                    ? null
+                    : false,
+                  dataRouteRegex: isRouteHandler
+                    ? null
                     : normalizeRouteRegex(
                         getNamedRouteRegex(
-                          prefetchDataRoute.replace(/\.prefetch\.rsc$/, ''),
+                          dataRoute.replace(/\.rsc$/, ''),
                           false
-                        ).re.source.replace(
-                          /\(\?:\\\/\)\?\$$/,
-                          '\\.prefetch\\.rsc$'
-                        )
+                        ).re.source.replace(/\(\?:\\\/\)\?\$$/, '\\.rsc$')
                       ),
+                  prefetchDataRoute,
+                  prefetchDataRouteRegex:
+                    isRouteHandler || !prefetchDataRoute
+                      ? undefined
+                      : normalizeRouteRegex(
+                          getNamedRouteRegex(
+                            prefetchDataRoute.replace(/\.prefetch\.rsc$/, ''),
+                            false
+                          ).re.source.replace(
+                            /\(\?:\\\/\)\?\$$/,
+                            '\\.prefetch\\.rsc$'
+                          )
+                        ),
+                }
               }
             }
-          }
 
-          const moveExportedPage = async (
-            originPage: string,
-            page: string,
-            file: string,
-            isSsg: boolean,
-            ext: 'html' | 'json',
-            additionalSsgFile = false
-          ) => {
-            return staticGenerationSpan
-              .traceChild('move-exported-page')
-              .traceAsyncFn(async () => {
-                file = `${file}.${ext}`
-                const orig = path.join(exportOptions.outdir, file)
-                const pagePath = getPagePath(
-                  originPage,
-                  distDir,
-                  undefined,
-                  false
-                )
+            const moveExportedPage = async (
+              originPage: string,
+              page: string,
+              file: string,
+              isSsg: boolean,
+              ext: 'html' | 'json',
+              additionalSsgFile = false
+            ) => {
+              return staticGenerationSpan
+                .traceChild('move-exported-page')
+                .traceAsyncFn(async () => {
+                  file = `${file}.${ext}`
+                  const orig = path.join(exportOptions.outdir, file)
+                  const pagePath = getPagePath(
+                    originPage,
+                    distDir,
+                    undefined,
+                    false
+                  )
 
-                const relativeDest = path
-                  .relative(
-                    path.join(distDir, SERVER_DIRECTORY),
-                    path.join(
+                  const relativeDest = path
+                    .relative(
+                      path.join(distDir, SERVER_DIRECTORY),
                       path.join(
-                        pagePath,
-                        // strip leading / and then recurse number of nested dirs
-                        // to place from base folder
-                        originPage
-                          .slice(1)
-                          .split('/')
-                          .map(() => '..')
-                          .join('/')
-                      ),
-                      file
-                    )
-                  )
-                  .replace(/\\/g, '/')
-
-                if (
-                  !isSsg &&
-                  !(
-                    // don't add static status page to manifest if it's
-                    // the default generated version e.g. no pages/500
-                    (
-                      STATIC_STATUS_PAGES.includes(page) &&
-                      !usedStaticStatusPages.includes(page)
-                    )
-                  )
-                ) {
-                  pagesManifest[page] = relativeDest
-                }
-
-                const dest = path.join(distDir, SERVER_DIRECTORY, relativeDest)
-                const isNotFound = ssgNotFoundPaths.includes(page)
-
-                // for SSG files with i18n the non-prerendered variants are
-                // output with the locale prefixed so don't attempt moving
-                // without the prefix
-                if ((!i18n || additionalSsgFile) && !isNotFound) {
-                  await fs.mkdir(path.dirname(dest), { recursive: true })
-                  await fs.rename(orig, dest)
-                } else if (i18n && !isSsg) {
-                  // this will be updated with the locale prefixed variant
-                  // since all files are output with the locale prefix
-                  delete pagesManifest[page]
-                }
-
-                if (i18n) {
-                  if (additionalSsgFile) return
-
-                  for (const locale of i18n.locales) {
-                    const curPath = `/${locale}${page === '/' ? '' : page}`
-                    const localeExt = page === '/' ? path.extname(file) : ''
-                    const relativeDestNoPages = relativeDest.slice(
-                      'pages/'.length
-                    )
-
-                    if (isSsg && ssgNotFoundPaths.includes(curPath)) {
-                      continue
-                    }
-
-                    const updatedRelativeDest = path
-                      .join(
-                        'pages',
-                        locale + localeExt,
-                        // if it's the top-most index page we want it to be locale.EXT
-                        // instead of locale/index.html
-                        page === '/' ? '' : relativeDestNoPages
+                        path.join(
+                          pagePath,
+                          // strip leading / and then recurse number of nested dirs
+                          // to place from base folder
+                          originPage
+                            .slice(1)
+                            .split('/')
+                            .map(() => '..')
+                            .join('/')
+                        ),
+                        file
                       )
-                      .replace(/\\/g, '/')
-
-                    const updatedOrig = path.join(
-                      exportOptions.outdir,
-                      locale + localeExt,
-                      page === '/' ? '' : file
                     )
-                    const updatedDest = path.join(
-                      distDir,
-                      SERVER_DIRECTORY,
-                      updatedRelativeDest
-                    )
+                    .replace(/\\/g, '/')
 
-                    if (!isSsg) {
-                      pagesManifest[curPath] = updatedRelativeDest
-                    }
-                    await fs.mkdir(path.dirname(updatedDest), {
-                      recursive: true,
-                    })
-                    await fs.rename(updatedOrig, updatedDest)
+                  if (
+                    !isSsg &&
+                    !(
+                      // don't add static status page to manifest if it's
+                      // the default generated version e.g. no pages/500
+                      (
+                        STATIC_STATUS_PAGES.includes(page) &&
+                        !usedStaticStatusPages.includes(page)
+                      )
+                    )
+                  ) {
+                    pagesManifest[page] = relativeDest
                   }
-                }
-              })
-          }
 
-          async function moveExportedAppNotFoundTo404() {
-            return staticGenerationSpan
-              .traceChild('move-exported-app-not-found-')
-              .traceAsyncFn(async () => {
-                const orig = path.join(
-                  distDir,
-                  'server',
-                  'app',
-                  '_not-found.html'
-                )
-                const updatedRelativeDest = path
-                  .join('pages', '404.html')
-                  .replace(/\\/g, '/')
-
-                if (existsSync(orig)) {
-                  await fs.copyFile(
-                    orig,
-                    path.join(distDir, 'server', updatedRelativeDest)
+                  const dest = path.join(
+                    distDir,
+                    SERVER_DIRECTORY,
+                    relativeDest
                   )
-                  pagesManifest['/404'] = updatedRelativeDest
-                }
-              })
-          }
+                  const isNotFound = ssgNotFoundPaths.includes(page)
 
-          // If there's /not-found inside app, we prefer it over the pages 404
-          if (hasStaticApp404) {
-            await moveExportedAppNotFoundTo404()
-          } else {
-            // Only move /404 to /404 when there is no custom 404 as in that case we don't know about the 404 page
-            if (!hasPages404 && !hasApp404 && useStaticPages404) {
-              await moveExportedPage('/_error', '/404', '/404', false, 'html')
-            }
-          }
-
-          if (useDefaultStatic500) {
-            await moveExportedPage('/_error', '/500', '/500', false, 'html')
-          }
-
-          for (const page of combinedPages) {
-            const isSsg = ssgPages.has(page)
-            const isStaticSsgFallback = ssgStaticFallbackPages.has(page)
-            const isDynamic = isDynamicRoute(page)
-            const hasAmp = hybridAmpPages.has(page)
-            const file = normalizePagePath(page)
-
-            const pageInfo = pageInfos.get(page)
-            const durationInfo = exportResult.byPage.get(page)
-            if (pageInfo && durationInfo) {
-              // Set Build Duration
-              if (pageInfo.ssgPageRoutes) {
-                pageInfo.ssgPageDurations = pageInfo.ssgPageRoutes.map(
-                  (pagePath) => {
-                    const duration = durationInfo.durationsByPath.get(pagePath)
-                    if (typeof duration === 'undefined') {
-                      throw new Error("Invariant: page wasn't built")
-                    }
-
-                    return duration
+                  // for SSG files with i18n the non-prerendered variants are
+                  // output with the locale prefixed so don't attempt moving
+                  // without the prefix
+                  if ((!i18n || additionalSsgFile) && !isNotFound) {
+                    await fs.mkdir(path.dirname(dest), { recursive: true })
+                    await fs.rename(orig, dest)
+                  } else if (i18n && !isSsg) {
+                    // this will be updated with the locale prefixed variant
+                    // since all files are output with the locale prefix
+                    delete pagesManifest[page]
                   }
-                )
+
+                  if (i18n) {
+                    if (additionalSsgFile) return
+
+                    for (const locale of i18n.locales) {
+                      const curPath = `/${locale}${page === '/' ? '' : page}`
+                      const localeExt = page === '/' ? path.extname(file) : ''
+                      const relativeDestNoPages = relativeDest.slice(
+                        'pages/'.length
+                      )
+
+                      if (isSsg && ssgNotFoundPaths.includes(curPath)) {
+                        continue
+                      }
+
+                      const updatedRelativeDest = path
+                        .join(
+                          'pages',
+                          locale + localeExt,
+                          // if it's the top-most index page we want it to be locale.EXT
+                          // instead of locale/index.html
+                          page === '/' ? '' : relativeDestNoPages
+                        )
+                        .replace(/\\/g, '/')
+
+                      const updatedOrig = path.join(
+                        exportOptions.outdir,
+                        locale + localeExt,
+                        page === '/' ? '' : file
+                      )
+                      const updatedDest = path.join(
+                        distDir,
+                        SERVER_DIRECTORY,
+                        updatedRelativeDest
+                      )
+
+                      if (!isSsg) {
+                        pagesManifest[curPath] = updatedRelativeDest
+                      }
+                      await fs.mkdir(path.dirname(updatedDest), {
+                        recursive: true,
+                      })
+                      await fs.rename(updatedOrig, updatedDest)
+                    }
+                  }
+                })
+            }
+
+            async function moveExportedAppNotFoundTo404() {
+              return staticGenerationSpan
+                .traceChild('move-exported-app-not-found-')
+                .traceAsyncFn(async () => {
+                  const orig = path.join(
+                    distDir,
+                    'server',
+                    'app',
+                    '_not-found.html'
+                  )
+                  const updatedRelativeDest = path
+                    .join('pages', '404.html')
+                    .replace(/\\/g, '/')
+
+                  if (existsSync(orig)) {
+                    await fs.copyFile(
+                      orig,
+                      path.join(distDir, 'server', updatedRelativeDest)
+                    )
+                    pagesManifest['/404'] = updatedRelativeDest
+                  }
+                })
+            }
+
+            // If there's /not-found inside app, we prefer it over the pages 404
+            if (hasStaticApp404) {
+              await moveExportedAppNotFoundTo404()
+            } else {
+              // Only move /404 to /404 when there is no custom 404 as in that case we don't know about the 404 page
+              if (!hasPages404 && !hasApp404 && useStaticPages404) {
+                await moveExportedPage('/_error', '/404', '/404', false, 'html')
               }
-              pageInfo.pageDuration = durationInfo.durationsByPath.get(page)
             }
 
-            // The dynamic version of SSG pages are only prerendered if the
-            // fallback is enabled. Below, we handle the specific prerenders
-            // of these.
-            const hasHtmlOutput = !(isSsg && isDynamic && !isStaticSsgFallback)
-
-            if (hasHtmlOutput) {
-              await moveExportedPage(page, page, file, isSsg, 'html')
+            if (useDefaultStatic500) {
+              await moveExportedPage('/_error', '/500', '/500', false, 'html')
             }
 
-            if (hasAmp && (!isSsg || (isSsg && !isDynamic))) {
-              const ampPage = `${file}.amp`
-              await moveExportedPage(page, ampPage, ampPage, isSsg, 'html')
+            for (const page of combinedPages) {
+              const isSsg = ssgPages.has(page)
+              const isStaticSsgFallback = ssgStaticFallbackPages.has(page)
+              const isDynamic = isDynamicRoute(page)
+              const hasAmp = hybridAmpPages.has(page)
+              const file = normalizePagePath(page)
+
+              const pageInfo = pageInfos.get(page)
+              const durationInfo = exportResult.byPage.get(page)
+              if (pageInfo && durationInfo) {
+                // Set Build Duration
+                if (pageInfo.ssgPageRoutes) {
+                  pageInfo.ssgPageDurations = pageInfo.ssgPageRoutes.map(
+                    (pagePath) => {
+                      const duration =
+                        durationInfo.durationsByPath.get(pagePath)
+                      if (typeof duration === 'undefined') {
+                        throw new Error("Invariant: page wasn't built")
+                      }
+
+                      return duration
+                    }
+                  )
+                }
+                pageInfo.pageDuration = durationInfo.durationsByPath.get(page)
+              }
+
+              // The dynamic version of SSG pages are only prerendered if the
+              // fallback is enabled. Below, we handle the specific prerenders
+              // of these.
+              const hasHtmlOutput = !(
+                isSsg &&
+                isDynamic &&
+                !isStaticSsgFallback
+              )
+
+              if (hasHtmlOutput) {
+                await moveExportedPage(page, page, file, isSsg, 'html')
+              }
+
+              if (hasAmp && (!isSsg || (isSsg && !isDynamic))) {
+                const ampPage = `${file}.amp`
+                await moveExportedPage(page, ampPage, ampPage, isSsg, 'html')
+
+                if (isSsg) {
+                  await moveExportedPage(page, ampPage, ampPage, isSsg, 'json')
+                }
+              }
 
               if (isSsg) {
-                await moveExportedPage(page, ampPage, ampPage, isSsg, 'json')
-              }
-            }
+                // For a non-dynamic SSG page, we must copy its data file
+                // from export, we already moved the HTML file above
+                if (!isDynamic) {
+                  await moveExportedPage(page, page, file, isSsg, 'json')
 
-            if (isSsg) {
-              // For a non-dynamic SSG page, we must copy its data file
-              // from export, we already moved the HTML file above
-              if (!isDynamic) {
-                await moveExportedPage(page, page, file, isSsg, 'json')
+                  if (i18n) {
+                    // TODO: do we want to show all locale variants in build output
+                    for (const locale of i18n.locales) {
+                      const localePage = `/${locale}${page === '/' ? '' : page}`
 
-                if (i18n) {
-                  // TODO: do we want to show all locale variants in build output
-                  for (const locale of i18n.locales) {
-                    const localePage = `/${locale}${page === '/' ? '' : page}`
-
-                    finalPrerenderRoutes[localePage] = {
+                      finalPrerenderRoutes[localePage] = {
+                        initialRevalidateSeconds:
+                          exportResult.byPath.get(localePage)?.revalidate ??
+                          false,
+                        experimentalPPR: undefined,
+                        srcRoute: null,
+                        dataRoute: path.posix.join(
+                          '/_next/data',
+                          buildId,
+                          `${file}.json`
+                        ),
+                        prefetchDataRoute: undefined,
+                      }
+                    }
+                  } else {
+                    finalPrerenderRoutes[page] = {
                       initialRevalidateSeconds:
-                        exportResult.byPath.get(localePage)?.revalidate ??
-                        false,
+                        exportResult.byPath.get(page)?.revalidate ?? false,
                       experimentalPPR: undefined,
                       srcRoute: null,
                       dataRoute: path.posix.join(
@@ -2656,445 +2700,441 @@ export default async function build(
                         buildId,
                         `${file}.json`
                       ),
+                      // Pages does not have a prefetch data route.
                       prefetchDataRoute: undefined,
                     }
                   }
-                } else {
-                  finalPrerenderRoutes[page] = {
-                    initialRevalidateSeconds:
-                      exportResult.byPath.get(page)?.revalidate ?? false,
-                    experimentalPPR: undefined,
-                    srcRoute: null,
-                    dataRoute: path.posix.join(
-                      '/_next/data',
-                      buildId,
-                      `${file}.json`
-                    ),
-                    // Pages does not have a prefetch data route.
-                    prefetchDataRoute: undefined,
+                  // Set Page Revalidation Interval
+                  if (pageInfo) {
+                    pageInfo.initialRevalidateSeconds =
+                      exportResult.byPath.get(page)?.revalidate ?? false
                   }
-                }
-                // Set Page Revalidation Interval
-                if (pageInfo) {
-                  pageInfo.initialRevalidateSeconds =
-                    exportResult.byPath.get(page)?.revalidate ?? false
-                }
-              } else {
-                // For a dynamic SSG page, we did not copy its data exports and only
-                // copy the fallback HTML file (if present).
-                // We must also copy specific versions of this page as defined by
-                // `getStaticPaths` (additionalSsgPaths).
-                const extraRoutes = additionalSsgPaths.get(page) || []
-                for (const route of extraRoutes) {
-                  const pageFile = normalizePagePath(route)
-                  await moveExportedPage(
-                    page,
-                    route,
-                    pageFile,
-                    isSsg,
-                    'html',
-                    true
-                  )
-                  await moveExportedPage(
-                    page,
-                    route,
-                    pageFile,
-                    isSsg,
-                    'json',
-                    true
-                  )
-
-                  if (hasAmp) {
-                    const ampPage = `${pageFile}.amp`
+                } else {
+                  // For a dynamic SSG page, we did not copy its data exports and only
+                  // copy the fallback HTML file (if present).
+                  // We must also copy specific versions of this page as defined by
+                  // `getStaticPaths` (additionalSsgPaths).
+                  const extraRoutes = additionalSsgPaths.get(page) || []
+                  for (const route of extraRoutes) {
+                    const pageFile = normalizePagePath(route)
                     await moveExportedPage(
                       page,
-                      ampPage,
-                      ampPage,
+                      route,
+                      pageFile,
                       isSsg,
                       'html',
                       true
                     )
                     await moveExportedPage(
                       page,
-                      ampPage,
-                      ampPage,
+                      route,
+                      pageFile,
                       isSsg,
                       'json',
                       true
                     )
-                  }
 
-                  const initialRevalidateSeconds =
-                    exportResult.byPath.get(route)?.revalidate ?? false
+                    if (hasAmp) {
+                      const ampPage = `${pageFile}.amp`
+                      await moveExportedPage(
+                        page,
+                        ampPage,
+                        ampPage,
+                        isSsg,
+                        'html',
+                        true
+                      )
+                      await moveExportedPage(
+                        page,
+                        ampPage,
+                        ampPage,
+                        isSsg,
+                        'json',
+                        true
+                      )
+                    }
 
-                  if (typeof initialRevalidateSeconds === 'undefined') {
-                    throw new Error("Invariant: page wasn't built")
-                  }
+                    const initialRevalidateSeconds =
+                      exportResult.byPath.get(route)?.revalidate ?? false
 
-                  finalPrerenderRoutes[route] = {
-                    initialRevalidateSeconds,
-                    experimentalPPR: undefined,
-                    srcRoute: page,
-                    dataRoute: path.posix.join(
-                      '/_next/data',
-                      buildId,
-                      `${normalizePagePath(route)}.json`
-                    ),
-                    // Pages does not have a prefetch data route.
-                    prefetchDataRoute: undefined,
-                  }
+                    if (typeof initialRevalidateSeconds === 'undefined') {
+                      throw new Error("Invariant: page wasn't built")
+                    }
 
-                  // Set route Revalidation Interval
-                  if (pageInfo) {
-                    pageInfo.initialRevalidateSeconds = initialRevalidateSeconds
+                    finalPrerenderRoutes[route] = {
+                      initialRevalidateSeconds,
+                      experimentalPPR: undefined,
+                      srcRoute: page,
+                      dataRoute: path.posix.join(
+                        '/_next/data',
+                        buildId,
+                        `${normalizePagePath(route)}.json`
+                      ),
+                      // Pages does not have a prefetch data route.
+                      prefetchDataRoute: undefined,
+                    }
+
+                    // Set route Revalidation Interval
+                    if (pageInfo) {
+                      pageInfo.initialRevalidateSeconds =
+                        initialRevalidateSeconds
+                    }
                   }
                 }
               }
             }
-          }
 
-          // remove temporary export folder
-          await fs.rm(exportOptions.outdir, { recursive: true, force: true })
-          await fs.writeFile(
-            manifestPath,
-            formatManifest(pagesManifest),
-            'utf8'
-          )
-        })
-      }
-
-      const postBuildSpinner = createSpinner('Finalizing page optimization')
-      let buildTracesSpinner = createSpinner(`Collecting build traces`)
-
-      // ensure the worker is not left hanging
-      pagesStaticWorkers.close()
-      appStaticWorkers?.close()
-
-      const analysisEnd = process.hrtime(analysisBegin)
-      telemetry.record(
-        eventBuildOptimize(pagesPaths, {
-          durationInSeconds: analysisEnd[0],
-          staticPageCount: staticPages.size,
-          staticPropsPageCount: ssgPages.size,
-          serverPropsPageCount: serverPropsPages.size,
-          ssrPageCount:
-            pagesPaths.length -
-            (staticPages.size + ssgPages.size + serverPropsPages.size),
-          hasStatic404: useStaticPages404,
-          hasReportWebVitals:
-            namedExports?.includes('reportWebVitals') ?? false,
-          rewritesCount: combinedRewrites.length,
-          headersCount: headers.length,
-          redirectsCount: redirects.length - 1, // reduce one for trailing slash
-          headersWithHasCount: headers.filter((r: any) => !!r.has).length,
-          rewritesWithHasCount: combinedRewrites.filter((r: any) => !!r.has)
-            .length,
-          redirectsWithHasCount: redirects.filter((r: any) => !!r.has).length,
-          middlewareCount: Object.keys(rootPaths).length > 0 ? 1 : 0,
-          totalAppPagesCount,
-          staticAppPagesCount,
-          serverAppPagesCount,
-          edgeRuntimeAppCount,
-          edgeRuntimePagesCount,
-        })
-      )
-
-      if (NextBuildContext.telemetryPlugin) {
-        const events = eventBuildFeatureUsage(NextBuildContext.telemetryPlugin)
-        telemetry.record(events)
-        telemetry.record(
-          eventPackageUsedInGetServerSideProps(NextBuildContext.telemetryPlugin)
-        )
-      }
-
-      if (ssgPages.size > 0 || appDir) {
-        tbdPrerenderRoutes.forEach((tbdRoute) => {
-          const normalizedRoute = normalizePagePath(tbdRoute)
-          const dataRoute = path.posix.join(
-            '/_next/data',
-            buildId,
-            `${normalizedRoute}.json`
-          )
-
-          finalDynamicRoutes[tbdRoute] = {
-            routeRegex: normalizeRouteRegex(
-              getNamedRouteRegex(tbdRoute, false).re.source
-            ),
-            experimentalPPR: undefined,
-            dataRoute,
-            fallback: ssgBlockingFallbackPages.has(tbdRoute)
-              ? null
-              : ssgStaticFallbackPages.has(tbdRoute)
-              ? `${normalizedRoute}.html`
-              : false,
-            dataRouteRegex: normalizeRouteRegex(
-              getNamedRouteRegex(
-                dataRoute.replace(/\.json$/, ''),
-                false
-              ).re.source.replace(/\(\?:\\\/\)\?\$$/, '\\.json$')
-            ),
-            // Pages does not have a prefetch data route.
-            prefetchDataRoute: undefined,
-            prefetchDataRouteRegex: undefined,
-          }
-        })
-        const prerenderManifest: Readonly<PrerenderManifest> = {
-          version: 4,
-          routes: finalPrerenderRoutes,
-          dynamicRoutes: finalDynamicRoutes,
-          notFoundRoutes: ssgNotFoundPaths,
-          preview: previewProps,
-        }
-        NextBuildContext.previewModeId = previewProps.previewModeId
-        NextBuildContext.fetchCacheKeyPrefix =
-          config.experimental.fetchCacheKeyPrefix
-        NextBuildContext.allowedRevalidateHeaderKeys =
-          config.experimental.allowedRevalidateHeaderKeys
-
-        await fs.writeFile(
-          path.join(distDir, PRERENDER_MANIFEST),
-          formatManifest(prerenderManifest),
-          'utf8'
-        )
-        await fs.writeFile(
-          path.join(distDir, PRERENDER_MANIFEST).replace(/\.json$/, '.js'),
-          `self.__PRERENDER_MANIFEST=${JSON.stringify(
-            JSON.stringify(prerenderManifest)
-          )}`,
-          'utf8'
-        )
-        await generateClientSsgManifest(prerenderManifest, {
-          distDir,
-          buildId,
-          locales: config.i18n?.locales || [],
-        })
-      } else {
-        const prerenderManifest: Readonly<PrerenderManifest> = {
-          version: 4,
-          routes: {},
-          dynamicRoutes: {},
-          preview: previewProps,
-          notFoundRoutes: [],
-        }
-        await fs.writeFile(
-          path.join(distDir, PRERENDER_MANIFEST),
-          formatManifest(prerenderManifest),
-          'utf8'
-        )
-        await fs.writeFile(
-          path.join(distDir, PRERENDER_MANIFEST).replace(/\.json$/, '.js'),
-          `self.__PRERENDER_MANIFEST=${JSON.stringify(
-            JSON.stringify(prerenderManifest)
-          )}`,
-          'utf8'
-        )
-      }
-
-      const images = { ...config.images }
-      const { deviceSizes, imageSizes } = images
-      ;(images as any).sizes = [...deviceSizes, ...imageSizes]
-      images.remotePatterns = (config?.images?.remotePatterns || []).map(
-        (p: RemotePattern) => ({
-          // Should be the same as matchRemotePattern()
-          protocol: p.protocol,
-          hostname: makeRe(p.hostname).source,
-          port: p.port,
-          pathname: makeRe(p.pathname ?? '**').source,
-        })
-      )
-
-      await fs.writeFile(
-        path.join(distDir, IMAGES_MANIFEST),
-        formatManifest({
-          version: 1,
-          images,
-        }),
-        'utf8'
-      )
-      await fs.writeFile(
-        path.join(distDir, EXPORT_MARKER),
-        formatManifest({
-          version: 1,
-          hasExportPathMap: typeof config.exportPathMap === 'function',
-          exportTrailingSlash: config.trailingSlash === true,
-          isNextImageImported: isNextImageImported === true,
-        }),
-        'utf8'
-      )
-      await fs.unlink(path.join(distDir, EXPORT_DETAIL)).catch((err) => {
-        if (err.code === 'ENOENT') {
-          return Promise.resolve()
-        }
-        return Promise.reject(err)
-      })
-
-      if (debugOutput) {
-        nextBuildSpan
-          .traceChild('print-custom-routes')
-          .traceFn(() => printCustomRoutes({ redirects, rewrites, headers }))
-      }
-
-      if (config.analyticsId) {
-        console.log(
-          bold(green('Next.js Speed Insights')) +
-            ' is enabled for this production build. ' +
-            "You'll receive a Real Experience Score computed by all of your visitors."
-        )
-        console.log('')
-      }
-
-      if (Boolean(config.experimental.nextScriptWorkers)) {
-        await nextBuildSpan
-          .traceChild('verify-partytown-setup')
-          .traceAsyncFn(async () => {
-            await verifyPartytownSetup(
-              dir,
-              path.join(distDir, CLIENT_STATIC_FILES_PATH)
+            // remove temporary export folder
+            await fs.rm(exportOptions.outdir, { recursive: true, force: true })
+            await fs.writeFile(
+              manifestPath,
+              formatManifest(pagesManifest),
+              'utf8'
             )
           })
-      }
+        }
 
-      if (config.output === 'export') {
+        const postBuildSpinner = createSpinner('Finalizing page optimization')
+        let buildTracesSpinner = createSpinner(`Collecting build traces`)
+
+        // ensure the worker is not left hanging
+        pagesStaticWorkers.close()
+        appStaticWorkers?.close()
+
+        const analysisEnd = process.hrtime(analysisBegin)
+        telemetry.record(
+          eventBuildOptimize(pagesPaths, {
+            durationInSeconds: analysisEnd[0],
+            staticPageCount: staticPages.size,
+            staticPropsPageCount: ssgPages.size,
+            serverPropsPageCount: serverPropsPages.size,
+            ssrPageCount:
+              pagesPaths.length -
+              (staticPages.size + ssgPages.size + serverPropsPages.size),
+            hasStatic404: useStaticPages404,
+            hasReportWebVitals:
+              namedExports?.includes('reportWebVitals') ?? false,
+            rewritesCount: combinedRewrites.length,
+            headersCount: headers.length,
+            redirectsCount: redirects.length - 1, // reduce one for trailing slash
+            headersWithHasCount: headers.filter((r: any) => !!r.has).length,
+            rewritesWithHasCount: combinedRewrites.filter((r: any) => !!r.has)
+              .length,
+            redirectsWithHasCount: redirects.filter((r: any) => !!r.has).length,
+            middlewareCount: Object.keys(rootPaths).length > 0 ? 1 : 0,
+            totalAppPagesCount,
+            staticAppPagesCount,
+            serverAppPagesCount,
+            edgeRuntimeAppCount,
+            edgeRuntimePagesCount,
+          })
+        )
+
+        if (NextBuildContext.telemetryPlugin) {
+          const events = eventBuildFeatureUsage(
+            NextBuildContext.telemetryPlugin
+          )
+          telemetry.record(events)
+          telemetry.record(
+            eventPackageUsedInGetServerSideProps(
+              NextBuildContext.telemetryPlugin
+            )
+          )
+        }
+
+        if (ssgPages.size > 0 || appDir) {
+          tbdPrerenderRoutes.forEach((tbdRoute) => {
+            const normalizedRoute = normalizePagePath(tbdRoute)
+            const dataRoute = path.posix.join(
+              '/_next/data',
+              buildId,
+              `${normalizedRoute}.json`
+            )
+
+            finalDynamicRoutes[tbdRoute] = {
+              routeRegex: normalizeRouteRegex(
+                getNamedRouteRegex(tbdRoute, false).re.source
+              ),
+              experimentalPPR: undefined,
+              dataRoute,
+              fallback: ssgBlockingFallbackPages.has(tbdRoute)
+                ? null
+                : ssgStaticFallbackPages.has(tbdRoute)
+                ? `${normalizedRoute}.html`
+                : false,
+              dataRouteRegex: normalizeRouteRegex(
+                getNamedRouteRegex(
+                  dataRoute.replace(/\.json$/, ''),
+                  false
+                ).re.source.replace(/\(\?:\\\/\)\?\$$/, '\\.json$')
+              ),
+              // Pages does not have a prefetch data route.
+              prefetchDataRoute: undefined,
+              prefetchDataRouteRegex: undefined,
+            }
+          })
+          const prerenderManifest: Readonly<PrerenderManifest> = {
+            version: 4,
+            routes: finalPrerenderRoutes,
+            dynamicRoutes: finalDynamicRoutes,
+            notFoundRoutes: ssgNotFoundPaths,
+            preview: previewProps,
+          }
+          NextBuildContext.previewModeId = previewProps.previewModeId
+          NextBuildContext.fetchCacheKeyPrefix =
+            config.experimental.fetchCacheKeyPrefix
+          NextBuildContext.allowedRevalidateHeaderKeys =
+            config.experimental.allowedRevalidateHeaderKeys
+
+          await fs.writeFile(
+            path.join(distDir, PRERENDER_MANIFEST),
+            formatManifest(prerenderManifest),
+            'utf8'
+          )
+          await fs.writeFile(
+            path.join(distDir, PRERENDER_MANIFEST).replace(/\.json$/, '.js'),
+            `self.__PRERENDER_MANIFEST=${JSON.stringify(
+              JSON.stringify(prerenderManifest)
+            )}`,
+            'utf8'
+          )
+          await generateClientSsgManifest(prerenderManifest, {
+            distDir,
+            buildId,
+            locales: config.i18n?.locales || [],
+          })
+        } else {
+          const prerenderManifest: Readonly<PrerenderManifest> = {
+            version: 4,
+            routes: {},
+            dynamicRoutes: {},
+            preview: previewProps,
+            notFoundRoutes: [],
+          }
+          await fs.writeFile(
+            path.join(distDir, PRERENDER_MANIFEST),
+            formatManifest(prerenderManifest),
+            'utf8'
+          )
+          await fs.writeFile(
+            path.join(distDir, PRERENDER_MANIFEST).replace(/\.json$/, '.js'),
+            `self.__PRERENDER_MANIFEST=${JSON.stringify(
+              JSON.stringify(prerenderManifest)
+            )}`,
+            'utf8'
+          )
+        }
+
+        const images = { ...config.images }
+        const { deviceSizes, imageSizes } = images
+        ;(images as any).sizes = [...deviceSizes, ...imageSizes]
+        images.remotePatterns = (config?.images?.remotePatterns || []).map(
+          (p: RemotePattern) => ({
+            // Should be the same as matchRemotePattern()
+            protocol: p.protocol,
+            hostname: makeRe(p.hostname).source,
+            port: p.port,
+            pathname: makeRe(p.pathname ?? '**').source,
+          })
+        )
+
+        await fs.writeFile(
+          path.join(distDir, IMAGES_MANIFEST),
+          formatManifest({
+            version: 1,
+            images,
+          }),
+          'utf8'
+        )
+        await fs.writeFile(
+          path.join(distDir, EXPORT_MARKER),
+          formatManifest({
+            version: 1,
+            hasExportPathMap: typeof config.exportPathMap === 'function',
+            exportTrailingSlash: config.trailingSlash === true,
+            isNextImageImported: isNextImageImported === true,
+          }),
+          'utf8'
+        )
+        await fs.unlink(path.join(distDir, EXPORT_DETAIL)).catch((err) => {
+          if (err.code === 'ENOENT') {
+            return Promise.resolve()
+          }
+          return Promise.reject(err)
+        })
+
+        if (debugOutput) {
+          nextBuildSpan
+            .traceChild('print-custom-routes')
+            .traceFn(() => printCustomRoutes({ redirects, rewrites, headers }))
+        }
+
+        if (config.analyticsId) {
+          console.log(
+            bold(green('Next.js Speed Insights')) +
+              ' is enabled for this production build. ' +
+              "You'll receive a Real Experience Score computed by all of your visitors."
+          )
+          console.log('')
+        }
+
+        if (Boolean(config.experimental.nextScriptWorkers)) {
+          await nextBuildSpan
+            .traceChild('verify-partytown-setup')
+            .traceAsyncFn(async () => {
+              await verifyPartytownSetup(
+                dir,
+                path.join(distDir, CLIENT_STATIC_FILES_PATH)
+              )
+            })
+        }
+
+        if (config.output === 'export') {
+          if (buildTracesSpinner) {
+            buildTracesSpinner?.stop()
+            buildTracesSpinner = undefined
+          }
+
+          const exportApp: typeof import('../export').default =
+            require('../export').default
+
+          const pagesWorker = createStaticWorker(
+            incrementalCacheIpcPort,
+            incrementalCacheIpcValidationKey
+          )
+          const appWorker = createStaticWorker(
+            incrementalCacheIpcPort,
+            incrementalCacheIpcValidationKey
+          )
+
+          const options: ExportAppOptions = {
+            buildExport: false,
+            nextConfig: config,
+            enabledDirectories,
+            silent: true,
+            threads: config.experimental.cpus,
+            outdir: path.join(dir, configOutDir),
+            // The worker already explicitly binds `this` to each of the
+            // exposed methods.
+            exportAppPageWorker: appWorker?.exportPage,
+            exportPageWorker: pagesWorker?.exportPage,
+            endWorker: async () => {
+              await pagesWorker.end()
+              await appWorker.end()
+            },
+          }
+
+          await exportApp(dir, options, nextBuildSpan)
+
+          // ensure the worker is not left hanging
+          pagesWorker.close()
+          appWorker.close()
+        }
+        await buildTracesPromise
+
+        if (config.output === 'standalone') {
+          await nextBuildSpan
+            .traceChild('copy-traced-files')
+            .traceAsyncFn(async () => {
+              await copyTracedFiles(
+                dir,
+                distDir,
+                pageKeys.pages,
+                denormalizedAppPages,
+                outputFileTracingRoot,
+                requiredServerFiles.config,
+                middlewareManifest,
+                hasInstrumentationHook,
+                staticPages
+              )
+
+              if (config.output === 'standalone') {
+                for (const file of [
+                  ...requiredServerFiles.files,
+                  path.join(config.distDir, SERVER_FILES_MANIFEST),
+                  ...loadedEnvFiles.reduce<string[]>((acc, envFile) => {
+                    if (['.env', '.env.production'].includes(envFile.path)) {
+                      acc.push(envFile.path)
+                    }
+                    return acc
+                  }, []),
+                ]) {
+                  const filePath = path.join(dir, file)
+                  const outputPath = path.join(
+                    distDir,
+                    'standalone',
+                    path.relative(outputFileTracingRoot, filePath)
+                  )
+                  await fs.mkdir(path.dirname(outputPath), {
+                    recursive: true,
+                  })
+                  await fs.copyFile(filePath, outputPath)
+                }
+                await recursiveCopy(
+                  path.join(distDir, SERVER_DIRECTORY, 'pages'),
+                  path.join(
+                    distDir,
+                    'standalone',
+                    path.relative(outputFileTracingRoot, distDir),
+                    SERVER_DIRECTORY,
+                    'pages'
+                  ),
+                  { overwrite: true }
+                )
+                if (appDir) {
+                  const originalServerApp = path.join(
+                    distDir,
+                    SERVER_DIRECTORY,
+                    'app'
+                  )
+                  if (existsSync(originalServerApp)) {
+                    await recursiveCopy(
+                      originalServerApp,
+                      path.join(
+                        distDir,
+                        'standalone',
+                        path.relative(outputFileTracingRoot, distDir),
+                        SERVER_DIRECTORY,
+                        'app'
+                      ),
+                      { overwrite: true }
+                    )
+                  }
+                }
+              }
+            })
+        }
+
         if (buildTracesSpinner) {
-          buildTracesSpinner?.stop()
+          buildTracesSpinner.stopAndPersist()
           buildTracesSpinner = undefined
         }
 
-        const exportApp: typeof import('../export').default =
-          require('../export').default
+        if (postBuildSpinner) postBuildSpinner.stopAndPersist()
+        console.log()
 
-        const pagesWorker = createStaticWorker(
-          incrementalCacheIpcPort,
-          incrementalCacheIpcValidationKey
-        )
-        const appWorker = createStaticWorker(
-          incrementalCacheIpcPort,
-          incrementalCacheIpcValidationKey
-        )
-
-        const options: ExportAppOptions = {
-          buildExport: false,
-          nextConfig: config,
-          enabledDirectories,
-          silent: true,
-          threads: config.experimental.cpus,
-          outdir: path.join(dir, configOutDir),
-          // The worker already explicitly binds `this` to each of the
-          // exposed methods.
-          exportAppPageWorker: appWorker?.exportPage,
-          exportPageWorker: pagesWorker?.exportPage,
-          endWorker: async () => {
-            await pagesWorker.end()
-            await appWorker.end()
-          },
-        }
-
-        await exportApp(dir, options, nextBuildSpan)
-
-        // ensure the worker is not left hanging
-        pagesWorker.close()
-        appWorker.close()
-      }
-      await buildTracesPromise
-
-      if (config.output === 'standalone') {
-        await nextBuildSpan
-          .traceChild('copy-traced-files')
-          .traceAsyncFn(async () => {
-            await copyTracedFiles(
-              dir,
-              distDir,
-              pageKeys.pages,
-              denormalizedAppPages,
-              outputFileTracingRoot,
-              requiredServerFiles.config,
-              middlewareManifest,
-              hasInstrumentationHook,
-              staticPages
-            )
-
-            if (config.output === 'standalone') {
-              for (const file of [
-                ...requiredServerFiles.files,
-                path.join(config.distDir, SERVER_FILES_MANIFEST),
-                ...loadedEnvFiles.reduce<string[]>((acc, envFile) => {
-                  if (['.env', '.env.production'].includes(envFile.path)) {
-                    acc.push(envFile.path)
-                  }
-                  return acc
-                }, []),
-              ]) {
-                const filePath = path.join(dir, file)
-                const outputPath = path.join(
-                  distDir,
-                  'standalone',
-                  path.relative(outputFileTracingRoot, filePath)
-                )
-                await fs.mkdir(path.dirname(outputPath), {
-                  recursive: true,
-                })
-                await fs.copyFile(filePath, outputPath)
-              }
-              await recursiveCopy(
-                path.join(distDir, SERVER_DIRECTORY, 'pages'),
-                path.join(
-                  distDir,
-                  'standalone',
-                  path.relative(outputFileTracingRoot, distDir),
-                  SERVER_DIRECTORY,
-                  'pages'
-                ),
-                { overwrite: true }
-              )
-              if (appDir) {
-                const originalServerApp = path.join(
-                  distDir,
-                  SERVER_DIRECTORY,
-                  'app'
-                )
-                if (existsSync(originalServerApp)) {
-                  await recursiveCopy(
-                    originalServerApp,
-                    path.join(
-                      distDir,
-                      'standalone',
-                      path.relative(outputFileTracingRoot, distDir),
-                      SERVER_DIRECTORY,
-                      'app'
-                    ),
-                    { overwrite: true }
-                  )
-                }
-              }
-            }
+        await nextBuildSpan.traceChild('print-tree-view').traceAsyncFn(() =>
+          printTreeView(pageKeys, pageInfos, {
+            distPath: distDir,
+            buildId: buildId,
+            pagesDir,
+            useStaticPages404,
+            pageExtensions: config.pageExtensions,
+            appBuildManifest,
+            buildManifest,
+            middlewareManifest,
+            gzipSize: config.experimental.gzipSize,
           })
+        )
+
+        await nextBuildSpan
+          .traceChild('telemetry-flush')
+          .traceAsyncFn(() => telemetry.flush())
+      } finally {
+        if (incrementalCacheIpcServer) {
+          incrementalCacheIpcServer.close()
+        }
       }
-
-      if (buildTracesSpinner) {
-        buildTracesSpinner.stopAndPersist()
-        buildTracesSpinner = undefined
-      }
-
-      if (postBuildSpinner) postBuildSpinner.stopAndPersist()
-      console.log()
-
-      await nextBuildSpan.traceChild('print-tree-view').traceAsyncFn(() =>
-        printTreeView(pageKeys, pageInfos, {
-          distPath: distDir,
-          buildId: buildId,
-          pagesDir,
-          useStaticPages404,
-          pageExtensions: config.pageExtensions,
-          appBuildManifest,
-          buildManifest,
-          middlewareManifest,
-          gzipSize: config.experimental.gzipSize,
-        })
-      )
-
-      await nextBuildSpan
-        .traceChild('telemetry-flush')
-        .traceAsyncFn(() => telemetry.flush())
     })
 
     return buildResult

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -14,6 +14,7 @@ import { bold, yellow, green } from '../lib/picocolors'
 import crypto from 'crypto'
 import { isMatch, makeRe } from 'next/dist/compiled/micromatch'
 import { existsSync, promises as fs } from 'fs'
+import { Server } from 'http'
 import os from 'os'
 import { Worker } from '../lib/worker'
 import { defaultConfig } from '../server/config-shared'
@@ -363,7 +364,7 @@ export default async function build(
   const isCompile = buildMode === 'experimental-compile'
   const isGenerate = buildMode === 'experimental-generate'
 
-  let incrementalCacheIpcServer
+  let incrementalCacheIpcServer: Server | undefined
   try {
     const nextBuildSpan = trace('next-build', undefined, {
       buildMode: buildMode,
@@ -3110,8 +3111,6 @@ export default async function build(
     teardownHeapProfiler()
     teardownCrashReporter()
 
-    if (incrementalCacheIpcServer) {
-      incrementalCacheIpcServer.close()
-    }
+    incrementalCacheIpcServer?.close()
   }
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -363,6 +363,7 @@ export default async function build(
   const isCompile = buildMode === 'experimental-compile'
   const isGenerate = buildMode === 'experimental-generate'
 
+  let incrementalCacheIpcServer
   try {
     const nextBuildSpan = trace('next-build', undefined, {
       buildMode: buildMode,
@@ -1302,1107 +1303,1022 @@ export default async function build(
 
       let incrementalCacheIpcPort
       let incrementalCacheIpcValidationKey
-      let incrementalCacheIpcServer
 
-      try {
-        if (config.experimental.staticWorkerRequestDeduping) {
-          let CacheHandler
-          if (incrementalCacheHandlerPath) {
-            CacheHandler = require(path.isAbsolute(incrementalCacheHandlerPath)
-              ? incrementalCacheHandlerPath
-              : path.join(dir, incrementalCacheHandlerPath))
-            CacheHandler = CacheHandler.default || CacheHandler
-          }
-
-          const cacheInitialization = await initializeIncrementalCache({
-            fs: nodeFs,
-            dev: false,
-            pagesDir: true,
-            appDir: true,
-            fetchCache: true,
-            flushToDisk: config.experimental.isrFlushToDisk,
-            serverDistDir: path.join(distDir, 'server'),
-            fetchCacheKeyPrefix: config.experimental.fetchCacheKeyPrefix,
-            maxMemoryCacheSize: config.experimental.isrMemoryCacheSize,
-            getPrerenderManifest: () => ({
-              version: -1 as any, // letting us know this doesn't conform to spec
-              routes: {},
-              dynamicRoutes: {},
-              notFoundRoutes: [],
-              preview: null as any, // `preview` is special case read in next-dev-server
-            }),
-            requestHeaders: {},
-            CurCacheHandler: CacheHandler,
-            minimalMode: ciEnvironment.hasNextSupport,
-            allowedRevalidateHeaderKeys:
-              config.experimental.allowedRevalidateHeaderKeys,
-            experimental: { ppr: config.experimental.ppr === true },
-          })
-
-          incrementalCacheIpcPort = cacheInitialization.ipcPort
-          incrementalCacheIpcValidationKey =
-            cacheInitialization.ipcValidationKey
-          incrementalCacheIpcServer = cacheInitialization.ipcServer
+      if (config.experimental.staticWorkerRequestDeduping) {
+        let CacheHandler
+        if (incrementalCacheHandlerPath) {
+          CacheHandler = require(path.isAbsolute(incrementalCacheHandlerPath)
+            ? incrementalCacheHandlerPath
+            : path.join(dir, incrementalCacheHandlerPath))
+          CacheHandler = CacheHandler.default || CacheHandler
         }
 
-        const pagesStaticWorkers = createStaticWorker(
-          incrementalCacheIpcPort,
-          incrementalCacheIpcValidationKey
-        )
-        const appStaticWorkers = appDir
-          ? createStaticWorker(
-              incrementalCacheIpcPort,
-              incrementalCacheIpcValidationKey
-            )
-          : undefined
+        const cacheInitialization = await initializeIncrementalCache({
+          fs: nodeFs,
+          dev: false,
+          pagesDir: true,
+          appDir: true,
+          fetchCache: true,
+          flushToDisk: config.experimental.isrFlushToDisk,
+          serverDistDir: path.join(distDir, 'server'),
+          fetchCacheKeyPrefix: config.experimental.fetchCacheKeyPrefix,
+          maxMemoryCacheSize: config.experimental.isrMemoryCacheSize,
+          getPrerenderManifest: () => ({
+            version: -1 as any, // letting us know this doesn't conform to spec
+            routes: {},
+            dynamicRoutes: {},
+            notFoundRoutes: [],
+            preview: null as any, // `preview` is special case read in next-dev-server
+          }),
+          requestHeaders: {},
+          CurCacheHandler: CacheHandler,
+          minimalMode: ciEnvironment.hasNextSupport,
+          allowedRevalidateHeaderKeys:
+            config.experimental.allowedRevalidateHeaderKeys,
+          experimental: { ppr: config.experimental.ppr === true },
+        })
 
-        const analysisBegin = process.hrtime()
-        const staticCheckSpan = nextBuildSpan.traceChild('static-check')
+        incrementalCacheIpcPort = cacheInitialization.ipcPort
+        incrementalCacheIpcValidationKey = cacheInitialization.ipcValidationKey
+        incrementalCacheIpcServer = cacheInitialization.ipcServer
+      }
 
-        const functionsConfigManifest = {} as Record<
-          string,
-          Record<string, any>
-        >
-        const {
-          customAppGetInitialProps,
-          namedExports,
-          isNextImageImported,
-          hasSsrAmpPages,
-          hasNonStaticErrorPage,
-        } = await staticCheckSpan.traceAsyncFn(async () => {
-          if (isCompile) {
-            return {
-              customAppGetInitialProps: false,
-              namedExports: [],
-              isNextImageImported: true,
-              hasSsrAmpPages: !!pagesDir,
-              hasNonStaticErrorPage: true,
-            }
-          }
-
-          const { configFileName, publicRuntimeConfig, serverRuntimeConfig } =
-            config
-          const runtimeEnvConfig = { publicRuntimeConfig, serverRuntimeConfig }
-
-          const nonStaticErrorPageSpan = staticCheckSpan.traceChild(
-            'check-static-error-page'
+      const pagesStaticWorkers = createStaticWorker(
+        incrementalCacheIpcPort,
+        incrementalCacheIpcValidationKey
+      )
+      const appStaticWorkers = appDir
+        ? createStaticWorker(
+            incrementalCacheIpcPort,
+            incrementalCacheIpcValidationKey
           )
-          const errorPageHasCustomGetInitialProps =
-            nonStaticErrorPageSpan.traceAsyncFn(
-              async () =>
-                hasCustomErrorPage &&
-                (await pagesStaticWorkers.hasCustomGetInitialProps(
-                  '/_error',
-                  distDir,
-                  runtimeEnvConfig,
-                  false
-                ))
-            )
+        : undefined
 
-          const errorPageStaticResult = nonStaticErrorPageSpan.traceAsyncFn(
+      const analysisBegin = process.hrtime()
+      const staticCheckSpan = nextBuildSpan.traceChild('static-check')
+
+      const functionsConfigManifest = {} as Record<string, Record<string, any>>
+      const {
+        customAppGetInitialProps,
+        namedExports,
+        isNextImageImported,
+        hasSsrAmpPages,
+        hasNonStaticErrorPage,
+      } = await staticCheckSpan.traceAsyncFn(async () => {
+        if (isCompile) {
+          return {
+            customAppGetInitialProps: false,
+            namedExports: [],
+            isNextImageImported: true,
+            hasSsrAmpPages: !!pagesDir,
+            hasNonStaticErrorPage: true,
+          }
+        }
+
+        const { configFileName, publicRuntimeConfig, serverRuntimeConfig } =
+          config
+        const runtimeEnvConfig = { publicRuntimeConfig, serverRuntimeConfig }
+
+        const nonStaticErrorPageSpan = staticCheckSpan.traceChild(
+          'check-static-error-page'
+        )
+        const errorPageHasCustomGetInitialProps =
+          nonStaticErrorPageSpan.traceAsyncFn(
             async () =>
               hasCustomErrorPage &&
-              pagesStaticWorkers.isPageStatic({
-                dir,
-                page: '/_error',
+              (await pagesStaticWorkers.hasCustomGetInitialProps(
+                '/_error',
                 distDir,
-                configFileName,
                 runtimeEnvConfig,
-                httpAgentOptions: config.httpAgentOptions,
-                locales: config.i18n?.locales,
-                defaultLocale: config.i18n?.defaultLocale,
-                nextConfigOutput: config.output,
-                ppr: config.experimental.ppr === true,
-              })
+                false
+              ))
           )
 
-          const appPageToCheck = '/_app'
-
-          const customAppGetInitialPropsPromise =
-            pagesStaticWorkers.hasCustomGetInitialProps(
-              appPageToCheck,
+        const errorPageStaticResult = nonStaticErrorPageSpan.traceAsyncFn(
+          async () =>
+            hasCustomErrorPage &&
+            pagesStaticWorkers.isPageStatic({
+              dir,
+              page: '/_error',
               distDir,
+              configFileName,
               runtimeEnvConfig,
-              true
-            )
+              httpAgentOptions: config.httpAgentOptions,
+              locales: config.i18n?.locales,
+              defaultLocale: config.i18n?.defaultLocale,
+              nextConfigOutput: config.output,
+              ppr: config.experimental.ppr === true,
+            })
+        )
 
-          const namedExportsPromise = pagesStaticWorkers.getDefinedNamedExports(
+        const appPageToCheck = '/_app'
+
+        const customAppGetInitialPropsPromise =
+          pagesStaticWorkers.hasCustomGetInitialProps(
             appPageToCheck,
             distDir,
-            runtimeEnvConfig
+            runtimeEnvConfig,
+            true
           )
 
-          // eslint-disable-next-line @typescript-eslint/no-shadow
-          let isNextImageImported: boolean | undefined
-          // eslint-disable-next-line @typescript-eslint/no-shadow
-          let hasSsrAmpPages = false
+        const namedExportsPromise = pagesStaticWorkers.getDefinedNamedExports(
+          appPageToCheck,
+          distDir,
+          runtimeEnvConfig
+        )
 
-          const computedManifestData = await computeFromManifest(
-            { build: buildManifest, app: appBuildManifest },
-            distDir,
-            config.experimental.gzipSize
-          )
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        let isNextImageImported: boolean | undefined
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        let hasSsrAmpPages = false
 
-          const middlewareManifest: MiddlewareManifest = require(path.join(
-            distDir,
-            SERVER_DIRECTORY,
-            MIDDLEWARE_MANIFEST
-          ))
+        const computedManifestData = await computeFromManifest(
+          { build: buildManifest, app: appBuildManifest },
+          distDir,
+          config.experimental.gzipSize
+        )
 
-          const actionManifest = appDir
-            ? (require(path.join(
-                distDir,
-                SERVER_DIRECTORY,
-                SERVER_REFERENCE_MANIFEST + '.json'
-              )) as ActionManifest)
-            : null
-          const entriesWithAction = actionManifest ? new Set() : null
-          if (actionManifest && entriesWithAction) {
-            for (const id in actionManifest.node) {
-              for (const entry in actionManifest.node[id].workers) {
-                entriesWithAction.add(entry)
-              }
-            }
-            for (const id in actionManifest.edge) {
-              for (const entry in actionManifest.edge[id].workers) {
-                entriesWithAction.add(entry)
-              }
-            }
-          }
+        const middlewareManifest: MiddlewareManifest = require(path.join(
+          distDir,
+          SERVER_DIRECTORY,
+          MIDDLEWARE_MANIFEST
+        ))
 
-          for (const key of Object.keys(middlewareManifest?.functions)) {
-            if (key.startsWith('/api')) {
-              edgeRuntimePagesCount++
+        const actionManifest = appDir
+          ? (require(path.join(
+              distDir,
+              SERVER_DIRECTORY,
+              SERVER_REFERENCE_MANIFEST + '.json'
+            )) as ActionManifest)
+          : null
+        const entriesWithAction = actionManifest ? new Set() : null
+        if (actionManifest && entriesWithAction) {
+          for (const id in actionManifest.node) {
+            for (const entry in actionManifest.node[id].workers) {
+              entriesWithAction.add(entry)
             }
           }
+          for (const id in actionManifest.edge) {
+            for (const entry in actionManifest.edge[id].workers) {
+              entriesWithAction.add(entry)
+            }
+          }
+        }
 
-          await Promise.all(
-            Object.entries(pageKeys)
-              .reduce<Array<{ pageType: keyof typeof pageKeys; page: string }>>(
-                (acc, [key, files]) => {
-                  if (!files) {
-                    return acc
-                  }
+        for (const key of Object.keys(middlewareManifest?.functions)) {
+          if (key.startsWith('/api')) {
+            edgeRuntimePagesCount++
+          }
+        }
 
-                  const pageType = key as keyof typeof pageKeys
-
-                  for (const page of files) {
-                    acc.push({ pageType, page })
-                  }
-
+        await Promise.all(
+          Object.entries(pageKeys)
+            .reduce<Array<{ pageType: keyof typeof pageKeys; page: string }>>(
+              (acc, [key, files]) => {
+                if (!files) {
                   return acc
-                },
-                []
-              )
-              .map(({ pageType, page }) => {
-                const checkPageSpan = staticCheckSpan.traceChild('check-page', {
-                  page,
-                })
-                return checkPageSpan.traceAsyncFn(async () => {
-                  const actualPage = normalizePagePath(page)
-                  const [size, totalSize] = await getJsPageSizeInKb(
-                    pageType,
-                    actualPage,
-                    distDir,
-                    buildManifest,
-                    appBuildManifest,
-                    config.experimental.gzipSize,
-                    computedManifestData
-                  )
+                }
 
-                  let isPPR = false
-                  let isSSG = false
-                  let isStatic = false
-                  let isServerComponent = false
-                  let isHybridAmp = false
-                  let ssgPageRoutes: string[] | null = null
-                  let pagePath = ''
+                const pageType = key as keyof typeof pageKeys
 
-                  if (pageType === 'pages') {
-                    pagePath =
-                      pagesPaths.find((p) => {
-                        p = normalizePathSep(p)
-                        return (
-                          p.startsWith(actualPage + '.') ||
-                          p.startsWith(actualPage + '/index.')
-                        )
-                      }) || ''
-                  }
-                  let originalAppPath: string | undefined
+                for (const page of files) {
+                  acc.push({ pageType, page })
+                }
 
-                  if (pageType === 'app' && mappedAppPages) {
-                    for (const [originalPath, normalizedPath] of Object.entries(
-                      appPathRoutes
-                    )) {
-                      if (normalizedPath === page) {
-                        pagePath = mappedAppPages[originalPath].replace(
-                          /^private-next-app-dir/,
-                          ''
-                        )
-                        originalAppPath = originalPath
-                        break
-                      }
+                return acc
+              },
+              []
+            )
+            .map(({ pageType, page }) => {
+              const checkPageSpan = staticCheckSpan.traceChild('check-page', {
+                page,
+              })
+              return checkPageSpan.traceAsyncFn(async () => {
+                const actualPage = normalizePagePath(page)
+                const [size, totalSize] = await getJsPageSizeInKb(
+                  pageType,
+                  actualPage,
+                  distDir,
+                  buildManifest,
+                  appBuildManifest,
+                  config.experimental.gzipSize,
+                  computedManifestData
+                )
+
+                let isPPR = false
+                let isSSG = false
+                let isStatic = false
+                let isServerComponent = false
+                let isHybridAmp = false
+                let ssgPageRoutes: string[] | null = null
+                let pagePath = ''
+
+                if (pageType === 'pages') {
+                  pagePath =
+                    pagesPaths.find((p) => {
+                      p = normalizePathSep(p)
+                      return (
+                        p.startsWith(actualPage + '.') ||
+                        p.startsWith(actualPage + '/index.')
+                      )
+                    }) || ''
+                }
+                let originalAppPath: string | undefined
+
+                if (pageType === 'app' && mappedAppPages) {
+                  for (const [originalPath, normalizedPath] of Object.entries(
+                    appPathRoutes
+                  )) {
+                    if (normalizedPath === page) {
+                      pagePath = mappedAppPages[originalPath].replace(
+                        /^private-next-app-dir/,
+                        ''
+                      )
+                      originalAppPath = originalPath
+                      break
                     }
                   }
+                }
 
-                  const pageFilePath = isAppBuiltinNotFoundPage(pagePath)
-                    ? require.resolve(
-                        'next/dist/client/components/not-found-error'
-                      )
-                    : path.join(
-                        (pageType === 'pages' ? pagesDir : appDir) || '',
-                        pagePath
-                      )
+                const pageFilePath = isAppBuiltinNotFoundPage(pagePath)
+                  ? require.resolve(
+                      'next/dist/client/components/not-found-error'
+                    )
+                  : path.join(
+                      (pageType === 'pages' ? pagesDir : appDir) || '',
+                      pagePath
+                    )
 
-                  const staticInfo = pagePath
-                    ? await getPageStaticInfo({
-                        pageFilePath,
-                        nextConfig: config,
-                        pageType,
-                      })
-                    : undefined
+                const staticInfo = pagePath
+                  ? await getPageStaticInfo({
+                      pageFilePath,
+                      nextConfig: config,
+                      pageType,
+                    })
+                  : undefined
 
-                  if (staticInfo?.extraConfig) {
-                    functionsConfigManifest[page] = staticInfo.extraConfig
-                  }
+                if (staticInfo?.extraConfig) {
+                  functionsConfigManifest[page] = staticInfo.extraConfig
+                }
 
-                  const pageRuntime = middlewareManifest.functions[
-                    originalAppPath || page
-                  ]
-                    ? 'edge'
-                    : staticInfo?.runtime
+                const pageRuntime = middlewareManifest.functions[
+                  originalAppPath || page
+                ]
+                  ? 'edge'
+                  : staticInfo?.runtime
 
-                  if (!isCompile) {
-                    isServerComponent =
-                      pageType === 'app' &&
-                      staticInfo?.rsc !== RSC_MODULE_TYPES.client
+                if (!isCompile) {
+                  isServerComponent =
+                    pageType === 'app' &&
+                    staticInfo?.rsc !== RSC_MODULE_TYPES.client
 
-                    if (pageType === 'app' || !isReservedPage(page)) {
-                      try {
-                        let edgeInfo: any
+                  if (pageType === 'app' || !isReservedPage(page)) {
+                    try {
+                      let edgeInfo: any
 
-                        if (isEdgeRuntime(pageRuntime)) {
-                          if (pageType === 'app') {
-                            edgeRuntimeAppCount++
-                          } else {
-                            edgeRuntimePagesCount++
-                          }
-
-                          const manifestKey =
-                            pageType === 'pages' ? page : originalAppPath || ''
-
-                          edgeInfo = middlewareManifest.functions[manifestKey]
+                      if (isEdgeRuntime(pageRuntime)) {
+                        if (pageType === 'app') {
+                          edgeRuntimeAppCount++
+                        } else {
+                          edgeRuntimePagesCount++
                         }
 
-                        let isPageStaticSpan =
-                          checkPageSpan.traceChild('is-page-static')
-                        let workerResult = await isPageStaticSpan.traceAsyncFn(
-                          () => {
-                            return (
-                              pageType === 'app'
-                                ? appStaticWorkers
-                                : pagesStaticWorkers
-                            )!.isPageStatic({
-                              dir,
-                              page,
-                              originalAppPath,
-                              distDir,
-                              configFileName,
-                              runtimeEnvConfig,
-                              httpAgentOptions: config.httpAgentOptions,
-                              locales: config.i18n?.locales,
-                              defaultLocale: config.i18n?.defaultLocale,
-                              parentId: isPageStaticSpan.id,
-                              pageRuntime,
-                              edgeInfo,
-                              pageType,
-                              incrementalCacheHandlerPath:
-                                config.experimental.incrementalCacheHandlerPath,
-                              isrFlushToDisk:
-                                config.experimental.isrFlushToDisk,
-                              maxMemoryCacheSize:
-                                config.experimental.isrMemoryCacheSize,
-                              nextConfigOutput: config.output,
-                              ppr: config.experimental.ppr === true,
-                            })
-                          }
-                        )
+                        const manifestKey =
+                          pageType === 'pages' ? page : originalAppPath || ''
 
-                        if (pageType === 'app' && originalAppPath) {
-                          appNormalizedPaths.set(originalAppPath, page)
-                          // TODO-APP: handle prerendering with edge
-                          if (isEdgeRuntime(pageRuntime)) {
-                            isStatic = false
-                            isSSG = false
+                        edgeInfo = middlewareManifest.functions[manifestKey]
+                      }
 
-                            Log.warnOnce(
-                              `Using edge runtime on a page currently disables static generation for that page`
-                            )
-                          } else {
-                            // If this route can be partially pre-rendered, then
-                            // mark it as such and mark it that it can be
-                            // generated server-side.
-                            if (workerResult.isPPR) {
-                              isPPR = workerResult.isPPR
-                              isSSG = true
-                              isStatic = true
+                      let isPageStaticSpan =
+                        checkPageSpan.traceChild('is-page-static')
+                      let workerResult = await isPageStaticSpan.traceAsyncFn(
+                        () => {
+                          return (
+                            pageType === 'app'
+                              ? appStaticWorkers
+                              : pagesStaticWorkers
+                          )!.isPageStatic({
+                            dir,
+                            page,
+                            originalAppPath,
+                            distDir,
+                            configFileName,
+                            runtimeEnvConfig,
+                            httpAgentOptions: config.httpAgentOptions,
+                            locales: config.i18n?.locales,
+                            defaultLocale: config.i18n?.defaultLocale,
+                            parentId: isPageStaticSpan.id,
+                            pageRuntime,
+                            edgeInfo,
+                            pageType,
+                            incrementalCacheHandlerPath:
+                              config.experimental.incrementalCacheHandlerPath,
+                            isrFlushToDisk: config.experimental.isrFlushToDisk,
+                            maxMemoryCacheSize:
+                              config.experimental.isrMemoryCacheSize,
+                            nextConfigOutput: config.output,
+                            ppr: config.experimental.ppr === true,
+                          })
+                        }
+                      )
 
-                              appStaticPaths.set(originalAppPath, [])
-                              appStaticPathsEncoded.set(originalAppPath, [])
-                            }
+                      if (pageType === 'app' && originalAppPath) {
+                        appNormalizedPaths.set(originalAppPath, page)
+                        // TODO-APP: handle prerendering with edge
+                        if (isEdgeRuntime(pageRuntime)) {
+                          isStatic = false
+                          isSSG = false
 
-                            if (
-                              workerResult.encodedPrerenderRoutes &&
-                              workerResult.prerenderRoutes
-                            ) {
-                              appStaticPaths.set(
-                                originalAppPath,
-                                workerResult.prerenderRoutes
-                              )
-                              appStaticPathsEncoded.set(
-                                originalAppPath,
-                                workerResult.encodedPrerenderRoutes
-                              )
-                              ssgPageRoutes = workerResult.prerenderRoutes
-                              isSSG = true
-                            }
-
-                            const appConfig = workerResult.appConfig || {}
-                            if (appConfig.revalidate !== 0) {
-                              const isDynamic = isDynamicRoute(page)
-                              const hasGenerateStaticParams =
-                                !!workerResult.prerenderRoutes?.length
-
-                              if (
-                                config.output === 'export' &&
-                                isDynamic &&
-                                !hasGenerateStaticParams
-                              ) {
-                                throw new Error(
-                                  `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
-                                )
-                              }
-
-                              if (
-                                // Mark the app as static if:
-                                // - It has no dynamic param
-                                // - It doesn't have generateStaticParams but `dynamic` is set to
-                                //   `error` or `force-static`
-                                !isDynamic
-                              ) {
-                                appStaticPaths.set(originalAppPath, [page])
-                                appStaticPathsEncoded.set(originalAppPath, [
-                                  page,
-                                ])
-                                isStatic = true
-                              } else if (
-                                isDynamic &&
-                                !hasGenerateStaticParams &&
-                                (appConfig.dynamic === 'error' ||
-                                  appConfig.dynamic === 'force-static')
-                              ) {
-                                appStaticPaths.set(originalAppPath, [])
-                                appStaticPathsEncoded.set(originalAppPath, [])
-                                isStatic = true
-                                isPPR = false
-                              }
-                            }
-
-                            if (workerResult.prerenderFallback) {
-                              // whether or not to allow requests for paths not
-                              // returned from generateStaticParams
-                              appDynamicParamPaths.add(originalAppPath)
-                            }
-                            appDefaultConfigs.set(originalAppPath, appConfig)
-
-                            // Only generate the app prefetch rsc if the route is
-                            // an app page.
-                            if (
-                              !isStatic &&
-                              !isAppRouteRoute(originalAppPath) &&
-                              !isDynamicRoute(originalAppPath) &&
-                              !isPPR
-                            ) {
-                              appPrefetchPaths.set(originalAppPath, page)
-                            }
-                          }
+                          Log.warnOnce(
+                            `Using edge runtime on a page currently disables static generation for that page`
+                          )
                         } else {
-                          if (isEdgeRuntime(pageRuntime)) {
-                            if (workerResult.hasStaticProps) {
-                              console.warn(
-                                `"getStaticProps" is not yet supported fully with "experimental-edge", detected on ${page}`
-                              )
-                            }
-                            // TODO: add handling for statically rendering edge
-                            // pages and allow edge with Prerender outputs
-                            workerResult.isStatic = false
-                            workerResult.hasStaticProps = false
+                          // If this route can be partially pre-rendered, then
+                          // mark it as such and mark it that it can be
+                          // generated server-side.
+                          if (workerResult.isPPR) {
+                            isPPR = workerResult.isPPR
+                            isSSG = true
+                            isStatic = true
+
+                            appStaticPaths.set(originalAppPath, [])
+                            appStaticPathsEncoded.set(originalAppPath, [])
                           }
 
                           if (
-                            workerResult.isStatic === false &&
-                            (workerResult.isHybridAmp || workerResult.isAmpOnly)
+                            workerResult.encodedPrerenderRoutes &&
+                            workerResult.prerenderRoutes
                           ) {
-                            hasSsrAmpPages = true
-                          }
-
-                          if (workerResult.isHybridAmp) {
-                            isHybridAmp = true
-                            hybridAmpPages.add(page)
-                          }
-
-                          if (workerResult.isNextImageImported) {
-                            isNextImageImported = true
-                          }
-
-                          if (workerResult.hasStaticProps) {
-                            ssgPages.add(page)
-                            isSSG = true
-
-                            if (
-                              workerResult.prerenderRoutes &&
+                            appStaticPaths.set(
+                              originalAppPath,
+                              workerResult.prerenderRoutes
+                            )
+                            appStaticPathsEncoded.set(
+                              originalAppPath,
                               workerResult.encodedPrerenderRoutes
-                            ) {
-                              additionalSsgPaths.set(
-                                page,
-                                workerResult.prerenderRoutes
-                              )
-                              additionalSsgPathsEncoded.set(
-                                page,
-                                workerResult.encodedPrerenderRoutes
-                              )
-                              ssgPageRoutes = workerResult.prerenderRoutes
-                            }
-
-                            if (workerResult.prerenderFallback === 'blocking') {
-                              ssgBlockingFallbackPages.add(page)
-                            } else if (
-                              workerResult.prerenderFallback === true
-                            ) {
-                              ssgStaticFallbackPages.add(page)
-                            }
-                          } else if (workerResult.hasServerProps) {
-                            serverPropsPages.add(page)
-                          } else if (
-                            workerResult.isStatic &&
-                            !isServerComponent &&
-                            (await customAppGetInitialPropsPromise) === false
-                          ) {
-                            staticPages.add(page)
-                            isStatic = true
-                          } else if (isServerComponent) {
-                            // This is a static server component page that doesn't have
-                            // gSP or gSSP. We still treat it as a SSG page.
-                            ssgPages.add(page)
+                            )
+                            ssgPageRoutes = workerResult.prerenderRoutes
                             isSSG = true
                           }
 
-                          if (hasPages404 && page === '/404') {
+                          const appConfig = workerResult.appConfig || {}
+                          if (appConfig.revalidate !== 0) {
+                            const isDynamic = isDynamicRoute(page)
+                            const hasGenerateStaticParams =
+                              !!workerResult.prerenderRoutes?.length
+
                             if (
-                              !workerResult.isStatic &&
-                              !workerResult.hasStaticProps
+                              config.output === 'export' &&
+                              isDynamic &&
+                              !hasGenerateStaticParams
                             ) {
                               throw new Error(
-                                `\`pages/404\` ${STATIC_STATUS_PAGE_GET_INITIAL_PROPS_ERROR}`
+                                `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
                               )
                             }
-                            // we need to ensure the 404 lambda is present since we use
-                            // it when _app has getInitialProps
+
                             if (
-                              (await customAppGetInitialPropsPromise) &&
-                              !workerResult.hasStaticProps
+                              // Mark the app as static if:
+                              // - It has no dynamic param
+                              // - It doesn't have generateStaticParams but `dynamic` is set to
+                              //   `error` or `force-static`
+                              !isDynamic
                             ) {
-                              staticPages.delete(page)
+                              appStaticPaths.set(originalAppPath, [page])
+                              appStaticPathsEncoded.set(originalAppPath, [page])
+                              isStatic = true
+                            } else if (
+                              isDynamic &&
+                              !hasGenerateStaticParams &&
+                              (appConfig.dynamic === 'error' ||
+                                appConfig.dynamic === 'force-static')
+                            ) {
+                              appStaticPaths.set(originalAppPath, [])
+                              appStaticPathsEncoded.set(originalAppPath, [])
+                              isStatic = true
+                              isPPR = false
                             }
                           }
 
+                          if (workerResult.prerenderFallback) {
+                            // whether or not to allow requests for paths not
+                            // returned from generateStaticParams
+                            appDynamicParamPaths.add(originalAppPath)
+                          }
+                          appDefaultConfigs.set(originalAppPath, appConfig)
+
+                          // Only generate the app prefetch rsc if the route is
+                          // an app page.
                           if (
-                            STATIC_STATUS_PAGES.includes(page) &&
+                            !isStatic &&
+                            !isAppRouteRoute(originalAppPath) &&
+                            !isDynamicRoute(originalAppPath) &&
+                            !isPPR
+                          ) {
+                            appPrefetchPaths.set(originalAppPath, page)
+                          }
+                        }
+                      } else {
+                        if (isEdgeRuntime(pageRuntime)) {
+                          if (workerResult.hasStaticProps) {
+                            console.warn(
+                              `"getStaticProps" is not yet supported fully with "experimental-edge", detected on ${page}`
+                            )
+                          }
+                          // TODO: add handling for statically rendering edge
+                          // pages and allow edge with Prerender outputs
+                          workerResult.isStatic = false
+                          workerResult.hasStaticProps = false
+                        }
+
+                        if (
+                          workerResult.isStatic === false &&
+                          (workerResult.isHybridAmp || workerResult.isAmpOnly)
+                        ) {
+                          hasSsrAmpPages = true
+                        }
+
+                        if (workerResult.isHybridAmp) {
+                          isHybridAmp = true
+                          hybridAmpPages.add(page)
+                        }
+
+                        if (workerResult.isNextImageImported) {
+                          isNextImageImported = true
+                        }
+
+                        if (workerResult.hasStaticProps) {
+                          ssgPages.add(page)
+                          isSSG = true
+
+                          if (
+                            workerResult.prerenderRoutes &&
+                            workerResult.encodedPrerenderRoutes
+                          ) {
+                            additionalSsgPaths.set(
+                              page,
+                              workerResult.prerenderRoutes
+                            )
+                            additionalSsgPathsEncoded.set(
+                              page,
+                              workerResult.encodedPrerenderRoutes
+                            )
+                            ssgPageRoutes = workerResult.prerenderRoutes
+                          }
+
+                          if (workerResult.prerenderFallback === 'blocking') {
+                            ssgBlockingFallbackPages.add(page)
+                          } else if (workerResult.prerenderFallback === true) {
+                            ssgStaticFallbackPages.add(page)
+                          }
+                        } else if (workerResult.hasServerProps) {
+                          serverPropsPages.add(page)
+                        } else if (
+                          workerResult.isStatic &&
+                          !isServerComponent &&
+                          (await customAppGetInitialPropsPromise) === false
+                        ) {
+                          staticPages.add(page)
+                          isStatic = true
+                        } else if (isServerComponent) {
+                          // This is a static server component page that doesn't have
+                          // gSP or gSSP. We still treat it as a SSG page.
+                          ssgPages.add(page)
+                          isSSG = true
+                        }
+
+                        if (hasPages404 && page === '/404') {
+                          if (
                             !workerResult.isStatic &&
                             !workerResult.hasStaticProps
                           ) {
                             throw new Error(
-                              `\`pages${page}\` ${STATIC_STATUS_PAGE_GET_INITIAL_PROPS_ERROR}`
+                              `\`pages/404\` ${STATIC_STATUS_PAGE_GET_INITIAL_PROPS_ERROR}`
                             )
                           }
+                          // we need to ensure the 404 lambda is present since we use
+                          // it when _app has getInitialProps
+                          if (
+                            (await customAppGetInitialPropsPromise) &&
+                            !workerResult.hasStaticProps
+                          ) {
+                            staticPages.delete(page)
+                          }
                         }
-                      } catch (err) {
-                        if (
-                          !isError(err) ||
-                          err.message !== 'INVALID_DEFAULT_EXPORT'
-                        )
-                          throw err
-                        invalidPages.add(page)
-                      }
-                    }
 
-                    if (pageType === 'app') {
-                      if (isSSG || isStatic) {
-                        staticAppPagesCount++
-                      } else {
-                        serverAppPagesCount++
+                        if (
+                          STATIC_STATUS_PAGES.includes(page) &&
+                          !workerResult.isStatic &&
+                          !workerResult.hasStaticProps
+                        ) {
+                          throw new Error(
+                            `\`pages${page}\` ${STATIC_STATUS_PAGE_GET_INITIAL_PROPS_ERROR}`
+                          )
+                        }
                       }
+                    } catch (err) {
+                      if (
+                        !isError(err) ||
+                        err.message !== 'INVALID_DEFAULT_EXPORT'
+                      )
+                        throw err
+                      invalidPages.add(page)
                     }
                   }
 
-                  pageInfos.set(page, {
-                    size,
-                    totalSize,
-                    isStatic,
-                    isSSG,
-                    isPPR,
-                    isHybridAmp,
-                    ssgPageRoutes,
-                    initialRevalidateSeconds: false,
-                    runtime: pageRuntime,
-                    pageDuration: undefined,
-                    ssgPageDurations: undefined,
-                    hasEmptyPrelude: undefined,
-                  })
+                  if (pageType === 'app') {
+                    if (isSSG || isStatic) {
+                      staticAppPagesCount++
+                    } else {
+                      serverAppPagesCount++
+                    }
+                  }
+                }
+
+                pageInfos.set(page, {
+                  size,
+                  totalSize,
+                  isStatic,
+                  isSSG,
+                  isPPR,
+                  isHybridAmp,
+                  ssgPageRoutes,
+                  initialRevalidateSeconds: false,
+                  runtime: pageRuntime,
+                  pageDuration: undefined,
+                  ssgPageDurations: undefined,
+                  hasEmptyPrelude: undefined,
                 })
               })
-          )
-
-          const errorPageResult = await errorPageStaticResult
-          const nonStaticErrorPage =
-            (await errorPageHasCustomGetInitialProps) ||
-            (errorPageResult && errorPageResult.hasServerProps)
-
-          const returnValue = {
-            customAppGetInitialProps: await customAppGetInitialPropsPromise,
-            namedExports: await namedExportsPromise,
-            isNextImageImported,
-            hasSsrAmpPages,
-            hasNonStaticErrorPage: nonStaticErrorPage,
-          }
-
-          return returnValue
-        })
-
-        if (postCompileSpinner) postCompileSpinner.stopAndPersist()
-
-        if (customAppGetInitialProps) {
-          console.warn(
-            bold(yellow(`Warning: `)) +
-              yellow(
-                `You have opted-out of Automatic Static Optimization due to \`getInitialProps\` in \`pages/_app\`. This does not opt-out pages with \`getStaticProps\``
-              )
-          )
-          console.warn(
-            'Read more: https://nextjs.org/docs/messages/opt-out-auto-static-optimization\n'
-          )
-        }
-
-        if (!hasSsrAmpPages) {
-          requiredServerFiles.ignore.push(
-            path.relative(
-              dir,
-              path.join(
-                path.dirname(
-                  require.resolve(
-                    'next/dist/compiled/@ampproject/toolbox-optimizer'
-                  )
-                ),
-                '**/*'
-              )
-            )
-          )
-        }
-
-        if (Object.keys(functionsConfigManifest).length > 0) {
-          const manifest: {
-            version: number
-            functions: Record<string, Record<string, string | number>>
-          } = {
-            version: 1,
-            functions: functionsConfigManifest,
-          }
-
-          await fs.writeFile(
-            path.join(distDir, SERVER_DIRECTORY, FUNCTIONS_CONFIG_MANIFEST),
-            formatManifest(manifest),
-            'utf8'
-          )
-        }
-
-        if (!isGenerate && config.outputFileTracing && !buildTracesPromise) {
-          buildTracesPromise = collectBuildTraces({
-            dir,
-            config,
-            distDir,
-            pageKeys,
-            pageInfos: Object.entries(pageInfos),
-            staticPages: [...staticPages],
-            nextBuildSpan,
-            hasSsrAmpPages,
-            buildTraceContext,
-            outputFileTracingRoot,
-          }).catch((err) => {
-            console.error(err)
-            process.exit(1)
-          })
-        }
-
-        if (serverPropsPages.size > 0 || ssgPages.size > 0) {
-          // We update the routes manifest after the build with the
-          // data routes since we can't determine these until after build
-          routesManifest.dataRoutes = getSortedRoutes([
-            ...serverPropsPages,
-            ...ssgPages,
-          ]).map((page) => {
-            return buildDataRoute(page, buildId)
-          })
-
-          await fs.writeFile(
-            routesManifestPath,
-            formatManifest(routesManifest),
-            'utf8'
-          )
-        }
-
-        // Since custom _app.js can wrap the 404 page we have to opt-out of static optimization if it has getInitialProps
-        // Only export the static 404 when there is no /_error present
-        const useStaticPages404 =
-          !customAppGetInitialProps && (!hasNonStaticErrorPage || hasPages404)
-
-        if (invalidPages.size > 0) {
-          const err = new Error(
-            `Build optimization failed: found page${
-              invalidPages.size === 1 ? '' : 's'
-            } without a React Component as default export in \n${[
-              ...invalidPages,
-            ]
-              .map((pg) => `pages${pg}`)
-              .join(
-                '\n'
-              )}\n\nSee https://nextjs.org/docs/messages/page-without-valid-component for more info.\n`
-          ) as NextError
-          err.code = 'BUILD_OPTIMIZATION_FAILED'
-          throw err
-        }
-
-        await writeBuildId(distDir, buildId)
-
-        if (config.experimental.optimizeCss) {
-          const globOrig =
-            require('next/dist/compiled/glob') as typeof import('next/dist/compiled/glob')
-
-          const cssFilePaths = await new Promise<string[]>(
-            (resolve, reject) => {
-              globOrig(
-                '**/*.css',
-                { cwd: path.join(distDir, 'static') },
-                (err, files) => {
-                  if (err) {
-                    return reject(err)
-                  }
-                  resolve(files)
-                }
-              )
-            }
-          )
-
-          requiredServerFiles.files.push(
-            ...cssFilePaths.map((filePath) =>
-              path.join(config.distDir, 'static', filePath)
-            )
-          )
-        }
-
-        const features: EventBuildFeatureUsage[] = [
-          {
-            featureName: 'experimental/optimizeCss',
-            invocationCount: config.experimental.optimizeCss ? 1 : 0,
-          },
-          {
-            featureName: 'experimental/nextScriptWorkers',
-            invocationCount: config.experimental.nextScriptWorkers ? 1 : 0,
-          },
-          {
-            featureName: 'optimizeFonts',
-            invocationCount: config.optimizeFonts ? 1 : 0,
-          },
-        ]
-        telemetry.record(
-          features.map((feature) => {
-            return {
-              eventName: EVENT_BUILD_FEATURE_USAGE,
-              payload: feature,
-            }
-          })
+            })
         )
+
+        const errorPageResult = await errorPageStaticResult
+        const nonStaticErrorPage =
+          (await errorPageHasCustomGetInitialProps) ||
+          (errorPageResult && errorPageResult.hasServerProps)
+
+        const returnValue = {
+          customAppGetInitialProps: await customAppGetInitialPropsPromise,
+          namedExports: await namedExportsPromise,
+          isNextImageImported,
+          hasSsrAmpPages,
+          hasNonStaticErrorPage: nonStaticErrorPage,
+        }
+
+        return returnValue
+      })
+
+      if (postCompileSpinner) postCompileSpinner.stopAndPersist()
+
+      if (customAppGetInitialProps) {
+        console.warn(
+          bold(yellow(`Warning: `)) +
+            yellow(
+              `You have opted-out of Automatic Static Optimization due to \`getInitialProps\` in \`pages/_app\`. This does not opt-out pages with \`getStaticProps\``
+            )
+        )
+        console.warn(
+          'Read more: https://nextjs.org/docs/messages/opt-out-auto-static-optimization\n'
+        )
+      }
+
+      if (!hasSsrAmpPages) {
+        requiredServerFiles.ignore.push(
+          path.relative(
+            dir,
+            path.join(
+              path.dirname(
+                require.resolve(
+                  'next/dist/compiled/@ampproject/toolbox-optimizer'
+                )
+              ),
+              '**/*'
+            )
+          )
+        )
+      }
+
+      if (Object.keys(functionsConfigManifest).length > 0) {
+        const manifest: {
+          version: number
+          functions: Record<string, Record<string, string | number>>
+        } = {
+          version: 1,
+          functions: functionsConfigManifest,
+        }
 
         await fs.writeFile(
-          path.join(distDir, SERVER_FILES_MANIFEST),
-          formatManifest(requiredServerFiles),
+          path.join(distDir, SERVER_DIRECTORY, FUNCTIONS_CONFIG_MANIFEST),
+          formatManifest(manifest),
           'utf8'
         )
+      }
 
-        const middlewareManifest: MiddlewareManifest = JSON.parse(
-          await fs.readFile(
-            path.join(distDir, SERVER_DIRECTORY, MIDDLEWARE_MANIFEST),
-            'utf8'
-          )
-        )
+      if (!isGenerate && config.outputFileTracing && !buildTracesPromise) {
+        buildTracesPromise = collectBuildTraces({
+          dir,
+          config,
+          distDir,
+          pageKeys,
+          pageInfos: Object.entries(pageInfos),
+          staticPages: [...staticPages],
+          nextBuildSpan,
+          hasSsrAmpPages,
+          buildTraceContext,
+          outputFileTracingRoot,
+        }).catch((err) => {
+          console.error(err)
+          process.exit(1)
+        })
+      }
 
-        const finalPrerenderRoutes: { [route: string]: SsgRoute } = {}
-        const finalDynamicRoutes: PrerenderManifest['dynamicRoutes'] = {}
-        const tbdPrerenderRoutes: string[] = []
-        let ssgNotFoundPaths: string[] = []
-
-        const { i18n } = config
-
-        const usedStaticStatusPages = STATIC_STATUS_PAGES.filter(
-          (page) =>
-            mappedPages[page] &&
-            mappedPages[page].startsWith('private-next-pages')
-        )
-        usedStaticStatusPages.forEach((page) => {
-          if (!ssgPages.has(page) && !customAppGetInitialProps) {
-            staticPages.add(page)
-          }
+      if (serverPropsPages.size > 0 || ssgPages.size > 0) {
+        // We update the routes manifest after the build with the
+        // data routes since we can't determine these until after build
+        routesManifest.dataRoutes = getSortedRoutes([
+          ...serverPropsPages,
+          ...ssgPages,
+        ]).map((page) => {
+          return buildDataRoute(page, buildId)
         })
 
-        const hasPages500 = usedStaticStatusPages.includes('/500')
-        const useDefaultStatic500 =
-          !hasPages500 && !hasNonStaticErrorPage && !customAppGetInitialProps
+        await fs.writeFile(
+          routesManifestPath,
+          formatManifest(routesManifest),
+          'utf8'
+        )
+      }
 
-        const combinedPages = [...staticPages, ...ssgPages]
-        const isApp404Static = appStaticPaths.has('/_not-found')
-        const hasStaticApp404 = hasApp404 && isApp404Static
+      // Since custom _app.js can wrap the 404 page we have to opt-out of static optimization if it has getInitialProps
+      // Only export the static 404 when there is no /_error present
+      const useStaticPages404 =
+        !customAppGetInitialProps && (!hasNonStaticErrorPage || hasPages404)
 
-        // we need to trigger automatic exporting when we have
-        // - static 404/500
-        // - getStaticProps paths
-        // - experimental app is enabled
-        if (
-          !isCompile &&
-          (combinedPages.length > 0 ||
-            useStaticPages404 ||
-            useDefaultStatic500 ||
-            appDir)
-        ) {
-          const staticGenerationSpan =
-            nextBuildSpan.traceChild('static-generation')
-          await staticGenerationSpan.traceAsyncFn(async () => {
-            detectConflictingPaths(
-              [
-                ...combinedPages,
-                ...pageKeys.pages.filter(
-                  (page) => !combinedPages.includes(page)
-                ),
-              ],
-              ssgPages,
-              additionalSsgPaths
-            )
-            const exportApp: ExportAppWorker = require('../export').default
+      if (invalidPages.size > 0) {
+        const err = new Error(
+          `Build optimization failed: found page${
+            invalidPages.size === 1 ? '' : 's'
+          } without a React Component as default export in \n${[...invalidPages]
+            .map((pg) => `pages${pg}`)
+            .join(
+              '\n'
+            )}\n\nSee https://nextjs.org/docs/messages/page-without-valid-component for more info.\n`
+        ) as NextError
+        err.code = 'BUILD_OPTIMIZATION_FAILED'
+        throw err
+      }
 
-            const exportConfig: NextConfigComplete = {
-              ...config,
-              // Default map will be the collection of automatic statically exported
-              // pages and incremental pages.
-              // n.b. we cannot handle this above in combinedPages because the dynamic
-              // page must be in the `pages` array, but not in the mapping.
-              exportPathMap: (defaultMap: ExportPathMap) => {
-                // Dynamically routed pages should be prerendered to be used as
-                // a client-side skeleton (fallback) while data is being fetched.
-                // This ensures the end-user never sees a 500 or slow response from the
-                // server.
-                //
-                // Note: prerendering disables automatic static optimization.
-                ssgPages.forEach((page) => {
-                  if (isDynamicRoute(page)) {
-                    tbdPrerenderRoutes.push(page)
+      await writeBuildId(distDir, buildId)
 
-                    if (ssgStaticFallbackPages.has(page)) {
-                      // Override the rendering for the dynamic page to be treated as a
-                      // fallback render.
-                      if (i18n) {
-                        defaultMap[`/${i18n.defaultLocale}${page}`] = {
-                          page,
-                          query: { __nextFallback: 'true' },
-                        }
-                      } else {
-                        defaultMap[page] = {
-                          page,
-                          query: { __nextFallback: 'true' },
-                        }
+      if (config.experimental.optimizeCss) {
+        const globOrig =
+          require('next/dist/compiled/glob') as typeof import('next/dist/compiled/glob')
+
+        const cssFilePaths = await new Promise<string[]>((resolve, reject) => {
+          globOrig(
+            '**/*.css',
+            { cwd: path.join(distDir, 'static') },
+            (err, files) => {
+              if (err) {
+                return reject(err)
+              }
+              resolve(files)
+            }
+          )
+        })
+
+        requiredServerFiles.files.push(
+          ...cssFilePaths.map((filePath) =>
+            path.join(config.distDir, 'static', filePath)
+          )
+        )
+      }
+
+      const features: EventBuildFeatureUsage[] = [
+        {
+          featureName: 'experimental/optimizeCss',
+          invocationCount: config.experimental.optimizeCss ? 1 : 0,
+        },
+        {
+          featureName: 'experimental/nextScriptWorkers',
+          invocationCount: config.experimental.nextScriptWorkers ? 1 : 0,
+        },
+        {
+          featureName: 'optimizeFonts',
+          invocationCount: config.optimizeFonts ? 1 : 0,
+        },
+      ]
+      telemetry.record(
+        features.map((feature) => {
+          return {
+            eventName: EVENT_BUILD_FEATURE_USAGE,
+            payload: feature,
+          }
+        })
+      )
+
+      await fs.writeFile(
+        path.join(distDir, SERVER_FILES_MANIFEST),
+        formatManifest(requiredServerFiles),
+        'utf8'
+      )
+
+      const middlewareManifest: MiddlewareManifest = JSON.parse(
+        await fs.readFile(
+          path.join(distDir, SERVER_DIRECTORY, MIDDLEWARE_MANIFEST),
+          'utf8'
+        )
+      )
+
+      const finalPrerenderRoutes: { [route: string]: SsgRoute } = {}
+      const finalDynamicRoutes: PrerenderManifest['dynamicRoutes'] = {}
+      const tbdPrerenderRoutes: string[] = []
+      let ssgNotFoundPaths: string[] = []
+
+      const { i18n } = config
+
+      const usedStaticStatusPages = STATIC_STATUS_PAGES.filter(
+        (page) =>
+          mappedPages[page] &&
+          mappedPages[page].startsWith('private-next-pages')
+      )
+      usedStaticStatusPages.forEach((page) => {
+        if (!ssgPages.has(page) && !customAppGetInitialProps) {
+          staticPages.add(page)
+        }
+      })
+
+      const hasPages500 = usedStaticStatusPages.includes('/500')
+      const useDefaultStatic500 =
+        !hasPages500 && !hasNonStaticErrorPage && !customAppGetInitialProps
+
+      const combinedPages = [...staticPages, ...ssgPages]
+      const isApp404Static = appStaticPaths.has('/_not-found')
+      const hasStaticApp404 = hasApp404 && isApp404Static
+
+      // we need to trigger automatic exporting when we have
+      // - static 404/500
+      // - getStaticProps paths
+      // - experimental app is enabled
+      if (
+        !isCompile &&
+        (combinedPages.length > 0 ||
+          useStaticPages404 ||
+          useDefaultStatic500 ||
+          appDir)
+      ) {
+        const staticGenerationSpan =
+          nextBuildSpan.traceChild('static-generation')
+        await staticGenerationSpan.traceAsyncFn(async () => {
+          detectConflictingPaths(
+            [
+              ...combinedPages,
+              ...pageKeys.pages.filter((page) => !combinedPages.includes(page)),
+            ],
+            ssgPages,
+            additionalSsgPaths
+          )
+          const exportApp: ExportAppWorker = require('../export').default
+
+          const exportConfig: NextConfigComplete = {
+            ...config,
+            // Default map will be the collection of automatic statically exported
+            // pages and incremental pages.
+            // n.b. we cannot handle this above in combinedPages because the dynamic
+            // page must be in the `pages` array, but not in the mapping.
+            exportPathMap: (defaultMap: ExportPathMap) => {
+              // Dynamically routed pages should be prerendered to be used as
+              // a client-side skeleton (fallback) while data is being fetched.
+              // This ensures the end-user never sees a 500 or slow response from the
+              // server.
+              //
+              // Note: prerendering disables automatic static optimization.
+              ssgPages.forEach((page) => {
+                if (isDynamicRoute(page)) {
+                  tbdPrerenderRoutes.push(page)
+
+                  if (ssgStaticFallbackPages.has(page)) {
+                    // Override the rendering for the dynamic page to be treated as a
+                    // fallback render.
+                    if (i18n) {
+                      defaultMap[`/${i18n.defaultLocale}${page}`] = {
+                        page,
+                        query: { __nextFallback: 'true' },
                       }
                     } else {
-                      // Remove dynamically routed pages from the default path map when
-                      // fallback behavior is disabled.
-                      delete defaultMap[page]
-                    }
-                  }
-                })
-
-                // Append the "well-known" routes we should prerender for, e.g. blog
-                // post slugs.
-                additionalSsgPaths.forEach((routes, page) => {
-                  const encodedRoutes = additionalSsgPathsEncoded.get(page)
-
-                  routes.forEach((route, routeIdx) => {
-                    defaultMap[route] = {
-                      page,
-                      query: { __nextSsgPath: encodedRoutes?.[routeIdx] },
-                    }
-                  })
-                })
-
-                if (useStaticPages404) {
-                  defaultMap['/404'] = {
-                    page: hasPages404 ? '/404' : '/_error',
-                  }
-                }
-
-                if (useDefaultStatic500) {
-                  defaultMap['/500'] = {
-                    page: '/_error',
-                  }
-                }
-
-                // TODO: output manifest specific to app paths and their
-                // revalidate periods and dynamicParams settings
-                appStaticPaths.forEach((routes, originalAppPath) => {
-                  const encodedRoutes =
-                    appStaticPathsEncoded.get(originalAppPath)
-                  const appConfig = appDefaultConfigs.get(originalAppPath) || {}
-
-                  routes.forEach((route, routeIdx) => {
-                    defaultMap[route] = {
-                      page: originalAppPath,
-                      query: { __nextSsgPath: encodedRoutes?.[routeIdx] },
-                      _isDynamicError: appConfig.dynamic === 'error',
-                      _isAppDir: true,
-                    }
-                  })
-                })
-
-                // Ensure we don't generate explicit app prefetches while in PPR.
-                if (config.experimental.ppr && appPrefetchPaths.size > 0) {
-                  throw new Error(
-                    "Invariant: explicit app prefetches shouldn't generated with PPR"
-                  )
-                }
-
-                for (const [originalAppPath, page] of appPrefetchPaths) {
-                  defaultMap[page] = {
-                    page: originalAppPath,
-                    query: {},
-                    _isAppDir: true,
-                    _isAppPrefetch: true,
-                  }
-                }
-
-                if (i18n) {
-                  for (const page of [
-                    ...staticPages,
-                    ...ssgPages,
-                    ...(useStaticPages404 ? ['/404'] : []),
-                    ...(useDefaultStatic500 ? ['/500'] : []),
-                  ]) {
-                    const isSsg = ssgPages.has(page)
-                    const isDynamic = isDynamicRoute(page)
-                    const isFallback = isSsg && ssgStaticFallbackPages.has(page)
-
-                    for (const locale of i18n.locales) {
-                      // skip fallback generation for SSG pages without fallback mode
-                      if (isSsg && isDynamic && !isFallback) continue
-                      const outputPath = `/${locale}${page === '/' ? '' : page}`
-
-                      defaultMap[outputPath] = {
-                        page: defaultMap[page]?.page || page,
-                        query: {
-                          __nextLocale: locale,
-                          __nextFallback: isFallback ? 'true' : undefined,
-                        },
+                      defaultMap[page] = {
+                        page,
+                        query: { __nextFallback: 'true' },
                       }
                     }
-
-                    if (isSsg) {
-                      // remove non-locale prefixed variant from defaultMap
-                      delete defaultMap[page]
-                    }
-                  }
-                }
-                return defaultMap
-              },
-            }
-
-            const exportOptions: ExportAppOptions = {
-              nextConfig: exportConfig,
-              enabledDirectories,
-              silent: false,
-              buildExport: true,
-              debugOutput,
-              threads: config.experimental.cpus,
-              pages: combinedPages,
-              outdir: path.join(distDir, 'export'),
-              statusMessage: 'Generating static pages',
-              // The worker already explicitly binds `this` to each of the
-              // exposed methods.
-              exportAppPageWorker: appStaticWorkers?.exportPage,
-              exportPageWorker: pagesStaticWorkers?.exportPage,
-              endWorker: async () => {
-                await pagesStaticWorkers.end()
-                await appStaticWorkers?.end()
-              },
-            }
-
-            const exportResult = await exportApp(
-              dir,
-              exportOptions,
-              nextBuildSpan
-            )
-
-            // If there was no result, there's nothing more to do.
-            if (!exportResult) return
-
-            ssgNotFoundPaths = Array.from(exportResult.ssgNotFoundPaths)
-
-            // remove server bundles that were exported
-            for (const page of staticPages) {
-              const serverBundle = getPagePath(page, distDir, undefined, false)
-              await fs.unlink(serverBundle)
-            }
-
-            for (const [originalAppPath, routes] of appStaticPaths) {
-              const page = appNormalizedPaths.get(originalAppPath) || ''
-              const appConfig = appDefaultConfigs.get(originalAppPath) || {}
-              let hasDynamicData =
-                appConfig.revalidate === 0 ||
-                exportResult.byPath.get(page)?.revalidate === 0
-
-              if (hasDynamicData && pageInfos.get(page)?.isStatic) {
-                // if the page was marked as being static, but it contains dynamic data
-                // (ie, in the case of a static generation bailout), then it should be marked dynamic
-                pageInfos.set(page, {
-                  ...(pageInfos.get(page) as PageInfo),
-                  isStatic: false,
-                  isSSG: false,
-                })
-              }
-
-              const isRouteHandler = isAppRouteRoute(originalAppPath)
-
-              // When this is an app page and PPR is enabled, the route supports
-              // partial pre-rendering.
-              const experimentalPPR =
-                !isRouteHandler && config.experimental.ppr === true
-                  ? true
-                  : undefined
-
-              // this flag is used to selectively bypass the static cache and invoke the lambda directly
-              // to enable server actions on static routes
-              const bypassFor: RouteHas[] = [
-                { type: 'header', key: ACTION },
-                {
-                  type: 'header',
-                  key: 'content-type',
-                  value: 'multipart/form-data',
-                },
-              ]
-
-              routes.forEach((route) => {
-                if (isDynamicRoute(page) && route === page) return
-                if (route === '/_not-found') return
-
-                const {
-                  revalidate = appConfig.revalidate ?? false,
-                  metadata = {},
-                  hasEmptyPrelude,
-                  hasPostponed,
-                } = exportResult.byPath.get(route) ?? {}
-
-                pageInfos.set(route, {
-                  ...(pageInfos.get(route) as PageInfo),
-                  hasPostponed,
-                  hasEmptyPrelude,
-                })
-
-                // update the page (eg /blog/[slug]) to also have the postpone metadata
-                pageInfos.set(page, {
-                  ...(pageInfos.get(page) as PageInfo),
-                  hasPostponed,
-                  hasEmptyPrelude,
-                })
-
-                if (revalidate !== 0) {
-                  const normalizedRoute = normalizePagePath(route)
-
-                  let dataRoute: string | null
-                  if (isRouteHandler) {
-                    dataRoute = null
                   } else {
-                    dataRoute = path.posix.join(
-                      `${normalizedRoute}${RSC_SUFFIX}`
-                    )
+                    // Remove dynamically routed pages from the default path map when
+                    // fallback behavior is disabled.
+                    delete defaultMap[page]
                   }
-
-                  let prefetchDataRoute: string | null | undefined
-                  if (experimentalPPR) {
-                    prefetchDataRoute = path.posix.join(
-                      `${normalizedRoute}${RSC_PREFETCH_SUFFIX}`
-                    )
-                  }
-
-                  const routeMeta: Partial<SsgRoute> = {}
-
-                  if (metadata.status !== 200) {
-                    routeMeta.initialStatus = metadata.status
-                  }
-
-                  const exportHeaders = metadata.headers
-                  const headerKeys = Object.keys(exportHeaders || {})
-
-                  if (exportHeaders && headerKeys.length) {
-                    routeMeta.initialHeaders = {}
-
-                    // normalize header values as initialHeaders
-                    // must be Record<string, string>
-                    for (const key of headerKeys) {
-                      let value = exportHeaders[key]
-
-                      if (Array.isArray(value)) {
-                        if (key === 'set-cookie') {
-                          value = value.join(',')
-                        } else {
-                          value = value[value.length - 1]
-                        }
-                      }
-
-                      if (typeof value === 'string') {
-                        routeMeta.initialHeaders[key] = value
-                      }
-                    }
-                  }
-
-                  finalPrerenderRoutes[route] = {
-                    ...routeMeta,
-                    experimentalPPR,
-                    experimentalBypassFor: bypassFor,
-                    initialRevalidateSeconds: revalidate,
-                    srcRoute: page,
-                    dataRoute,
-                    prefetchDataRoute,
-                  }
-                } else {
-                  hasDynamicData = true
-                  // we might have determined during prerendering that this page
-                  // used dynamic data
-                  pageInfos.set(route, {
-                    ...(pageInfos.get(route) as PageInfo),
-                    isSSG: false,
-                    isStatic: false,
-                  })
                 }
               })
 
-              if (!hasDynamicData && isDynamicRoute(originalAppPath)) {
-                const normalizedRoute = normalizePagePath(page)
-                const dataRoute = path.posix.join(
-                  `${normalizedRoute}${RSC_SUFFIX}`
+              // Append the "well-known" routes we should prerender for, e.g. blog
+              // post slugs.
+              additionalSsgPaths.forEach((routes, page) => {
+                const encodedRoutes = additionalSsgPathsEncoded.get(page)
+
+                routes.forEach((route, routeIdx) => {
+                  defaultMap[route] = {
+                    page,
+                    query: { __nextSsgPath: encodedRoutes?.[routeIdx] },
+                  }
+                })
+              })
+
+              if (useStaticPages404) {
+                defaultMap['/404'] = {
+                  page: hasPages404 ? '/404' : '/_error',
+                }
+              }
+
+              if (useDefaultStatic500) {
+                defaultMap['/500'] = {
+                  page: '/_error',
+                }
+              }
+
+              // TODO: output manifest specific to app paths and their
+              // revalidate periods and dynamicParams settings
+              appStaticPaths.forEach((routes, originalAppPath) => {
+                const encodedRoutes = appStaticPathsEncoded.get(originalAppPath)
+                const appConfig = appDefaultConfigs.get(originalAppPath) || {}
+
+                routes.forEach((route, routeIdx) => {
+                  defaultMap[route] = {
+                    page: originalAppPath,
+                    query: { __nextSsgPath: encodedRoutes?.[routeIdx] },
+                    _isDynamicError: appConfig.dynamic === 'error',
+                    _isAppDir: true,
+                  }
+                })
+              })
+
+              // Ensure we don't generate explicit app prefetches while in PPR.
+              if (config.experimental.ppr && appPrefetchPaths.size > 0) {
+                throw new Error(
+                  "Invariant: explicit app prefetches shouldn't generated with PPR"
                 )
+              }
+
+              for (const [originalAppPath, page] of appPrefetchPaths) {
+                defaultMap[page] = {
+                  page: originalAppPath,
+                  query: {},
+                  _isAppDir: true,
+                  _isAppPrefetch: true,
+                }
+              }
+
+              if (i18n) {
+                for (const page of [
+                  ...staticPages,
+                  ...ssgPages,
+                  ...(useStaticPages404 ? ['/404'] : []),
+                  ...(useDefaultStatic500 ? ['/500'] : []),
+                ]) {
+                  const isSsg = ssgPages.has(page)
+                  const isDynamic = isDynamicRoute(page)
+                  const isFallback = isSsg && ssgStaticFallbackPages.has(page)
+
+                  for (const locale of i18n.locales) {
+                    // skip fallback generation for SSG pages without fallback mode
+                    if (isSsg && isDynamic && !isFallback) continue
+                    const outputPath = `/${locale}${page === '/' ? '' : page}`
+
+                    defaultMap[outputPath] = {
+                      page: defaultMap[page]?.page || page,
+                      query: {
+                        __nextLocale: locale,
+                        __nextFallback: isFallback ? 'true' : undefined,
+                      },
+                    }
+                  }
+
+                  if (isSsg) {
+                    // remove non-locale prefixed variant from defaultMap
+                    delete defaultMap[page]
+                  }
+                }
+              }
+              return defaultMap
+            },
+          }
+
+          const exportOptions: ExportAppOptions = {
+            nextConfig: exportConfig,
+            enabledDirectories,
+            silent: false,
+            buildExport: true,
+            debugOutput,
+            threads: config.experimental.cpus,
+            pages: combinedPages,
+            outdir: path.join(distDir, 'export'),
+            statusMessage: 'Generating static pages',
+            // The worker already explicitly binds `this` to each of the
+            // exposed methods.
+            exportAppPageWorker: appStaticWorkers?.exportPage,
+            exportPageWorker: pagesStaticWorkers?.exportPage,
+            endWorker: async () => {
+              await pagesStaticWorkers.end()
+              await appStaticWorkers?.end()
+            },
+          }
+
+          const exportResult = await exportApp(
+            dir,
+            exportOptions,
+            nextBuildSpan
+          )
+
+          // If there was no result, there's nothing more to do.
+          if (!exportResult) return
+
+          ssgNotFoundPaths = Array.from(exportResult.ssgNotFoundPaths)
+
+          // remove server bundles that were exported
+          for (const page of staticPages) {
+            const serverBundle = getPagePath(page, distDir, undefined, false)
+            await fs.unlink(serverBundle)
+          }
+
+          for (const [originalAppPath, routes] of appStaticPaths) {
+            const page = appNormalizedPaths.get(originalAppPath) || ''
+            const appConfig = appDefaultConfigs.get(originalAppPath) || {}
+            let hasDynamicData =
+              appConfig.revalidate === 0 ||
+              exportResult.byPath.get(page)?.revalidate === 0
+
+            if (hasDynamicData && pageInfos.get(page)?.isStatic) {
+              // if the page was marked as being static, but it contains dynamic data
+              // (ie, in the case of a static generation bailout), then it should be marked dynamic
+              pageInfos.set(page, {
+                ...(pageInfos.get(page) as PageInfo),
+                isStatic: false,
+                isSSG: false,
+              })
+            }
+
+            const isRouteHandler = isAppRouteRoute(originalAppPath)
+
+            // When this is an app page and PPR is enabled, the route supports
+            // partial pre-rendering.
+            const experimentalPPR =
+              !isRouteHandler && config.experimental.ppr === true
+                ? true
+                : undefined
+
+            // this flag is used to selectively bypass the static cache and invoke the lambda directly
+            // to enable server actions on static routes
+            const bypassFor: RouteHas[] = [
+              { type: 'header', key: ACTION },
+              {
+                type: 'header',
+                key: 'content-type',
+                value: 'multipart/form-data',
+              },
+            ]
+
+            routes.forEach((route) => {
+              if (isDynamicRoute(page) && route === page) return
+              if (route === '/_not-found') return
+
+              const {
+                revalidate = appConfig.revalidate ?? false,
+                metadata = {},
+                hasEmptyPrelude,
+                hasPostponed,
+              } = exportResult.byPath.get(route) ?? {}
+
+              pageInfos.set(route, {
+                ...(pageInfos.get(route) as PageInfo),
+                hasPostponed,
+                hasEmptyPrelude,
+              })
+
+              // update the page (eg /blog/[slug]) to also have the postpone metadata
+              pageInfos.set(page, {
+                ...(pageInfos.get(page) as PageInfo),
+                hasPostponed,
+                hasEmptyPrelude,
+              })
+
+              if (revalidate !== 0) {
+                const normalizedRoute = normalizePagePath(route)
+
+                let dataRoute: string | null
+                if (isRouteHandler) {
+                  dataRoute = null
+                } else {
+                  dataRoute = path.posix.join(`${normalizedRoute}${RSC_SUFFIX}`)
+                }
 
                 let prefetchDataRoute: string | null | undefined
                 if (experimentalPPR) {
@@ -2411,288 +2327,330 @@ export default async function build(
                   )
                 }
 
-                pageInfos.set(page, {
-                  ...(pageInfos.get(page) as PageInfo),
-                  isDynamicAppRoute: true,
-                  // if PPR is turned on and the route contains a dynamic segment,
-                  // we assume it'll be partially prerendered
-                  hasPostponed: experimentalPPR,
-                })
+                const routeMeta: Partial<SsgRoute> = {}
 
-                // TODO: create a separate manifest to allow enforcing
-                // dynamicParams for non-static paths?
-                finalDynamicRoutes[page] = {
+                if (metadata.status !== 200) {
+                  routeMeta.initialStatus = metadata.status
+                }
+
+                const exportHeaders = metadata.headers
+                const headerKeys = Object.keys(exportHeaders || {})
+
+                if (exportHeaders && headerKeys.length) {
+                  routeMeta.initialHeaders = {}
+
+                  // normalize header values as initialHeaders
+                  // must be Record<string, string>
+                  for (const key of headerKeys) {
+                    let value = exportHeaders[key]
+
+                    if (Array.isArray(value)) {
+                      if (key === 'set-cookie') {
+                        value = value.join(',')
+                      } else {
+                        value = value[value.length - 1]
+                      }
+                    }
+
+                    if (typeof value === 'string') {
+                      routeMeta.initialHeaders[key] = value
+                    }
+                  }
+                }
+
+                finalPrerenderRoutes[route] = {
+                  ...routeMeta,
                   experimentalPPR,
                   experimentalBypassFor: bypassFor,
-                  routeRegex: normalizeRouteRegex(
-                    getNamedRouteRegex(page, false).re.source
-                  ),
+                  initialRevalidateSeconds: revalidate,
+                  srcRoute: page,
                   dataRoute,
-                  // if dynamicParams are enabled treat as fallback:
-                  // 'blocking' if not it's fallback: false
-                  fallback: appDynamicParamPaths.has(originalAppPath)
-                    ? null
-                    : false,
-                  dataRouteRegex: isRouteHandler
-                    ? null
-                    : normalizeRouteRegex(
-                        getNamedRouteRegex(
-                          dataRoute.replace(/\.rsc$/, ''),
-                          false
-                        ).re.source.replace(/\(\?:\\\/\)\?\$$/, '\\.rsc$')
-                      ),
                   prefetchDataRoute,
-                  prefetchDataRouteRegex:
-                    isRouteHandler || !prefetchDataRoute
-                      ? undefined
-                      : normalizeRouteRegex(
-                          getNamedRouteRegex(
-                            prefetchDataRoute.replace(/\.prefetch\.rsc$/, ''),
-                            false
-                          ).re.source.replace(
-                            /\(\?:\\\/\)\?\$$/,
-                            '\\.prefetch\\.rsc$'
-                          )
-                        ),
                 }
-              }
-            }
-
-            const moveExportedPage = async (
-              originPage: string,
-              page: string,
-              file: string,
-              isSsg: boolean,
-              ext: 'html' | 'json',
-              additionalSsgFile = false
-            ) => {
-              return staticGenerationSpan
-                .traceChild('move-exported-page')
-                .traceAsyncFn(async () => {
-                  file = `${file}.${ext}`
-                  const orig = path.join(exportOptions.outdir, file)
-                  const pagePath = getPagePath(
-                    originPage,
-                    distDir,
-                    undefined,
-                    false
-                  )
-
-                  const relativeDest = path
-                    .relative(
-                      path.join(distDir, SERVER_DIRECTORY),
-                      path.join(
-                        path.join(
-                          pagePath,
-                          // strip leading / and then recurse number of nested dirs
-                          // to place from base folder
-                          originPage
-                            .slice(1)
-                            .split('/')
-                            .map(() => '..')
-                            .join('/')
-                        ),
-                        file
-                      )
-                    )
-                    .replace(/\\/g, '/')
-
-                  if (
-                    !isSsg &&
-                    !(
-                      // don't add static status page to manifest if it's
-                      // the default generated version e.g. no pages/500
-                      (
-                        STATIC_STATUS_PAGES.includes(page) &&
-                        !usedStaticStatusPages.includes(page)
-                      )
-                    )
-                  ) {
-                    pagesManifest[page] = relativeDest
-                  }
-
-                  const dest = path.join(
-                    distDir,
-                    SERVER_DIRECTORY,
-                    relativeDest
-                  )
-                  const isNotFound = ssgNotFoundPaths.includes(page)
-
-                  // for SSG files with i18n the non-prerendered variants are
-                  // output with the locale prefixed so don't attempt moving
-                  // without the prefix
-                  if ((!i18n || additionalSsgFile) && !isNotFound) {
-                    await fs.mkdir(path.dirname(dest), { recursive: true })
-                    await fs.rename(orig, dest)
-                  } else if (i18n && !isSsg) {
-                    // this will be updated with the locale prefixed variant
-                    // since all files are output with the locale prefix
-                    delete pagesManifest[page]
-                  }
-
-                  if (i18n) {
-                    if (additionalSsgFile) return
-
-                    for (const locale of i18n.locales) {
-                      const curPath = `/${locale}${page === '/' ? '' : page}`
-                      const localeExt = page === '/' ? path.extname(file) : ''
-                      const relativeDestNoPages = relativeDest.slice(
-                        'pages/'.length
-                      )
-
-                      if (isSsg && ssgNotFoundPaths.includes(curPath)) {
-                        continue
-                      }
-
-                      const updatedRelativeDest = path
-                        .join(
-                          'pages',
-                          locale + localeExt,
-                          // if it's the top-most index page we want it to be locale.EXT
-                          // instead of locale/index.html
-                          page === '/' ? '' : relativeDestNoPages
-                        )
-                        .replace(/\\/g, '/')
-
-                      const updatedOrig = path.join(
-                        exportOptions.outdir,
-                        locale + localeExt,
-                        page === '/' ? '' : file
-                      )
-                      const updatedDest = path.join(
-                        distDir,
-                        SERVER_DIRECTORY,
-                        updatedRelativeDest
-                      )
-
-                      if (!isSsg) {
-                        pagesManifest[curPath] = updatedRelativeDest
-                      }
-                      await fs.mkdir(path.dirname(updatedDest), {
-                        recursive: true,
-                      })
-                      await fs.rename(updatedOrig, updatedDest)
-                    }
-                  }
+              } else {
+                hasDynamicData = true
+                // we might have determined during prerendering that this page
+                // used dynamic data
+                pageInfos.set(route, {
+                  ...(pageInfos.get(route) as PageInfo),
+                  isSSG: false,
+                  isStatic: false,
                 })
-            }
-
-            async function moveExportedAppNotFoundTo404() {
-              return staticGenerationSpan
-                .traceChild('move-exported-app-not-found-')
-                .traceAsyncFn(async () => {
-                  const orig = path.join(
-                    distDir,
-                    'server',
-                    'app',
-                    '_not-found.html'
-                  )
-                  const updatedRelativeDest = path
-                    .join('pages', '404.html')
-                    .replace(/\\/g, '/')
-
-                  if (existsSync(orig)) {
-                    await fs.copyFile(
-                      orig,
-                      path.join(distDir, 'server', updatedRelativeDest)
-                    )
-                    pagesManifest['/404'] = updatedRelativeDest
-                  }
-                })
-            }
-
-            // If there's /not-found inside app, we prefer it over the pages 404
-            if (hasStaticApp404) {
-              await moveExportedAppNotFoundTo404()
-            } else {
-              // Only move /404 to /404 when there is no custom 404 as in that case we don't know about the 404 page
-              if (!hasPages404 && !hasApp404 && useStaticPages404) {
-                await moveExportedPage('/_error', '/404', '/404', false, 'html')
               }
-            }
+            })
 
-            if (useDefaultStatic500) {
-              await moveExportedPage('/_error', '/500', '/500', false, 'html')
-            }
-
-            for (const page of combinedPages) {
-              const isSsg = ssgPages.has(page)
-              const isStaticSsgFallback = ssgStaticFallbackPages.has(page)
-              const isDynamic = isDynamicRoute(page)
-              const hasAmp = hybridAmpPages.has(page)
-              const file = normalizePagePath(page)
-
-              const pageInfo = pageInfos.get(page)
-              const durationInfo = exportResult.byPage.get(page)
-              if (pageInfo && durationInfo) {
-                // Set Build Duration
-                if (pageInfo.ssgPageRoutes) {
-                  pageInfo.ssgPageDurations = pageInfo.ssgPageRoutes.map(
-                    (pagePath) => {
-                      const duration =
-                        durationInfo.durationsByPath.get(pagePath)
-                      if (typeof duration === 'undefined') {
-                        throw new Error("Invariant: page wasn't built")
-                      }
-
-                      return duration
-                    }
-                  )
-                }
-                pageInfo.pageDuration = durationInfo.durationsByPath.get(page)
-              }
-
-              // The dynamic version of SSG pages are only prerendered if the
-              // fallback is enabled. Below, we handle the specific prerenders
-              // of these.
-              const hasHtmlOutput = !(
-                isSsg &&
-                isDynamic &&
-                !isStaticSsgFallback
+            if (!hasDynamicData && isDynamicRoute(originalAppPath)) {
+              const normalizedRoute = normalizePagePath(page)
+              const dataRoute = path.posix.join(
+                `${normalizedRoute}${RSC_SUFFIX}`
               )
 
-              if (hasHtmlOutput) {
-                await moveExportedPage(page, page, file, isSsg, 'html')
+              let prefetchDataRoute: string | null | undefined
+              if (experimentalPPR) {
+                prefetchDataRoute = path.posix.join(
+                  `${normalizedRoute}${RSC_PREFETCH_SUFFIX}`
+                )
               }
 
-              if (hasAmp && (!isSsg || (isSsg && !isDynamic))) {
-                const ampPage = `${file}.amp`
-                await moveExportedPage(page, ampPage, ampPage, isSsg, 'html')
+              pageInfos.set(page, {
+                ...(pageInfos.get(page) as PageInfo),
+                isDynamicAppRoute: true,
+                // if PPR is turned on and the route contains a dynamic segment,
+                // we assume it'll be partially prerendered
+                hasPostponed: experimentalPPR,
+              })
 
-                if (isSsg) {
-                  await moveExportedPage(page, ampPage, ampPage, isSsg, 'json')
+              // TODO: create a separate manifest to allow enforcing
+              // dynamicParams for non-static paths?
+              finalDynamicRoutes[page] = {
+                experimentalPPR,
+                experimentalBypassFor: bypassFor,
+                routeRegex: normalizeRouteRegex(
+                  getNamedRouteRegex(page, false).re.source
+                ),
+                dataRoute,
+                // if dynamicParams are enabled treat as fallback:
+                // 'blocking' if not it's fallback: false
+                fallback: appDynamicParamPaths.has(originalAppPath)
+                  ? null
+                  : false,
+                dataRouteRegex: isRouteHandler
+                  ? null
+                  : normalizeRouteRegex(
+                      getNamedRouteRegex(
+                        dataRoute.replace(/\.rsc$/, ''),
+                        false
+                      ).re.source.replace(/\(\?:\\\/\)\?\$$/, '\\.rsc$')
+                    ),
+                prefetchDataRoute,
+                prefetchDataRouteRegex:
+                  isRouteHandler || !prefetchDataRoute
+                    ? undefined
+                    : normalizeRouteRegex(
+                        getNamedRouteRegex(
+                          prefetchDataRoute.replace(/\.prefetch\.rsc$/, ''),
+                          false
+                        ).re.source.replace(
+                          /\(\?:\\\/\)\?\$$/,
+                          '\\.prefetch\\.rsc$'
+                        )
+                      ),
+              }
+            }
+          }
+
+          const moveExportedPage = async (
+            originPage: string,
+            page: string,
+            file: string,
+            isSsg: boolean,
+            ext: 'html' | 'json',
+            additionalSsgFile = false
+          ) => {
+            return staticGenerationSpan
+              .traceChild('move-exported-page')
+              .traceAsyncFn(async () => {
+                file = `${file}.${ext}`
+                const orig = path.join(exportOptions.outdir, file)
+                const pagePath = getPagePath(
+                  originPage,
+                  distDir,
+                  undefined,
+                  false
+                )
+
+                const relativeDest = path
+                  .relative(
+                    path.join(distDir, SERVER_DIRECTORY),
+                    path.join(
+                      path.join(
+                        pagePath,
+                        // strip leading / and then recurse number of nested dirs
+                        // to place from base folder
+                        originPage
+                          .slice(1)
+                          .split('/')
+                          .map(() => '..')
+                          .join('/')
+                      ),
+                      file
+                    )
+                  )
+                  .replace(/\\/g, '/')
+
+                if (
+                  !isSsg &&
+                  !(
+                    // don't add static status page to manifest if it's
+                    // the default generated version e.g. no pages/500
+                    (
+                      STATIC_STATUS_PAGES.includes(page) &&
+                      !usedStaticStatusPages.includes(page)
+                    )
+                  )
+                ) {
+                  pagesManifest[page] = relativeDest
                 }
+
+                const dest = path.join(distDir, SERVER_DIRECTORY, relativeDest)
+                const isNotFound = ssgNotFoundPaths.includes(page)
+
+                // for SSG files with i18n the non-prerendered variants are
+                // output with the locale prefixed so don't attempt moving
+                // without the prefix
+                if ((!i18n || additionalSsgFile) && !isNotFound) {
+                  await fs.mkdir(path.dirname(dest), { recursive: true })
+                  await fs.rename(orig, dest)
+                } else if (i18n && !isSsg) {
+                  // this will be updated with the locale prefixed variant
+                  // since all files are output with the locale prefix
+                  delete pagesManifest[page]
+                }
+
+                if (i18n) {
+                  if (additionalSsgFile) return
+
+                  for (const locale of i18n.locales) {
+                    const curPath = `/${locale}${page === '/' ? '' : page}`
+                    const localeExt = page === '/' ? path.extname(file) : ''
+                    const relativeDestNoPages = relativeDest.slice(
+                      'pages/'.length
+                    )
+
+                    if (isSsg && ssgNotFoundPaths.includes(curPath)) {
+                      continue
+                    }
+
+                    const updatedRelativeDest = path
+                      .join(
+                        'pages',
+                        locale + localeExt,
+                        // if it's the top-most index page we want it to be locale.EXT
+                        // instead of locale/index.html
+                        page === '/' ? '' : relativeDestNoPages
+                      )
+                      .replace(/\\/g, '/')
+
+                    const updatedOrig = path.join(
+                      exportOptions.outdir,
+                      locale + localeExt,
+                      page === '/' ? '' : file
+                    )
+                    const updatedDest = path.join(
+                      distDir,
+                      SERVER_DIRECTORY,
+                      updatedRelativeDest
+                    )
+
+                    if (!isSsg) {
+                      pagesManifest[curPath] = updatedRelativeDest
+                    }
+                    await fs.mkdir(path.dirname(updatedDest), {
+                      recursive: true,
+                    })
+                    await fs.rename(updatedOrig, updatedDest)
+                  }
+                }
+              })
+          }
+
+          async function moveExportedAppNotFoundTo404() {
+            return staticGenerationSpan
+              .traceChild('move-exported-app-not-found-')
+              .traceAsyncFn(async () => {
+                const orig = path.join(
+                  distDir,
+                  'server',
+                  'app',
+                  '_not-found.html'
+                )
+                const updatedRelativeDest = path
+                  .join('pages', '404.html')
+                  .replace(/\\/g, '/')
+
+                if (existsSync(orig)) {
+                  await fs.copyFile(
+                    orig,
+                    path.join(distDir, 'server', updatedRelativeDest)
+                  )
+                  pagesManifest['/404'] = updatedRelativeDest
+                }
+              })
+          }
+
+          // If there's /not-found inside app, we prefer it over the pages 404
+          if (hasStaticApp404) {
+            await moveExportedAppNotFoundTo404()
+          } else {
+            // Only move /404 to /404 when there is no custom 404 as in that case we don't know about the 404 page
+            if (!hasPages404 && !hasApp404 && useStaticPages404) {
+              await moveExportedPage('/_error', '/404', '/404', false, 'html')
+            }
+          }
+
+          if (useDefaultStatic500) {
+            await moveExportedPage('/_error', '/500', '/500', false, 'html')
+          }
+
+          for (const page of combinedPages) {
+            const isSsg = ssgPages.has(page)
+            const isStaticSsgFallback = ssgStaticFallbackPages.has(page)
+            const isDynamic = isDynamicRoute(page)
+            const hasAmp = hybridAmpPages.has(page)
+            const file = normalizePagePath(page)
+
+            const pageInfo = pageInfos.get(page)
+            const durationInfo = exportResult.byPage.get(page)
+            if (pageInfo && durationInfo) {
+              // Set Build Duration
+              if (pageInfo.ssgPageRoutes) {
+                pageInfo.ssgPageDurations = pageInfo.ssgPageRoutes.map(
+                  (pagePath) => {
+                    const duration = durationInfo.durationsByPath.get(pagePath)
+                    if (typeof duration === 'undefined') {
+                      throw new Error("Invariant: page wasn't built")
+                    }
+
+                    return duration
+                  }
+                )
               }
+              pageInfo.pageDuration = durationInfo.durationsByPath.get(page)
+            }
+
+            // The dynamic version of SSG pages are only prerendered if the
+            // fallback is enabled. Below, we handle the specific prerenders
+            // of these.
+            const hasHtmlOutput = !(isSsg && isDynamic && !isStaticSsgFallback)
+
+            if (hasHtmlOutput) {
+              await moveExportedPage(page, page, file, isSsg, 'html')
+            }
+
+            if (hasAmp && (!isSsg || (isSsg && !isDynamic))) {
+              const ampPage = `${file}.amp`
+              await moveExportedPage(page, ampPage, ampPage, isSsg, 'html')
 
               if (isSsg) {
-                // For a non-dynamic SSG page, we must copy its data file
-                // from export, we already moved the HTML file above
-                if (!isDynamic) {
-                  await moveExportedPage(page, page, file, isSsg, 'json')
+                await moveExportedPage(page, ampPage, ampPage, isSsg, 'json')
+              }
+            }
 
-                  if (i18n) {
-                    // TODO: do we want to show all locale variants in build output
-                    for (const locale of i18n.locales) {
-                      const localePage = `/${locale}${page === '/' ? '' : page}`
+            if (isSsg) {
+              // For a non-dynamic SSG page, we must copy its data file
+              // from export, we already moved the HTML file above
+              if (!isDynamic) {
+                await moveExportedPage(page, page, file, isSsg, 'json')
 
-                      finalPrerenderRoutes[localePage] = {
-                        initialRevalidateSeconds:
-                          exportResult.byPath.get(localePage)?.revalidate ??
-                          false,
-                        experimentalPPR: undefined,
-                        srcRoute: null,
-                        dataRoute: path.posix.join(
-                          '/_next/data',
-                          buildId,
-                          `${file}.json`
-                        ),
-                        prefetchDataRoute: undefined,
-                      }
-                    }
-                  } else {
-                    finalPrerenderRoutes[page] = {
+                if (i18n) {
+                  // TODO: do we want to show all locale variants in build output
+                  for (const locale of i18n.locales) {
+                    const localePage = `/${locale}${page === '/' ? '' : page}`
+
+                    finalPrerenderRoutes[localePage] = {
                       initialRevalidateSeconds:
-                        exportResult.byPath.get(page)?.revalidate ?? false,
+                        exportResult.byPath.get(localePage)?.revalidate ??
+                        false,
                       experimentalPPR: undefined,
                       srcRoute: null,
                       dataRoute: path.posix.join(
@@ -2700,441 +2658,445 @@ export default async function build(
                         buildId,
                         `${file}.json`
                       ),
-                      // Pages does not have a prefetch data route.
                       prefetchDataRoute: undefined,
                     }
                   }
-                  // Set Page Revalidation Interval
-                  if (pageInfo) {
-                    pageInfo.initialRevalidateSeconds =
-                      exportResult.byPath.get(page)?.revalidate ?? false
-                  }
                 } else {
-                  // For a dynamic SSG page, we did not copy its data exports and only
-                  // copy the fallback HTML file (if present).
-                  // We must also copy specific versions of this page as defined by
-                  // `getStaticPaths` (additionalSsgPaths).
-                  const extraRoutes = additionalSsgPaths.get(page) || []
-                  for (const route of extraRoutes) {
-                    const pageFile = normalizePagePath(route)
+                  finalPrerenderRoutes[page] = {
+                    initialRevalidateSeconds:
+                      exportResult.byPath.get(page)?.revalidate ?? false,
+                    experimentalPPR: undefined,
+                    srcRoute: null,
+                    dataRoute: path.posix.join(
+                      '/_next/data',
+                      buildId,
+                      `${file}.json`
+                    ),
+                    // Pages does not have a prefetch data route.
+                    prefetchDataRoute: undefined,
+                  }
+                }
+                // Set Page Revalidation Interval
+                if (pageInfo) {
+                  pageInfo.initialRevalidateSeconds =
+                    exportResult.byPath.get(page)?.revalidate ?? false
+                }
+              } else {
+                // For a dynamic SSG page, we did not copy its data exports and only
+                // copy the fallback HTML file (if present).
+                // We must also copy specific versions of this page as defined by
+                // `getStaticPaths` (additionalSsgPaths).
+                const extraRoutes = additionalSsgPaths.get(page) || []
+                for (const route of extraRoutes) {
+                  const pageFile = normalizePagePath(route)
+                  await moveExportedPage(
+                    page,
+                    route,
+                    pageFile,
+                    isSsg,
+                    'html',
+                    true
+                  )
+                  await moveExportedPage(
+                    page,
+                    route,
+                    pageFile,
+                    isSsg,
+                    'json',
+                    true
+                  )
+
+                  if (hasAmp) {
+                    const ampPage = `${pageFile}.amp`
                     await moveExportedPage(
                       page,
-                      route,
-                      pageFile,
+                      ampPage,
+                      ampPage,
                       isSsg,
                       'html',
                       true
                     )
                     await moveExportedPage(
                       page,
-                      route,
-                      pageFile,
+                      ampPage,
+                      ampPage,
                       isSsg,
                       'json',
                       true
                     )
+                  }
 
-                    if (hasAmp) {
-                      const ampPage = `${pageFile}.amp`
-                      await moveExportedPage(
-                        page,
-                        ampPage,
-                        ampPage,
-                        isSsg,
-                        'html',
-                        true
-                      )
-                      await moveExportedPage(
-                        page,
-                        ampPage,
-                        ampPage,
-                        isSsg,
-                        'json',
-                        true
-                      )
-                    }
+                  const initialRevalidateSeconds =
+                    exportResult.byPath.get(route)?.revalidate ?? false
 
-                    const initialRevalidateSeconds =
-                      exportResult.byPath.get(route)?.revalidate ?? false
+                  if (typeof initialRevalidateSeconds === 'undefined') {
+                    throw new Error("Invariant: page wasn't built")
+                  }
 
-                    if (typeof initialRevalidateSeconds === 'undefined') {
-                      throw new Error("Invariant: page wasn't built")
-                    }
+                  finalPrerenderRoutes[route] = {
+                    initialRevalidateSeconds,
+                    experimentalPPR: undefined,
+                    srcRoute: page,
+                    dataRoute: path.posix.join(
+                      '/_next/data',
+                      buildId,
+                      `${normalizePagePath(route)}.json`
+                    ),
+                    // Pages does not have a prefetch data route.
+                    prefetchDataRoute: undefined,
+                  }
 
-                    finalPrerenderRoutes[route] = {
-                      initialRevalidateSeconds,
-                      experimentalPPR: undefined,
-                      srcRoute: page,
-                      dataRoute: path.posix.join(
-                        '/_next/data',
-                        buildId,
-                        `${normalizePagePath(route)}.json`
-                      ),
-                      // Pages does not have a prefetch data route.
-                      prefetchDataRoute: undefined,
-                    }
-
-                    // Set route Revalidation Interval
-                    if (pageInfo) {
-                      pageInfo.initialRevalidateSeconds =
-                        initialRevalidateSeconds
-                    }
+                  // Set route Revalidation Interval
+                  if (pageInfo) {
+                    pageInfo.initialRevalidateSeconds = initialRevalidateSeconds
                   }
                 }
               }
             }
-
-            // remove temporary export folder
-            await fs.rm(exportOptions.outdir, { recursive: true, force: true })
-            await fs.writeFile(
-              manifestPath,
-              formatManifest(pagesManifest),
-              'utf8'
-            )
-          })
-        }
-
-        const postBuildSpinner = createSpinner('Finalizing page optimization')
-        let buildTracesSpinner = createSpinner(`Collecting build traces`)
-
-        // ensure the worker is not left hanging
-        pagesStaticWorkers.close()
-        appStaticWorkers?.close()
-
-        const analysisEnd = process.hrtime(analysisBegin)
-        telemetry.record(
-          eventBuildOptimize(pagesPaths, {
-            durationInSeconds: analysisEnd[0],
-            staticPageCount: staticPages.size,
-            staticPropsPageCount: ssgPages.size,
-            serverPropsPageCount: serverPropsPages.size,
-            ssrPageCount:
-              pagesPaths.length -
-              (staticPages.size + ssgPages.size + serverPropsPages.size),
-            hasStatic404: useStaticPages404,
-            hasReportWebVitals:
-              namedExports?.includes('reportWebVitals') ?? false,
-            rewritesCount: combinedRewrites.length,
-            headersCount: headers.length,
-            redirectsCount: redirects.length - 1, // reduce one for trailing slash
-            headersWithHasCount: headers.filter((r: any) => !!r.has).length,
-            rewritesWithHasCount: combinedRewrites.filter((r: any) => !!r.has)
-              .length,
-            redirectsWithHasCount: redirects.filter((r: any) => !!r.has).length,
-            middlewareCount: Object.keys(rootPaths).length > 0 ? 1 : 0,
-            totalAppPagesCount,
-            staticAppPagesCount,
-            serverAppPagesCount,
-            edgeRuntimeAppCount,
-            edgeRuntimePagesCount,
-          })
-        )
-
-        if (NextBuildContext.telemetryPlugin) {
-          const events = eventBuildFeatureUsage(
-            NextBuildContext.telemetryPlugin
-          )
-          telemetry.record(events)
-          telemetry.record(
-            eventPackageUsedInGetServerSideProps(
-              NextBuildContext.telemetryPlugin
-            )
-          )
-        }
-
-        if (ssgPages.size > 0 || appDir) {
-          tbdPrerenderRoutes.forEach((tbdRoute) => {
-            const normalizedRoute = normalizePagePath(tbdRoute)
-            const dataRoute = path.posix.join(
-              '/_next/data',
-              buildId,
-              `${normalizedRoute}.json`
-            )
-
-            finalDynamicRoutes[tbdRoute] = {
-              routeRegex: normalizeRouteRegex(
-                getNamedRouteRegex(tbdRoute, false).re.source
-              ),
-              experimentalPPR: undefined,
-              dataRoute,
-              fallback: ssgBlockingFallbackPages.has(tbdRoute)
-                ? null
-                : ssgStaticFallbackPages.has(tbdRoute)
-                ? `${normalizedRoute}.html`
-                : false,
-              dataRouteRegex: normalizeRouteRegex(
-                getNamedRouteRegex(
-                  dataRoute.replace(/\.json$/, ''),
-                  false
-                ).re.source.replace(/\(\?:\\\/\)\?\$$/, '\\.json$')
-              ),
-              // Pages does not have a prefetch data route.
-              prefetchDataRoute: undefined,
-              prefetchDataRouteRegex: undefined,
-            }
-          })
-          const prerenderManifest: Readonly<PrerenderManifest> = {
-            version: 4,
-            routes: finalPrerenderRoutes,
-            dynamicRoutes: finalDynamicRoutes,
-            notFoundRoutes: ssgNotFoundPaths,
-            preview: previewProps,
           }
-          NextBuildContext.previewModeId = previewProps.previewModeId
-          NextBuildContext.fetchCacheKeyPrefix =
-            config.experimental.fetchCacheKeyPrefix
-          NextBuildContext.allowedRevalidateHeaderKeys =
-            config.experimental.allowedRevalidateHeaderKeys
 
+          // remove temporary export folder
+          await fs.rm(exportOptions.outdir, { recursive: true, force: true })
           await fs.writeFile(
-            path.join(distDir, PRERENDER_MANIFEST),
-            formatManifest(prerenderManifest),
+            manifestPath,
+            formatManifest(pagesManifest),
             'utf8'
           )
-          await fs.writeFile(
-            path.join(distDir, PRERENDER_MANIFEST).replace(/\.json$/, '.js'),
-            `self.__PRERENDER_MANIFEST=${JSON.stringify(
-              JSON.stringify(prerenderManifest)
-            )}`,
-            'utf8'
-          )
-          await generateClientSsgManifest(prerenderManifest, {
-            distDir,
-            buildId,
-            locales: config.i18n?.locales || [],
-          })
-        } else {
-          const prerenderManifest: Readonly<PrerenderManifest> = {
-            version: 4,
-            routes: {},
-            dynamicRoutes: {},
-            preview: previewProps,
-            notFoundRoutes: [],
-          }
-          await fs.writeFile(
-            path.join(distDir, PRERENDER_MANIFEST),
-            formatManifest(prerenderManifest),
-            'utf8'
-          )
-          await fs.writeFile(
-            path.join(distDir, PRERENDER_MANIFEST).replace(/\.json$/, '.js'),
-            `self.__PRERENDER_MANIFEST=${JSON.stringify(
-              JSON.stringify(prerenderManifest)
-            )}`,
-            'utf8'
-          )
-        }
-
-        const images = { ...config.images }
-        const { deviceSizes, imageSizes } = images
-        ;(images as any).sizes = [...deviceSizes, ...imageSizes]
-        images.remotePatterns = (config?.images?.remotePatterns || []).map(
-          (p: RemotePattern) => ({
-            // Should be the same as matchRemotePattern()
-            protocol: p.protocol,
-            hostname: makeRe(p.hostname).source,
-            port: p.port,
-            pathname: makeRe(p.pathname ?? '**').source,
-          })
-        )
-
-        await fs.writeFile(
-          path.join(distDir, IMAGES_MANIFEST),
-          formatManifest({
-            version: 1,
-            images,
-          }),
-          'utf8'
-        )
-        await fs.writeFile(
-          path.join(distDir, EXPORT_MARKER),
-          formatManifest({
-            version: 1,
-            hasExportPathMap: typeof config.exportPathMap === 'function',
-            exportTrailingSlash: config.trailingSlash === true,
-            isNextImageImported: isNextImageImported === true,
-          }),
-          'utf8'
-        )
-        await fs.unlink(path.join(distDir, EXPORT_DETAIL)).catch((err) => {
-          if (err.code === 'ENOENT') {
-            return Promise.resolve()
-          }
-          return Promise.reject(err)
         })
+      }
 
-        if (debugOutput) {
-          nextBuildSpan
-            .traceChild('print-custom-routes')
-            .traceFn(() => printCustomRoutes({ redirects, rewrites, headers }))
-        }
+      const postBuildSpinner = createSpinner('Finalizing page optimization')
+      let buildTracesSpinner = createSpinner(`Collecting build traces`)
 
-        if (config.analyticsId) {
-          console.log(
-            bold(green('Next.js Speed Insights')) +
-              ' is enabled for this production build. ' +
-              "You'll receive a Real Experience Score computed by all of your visitors."
+      // ensure the worker is not left hanging
+      pagesStaticWorkers.close()
+      appStaticWorkers?.close()
+
+      const analysisEnd = process.hrtime(analysisBegin)
+      telemetry.record(
+        eventBuildOptimize(pagesPaths, {
+          durationInSeconds: analysisEnd[0],
+          staticPageCount: staticPages.size,
+          staticPropsPageCount: ssgPages.size,
+          serverPropsPageCount: serverPropsPages.size,
+          ssrPageCount:
+            pagesPaths.length -
+            (staticPages.size + ssgPages.size + serverPropsPages.size),
+          hasStatic404: useStaticPages404,
+          hasReportWebVitals:
+            namedExports?.includes('reportWebVitals') ?? false,
+          rewritesCount: combinedRewrites.length,
+          headersCount: headers.length,
+          redirectsCount: redirects.length - 1, // reduce one for trailing slash
+          headersWithHasCount: headers.filter((r: any) => !!r.has).length,
+          rewritesWithHasCount: combinedRewrites.filter((r: any) => !!r.has)
+            .length,
+          redirectsWithHasCount: redirects.filter((r: any) => !!r.has).length,
+          middlewareCount: Object.keys(rootPaths).length > 0 ? 1 : 0,
+          totalAppPagesCount,
+          staticAppPagesCount,
+          serverAppPagesCount,
+          edgeRuntimeAppCount,
+          edgeRuntimePagesCount,
+        })
+      )
+
+      if (NextBuildContext.telemetryPlugin) {
+        const events = eventBuildFeatureUsage(NextBuildContext.telemetryPlugin)
+        telemetry.record(events)
+        telemetry.record(
+          eventPackageUsedInGetServerSideProps(NextBuildContext.telemetryPlugin)
+        )
+      }
+
+      if (ssgPages.size > 0 || appDir) {
+        tbdPrerenderRoutes.forEach((tbdRoute) => {
+          const normalizedRoute = normalizePagePath(tbdRoute)
+          const dataRoute = path.posix.join(
+            '/_next/data',
+            buildId,
+            `${normalizedRoute}.json`
           )
-          console.log('')
-        }
 
-        if (Boolean(config.experimental.nextScriptWorkers)) {
-          await nextBuildSpan
-            .traceChild('verify-partytown-setup')
-            .traceAsyncFn(async () => {
-              await verifyPartytownSetup(
-                dir,
-                path.join(distDir, CLIENT_STATIC_FILES_PATH)
-              )
-            })
-        }
-
-        if (config.output === 'export') {
-          if (buildTracesSpinner) {
-            buildTracesSpinner?.stop()
-            buildTracesSpinner = undefined
+          finalDynamicRoutes[tbdRoute] = {
+            routeRegex: normalizeRouteRegex(
+              getNamedRouteRegex(tbdRoute, false).re.source
+            ),
+            experimentalPPR: undefined,
+            dataRoute,
+            fallback: ssgBlockingFallbackPages.has(tbdRoute)
+              ? null
+              : ssgStaticFallbackPages.has(tbdRoute)
+              ? `${normalizedRoute}.html`
+              : false,
+            dataRouteRegex: normalizeRouteRegex(
+              getNamedRouteRegex(
+                dataRoute.replace(/\.json$/, ''),
+                false
+              ).re.source.replace(/\(\?:\\\/\)\?\$$/, '\\.json$')
+            ),
+            // Pages does not have a prefetch data route.
+            prefetchDataRoute: undefined,
+            prefetchDataRouteRegex: undefined,
           }
-
-          const exportApp: typeof import('../export').default =
-            require('../export').default
-
-          const pagesWorker = createStaticWorker(
-            incrementalCacheIpcPort,
-            incrementalCacheIpcValidationKey
-          )
-          const appWorker = createStaticWorker(
-            incrementalCacheIpcPort,
-            incrementalCacheIpcValidationKey
-          )
-
-          const options: ExportAppOptions = {
-            buildExport: false,
-            nextConfig: config,
-            enabledDirectories,
-            silent: true,
-            threads: config.experimental.cpus,
-            outdir: path.join(dir, configOutDir),
-            // The worker already explicitly binds `this` to each of the
-            // exposed methods.
-            exportAppPageWorker: appWorker?.exportPage,
-            exportPageWorker: pagesWorker?.exportPage,
-            endWorker: async () => {
-              await pagesWorker.end()
-              await appWorker.end()
-            },
-          }
-
-          await exportApp(dir, options, nextBuildSpan)
-
-          // ensure the worker is not left hanging
-          pagesWorker.close()
-          appWorker.close()
+        })
+        const prerenderManifest: Readonly<PrerenderManifest> = {
+          version: 4,
+          routes: finalPrerenderRoutes,
+          dynamicRoutes: finalDynamicRoutes,
+          notFoundRoutes: ssgNotFoundPaths,
+          preview: previewProps,
         }
-        await buildTracesPromise
+        NextBuildContext.previewModeId = previewProps.previewModeId
+        NextBuildContext.fetchCacheKeyPrefix =
+          config.experimental.fetchCacheKeyPrefix
+        NextBuildContext.allowedRevalidateHeaderKeys =
+          config.experimental.allowedRevalidateHeaderKeys
 
-        if (config.output === 'standalone') {
-          await nextBuildSpan
-            .traceChild('copy-traced-files')
-            .traceAsyncFn(async () => {
-              await copyTracedFiles(
-                dir,
-                distDir,
-                pageKeys.pages,
-                denormalizedAppPages,
-                outputFileTracingRoot,
-                requiredServerFiles.config,
-                middlewareManifest,
-                hasInstrumentationHook,
-                staticPages
-              )
-
-              if (config.output === 'standalone') {
-                for (const file of [
-                  ...requiredServerFiles.files,
-                  path.join(config.distDir, SERVER_FILES_MANIFEST),
-                  ...loadedEnvFiles.reduce<string[]>((acc, envFile) => {
-                    if (['.env', '.env.production'].includes(envFile.path)) {
-                      acc.push(envFile.path)
-                    }
-                    return acc
-                  }, []),
-                ]) {
-                  const filePath = path.join(dir, file)
-                  const outputPath = path.join(
-                    distDir,
-                    'standalone',
-                    path.relative(outputFileTracingRoot, filePath)
-                  )
-                  await fs.mkdir(path.dirname(outputPath), {
-                    recursive: true,
-                  })
-                  await fs.copyFile(filePath, outputPath)
-                }
-                await recursiveCopy(
-                  path.join(distDir, SERVER_DIRECTORY, 'pages'),
-                  path.join(
-                    distDir,
-                    'standalone',
-                    path.relative(outputFileTracingRoot, distDir),
-                    SERVER_DIRECTORY,
-                    'pages'
-                  ),
-                  { overwrite: true }
-                )
-                if (appDir) {
-                  const originalServerApp = path.join(
-                    distDir,
-                    SERVER_DIRECTORY,
-                    'app'
-                  )
-                  if (existsSync(originalServerApp)) {
-                    await recursiveCopy(
-                      originalServerApp,
-                      path.join(
-                        distDir,
-                        'standalone',
-                        path.relative(outputFileTracingRoot, distDir),
-                        SERVER_DIRECTORY,
-                        'app'
-                      ),
-                      { overwrite: true }
-                    )
-                  }
-                }
-              }
-            })
+        await fs.writeFile(
+          path.join(distDir, PRERENDER_MANIFEST),
+          formatManifest(prerenderManifest),
+          'utf8'
+        )
+        await fs.writeFile(
+          path.join(distDir, PRERENDER_MANIFEST).replace(/\.json$/, '.js'),
+          `self.__PRERENDER_MANIFEST=${JSON.stringify(
+            JSON.stringify(prerenderManifest)
+          )}`,
+          'utf8'
+        )
+        await generateClientSsgManifest(prerenderManifest, {
+          distDir,
+          buildId,
+          locales: config.i18n?.locales || [],
+        })
+      } else {
+        const prerenderManifest: Readonly<PrerenderManifest> = {
+          version: 4,
+          routes: {},
+          dynamicRoutes: {},
+          preview: previewProps,
+          notFoundRoutes: [],
         }
+        await fs.writeFile(
+          path.join(distDir, PRERENDER_MANIFEST),
+          formatManifest(prerenderManifest),
+          'utf8'
+        )
+        await fs.writeFile(
+          path.join(distDir, PRERENDER_MANIFEST).replace(/\.json$/, '.js'),
+          `self.__PRERENDER_MANIFEST=${JSON.stringify(
+            JSON.stringify(prerenderManifest)
+          )}`,
+          'utf8'
+        )
+      }
 
+      const images = { ...config.images }
+      const { deviceSizes, imageSizes } = images
+      ;(images as any).sizes = [...deviceSizes, ...imageSizes]
+      images.remotePatterns = (config?.images?.remotePatterns || []).map(
+        (p: RemotePattern) => ({
+          // Should be the same as matchRemotePattern()
+          protocol: p.protocol,
+          hostname: makeRe(p.hostname).source,
+          port: p.port,
+          pathname: makeRe(p.pathname ?? '**').source,
+        })
+      )
+
+      await fs.writeFile(
+        path.join(distDir, IMAGES_MANIFEST),
+        formatManifest({
+          version: 1,
+          images,
+        }),
+        'utf8'
+      )
+      await fs.writeFile(
+        path.join(distDir, EXPORT_MARKER),
+        formatManifest({
+          version: 1,
+          hasExportPathMap: typeof config.exportPathMap === 'function',
+          exportTrailingSlash: config.trailingSlash === true,
+          isNextImageImported: isNextImageImported === true,
+        }),
+        'utf8'
+      )
+      await fs.unlink(path.join(distDir, EXPORT_DETAIL)).catch((err) => {
+        if (err.code === 'ENOENT') {
+          return Promise.resolve()
+        }
+        return Promise.reject(err)
+      })
+
+      if (debugOutput) {
+        nextBuildSpan
+          .traceChild('print-custom-routes')
+          .traceFn(() => printCustomRoutes({ redirects, rewrites, headers }))
+      }
+
+      if (config.analyticsId) {
+        console.log(
+          bold(green('Next.js Speed Insights')) +
+            ' is enabled for this production build. ' +
+            "You'll receive a Real Experience Score computed by all of your visitors."
+        )
+        console.log('')
+      }
+
+      if (Boolean(config.experimental.nextScriptWorkers)) {
+        await nextBuildSpan
+          .traceChild('verify-partytown-setup')
+          .traceAsyncFn(async () => {
+            await verifyPartytownSetup(
+              dir,
+              path.join(distDir, CLIENT_STATIC_FILES_PATH)
+            )
+          })
+      }
+
+      if (config.output === 'export') {
         if (buildTracesSpinner) {
-          buildTracesSpinner.stopAndPersist()
+          buildTracesSpinner?.stop()
           buildTracesSpinner = undefined
         }
 
-        if (postBuildSpinner) postBuildSpinner.stopAndPersist()
-        console.log()
+        const exportApp: typeof import('../export').default =
+          require('../export').default
 
-        await nextBuildSpan.traceChild('print-tree-view').traceAsyncFn(() =>
-          printTreeView(pageKeys, pageInfos, {
-            distPath: distDir,
-            buildId: buildId,
-            pagesDir,
-            useStaticPages404,
-            pageExtensions: config.pageExtensions,
-            appBuildManifest,
-            buildManifest,
-            middlewareManifest,
-            gzipSize: config.experimental.gzipSize,
-          })
+        const pagesWorker = createStaticWorker(
+          incrementalCacheIpcPort,
+          incrementalCacheIpcValidationKey
+        )
+        const appWorker = createStaticWorker(
+          incrementalCacheIpcPort,
+          incrementalCacheIpcValidationKey
         )
 
-        await nextBuildSpan
-          .traceChild('telemetry-flush')
-          .traceAsyncFn(() => telemetry.flush())
-      } finally {
-        if (incrementalCacheIpcServer) {
-          incrementalCacheIpcServer.close()
+        const options: ExportAppOptions = {
+          buildExport: false,
+          nextConfig: config,
+          enabledDirectories,
+          silent: true,
+          threads: config.experimental.cpus,
+          outdir: path.join(dir, configOutDir),
+          // The worker already explicitly binds `this` to each of the
+          // exposed methods.
+          exportAppPageWorker: appWorker?.exportPage,
+          exportPageWorker: pagesWorker?.exportPage,
+          endWorker: async () => {
+            await pagesWorker.end()
+            await appWorker.end()
+          },
         }
+
+        await exportApp(dir, options, nextBuildSpan)
+
+        // ensure the worker is not left hanging
+        pagesWorker.close()
+        appWorker.close()
       }
+      await buildTracesPromise
+
+      if (config.output === 'standalone') {
+        await nextBuildSpan
+          .traceChild('copy-traced-files')
+          .traceAsyncFn(async () => {
+            await copyTracedFiles(
+              dir,
+              distDir,
+              pageKeys.pages,
+              denormalizedAppPages,
+              outputFileTracingRoot,
+              requiredServerFiles.config,
+              middlewareManifest,
+              hasInstrumentationHook,
+              staticPages
+            )
+
+            if (config.output === 'standalone') {
+              for (const file of [
+                ...requiredServerFiles.files,
+                path.join(config.distDir, SERVER_FILES_MANIFEST),
+                ...loadedEnvFiles.reduce<string[]>((acc, envFile) => {
+                  if (['.env', '.env.production'].includes(envFile.path)) {
+                    acc.push(envFile.path)
+                  }
+                  return acc
+                }, []),
+              ]) {
+                const filePath = path.join(dir, file)
+                const outputPath = path.join(
+                  distDir,
+                  'standalone',
+                  path.relative(outputFileTracingRoot, filePath)
+                )
+                await fs.mkdir(path.dirname(outputPath), {
+                  recursive: true,
+                })
+                await fs.copyFile(filePath, outputPath)
+              }
+              await recursiveCopy(
+                path.join(distDir, SERVER_DIRECTORY, 'pages'),
+                path.join(
+                  distDir,
+                  'standalone',
+                  path.relative(outputFileTracingRoot, distDir),
+                  SERVER_DIRECTORY,
+                  'pages'
+                ),
+                { overwrite: true }
+              )
+              if (appDir) {
+                const originalServerApp = path.join(
+                  distDir,
+                  SERVER_DIRECTORY,
+                  'app'
+                )
+                if (existsSync(originalServerApp)) {
+                  await recursiveCopy(
+                    originalServerApp,
+                    path.join(
+                      distDir,
+                      'standalone',
+                      path.relative(outputFileTracingRoot, distDir),
+                      SERVER_DIRECTORY,
+                      'app'
+                    ),
+                    { overwrite: true }
+                  )
+                }
+              }
+            }
+          })
+      }
+
+      if (buildTracesSpinner) {
+        buildTracesSpinner.stopAndPersist()
+        buildTracesSpinner = undefined
+      }
+
+      if (postBuildSpinner) postBuildSpinner.stopAndPersist()
+      console.log()
+
+      await nextBuildSpan.traceChild('print-tree-view').traceAsyncFn(() =>
+        printTreeView(pageKeys, pageInfos, {
+          distPath: distDir,
+          buildId: buildId,
+          pagesDir,
+          useStaticPages404,
+          pageExtensions: config.pageExtensions,
+          appBuildManifest,
+          buildManifest,
+          middlewareManifest,
+          gzipSize: config.experimental.gzipSize,
+        })
+      )
+
+      await nextBuildSpan
+        .traceChild('telemetry-flush')
+        .traceAsyncFn(() => telemetry.flush())
     })
 
     return buildResult
@@ -3147,5 +3109,9 @@ export default async function build(
     teardownTraceSubscriber()
     teardownHeapProfiler()
     teardownCrashReporter()
+
+    if (incrementalCacheIpcServer) {
+      incrementalCacheIpcServer.close()
+    }
   }
 }

--- a/packages/next/src/server/lib/incremental-cache-server.ts
+++ b/packages/next/src/server/lib/incremental-cache-server.ts
@@ -6,6 +6,7 @@ let initializeResult:
   | {
       ipcPort: number
       ipcValidationKey: string
+      ipcServer: import('http').Server
     }
 
 export async function initialize(
@@ -13,7 +14,7 @@ export async function initialize(
 ): Promise<NonNullable<typeof initializeResult>> {
   const incrementalCache = new IncrementalCache(...constructorArgs)
 
-  const { ipcPort, ipcValidationKey } = await createIpcServer({
+  const { ipcPort, ipcValidationKey, ipcServer } = await createIpcServer({
     async revalidateTag(
       ...args: Parameters<IncrementalCache['revalidateTag']>
     ) {
@@ -40,5 +41,6 @@ export async function initialize(
   return {
     ipcPort,
     ipcValidationKey,
+    ipcServer,
   }
 }


### PR DESCRIPTION
### What 

This fixes a bug which causes the build to hang indefinitely when using `experimental-generate` and `staticWorkerRequestDeduping`.

The issue at hand is simply that an HTTP server instance is started, but never closed, so it keeps listening and the process fails to exit even though the build is complete.

**Link to the code that reproduces this issue**
https://git.vdb.to/cerc-io/test-progressive-web-app/src/branch/telackey/nxtrepo

To Reproduce
```
npm install
npm run compile
npm run generate
```

Bug: https://github.com/vercel/next.js/issues/58274
Discord: https://discord.com/channels/752553802359505017/1172259310290612384

### Why?

The build should exit cleanly.

### How?

This retrieves the `ipcServer` instance along with the port and validation key, and calls `close()` on it in the `finally` block to make sure that it is cleaned up.

Fixes #58274

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
