### PR TITLE
Fix dictionaries path 13-internationalization.mdx

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/13-internationalization.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/13-internationalization.mdx
@@ -102,7 +102,7 @@ Let’s assume we want to support both English and Dutch content inside our appl
 
 We can then create a `getDictionary` function to load the translations for the requested locale:
 
-```jsx filename="app/[lang]/dictionaries.js"
+```jsx filename="app/dictionaries.js"
 import 'server-only'
 
 const dictionaries = {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

Hello, we can see in the documentation examples dictionaries is not inside [lang]
<img width="619" alt="image" src="https://github.com/vercel/next.js/assets/15522791/bc157ecd-2ac4-4b15-9d38-c6df4656b1c4">

But we can see the documentation is wrong:

<img width="702" alt="image" src="https://github.com/vercel/next.js/assets/15522791/3de86626-8d0d-4ade-a5d7-b1255bf99fea">

Specifying it inside [lang] is leading to confusion.