### PR TITLE
feat: `NextResponse.permanentRedirect()`

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/next-response.mdx
+++ b/docs/02-app/02-api-reference/04-functions/next-response.mdx
@@ -80,17 +80,21 @@ export async function GET(request) {
 }
 ```
 
-## `redirect()`
+## `redirect()` and `permanentRedirect()`
 
-Produce a response that redirects to a [URL](https://developer.mozilla.org/docs/Web/API/URL).
+Produce a response that redirects to a [URL](https://developer.mozilla.org/docs/Web/API/URL). `NextResponse.redirect()` produces a temporary redirect response with a `307` status code by default, while `NextResponse.permanentRedirect()` produces a permanent redirect response with a `308` status code.
 
 ```ts
 import { NextResponse } from 'next/server'
 
+// For temporary redirects:
 return NextResponse.redirect(new URL('/new', request.url))
+
+// For permanent redirects:
+return NextResponse.permanentRedirect(new URL('/new', request.url))
 ```
 
-The [URL](https://developer.mozilla.org/docs/Web/API/URL) can be created and modified before being used in the `NextResponse.redirect()` method. For example, you can use the `request.nextUrl` property to get the current URL, and then modify it to redirect to a different URL.
+The [URL](https://developer.mozilla.org/docs/Web/API/URL) can be created and modified before being used in the `NextResponse.redirect()` and `NextResponse.permanentRedirect()` methods. For example, you can use the `request.nextUrl` property to get the current URL, and then modify it to redirect to a different URL.
 
 ```ts
 import { NextResponse } from 'next/server'
@@ -102,6 +106,22 @@ loginUrl.searchParams.set('from', request.nextUrl.pathname)
 // And redirect to the new URL
 return NextResponse.redirect(loginUrl)
 ```
+
+### Use other status codes for redirects
+
+If you need to use `301`, `302` or `303` status codes for redirects, the second argument of `NextResponse.redirect()` can be used to specify the status code. Note that `NextResponse.permanentRedirect()` doesn't allow this and always uses the `308` status code.
+
+```ts
+import { NextResponse } from 'next/server'
+
+// You can use a number to specify the status code
+return NextResponse.redirect(new URL('/new', request.url), 301)
+
+// or use an object
+return NextResponse.redirect(new URL('/new', request.url), { status: 301 })
+```
+
+> **Good to know**: Only `301`, `302`, `303`, `307` and `308` status codes are allowed here. Using other status codes will result in an error.
 
 ## `rewrite()`
 

--- a/packages/next/src/server/web/spec-extension/response.ts
+++ b/packages/next/src/server/web/spec-extension/response.ts
@@ -93,6 +93,10 @@ export class NextResponse<Body = unknown> extends Response {
     })
   }
 
+  static permanentRedirect(url: string | NextURL | URL, init?: ResponseInit) {
+    return NextResponse.redirect(url, { ...init, status: 308 })
+  }
+
   static rewrite(
     destination: string | NextURL | URL,
     init?: MiddlewareResponseInit

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -184,6 +184,21 @@ createNextDescribe(
           expect(await res.text()).toBeEmpty()
         })
 
+        it('supports the NextResponse.permanentRedirect() helper', async () => {
+          const res = await next.fetch(
+            basePath + '/hooks/permanent-redirect/response',
+            {
+              // "Manually" perform the redirect, we want to inspect the
+              // redirection response, so don't actually follow it.
+              redirect: 'manual',
+            }
+          )
+
+          expect(res.status).toEqual(308)
+          expect(res.headers.get('location')).toEqual('https://nextjs.org/')
+          expect(await res.text()).toBeEmpty()
+        })
+
         it('supports the NextResponse.json() helper', async () => {
           const meta = { ping: 'pong' }
           const res = await next.fetch(basePath + '/hooks/json', {

--- a/test/e2e/app-dir/app-routes/app/hooks/permanent-redirect/response/route.ts
+++ b/test/e2e/app-dir/app-routes/app/hooks/permanent-redirect/response/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.permanentRedirect('https://nextjs.org/')
+}


### PR DESCRIPTION
### What?

Implement `NextResponse.permanentRedirect()`, write tests and update documentation.

### Why?

Although `NextResponse.redirect()` already accepts a second argument that can be used to specify the status code, it's not documented so many people don't know about that.

Also, with `NextResponse.permanentRedirect()` it would be easier for users to produce permanent redirect responses compared to `NextResponse.redirect(..., 308)` or `NextResponse.redirect(..., { status: 308 })`, especially for users having editor auto-completion.
