### PR TITLE
ci: don't try to upload to datadog for docs only changes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,6 +28,37 @@ env:
   NEXT_TEST_JOB: 1
 
 jobs:
+  changes:
+    name: Determine changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 25
+
+      - name: check for docs only change
+        id: docs-change
+        run: |
+          echo "DOCS_ONLY<<EOF" >> $GITHUB_OUTPUT;
+          echo "$(node scripts/run-for-change.js --not --type docs --exec echo 'false')" >> $GITHUB_OUTPUT;
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - name: check for release
+        id: is-release
+        run: |
+          if [[ $(node ./scripts/check-is-release.js 2> /dev/null || :) = v* ]];
+            then
+              echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
+            else
+              echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
+          fi
+
+    outputs:
+      docs-only: ${{ steps.docs-change.outputs.DOCS_ONLY != 'false' }}
+      is-release: ${{ steps.is-release.outputs.IS_RELEASE == 'true' }}
+
   build-native:
     name: build-native
     uses: ./.github/workflows/build_reusable.yml
@@ -66,21 +97,21 @@ jobs:
 
   check-types-precompiled:
     name: types and precompiled
-    needs: ['build-native', 'build-next']
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: pnpm types-and-precompiled
-      skipForDocsOnly: 'yes'
     secrets: inherit
 
   test-cargo-unit:
     name: test cargo unit
