### PR TITLE
skip flushToDisk in minimal mode for fetch cache

### DIFF
--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -5,15 +5,25 @@ import { IncrementalCache } from '../../server/lib/incremental-cache'
 import { hasNextSupport } from '../../telemetry/ci-info'
 import { nodeFs } from '../../server/lib/node-fs-methods'
 
-export function createIncrementalCache(
-  incrementalCacheHandlerPath: string | undefined,
-  isrMemoryCacheSize: number | undefined,
-  fetchCacheKeyPrefix: string | undefined,
-  distDir: string,
-  dir: string,
-  enabledDirectories: NextEnabledDirectories,
+export function createIncrementalCache({
+  incrementalCacheHandlerPath,
+  isrMemoryCacheSize,
+  fetchCacheKeyPrefix,
+  distDir,
+  dir,
+  enabledDirectories,
+  experimental,
+  flushToDisk,
+}: {
+  incrementalCacheHandlerPath?: string
+  isrMemoryCacheSize?: number
+  fetchCacheKeyPrefix?: string
+  distDir: string
+  dir: string
+  enabledDirectories: NextEnabledDirectories
   experimental: { ppr: boolean }
-) {
+  flushToDisk?: boolean
+}) {
   // Custom cache handler overrides.
   let CacheHandler: any
   if (incrementalCacheHandlerPath) {
@@ -26,7 +36,7 @@ export function createIncrementalCache(
   const incrementalCache = new IncrementalCache({
     dev: false,
     requestHeaders: {},
-    flushToDisk: true,
+    flushToDisk,
     fetchCache: true,
     maxMemoryCacheSize: isrMemoryCacheSize,
     fetchCacheKeyPrefix,

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -218,7 +218,7 @@ async function exportPageImpl(
     // cache instance for this page.
     const incrementalCache =
       isAppDir && fetchCache
-        ? createIncrementalCache(
+        ? createIncrementalCache({
             incrementalCacheHandlerPath,
             isrMemoryCacheSize,
             fetchCacheKeyPrefix,
@@ -226,8 +226,11 @@ async function exportPageImpl(
             dir,
             enabledDirectories,
             // PPR is not available for Pages.
-            { ppr: false }
-          )
+            experimental: { ppr: false },
+            // skip writing to disk in minimal mode for now, pending some
+            // changes to better support it
+            flushToDisk: !hasNextSupport,
+          })
         : undefined
 
     // Handle App Routes.


### PR DESCRIPTION
This temporarily disables flushing fetch cache to disk during builds in minimal mode as some additional changes are needed to support it better.

[slack context](https://vercel.slack.com/archives/C042LHPJ1NX/p1699928670252259?thread_ts=1699468188.418499&cid=C042LHPJ1NX)