### PR TITLE
fix typedRoutes when used with webpackBuildWorker

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -806,6 +806,7 @@ export const defaultConfig: NextConfig = {
       process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
         ? true
         : false,
+    webpackBuildWorker: false,
   },
 }
 

--- a/test/production/app-dir/typed-routes-with-webpack-worker/bad-routes/app/api/hello/route.ts
+++ b/test/production/app-dir/typed-routes-with-webpack-worker/bad-routes/app/api/hello/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const runtime = 'edge'
+
+export async function GET(request: NextRequest) {
+  return NextResponse.json({ hello: 'world' })
+}

--- a/test/production/app-dir/typed-routes-with-webpack-worker/bad-routes/app/layout.tsx
+++ b/test/production/app-dir/typed-routes-with-webpack-worker/bad-routes/app/layout.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export const dynamic = 'force-dynamic'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/typed-routes-with-webpack-worker/bad-routes/app/page.tsx
+++ b/test/production/app-dir/typed-routes-with-webpack-worker/bad-routes/app/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <Link href="/asdfasdfasdf">Hello, world!</Link>
+    </main>
+  )
+}

--- a/test/production/app-dir/typed-routes-with-webpack-worker/bad-routes/next.config.js
+++ b/test/production/app-dir/typed-routes-with-webpack-worker/bad-routes/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  experimental: {
+    typedRoutes: true,
+    webpackBuildWorker: true,
+  },
+}

--- a/test/production/app-dir/typed-routes-with-webpack-worker/good-routes/app/api/hello/route.ts
+++ b/test/production/app-dir/typed-routes-with-webpack-worker/good-routes/app/api/hello/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const runtime = 'edge'
+
+export async function GET(request: NextRequest) {
+  return NextResponse.json({ hello: 'world' })
+}

--- a/test/production/app-dir/typed-routes-with-webpack-worker/good-routes/app/layout.tsx
+++ b/test/production/app-dir/typed-routes-with-webpack-worker/good-routes/app/layout.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export const dynamic = 'force-dynamic'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/typed-routes-with-webpack-worker/good-routes/app/page.tsx
+++ b/test/production/app-dir/typed-routes-with-webpack-worker/good-routes/app/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <Link href="/">Hello, world!</Link>
+    </main>
+  )
+}

--- a/test/production/app-dir/typed-routes-with-webpack-worker/good-routes/next.config.js
+++ b/test/production/app-dir/typed-routes-with-webpack-worker/good-routes/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  experimental: {
+    typedRoutes: true,
+    webpackBuildWorker: true,
+  },
+}

--- a/test/production/app-dir/typed-routes-with-webpack-worker/typed-routes-with-webpack-worker.test.ts
+++ b/test/production/app-dir/typed-routes-with-webpack-worker/typed-routes-with-webpack-worker.test.ts
@@ -1,0 +1,40 @@
+import { nextBuild } from 'next-test-utils'
+import path from 'path'
+
+describe('app dir - typed-routes-with-webpack-worker', () => {
+  it('builds successfully without errors', async () => {
+    const output = await nextBuild(
+      path.join(__dirname, 'good-routes'),
+      undefined,
+      {
+        stdout: true,
+        stderr: true,
+      }
+    )
+
+    // check for the experimental flag warning
+    expect(output.stdout).toContain('webpackBuildWorker')
+    // should have a successful build
+    expect(output.code).toBe(0)
+    // with no errors
+    expect(output.stderr).not.toContain(`"/" is not an existing route.`)
+  })
+
+  it('builds with valid errors', async () => {
+    const output = await nextBuild(
+      path.join(__dirname, 'bad-routes'),
+      undefined,
+      {
+        stdout: true,
+        stderr: true,
+      }
+    )
+
+    // check for the experimental flag warning
+    expect(output.stdout).toContain('webpackBuildWorker')
+    // should have a failed build
+    expect(output.code).toBe(1)
+    // with correct error
+    expect(output.stderr).toContain(`"/asdfasdfasdf" is not an existing route.`)
+  })
+})


### PR DESCRIPTION
When using `experimental.typedRoutes` in conjunction with `experimental.webpackBuildWorker`, type errors would be erroneously thrown during build.

This is because the build workers are parallelized between multiple runtimes (edge, server, client), but the `typedRoutes` is unique to each `webpackBuild`. The state needs to shared between the different compile steps for each instance of the types plugin. 

This leverages plugin state to keep share the `typedRoutes` state amongst the different workers. 

Closes NEXT-1734
Fixes #58369
