### PR TITLE
build(cargo): bump up turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "serde",
  "smallvec",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "serde",
@@ -7678,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7710,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7737,7 +7737,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7751,7 +7751,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7798,7 +7798,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "base16",
  "hex",
@@ -7810,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7824,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7834,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "mimalloc",
 ]
@@ -7842,7 +7842,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7867,7 +7867,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7898,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7939,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7962,7 +7962,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7980,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8010,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8036,7 +8036,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8060,7 +8060,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8097,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8131,7 +8131,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "serde",
  "serde_json",
@@ -8142,7 +8142,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8165,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "serde",
@@ -8233,7 +8233,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8248,7 +8248,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8283,7 +8283,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "serde",
@@ -8299,7 +8299,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8325,7 +8325,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231127.4#df8666fcd6177e926e7f17c63860e62cdc9ded34"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ swc_core = { version = "0.86.81", features = [
 testing = { version = "0.35.11" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231127.4" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231128.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231127.4" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231128.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231127.4" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231128.2" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -195,7 +195,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.22.6",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1074,8 +1074,8 @@ importers:
         specifier: 0.22.6
         version: 0.22.6
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -24648,9 +24648,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231127.4'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -14886,12 +14886,11 @@
       "Handle new URL asset references in next dev should render the /ssr page",
       "Handle new URL asset references in next dev should render the /static page",
       "Handle new URL asset references in next dev should respond on basename api",
-      "Handle new URL asset references in next dev should respond on size api"
-    ],
-    "failed": [
+      "Handle new URL asset references in next dev should respond on size api",
       "Handle new URL asset references in next dev should client-render the /ssg page",
       "Handle new URL asset references in next dev should client-render the /ssr page"
     ],
+    "failed": [],
     "pending": [
       "Handle new URL asset references in next build should client-render the /ssg page",
       "Handle new URL asset references in next build should client-render the /ssr page",


### PR DESCRIPTION
### What?

Bump up turbopack which includes url rewrite related improvements. This makes `test/integration/url` test passes.

Note there are some lacking behavior around edge runtime + url behavior, it is being tracked in PACK-2014.

Closes PACK-2051