### PR TITLE
fix(turbopack): treat .mdx as valid ecma asset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "serde",
  "smallvec",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "serde",
@@ -7678,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7710,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7737,7 +7737,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7751,7 +7751,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7798,7 +7798,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "base16",
  "hex",
@@ -7810,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7824,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7834,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "mimalloc",
 ]
@@ -7842,7 +7842,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7867,7 +7867,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7898,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7939,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7962,7 +7962,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7980,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8010,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8036,7 +8036,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8060,7 +8060,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8097,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8131,7 +8131,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "serde",
  "serde_json",
@@ -8142,7 +8142,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8165,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "serde",
@@ -8233,7 +8233,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8248,7 +8248,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8283,7 +8283,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "serde",
@@ -8299,7 +8299,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8325,7 +8325,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.3#cb1496ca9ee93f5270041e4988080c2eb52b0e35"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ swc_core = { version = "0.86.81", features = [
 testing = { version = "0.35.11" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231127.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231127.4" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231127.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231127.4" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231127.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231127.4" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/src/next_client/transforms.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/transforms.rs
@@ -25,26 +25,34 @@ pub async fn get_next_client_transforms_rules(
 
     let modularize_imports_config = &next_config.await?.modularize_imports;
     if let Some(modularize_imports_config) = modularize_imports_config {
-        rules.push(get_next_modularize_imports_rule(modularize_imports_config));
+        rules.push(get_next_modularize_imports_rule(
+            modularize_imports_config,
+            *next_config.mdx_rs().await?,
+        ));
     }
 
-    rules.push(get_next_font_transform_rule());
+    let mdx_rs = *next_config.mdx_rs().await?;
+    rules.push(get_next_font_transform_rule(mdx_rs));
 
     let pages_dir = match context_ty {
         ClientContextType::Pages { pages_dir } => {
             rules.push(
-                get_next_pages_transforms_rule(pages_dir, ExportFilter::StripDataExports).await?,
+                get_next_pages_transforms_rule(pages_dir, ExportFilter::StripDataExports, mdx_rs)
+                    .await?,
             );
             Some(pages_dir)
         }
         ClientContextType::App { .. } => {
-            rules.push(get_server_actions_transform_rule(ActionsTransform::Client));
+            rules.push(get_server_actions_transform_rule(
+                ActionsTransform::Client,
+                mdx_rs,
+            ));
             None
         }
         ClientContextType::Fallback | ClientContextType::Other => None,
     };
 
-    rules.push(get_next_dynamic_transform_rule(false, false, pages_dir, mode).await?);
+    rules.push(get_next_dynamic_transform_rule(false, false, pages_dir, mode, mdx_rs).await?);
 
     rules.push(get_next_image_rule());
 

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -255,7 +255,9 @@ pub async fn get_server_module_options_context(
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<ModuleOptionsContext>> {
     let custom_rules = get_next_server_transforms_rules(next_config, ty.into_value(), mode).await?;
-    let internal_custom_rules = get_next_server_internal_transforms_rules(ty.into_value()).await?;
+    let internal_custom_rules =
+        get_next_server_internal_transforms_rules(ty.into_value(), *next_config.mdx_rs().await?)
+            .await?;
 
     let foreign_code_context_condition =
         foreign_code_context_condition(next_config, project_path).await?;

--- a/packages/next-swc/crates/next-core/src/next_server/transforms.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/transforms.rs
@@ -25,10 +25,14 @@ pub async fn get_next_server_transforms_rules(
     let mut rules = vec![];
 
     let modularize_imports_config = &next_config.await?.modularize_imports;
+    let mdx_rs = *next_config.mdx_rs().await?;
     if let Some(modularize_imports_config) = modularize_imports_config {
-        rules.push(get_next_modularize_imports_rule(modularize_imports_config));
+        rules.push(get_next_modularize_imports_rule(
+            modularize_imports_config,
+            mdx_rs,
+        ));
     }
-    rules.push(get_next_font_transform_rule());
+    rules.push(get_next_font_transform_rule(mdx_rs));
 
     let (is_server_components, pages_dir) = match context_ty {
         ServerContextType::Pages { pages_dir } | ServerContextType::PagesApi { pages_dir } => {
@@ -36,19 +40,26 @@ pub async fn get_next_server_transforms_rules(
         }
         ServerContextType::PagesData { pages_dir } => {
             rules.push(
-                get_next_pages_transforms_rule(pages_dir, ExportFilter::StripDefaultExport).await?,
+                get_next_pages_transforms_rule(pages_dir, ExportFilter::StripDefaultExport, mdx_rs)
+                    .await?,
             );
             (false, Some(pages_dir))
         }
         ServerContextType::AppSSR { .. } => {
             // Yah, this is SSR, but this is still treated as a Client transform layer.
-            rules.push(get_server_actions_transform_rule(ActionsTransform::Client));
+            rules.push(get_server_actions_transform_rule(
+                ActionsTransform::Client,
+                mdx_rs,
+            ));
             (false, None)
         }
         ServerContextType::AppRSC {
             client_transition, ..
         } => {
-            rules.push(get_server_actions_transform_rule(ActionsTransform::Server));
+            rules.push(get_server_actions_transform_rule(
+                ActionsTransform::Server,
+                mdx_rs,
+            ));
             if let Some(client_transition) = client_transition {
                 rules.push(get_next_css_client_reference_transforms_rule(
                     client_transition,
@@ -60,7 +71,10 @@ pub async fn get_next_server_transforms_rules(
         ServerContextType::Middleware { .. } => (false, None),
     };
 
-    rules.push(get_next_dynamic_transform_rule(true, is_server_components, pages_dir, mode).await?);
+    rules.push(
+        get_next_dynamic_transform_rule(true, is_server_components, pages_dir, mode, mdx_rs)
+            .await?,
+    );
 
     rules.push(get_next_image_rule());
 
@@ -71,23 +85,24 @@ pub async fn get_next_server_transforms_rules(
 /// transforms, but which are only applied to internal modules.
 pub async fn get_next_server_internal_transforms_rules(
     context_ty: ServerContextType,
+    mdx_rs: bool,
 ) -> Result<Vec<ModuleRule>> {
     let mut rules = vec![];
 
     match context_ty {
         ServerContextType::Pages { .. } => {
             // Apply next/font transforms to foreign code
-            rules.push(get_next_font_transform_rule());
+            rules.push(get_next_font_transform_rule(mdx_rs));
         }
         ServerContextType::PagesApi { .. } => {}
         ServerContextType::PagesData { .. } => {}
         ServerContextType::AppSSR { .. } => {
-            rules.push(get_next_font_transform_rule());
+            rules.push(get_next_font_transform_rule(mdx_rs));
         }
         ServerContextType::AppRSC {
             client_transition, ..
         } => {
-            rules.push(get_next_font_transform_rule());
+            rules.push(get_next_font_transform_rule(mdx_rs));
             if let Some(client_transition) = client_transition {
                 rules.push(get_next_css_client_reference_transforms_rule(
                     client_transition,

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
@@ -56,16 +56,28 @@ pub fn get_next_image_rule() -> ModuleRule {
 }
 
 /// Returns a rule which applies the Next.js dynamic transform.
-pub(crate) fn module_rule_match_js_no_url() -> ModuleRuleCondition {
+pub(crate) fn module_rule_match_js_no_url(enable_mdx_rs: bool) -> ModuleRuleCondition {
+    let mut conditions = vec![
+        ModuleRuleCondition::ResourcePathEndsWith(".js".to_string()),
+        ModuleRuleCondition::ResourcePathEndsWith(".jsx".to_string()),
+        ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
+        ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
+    ];
+
+    if enable_mdx_rs {
+        conditions.append(
+            vec![
+                ModuleRuleCondition::ResourcePathEndsWith(".md".to_string()),
+                ModuleRuleCondition::ResourcePathEndsWith(".mdx".to_string()),
+            ]
+            .as_mut(),
+        );
+    }
+
     ModuleRuleCondition::all(vec![
         ModuleRuleCondition::not(ModuleRuleCondition::ReferenceType(ReferenceType::Url(
             UrlReferenceSubType::Undefined,
         ))),
-        ModuleRuleCondition::any(vec![
-            ModuleRuleCondition::ResourcePathEndsWith(".js".to_string()),
-            ModuleRuleCondition::ResourcePathEndsWith(".jsx".to_string()),
-            ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
-            ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
-        ]),
+        ModuleRuleCondition::any(conditions),
     ])
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/modularize_imports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/modularize_imports.rs
@@ -44,12 +44,13 @@ pub enum Transform {
 /// Returns a rule which applies the Next.js modularize imports transform.
 pub fn get_next_modularize_imports_rule(
     modularize_imports_config: &IndexMap<String, ModularizeImportPackageConfig>,
+    enable_mdx_rs: bool,
 ) -> ModuleRule {
     let transformer = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
         ModularizeImportsTransformer::new(modularize_imports_config),
     ) as _));
     ModuleRule::new(
-        module_rule_match_js_no_url(),
+        module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
             transformer,
         ]))],

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -28,6 +28,7 @@ pub async fn get_next_dynamic_transform_rule(
     is_react_server_layer: bool,
     pages_dir: Option<Vc<FileSystemPath>>,
     mode: NextMode,
+    enable_mdx_rs: bool,
 ) -> Result<ModuleRule> {
     let dynamic_transform = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextJsDynamic {
         is_server_compiler,
@@ -39,7 +40,7 @@ pub async fn get_next_dynamic_transform_rule(
         mode,
     }) as _));
     Ok(ModuleRule::new(
-        module_rule_match_js_no_url(),
+        module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
             dynamic_transform,
         ]))],

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_font.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_font.rs
@@ -10,7 +10,7 @@ use turbopack_binding::turbopack::{
 use super::module_rule_match_js_no_url;
 
 /// Returns a rule which applies the Next.js font transform.
-pub fn get_next_font_transform_rule() -> ModuleRule {
+pub fn get_next_font_transform_rule(enable_mdx_rs: bool) -> ModuleRule {
     let font_loaders = vec![
         "next/font/google".into(),
         "@next/font/google".into(),
@@ -22,7 +22,7 @@ pub fn get_next_font_transform_rule() -> ModuleRule {
         EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextJsFont { font_loaders }) as _));
     ModuleRule::new(
         // TODO: Only match in pages (not pages/api), app/, etc.
-        module_rule_match_js_no_url(),
+        module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
             transformer,
         ]))],

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -23,6 +23,7 @@ use super::module_rule_match_js_no_url;
 pub async fn get_next_pages_transforms_rule(
     pages_dir: Vc<FileSystemPath>,
     export_filter: ExportFilter,
+    enable_mdx_rs: bool,
 ) -> Result<ModuleRule> {
     // Apply the Next SSG transform to all pages.
     let strip_transform = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
@@ -51,7 +52,7 @@ pub async fn get_next_pages_transforms_rule(
                     ),
                 ])),
             ]),
-            module_rule_match_js_no_url(),
+            module_rule_match_js_no_url(enable_mdx_rs),
         ]),
         vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
             strip_transform,

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -20,11 +20,14 @@ pub enum ActionsTransform {
 }
 
 /// Returns a rule which applies the Next.js Server Actions transform.
-pub fn get_server_actions_transform_rule(transform: ActionsTransform) -> ModuleRule {
+pub fn get_server_actions_transform_rule(
+    transform: ActionsTransform,
+    enable_mdx_rs: bool,
+) -> ModuleRule {
     let transformer =
         EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextServerActions { transform }) as _));
     ModuleRule::new(
-        module_rule_match_js_no_url(),
+        module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
             transformer,
         ]))],

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -195,7 +195,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.3",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1074,8 +1074,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.3
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.3(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -24648,9 +24648,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.3(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.3}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.3'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What

Pairing with https://github.com/vercel/turbo/pull/6602, enables ecma-related transform support in mdx. notably fixes test cases in https://github.com/vercel/next.js/pull/58968 .

With turbopack side fix, still modularize imports are not being applied as we limite it to .js* extension only. PR expands it to include mdx if mdx is enabled. PR is failling until turbopack side fix lands.

Closes PACK-2045