-    needs: ['build-next']
+    needs: ['changes', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipForDocsOnly: 'yes'
       needsRust: 'yes'
       skipInstallBuild: 'yes'
       skipNativeBuild: 'yes'
@@ -90,11 +121,11 @@ jobs:
 
   test-cargo-integration:
     name: test cargo integration
-    needs: ['build-next']
+    needs: ['changes', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipForDocsOnly: 'yes'
       needsNextest: 'yes'
       needsRust: 'yes'
       skipNativeBuild: 'yes'
@@ -102,23 +133,22 @@ jobs:
 
   test-cargo-bench:
     name: test cargo benchmarks
-    needs: ['build-next']
+    needs: ['changes', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' || needs.changes.outputs.is-release == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipForDocsOnly: 'yes'
-      skipForRelease: 'yes'
       needsRust: 'yes'
       skipNativeBuild: 'yes'
       afterBuild: xvfb-run turbo run test-cargo-bench
 
   rust-check:
     name: rust check
-    needs: ['build-next']
+    needs: ['changes', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipForDocsOnly: 'yes'
       needsRust: 'yes'
       skipInstallBuild: 'yes'
       skipNativeBuild: 'yes'
@@ -127,20 +157,23 @@ jobs:
 
   test-turbopack-dev:
     name: test turbopack dev
-    needs: ['build-native', 'build-next']
+    needs: ['changes', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
     strategy:
       fail-fast: false
       matrix:
         group: [1, 2, 3, 4, 5]
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipForDocsOnly: 'yes'
       afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-tests-manifest.json" TURBOPACK=1 NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=dev node run-tests.js --test-pattern '^(test\/(development|e2e))/.*\.test\.(js|jsx|ts|tsx)$' --timings -g ${{ matrix.group }}/5 -c ${TEST_CONCURRENCY}
     secrets: inherit
 
   test-turbopack-integration:
     name: test turbopack integration
-    needs: ['build-native', 'build-next']
+    needs: ['changes', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -148,21 +181,24 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.17.0
-      skipForDocsOnly: 'yes'
       afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-tests-manifest.json" TURBOPACK=1 node run-tests.js --timings -g ${{ matrix.group }}/5 -c ${TEST_CONCURRENCY} --type integration
     secrets: inherit
 
   test-next-swc-wasm:
     name: test next-swc wasm
-    needs: ['build-native', 'build-next']
+    needs: ['changes', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipForDocsOnly: 'yes'
       afterBuild: rustup target add wasm32-unknown-unknown && curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh && node ./scripts/normalize-version-bump.js && turbo run build-wasm -- --target nodejs --features tracing/release_max_level_info && git checkout . && mv packages/next-swc/crates/wasm/pkg packages/next-swc/crates/wasm/pkg-nodejs && node ./scripts/setup-wasm.mjs && NEXT_TEST_MODE=start TEST_WASM=true node run-tests.js test/production/pages-dir/production/test/index.test.ts test/e2e/streaming-ssr/index.test.ts
     secrets: inherit
 
   test-unit:
     name: test unit
+    needs: ['changes']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -171,40 +207,43 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ matrix.node }}
-      skipForDocsOnly: 'yes'
       afterBuild: node run-tests.js -c ${TEST_CONCURRENCY} --type unit
 
     secrets: inherit
 
   test-dev:
     name: test dev
-    needs: ['build-native', 'build-next']
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
     strategy:
       fail-fast: false
       matrix:
         group: [1, 2, 3]
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipForDocsOnly: 'yes'
       afterBuild: NEXT_TEST_MODE=dev node run-tests.js --timings -g ${{ matrix.group }}/3 -c ${TEST_CONCURRENCY} --type development
     secrets: inherit
 
   test-prod:
     name: test prod
-    needs: ['build-native', 'build-next']
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
     strategy:
       fail-fast: false
       matrix:
         group: [1, 2, 3, 4, 5]
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipForDocsOnly: 'yes'
       afterBuild: NEXT_TEST_MODE=start node run-tests.js --timings -g ${{ matrix.group }}/5 -c ${TEST_CONCURRENCY} --type production
     secrets: inherit
 
   test-integration:
     name: test integration
-    needs: ['build-native', 'build-next']
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -212,17 +251,16 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.17.0
-      skipForDocsOnly: 'yes'
       afterBuild: node run-tests.js --timings -g ${{ matrix.group }}/12 -c ${TEST_CONCURRENCY} --type integration
     secrets: inherit
 
   test-firefox-safari:
     name: test firefox and safari
-    needs: ['build-native', 'build-next']
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipForDocsOnly: 'yes'
       afterBuild: pnpm playwright install && BROWSER_NAME=firefox node run-tests.js test/production/pages-dir/production/test/index.test.ts && BROWSER_NAME=safari NEXT_TEST_MODE=start node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/e2e/basepath.test.ts && BROWSER_NAME=safari DEVICE_NAME='iPhone XR' node run-tests.js -c 1 test/production/prerender-prefetch/index.test.ts
     secrets: inherit
 
@@ -230,7 +268,9 @@ jobs:
   # Manifest generated via: https://gist.github.com/wyattjoh/2ceaebd82a5bcff4819600fd60126431
   test-ppr-integration:
     name: test ppr integration
-    needs: ['build-native', 'build-next']
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -238,39 +278,41 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.17.0
-      skipForDocsOnly: 'yes'
       afterBuild: __NEXT_EXPERIMENTAL_PPR=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" node run-tests.js --timings -g ${{ matrix.group }}/3 -c ${TEST_CONCURRENCY} --type integration
     secrets: inherit
 
   test-ppr-dev:
     name: test ppr dev
-    needs: ['build-native', 'build-next']
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
     strategy:
       fail-fast: false
       matrix:
         group: [1, 2, 3]
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipForDocsOnly: 'yes'
       afterBuild: __NEXT_EXPERIMENTAL_PPR=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" NEXT_TEST_MODE=dev node run-tests.js --timings -g ${{ matrix.group }}/3 -c ${TEST_CONCURRENCY} --type development
     secrets: inherit
 
   test-ppr-prod:
     name: test ppr prod
-    needs: ['build-native', 'build-next']
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
     strategy:
       fail-fast: false
       matrix:
         group: [1, 2, 3]
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipForDocsOnly: 'yes'
       afterBuild: __NEXT_EXPERIMENTAL_PPR=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" NEXT_TEST_MODE=start node run-tests.js --timings -g ${{ matrix.group }}/3 -c ${TEST_CONCURRENCY} --type production
     secrets: inherit
 
   report-test-results:
     needs:
       [
+        'changes',
         'test-unit',
         'test-dev',
         'test-prod',
@@ -281,7 +323,8 @@ jobs:
         'test-turbopack-dev',
         'test-turbopack-integration',
       ]
-    if: always()
+    if: ${{ always() && needs.changes.outputs.docs-only == 'false' && !github.event.pull_request.head.repo.fork }}
+
     runs-on: ubuntu-latest
     name: report test results to datadog
     steps:
@@ -333,4 +376,4 @@ jobs:
     name: thank you, next
     steps:
       - run: exit 1
-        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')) }}
+        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -25,14 +25,6 @@ on:
         required: false
         description: 'whether to upload analyzer artifacts'
         type: string
-      skipForDocsOnly:
-        required: false
-        description: 'skip for docs only changes'
-        type: string
-      skipForRelease:
-        required: false
-        description: 'skip for release'
-        type: string
       nodeVersion:
         required: false
         description: 'version of Node.js to use'
@@ -130,28 +122,15 @@ jobs:
       - run: cargo clean
         if: ${{ inputs.skipNativeBuild != 'yes' || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
 
-      - run: echo "DOCS_CHANGE<<EOF" >> $GITHUB_OUTPUT; echo "$(node scripts/run-for-change.js --not --type docs --exec echo 'nope')" >> $GITHUB_OUTPUT; echo 'EOF' >> $GITHUB_OUTPUT
-        name: check docs only change
-        id: docs-change
-
-      - id: is-release
-        run: |
-          if [[ $(node ./scripts/check-is-release.js 2> /dev/null || :) = v* ]];
-            then
-              echo "IS_RELEASE=yes" >> $GITHUB_OUTPUT
-            else
-              echo "IS_RELEASE=nope" >> $GITHUB_OUTPUT
-          fi
-
       # normalize versions before build-native for better cache hits
       - run: node scripts/normalize-version-bump.js
         name: normalize versions
 
       - run: turbo run build-native-release -vvv --remote-cache-timeout 90 --summarize -- --target x86_64-unknown-linux-gnu
-        if: ${{ inputs.skipNativeBuild != 'yes' && steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
+        if: ${{ inputs.skipNativeBuild != 'yes' }}
 
       - name: Upload next-swc artifact
-        if: ${{ inputs.uploadSwcArtifact == 'yes' && steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
+        if: ${{ inputs.uploadSwcArtifact == 'yes' }}
         uses: actions/upload-artifact@v3
         with:
           name: next-swc-binary
@@ -176,7 +155,6 @@ jobs:
       - run: turbo run get-test-timings -- --build ${{ github.sha }}
 
       - run: /bin/bash -c "${{ inputs.afterBuild }}"
-        if: ${{(inputs.skipForDocsOnly != 'yes' || steps.docs-change.outputs.DOCS_CHANGE == 'nope') && (inputs.skipForRelease != 'yes' || steps.is-release.outputs.IS_RELEASE == 'nope')}}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/scripts/run-for-change.js
+++ b/scripts/run-for-change.js
@@ -60,9 +60,8 @@ async function main() {
   const remoteUrl =
     eventData?.head?.repo?.full_name ||
     process.env.GITHUB_REPOSITORY ||
-    (await exec('git remote get-url origin').stdout)
+    (await exec('git remote get-url origin')).stdout
 
-  let changedFilesOutput = ''
   const isCanary =
     branchName.trim() === 'canary' && remoteUrl.includes('vercel/next.js')
 
@@ -85,7 +84,7 @@ async function main() {
     }
   )
   console.error({ branchName, remoteUrl, isCanary, changesResult })
-  changedFilesOutput = changesResult.stdout
+  const changedFilesOutput = changesResult.stdout
 
   const typeIndex = process.argv.indexOf('--type')
   const type = typeIndex > -1 && process.argv[typeIndex + 1]


### PR DESCRIPTION
### What?

The `test-reports` artifact will be empty when we only have docs changes.

This PR also moves checking for docs only changes and releases up to the `build_and_test` workflow instead of checking in each nested workflow allowing us to skip earlier.

This also skips uploading to datadog on PRs from forks.

Closes PACK-2055