### PR TITLE
ci: unify reset project script

### DIFF
--- a/.github/workflows/test_e2e_deploy.yml
+++ b/.github/workflows/test_e2e_deploy.yml
@@ -47,7 +47,7 @@ jobs:
 
       - run: npm i -g vercel@latest
 
-      - run: RESET_VC_PROJECT=true node scripts/reset-vercel-project.mjs
+      - run: node scripts/run-project-reset.mjs
         name: Reset test project
 
       - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.35.1-jammy /bin/bash -c "cd /work && NODE_VERSION=${{ env.NODE_LTS_VERSION }} ./scripts/setup-node.sh && corepack enable > /dev/null && NEXT_JUNIT_TEST_REPORT=true DATADOG_API_KEY=${DATADOG_API_KEY} DD_ENV=ci VERCEL_TEST_TOKEN=${{ secrets.VERCEL_TEST_TOKEN }} VERCEL_TEST_TEAM=vtest314-next-e2e-tests NEXT_TEST_JOB=1 NEXT_TEST_MODE=deploy TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN }} NEXT_TEST_CONTINUE_ON_ERROR=1 xvfb-run node run-tests.js --type e2e --timings -g ${{ matrix.group }}/2 -c 1 >> /proc/1/fd/1"

--- a/bench/vercel/project-utils.js
+++ b/bench/vercel/project-utils.js
@@ -1,6 +1,5 @@
 import { config } from 'dotenv'
 
-import fetch from 'node-fetch'
 import execa from 'execa'
 import path from 'path'
 import url from 'url'
@@ -8,6 +7,7 @@ import { generatePackageJson } from './generate-package-json.js'
 import { Listr } from 'listr2'
 import { forceCrash } from './bench.js'
 import { red } from '../../packages/next/dist/lib/picocolors.js'
+import { resetProject } from '../../scripts/reset-project.mjs'
 
 config()
 
@@ -36,7 +36,7 @@ export async function generateProjects() {
               {
                 title: 'Resetting project',
                 task: async () => {
-                  await resetProject(ORIGIN_PROJECT_NAME)
+                  await resetProject(TEST_TEAM_NAME, ORIGIN_PROJECT_NAME)
                 },
               },
               {
@@ -73,7 +73,7 @@ export async function generateProjects() {
               {
                 title: 'Resetting project',
                 task: async () => {
-                  await resetProject(HEAD_PROJECT_NAME)
+                  await resetProject(TEST_TEAM_NAME, HEAD_PROJECT_NAME)
                 },
               },
               {
@@ -114,51 +114,6 @@ export async function cleanupProjectFolders() {
     execa('rm', ['-rf', originAppFolder]),
     execa('rm', ['-rf', headAppFolder]),
   ])
-}
-
-async function resetProject(projectName) {
-  const deleteRes = await fetch(
-    `https://vercel.com/api/v8/projects/${encodeURIComponent(
-      projectName
-    )}?teamId=${TEST_TEAM_NAME}`,
-    {
-      method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${TEST_TOKEN}`,
-      },
-    }
-  )
-
-  if (!deleteRes.ok && deleteRes.status !== 404) {
-    throw new Error(
-      `Failed to delete project got status ${
-        deleteRes.status
-      }, ${await deleteRes.text()}`
-    )
-  }
-
-  const createRes = await fetch(
-    `https://vercel.com/api/v8/projects?teamId=${TEST_TEAM_NAME}`,
-    {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        Authorization: `Bearer ${TEST_TOKEN}`,
-      },
-      body: JSON.stringify({
-        framework: 'nextjs',
-        name: projectName,
-      }),
-    }
-  )
-
-  if (!createRes.ok) {
-    throw new Error(
-      `Failed to create project got status ${
-        createRes.status
-      }, ${await createRes.text()}`
-    )
-  }
 }
 
 export async function deployProject(projectName, appFolder) {

--- a/scripts/reset-project.mjs
+++ b/scripts/reset-project.mjs
@@ -4,12 +4,15 @@ export const TEST_PROJECT_NAME = 'vtest314-e2e-tests'
 export const TEST_TEAM_NAME = process.env.VERCEL_TEST_TEAM
 export const TEST_TOKEN = process.env.VERCEL_TEST_TOKEN
 
-async function resetProject() {
+export async function resetProject(
+  teamId = TEST_TEAM_NAME,
+  projectName = TEST_PROJECT_NAME
+) {
   // TODO: error/bail if existing deployments are pending
   const deleteRes = await fetch(
     `https://vercel.com/api/v8/projects/${encodeURIComponent(
-      TEST_PROJECT_NAME
-    )}?teamId=${TEST_TEAM_NAME}`,
+      projectName
+    )}?teamId=${teamId}`,
     {
       method: 'DELETE',
       headers: {
@@ -27,7 +30,7 @@ async function resetProject() {
   }
 
   const createRes = await fetch(
-    `https://vercel.com/api/v8/projects?teamId=${TEST_TEAM_NAME}`,
+    `https://vercel.com/api/v8/projects?teamId=${teamId}`,
     {
       method: 'POST',
       headers: {
@@ -36,7 +39,7 @@ async function resetProject() {
       },
       body: JSON.stringify({
         framework: 'nextjs',
-        name: TEST_PROJECT_NAME,
+        name: projectName,
       }),
     }
   )
@@ -50,10 +53,6 @@ async function resetProject() {
   }
 
   console.log(
-    `Successfully created fresh Vercel project ${TEST_TEAM_NAME}/${TEST_PROJECT_NAME}`
+    `Successfully created fresh Vercel project ${teamId}/${projectName}`
   )
-}
-
-if (process.env.RESET_VC_PROJECT) {
-  resetProject().catch(console.error)
 }

--- a/scripts/run-project-reset.mjs
+++ b/scripts/run-project-reset.mjs
@@ -1,0 +1,3 @@
+import { resetProject } from './reset-project.mjs'
+
+resetProject().catch(console.error)

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -7,7 +7,7 @@ import {
   TEST_PROJECT_NAME,
   TEST_TEAM_NAME,
   TEST_TOKEN,
-} from '../../../scripts/reset-vercel-project.mjs'
+} from '../../../scripts/reset-project.mjs'
 import fetch from 'node-fetch'
 import { Span } from 'next/src/trace'
 


### PR DESCRIPTION
We have identical `resetProject` code used in `bench/vercel` and our e2e workflow action -- this updates the `resetProject` script to side-effects free (hence removing the env var) and shared between bench & e2e

Closes NEXT-1731