### PR TITLE
feat: Support WebSocket API routes, Upgrade requests

### DIFF
--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -85,6 +85,12 @@ export async function exportAppRoute(
     const module = await RouteModuleLoader.load<AppRouteRouteModule>(filename)
     const response = await module.handle(request, context)
 
+    if (response === 'Upgraded') {
+      return {
+        revalidate: 0,
+      }
+    }
+
     const isValidStatus = response.status < 400 || response.status === 404
     if (!isValidStatus) {
       return { revalidate: 0 }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2237,6 +2237,9 @@ export default abstract class Server<ServerOptions extends Options = Options> {
             )
 
             const response = await routeModule.handle(request, context)
+            if (response === 'Upgraded') {
+              return null
+            }
 
             ;(req as any).fetchMetrics = (
               context.renderOpts as any

--- a/packages/next/src/server/future/route-modules/app-route/module.ts
+++ b/packages/next/src/server/future/route-modules/app-route/module.ts
@@ -1,8 +1,11 @@
 import type { NextConfig } from '../../../config-shared'
 import type { AppRouteRouteDefinition } from '../../route-definitions/app-route-route-definition'
 import type { AppConfig } from '../../../../build/utils'
-import type { NextRequest } from '../../../web/spec-extension/request'
 import type { PrerenderManifest } from '../../../../build'
+import {
+  isUpgradeError,
+  type NextRequest,
+} from '../../../web/spec-extension/request'
 
 import {
   RouteModule,
@@ -453,7 +456,7 @@ export class AppRouteRouteModule extends RouteModule<
   public async handle(
     request: NextRequest,
     context: AppRouteRouteHandlerContext
-  ): Promise<Response> {
+  ): Promise<Response | 'Upgraded'> {
     try {
       // Execute the route to get the response.
       const response = await this.execute(request, context)
@@ -461,6 +464,10 @@ export class AppRouteRouteModule extends RouteModule<
       // The response was handled, return it.
       return response
     } catch (err) {
+      if (isUpgradeError(err)) {
+        return 'Upgraded'
+      }
+
       // Try to resolve the error to a response, else throw it again.
       const response = resolveHandlerError(err)
       if (!response) throw err

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -6,7 +6,7 @@ import '../require-hook'
 
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { SelfSignedCertificate } from '../../lib/mkcert'
-import type { WorkerRequestHandler, WorkerUpgradeHandler } from './types'
+import type { WorkerRequestHandler } from './types'
 
 import fs from 'fs'
 import v8 from 'v8'
@@ -116,17 +116,6 @@ export async function startServer(
     }
     throw new Error('Invariant request handler was not setup')
   }
-  let upgradeHandler: WorkerUpgradeHandler = async (
-    req,
-    socket,
-    head
-  ): Promise<void> => {
-    if (handlersPromise) {
-      await handlersPromise
-      return upgradeHandler(req, socket, head)
-    }
-    throw new Error('Invariant upgrade handler was not setup')
-  }
 
   // setup server listener as fast as possible
   if (selfSignedCertificate && !isDev) {
@@ -182,15 +171,6 @@ export async function startServer(
   if (keepAliveTimeout) {
     server.keepAliveTimeout = keepAliveTimeout
   }
-  server.on('upgrade', async (req, socket, head) => {
-    try {
-      await upgradeHandler(req, socket, head)
-    } catch (err) {
-      socket.destroy()
-      Log.error(`Failed to handle request for ${req.url}`)
-      console.error(err)
-    }
-  })
 
   let portRetryCount = 0
 
@@ -291,7 +271,7 @@ export async function startServer(
         process.on('uncaughtException', exception)
         process.on('unhandledRejection', exception)
 
-        const initResult = await getRequestHandlers({
+        requestHandler = await getRequestHandlers({
           dir,
           port,
           isDev,
@@ -303,8 +283,6 @@ export async function startServer(
           experimentalTestProxy: !!isExperimentalTestProxy,
           experimentalHttpsServer: !!selfSignedCertificate,
         })
-        requestHandler = initResult[0]
-        upgradeHandler = initResult[1]
 
         const startServerProcessDuration =
           performance.mark('next-start-end') &&

--- a/packages/next/src/server/lib/types.ts
+++ b/packages/next/src/server/lib/types.ts
@@ -1,14 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 
-import type { Duplex } from 'stream'
-
 export type WorkerRequestHandler = (
   req: IncomingMessage,
   res: ServerResponse
 ) => Promise<any>
-
-export type WorkerUpgradeHandler = (
-  req: IncomingMessage,
-  socket: Duplex,
-  head: Buffer
-) => any

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -110,6 +110,9 @@ export class EdgeRouteModuleWrapper {
 
     // Get the response from the handler.
     const res = await this.routeModule.handle(request, context)
+    if (res === 'Upgraded') {
+      throw new Error('Unreachable - Edge routes cannot be upgraded')
+    }
 
     const waitUntilPromises = [internal_getCurrentFunctionWaitUntil()]
     if (context.renderOpts.waitUntil) {

--- a/packages/next/src/server/web/spec-extension/adapters/next-request.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/next-request.ts
@@ -102,6 +102,7 @@ export class NextRequestAdapter {
       // @ts-expect-error - see https://github.com/whatwg/fetch/pull/1457
       duplex: 'half',
       signal,
+      rawRequest: request.originalRequest,
       // geo
       // ip
       // nextConfig

--- a/packages/next/src/server/web/spec-extension/request-upgrade.ts
+++ b/packages/next/src/server/web/spec-extension/request-upgrade.ts
@@ -1,0 +1,73 @@
+import type * as stream from 'node:stream'
+
+declare module 'node:stream' {
+  interface Duplex {
+    [REQUEST_UPGRADED]?: boolean
+    _httpMessage?: {
+      _headerSent?: boolean
+    }
+  }
+}
+
+const REQUEST_UPGRADED = Symbol('REQUEST_UPGRADED')
+
+export function markSocketUpgraded(socket: stream.Duplex) {
+  socket[REQUEST_UPGRADED] = true
+}
+
+export function isSocketUpgraded(socket: stream.Duplex) {
+  return socket[REQUEST_UPGRADED]
+}
+
+const badRequestResponse = Buffer.from(
+  `HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n`,
+  'ascii'
+)
+const requestTimeoutResponse = Buffer.from(
+  `HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n`,
+  'ascii'
+)
+const requestHeaderFieldsTooLargeResponse = Buffer.from(
+  `HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n`,
+  'ascii'
+)
+
+/**
+ * Allow a socket to be upgraded without triggering an HTTP request timeout response.
+ *
+ * We work around the behavior of the Node.js HTTP server which incorrectly detects an upgraded
+ * request as expiring. We preserve the default behavior of Node with its existing error handling.
+ *
+ * See: https://github.com/nodejs/node/blob/v20.10.0/lib/_http_server.js#L873-L907
+ */
+export function handleClientError(
+  e: NodeJS.ErrnoException,
+  socket: stream.Duplex
+) {
+  if (isSocketUpgraded(socket)) {
+    return
+  }
+
+  // Begin Node.js implementation:
+  if (
+    socket.writable &&
+    (!socket?._httpMessage || !socket?._httpMessage?._headerSent)
+  ) {
+    let response
+
+    switch (e.code) {
+      case 'HPE_HEADER_OVERFLOW':
+        response = requestHeaderFieldsTooLargeResponse
+        break
+      case 'ERR_HTTP_REQUEST_TIMEOUT':
+        response = requestTimeoutResponse
+        break
+      default:
+        response = badRequestResponse
+        break
+    }
+
+    socket.write(response)
+  }
+  socket.destroy(e)
+}

--- a/packages/next/src/server/web/spec-extension/request.ts
+++ b/packages/next/src/server/web/spec-extension/request.ts
@@ -6,6 +6,7 @@ import { NextURL } from '../next-url'
 import { toNodeOutgoingHttpHeaders, validateURL } from '../utils'
 import { RemovedUAError, RemovedPageError } from '../error'
 import { RequestCookies } from './cookies'
+import { markSocketUpgraded } from './request-upgrade'
 import { scheduleOnNextTick } from '../../../lib/scheduler'
 
 export const RequestUpgradedName = 'RequestUpgraded'
@@ -125,6 +126,7 @@ export class NextRequest extends Request {
       )
     }
 
+    markSocketUpgraded(rawRequest.socket)
     scheduleOnNextTick(() => handler(rawRequest, rawRequest.socket))
 
     throw new RequestUpgraded('upgrade')

--- a/packages/next/src/server/web/spec-extension/request.ts
+++ b/packages/next/src/server/web/spec-extension/request.ts
@@ -1,9 +1,23 @@
+import type { IncomingMessage } from 'node:http'
+import type { Duplex } from 'node:stream'
 import type { I18NConfig } from '../../config-shared'
 import type { RequestData } from '../types'
 import { NextURL } from '../next-url'
 import { toNodeOutgoingHttpHeaders, validateURL } from '../utils'
 import { RemovedUAError, RemovedPageError } from '../error'
 import { RequestCookies } from './cookies'
+import { scheduleOnNextTick } from '../../../lib/scheduler'
+
+export const RequestUpgradedName = 'RequestUpgraded'
+export class RequestUpgraded extends Error {
+  public readonly name = RequestUpgradedName
+}
+
+export function isUpgradeError(
+  e: any
+): e is Error & { name: typeof RequestUpgradedName } {
+  return e?.name === RequestUpgradedName
+}
 
 export const INTERNALS = Symbol('internal request')
 
@@ -14,6 +28,7 @@ export class NextRequest extends Request {
     ip?: string
     url: string
     nextUrl: NextURL
+    rawRequest?: IncomingMessage
   }
 
   constructor(input: URL | RequestInfo, init: RequestInit = {}) {
@@ -34,6 +49,7 @@ export class NextRequest extends Request {
       url: process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE
         ? url
         : nextUrl.toString(),
+      rawRequest: init.rawRequest,
     }
   }
 
@@ -98,6 +114,21 @@ export class NextRequest extends Request {
   public get url() {
     return this[INTERNALS].url
   }
+
+  public upgrade(
+    handler: (request: IncomingMessage, socket: Duplex) => void
+  ): never {
+    const rawRequest = this[INTERNALS].rawRequest
+    if (!rawRequest) {
+      throw new Error(
+        'Cannot upgrade to websocket, this feature is not compatible with the edge runtime.'
+      )
+    }
+
+    scheduleOnNextTick(() => handler(rawRequest, rawRequest.socket))
+
+    throw new RequestUpgraded('upgrade')
+  }
 }
 
 export interface RequestInit extends globalThis.RequestInit {
@@ -113,4 +144,5 @@ export interface RequestInit extends globalThis.RequestInit {
     trailingSlash?: boolean
   }
   signal?: AbortSignal
+  rawRequest?: IncomingMessage
 }

--- a/test/e2e/app-dir/app-routes/app/api/websocket/route.ts
+++ b/test/e2e/app-dir/app-routes/app/api/websocket/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from 'next/server'
+import * as ws from 'ws'
+
+export const dynamic = 'force-dynamic'
+
+export const GET = async (req: NextRequest): Promise<Response> => {
+  req.upgrade((request, socket) => {
+    const server = new ws.WebSocketServer({ noServer: true })
+
+    server.handleUpgrade(request, socket, Buffer.alloc(0), (ws) => {
+      ws.on('message', (message) => {
+        if (message.toString('utf8') === 'ping') {
+          ws.send('pong')
+        }
+      })
+
+      ws.on('error', (err) => {
+        server.close()
+      })
+
+      ws.on('close', () => {
+        server.close()
+      })
+    })
+  })
+}

--- a/test/e2e/app-dir/app-routes/package.json
+++ b/test/e2e/app-dir/app-routes/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "ws": "^8"
+  }
+}


### PR DESCRIPTION
Enables route handlers to receive and act on `Connection: Upgrade` requests, such as WebSockets, when using the Node runtime. To enable this, the base http server has the `on('upgrade')` handler removed. In this author's opinion, that handler is an anti-pattern as it makes it much more difficult to handle middleware and other request lifecycle behavior.

By passing the raw request to the route handler and implementing a `NextResponse.upgrade()` response value to opt out of additional processing that would write to the socket, the route handler can handle an upgrade request itself.

Fixes #58698 (feature request)
Fixes #56368 (caused by next-ws / websocket middleware)

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
