### PR TITLE
Update checkout step

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -89,6 +89,8 @@ jobs:
       - run: corepack enable
       - run: pwd
 
+      - run: rm -rf .git
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 25


### PR DESCRIPTION
When jobs are cancelled we can end up with a bad `.git` tree so this updates to have a fresh checkout step to avoid this

x-ref: https://github.com/vercel/next.js/actions/runs/7036193103/job/19148358339?pr=59076