### PR TITLE
Updates the `with-vitest` example. Unlocks the tests passing with `server-only` usage

### DIFF
--- a/examples/with-vitest/app/rsc/page.test.tsx
+++ b/examples/with-vitest/app/rsc/page.test.tsx
@@ -1,6 +1,12 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import Page from './page'
+
+// Disables a package that checks that code is only executed on the server side.
+// Also, this mock can be defined in the Vitest setup file.
+vi.mock('server-only', () => {
+  return {}
+})
 
 test('App Router: Works with Server Components', () => {
   render(<Page />)

--- a/examples/with-vitest/app/rsc/page.tsx
+++ b/examples/with-vitest/app/rsc/page.tsx
@@ -1,7 +1,6 @@
-// import 'server-only' does not currently
-// work with Vitest
+import 'server-only'
 
-export const metdata = {
+export const metadata = {
   title: 'App Router',
 }
 


### PR DESCRIPTION
### What?

Updates the `with-vitest` example by @leerob with suggesting how to pass tests with `server-only` package usage.

### Why?

Package usage was commented with description that Vitest not support `server-only`.  
But in fact, we can just mock it, like other common external lib and resolve this problem.

### How?

Two ways:

- mock `server-only` directly in the test file
- mock `server-only` in the Vitest setup file

---
