### PR TITLE
Docs: Rename React Query to TanStack Query

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/01-fetching-caching-and-revalidating.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/01-fetching-caching-and-revalidating.mdx
@@ -293,7 +293,7 @@ See the [Route Handler](/docs/app/building-your-application/routing/route-handle
 
 ## Fetching Data on the Client with third-party libraries
 
-You can also fetch data on the client using a third-party library such as [SWR](https://swr.vercel.app/) or [React Query](https://tanstack.com/query/latest). These libraries provide their own APIs for memoizing requests, caching, revalidating, and mutating data.
+You can also fetch data on the client using a third-party library such as [SWR](https://swr.vercel.app/) or [TanStack Query](https://tanstack.com/query/latest). These libraries provide their own APIs for memoizing requests, caching, revalidating, and mutating data.
 
 > **Future APIs**:
 >


### PR DESCRIPTION
Update documentation as React Query has been renamed to TanStack Query.