### PR TITLE
Fix dynamic usage errors logging unexpectedly

### DIFF
--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -34,10 +34,6 @@ import { getParams } from './helpers/get-params'
 import { createIncrementalCache } from './helpers/create-incremental-cache'
 import { isPostpone } from '../server/lib/router-utils/is-postpone'
 import { isMissingPostponeDataError } from '../server/app-render/is-missing-postpone-error'
-import { isNotFoundError } from '../client/components/not-found'
-import { NEXT_DYNAMIC_NO_SSR_CODE } from '../shared/lib/lazy-dynamic/no-ssr-error'
-import { DYNAMIC_ERROR_CODE } from '../client/components/hooks-server-context'
-import { isRedirectError } from '../client/components/redirect'
 import { isDynamicUsageError } from './helpers/is-dynamic-usage-error'
 
 const envConfig = require('../shared/lib/runtime-config.external')

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -38,6 +38,7 @@ import { isNotFoundError } from '../client/components/not-found'
 import { NEXT_DYNAMIC_NO_SSR_CODE } from '../shared/lib/lazy-dynamic/no-ssr-error'
 import { DYNAMIC_ERROR_CODE } from '../client/components/hooks-server-context'
 import { isRedirectError } from '../client/components/redirect'
+import { isDynamicUsageError } from './helpers/is-dynamic-usage-error'
 
 const envConfig = require('../shared/lib/runtime-config.external')
 
@@ -388,15 +389,7 @@ process.on('unhandledRejection', (err: unknown) => {
   }
 
   // we don't want to log these errors
-  if (
-    err &&
-    typeof err === 'object' &&
-    'digest' in err &&
-    (err.digest === DYNAMIC_ERROR_CODE ||
-      isNotFoundError(err) ||
-      err.digest === NEXT_DYNAMIC_NO_SSR_CODE ||
-      isRedirectError(err))
-  ) {
+  if (isDynamicUsageError(err)) {
     return
   }
 

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -1,11 +1,8 @@
-import { DYNAMIC_ERROR_CODE } from '../../client/components/hooks-server-context'
 import stringHash from 'next/dist/compiled/string-hash'
 import { formatServerError } from '../../lib/format-server-error'
-import { isNotFoundError } from '../../client/components/not-found'
-import { isRedirectError } from '../../client/components/redirect'
-import { NEXT_DYNAMIC_NO_SSR_CODE } from '../../shared/lib/lazy-dynamic/no-ssr-error'
 import { SpanStatusCode, getTracer } from '../lib/trace/tracer'
 import { isAbortError } from '../pipe-readable'
+import { isDynamicUsageError } from '../../export/helpers/is-dynamic-usage-error'
 
 export type ErrorHandler = (err: any) => string | undefined
 
@@ -37,13 +34,7 @@ export function createErrorHandler({
   return (err) => {
     if (allCapturedErrors) allCapturedErrors.push(err)
 
-    if (
-      err &&
-      (err.digest === DYNAMIC_ERROR_CODE ||
-        isNotFoundError(err) ||
-        err.digest === NEXT_DYNAMIC_NO_SSR_CODE ||
-        isRedirectError(err))
-    ) {
+    if (isDynamicUsageError(err)) {
       return err.digest
     }
 

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2375,6 +2375,7 @@ export async function next_compile(task, opts) {
       'nextbuild',
       'nextbuildjest',
       'nextbuildstatic',
+      'nextbuildstatic_esm',
       'nextbuild_esm',
       'pages',
       'pages_esm',
@@ -2522,6 +2523,14 @@ export async function nextbuildstatic(task, opts) {
     .target('dist/export')
 }
 
+// export is a reserved keyword for functions
+export async function nextbuildstatic_esm(task, opts) {
+  await task
+    .source('src/export/**/!(*.test).+(js|ts|tsx)')
+    .swc('server', { dev: opts.dev, esm: true })
+    .target('dist/esm/export')
+}
+
 export async function pages_app(task, opts) {
   await task
     .source('src/pages/_app.tsx')
@@ -2641,6 +2650,7 @@ export default async function (task) {
     opts
   )
   await task.watch('src/export', 'nextbuildstatic', opts)
+  await task.watch('src/export', 'nextbuildstatic_esm', opts)
   await task.watch('src/client', 'client', opts)
   await task.watch('src/client', 'client_esm', opts)
   await task.watch('src/lib', 'lib', opts)


### PR DESCRIPTION
This ensures we don't spam build logs with dynamic usage errors or similar unexpectedly as they can be caught by this worker process listener but shouldn't be logged. 

Closes NEXT-1763