### PR TITLE
Fix bugs with baseUrl and mdxRs

### DIFF
--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -28,12 +28,7 @@ module.exports =
         ]
         config.module.rules.push({
           test: extension,
-          use: [
-            nextConfig?.experimental?.mdxRs
-              ? undefined
-              : options.defaultLoaders.babel,
-            loader,
-          ].filter(Boolean),
+          use: [options.defaultLoaders.babel, loader],
         })
 
         if (typeof nextConfig.webpack === 'function') {

--- a/packages/next/src/build/load-jsconfig.ts
+++ b/packages/next/src/build/load-jsconfig.ts
@@ -37,10 +37,20 @@ function parseJsonFile(filePath: string) {
   }
 }
 
+export type ResolvedBaseUrl =
+  | { baseUrl: string; isImplicit: boolean }
+  | undefined
+
+export type JsConfig = { compilerOptions: Record<string, any> } | undefined
+
 export default async function loadJsConfig(
   dir: string,
   config: NextConfigComplete
-) {
+): Promise<{
+  useTypeScript: boolean
+  jsConfig: JsConfig
+  resolvedBaseUrl: ResolvedBaseUrl
+}> {
   let typeScriptPath: string | undefined
   try {
     const deps = await hasNecessaryDependencies(dir, [
@@ -81,12 +91,18 @@ export default async function loadJsConfig(
     implicitBaseurl = path.dirname(jsConfigPath)
   }
 
-  let resolvedBaseUrl
-  if (jsConfig) {
-    if (jsConfig.compilerOptions?.baseUrl) {
-      resolvedBaseUrl = path.resolve(dir, jsConfig.compilerOptions.baseUrl)
-    } else {
-      resolvedBaseUrl = implicitBaseurl
+  let resolvedBaseUrl: ResolvedBaseUrl
+  if (jsConfig?.compilerOptions?.baseUrl) {
+    resolvedBaseUrl = {
+      baseUrl: path.resolve(dir, jsConfig.compilerOptions.baseUrl),
+      isImplicit: false,
+    }
+  } else {
+    if (implicitBaseurl) {
+      resolvedBaseUrl = {
+        baseUrl: implicitBaseurl,
+        isImplicit: true,
+      }
     }
   }
 

--- a/packages/next/src/build/swc/jest-transformer.ts
+++ b/packages/next/src/build/swc/jest-transformer.ts
@@ -36,11 +36,12 @@ import type {
 } from '@jest/transform'
 import type { Config } from '@jest/types'
 import type { NextConfig, ExperimentalConfig } from '../../server/config-shared'
+import type { ResolvedBaseUrl } from '../load-jsconfig'
 
 type TransformerConfig = Config.TransformerConfig[1]
 export interface JestTransformerConfig extends TransformerConfig {
   jsConfig: any
-  resolvedBaseUrl?: string
+  resolvedBaseUrl?: ResolvedBaseUrl
   pagesDir?: string
   serverComponents?: boolean
   isEsmProject: boolean

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -4,6 +4,7 @@ import type {
   EmotionConfig,
   StyledComponentsConfig,
 } from '../../server/config-shared'
+import type { ResolvedBaseUrl } from '../load-jsconfig'
 
 const nextDistPath =
   /(next[\\/]dist[\\/]shared[\\/]lib)|(next[\\/]dist[\\/]client)|(next[\\/]dist[\\/]pages)/
@@ -52,7 +53,7 @@ function getBaseSWCOptions({
   modularizeImports?: NextConfig['modularizeImports']
   compilerOptions: NextConfig['compiler']
   swcPlugins: ExperimentalConfig['swcPlugins']
-  resolvedBaseUrl?: string
+  resolvedBaseUrl?: ResolvedBaseUrl
   jsConfig: any
   swcCacheDir?: string
   serverComponents?: boolean
@@ -77,7 +78,7 @@ function getBaseSWCOptions({
     jsc: {
       ...(resolvedBaseUrl && paths
         ? {
-            baseUrl: resolvedBaseUrl,
+            baseUrl: resolvedBaseUrl.baseUrl,
             paths,
           }
         : {}),
@@ -257,7 +258,7 @@ export function getJestSWCOptions({
   swcPlugins: ExperimentalConfig['swcPlugins']
   compilerOptions: NextConfig['compiler']
   jsConfig: any
-  resolvedBaseUrl?: string
+  resolvedBaseUrl?: ResolvedBaseUrl
   pagesDir?: string
   serverComponents?: boolean
 }) {
@@ -298,6 +299,8 @@ export function getJestSWCOptions({
 }
 
 export function getLoaderSWCOptions({
+  // This is not passed yet as "paths" resolving is handled by webpack currently.
+  // resolvedBaseUrl,
   filename,
   development,
   isServer,
@@ -316,9 +319,7 @@ export function getLoaderSWCOptions({
   relativeFilePathFromRoot,
   serverComponents,
   isReactServerLayer,
-}: // This is not passed yet as "paths" resolving is handled by webpack currently.
-// resolvedBaseUrl,
-{
+}: {
   filename: string
   development: boolean
   isServer: boolean

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1810,7 +1810,6 @@ export default async function getBaseWebpackConfig(
 
   // Support tsconfig and jsconfig baseUrl
   // Only add the baseUrl if it's explicitly set in tsconfig/jsconfig
-  console.log({ resolvedBaseUrl })
   if (resolvedBaseUrl && !resolvedBaseUrl.isImplicit) {
     webpackConfig.resolve?.modules?.push(resolvedBaseUrl.baseUrl)
   }

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -51,7 +51,10 @@ import type {
 } from './webpack/plugins/telemetry-plugin'
 import type { Span } from '../trace'
 import type { MiddlewareMatcher } from './analysis/get-page-static-info'
-import loadJsConfig from './load-jsconfig'
+import loadJsConfig, {
+  type JsConfig,
+  type ResolvedBaseUrl,
+} from './load-jsconfig'
 import { loadBindings } from './swc'
 import { AppBuildManifestPlugin } from './webpack/plugins/app-build-manifest-plugin'
 import { SubresourceIntegrityPlugin } from './webpack/plugins/subresource-integrity-plugin'
@@ -231,7 +234,11 @@ export async function loadProjectInfo({
   dir: string
   config: NextConfigComplete
   dev: boolean
-}) {
+}): Promise<{
+  jsConfig: JsConfig
+  resolvedBaseUrl: ResolvedBaseUrl
+  supportedBrowsers: string[] | undefined
+}> {
   const { jsConfig, resolvedBaseUrl } = await loadJsConfig(dir, config)
   const supportedBrowsers = await getSupportedBrowsers(dir, dev)
   return {
@@ -310,7 +317,7 @@ export default async function getBaseWebpackConfig(
     middlewareMatchers?: MiddlewareMatcher[]
     noMangling?: boolean
     jsConfig: any
-    resolvedBaseUrl: string | undefined
+    resolvedBaseUrl: ResolvedBaseUrl
     supportedBrowsers: string[] | undefined
     clientRouterFilters?: {
       staticFilter: ReturnType<
@@ -1802,16 +1809,18 @@ export default async function getBaseWebpackConfig(
   }
 
   // Support tsconfig and jsconfig baseUrl
-  if (resolvedBaseUrl) {
-    webpackConfig.resolve?.modules?.push(resolvedBaseUrl)
+  // Only add the baseUrl if it's explicitly set in tsconfig/jsconfig
+  console.log({ resolvedBaseUrl })
+  if (resolvedBaseUrl && !resolvedBaseUrl.isImplicit) {
+    webpackConfig.resolve?.modules?.push(resolvedBaseUrl.baseUrl)
   }
 
-  // allows add JsConfigPathsPlugin to allow hot-reloading
+  // always add JsConfigPathsPlugin to allow hot-reloading
   // if the config is added/removed
   webpackConfig.resolve?.plugins?.unshift(
     new JsConfigPathsPlugin(
       jsConfig?.compilerOptions?.paths || {},
-      resolvedBaseUrl || dir
+      resolvedBaseUrl
     )
   )
 

--- a/packages/next/src/build/webpack/plugins/jsconfig-paths-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/jsconfig-paths-plugin.ts
@@ -6,6 +6,7 @@
 import path from 'path'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { debug } from 'next/dist/compiled/debug'
+import type { ResolvedBaseUrl } from '../../load-jsconfig'
 
 const log = debug('next:jsconfig-paths-plugin')
 
@@ -168,10 +169,10 @@ type Paths = { [match: string]: string[] }
  */
 export class JsConfigPathsPlugin implements webpack.ResolvePluginInstance {
   paths: Paths
-  resolvedBaseUrl: string
+  resolvedBaseUrl: ResolvedBaseUrl
   jsConfigPlugin: true
 
-  constructor(paths: Paths, resolvedBaseUrl: string) {
+  constructor(paths: Paths, resolvedBaseUrl: ResolvedBaseUrl) {
     this.paths = paths
     this.resolvedBaseUrl = resolvedBaseUrl
     this.jsConfigPlugin = true
@@ -189,6 +190,10 @@ export class JsConfigPathsPlugin implements webpack.ResolvePluginInstance {
           resolveContext: any,
           callback: (err?: any, result?: any) => void
         ) => {
+          const resolvedBaseUrl = this.resolvedBaseUrl
+          if (resolvedBaseUrl === undefined) {
+            return callback()
+          }
           const paths = this.paths
           const pathsKeys = Object.keys(paths)
 
@@ -248,7 +253,7 @@ export class JsConfigPathsPlugin implements webpack.ResolvePluginInstance {
                 // try next path candidate
                 return pathCallback()
               }
-              const candidate = path.join(this.resolvedBaseUrl, curPath)
+              const candidate = path.join(resolvedBaseUrl.baseUrl, curPath)
               const obj = Object.assign({}, request, {
                 request: candidate,
               })

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -2089,15 +2089,21 @@ async function startWatcher(opts: SetupOpts) {
                   (item) => item === currentResolvedBaseUrl
                 )
 
-                if (
-                  resolvedBaseUrl &&
-                  resolvedBaseUrl !== currentResolvedBaseUrl
-                ) {
-                  // remove old baseUrl and add new one
-                  if (resolvedUrlIndex && resolvedUrlIndex > -1) {
-                    config.resolve?.modules?.splice(resolvedUrlIndex, 1)
+                if (resolvedBaseUrl) {
+                  if (
+                    resolvedBaseUrl.baseUrl !== currentResolvedBaseUrl.baseUrl
+                  ) {
+                    // remove old baseUrl and add new one
+                    if (resolvedUrlIndex && resolvedUrlIndex > -1) {
+                      config.resolve?.modules?.splice(resolvedUrlIndex, 1)
+                    }
+
+                    // If the resolvedBaseUrl is implicit we only remove the previous value.
+                    // Only add the baseUrl if it's explicitly set in tsconfig/jsconfig
+                    if (!resolvedBaseUrl.isImplicit) {
+                      config.resolve?.modules?.push(resolvedBaseUrl.baseUrl)
+                    }
                   }
-                  config.resolve?.modules?.push(resolvedBaseUrl)
                 }
 
                 if (jsConfig?.compilerOptions?.paths && resolvedBaseUrl) {

--- a/test/e2e/app-dir/modularizeimports/.gitignore
+++ b/test/e2e/app-dir/modularizeimports/.gitignore
@@ -1,0 +1,1 @@
+!tsconfig.json

--- a/test/e2e/app-dir/modularizeimports/app/layout.tsx
+++ b/test/e2e/app-dir/modularizeimports/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/modularizeimports/app/mdx/apage.mdx
+++ b/test/e2e/app-dir/modularizeimports/app/mdx/apage.mdx
@@ -1,0 +1,7 @@
+import { Cart, Search } from 'design-system/icons'
+
+# ModularizeImports
+
+<Cart />
+
+<Search />

--- a/test/e2e/app-dir/modularizeimports/app/mdx/apage.mdx
+++ b/test/e2e/app-dir/modularizeimports/app/mdx/apage.mdx
@@ -1,7 +1,0 @@
-import { Cart, Search } from 'design-system/icons'
-
-# ModularizeImports
-
-<Cart />
-
-<Search />

--- a/test/e2e/app-dir/modularizeimports/app/page.js
+++ b/test/e2e/app-dir/modularizeimports/app/page.js
@@ -1,0 +1,11 @@
+import { Cart, Search } from 'design-system/icons'
+
+export default function Page() {
+  return (
+    <>
+      <h1>ModularizeImports</h1>
+      <Cart />
+      <Search />
+    </>
+  )
+}

--- a/test/e2e/app-dir/modularizeimports/design-system/icons/cart.js
+++ b/test/e2e/app-dir/modularizeimports/design-system/icons/cart.js
@@ -1,0 +1,3 @@
+export function Cart() {
+  return <p id="cart-icon">Cart Icon</p>
+}

--- a/test/e2e/app-dir/modularizeimports/design-system/icons/search.js
+++ b/test/e2e/app-dir/modularizeimports/design-system/icons/search.js
@@ -1,0 +1,3 @@
+export function Search() {
+  return <p id="search-icon">Search Icon</p>
+}

--- a/test/e2e/app-dir/modularizeimports/mdx-components.tsx
+++ b/test/e2e/app-dir/modularizeimports/mdx-components.tsx
@@ -1,0 +1,5 @@
+export function useMDXComponents(components) {
+  return {
+    ...components,
+  }
+}

--- a/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
+++ b/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
@@ -1,0 +1,26 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'modularizeImports',
+  {
+    files: __dirname,
+    dependencies: {
+      '@next/mdx': 'canary',
+      '@mdx-js/loader': '^2.2.1',
+      '@mdx-js/react': '^2.2.1',
+    },
+  },
+  ({ next }) => {
+    it('should work', async () => {
+      const $ = await next.render$('/')
+      expect($('#cart-icon').text()).toBe('Cart Icon')
+      expect($('#search-icon').text()).toBe('Search Icon')
+    })
+
+    it('should work with MDX', async () => {
+      const $ = await next.render$('/mdx')
+      expect($('#cart-icon').text()).toBe('Cart Icon')
+      expect($('#search-icon').text()).toBe('Search Icon')
+    })
+  }
+)

--- a/test/e2e/app-dir/modularizeimports/next.config.js
+++ b/test/e2e/app-dir/modularizeimports/next.config.js
@@ -1,0 +1,19 @@
+const withMDX = require('@next/mdx')()
+
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
+  modularizeImports: {
+    'design-system/icons': {
+      transform: 'design-system/icons/{{ kebabCase member }}',
+      skipDefaultConversion: true,
+    },
+  },
+  experimental: {
+    // mdxRs: true,
+  },
+}
+
+module.exports = withMDX(nextConfig)

--- a/test/e2e/app-dir/modularizeimports/next.config.js
+++ b/test/e2e/app-dir/modularizeimports/next.config.js
@@ -12,7 +12,7 @@ const nextConfig = {
     },
   },
   experimental: {
-    // mdxRs: true,
+    mdxRs: true,
   },
 }
 

--- a/test/e2e/app-dir/modularizeimports/pages/mdx/index.mdx
+++ b/test/e2e/app-dir/modularizeimports/pages/mdx/index.mdx
@@ -1,0 +1,7 @@
+import { Cart, Search } from 'design-system/icons'
+
+# ModularizeImports
+
+<Cart />
+
+<Search />

--- a/test/e2e/app-dir/modularizeimports/tsconfig.json
+++ b/test/e2e/app-dir/modularizeimports/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What?

Was investigating an issue with Turbopack and MDX, in the process found a few bugs:

- When you have a `tsconfig.json` or `jsconfig.json` the `baseUrl: '.'` is used by default which causes the top-level directories to be available as e.g. `design-system` (without a prefix).
	-  This is not how TypeScript's default setting for `baseUrl` works. While it should resolve `paths` relative to `.` when none is specified it does not do additional resolving for the top level directories/files.
	- When `"baseUrl": "."` is added to `tsconfig.js` explicitly it handles the top level directories.
- `modularizeImports` and other SWC transforms weren't applied to `.mdx` files when `experimental.mdxRs` is enabled, which caused compilation to fail.
- `modularIzeImports` and other SWC transforms are not applied to `.mdx` files when using Turbopack.
	- @kwonoj is investigating this, will be handled in a follow-up PR.

## How?

- Added a test suite for `modularizeImports` with MDX tests
- Removed the condition that disables swcLoader in webpack when using mdxRs
- Changed the check for `tsconfig.json` / `jsconfig.json` baseUrl to include if it was implicitly or explicitly set, disabled the module resolving when it is implicitly set


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
