### PR TITLE
fix: ignore basepath when checking matched slots

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -547,7 +547,7 @@ export async function createEntrypoints(
     }
 
     // TODO: find a better place to do this
-    normalizeCatchAllRoutes(appPathsPerRoute)
+    normalizeCatchAllRoutes(appPathsPerRoute, undefined, config.basePath)
 
     // Make sure to sort parallel routes to make the result deterministic.
     appPathsPerRoute = Object.fromEntries(

--- a/packages/next/src/build/normalize-catchall-routes.ts
+++ b/packages/next/src/build/normalize-catchall-routes.ts
@@ -9,23 +9,28 @@ import { AppPathnameNormalizer } from '../server/future/normalizers/built/app/ap
  */
 export function normalizeCatchAllRoutes(
   appPaths: Record<string, string[]>,
-  normalizer = new AppPathnameNormalizer()
+  normalizer = new AppPathnameNormalizer(),
+  basePath = ''
 ) {
   const catchAllRoutes = [
     ...new Set(Object.values(appPaths).flat().filter(isCatchAllRoute)),
   ]
 
   for (const appPath of Object.keys(appPaths)) {
+    const appPathWithoutBase = appPath.startsWith(basePath)
+      ? appPath.slice(basePath.length)
+      : appPath
+
     for (const catchAllRoute of catchAllRoutes) {
       const normalizedCatchAllRoute = normalizer.normalize(catchAllRoute)
       const normalizedCatchAllRouteBasePath = normalizedCatchAllRoute.slice(
         0,
         normalizedCatchAllRoute.indexOf('[')
-      )
+      );
 
       if (
         // first check if the appPath could match the catch-all
-        appPath.startsWith(normalizedCatchAllRouteBasePath) &&
+        appPathWithoutBase.startsWith(normalizedCatchAllRouteBasePath) &&
         // then check if there's not already a slot value that could match the catch-all
         !appPaths[appPath].some((path) => hasMatchedSlots(path, catchAllRoute))
       ) {

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -247,7 +247,7 @@ export default class DevServer extends Server {
       )
 
       matchers.push(
-        new DevAppPageRouteMatcherProvider(appDir, extensions, fileReader)
+        new DevAppPageRouteMatcherProvider(appDir, extensions, fileReader, this.nextConfig.basePath)
       )
       matchers.push(
         new DevAppRouteRouteMatcherProvider(appDir, extensions, fileReader)

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-app-page-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-app-page-route-matcher-provider.ts
@@ -9,15 +9,19 @@ import { normalizeCatchAllRoutes } from '../../../../build/normalize-catchall-ro
 export class DevAppPageRouteMatcherProvider extends FileCacheRouteMatcherProvider<AppPageRouteMatcher> {
   private readonly expression: RegExp
   private readonly normalizers: DevAppNormalizers
+  basePath: string
 
   constructor(
     appDir: string,
     extensions: ReadonlyArray<string>,
-    reader: FileReader
+    reader: FileReader,
+    basePath: string
   ) {
     super(appDir, reader)
 
     this.normalizers = new DevAppNormalizers(appDir, extensions)
+
+    this.basePath = basePath
 
     // Match any page file that ends with `/page.${extension}` under the app
     // directory.
@@ -57,7 +61,7 @@ export class DevAppPageRouteMatcherProvider extends FileCacheRouteMatcherProvide
       else appPaths[pathname] = [page]
     }
 
-    normalizeCatchAllRoutes(appPaths)
+    normalizeCatchAllRoutes(appPaths, undefined, basePath)
 
     const matchers: Array<AppPageRouteMatcher> = []
     for (const filename of routeFilenames) {


### PR DESCRIPTION
### What?
A first draft attempt to fix an issue uncovered while working with parallel routes and a basePath config: https://github.com/vercel/next.js/issues/58268

### Why?
I'd like to be able to use parallel routes for modals even when utilizing a basePath config.

### How?
Strips out the basePath when checking for matched slots.

Closes NEXT-
Fixes https://github.com/vercel/next.js/issues/58268

-->
