### PR TITLE
route handlers: make req.cookies opt you into dynamic

### DIFF
--- a/packages/next/src/server/future/route-modules/app-route/helpers/proxy-request.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/proxy-request.ts
@@ -107,6 +107,7 @@ export function proxyRequest(
       // request.nextUrl we bail since it includes query
       // values that can be relied on dynamically
       case 'url':
+      case 'cookies':
       case 'body':
       case 'blob':
       case 'json':

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -423,6 +423,19 @@ createNextDescribe(
         })
       })
 
+      describe('req.cookies', () => {
+        it('gets the correct values', async () => {
+          const res = await next.fetch(basePath + '/hooks/cookies/req', {
+            headers: cookieWithRequestMeta({ ping: 'pong' }),
+          })
+
+          expect(res.status).toEqual(200)
+
+          const meta = getRequestMeta(res.headers)
+          expect(meta.ping).toEqual('pong')
+        })
+      })
+
       describe('cookies().has()', () => {
         it('gets the correct values', async () => {
           const res = await next.fetch(basePath + '/hooks/cookies/has')

--- a/test/e2e/app-dir/app-routes/app/hooks/cookies/req/route.ts
+++ b/test/e2e/app-dir/app-routes/app/hooks/cookies/req/route.ts
@@ -3,7 +3,6 @@ import { NextRequest } from 'next/server'
 
 export async function GET(req: NextRequest) {
   // Put the request meta in the response directly as meta again.
-  console.log('req.cookies', req.cookies)
   const meta = getRequestMeta(req.cookies)
 
   return new Response(null, {

--- a/test/e2e/app-dir/app-routes/app/hooks/cookies/req/route.ts
+++ b/test/e2e/app-dir/app-routes/app/hooks/cookies/req/route.ts
@@ -1,0 +1,13 @@
+import { getRequestMeta, withRequestMeta } from '../../../../helpers'
+import { NextRequest } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  // Put the request meta in the response directly as meta again.
+  console.log('req.cookies', req.cookies)
+  const meta = getRequestMeta(req.cookies)
+
+  return new Response(null, {
+    status: 200,
+    headers: withRequestMeta(meta),
+  })
+}


### PR DESCRIPTION
This PR fixes an issue where users would try to access `req.cookies` from a route handler and be unable to read from it.

This issue was caused by `req.cookies` not opting you into dynamic behaviour, unlike `cookies()` from `next/headers`. This fixes it.



<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
