### PR TITLE
Fix next internal is missing in flight manifest

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -56,6 +56,8 @@ const PAGE_SEGMENT = 'page$'
 const PARALLEL_CHILDREN_SEGMENT = 'children$'
 
 const defaultNotFoundPath = 'next/dist/client/components/not-found-error'
+const defaultGlobalErrorPath = 'next/dist/client/components/error-boundary'
+const defaultLayoutPath = 'next/dist/client/components/default-layout'
 
 type DirResolver = (pathToResolve: string) => string
 type PathResolver = (
@@ -176,7 +178,7 @@ async function createTreeCodeFromPath(
   treeCode: string
   pages: string
   rootLayout: string | undefined
-  globalError: string | undefined
+  globalError: string
 }> {
   const splittedPath = pagePath.split(/[\\/]/, 1)
   const isNotFoundRoute = page === '/_not-found'
@@ -188,7 +190,7 @@ async function createTreeCodeFromPath(
   const pages: string[] = []
 
   let rootLayout: string | undefined
-  let globalError: string | undefined
+  let globalError: string = defaultGlobalErrorPath
 
   async function resolveAdjacentParallelSegments(
     segmentPath: string
@@ -345,14 +347,17 @@ async function createTreeCodeFromPath(
         rootLayout = layoutPath
 
         if (isDefaultNotFound && !layoutPath) {
-          rootLayout = 'next/dist/client/components/default-layout'
+          rootLayout = defaultLayoutPath
           definedFilePaths.push(['layout', rootLayout])
         }
 
         if (layoutPath) {
-          globalError = await resolver(
+          const resolvedGlobalErrorPath = await resolver(
             `${path.dirname(layoutPath)}/${GLOBAL_ERROR_FILE_TYPE}`
           )
+          if (resolvedGlobalErrorPath) {
+            globalError = resolvedGlobalErrorPath
+          }
         }
       }
 
@@ -698,9 +703,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
     {
       VAR_DEFINITION_PAGE: page,
       VAR_DEFINITION_PATHNAME: pathname,
-      VAR_MODULE_GLOBAL_ERROR: treeCodeResult.globalError
-        ? treeCodeResult.globalError
-        : 'next/dist/client/components/error-boundary',
+      VAR_MODULE_GLOBAL_ERROR: treeCodeResult.globalError,
       VAR_ORIGINAL_PATHNAME: page,
     },
     {

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -393,14 +393,14 @@ export class FlightClientEntryPlugin {
       // We need to create extra action entries that are created from the
       // client layer.
       // Start from each entry's created SSR dependency from our previous step.
-      for (const [name, ssrEntryDepdendencies] of Object.entries(
+      for (const [name, ssrEntryDependencies] of Object.entries(
         createdSSRDependenciesForEntry
       )) {
         // Collect from all entries, e.g. layout.js, page.js, loading.js, ...
-        // add agregate them.
+        // add aggregate them.
         const actionEntryImports = this.collectClientActionsFromDependencies({
           compilation,
-          dependencies: ssrEntryDepdendencies,
+          dependencies: ssrEntryDependencies,
         })
 
         if (actionEntryImports.size > 0) {

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -16,7 +16,10 @@ import { staticGenerationBailout } from '../../client/components/static-generati
 import StaticGenerationSearchParamsBailoutProvider from '../../client/components/static-generation-searchparams-bailout-provider'
 import { createSearchParamsBailoutProxy } from '../../client/components/searchparams-bailout-proxy'
 import * as serverHooks from '../../client/components/hooks-server-context'
+import { NotFoundBoundary } from '../../client/components/not-found-boundary'
 import { patchFetch as _patchFetch } from '../lib/patch-fetch'
+// not being used but needs to be included in the client manifest for /_not-found
+import '../../client/components/error-boundary'
 
 import {
   preloadStyle,
@@ -25,9 +28,6 @@ import {
 } from '../../server/app-render/rsc/preloads'
 
 import { taintObjectReference } from '../../server/app-render/rsc/taint'
-
-const { NotFoundBoundary } =
-  require('next/dist/client/components/not-found-boundary') as typeof import('../../client/components/not-found-boundary')
 
 // patchFetch makes use of APIs such as `React.unstable_postpone` which are only available
 // in the experimental channel of React, so export it from here so that it comes from the bundled runtime

--- a/test/e2e/app-dir/global-error/catch-all/app/[lang]/[...slug]/page.js
+++ b/test/e2e/app-dir/global-error/catch-all/app/[lang]/[...slug]/page.js
@@ -1,0 +1,6 @@
+export default async function Page({ params }) {
+  if (params.slug[0] === 'error') {
+    throw new Error('trigger error')
+  }
+  return 'catch-all page'
+}

--- a/test/e2e/app-dir/global-error/catch-all/app/[lang]/global-error.js
+++ b/test/e2e/app-dir/global-error/catch-all/app/[lang]/global-error.js
@@ -1,0 +1,11 @@
+'use client'
+
+export default function GlobalError() {
+  return (
+    <html>
+      <body>
+        <div id="global-error">global-error</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/global-error/catch-all/app/[lang]/layout.js
+++ b/test/e2e/app-dir/global-error/catch-all/app/[lang]/layout.js
@@ -1,0 +1,7 @@
+export default async function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/global-error/catch-all/app/[lang]/layout.js
+++ b/test/e2e/app-dir/global-error/catch-all/app/[lang]/layout.js
@@ -5,3 +5,5 @@ export default async function RootLayout({ children }) {
     </html>
   )
 }
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/global-error/catch-all/index.test.ts
+++ b/test/e2e/app-dir/global-error/catch-all/index.test.ts
@@ -1,0 +1,29 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'app dir - global error - with catch-all route',
+  {
+    files: __dirname,
+    skipDeployment: true,
+  },
+  ({ next, isNextStart }) => {
+    it('should render catch-all route correctly', async () => {
+      expect(await next.render('/en/foo')).toContain('catch-all page')
+    })
+
+    it('should render 404 page correctly', async () => {
+      expect(await next.render('/en')).toContain(
+        'This page could not be found.'
+      )
+    })
+
+    if (isNextStart) {
+      it('should render global error correctly', async () => {
+        const browser = await next.browser('/en/error')
+
+        const text = await browser.elementByCss('#global-error').text()
+        expect(text).toBe('global-error')
+      })
+    }
+  }
+)

--- a/test/e2e/app-dir/global-error/next.config.js
+++ b/test/e2e/app-dir/global-error/next.config.js
@@ -1,1 +1,0 @@
-module.exports = {}


### PR DESCRIPTION
`/_not-found` with default `global-error` route requires `next/dist/client/components/error-boundary` as part of the flight manifest entry but in the test case showed in this PR, the default global-error file is part of the app-internals chunk, but it's not being recogonized as an entry and being injected like other client components into flight manifest.

Force including it into the client entry so it will also show up in manifest

Fixes #56259 
Fixes #59053 

Closes NEXT-1754
Closes NEXT-1749