### PR TITLE
Fix history.push/replaceState to preserve the native API semantics

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -231,7 +231,8 @@ const originalReplaceState =
     ? window.history.replaceState.bind(window.history)
     : null
 
-function copyNextJsInternalHistoryState(data: any) {
+function copyNextJsInternalHistoryState(data: any): any {
+  if (data == null || data === undefined) data = {}
   const currentState = window.history.state
   const __NA = currentState?.__NA
   if (__NA) {
@@ -242,6 +243,7 @@ function copyNextJsInternalHistoryState(data: any) {
   if (__PRIVATE_NEXTJS_INTERNALS_TREE) {
     data.__PRIVATE_NEXTJS_INTERNALS_TREE = __PRIVATE_NEXTJS_INTERNALS_TREE
   }
+  return data
 }
 
 /**
@@ -459,7 +461,7 @@ function Router({
         startTransition(() => {
           dispatch({
             type: ACTION_RESTORE,
-            url: new URL(url ?? window.location.href),
+            url: new URL(url ?? '', window.location.href),
             tree: window.history.state.__PRIVATE_NEXTJS_INTERNALS_TREE,
           })
         })
@@ -476,7 +478,7 @@ function Router({
           _unused: string,
           url?: string | URL | null
         ): void {
-          copyNextJsInternalHistoryState(data)
+          data = copyNextJsInternalHistoryState(data)
 
           applyUrlFromHistoryPushReplace(url)
 
@@ -494,7 +496,7 @@ function Router({
           _unused: string,
           url?: string | URL | null
         ): void {
-          copyNextJsInternalHistoryState(data)
+          data = copyNextJsInternalHistoryState(data)
 
           if (url) {
             applyUrlFromHistoryPushReplace(url)

--- a/test/e2e/app-dir/shallow-routing/app/(shallow)/pushstate-new-pathname/page.tsx
+++ b/test/e2e/app-dir/shallow-routing/app/(shallow)/pushstate-new-pathname/page.tsx
@@ -9,9 +9,7 @@ export default function Page() {
       <pre id="my-data">{pathname}</pre>
       <button
         onClick={() => {
-          const url = new URL(window.location.href)
-          url.pathname = '/my-non-existent-path'
-          window.history.pushState({}, '', url)
+          window.history.pushState(undefined, '', '/my-non-existent-path')
         }}
         id="push-pathname"
       >

--- a/test/e2e/app-dir/shallow-routing/app/(shallow)/replacestate-new-pathname/page.tsx
+++ b/test/e2e/app-dir/shallow-routing/app/(shallow)/replacestate-new-pathname/page.tsx
@@ -9,9 +9,7 @@ export default function Page() {
       <pre id="my-data">{pathname}</pre>
       <button
         onClick={() => {
-          const url = new URL(window.location.href)
-          url.pathname = '/my-non-existent-path'
-          window.history.replaceState({}, '', url)
+          window.history.replaceState(null, '', '/my-non-existent-path')
         }}
         id="replace-pathname"
       >


### PR DESCRIPTION
Supported native API nuances:

1. The `data` parameter can be `null` or `undefined`.
2. A relative `url` is allowed.
