### PR TITLE
chore(turbopack): check for unsupported next config options instead of supported ones

### DIFF
--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -4,147 +4,53 @@ import loadConfig from '../server/config'
 import * as Log from '../build/output/log'
 import { PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
 
-const supportedTurbopackNextConfigOptions = [
-  // Options that affect compilation
-  'output',
-  'crossOrigin',
-  'configFileName',
-  'env',
-  'basePath',
-  'modularizeImports',
-  'compiler.emotion',
-  'compiler.relay',
-  'compiler.styledComponents',
-  'images',
-  'pageExtensions',
-  'onDemandEntries',
-  'rewrites',
-  'redirects',
-  'headers',
-  'reactStrictMode',
-  'swcMinify',
-  'transpilePackages',
-  'trailingSlash',
-  'i18n.defaultLocale',
-  'i18n.domains',
-  'i18n.localeDetection',
-  'i18n.locales',
-  'sassOptions',
-  'configOrigin',
-  'httpAgentOptions',
-  'useFileSystemPublicRoutes',
-  'generateEtags',
-  'assetPrefix',
-  'distDir',
-  'skipMiddlewareUrlNormalize',
-  'skipTrailingSlashRedirect',
-  'amp',
-  'devIndicators',
-  'analyticsId',
-
-  // Options that are ignored as they don't affect Turbopack
-  'webpack',
-  'onDemandEntries',
-  'experimental.cpus',
-  'serverRuntimeConfig',
-  'publicRuntimeConfig',
-  'exportPathMap',
-
-  // Experimental options that affect compilation
-  'experimental.swcPlugins',
-  'experimental.strictNextHead',
-  'experimental.manualClientBasePath',
-  'experimental.middlewarePrefetch',
-  'experimental.optimizeCss',
-  'experimental.nextScriptWorkers',
-  'experimental.optimisticClientCache',
-  'experimental.webVitalsAttribution',
-  'experimental.externalMiddlewareRewritesResolve',
-  'experimental.serverComponentsExternalPackages',
-  'experimental.mdxRs',
-  'experimental.turbo',
-  'experimental.useDeploymentId',
-  'experimental.useDeploymentIdServerActions',
-  'experimental.deploymentId',
-  'experimental.useLightningcss',
-  'experimental.windowHistorySupport',
-  'experimental.instrumentationHook',
-  'experimental.externalDir',
-
-  // Experimental options that don't affect compilation
-  'experimental.ppr',
-  'experimental.taint',
-  'experimental.proxyTimeout',
-  'experimental.caseSensitiveRoutes',
-  'experimental.workerThreads',
-  'experimental.isrFlushToDisk',
-  'experimental.logging.level',
-  'experimental.logging.fullUrl',
-  'logging.fetches.fullUrl',
-  'experimental.scrollRestoration',
-  'experimental.forceSwcTransforms',
-  'experimental.serverActions.bodySizeLimit',
-  'experimental.serverActions.allowedOrigins',
-  'experimental.memoryBasedWorkersCount',
-  'experimental.clientRouterFilterRedirects',
-  'experimental.webpackBuildWorker',
-  'experimental.parallelServerCompiles',
-  'experimental.parallelServerBuildTraces',
-  'experimental.appDocumentPreloading',
-  'experimental.incrementalCacheHandlerPath',
-  'experimental.amp',
-  'experimental.disableOptimizedLoading',
-  'experimental.isrMemoryCacheSize',
-  'experimental.largePageDataBytes',
-  'experimental.gzipSize',
-  'experimental.trustHostHeader',
+const unsupportedTurbopackNextConfigOptions = [
+  // is this supported?
+  // 'amp',
+  // 'experimental.amp',
 
   // Left to be implemented (priority)
-  // 'experimental.ppr', // Checked in `needs-experimental-react.ts`
-  // clientRouterFilter is `true` by default currently in config-shared.ts,
-  // might be removed as an option altogether.
-  'experimental.clientRouterFilter',
-  'experimental.optimizePackageImports',
+  // 'experimental.clientRouterFilter',
+  // 'experimental.optimizePackageImports',
   // 'compiler.emotion',
-  // 'compiler.reactRemoveProperties',
+  'compiler.reactRemoveProperties',
   // 'compiler.relay',
-  // 'compiler.removeConsole',
+  'compiler.removeConsole',
   // 'compiler.styledComponents',
-  // 'experimental.fetchCacheKeyPrefix',
+  'experimental.fetchCacheKeyPrefix',
 
   // Left to be implemented
-  'excludeDefaultMomentLocales',
-  'experimental.optimizeServerReact',
-  // 'experimental.clientRouterFilterAllowedRate',
-  'experimental.serverMinification',
-  'experimental.serverSourceMaps',
+  // 'excludeDefaultMomentLocales',
+  // 'experimental.optimizeServerReact',
+  'experimental.clientRouterFilterAllowedRate',
+  // 'experimental.serverMinification',
+  // 'experimental.serverSourceMaps',
 
-  // 'experimental.adjustFontFallbacks',
-  // 'experimental.adjustFontFallbacksWithSizeAdjust',
-  // 'experimental.allowedRevalidateHeaderKeys',
-  // 'experimental.bundlePagesExternals',
-  // 'experimental.extensionAlias',
-  // 'experimental.fallbackNodePolyfills',
+  'experimental.adjustFontFallbacks',
+  'experimental.adjustFontFallbacksWithSizeAdjust',
+  'experimental.allowedRevalidateHeaderKeys',
+  'experimental.bundlePagesExternals',
+  'experimental.extensionAlias',
+  'experimental.fallbackNodePolyfills',
 
-  // 'experimental.sri.algorithm',
-  // 'experimental.swcTraceProfiling',
-  // 'experimental.typedRoutes',
+  'experimental.sri.algorithm',
+  'experimental.swcTraceProfiling',
+  'experimental.typedRoutes',
 
   // Left to be implemented (Might not be needed for Turbopack)
-  // 'experimental.craCompat',
-  // 'experimental.disablePostcssPresetEnv',
-  // 'experimental.esmExternals',
+  'experimental.craCompat',
+  'experimental.disablePostcssPresetEnv',
+  'experimental.esmExternals',
   // This is used to force swc-loader to run regardless of finding Babel.
-  // 'experimental.forceSwcTransforms',
-  // 'experimental.fullySpecified',
-  // 'experimental.urlImports',
+  'experimental.forceSwcTransforms',
+  'experimental.fullySpecified',
+  'experimental.urlImports',
 ]
 
 // The following will need to be supported by `next build --turbo`
 const prodSpecificTurboNextConfigOptions = [
   'eslint',
   'typescript',
-  'staticPageGenerationTimeout',
   'outputFileTracing',
   'generateBuildId',
   'compress',
@@ -242,12 +148,9 @@ export async function validateTurboNextConfig({
 
     const customKeys = flattenKeys(rawNextConfig)
 
-    let supportedKeys = isDev
-      ? [
-          ...supportedTurbopackNextConfigOptions,
-          ...prodSpecificTurboNextConfigOptions,
-        ]
-      : supportedTurbopackNextConfigOptions
+    let unsupportedKeys = isDev
+      ? unsupportedTurbopackNextConfigOptions
+      : prodSpecificTurboNextConfigOptions
 
     for (const key of customKeys) {
       if (key.startsWith('webpack')) {
@@ -257,20 +160,22 @@ export async function validateTurboNextConfig({
         hasTurbo = true
       }
 
-      let isSupported =
-        supportedKeys.some(
-          (supportedKey) =>
+      let isUnsupported =
+        unsupportedKeys.some(
+          (unsupportedKey) =>
             // Either the key matches (or is a more specific subkey) of
-            // supportedKey, or the key is the path to a specific subkey.
-            // | key     | supportedKey |
-            // |---------|--------------|
-            // | foo     | foo          |
-            // | foo.bar | foo          |
-            // | foo     | foo.bar      |
-            key.startsWith(supportedKey) || supportedKey.startsWith(`${key}.`)
-        ) ||
-        getDeepValue(rawNextConfig, key) === getDeepValue(defaultConfig, key)
-      if (!isSupported) {
+            // unsupportedKey, or the key is the path to a specific subkey.
+            // | key     | unsupportedKey |
+            // |---------|----------------|
+            // | foo     | foo            |
+            // | foo.bar | foo            |
+            // | foo     | foo.bar        |
+            key.startsWith(unsupportedKey) ||
+            unsupportedKey.startsWith(`${key}.`)
+        ) &&
+        getDeepValue(rawNextConfig, key) !== getDeepValue(defaultConfig, key)
+
+      if (isUnsupported) {
         unsupportedConfig.push(key)
       }
     }


### PR DESCRIPTION
### Why?

We have more supported options than unsupported ones.
Also new options added to next.js now should always be supported by turbopack.


Closes PACK-2023

