### PR TITLE
fix server actions behavior on intercepted routes

### DIFF
--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -14,7 +14,7 @@ import fs from 'fs/promises'
 import * as Log from '../../../build/output/log'
 import setupDebug from 'next/dist/compiled/debug'
 import LRUCache from 'next/dist/compiled/lru-cache'
-import loadCustomRoutes from '../../../lib/load-custom-routes'
+import loadCustomRoutes, { type Rewrite } from '../../../lib/load-custom-routes'
 import { modifyRouteRegex } from '../../../lib/redirect-status'
 import { FileType, fileExists } from '../../../lib/file-exists'
 import { recursiveReadDir } from '../../../lib/recursive-readdir'
@@ -395,7 +395,7 @@ export async function setupFsCheck(opts: {
 
     interceptionRoutes: undefined as
       | undefined
-      | ReturnType<typeof buildCustomRoute>[],
+      | ReturnType<typeof buildCustomRoute<Rewrite>>[],
 
     devVirtualFsItems: new Set<string>(),
 

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -929,6 +929,46 @@ createNextDescribe(
       )
     })
 
+    it('should work with interception routes', async () => {
+      const browser = await next.browser('/interception-routes')
+
+      await check(
+        () => browser.elementById('children-data').text(),
+        /Open modal/
+      )
+
+      await browser.elementByCss("[href='/interception-routes/test']").click()
+
+      // verify the URL is correct
+      await check(() => browser.url(), /interception-routes\/test/)
+
+      // the intercepted text should appear
+      await check(() => browser.elementById('modal-data').text(), /in "modal"/)
+
+      // Submit the action
+      await browser.elementById('submit-intercept-action').click()
+
+      // Action log should be in server console
+      await check(() => next.cliOutput, /Action Submitted \(Intercepted\)/)
+
+      await browser.refresh()
+
+      // the modal text should be gone
+      expect(await browser.hasElementByCssSelector('#modal-data')).toBeFalsy()
+
+      // The page text should show
+      await check(
+        () => browser.elementById('children-data').text(),
+        /in "page"/
+      )
+
+      // Submit the action
+      await browser.elementById('submit-page-action').click()
+
+      // Action log should be in server console
+      await check(() => next.cliOutput, /Action Submitted \(Page\)/)
+    })
+
     describe('encryption', () => {
       it('should send encrypted values from the closed over closure', async () => {
         const res = await next.fetch('/encryption')

--- a/test/e2e/app-dir/actions/app/interception-routes/(with-modal)/@modal/(.)test/page.js
+++ b/test/e2e/app-dir/actions/app/interception-routes/(with-modal)/@modal/(.)test/page.js
@@ -1,0 +1,16 @@
+export default function TestPageIntercepted() {
+  async function action(data) {
+    'use server'
+
+    console.log('Action Submitted (Intercepted)')
+  }
+
+  return (
+    <form action={action}>
+      in "modal"
+      <button type="submit" id="submit-intercept-action">
+        Test
+      </button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/actions/app/interception-routes/(with-modal)/@modal/default.js
+++ b/test/e2e/app-dir/actions/app/interception-routes/(with-modal)/@modal/default.js
@@ -1,0 +1,3 @@
+export default function Empty() {
+  return null
+}

--- a/test/e2e/app-dir/actions/app/interception-routes/(with-modal)/layout.js
+++ b/test/e2e/app-dir/actions/app/interception-routes/(with-modal)/layout.js
@@ -1,0 +1,8 @@
+export default function Layout({ children, modal }) {
+  return (
+    <>
+      <div id="modal-data">{modal}</div>
+      <div id="children-data">{children}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions/app/interception-routes/(with-modal)/page.js
+++ b/test/e2e/app-dir/actions/app/interception-routes/(with-modal)/page.js
@@ -1,0 +1,5 @@
+import Link from 'next/link'
+
+export default function InterceptedPage() {
+  return <Link href="/interception-routes/test">Open modal</Link>
+}

--- a/test/e2e/app-dir/actions/app/interception-routes/test/page.js
+++ b/test/e2e/app-dir/actions/app/interception-routes/test/page.js
@@ -1,0 +1,16 @@
+export default function TestPage() {
+  async function action(data) {
+    'use server'
+
+    console.log('Action Submitted (Page)')
+  }
+
+  return (
+    <form action={action} id="children-data">
+      in "page"
+      <button type="submit" id="submit-page-action">
+        Test
+      </button>
+    </form>
+  )
+}


### PR DESCRIPTION
### What?
When using a server action on an intercepted route, when submitting that action, you'd expect it to correspond with the page you're currently on. However if you have route interception set up, and you load the page rather than the intercepted page, submitting the action would `POST` to the intercepted page. This would result in a 404 error because the action ID you're attempting to submit wouldn't be found on the requested page.

### Why?
Interception routes rely on the `Next-Url` request header to determine if an interception should occur via a rewrite. However, server actions are submitted with this header as well, so the rewrite will be applied to the `POST` request corresponding with a non-existent action, or an action on the intercepted page.

### How?
When loading a page that has an intercepted route, `nextUrl` should be consistent with URL derived from the flight router state tree. But when an interception occurs via navigation, `nextUrl` will now deviate. I'm using this to determine whether or not `Next-Url` should be forwarded along in the `POST` request. 

Closes NEXT-1436
Fixes #52591
Fixes #49934
Fixes #58049
