### PR TITLE
fix: Don't reset shallow URL updates on prefetch

### DIFF
--- a/test/production/app-dir/dont-reset-shallow-url-updates-on-prefetch/app/layout.tsx
+++ b/test/production/app-dir/dont-reset-shallow-url-updates-on-prefetch/app/layout.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/dont-reset-shallow-url-updates-on-prefetch/app/other/page.tsx
+++ b/test/production/app-dir/dont-reset-shallow-url-updates-on-prefetch/app/other/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Page() {
+  return <p>Prefetch target page</p>
+}

--- a/test/production/app-dir/dont-reset-shallow-url-updates-on-prefetch/app/page.tsx
+++ b/test/production/app-dir/dont-reset-shallow-url-updates-on-prefetch/app/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+
+export default function Page() {
+  const setShallowSearchParams = React.useCallback(() => {
+    // Maintain history state, but set a shallow search param
+    history.replaceState(history.state, '', '?foo=bar')
+  }, [])
+  return (
+    <>
+      <button onClick={setShallowSearchParams}>Click me first</button>
+      <Link href="/other" prefetch>
+        Then hover me
+      </Link>
+    </>
+  )
+}

--- a/test/production/app-dir/dont-reset-shallow-url-updates-on-prefetch/dont-reset-shallow-url-updates-on-prefetch.test.ts
+++ b/test/production/app-dir/dont-reset-shallow-url-updates-on-prefetch/dont-reset-shallow-url-updates-on-prefetch.test.ts
@@ -1,0 +1,21 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'dont-reset-shallow-url-updates-on-prefetch',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should work using browser', async () => {
+      const browser = await next.browser('/')
+      const button = await browser.elementByCss('button')
+      await button.click()
+      expect(await browser.url()).toMatch(/\?foo=bar$/)
+      const link = await browser.elementByCss('a')
+      await link.hover()
+      // Hovering a prefetch link should keep the URL intact
+      expect(await browser.url()).toMatch(/\?foo=bar$/)
+      // await browser.elementByCss('uncomment-to-keep-the-browser-open')
+    })
+  }
+)

--- a/test/production/app-dir/dont-reset-shallow-url-updates-on-prefetch/next.config.js
+++ b/test/production/app-dir/dont-reset-shallow-url-updates-on-prefetch/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Original PR [#58297](https://github.com/vercel/next.js/pull/58297) from [franky47](https://github.com/franky47)

Description
Between 14.0.2-canary.6 and 14.0.2-canary.7, a change was introduced in https://github.com/vercel/next.js/pull/56497 that turned the Redux store state into a Promise, rather than a synchronous state update.

This caused the sync function -- used to send state updates to the Redux Devtools -- to be recreated on every dispatch, which in turn, by referential instability, caused the HistoryUpdater component to re-render and trigger a history.replaceState with no particular change, but with the internal canonicalUrl.

When an app does a soft/shallow navigation by calling history methods directly (currently the only way to do shallow search params updates in the app router), these changes would have been overwritten by any prefetch (eg: hovering or mounting a Link), which is usually a no-op for the navigation state.

This PR removes the sync function for the Redux devtools, as it cannot function as-is: actual state updates need to be awaited and forwarded somewhere else in the router if this behaviour is to be maintained, and should be decoupled from history calls to prevent side-effects.

Context
I maintain [next-usequerystate](https://github.com/47ng/next-usequerystate), which is used in the Vercel dashboard, and which is impacted by this change (see
https://github.com/47ng/next-usequerystate/issues/388).

History
@timneutkens introduced the sync function and the whole Redux devtools reducer in https://github.com/vercel/next.js/pull/39866, with the note:

a new hook useReducerWithReduxDevtools has been added, we'll probably want to put this behind a compile-time flag when the new router is marked stable but until then it's useful to have it enabled by default (only
when you have Redux Devtools installed ofcourse).

If a different direction is needed to keep sending RENDER_SYNC actions to Redux devtools, I'll be happy to rework this PR to move the sync function into the action queue.

Changes
 Added e2e test. Requires a start mode as prefetch links are disabled in development. Test was verified to fail from next@>=12.0.2-canary.7 without the fix.