### PR TITLE
Revert "Add cacheNodeSeedData to RSC payload (#58566)"

### DIFF
--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -11,15 +11,14 @@ export function applyFlightData(
   wasPrefetched: boolean = false
 ): boolean {
   // The one before last item is the router state tree patch
-  const [treePatch, subTreeData, head /* , cacheNodeSeedData */] =
-    flightDataPath.slice(-4)
+  const [treePatch, subTreeData, head] = flightDataPath.slice(-3)
 
   // Handles case where prefetch only returns the router tree patch without rendered components.
   if (subTreeData === null) {
     return false
   }
 
-  if (flightDataPath.length === 4) {
+  if (flightDataPath.length === 3) {
     cache.status = CacheStates.READY
     cache.subTreeData = subTreeData
     fillLazyItemsTillLeafWithHead(

--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.test.tsx
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.test.tsx
@@ -37,7 +37,6 @@ const getFlightData = (): FlightData => {
       <>
         <title>About page!</title>
       </>,
-      null,
     ],
   ]
 }
@@ -53,8 +52,8 @@ describe('applyRouterStatePatchToTree', () => {
 
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
-    const [treePatch /*, subTreeData, head*/] = flightDataPath.slice(-4)
-    const flightSegmentPath = flightDataPath.slice(0, -5)
+    const [treePatch /*, subTreeData, head*/] = flightDataPath.slice(-3)
+    const flightSegmentPath = flightDataPath.slice(0, -4)
 
     const newRouterStateTree = applyRouterStatePatchToTree(
       ['', ...flightSegmentPath],

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -14,7 +14,7 @@ export function fillCacheWithNewSubTreeData(
   flightDataPath: FlightDataPath,
   wasPrefetched?: boolean
 ): void {
-  const isLastEntry = flightDataPath.length <= 6
+  const isLastEntry = flightDataPath.length <= 5
   const [parallelRouteKey, segment] = flightDataPath
 
   const cacheKey = createRouterCacheKey(segment)

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -30,7 +30,6 @@ const getFlightData = (): FlightData => {
       <>
         <title>About page!</title>
       </>,
-      null,
     ],
   ]
 }
@@ -89,7 +88,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [treePatch, _subTreeData, head] = flightDataPath.slice(-4)
+    const [treePatch, _subTreeData, head] = flightDataPath.slice(-3)
     fillLazyItemsTillLeafWithHead(cache, existingCache, treePatch, head)
 
     const expectedCache: CacheNode = {

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -22,7 +22,6 @@ const getFlightData = (): FlightData => {
       <>
         <title>About page!</title>
       </>,
-      null,
     ],
   ]
 }
@@ -80,7 +79,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
 
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
-    const flightSegmentPath = flightDataPath.slice(0, -4)
+    const flightSegmentPath = flightDataPath.slice(0, -3)
 
     // @ts-expect-error TODO-APP: investigate why this is not a TS error in router-reducer.
     cache.status = CacheStates.READY

--- a/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
@@ -59,7 +59,7 @@ function fastRefreshReducerImpl(
 
       for (const flightDataPath of flightData) {
         // FlightDataPath with more than two items means unexpected Flight data was returned
-        if (flightDataPath.length !== 4) {
+        if (flightDataPath.length !== 3) {
           // TODO-APP: handle this case better
           console.log('REFRESH FAILED')
           return state

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
@@ -32,7 +32,6 @@ const flightData: FlightData = [
     <>
       <title>About page!</title>
     </>,
-    null,
   ],
 ]
 
@@ -64,7 +63,6 @@ const demographicsFlightData: FlightData = [
     <>
       <title>Demographics Head</title>
     </>,
-    null,
   ],
 ]
 

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -175,10 +175,10 @@ export function navigateReducer(
       for (const flightDataPath of flightData) {
         const flightSegmentPath = flightDataPath.slice(
           0,
-          -5
+          -4
         ) as unknown as FlightSegmentPath
         // The one before last item is the router state tree patch
-        const treePatch = flightDataPath.slice(-4)[0] as FlightRouterState
+        const treePatch = flightDataPath.slice(-3)[0] as FlightRouterState
 
         // TODO-APP: remove ''
         const flightSegmentPathWithLeadingEmpty = ['', ...flightSegmentPath]

--- a/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
@@ -27,7 +27,6 @@ jest.mock('../fetch-server-response', () => {
       <>
         <title>About page!</title>
       </>,
-      null,
     ],
   ]
   return {

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
@@ -36,7 +36,6 @@ jest.mock('../fetch-server-response', () => {
       <>
         <title>Linking page!</title>
       </>,
-      null,
     ],
   ]
   return {

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -57,8 +57,8 @@ export function refreshReducer(
       cache.data = null
 
       for (const flightDataPath of flightData) {
-        // FlightDataPath with more than four items means unexpected Flight data was returned
-        if (flightDataPath.length !== 4) {
+        // FlightDataPath with more than two items means unexpected Flight data was returned
+        if (flightDataPath.length !== 3) {
           // TODO-APP: handle this case better
           console.log('REFRESH FAILED')
           return state
@@ -95,7 +95,7 @@ export function refreshReducer(
         }
 
         // The one before last item is the router state tree patch
-        const [subTreeData, head] = flightDataPath.slice(-3)
+        const [subTreeData, head] = flightDataPath.slice(-2)
 
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (subTreeData !== null) {

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -206,7 +206,7 @@ export function serverActionReducer(
 
       for (const flightDataPath of flightData) {
         // FlightDataPath with more than two items means unexpected Flight data was returned
-        if (flightDataPath.length !== 4) {
+        if (flightDataPath.length !== 3) {
           // TODO-APP: handle this case better
           console.log('SERVER ACTION APPLY FAILED')
           return state
@@ -235,7 +235,7 @@ export function serverActionReducer(
         }
 
         // The one before last item is the router state tree patch
-        const [subTreeData, head] = flightDataPath.slice(-3)
+        const [subTreeData, head] = flightDataPath.slice(-2)
 
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (subTreeData !== null) {

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
@@ -30,7 +30,6 @@ jest.mock('../fetch-server-response', () => {
       <>
         <title>About page!</title>
       </>,
-      null,
     ],
   ]
   return {
@@ -62,7 +61,6 @@ const flightDataForPatch: FlightData = [
     <>
       <title>Somewhere page!</title>
     </>,
-    null,
   ],
 ]
 

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -49,10 +49,10 @@ export function serverPatchReducer(
   let currentCache = state.cache
 
   for (const flightDataPath of flightData) {
-    // Slices off the last segment (which is at -5) as it doesn't exist in the tree yet
-    const flightSegmentPath = flightDataPath.slice(0, -5)
+    // Slices off the last segment (which is at -4) as it doesn't exist in the tree yet
+    const flightSegmentPath = flightDataPath.slice(0, -4)
 
-    const [treePatch] = flightDataPath.slice(-4, -3)
+    const [treePatch] = flightDataPath.slice(-3, -2)
     const newTree = applyRouterStatePatchToTree(
       // TODO-APP: remove ''
       ['', ...flightSegmentPath],

--- a/packages/next/src/client/components/router-reducer/should-hard-navigate.test.tsx
+++ b/packages/next/src/client/components/router-reducer/should-hard-navigate.test.tsx
@@ -39,7 +39,6 @@ describe('shouldHardNavigate', () => {
           <>
             <title>About page!</title>
           </>,
-          null,
         ],
       ]
     }
@@ -51,7 +50,7 @@ describe('shouldHardNavigate', () => {
 
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
-    const flightSegmentPath = flightDataPath.slice(0, -4)
+    const flightSegmentPath = flightDataPath.slice(0, -3)
 
     const result = shouldHardNavigate(
       ['', ...flightSegmentPath],
@@ -97,7 +96,6 @@ describe('shouldHardNavigate', () => {
           ],
           null,
           null,
-          null,
         ],
       ]
     }
@@ -109,7 +107,7 @@ describe('shouldHardNavigate', () => {
 
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
-    const flightSegmentPath = flightDataPath.slice(0, -4)
+    const flightSegmentPath = flightDataPath.slice(0, -3)
 
     const result = shouldHardNavigate(
       ['', ...flightSegmentPath],
@@ -155,7 +153,6 @@ describe('shouldHardNavigate', () => {
           ],
           null,
           null,
-          null,
         ],
       ]
     }
@@ -167,7 +164,7 @@ describe('shouldHardNavigate', () => {
 
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
-    const flightSegmentPath = flightDataPath.slice(0, -4)
+    const flightSegmentPath = flightDataPath.slice(0, -3)
 
     const result = shouldHardNavigate(
       ['', ...flightSegmentPath],

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -87,8 +87,7 @@ export type FlightDataPath =
       /* segment of the rendered slice: */ Segment,
       /* treePatch */ FlightRouterState,
       /* subTreeData: */ React.ReactNode | null, // Can be null during prefetch if there's no loading component
-      /* head */ React.ReactNode | null,
-      /* cacheNodeSeedData */ null
+      /* head */ React.ReactNode | null
     ]
 
 /**

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -181,7 +181,6 @@ export async function walkTreeWithFlightRouterState({
                 </>
               )
             })(),
-        null,
       ],
     ]
   }


### PR DESCRIPTION
This reverts commit d5aea2c5cf462b3d1c31fb250c1f8b5eae3664fb, which added an additional field to the RSC payload intended to represent a tree of subtree data for all the nested layouts in a response. I didn't think about the fact that the subtreeData slot, which represents the node at the root of the subtree, would be included twice.

Instead, we should replace the subtreeData slot to be of the CacheNodeSeedData tree type, instead of just a single node. I'll do that in following PRs.