### PR TITLE
fix: Update import statement for useRouter

### DIFF
--- a/docs/03-pages/02-api-reference/02-functions/use-router.mdx
+++ b/docs/03-pages/02-api-reference/02-functions/use-router.mdx
@@ -6,7 +6,7 @@ description: Learn more about the API of the Next.js Router, and access the rout
 If you want to access the [`router` object](#router-object) inside any function component in your app, you can use the `useRouter` hook, take a look at the following example:
 
 ```jsx
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 function ActiveLink({ children, href }) {
   const router = useRouter()
@@ -79,7 +79,7 @@ router.push(url, as, options)
 Navigating to `pages/about.js`, which is a predefined route:
 
 ```jsx
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function Page() {
   const router = useRouter()
@@ -95,7 +95,7 @@ export default function Page() {
 Navigating `pages/post/[pid].js`, which is a dynamic route:
 
 ```jsx
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function Page() {
   const router = useRouter()
@@ -112,7 +112,7 @@ Redirecting the user to `pages/login.js`, useful for pages behind [authenticatio
 
 ```jsx
 import { useEffect } from 'react'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 // Here you would fetch and return the user
 const useUser = () => ({ user: null, loading: false })
@@ -138,7 +138,7 @@ When navigating to the same page in Next.js, the page's state **will not** be re
 ```jsx filename="pages/[slug].js"
 import Link from 'next/link'
 import { useState } from 'react'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function Page(props) {
   const router = useRouter()
@@ -169,7 +169,7 @@ If you do not want this behavior, you have a couple of options:
 - Use a React `key` to [tell React to remount the component](https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key). To do this for all pages, you can use a custom app:
 
   ```jsx filename="pages/_app.js"
-  import { useRouter } from 'next/router'
+  import { useRouter } from 'next/navigation'
 
   export default function MyApp({ Component, pageProps }) {
     const router = useRouter()
@@ -182,7 +182,7 @@ If you do not want this behavior, you have a couple of options:
 You can use a URL object in the same way you can use it for [`next/link`](/docs/pages/api-reference/components/link#with-url-object). Works for both the `url` and `as` parameters:
 
 ```jsx
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function ReadMore({ post }) {
   const router = useRouter()
@@ -216,7 +216,7 @@ router.replace(url, as, options)
 Take a look at the following example:
 
 ```jsx
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function Page() {
   const router = useRouter()
@@ -248,7 +248,7 @@ Let's say you have a login page, and after a login, you redirect the user to the
 
 ```jsx
 import { useCallback, useEffect } from 'react'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function Login() {
   const router = useRouter()
@@ -300,7 +300,7 @@ You could use `beforePopState` to manipulate the request, or force a SSR refresh
 
 ```jsx
 import { useEffect } from 'react'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function Page() {
   const router = useRouter()
@@ -327,7 +327,7 @@ export default function Page() {
 Navigate back in history. Equivalent to clicking the browser’s back button. It executes `window.history.back()`.
 
 ```jsx
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function Page() {
   const router = useRouter()
@@ -345,7 +345,7 @@ export default function Page() {
 Reload the current URL. Equivalent to clicking the browser’s refresh button. It executes `window.location.reload()`.
 
 ```jsx
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function Page() {
   const router = useRouter()
@@ -376,7 +376,7 @@ For example, to listen to the router event `routeChangeStart`, open or create `p
 
 ```jsx
 import { useEffect } from 'react'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function MyApp({ Component, pageProps }) {
   const router = useRouter()
@@ -411,7 +411,7 @@ If a route load is cancelled (for example, by clicking two links rapidly in succ
 
 ```jsx
 import { useEffect } from 'react'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function MyApp({ Component, pageProps }) {
   const router = useRouter()
@@ -452,7 +452,7 @@ The affected methods are:
 
 ```jsx
 import { useEffect } from 'react'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 // Here you would fetch and return the user
 const useUser = () => ({ user: null, loading: false })
@@ -490,7 +490,7 @@ If [`useRouter`](#router-object) is not the best fit for you, `withRouter` can a
 ### Usage
 
 ```jsx
-import { withRouter } from 'next/router'
+import { withRouter } from 'next/navigation'
 
 function Page({ router }) {
   return <p>{router.pathname}</p>
@@ -505,7 +505,7 @@ To use class components with `withRouter`, the component needs to accept a route
 
 ```tsx
 import React from 'react'
-import { withRouter, NextRouter } from 'next/router'
+import { withRouter, NextRouter } from 'next/navigation'
 
 interface WithRouterProps {
   router: NextRouter


### PR DESCRIPTION
The `useRouter` hook is now imported from 'next/navigation' instead of 'next/router' to align with the latest Next.js updates.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Updated the import statement for the `useRouter` hook component to use 'next/navigation' instead of 'next/router'.
### Why?
Next.js has introduced changes in the import path for `useRouter`, and this PR ensures the code aligns with the latest Next.js updates.



-->
