### PR TITLE
chore(CI): allow up to 10 retries for jest

### DIFF
--- a/test/jest-setup-after-env.ts
+++ b/test/jest-setup-after-env.ts
@@ -6,3 +6,7 @@ expect.extend(matchers)
 // A default max-timeout of 90 seconds is allowed
 // per test we should aim to bring this down though
 jest.setTimeout((process.platform === 'win32' ? 180 : 60) * 1000)
+
+if (process.env.CI) {
+  jest.retryTimes(10)
+}


### PR DESCRIPTION
### Why?

We have too many flaky tests and would like to report on actual failures on canary

Closes PACK-2021