### PR TITLE
turbopack: Don't error with legacy server actions boolean

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -442,7 +442,7 @@ pub struct ExperimentalConfig {
     pub optimize_css: Option<serde_json::Value>,
     pub next_script_workers: Option<bool>,
     pub web_vitals_attribution: Option<Vec<String>>,
-    pub server_actions: Option<ServerActions>,
+    pub server_actions: Option<ServerActionsOrLegacyBool>,
     pub sri: Option<SubResourceIntegrity>,
 
     // ---
@@ -511,7 +511,18 @@ pub struct SubResourceIntegrity {
     pub algorithm: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, TraceRawVcs)]
+#[serde(untagged)]
+pub enum ServerActionsOrLegacyBool {
+    /// The current way to configure server actions sub behaviors.
+    ServerActionsConfig(ServerActions),
+
+    /// The legacy way to disable server actions. This is no longer used, server
+    /// actions is always enabled.
+    LegacyBool(bool),
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, TraceRawVcs)]
 #[serde(rename_all = "camelCase")]
 pub struct ServerActions {
     /// Allows adjusting body parser size limit for server actions.

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -253,7 +253,17 @@ export async function validateTurboNextConfig({
       }
 
       let isSupported =
-        supportedKeys.some((supportedKey) => key.startsWith(supportedKey)) ||
+        supportedKeys.some(
+          (supportedKey) =>
+            // Either the key matches (or is a more specific subkey) of
+            // supportedKey, or the key is the path to a specific subkey.
+            // | key     | supportedKey |
+            // |---------|--------------|
+            // | foo     | foo          |
+            // | foo.bar | foo          |
+            // | foo     | foo.bar      |
+            key.startsWith(supportedKey) || supportedKey.startsWith(`${key}.`)
+        ) ||
         getDeepValue(rawNextConfig, key) === getDeepValue(defaultConfig, key)
       if (!isSupported) {
         unsupportedConfig.push(key)


### PR DESCRIPTION
### What?

This stops Turbopack from erroring out when trying to parse apps using NextConfig's legacy `experimental.serverActions` boolean value.

### Why?

Old apps may not have removed the legacy boolean flag, but should still run.

### How?

At first I attempted updating Zod's configuration to use a default option config when a boolean was encountered, and passing the updated config to Turbopack, but this would hide the warning message. Then I tried implementing a custom `Deserializer` on the Rust side to handle boolean values and default. But, it was just so much easier to implement with a enum supporting both the current and the legacy configuration.

Closes PACK-1962