### PR TITLE
remove NODE_ENV override in standalone server

### DIFF
--- a/bench/next-minimal-server/bin/minimal-server.js
+++ b/bench/next-minimal-server/bin/minimal-server.js
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-process.env.NODE_ENV = 'production'
-
 require('../../../test/lib/react-channel-require-hook')
 
 console.time('next-cold-start')

--- a/docs/02-app/02-api-reference/05-next-config-js/output.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/output.mdx
@@ -21,7 +21,7 @@ To leverage the `.nft.json` files emitted to the `.next` output directory, you c
 
 ## Automatically Copying Traced Files
 
-Next.js can automatically create a `standalone` folder that copies only the necessary files for a production deployment including select files in `node_modules`.
+Next.js can automatically create a `standalone` folder that copies only the necessary files for a deployment including select files in `node_modules`.
 
 To leverage this automatic copying you can enable it in your `next.config.js`:
 

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1986,7 +1986,6 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 const dir = path.join(__dirname)
 
-process.env.NODE_ENV = 'production'
 process.chdir(__dirname)
 
 // Make sure commands gracefully respect termination signals (e.g. from Docker)

--- a/scripts/minimal-server.js
+++ b/scripts/minimal-server.js
@@ -1,8 +1,6 @@
 console.time('next-wall-time')
 // Usage: node scripts/minimal-server.js <path-to-app-dir-build> <path-to-page>
-// This script is used to run a minimal Next.js server in production mode.
-
-process.env.NODE_ENV = 'production'
+// This script is used to run a minimal Next.js server
 
 // Change this to 'experimental' to opt into the React experimental channel (needed for server actions, ppr)
 process.env.__NEXT_PRIVATE_PREBUNDLED_REACT = 'next'


### PR DESCRIPTION
### What?
remove NODE_ENV override on standalone server

### Why?
in order to be able to deploy next.js in different environments, using a single docker image.

## Fixes
https://github.com/vercel/next.js/issues/58294
