### PR TITLE
Fix ssgCacheKey in minimal mode

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1025,8 +1025,9 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
           let srcPathname = matchedPath
           let pageIsDynamic = isDynamicRoute(srcPathname)
+
           if (!pageIsDynamic) {
-            const match = await this.matchers.match(urlPathname, {
+            const match = await this.matchers.match(srcPathname, {
               i18n: localeAnalysisResult,
             })
 
@@ -1034,7 +1035,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
             if (match) {
               srcPathname = match.definition.pathname
               // The page is dynamic if the params are defined.
-              pageIsDynamic = typeof match?.params !== 'undefined'
+              pageIsDynamic = typeof match.params !== 'undefined'
             }
           }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1024,15 +1024,19 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           matchedPath = denormalizePagePath(matchedPath)
 
           let srcPathname = matchedPath
-          const match = await this.matchers.match(matchedPath, {
-            i18n: localeAnalysisResult,
-          })
+          let pageIsDynamic = isDynamicRoute(srcPathname)
+          if (!pageIsDynamic) {
+            const match = await this.matchers.match(urlPathname, {
+              i18n: localeAnalysisResult,
+            })
 
-          // Update the source pathname to the matched page's pathname.
-          if (match) srcPathname = match.definition.pathname
-
-          // The page is dynamic if the params are defined.
-          const pageIsDynamic = typeof match?.params !== 'undefined'
+            // Update the source pathname to the matched page's pathname.
+            if (match) {
+              srcPathname = match.definition.pathname
+              // The page is dynamic if the params are defined.
+              pageIsDynamic = typeof match?.params !== 'undefined'
+            }
+          }
 
           // The rest of this function can't handle i18n properly, so ensure we
           // restore the pathname with the locale information stripped from it


### PR DESCRIPTION
This ensures we use the correct `srcPathname` in minimal mode so that we can normalize the URL and generate the correct `ssgCacheKey` which is used for request caching/de-duping.

We aren't able to add a reliable test case for this as it is a race condition within a second of a previous request although this was verified against a stress test repro here https://overlapping-segments-h1455lwvk-vtest314-ijjk-testing.vercel.app/repro/tutorials/demo

This behavior seems to have regressed in https://github.com/vercel/next.js/pull/45716 

Closes NEXT-1777