### PR TITLE
Add documentation note about middleware and runtimes

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/11-middleware.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/11-middleware.mdx
@@ -388,7 +388,9 @@ export default async function middleware(req) {
 }
 ```
 
-`export const runtime='nodejs'` is not supported. Middleware may only use the [Edge runtime](/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes).
+## Runtime
+
+Middleware currently only supports the [Edge runtime](/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes). The Node.js runtime can not be used.
 
 ## Version History
 

--- a/docs/02-app/01-building-your-application/01-routing/11-middleware.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/11-middleware.mdx
@@ -388,6 +388,8 @@ export default async function middleware(req) {
 }
 ```
 
+`export const runtime='nodejs'` is not supported. Middleware may only use the [Edge runtime](/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes).
+
 ## Version History
 
 | Version   | Changes                                                                                       |


### PR DESCRIPTION
At this time Middleware only supports the Edge runtime. This has caused confusion for users attempting to user Node.js only libraries in Middleware. This simply adds a note that the Node.js runtime cannot be used.

See [Switchable Runtime for Middleware](https://github.com/vercel/next.js/discussions/46722) for more more information.

Adding this as I've been tripped up by this before, and having it in the documentation should make it easier for others to find.