### PR TITLE
fix interception routes with rewrites

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -4,6 +4,7 @@ import type {
   ReducerState,
   RestoreAction,
 } from '../router-reducer-types'
+import { extractPathFromFlightRouterState } from '../compute-changed-path'
 
 export function restoreReducer(
   state: ReadonlyReducerState,
@@ -27,6 +28,6 @@ export function restoreReducer(
     prefetchCache: state.prefetchCache,
     // Restore provided tree
     tree: tree,
-    nextUrl: url.pathname,
+    nextUrl: extractPathFromFlightRouterState(tree) ?? url.pathname,
   }
 }

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/@modal/(.)photos/[id]/page.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/@modal/(.)photos/[id]/page.tsx
@@ -1,0 +1,7 @@
+export default function PhotoModal({
+  params: { id: photoId },
+}: {
+  params: { id: string }
+}) {
+  return <div>Intercepted Photo ID: {photoId}</div>
+}

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/layout.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/layout.tsx
@@ -6,6 +6,10 @@ export default function Layout({ children, modal, params }) {
       <div>
         <Link href="/feed">feed</Link>
       </div>
+      <div>
+        Photos: <Link href="/photos/1">Photo 1</Link>{' '}
+        <Link href="/photos/2">Photo 2</Link>
+      </div>
       <div>{params.lang}</div>
       <div id="children">{children}</div>
       <div id="modal">{modal}</div>

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/photos/[id]/page.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/photos/[id]/page.tsx
@@ -1,0 +1,7 @@
+export default function PhotoPage({
+  params: { id },
+}: {
+  params: { id: string }
+}) {
+  return <div>Page Photo ID: {id}</div>
+}

--- a/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
+++ b/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
@@ -31,5 +31,22 @@ createNextDescribe(
 
       await check(() => browser.waitForElementByCss('#modal').text(), '')
     })
+
+    it('should continue to work after using browser back button and following another intercepting route', async () => {
+      const browser = await next.browser('/')
+      await check(() => browser.elementById('children').text(), 'root')
+
+      await browser.elementByCss('[href="/photos/1"]').click()
+      await check(
+        () => browser.elementById('modal').text(),
+        'Intercepted Photo ID: 1'
+      )
+      await browser.back()
+      await browser.elementByCss('[href="/photos/2"]').click()
+      await check(
+        () => browser.elementById('modal').text(),
+        'Intercepted Photo ID: 2'
+      )
+    })
   }
 )


### PR DESCRIPTION
### What?
When using interception routes & rewrites, on first interception the router will properly handle the request. But when using the back button and attempting another interception, it won't work

### Why?
Intercepting routes rely on the accuracy of `nextUrl` -- but when `ACTION_RESTORE` is dispatched (in the `popstate` event), `nextUrl` is restored from `url.pathname` rather than the flight router state. 

### How?
This uses the `extractPathFromFlightRouterState` util which will properly handle setting `nextUrl`. This util is also used when creating the initial router state. 

Closes NEXT-1747
Fixes #56072