### PR TITLE
ci: don't retry or notify on failures from forks

### DIFF
--- a/.github/workflows/retry_test.yml
+++ b/.github/workflows/retry_test.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   retry-on-failure:
     name: retry failed jobs
-    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt < 3 }}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt < 3 && github.repository == 'vercel/next.js' }}
     runs-on: ubuntu-latest
     steps:
       - name: send retry request to GitHub API
@@ -31,7 +31,7 @@ jobs:
 
   report-failure:
     name: report failure to slack
-    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt >= 3 }}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt >= 3 && github.repository == 'vercel/next.js' }}
     runs-on: ubuntu-latest
     steps:
       - name: send webhook


### PR DESCRIPTION
### Why?

For some reason the retry action can be triggered if there's a PR from the canary branch of a fork.
https://github.com/vercel/next.js/actions/runs/7040561852/attempts/3



Closes PACK-2062