### PR TITLE
Fixed the import statement in MDX docs

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
@@ -67,7 +67,7 @@ export function useMDXComponents(components) {
 Update the `next.config.js` file at your project's root to configure it to use MDX:
 
 ```js filename="next.config.js"
-const withMDX = require('@next/mdx')()
+const nextMDX = require('@next/mdx')()
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -76,7 +76,7 @@ const nextConfig = {
   // Optionally, add any other Next.js config below
 }
 
-module.exports = withMDX(nextConfig)
+module.exports = nextMDX()(nextConfig)
 ```
 
 <AppOnly>


### PR DESCRIPTION
### What?
I switched import statement of`withMDX` to `nextMDX` according to `@next/mdx/index.d.ts`.
### Why?
I found `withMDX` doesn't work when I ran `yarn dev` following the MDX tutorial.
### How?
I referred to `@next/mdx/index.d.ts` and thought it should be curried function using `nextMDX`.
