### PR TITLE
Add typesVersion field in package.json for @next/third-parties

### DIFF
--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -9,6 +9,13 @@
     "./google": "./dist/google/index.js"
   },
   "types": "dist/types/google.d.ts",
+  "typesVersions": {
+    "*": {
+      "google": [
+        "dist/google"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
I tried to import `@next/third-parties/google` but typescript server throwed module not found error.

This fixes it.