### PR TITLE
Clarify it's Next that extends fetch(), not React

### DIFF
--- a/docs/02-app/01-building-your-application/04-caching/index.mdx
+++ b/docs/02-app/01-building-your-application/04-caching/index.mdx
@@ -33,7 +33,7 @@ Caching behavior changes depending on whether the route is statically or dynamic
 
 ## Request Memoization
 
-React extends the [`fetch` API](#fetch) to automatically **memoize** requests that have the same URL and options. This means you can call a fetch function for the same data in multiple places in a React component tree while only executing it once.
+Next.js extends the [`fetch` API](#fetch) to automatically **memoize** requests that have the same URL and options. This means you can call a fetch function for the same data in multiple places in a React component tree while only executing it once.
 
 <Image
   alt="Deduplicated Fetch Requests"


### PR DESCRIPTION
Per Next Docs and React docs, it's Next that does this, not React.

Per [Fetch API page](https://nextjs.org/docs/app/api-reference/functions/fetch): 

> Next.js extends the native [Web fetch() API](https://developer.mozilla.org/docs/Web/API/Fetch_API) to allow each request on the server to set its own persistent caching semantics.

Nowhere in the React docs is extension of fetch() mentioned. In fact, this page (edited here) is the only place on the internet making the claim that React extends `fetch()`. What React does offer is `useMemo`, and other hooks that have 'memoization' features, but seemingly nothing at all which punches new functionality onto `fetch()`. 