### PR TITLE
Add NEXT_MANUAL_SIG_HANDLE handling to start-server.ts

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -280,9 +280,11 @@ export async function startServer(
           console.error(err)
         }
         process.on('exit', (code) => cleanup(code))
-        // callback value is signal string, exit with 0
-        process.on('SIGINT', () => cleanup(0))
-        process.on('SIGTERM', () => cleanup(0))
+        if (!process.env.NEXT_MANUAL_SIG_HANDLE) {
+          // callback value is signal string, exit with 0
+          process.on('SIGINT', () => cleanup(0))
+          process.on('SIGTERM', () => cleanup(0))
+        }
         process.on('rejectionHandled', () => {
           // It is ok to await a Promise late in Next.js as it allows for better
           // prefetching patterns to avoid waterfalls. We ignore loggining these.


### PR DESCRIPTION
If a manual signal handler is registered, SIGINT and SIGTERM should not be handled by Next.js. This was already the case in the standalone server.js but was missing here, rendering the env flag useless.

With this fix, the example given in https://nextjs.org/docs/pages/building-your-application/deploying#manual-graceful-shutdowns is working (again).

Fixes #56810.