### PR TITLE
place virtual module inside the project directory

### DIFF
--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -826,6 +826,7 @@ impl AppEndpoint {
                 let (loader, manifest) = create_server_actions_manifest(
                     Vc::upcast(app_entry.rsc_entry),
                     get_app_server_reference_modules(client_reference_types),
+                    this.app_project.project().project_path(),
                     node_root,
                     &app_entry.pathname,
                     &app_entry.original_name,
@@ -977,6 +978,7 @@ impl AppEndpoint {
                 let (loader, manifest) = create_server_actions_manifest(
                     Vc::upcast(app_entry.rsc_entry),
                     get_app_server_reference_modules(client_reference_types),
+                    this.app_project.project().project_path(),
                     node_root,
                     &app_entry.pathname,
                     &app_entry.original_name,


### PR DESCRIPTION
### What?

This virtual module was created in a weird path/filesystem: [node]/.next/server/app/.../page/actions.js. It's in the output filesystem, which can't access the monorepo root, so it can't resolve the tsconfig. But it shouldn't be in that filesystem in first place.


Closes PACK-2025