### PR TITLE
fix(next-core): do not panic when parsing segment config

### DIFF
--- a/packages/next-swc/crates/next-core/src/app_segment_config.rs
+++ b/packages/next-swc/crates/next-core/src/app_segment_config.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use swc_core::{
-    common::{source_map::Pos, Span, Spanned},
+    common::{source_map::Pos, Span, Spanned, GLOBALS},
     ecma::ast::{Expr, Ident, Program},
 };
 use turbo_tasks::{trace::TraceRawVcs, TryJoinIterExt, ValueDefault, Vc};
@@ -243,33 +243,37 @@ pub async fn parse_segment_config_from_source(
     let ParseResult::Ok {
         program: Program::Module(module_ast),
         eval_context,
+        globals,
         ..
     } = result
     else {
         return Ok(Default::default());
     };
 
-    let mut config = NextSegmentConfig::default();
+    let config = GLOBALS.set(globals, || {
+        let mut config = NextSegmentConfig::default();
 
-    for item in &module_ast.body {
-        let Some(decl) = item
-            .as_module_decl()
-            .and_then(|mod_decl| mod_decl.as_export_decl())
-            .and_then(|export_decl| export_decl.decl.as_var())
-        else {
-            continue;
-        };
-
-        for decl in &decl.decls {
-            let Some(ident) = decl.name.as_ident().map(|ident| ident.deref()) else {
+        for item in &module_ast.body {
+            let Some(decl) = item
+                .as_module_decl()
+                .and_then(|mod_decl| mod_decl.as_export_decl())
+                .and_then(|export_decl| export_decl.decl.as_var())
+            else {
                 continue;
             };
 
-            if let Some(init) = decl.init.as_ref() {
-                parse_config_value(source, &mut config, ident, init, eval_context);
+            for decl in &decl.decls {
+                let Some(ident) = decl.name.as_ident().map(|ident| ident.deref()) else {
+                    continue;
+                };
+
+                if let Some(init) = decl.init.as_ref() {
+                    parse_config_value(source, &mut config, ident, init, eval_context);
+                }
             }
         }
-    }
+        config
+    });
 
     Ok(config.cell())
 }

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -6365,10 +6365,11 @@
     "runtimeError": false
   },
   "test/integration/app-dir-export/test/dynamic-missing-gsp-dev.test.ts": {
-    "passed": [],
-    "failed": [
-      "app dir - with output export - dynamic missing gsp dev development mode should error when client component has generateStaticParams",
+    "passed": [
       "app dir - with output export - dynamic missing gsp dev development mode should error when dynamic route is missing generateStaticParams"
+    ],
+    "failed": [
+      "app dir - with output export - dynamic missing gsp dev development mode should error when client component has generateStaticParams"
     ],
     "pending": [],
     "flakey": [],


### PR DESCRIPTION
### What?

fixes panic

```
   Expected substring: "Page \"/another/[slug]/page\" cannot use both \"use client\" and export function \"generateStaticParams()\"."
    Received string:    " ⨯ Error: A task panicked: cannot access a scoped thread local variable without calling `set` first·
    Debug info:
    - Execution of parse_segment_config_from_loader_tree failed
    - A task panicked: cannot access a scoped thread local variable without calling `set` first
 ```

by missing globals in eval context.

Still `should error when client component has generateStaticParams` is failing, since turbopack doesn't have equivalent to `get-page-static-info`.

Closes PACK-2065