### PR TITLE
fix behavior when revisiting an intercepted route

### DIFF
--- a/packages/next/src/client/components/router-reducer/handle-mutable.ts
+++ b/packages/next/src/client/components/router-reducer/handle-mutable.ts
@@ -16,6 +16,21 @@ export function handleMutable(
   // shouldScroll is true by default, can override to false.
   const shouldScroll = mutable.shouldScroll ?? true
 
+  let nextUrl = state.nextUrl
+
+  if (isNotUndefined(mutable.patchedTree)) {
+    // If we received a patched tree, we need to compute the changed path.
+    const changedPath = computeChangedPath(state.tree, mutable.patchedTree)
+    if (changedPath) {
+      // If the tree changed, we need to update the nextUrl
+      nextUrl = changedPath
+    } else if (!nextUrl) {
+      // if the tree ends up being the same (ie, no changed path), and we don't have a nextUrl, then we should use the canonicalUrl
+      nextUrl = state.canonicalUrl
+    }
+    // otherwise this will be a no-op and continue to use the existing nextUrl
+  }
+
   return {
     buildId: state.buildId,
     // Set href.
@@ -72,9 +87,6 @@ export function handleMutable(
     tree: isNotUndefined(mutable.patchedTree)
       ? mutable.patchedTree
       : state.tree,
-    nextUrl: isNotUndefined(mutable.patchedTree)
-      ? computeChangedPath(state.tree, mutable.patchedTree) ??
-        state.canonicalUrl
-      : state.nextUrl,
+    nextUrl,
   }
 }

--- a/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
+++ b/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
@@ -48,5 +48,43 @@ createNextDescribe(
         'Intercepted Photo ID: 2'
       )
     })
+
+    it('should continue to show the intercepted page when revisiting it', async () => {
+      const browser = await next.browser('/')
+      await check(() => browser.elementById('children').text(), 'root')
+
+      await browser.elementByCss('[href="/photos/1"]').click()
+
+      // we should be showing the modal and not the page
+      await check(
+        () => browser.elementById('modal').text(),
+        'Intercepted Photo ID: 1'
+      )
+
+      await browser.refresh()
+
+      // page should show after reloading the browser
+      await check(
+        () => browser.elementById('children').text(),
+        'Page Photo ID: 1'
+      )
+
+      // modal should no longer be showing
+      await check(() => browser.elementById('modal').text(), '')
+
+      await browser.back()
+
+      // revisit the same page that was intercepted
+      await browser.elementByCss('[href="/photos/1"]').click()
+
+      // ensure that we're still showing the modal and not the page
+      await check(
+        () => browser.elementById('modal').text(),
+        'Intercepted Photo ID: 1'
+      )
+
+      // page content should not have changed
+      await check(() => browser.elementById('children').text(), 'root')
+    })
   }
 )


### PR DESCRIPTION
### What?
When using rewrites, in the scenario where a user visits an intercepted route, reloads the page, goes back, and then revisits the same route, we serve the page rather than the intercepted route.

### Why?
#59094 fixed the case where `ACTION_RESTORE` was not restoring `nextUrl` properly. However there's a separate issue where when the `SERVER_PATCH` action comes in, `handleMutable` attempts to compute `nextUrl` by comparing the patched tree with the current tree. In the case of the popstate event, both trees are the same, so the logic is currently configured to fallback to `canonicalUrl`, which is not the correct URL to use in the case of rewrites.

### How?
If the computed changed path is null, we should only fallback to using `canonicalUrl` if we don't have a valid `nextUrl` that we can use. 

Closes NEXT-1747
Fixes #56072
