### PR TITLE
Remove `cache` field from action types

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -166,7 +166,6 @@ function useServerActionDispatcher(dispatch: React.Dispatch<ReducerActions>) {
           ...actionPayload,
           type: ACTION_SERVER_ACTION,
           mutable: {},
-          cache: createEmptyCacheNode(),
         })
       })
     },
@@ -193,7 +192,6 @@ function useChangeByServerResponse(
           flightData,
           previousTree,
           overrideCanonicalUrl,
-          cache: createEmptyCacheNode(),
           mutable: {},
         })
       })
@@ -214,7 +212,6 @@ function useNavigate(dispatch: React.Dispatch<ReducerActions>): RouterNavigate {
         locationSearch: location.search,
         shouldScroll: shouldScroll ?? true,
         navigateType,
-        cache: createEmptyCacheNode(),
         mutable: {},
       })
     },
@@ -344,7 +341,6 @@ function Router({
         startTransition(() => {
           dispatch({
             type: ACTION_REFRESH,
-            cache: createEmptyCacheNode(),
             mutable: {},
             origin: window.location.origin,
           })
@@ -360,7 +356,6 @@ function Router({
           startTransition(() => {
             dispatch({
               type: ACTION_FAST_REFRESH,
-              cache: createEmptyCacheNode(),
               mutable: {},
               origin: window.location.origin,
             })

--- a/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
@@ -10,13 +10,15 @@ import type {
 import { handleExternalUrl } from './navigate-reducer'
 import { handleMutable } from '../handle-mutable'
 import { applyFlightData } from '../apply-flight-data'
+import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
+import { createEmptyCacheNode } from '../../app-router'
 
 // A version of refresh reducer that keeps the cache around instead of wiping all of it.
 function fastRefreshReducerImpl(
   state: ReadonlyReducerState,
   action: FastRefreshAction
 ): ReducerState {
-  const { cache, mutable, origin } = action
+  const { mutable, origin } = action
   const href = state.canonicalUrl
 
   const isForCurrentTree =
@@ -28,16 +30,15 @@ function fastRefreshReducerImpl(
 
   mutable.preserveCustomHistoryState = false
 
-  if (!cache.data) {
-    // TODO-APP: verify that `href` is not an external url.
-    // Fetch data from the root of the tree.
-    cache.data = fetchServerResponse(
-      new URL(href, origin),
-      [state.tree[0], state.tree[1], state.tree[2], 'refetch'],
-      state.nextUrl,
-      state.buildId
-    )
-  }
+  const cache: CacheNode = createEmptyCacheNode()
+  // TODO-APP: verify that `href` is not an external url.
+  // Fetch data from the root of the tree.
+  cache.data = fetchServerResponse(
+    new URL(href, origin),
+    [state.tree[0], state.tree[1], state.tree[2], 'refetch'],
+    state.nextUrl,
+    state.buildId
+  )
 
   return cache.data.then(
     ([flightData, canonicalUrlOverride]) => {

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
@@ -187,12 +187,6 @@ describe('navigateReducer', () => {
       locationSearch: '',
       navigateType: 'push',
       shouldScroll: true,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 
@@ -401,12 +395,6 @@ describe('navigateReducer', () => {
       locationSearch: '',
       navigateType: 'push',
       shouldScroll: true,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 
@@ -596,12 +584,6 @@ describe('navigateReducer', () => {
       locationSearch: '',
       navigateType: 'push',
       shouldScroll: true,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 
@@ -755,12 +737,6 @@ describe('navigateReducer', () => {
       locationSearch: '',
       navigateType: 'replace',
       shouldScroll: true,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 
@@ -911,12 +887,6 @@ describe('navigateReducer', () => {
       locationSearch: '',
       navigateType: 'push',
       shouldScroll: false, // should not scroll
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 
@@ -1081,12 +1051,6 @@ describe('navigateReducer', () => {
       navigateType: 'push',
       locationSearch: '',
       shouldScroll: true,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 
@@ -1364,12 +1328,6 @@ describe('navigateReducer', () => {
       locationSearch: '',
       navigateType: 'push',
       shouldScroll: true,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 
@@ -1569,12 +1527,6 @@ describe('navigateReducer', () => {
       locationSearch: '',
       navigateType: 'push',
       shouldScroll: true,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {
         canonicalUrl: '/linking#hash',
         previousTree: initialTree,
@@ -1718,12 +1670,6 @@ describe('navigateReducer', () => {
       locationSearch: '',
       navigateType: 'push',
       shouldScroll: true,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -27,6 +27,7 @@ import {
 } from '../get-prefetch-cache-entry-status'
 import { prunePrefetchCache } from './prune-prefetch-cache'
 import { prefetchQueue } from './prefetch-reducer'
+import { createEmptyCacheNode } from '../../app-router'
 
 export function handleExternalUrl(
   state: ReadonlyReducerState,
@@ -98,8 +99,7 @@ export function navigateReducer(
   state: ReadonlyReducerState,
   action: NavigateAction
 ): ReducerState {
-  const { url, isExternalUrl, navigateType, cache, mutable, shouldScroll } =
-    action
+  const { url, isExternalUrl, navigateType, mutable, shouldScroll } = action
   const { hash } = url
   const href = createHrefFromUrl(url)
   const pendingPush = navigateType === 'push'
@@ -207,6 +207,7 @@ export function navigateReducer(
             return handleExternalUrl(state, mutable, href, pendingPush)
           }
 
+          const cache: CacheNode = createEmptyCacheNode()
           let applied = applyFlightData(
             currentCache,
             cache,

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
@@ -135,12 +135,6 @@ describe('refreshReducer', () => {
     })
     const action: RefreshAction = {
       type: ACTION_REFRESH,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
       origin: new URL('/linking', 'https://localhost').origin,
     }
@@ -297,12 +291,6 @@ describe('refreshReducer', () => {
 
     const action: RefreshAction = {
       type: ACTION_REFRESH,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
       origin: new URL('/linking', 'https://localhost').origin,
     }
@@ -485,12 +473,6 @@ describe('refreshReducer', () => {
 
     const action: RefreshAction = {
       type: ACTION_REFRESH,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
       origin: new URL('/linking', 'https://localhost').origin,
     }
@@ -722,12 +704,6 @@ describe('refreshReducer', () => {
 
     const action: RefreshAction = {
       type: ACTION_REFRESH,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
       origin: new URL('/linking', 'https://localhost').origin,
     }

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -9,14 +9,18 @@ import type {
 } from '../router-reducer-types'
 import { handleExternalUrl } from './navigate-reducer'
 import { handleMutable } from '../handle-mutable'
-import { CacheStates } from '../../../../shared/lib/app-router-context.shared-runtime'
+import {
+  CacheStates,
+  type CacheNode,
+} from '../../../../shared/lib/app-router-context.shared-runtime'
 import { fillLazyItemsTillLeafWithHead } from '../fill-lazy-items-till-leaf-with-head'
+import { createEmptyCacheNode } from '../../app-router'
 
 export function refreshReducer(
   state: ReadonlyReducerState,
   action: RefreshAction
 ): ReducerState {
-  const { cache, mutable, origin } = action
+  const { mutable, origin } = action
   const href = state.canonicalUrl
 
   let currentTree = state.tree
@@ -30,16 +34,15 @@ export function refreshReducer(
 
   mutable.preserveCustomHistoryState = false
 
-  if (!cache.data) {
-    // TODO-APP: verify that `href` is not an external url.
-    // Fetch data from the root of the tree.
-    cache.data = fetchServerResponse(
-      new URL(href, origin),
-      [currentTree[0], currentTree[1], currentTree[2], 'refetch'],
-      state.nextUrl,
-      state.buildId
-    )
-  }
+  const cache: CacheNode = createEmptyCacheNode()
+  // TODO-APP: verify that `href` is not an external url.
+  // Fetch data from the root of the tree.
+  cache.data = fetchServerResponse(
+    new URL(href, origin),
+    [currentTree[0], currentTree[1], currentTree[2], 'refetch'],
+    state.nextUrl,
+    state.buildId
+  )
 
   return cache.data.then(
     ([flightData, canonicalUrlOverride]) => {

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -32,9 +32,13 @@ import { createHrefFromUrl } from '../create-href-from-url'
 import { handleExternalUrl } from './navigate-reducer'
 import { applyRouterStatePatchToTree } from '../apply-router-state-patch-to-tree'
 import { isNavigatingToNewRootLayout } from '../is-navigating-to-new-root-layout'
-import { CacheStates } from '../../../../shared/lib/app-router-context.shared-runtime'
+import {
+  CacheStates,
+  type CacheNode,
+} from '../../../../shared/lib/app-router-context.shared-runtime'
 import { handleMutable } from '../handle-mutable'
 import { fillLazyItemsTillLeafWithHead } from '../fill-lazy-items-till-leaf-with-head'
+import { createEmptyCacheNode } from '../../app-router'
 
 type FetchServerActionResult = {
   redirectLocation: URL | undefined
@@ -145,7 +149,7 @@ export function serverActionReducer(
   state: ReadonlyReducerState,
   action: ServerActionAction
 ): ReducerState {
-  const { mutable, cache, resolve, reject } = action
+  const { mutable, resolve, reject } = action
   const href = state.canonicalUrl
 
   let currentTree = state.tree
@@ -241,6 +245,7 @@ export function serverActionReducer(
 
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (subTreeData !== null) {
+          const cache: CacheNode = createEmptyCacheNode()
           cache.status = CacheStates.READY
           cache.subTreeData = subTreeData
           fillLazyItemsTillLeafWithHead(

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
@@ -171,12 +171,6 @@ describe('serverPatchReducer', () => {
         true,
       ],
       overrideCanonicalUrl: undefined,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 
@@ -363,12 +357,6 @@ describe('serverPatchReducer', () => {
         true,
       ],
       overrideCanonicalUrl: undefined,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 
@@ -502,12 +490,6 @@ describe('serverPatchReducer', () => {
       locationSearch: '',
       navigateType: 'push',
       shouldScroll: true,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 
@@ -544,12 +526,6 @@ describe('serverPatchReducer', () => {
         true,
       ],
       overrideCanonicalUrl: undefined,
-      cache: {
-        status: CacheStates.LAZY_INITIALIZED,
-        data: null,
-        subTreeData: null,
-        parallelRoutes: new Map(),
-      },
       mutable: {},
     }
 

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -9,13 +9,14 @@ import type {
 import { handleExternalUrl } from './navigate-reducer'
 import { applyFlightData } from '../apply-flight-data'
 import { handleMutable } from '../handle-mutable'
+import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
+import { createEmptyCacheNode } from '../../app-router'
 
 export function serverPatchReducer(
   state: ReadonlyReducerState,
   action: ServerPatchAction
 ): ReducerState {
-  const { flightData, previousTree, overrideCanonicalUrl, cache, mutable } =
-    action
+  const { flightData, previousTree, overrideCanonicalUrl, mutable } = action
 
   const isForCurrentTree =
     JSON.stringify(previousTree) === JSON.stringify(state.tree)
@@ -81,6 +82,7 @@ export function serverPatchReducer(
       mutable.canonicalUrl = canonicalUrlOverrideHref
     }
 
+    const cache: CacheNode = createEmptyCacheNode()
     applyFlightData(currentCache, cache, flightDataPath)
 
     mutable.previousTree = currentTree

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -52,14 +52,12 @@ export interface ServerActionMutable extends Mutable {
  */
 export interface RefreshAction {
   type: typeof ACTION_REFRESH
-  cache: CacheNode
   mutable: Mutable
   origin: Location['origin']
 }
 
 export interface FastRefreshAction {
   type: typeof ACTION_FAST_REFRESH
-  cache: CacheNode
   mutable: Mutable
   origin: Location['origin']
 }
@@ -77,7 +75,6 @@ export interface ServerActionAction {
   actionArgs: any[]
   resolve: (value: any) => void
   reject: (reason?: any) => void
-  cache: CacheNode
   mutable: ServerActionMutable
 }
 
@@ -118,7 +115,6 @@ export interface NavigateAction {
   locationSearch: Location['search']
   navigateType: 'push' | 'replace'
   shouldScroll: boolean
-  cache: CacheNode
   mutable: Mutable
 }
 
@@ -145,7 +141,6 @@ export interface ServerPatchAction {
   flightData: FlightData
   previousTree: FlightRouterState
   overrideCanonicalUrl: URL | undefined
-  cache: CacheNode
   mutable: Mutable
 }
 

--- a/packages/next/src/shared/lib/router/action-queue.ts
+++ b/packages/next/src/shared/lib/router/action-queue.ts
@@ -10,7 +10,6 @@ import {
 import type { ReduxDevToolsInstance } from '../../../client/components/use-reducer-with-devtools'
 import { reducer } from '../../../client/components/router-reducer/router-reducer'
 import React, { startTransition } from 'react'
-import { createEmptyCacheNode } from '../../../client/components/app-router'
 
 export type DispatchStatePromise = React.Dispatch<ReducerState>
 
@@ -82,7 +81,6 @@ async function runAction({
         actionQueue.dispatch(
           {
             type: ACTION_REFRESH,
-            cache: createEmptyCacheNode(),
             mutable: {},
             origin: window.location.origin,
           },


### PR DESCRIPTION
The app router reducer state used to be managed by `useReducer`, so it was written to be resilient to rebasing — the same action may be processed multiple times. Now that we've lifted the reducer outside of React (#56497), each action runs only a single time. So we can simplify some of the logic.

Previously, actions that update that cache were passed an empty cache object as part of the action payload. Now, we can instead create these objects on demand in the reducer.

(We should do the same for the `mutable` object, but there's a unit test which relies on this implementation detail, so I've left that for a separate PR.)

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
