### PR TITLE
fix(test): don't use latest sharp

### DIFF
--- a/test/integration/image-optimizer/test/sharp.test.ts
+++ b/test/integration/image-optimizer/test/sharp.test.ts
@@ -14,7 +14,7 @@ describe('with latest sharp', () => {
         packageManager: 'yarn@1.22.19',
       })
     )
-    await execa('yarn', ['add', 'sharp'], {
+    await execa('yarn', ['add', 'sharp@^0.32.0'], {
       cwd: appDir,
       stdio: 'inherit',
     })


### PR DESCRIPTION
### Why?
We use `yarn@1` to install test dependencies and `sharp@0.33.0` doesn't allow installing the native binaries with `yarn@1` for some reason.

See: https://github.com/lovell/sharp/issues/3871


Closes PACK-2058