### PR TITLE
Support generating multi-meta tags for metadata api other prop

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -930,6 +930,20 @@ export const metadata = {
 <meta name="custom" content="meta" />
 ```
 
+If you want to generate multiple same key meta tags you can use array value.
+
+```jsx filename="layout.js | page.js"
+export const metadata = {
+  other: {
+    custom: ['meta1', 'meta2'],
+  },
+}
+```
+
+```html filename="<head> output" hideLineNumbers
+<meta name="custom" content="meta1" /> <meta name="custom" content="meta2" />
+```
+
 ## Unsupported Metadata
 
 The following metadata types do not currently have built-in support. However, they can still be rendered in the layout or page itself.

--- a/packages/next/src/lib/metadata/generate/alternate.tsx
+++ b/packages/next/src/lib/metadata/generate/alternate.tsx
@@ -1,7 +1,7 @@
 import type { ResolvedMetadata } from '../types/metadata-interface'
+import type { AlternateLinkDescriptor } from '../types/alternative-urls-types'
 
 import React from 'react'
-import type { AlternateLinkDescriptor } from '../types/alternative-urls-types'
 import { MetaFilter } from './meta'
 
 function AlternateLink({

--- a/packages/next/src/lib/metadata/generate/basic.tsx
+++ b/packages/next/src/lib/metadata/generate/basic.tsx
@@ -87,12 +87,15 @@ export function BasicMeta({ metadata }: { metadata: ResolvedMetadata }) {
     Meta({ name: 'category', content: metadata.category }),
     Meta({ name: 'classification', content: metadata.classification }),
     ...(metadata.other
-      ? Object.entries(metadata.other).map(([name, content]) =>
-          Meta({
-            name,
-            content: Array.isArray(content) ? content.join(',') : content,
-          })
-        )
+      ? Object.entries(metadata.other).map(([name, content]) => {
+          if (Array.isArray(content)) {
+            return content.map((contentItem) =>
+              Meta({ name, content: contentItem })
+            )
+          } else {
+            return Meta({ name, content })
+          }
+        })
       : []),
   ])
 }

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -359,6 +359,7 @@ createNextDescribe(
           'yandex-verification': 'yandex',
           me: ['my-email', 'my-link'],
         })
+        expect($('meta[name="me"]').length).toBe(2)
       })
 
       it('should support appLinks tags', async () => {


### PR DESCRIPTION
Give flexibility to generate multiple same-key metadata k-v

```js
export const metadata = {
  other: {
    'my-own-meta-name': ['1','2']
  }
}
```

#### Before
```html
<meta key="my-own-meta-name" value="1,2">
```

#### Now
```html
<meta key="my-own-meta-name" value="1">
<meta key="my-own-meta-name" value="2">
```

When you want to have the array joined like value, you can do it when you pass the value down to `other` property. And if you want multiple one, you could specify array to generate them

Closes #57051 
Closes NEXT-1746