### PR TITLE
docs: Update runtime table

### DIFF
--- a/docs/02-app/01-building-your-application/03-rendering/04-edge-and-nodejs-runtimes.mdx
+++ b/docs/02-app/01-building-your-application/03-rendering/04-edge-and-nodejs-runtimes.mdx
@@ -16,18 +16,18 @@ On the server, there are two runtimes where parts of your application code can b
 
 There are many considerations to make when choosing a runtime. This table shows the major differences at a glance. If you want a more in-depth analysis of the differences, check out the sections below.
 
-|                                                                                                                                                     | Node   | Serverless | Edge             |
-| --------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------- | ---------------- |
-| [Cold Boot](https://vercel.com/docs/concepts/get-started/compute#cold-and-hot-boots?utm_source=next-site&utm_medium=docs&utm_campaign=next-website) | /      | ~250ms     | Instant          |
-| [HTTP Streaming](/docs/app/building-your-application/routing/loading-ui-and-streaming)                                                              | Yes    | Yes        | Yes              |
-| IO                                                                                                                                                  | All    | All        | `fetch`          |
-| Scalability                                                                                                                                         | /      | High       | Highest          |
-| Security                                                                                                                                            | Normal | High       | High             |
-| Latency                                                                                                                                             | Normal | Low        | Lowest           |
-| npm Packages                                                                                                                                        | All    | All        | A smaller subset |
-| [Static Rendering](/docs/app/building-your-application/rendering/server-components#static-rendering-default)                                        | Yes    | Yes        | No               |
-| [Dynamic Rendering](/docs/app/building-your-application/rendering/server-components#dynamic-rendering)                                              | Yes    | Yes        | Yes              |
-| [Data Revalidation w/ `fetch`](/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#revalidating-data)               | Yes    | Yes        | Yes              |
+|                                                                                                                                       | Node   | Serverless | Edge             |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------- | ---------------- |
+| Cold Boot                                                                                                                             | /      | Normal     | Low              |
+| [HTTP Streaming](/docs/app/building-your-application/routing/loading-ui-and-streaming)                                                | Yes    | Yes        | Yes              |
+| IO                                                                                                                                    | All    | All        | `fetch`          |
+| Scalability                                                                                                                           | /      | High       | Highest          |
+| Security                                                                                                                              | Normal | High       | High             |
+| Latency                                                                                                                               | Normal | Low        | Lowest           |
+| npm Packages                                                                                                                          | All    | All        | A smaller subset |
+| [Static Rendering](/docs/app/building-your-application/rendering/server-components#static-rendering-default)                          | Yes    | Yes        | No               |
+| [Dynamic Rendering](/docs/app/building-your-application/rendering/server-components#dynamic-rendering)                                | Yes    | Yes        | Yes              |
+| [Data Revalidation w/ `fetch`](/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#revalidating-data) | Yes    | Yes        | Yes              |
 
 ### Edge Runtime
 


### PR DESCRIPTION
Adds a bit more clarity that while the edge runtime certainly enables faster startups than the Node.js runtime (by being in general lighter), it does not mean the additional user code added will not affect the boot time. Hello world might be instant but I believe "low" better reflects that it _will_ grow with user code added.