### PR TITLE
[Instrumentation] Don't treat instrumentation hook as pages

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -51,6 +51,7 @@ import { normalizePathSep } from '../../shared/lib/page-path/normalize-path-sep'
 import getRouteFromEntrypoint from '../get-route-from-entrypoint'
 import {
   difference,
+  isInstrumentationHookFile,
   isMiddlewareFile,
   isMiddlewareFilename,
 } from '../../build/utils'
@@ -955,7 +956,8 @@ export default class HotReloader implements NextJsHotReloaderInterface {
                 } else if (
                   !isMiddlewareFile(page) &&
                   !isInternalComponent(relativeRequest) &&
-                  !isNonRoutePagesPage(page)
+                  !isNonRoutePagesPage(page) &&
+                  !(isInstrumentationHookFile(page) && pageType === 'root')
                 ) {
                   value = getRouteLoaderEntry({
                     kind: RouteKind.PAGES,


### PR DESCRIPTION
This PR doesn't treat an instrumentation hook as a `PAGES` page which avoids compiling `_app`, `_document`, and `_error` when compiling the instrumentation hook.