### PR TITLE
ci: disable deployment protection for e2e test project

### DIFF
--- a/.github/workflows/test_e2e_deploy.yml
+++ b/.github/workflows/test_e2e_deploy.yml
@@ -47,7 +47,7 @@ jobs:
 
       - run: npm i -g vercel@latest
 
-      - run: node scripts/run-project-reset.mjs
+      - run: node scripts/run-e2e-test-project-reset.mjs
         name: Reset test project
 
       - run: docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.35.1-jammy /bin/bash -c "cd /work && NODE_VERSION=${{ env.NODE_LTS_VERSION }} ./scripts/setup-node.sh && corepack enable > /dev/null && NEXT_JUNIT_TEST_REPORT=true DATADOG_API_KEY=${DATADOG_API_KEY} DD_ENV=ci VERCEL_TEST_TOKEN=${{ secrets.VERCEL_TEST_TOKEN }} VERCEL_TEST_TEAM=vtest314-next-e2e-tests NEXT_TEST_JOB=1 NEXT_TEST_MODE=deploy TEST_TIMINGS_TOKEN=${{ secrets.TEST_TIMINGS_TOKEN }} NEXT_TEST_CONTINUE_ON_ERROR=1 xvfb-run node run-tests.js --type e2e --timings -g ${{ matrix.group }}/2 -c 1 >> /proc/1/fd/1"

--- a/bench/vercel/project-utils.js
+++ b/bench/vercel/project-utils.js
@@ -36,7 +36,11 @@ export async function generateProjects() {
               {
                 title: 'Resetting project',
                 task: async () => {
-                  await resetProject(TEST_TEAM_NAME, ORIGIN_PROJECT_NAME)
+                  await resetProject({
+                    teamId: TEST_TEAM_NAME,
+                    projectName: ORIGIN_PROJECT_NAME,
+                    disableDeploymentProtection: true,
+                  })
                 },
               },
               {
@@ -73,7 +77,11 @@ export async function generateProjects() {
               {
                 title: 'Resetting project',
                 task: async () => {
-                  await resetProject(TEST_TEAM_NAME, HEAD_PROJECT_NAME)
+                  await resetProject({
+                    teamId: TEST_TEAM_NAME,
+                    projectName: HEAD_PROJECT_NAME,
+                    disableDeploymentProtection: true,
+                  })
                 },
               },
               {

--- a/scripts/run-e2e-test-project-reset.mjs
+++ b/scripts/run-e2e-test-project-reset.mjs
@@ -1,0 +1,11 @@
+import {
+  resetProject,
+  TEST_PROJECT_NAME,
+  TEST_TEAM_NAME,
+} from './reset-project.mjs'
+
+resetProject({
+  projectName: TEST_PROJECT_NAME,
+  teamId: TEST_TEAM_NAME,
+  disableDeploymentProtection: true,
+}).catch(console.error)

--- a/scripts/run-project-reset.mjs
+++ b/scripts/run-project-reset.mjs
@@ -1,3 +1,0 @@
-import { resetProject } from './reset-project.mjs'
-
-resetProject().catch(console.error)


### PR DESCRIPTION
Since we reset the test project on every e2e CI run, deployment protection is automatically enabled by default.

This adds an option to the reset project workflow to disable deployment protection. Our test runners need to be able to hit these pages from an unauthenticated browser in order for the tests to work. 

Verified tests are running properly in [this run](https://github.com/vercel/next.js/actions/runs/6971348806/job/18971225559) (fixing any failing tests themselves are out of scope for this PR; will evaluate once the run finishes)

Closes NEXT-1732