### PR TITLE
fix: remove antd from default modularizeImports

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -818,9 +818,6 @@ function assignDefaults(
         '*': 'react-bootstrap/{{member}}',
       },
     },
-    antd: {
-      transform: 'antd/es/{{kebabCase member}}',
-    },
     ahooks: {
       transform: {
         createUpdateEffect:


### PR DESCRIPTION
### Fixing a bug

Fix for https://github.com/ant-design/ant-design/issues/46053
Noticed that next server in app-router will import antd from 'antd/es' by default, and this PR https://github.com/vercel/next.js/pull/57968 was commited. 
And in nextjs@14.0.3 it doesn't work in pages-router again because next server could not import antd from 'antd/es' - it should be cjs module.

So it differs in app-router and pages-router, and we cannot specify where to import components from antd, either from 'antd/es' or from 'antd/lib' will break.

The best way is to remove this optimization for antd.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### How?

Closes NEXT-
Fixes #

-->