### PR TITLE
Add cacheNodeSeedData to RSC payload

### DIFF
--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -11,14 +11,15 @@ export function applyFlightData(
   wasPrefetched: boolean = false
 ): boolean {
   // The one before last item is the router state tree patch
-  const [treePatch, subTreeData, head] = flightDataPath.slice(-3)
+  const [treePatch, subTreeData, head /* , cacheNodeSeedData */] =
+    flightDataPath.slice(-4)
 
   // Handles case where prefetch only returns the router tree patch without rendered components.
   if (subTreeData === null) {
     return false
   }
 
-  if (flightDataPath.length === 3) {
+  if (flightDataPath.length === 4) {
     cache.status = CacheStates.READY
     cache.subTreeData = subTreeData
     fillLazyItemsTillLeafWithHead(

--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.test.tsx
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.test.tsx
@@ -37,6 +37,7 @@ const getFlightData = (): FlightData => {
       <>
         <title>About page!</title>
       </>,
+      null,
     ],
   ]
 }
@@ -52,8 +53,8 @@ describe('applyRouterStatePatchToTree', () => {
 
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
-    const [treePatch /*, subTreeData, head*/] = flightDataPath.slice(-3)
-    const flightSegmentPath = flightDataPath.slice(0, -4)
+    const [treePatch /*, subTreeData, head*/] = flightDataPath.slice(-4)
+    const flightSegmentPath = flightDataPath.slice(0, -5)
 
     const newRouterStateTree = applyRouterStatePatchToTree(
       ['', ...flightSegmentPath],

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -14,7 +14,7 @@ export function fillCacheWithNewSubTreeData(
   flightDataPath: FlightDataPath,
   wasPrefetched?: boolean
 ): void {
-  const isLastEntry = flightDataPath.length <= 5
+  const isLastEntry = flightDataPath.length <= 6
   const [parallelRouteKey, segment] = flightDataPath
 
   const cacheKey = createRouterCacheKey(segment)

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -30,6 +30,7 @@ const getFlightData = (): FlightData => {
       <>
         <title>About page!</title>
       </>,
+      null,
     ],
   ]
 }
@@ -88,7 +89,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [treePatch, _subTreeData, head] = flightDataPath.slice(-3)
+    const [treePatch, _subTreeData, head] = flightDataPath.slice(-4)
     fillLazyItemsTillLeafWithHead(cache, existingCache, treePatch, head)
 
     const expectedCache: CacheNode = {

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -22,6 +22,7 @@ const getFlightData = (): FlightData => {
       <>
         <title>About page!</title>
       </>,
+      null,
     ],
   ]
 }
@@ -79,7 +80,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
 
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
-    const flightSegmentPath = flightDataPath.slice(0, -3)
+    const flightSegmentPath = flightDataPath.slice(0, -4)
 
     // @ts-expect-error TODO-APP: investigate why this is not a TS error in router-reducer.
     cache.status = CacheStates.READY

--- a/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
@@ -59,7 +59,7 @@ function fastRefreshReducerImpl(
 
       for (const flightDataPath of flightData) {
         // FlightDataPath with more than two items means unexpected Flight data was returned
-        if (flightDataPath.length !== 3) {
+        if (flightDataPath.length !== 4) {
           // TODO-APP: handle this case better
           console.log('REFRESH FAILED')
           return state

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
@@ -32,6 +32,7 @@ const flightData: FlightData = [
     <>
       <title>About page!</title>
     </>,
+    null,
   ],
 ]
 
@@ -63,6 +64,7 @@ const demographicsFlightData: FlightData = [
     <>
       <title>Demographics Head</title>
     </>,
+    null,
   ],
 ]
 

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -175,10 +175,10 @@ export function navigateReducer(
       for (const flightDataPath of flightData) {
         const flightSegmentPath = flightDataPath.slice(
           0,
-          -4
+          -5
         ) as unknown as FlightSegmentPath
         // The one before last item is the router state tree patch
-        const treePatch = flightDataPath.slice(-3)[0] as FlightRouterState
+        const treePatch = flightDataPath.slice(-4)[0] as FlightRouterState
 
         // TODO-APP: remove ''
         const flightSegmentPathWithLeadingEmpty = ['', ...flightSegmentPath]

--- a/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
@@ -27,6 +27,7 @@ jest.mock('../fetch-server-response', () => {
       <>
         <title>About page!</title>
       </>,
+      null,
     ],
   ]
   return {

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
@@ -36,6 +36,7 @@ jest.mock('../fetch-server-response', () => {
       <>
         <title>Linking page!</title>
       </>,
+      null,
     ],
   ]
   return {

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -57,8 +57,8 @@ export function refreshReducer(
       cache.data = null
 
       for (const flightDataPath of flightData) {
-        // FlightDataPath with more than two items means unexpected Flight data was returned
-        if (flightDataPath.length !== 3) {
+        // FlightDataPath with more than four items means unexpected Flight data was returned
+        if (flightDataPath.length !== 4) {
           // TODO-APP: handle this case better
           console.log('REFRESH FAILED')
           return state
@@ -95,7 +95,7 @@ export function refreshReducer(
         }
 
         // The one before last item is the router state tree patch
-        const [subTreeData, head] = flightDataPath.slice(-2)
+        const [subTreeData, head] = flightDataPath.slice(-3)
 
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (subTreeData !== null) {

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -206,7 +206,7 @@ export function serverActionReducer(
 
       for (const flightDataPath of flightData) {
         // FlightDataPath with more than two items means unexpected Flight data was returned
-        if (flightDataPath.length !== 3) {
+        if (flightDataPath.length !== 4) {
           // TODO-APP: handle this case better
           console.log('SERVER ACTION APPLY FAILED')
           return state
@@ -235,7 +235,7 @@ export function serverActionReducer(
         }
 
         // The one before last item is the router state tree patch
-        const [subTreeData, head] = flightDataPath.slice(-2)
+        const [subTreeData, head] = flightDataPath.slice(-3)
 
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (subTreeData !== null) {

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
@@ -30,6 +30,7 @@ jest.mock('../fetch-server-response', () => {
       <>
         <title>About page!</title>
       </>,
+      null,
     ],
   ]
   return {
@@ -61,6 +62,7 @@ const flightDataForPatch: FlightData = [
     <>
       <title>Somewhere page!</title>
     </>,
+    null,
   ],
 ]
 

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -49,10 +49,10 @@ export function serverPatchReducer(
   let currentCache = state.cache
 
   for (const flightDataPath of flightData) {
-    // Slices off the last segment (which is at -4) as it doesn't exist in the tree yet
-    const flightSegmentPath = flightDataPath.slice(0, -4)
+    // Slices off the last segment (which is at -5) as it doesn't exist in the tree yet
+    const flightSegmentPath = flightDataPath.slice(0, -5)
 
-    const [treePatch] = flightDataPath.slice(-3, -2)
+    const [treePatch] = flightDataPath.slice(-4, -3)
     const newTree = applyRouterStatePatchToTree(
       // TODO-APP: remove ''
       ['', ...flightSegmentPath],

--- a/packages/next/src/client/components/router-reducer/should-hard-navigate.test.tsx
+++ b/packages/next/src/client/components/router-reducer/should-hard-navigate.test.tsx
@@ -39,6 +39,7 @@ describe('shouldHardNavigate', () => {
           <>
             <title>About page!</title>
           </>,
+          null,
         ],
       ]
     }
@@ -50,7 +51,7 @@ describe('shouldHardNavigate', () => {
 
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
-    const flightSegmentPath = flightDataPath.slice(0, -3)
+    const flightSegmentPath = flightDataPath.slice(0, -4)
 
     const result = shouldHardNavigate(
       ['', ...flightSegmentPath],
@@ -96,6 +97,7 @@ describe('shouldHardNavigate', () => {
           ],
           null,
           null,
+          null,
         ],
       ]
     }
@@ -107,7 +109,7 @@ describe('shouldHardNavigate', () => {
 
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
-    const flightSegmentPath = flightDataPath.slice(0, -3)
+    const flightSegmentPath = flightDataPath.slice(0, -4)
 
     const result = shouldHardNavigate(
       ['', ...flightSegmentPath],
@@ -153,6 +155,7 @@ describe('shouldHardNavigate', () => {
           ],
           null,
           null,
+          null,
         ],
       ]
     }
@@ -164,7 +167,7 @@ describe('shouldHardNavigate', () => {
 
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
-    const flightSegmentPath = flightDataPath.slice(0, -3)
+    const flightSegmentPath = flightDataPath.slice(0, -4)
 
     const result = shouldHardNavigate(
       ['', ...flightSegmentPath],

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -72,7 +72,8 @@ export type FlightDataPath =
       /* segment of the rendered slice: */ Segment,
       /* treePatch */ FlightRouterState,
       /* subTreeData: */ React.ReactNode | null, // Can be null during prefetch if there's no loading component
-      /* head */ React.ReactNode | null
+      /* head */ React.ReactNode | null,
+      /* cacheNodeSeedData */ null
     ]
 
 /**

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -178,6 +178,7 @@ export async function walkTreeWithFlightRouterState({
                 </>
               )
             })(),
+        null,
       ],
     ]
   }


### PR DESCRIPTION
This adds an additional item to the FlightData type. The type of the field is currently `null`, but eventually this slot will represent a tree of data that is used to seed the cache nodes.

This is a fragile change because the FlightData type is not covered by TypeScript. This was an intentional decision to optimize the size of the Flight payload. It's made more tricky because there are many places in the codebase that access the fields of FlightData using direct indexing, e.g. `flightData[0]`.

To minimze the number of places I needed to update, I added the new field to the end of the array. However, many places access the fields using negative indexing (via the `slice` method), so I needed to update all of those. I also had to change any place that checked the length of the array.

In the future, when we introduce clever types like this that are intentionally unsound, we should contain the unsoundness to a single module by only accessing the type with getter functions. Something like:

```js
const treePath = getTreePatch(flightData);
const seedData = getCacheNodeSeedData(flightData);
```

and so on.

That way when we add a new field like this, we don't have to carefully update every single place that accesses the type. (TypeScript lacks the ability to mark a type as opaque, unfortunately, but I believe you can simulate it in other ways. This is one feature I miss from Flow.)

I considered adding these getter methods as part of this PR, but since we're in the middle of a larger refactor of the Flight response type, I'd prefer to change as little as possible for now until we can land an MVP of PPR for client navigations. (That being said, if we struggle to land this, I'll reconsider.)

My strategy for finding the places that needed to update was to change the type of FlightDataPath to a nonsense type (e.g. number) and track down all the TypeScript errors. I also searched for all references to variables named `flightDataPath` or similar. I also referred to a prior PR, #42791, which added the `head` field to the FlightDataPath type.

Because of the nature of the change, there's a moderately elevated risk that this will break something. However, if something does slip through the cracks, it's likely to fail fast, given how common most of these paths are; I expect any egregious oversights would be caught by our e2e test suite.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
