### PR TITLE
use 303 status code for redirects in fetch actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -577,12 +577,14 @@ To configure the body size limit for Server Actions, see: https://nextjs.org/doc
       const redirectUrl = getURLFromRedirectError(err)
       const statusCode = getRedirectStatusCodeFromError(err)
 
-      // if it's a fetch action, we don't want to mess with the status code
-      // and we'll handle it on the client router
       await addRevalidationHeader(res, {
         staticGenerationStore,
         requestStore,
       })
+
+      // if it's a fetch action, we'll set the status code for logging/debugging purposes
+      // but we won't set a Location header, as the redirect will be handled by the client router
+      res.statusCode = statusCode
 
       if (isFetchAction) {
         return {
@@ -607,7 +609,6 @@ To configure the body size limit for Server Actions, see: https://nextjs.org/doc
       }
 
       res.setHeader('Location', redirectUrl)
-      res.statusCode = statusCode
       return {
         type: 'done',
         result: RenderResult.fromStatic(''),


### PR DESCRIPTION
### What?
A `redirect` that occurs during a fetch action will get a status code of 200, while the redirection logic is handled client-side. 

### Why?
In this scenario, the redirect is handled by the client router, so no `Location` is set on the action response. However for debugging / logging purposes, it'd be useful to still return the same status code used in other cases (see #58885)

### How?
Rather than selectively setting the status to 303 in the non-fetch action case, this always applies it. 

Closes NEXT-1745