### PR TITLE
disable flushToDisk during `generateStaticParams`

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1318,7 +1318,9 @@ export default async function build(
           pagesDir: true,
           appDir: true,
           fetchCache: true,
-          flushToDisk: config.experimental.isrFlushToDisk,
+          flushToDisk: ciEnvironment.hasNextSupport
+            ? false
+            : config.experimental.isrFlushToDisk,
           serverDistDir: path.join(distDir, 'server'),
           fetchCacheKeyPrefix: config.experimental.fetchCacheKeyPrefix,
           maxMemoryCacheSize: config.experimental.isrMemoryCacheSize,
@@ -1611,7 +1613,9 @@ export default async function build(
                             pageType,
                             incrementalCacheHandlerPath:
                               config.experimental.incrementalCacheHandlerPath,
-                            isrFlushToDisk: config.experimental.isrFlushToDisk,
+                            isrFlushToDisk: ciEnvironment.hasNextSupport
+                              ? false
+                              : config.experimental.isrFlushToDisk,
                             maxMemoryCacheSize:
                               config.experimental.isrMemoryCacheSize,
                             nextConfigOutput: config.output,


### PR DESCRIPTION
Follow-up to #58516 where a few spots where missed. This is only disabled in minimal mode. 

[Slack context](https://vercel.slack.com/archives/C042LHPJ1NX/p1700756778718459)