### PR TITLE
docs: fix typo in learn Chapter 10 `noting` -> `nothing`

### DIFF
--- a/docs/02-app/01-building-your-application/03-rendering/03-composition-patterns.mdx
+++ b/docs/02-app/01-building-your-application/03-rendering/03-composition-patterns.mdx
@@ -344,7 +344,7 @@ In a similar fashion, library authors creating packages to be consumed by other 
 
 You can optimize your package by using ['use client' deeper in the tree](#moving-client-components-down-the-tree), allowing the imported modules to be part of the Server Component module graph.
 
-It's worth noting some bundlers might strip out `"use client"` directives. You can find an example of how to configure esbuild to include the `"use client"` directive in the [React Wrap Balancer](https://github.com/shuding/react-wrap-balancer/blob/main/tsup.config.ts#L10-L13) and [Vercel Analytics](https://github.com/vercel/analytics/blob/main/packages/web/tsup.config.js#L26-L30) repositories.
+It's worth nothing some bundlers might strip out `"use client"` directives. You can find an example of how to configure esbuild to include the `"use client"` directive in the [React Wrap Balancer](https://github.com/shuding/react-wrap-balancer/blob/main/tsup.config.ts#L10-L13) and [Vercel Analytics](https://github.com/vercel/analytics/blob/main/packages/web/tsup.config.js#L26-L30) repositories.
 
 ## Client Components
 


### PR DESCRIPTION
fixed simple typo on learning chapter 10. 