### PR TITLE
Fix: Server actions standalone CSRF issue

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -911,7 +911,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         )
       }
 
-      req.headers['x-forwarded-host'] ??= req.headers["host"] || `${this.hostname}:${this.port}`
+      req.headers['x-forwarded-host'] ??= req.headers["host"] ?? this.hostname
       req.headers['x-forwarded-port'] ??= this.port?.toString()
       const { originalRequest } = req as NodeNextRequest
       req.headers['x-forwarded-proto'] ??= (originalRequest.socket as TLSSocket)

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -911,7 +911,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         )
       }
 
-      req.headers['x-forwarded-host'] ??= `${this.hostname}:${this.port}`
+      req.headers['x-forwarded-host'] ??= req.headers["host"] || `${this.hostname}:${this.port}`
       req.headers['x-forwarded-port'] ??= this.port?.toString()
       const { originalRequest } = req as NodeNextRequest
       req.headers['x-forwarded-proto'] ??= (originalRequest.socket as TLSSocket)


### PR DESCRIPTION
### Fixing a bug

- Related issues linked using:
fixes: #58295 

- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
Not sure quite how to write a test for this - can someone point me to an example of how to test standalone and server actions?

### What?
When using `standalone` mode (i.e. workers) and Server Actions without `process.env.HOSTNAME` set then `x-forward-host` is set to `${this.hostname}:${this.port}`. When using Server Actions the CSRF check fails if x-forwarded-hostname is not set as https://github.com/vercel/next.js/blob/1eee93cc94255ed17d853f64904752d4c840a9b1/packages/next/src/server/app-render/action-handler.ts#L291-L345 picks up the value set here which is incorrect.

### Why?
I'm not 100% sure that this is the correct fix as not sure why `x-forwarded-host` is being set to a default value however reverting to the behaviour that was present in determining this header before #57815 should fix at least some of the issues in #58295 

### How?

Closes NEXT-
Fixes  N/A
