### PR TITLE
fix async action queue behavior

### DIFF
--- a/packages/next/src/shared/lib/router/action-queue.ts
+++ b/packages/next/src/shared/lib/router/action-queue.ts
@@ -67,7 +67,6 @@ async function runAction({
   }
 
   actionQueue.pending = action
-  actionQueue.last = action
 
   const payload = action.payload
   const actionResult = actionQueue.action(prevState, payload)
@@ -142,6 +141,9 @@ function dispatchAction(
   // Check if the queue is empty
   if (actionQueue.pending === null) {
     // The queue is empty, so add the action and start it immediately
+    // Mark this action as the last in the queue
+    actionQueue.last = newAction
+
     runAction({
       actionQueue,
       action: newAction,
@@ -151,6 +153,9 @@ function dispatchAction(
     // Navigations take priority over any pending actions.
     // Mark the pending action as discarded (so the state is never applied) and start the navigation action immediately.
     actionQueue.pending.discarded = true
+
+    // Mark this action as the last in the queue
+    actionQueue.last = newAction
 
     // if the pending action was a server action, mark the queue as needing a refresh once events are processed
     if (actionQueue.pending.payload.type === ACTION_SERVER_ACTION) {
@@ -164,7 +169,7 @@ function dispatchAction(
     })
   } else {
     // The queue is not empty, so add the action to the end of the queue
-    // It will be started by finishRunningAction after the previous action finishes
+    // It will be started by runRemainingActions after the previous action finishes
     if (actionQueue.last !== null) {
       actionQueue.last.next = newAction
     }

--- a/test/e2e/app-dir/actions/app/use-transition/action.js
+++ b/test/e2e/app-dir/actions/app/use-transition/action.js
@@ -1,0 +1,9 @@
+'use server'
+
+export async function addToCart() {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve('Add to cart')
+    }, 1000)
+  })
+}

--- a/test/e2e/app-dir/actions/app/use-transition/page.js
+++ b/test/e2e/app-dir/actions/app/use-transition/page.js
@@ -1,0 +1,24 @@
+'use client'
+
+import { useTransition } from 'react'
+import { addToCart } from './action'
+
+export default function Page() {
+  const [isPending, startTransition] = useTransition()
+
+  return (
+    <div className="grid ">
+      <h1>Transition is: {isPending ? 'pending' : 'idle'} </h1>
+      <button
+        id="action-button"
+        onClick={() => {
+          startTransition(async () => {
+            await addToCart()
+          })
+        }}
+      >
+        Trigger action
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
### What?
When the router action queue receives a bunch of async actions in quick succession, some of those requests are dropped, and as a result, anything observing pending transitions will be stuck in a pending state.

### Why?
When adding items to the action queue, the intended behavior is for new actions to be added to the end of the action queue, to be picked up by `runRemainingActions` once the in-flight action is processed. However, new actions are erroneously overwriting pending actions in the queue rather than appending them, as `actionQueue.last` might have a pending action attached to it. 

### How?
This moves the assignment of `actionQueue.last` to always be in `dispatchAction`, rather than the function that processes the action, so that we always have a single spot where `last` is assigned and to prevent it from erroneously omitted/overwritten. 

Fixes #59011
