### PR TITLE
ci: direct datadog upload without going through artifacts

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -230,39 +230,6 @@ jobs:
       afterBuild: pnpm playwright install && BROWSER_NAME=firefox node run-tests.js test/production/pages-dir/production/test/index.test.ts && BROWSER_NAME=safari NEXT_TEST_MODE=start node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/e2e/basepath.test.ts && BROWSER_NAME=safari DEVICE_NAME='iPhone XR' node run-tests.js -c 1 test/production/prerender-prefetch/index.test.ts
     secrets: inherit
 
-  report-test-results:
-    needs:
-      [
-        'test-unit',
-        'test-dev',
-        'test-prod',
-        'test-integration',
-        'test-turbopack-dev',
-        'test-turbopack-integration',
-      ]
-    if: always()
-    runs-on: ubuntu-latest
-    name: report test results to datadog
-    steps:
-      - name: Download test report artifacts
-        id: download-test-reports
-        uses: actions/download-artifact@v3
-        with:
-          name: test-reports
-          path: test
-
-      - name: Upload test report to datadog
-        run: |
-          if [ -d ./test/test-junit-report ]; then
-            # Add a `test.type` tag to distinguish between turbopack and next.js runs
-            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:nextjs --service nextjs ./test/test-junit-report
-          fi
-
-          if [ -d ./test/turbopack-test-junit-report ]; then
-            # Add a `test.type` tag to distinguish between turbopack and next.js runs
-            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:turbopack --service nextjs ./test/turbopack-test-junit-report
-          fi
-
   tests-pass:
     needs:
       [

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -194,10 +194,23 @@ jobs:
 
       - name: Upload test report artifacts
         uses: actions/upload-artifact@v3
-        if: ${{ inputs.afterBuild && always() }}
+        if: ${{ always() && inputs.afterBuild }}
         with:
           name: test-reports
           path: |
             test/test-junit-report
             test/turbopack-test-junit-report
           if-no-files-found: ignore
+
+      - name: Upload test report to datadog
+        if: ${{ always() && inputs.afterBuild && !github.event.pull_request.head.repo.fork }}
+        run: |
+          if [ -d ./test/test-junit-report ]; then
+            # Add a `test.type` tag to distinguish between turbopack and next.js runs
+            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:nextjs --service nextjs ./test/test-junit-report
+          fi
+
+          if [ -d ./test/turbopack-test-junit-report ]; then
+            # Add a `test.type` tag to distinguish between turbopack and next.js runs
+            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:turbopack --service nextjs ./test/turbopack-test-junit-report
+          fi


### PR DESCRIPTION
### Why?

Worried a retry will cause all test results to be reported multiple times, it also takes 2 minute to download all the artifacts

This PR also disables reporting on PRs from forks