### PR TITLE
dedupe pending revalidation requests

### DIFF
--- a/packages/next/src/client/components/static-generation-async-storage.external.ts
+++ b/packages/next/src/client/components/static-generation-async-storage.external.ts
@@ -26,7 +26,7 @@ export interface StaticGenerationStore {
   revalidate?: false | number
   forceStatic?: boolean
   dynamicShouldError?: boolean
-  pendingRevalidates?: Promise<any>[]
+  pendingRevalidates?: Record<string, Promise<any>>
   postponeWasTriggered?: boolean
   postpone?: (reason: string) => never
 

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -111,7 +111,9 @@ async function addRevalidationHeader(
     requestStore: RequestStore
   }
 ) {
-  await Promise.all(staticGenerationStore.pendingRevalidates || [])
+  await Promise.all(
+    Object.values(staticGenerationStore.pendingRevalidates || [])
+  )
 
   // If a tag was revalidated, the client router needs to invalidate all the
   // client router cache as they may be stale. And if a path was revalidated, the
@@ -348,7 +350,9 @@ export async function handleAction({
 
       if (isFetchAction) {
         res.statusCode = 500
-        await Promise.all(staticGenerationStore.pendingRevalidates || [])
+        await Promise.all(
+          Object.values(staticGenerationStore.pendingRevalidates || [])
+        )
 
         const promise = Promise.reject(error)
         try {
@@ -640,7 +644,9 @@ To configure the body size limit for Server Actions, see: https://nextjs.org/doc
 
     if (isFetchAction) {
       res.statusCode = 500
-      await Promise.all(staticGenerationStore.pendingRevalidates || [])
+      await Promise.all(
+        Object.values(staticGenerationStore.pendingRevalidates || [])
+      )
       const promise = Promise.reject(err)
       try {
         // we need to await the promise to trigger the rejection early

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1037,7 +1037,7 @@ async function renderToHTMLOrFlightImpl(
       pageData: await stringifiedFlightPayloadPromise,
       // If we have pending revalidates, wait until they are all resolved.
       waitUntil: staticGenerationStore.pendingRevalidates
-        ? Promise.all(staticGenerationStore.pendingRevalidates)
+        ? Promise.all(Object.values(staticGenerationStore.pendingRevalidates))
         : undefined,
     }
   )

--- a/packages/next/src/server/future/route-modules/app-route/module.ts
+++ b/packages/next/src/server/future/route-modules/app-route/module.ts
@@ -368,7 +368,9 @@ export class AppRouteRouteModule extends RouteModule<
                       staticGenerationStore.fetchMetrics
 
                     context.renderOpts.waitUntil = Promise.all(
-                      staticGenerationStore.pendingRevalidates || []
+                      Object.values(
+                        staticGenerationStore.pendingRevalidates || []
+                      )
                     )
 
                     addImplicitTags(staticGenerationStore)

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -546,12 +546,11 @@ export function patchFetch({
             // so the revalidated entry has the updated data
             if (!(staticGenerationStore.isRevalidate && entry.isStale)) {
               if (entry.isStale) {
-                if (!staticGenerationStore.pendingRevalidates) {
-                  staticGenerationStore.pendingRevalidates = []
+                staticGenerationStore.pendingRevalidates ??= {}
+                if (!staticGenerationStore.pendingRevalidates[cacheKey]) {
+                  staticGenerationStore.pendingRevalidates[cacheKey] =
+                    doOriginalFetch(true).catch(console.error)
                 }
-                staticGenerationStore.pendingRevalidates.push(
-                  doOriginalFetch(true).catch(console.error)
-                )
               }
               const resData = entry.value.data
 

--- a/packages/next/src/server/web/spec-extension/revalidate-tag.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate-tag.ts
@@ -30,13 +30,13 @@ export function revalidateTag(tag: string) {
   }
 
   if (!store.pendingRevalidates) {
-    store.pendingRevalidates = []
+    store.pendingRevalidates = {}
   }
-  store.pendingRevalidates.push(
-    store.incrementalCache.revalidateTag?.(tag).catch((err) => {
+  store.pendingRevalidates[tag] = store.incrementalCache
+    .revalidateTag?.(tag)
+    .catch((err) => {
       console.error(`revalidateTag failed for ${tag}`, err)
     })
-  )
 
   // TODO: only revalidate if the path matches
   store.pathWasRevalidated = true

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -166,12 +166,11 @@ export function unstable_cache<T extends Callback>(
             return invokeCallback()
           } else {
             if (!store.pendingRevalidates) {
-              store.pendingRevalidates = []
+              store.pendingRevalidates = {}
             }
-            store.pendingRevalidates.push(
-              invokeCallback().catch((err) =>
+            store.pendingRevalidates[joinedKey] = invokeCallback().catch(
+              (err) =>
                 console.error(`revalidating cache with key: ${joinedKey}`, err)
-              )
             )
           }
         }

--- a/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
+++ b/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
@@ -1,4 +1,4 @@
-import { findPort } from 'next-test-utils'
+import { findPort, waitFor } from 'next-test-utils'
 import http from 'http'
 import { outdent } from 'outdent'
 import { FileRef, createNext } from 'e2e-utils'
@@ -78,6 +78,48 @@ describe('app-fetch-deduping', () => {
         await next.render('/test')
 
         let count = next.cliOutput.split('Starting...').length - 1
+        expect(count).toBe(1)
+
+        await next.destroy()
+      })
+
+      it('should dedupe pending revalidation requests', async () => {
+        const next = await createNext({
+          files: new FileRef(__dirname),
+        })
+
+        await next.patchFile(
+          'app/test/page.tsx',
+          outdent`
+          async function getTime() {
+            const res = await fetch("http://localhost:${next.appPort}/api/time", { next: { revalidate: 5 } })
+            return res.text()
+          }
+          
+          export default async function Home() {
+            await getTime()
+            await getTime()
+            const time = await getTime()
+          
+            return <h1>{time}</h1>
+          }
+        `
+        )
+
+        await next.render('/test')
+
+        let count = next.cliOutput.split('Starting...').length - 1
+        expect(count).toBe(1)
+
+        const outputIndex = next.cliOutput.length
+
+        // wait for the revalidation to finish
+        await waitFor(6000)
+
+        await next.render('/test')
+
+        count =
+          next.cliOutput.slice(outputIndex).split('Starting...').length - 1
         expect(count).toBe(1)
 
         await next.destroy()


### PR DESCRIPTION
### What?
We currently dedupe fetch requests, but if those fetch requests contain a `revalidate` time, when that window is expired all of those fetches will be invoked without deduping.

### Why?
We track revalidations on the `staticGenerationStore` but we don't have a way to dedupe them, as it's currently just an array. When the (patched) fetch is invoked and catches a stale entry, it'll push each fetch onto the `pendingRevalidates` array which will later be invoked via `Promise.all`. 

### How?
This updates the shape of `pendingRevalidates` to be a map, that way we can reliably dedupe if we see a key that is already pending revalidation. 

Closes NEXT-1744
[slack x-ref](https://vercel.slack.com/archives/C03S8ED1DKM/p1700836529460289)
