### PR TITLE
Fix encoding in encryption of Server Actions

### DIFF
--- a/packages/next/src/server/app-render/action-encryption.ts
+++ b/packages/next/src/server/app-render/action-encryption.ts
@@ -23,6 +23,9 @@ import {
   stringToUint8Array,
 } from './action-encryption-utils'
 
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
 async function decodeActionBoundArg(actionId: string, arg: string) {
   const key = await getActionEncryptionKey()
   if (typeof key === 'undefined') {
@@ -39,7 +42,7 @@ async function decodeActionBoundArg(actionId: string, arg: string) {
     throw new Error('Invalid Server Action payload.')
   }
 
-  const decrypted = arrayBufferToString(
+  const decrypted = textDecoder.decode(
     await decrypt(key, stringToUint8Array(ivValue), stringToUint8Array(payload))
   )
 
@@ -66,7 +69,7 @@ async function encodeActionBoundArg(actionId: string, arg: string) {
   const encrypted = await encrypt(
     key,
     randomBytes,
-    stringToUint8Array(actionId + arg)
+    textEncoder.encode(actionId + arg)
   )
 
   return btoa(ivValue + arrayBufferToString(encrypted))

--- a/test/e2e/app-dir/actions/app/server/page.js
+++ b/test/e2e/app-dir/actions/app/server/page.js
@@ -7,6 +7,10 @@ import { log } from './actions-2'
 
 export default function Page() {
   const two = { value: 2 }
+
+  // https://github.com/vercel/next.js/issues/58463
+  const data = '你好'
+
   return (
     <>
       <Counter
@@ -15,7 +19,11 @@ export default function Page() {
         slowInc={slowInc}
         double={async (x) => {
           'use server'
-          return x * two.value
+          if (data === '你好') {
+            return x * two.value
+          }
+          // Wrong answer
+          return 42
         }}
       />
       <Form />


### PR DESCRIPTION
Utils `stringToUint8Array` and `arrayBufferToString` assume that the values are just arbitrary fixed width data. However that doesn't work when we do unicode concatenation (`actionId + arg`) which requires Text encoder/decoder to be used.

Closes #58463, closes #58579. In general any complex unicode characters will cause the same issue, for example emojis.