### PR TITLE
fix hmr event, and avoid RSC fetch on any message

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
@@ -338,14 +338,16 @@ function processMessage(
         })
       )
 
-      const isHotUpdate =
-        obj.action !== HMR_ACTIONS_SENT_TO_BROWSER.SYNC &&
-        (!window.__NEXT_DATA__ || window.__NEXT_DATA__.page !== '/_error') &&
-        isUpdateAvailable()
+      if (!process.env.TURBOPACK) {
+        const isHotUpdate =
+          obj.action !== HMR_ACTIONS_SENT_TO_BROWSER.SYNC &&
+          (!window.__NEXT_DATA__ || window.__NEXT_DATA__.page !== '/_error') &&
+          isUpdateAvailable()
 
-      // Attempt to apply hot updates or reload.
-      if (isHotUpdate) {
-        handleHotUpdate()
+        // Attempt to apply hot updates or reload.
+        if (isHotUpdate) {
+          handleHotUpdate()
+        }
       }
       return
     }
@@ -367,13 +369,6 @@ function processMessage(
         router.fastRefresh()
         dispatcher.onRefresh()
       })
-
-      if (process.env.__NEXT_TEST_MODE) {
-        if (self.__NEXT_HMR_CB) {
-          self.__NEXT_HMR_CB()
-          self.__NEXT_HMR_CB = null
-        }
-      }
 
       return
     }
@@ -448,6 +443,16 @@ export default function HotReload({
       },
     }
   }, [dispatch])
+
+  useEffect(() => {
+    if (process.env.__NEXT_TEST_MODE) {
+      if (self.__NEXT_HMR_CB) {
+        self.__NEXT_HMR_CB()
+        self.__NEXT_HMR_CB = null
+      }
+    }
+    // currentHmrObj will change when ACTION_REFRESH is dispatched.
+  }, [state.currentHmrObj])
 
   const handleOnUnhandledError = useCallback((error: Error): void => {
     // Component stack is added to the error in use-error-handler in case there was a hydration errror

--- a/packages/next/src/client/components/react-dev-overlay/internal/error-overlay-reducer.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/error-overlay-reducer.ts
@@ -12,6 +12,7 @@ export const ACTION_UNHANDLED_REJECTION = 'unhandled-rejection'
 export const ACTION_VERSION_INFO = 'version-info'
 export const INITIAL_OVERLAY_STATE: OverlayState = {
   nextId: 1,
+  currentHmrObj: {},
   buildError: null,
   errors: [],
   notFound: false,
@@ -60,6 +61,7 @@ export type FastRefreshState =
     }
 
 export interface OverlayState {
+  currentHmrObj: {}
   nextId: number
   buildError: string | null
   errors: SupportedErrorEvent[]
@@ -109,6 +111,9 @@ export const errorOverlayReducer: React.Reducer<
     case ACTION_REFRESH: {
       return {
         ...state,
+        // Create a new hmrObj to track when a HMR was applied, this ensures the HMR callback `useEffect` will be called.
+        // Uses an object as the identity is unique, so anytime it changes it will trigger a new run of the effect.
+        currentHmrObj: {},
         buildError: null,
         errors:
           // Errors can come in during updates. In this case, UNHANDLED_ERROR


### PR DESCRIPTION
### What?

notify `__NEXT_HMR_CB` only when the RSC HMR update rerendered

### Why?

the event was too early
