### PR TITLE
update import path for GeitSans font to address deprecation warning

### DIFF
--- a/examples/with-supabase/app/layout.tsx
+++ b/examples/with-supabase/app/layout.tsx
@@ -1,4 +1,4 @@
-import { GeistSans } from 'geist/font'
+import { GeistSans } from 'geist/font/sans'
 import './globals.css'
 
 const defaultUrl = process.env.VERCEL_URL


### PR DESCRIPTION
### Summary

This PR updates the import path for the `GeistSans` font to address the deprecation warning.

### Changes

- Changed the import path from `geist/font` to `geist/font/sans` following the library's deprecation notice.
- Verified that no changes in font appearance or behavior occur with the new import path.

### Testing

- Visual inspection of the font rendering on all pages to ensure no changes in style or layout.
- Checked console logs for the absence of deprecation warnings.

### Additional Information
As per the library's recommendation, `GeistSans` is preferred for its smaller size, and we are already targeting modern browsers that support variable fonts. Therefore, there's no need to switch to the non-variable alternative.

The modified file is:
- `RootLayout.tsx`: Updated the import path for `GeistSans`.

