### PR TITLE
Revert "add test case to failing list for turbopack"

### DIFF
--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -3683,7 +3683,6 @@
     ],
     "failed": [
       "parallel-routes-and-interception parallel routes should apply the catch-all route to the parallel route if no matching route is found",
-      "parallel-routes-and-interception parallel routes Should match the catch-all routes of the more specific path, If there is more than one catch-all route",
       "parallel-routes-and-interception parallel routes should throw an error when a route groups causes a conflict with a parallel segment"
     ],
     "pending": [],


### PR DESCRIPTION
Reverts vercel/next.js#58435

Seems to be resulting in consistent CI failures

[x-ref](https://github.com/vercel/next.js/actions/runs/6856034177/job/18658084460)
[x-ref](https://github.com/vercel/next.js/actions/runs/6864944315/job/18667863954)