### PR TITLE
fix: ensure batch values are sharable

### DIFF
--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -15,6 +15,7 @@ import {
 import { isDynamicUsageError } from '../helpers/is-dynamic-usage-error'
 import {
   NEXT_CACHE_TAGS_HEADER,
+  NEXT_META_SUFFIX,
   RSC_PREFETCH_SUFFIX,
   RSC_SUFFIX,
 } from '../../lib/constants'
@@ -206,7 +207,7 @@ export async function exportAppPage(
 
     await fileWriter(
       ExportedAppPageFiles.META,
-      htmlFilepath.replace(/\.html$/, '.meta'),
+      htmlFilepath.replace(/\.html$/, NEXT_META_SUFFIX),
       JSON.stringify(meta, null, 2)
     )
 

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -4,7 +4,11 @@ import type { AppRouteRouteHandlerContext } from '../../server/future/route-modu
 import type { IncrementalCache } from '../../server/lib/incremental-cache'
 
 import { join } from 'path'
-import { NEXT_CACHE_TAGS_HEADER } from '../../lib/constants'
+import {
+  NEXT_BODY_SUFFIX,
+  NEXT_CACHE_TAGS_HEADER,
+  NEXT_META_SUFFIX,
+} from '../../lib/constants'
 import { NodeNextRequest } from '../../server/base-http/node'
 import { RouteModuleLoader } from '../../server/future/helpers/module-loader/route-module-loader'
 import {
@@ -104,7 +108,7 @@ export async function exportAppRoute(
     const body = Buffer.from(await blob.arrayBuffer())
     await fileWriter(
       ExportedAppRouteFiles.BODY,
-      htmlFilepath.replace(/\.html$/, '.body'),
+      htmlFilepath.replace(/\.html$/, NEXT_BODY_SUFFIX),
       body,
       'utf8'
     )
@@ -113,7 +117,7 @@ export async function exportAppRoute(
     const meta = { status: response.status, headers }
     await fileWriter(
       ExportedAppRouteFiles.META,
-      htmlFilepath.replace(/\.html$/, '.meta'),
+      htmlFilepath.replace(/\.html$/, NEXT_META_SUFFIX),
       JSON.stringify(meta)
     )
 

--- a/packages/next/src/export/routes/pages.ts
+++ b/packages/next/src/export/routes/pages.ts
@@ -11,7 +11,10 @@ import type {
   MockedResponse,
 } from '../../server/lib/mock-request'
 import { isInAmpMode } from '../../shared/lib/amp-mode'
-import { SERVER_PROPS_EXPORT_ERROR } from '../../lib/constants'
+import {
+  NEXT_DATA_SUFFIX,
+  SERVER_PROPS_EXPORT_ERROR,
+} from '../../lib/constants'
 import { NEXT_DYNAMIC_NO_SSR_CODE } from '../../shared/lib/lazy-dynamic/no-ssr-error'
 import AmpHtmlValidator from 'next/dist/compiled/amphtml-validator'
 import { FileType, fileExists } from '../../lib/file-exists'
@@ -187,7 +190,7 @@ export async function exportPages(
   if (metadata.pageData) {
     const dataFile = join(
       pagesDataDir,
-      htmlFilename.replace(/\.html$/, '.json')
+      htmlFilename.replace(/\.html$/, NEXT_DATA_SUFFIX)
     )
 
     await fileWriter(

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -10,6 +10,9 @@ export const NEXT_DID_POSTPONE_HEADER = 'x-nextjs-postponed'
 
 export const RSC_PREFETCH_SUFFIX = '.prefetch.rsc'
 export const RSC_SUFFIX = '.rsc'
+export const NEXT_DATA_SUFFIX = '.json'
+export const NEXT_META_SUFFIX = '.meta'
+export const NEXT_BODY_SUFFIX = '.body'
 
 export const NEXT_CACHE_TAGS_HEADER = 'x-next-cache-tags'
 export const NEXT_CACHE_SOFT_TAGS_HEADER = 'x-next-cache-soft-tags'

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -339,7 +339,13 @@ export default class FileSystemCache implements CacheHandler {
 
       await this.fs.writeFile(
         this.getFilePath(
-          `${key}.${isAppPath ? 'rsc' : 'json'}`,
+          `${key}${
+            isAppPath
+              ? this.experimental.ppr
+                ? RSC_PREFETCH_SUFFIX
+                : RSC_SUFFIX
+              : 'json'
+          }`,
           isAppPath ? 'app' : 'pages'
         ),
         isAppPath ? data.pageData : JSON.stringify(data.pageData)

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -10,6 +10,8 @@ import LRUCache from 'next/dist/compiled/lru-cache'
 import path from '../../../shared/lib/isomorphic/path'
 import {
   NEXT_CACHE_TAGS_HEADER,
+  NEXT_DATA_SUFFIX,
+  NEXT_META_SUFFIX,
   RSC_PREFETCH_SUFFIX,
   RSC_SUFFIX,
 } from '../../../lib/constants'
@@ -140,7 +142,10 @@ export default class FileSystemCache implements CacheHandler {
         const { mtime } = await this.fs.stat(filePath)
 
         const meta = JSON.parse(
-          await this.fs.readFile(filePath.replace(/\.body$/, '.meta'), 'utf8')
+          await this.fs.readFile(
+            filePath.replace(/\.body$/, NEXT_META_SUFFIX),
+            'utf8'
+          )
         )
 
         const cacheEntry: CacheHandlerValue = {
@@ -204,7 +209,7 @@ export default class FileSystemCache implements CacheHandler {
               )
             : JSON.parse(
                 await this.fs.readFile(
-                  this.getFilePath(`${key}.json`, 'pages'),
+                  this.getFilePath(`${key}${NEXT_DATA_SUFFIX}`, 'pages'),
                   'utf8'
                 )
               )
@@ -215,7 +220,7 @@ export default class FileSystemCache implements CacheHandler {
             try {
               meta = JSON.parse(
                 await this.fs.readFile(
-                  filePath.replace(/\.html$/, '.meta'),
+                  filePath.replace(/\.html$/, NEXT_META_SUFFIX),
                   'utf8'
                 )
               )
@@ -322,7 +327,7 @@ export default class FileSystemCache implements CacheHandler {
       }
 
       await this.fs.writeFile(
-        filePath.replace(/\.body$/, '.meta'),
+        filePath.replace(/\.body$/, NEXT_META_SUFFIX),
         JSON.stringify(meta, null, 2)
       )
       return
@@ -344,7 +349,7 @@ export default class FileSystemCache implements CacheHandler {
               ? this.experimental.ppr
                 ? RSC_PREFETCH_SUFFIX
                 : RSC_SUFFIX
-              : 'json'
+              : NEXT_DATA_SUFFIX
           }`,
           isAppPath ? 'app' : 'pages'
         ),
@@ -359,7 +364,7 @@ export default class FileSystemCache implements CacheHandler {
         }
 
         await this.fs.writeFile(
-          htmlPath.replace(/\.html$/, '.meta'),
+          htmlPath.replace(/\.html$/, NEXT_META_SUFFIX),
           JSON.stringify(meta)
         )
       }

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -115,7 +115,8 @@ export type ResponseCacheEntry = {
  */
 export type ResponseGenerator = (
   hasResolved: boolean,
-  previousCacheEntry?: IncrementalCacheItem
+  previousCacheEntry?: IncrementalCacheItem,
+  isRevalidating?: boolean
 ) => Promise<ResponseCacheEntry | null>
 
 export type IncrementalCacheItem = {

--- a/packages/next/src/server/response-cache/utils.ts
+++ b/packages/next/src/server/response-cache/utils.ts
@@ -1,0 +1,51 @@
+import type { IncrementalCacheItem, ResponseCacheEntry } from './types'
+
+import RenderResult from '../render-result'
+
+export async function fromResponseCacheEntry(
+  cacheEntry: ResponseCacheEntry
+): Promise<IncrementalCacheItem> {
+  return {
+    ...cacheEntry,
+    value:
+      cacheEntry.value?.kind === 'PAGE'
+        ? {
+            kind: 'PAGE',
+            html: await cacheEntry.value.html.toUnchunkedString(true),
+            postponed: cacheEntry.value.postponed,
+            pageData: cacheEntry.value.pageData,
+            headers: cacheEntry.value.headers,
+            status: cacheEntry.value.status,
+          }
+        : cacheEntry.value,
+  }
+}
+
+export async function toResponseCacheEntry(
+  response: IncrementalCacheItem
+): Promise<ResponseCacheEntry | null> {
+  if (!response) return null
+
+  if (response.value?.kind === 'FETCH') {
+    throw new Error(
+      'Invariant: unexpected cachedResponse of kind fetch in response cache'
+    )
+  }
+
+  return {
+    isMiss: response.isMiss,
+    isStale: response.isStale,
+    revalidate: response.revalidate,
+    value:
+      response.value?.kind === 'PAGE'
+        ? {
+            kind: 'PAGE',
+            html: RenderResult.fromStatic(response.value.html),
+            pageData: response.value.pageData,
+            postponed: response.value.postponed,
+            headers: response.value.headers,
+            status: response.value.status,
+          }
+        : response.value,
+  }
+}


### PR DESCRIPTION
Previously, the incremental cache returned objects with a readable stream (that were consumed). These can't be shared. Instead, this modifies the cache to instead return strings which are sharable.

This also fixes a bug related to revalidation when writing an updated prefetch RSC payload to the filesystem when PPR is enabled. Previously it just wrote to `.rsc` and now it correctly writes a `.prefetch.rsc` file instead.
