### PR TITLE
[experiment]: Enable `lightningcss` of `styled-jsx`

### DIFF
--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -202,7 +202,9 @@ where
                 turbopack_binding::swc::custom_transform::styled_jsx::visitor::styled_jsx(
                     cm.clone(),
                     file.name.clone(),
-                    config,
+                    turbopack_binding::swc::custom_transform::styled_jsx::visitor::Config{
+                        use_lightningcss: true,
+                    },
                 ),
             )
         } else {


### PR DESCRIPTION
### What?

I want to check for regressions of the apps before enabling it by default.

### Why?

### How?



Closes PACK-1939