### PR TITLE
[Docs] should run pnpm build before pnpm dev

### DIFF
--- a/contributing/core/developing-using-local-app.md
+++ b/contributing/core/developing-using-local-app.md
@@ -16,9 +16,11 @@ If you already have an app and it has dependencies, you can follow these steps:
 
 ## Set as a local dependency in package.json
 
-1. Run `pnpm dev` in the background in the Next.js monorepo.
+1. Run `pnpm build` in the Next.js monorepo.
 
-2. In your app's root directory, run:
+2. Run `pnpm dev` in the background in the Next.js monorepo.
+
+3. In your app's root directory, run:
 
    ```sh
    pnpm add ./path/to/next.js/{packages/next,node_modules/{react,react-dom}}
@@ -28,7 +30,7 @@ If you already have an app and it has dependencies, you can follow these steps:
 
    Note that Next.js will be copied from the locally compiled version as opposed to being downloaded from the NPM registry.
 
-3. Run your application as you normally would.
+4. Run your application as you normally would.
 
 ### Troubleshooting
 


### PR DESCRIPTION
Setting NextJS as a local dependency in package.json and running the app throws cannot find polyfill-nomodule.
`Error: Cannot find module './polyfills/polyfill-nomodule'`

You'll need an initial `pnpm build` before running pnpm dev as the module/no-module packages are not built during `pnpm dev`.
This fixes the docs for that.