### PR TITLE
fix: path issues on linux machines when build created on windows

### DIFF
--- a/packages/next/src/build/handle-externals.ts
+++ b/packages/next/src/build/handle-externals.ts
@@ -223,7 +223,7 @@ export function makeExternalHandler({
       if (isExternal) {
         // it's important we return the path that starts with `next/dist/` here instead of the absolute path
         // otherwise NFT will get tripped up
-        return `commonjs ${localRes.replace(/.*?next[/\\]dist/, 'next/dist')}`
+        return `commonjs ${localRes.replace(/.*?next[/\\]dist/, "next/dist").replace(/\\/g, "/")}`
       }
     }
 

--- a/packages/next/src/build/handle-externals.ts
+++ b/packages/next/src/build/handle-externals.ts
@@ -223,7 +223,7 @@ export function makeExternalHandler({
       if (isExternal) {
         // it's important we return the path that starts with `next/dist/` here instead of the absolute path
         // otherwise NFT will get tripped up
-        return `commonjs ${localRes.replace(/.*?next[/\\]dist/, "next/dist").replace(/\\/g, "/")}`
+        return `commonjs ${localRes.replace(/.*?next[/\\]dist/, 'next/dist').replace(/\\/g, '/')}`
       }
     }
 


### PR DESCRIPTION
### What?
The user gets an internal error 500 when visiting your website. You get "Error: Cannot find module 'next/dist\client\components\static-generation-async-storage-external.js'" on server logs. The specifics can be found in https://github.com/vercel/next.js/discussions/56010.

### Why?
If build was created on windows it is using '\\' in the paths whereas it has to be replaced with '/'. If the same build is deployed to linux based machines like app engine, it throws the error above.

### How?
By replacing 
`return `commonjs ${localRes.replace(/.*?next[/\\]dist/, "next/dist")}`
with 
`return `commonjs ${localRes.replace(/.*?next[/\\]dist/, "next/dist").replace(/\\/g, "/")}``
in
`next\build\handle-externals.js`

Closes NEXT-58244
Fixes #58244

-->
