### PR TITLE
Fix hydration error in headers example

### DIFF
--- a/examples/headers/pages/index.tsx
+++ b/examples/headers/pages/index.tsx
@@ -24,7 +24,7 @@ export default function Index() {
           <ul className={styles.list}>
             <li>
               <a href="/about">
-                <a>Visit /about (it contains a X-About-Custom-Header)</a>
+                Visit /about (it contains a X-About-Custom-Header)
               </a>
             </li>
             <li>


### PR DESCRIPTION
This PR fixes the hydration error in the headers example due to nesting of anchor tags, it was causing the whole app to crash at start.