### PR TITLE
Revert "fix hmr event, and avoid RSC fetch on any message"

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
@@ -338,16 +338,14 @@ function processMessage(
         })
       )
 
-      if (!process.env.TURBOPACK) {
-        const isHotUpdate =
-          obj.action !== HMR_ACTIONS_SENT_TO_BROWSER.SYNC &&
-          (!window.__NEXT_DATA__ || window.__NEXT_DATA__.page !== '/_error') &&
-          isUpdateAvailable()
+      const isHotUpdate =
+        obj.action !== HMR_ACTIONS_SENT_TO_BROWSER.SYNC &&
+        (!window.__NEXT_DATA__ || window.__NEXT_DATA__.page !== '/_error') &&
+        isUpdateAvailable()
 
-        // Attempt to apply hot updates or reload.
-        if (isHotUpdate) {
-          handleHotUpdate()
-        }
+      // Attempt to apply hot updates or reload.
+      if (isHotUpdate) {
+        handleHotUpdate()
       }
       return
     }
@@ -369,6 +367,13 @@ function processMessage(
         router.fastRefresh()
         dispatcher.onRefresh()
       })
+
+      if (process.env.__NEXT_TEST_MODE) {
+        if (self.__NEXT_HMR_CB) {
+          self.__NEXT_HMR_CB()
+          self.__NEXT_HMR_CB = null
+        }
+      }
 
       return
     }
@@ -443,16 +448,6 @@ export default function HotReload({
       },
     }
   }, [dispatch])
-
-  useEffect(() => {
-    if (process.env.__NEXT_TEST_MODE) {
-      if (self.__NEXT_HMR_CB) {
-        self.__NEXT_HMR_CB()
-        self.__NEXT_HMR_CB = null
-      }
-    }
-    // currentHmrObj will change when ACTION_REFRESH is dispatched.
-  }, [state.currentHmrObj])
 
   const handleOnUnhandledError = useCallback((error: Error): void => {
     // Component stack is added to the error in use-error-handler in case there was a hydration errror

--- a/packages/next/src/client/components/react-dev-overlay/internal/error-overlay-reducer.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/error-overlay-reducer.ts
@@ -12,7 +12,6 @@ export const ACTION_UNHANDLED_REJECTION = 'unhandled-rejection'
 export const ACTION_VERSION_INFO = 'version-info'
 export const INITIAL_OVERLAY_STATE: OverlayState = {
   nextId: 1,
-  currentHmrObj: {},
   buildError: null,
   errors: [],
   notFound: false,
@@ -61,7 +60,6 @@ export type FastRefreshState =
     }
 
 export interface OverlayState {
-  currentHmrObj: {}
   nextId: number
   buildError: string | null
   errors: SupportedErrorEvent[]
@@ -111,9 +109,6 @@ export const errorOverlayReducer: React.Reducer<
     case ACTION_REFRESH: {
       return {
         ...state,
-        // Create a new hmrObj to track when a HMR was applied, this ensures the HMR callback `useEffect` will be called.
-        // Uses an object as the identity is unique, so anytime it changes it will trigger a new run of the effect.
-        currentHmrObj: {},
         buildError: null,
         errors:
           // Errors can come in during updates. In this case, UNHANDLED_ERROR


### PR DESCRIPTION
Reverts vercel/next.js#58403

Seems to be resulting in consistent CI failures

[x-ref](https://github.com/vercel/next.js/actions/runs/6856034177/job/18658084460)
[x-ref](https://github.com/vercel/next.js/actions/runs/6864944315/job/18667863954)