### PR TITLE
Ensure stale build fetch data is not unexpectedly used

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -187,7 +187,7 @@ export default class FileSystemCache implements CacheHandler {
         const fileData = await this.fs.readFile(filePath, 'utf8')
         const { mtime } = await this.fs.stat(filePath)
 
-        if (kind === 'fetch') {
+        if (kind === 'fetch' && this.flushToDisk) {
           const lastModified = mtime.getTime()
           const parsedData: CachedFetchValue = JSON.parse(fileData)
           data = {

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -64,11 +64,12 @@ export class NextInstance {
   protected _parsedUrl: URL
   protected packageJson?: PackageJson = {}
   protected basePath?: string
-  protected env?: Record<string, string>
+  public env: Record<string, string>
   public forcedPort?: string
   public dirSuffix: string = ''
 
   constructor(opts: NextInstanceOpts) {
+    this.env = {}
     Object.assign(this, opts)
 
     if (!(global as any).isNextDeploy) {

--- a/test/production/app-dir/app-fetch-build-cache/app-fetch-build-cache.test.ts
+++ b/test/production/app-dir/app-fetch-build-cache/app-fetch-build-cache.test.ts
@@ -1,0 +1,33 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'app fetch build cache',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    let initialData
+
+    it('should have done initial build', async () => {
+      const $ = await next.render$('/')
+      expect($('#page').text()).toBe('index page')
+
+      initialData = $('#data').text()
+      expect(initialData).toBeTruthy()
+    })
+
+    it('should not use stale data if present', async () => {
+      await next.stop()
+
+      next.env['NOW_BUILDER'] = '1'
+      await next.start()
+
+      const $ = await next.render$('/')
+      expect($('#page').text()).toBe('index page')
+
+      const newData = $('#data').text()
+      expect(newData).toBeTruthy()
+      expect(newData).not.toBe(initialData)
+    })
+  }
+)

--- a/test/production/app-dir/app-fetch-build-cache/app/layout.tsx
+++ b/test/production/app-dir/app-fetch-build-cache/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/app-fetch-build-cache/app/page.tsx
+++ b/test/production/app-dir/app-fetch-build-cache/app/page.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export const revalidate = 30
+
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random'
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="page">index page</p>
+      <p id="data">{data}</p>
+    </>
+  )
+}

--- a/test/production/app-dir/app-fetch-build-cache/next.config.js
+++ b/test/production/app-dir/app-fetch-build-cache/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
If a build time fetch cache is present from a previous build we don't want to unexpectedly use it when flush to disk is set to false in a successive build as it can leverage stale data unexpectedly. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1701266754905909)

Closes NEXT-1750