### PR TITLE
fix: add type to webpack .mjs module rule

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2041,6 +2041,7 @@ export default async function getBaseWebpackConfig(
           ? [
               {
                 test: /\.m?js/,
+                type: 'javascript/auto',
                 resolve: {
                   fullySpecified: false,
                 },


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md
-->

this fixes an issue i ran into when importing the `shikiji` package.

see here for a reproduction of the issue: https://github.com/stefanprobst/issue-next-webpack-shikiji (which leads to: "export 'getHighlighterCore' (reexported as 'getHighlighterCore') was not found in './core.mjs' (module has no exports)")

x-ref: https://github.com/vercel/next.js/issues/17806
x-ref: https://github.com/antfu/shikiji/issues/13#issuecomment-1749588964