### PR TITLE
loading.tsx should have no effect on partial rendering when PPR is enabled

### DIFF
--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -58,7 +58,7 @@ export async function walkTreeWithFlightRouterState({
   ctx: AppRenderContext
 }): Promise<FlightDataPath[]> {
   const {
-    renderOpts: { nextFontManifest },
+    renderOpts: { nextFontManifest, experimental },
     query,
     isPrefetch,
     getDynamicParamFromSegment,
@@ -111,6 +111,8 @@ export async function walkTreeWithFlightRouterState({
     flightRouterState[3] === 'refetch'
 
   const shouldSkipComponentTree =
+    // loading.tsx has no effect on prefetching when PPR is enabled
+    !experimental.ppr &&
     isPrefetch &&
     !Boolean(components.loading) &&
     (flightRouterState ||

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -3,6 +3,11 @@ import { check, getRedboxHeader, hasRedbox, waitFor } from 'next-test-utils'
 import cheerio from 'cheerio'
 import stripAnsi from 'strip-ansi'
 
+// TODO: We should decide on an established pattern for gating test assertions
+// on experimental flags. For example, as a first step we could all the common
+// gates like this one into a single module.
+const isPPREnabledByDefault = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
 createNextDescribe(
   'app dir - basic',
   {
@@ -550,7 +555,12 @@ createNextDescribe(
     })
 
     // TODO-APP: Enable in development
-    ;(isDev ? it.skip : it)(
+    ;(isDev ||
+      // When PPR is enabled, the shared layouts re-render because we prefetch
+      // from the root. This will be addressed before GA.
+      isPPREnabledByDefault
+      ? it.skip
+      : it)(
       'should not rerender layout when navigating between routes in the same layout',
       async () => {
         const browser = await next.browser('/same-layout/first')
@@ -1334,7 +1344,12 @@ createNextDescribe(
       })
 
       // TODO-APP: disable failing test and investigate later
-      ;(isDev ? it.skip : it)(
+      ;(isDev ||
+        // When PPR is enabled, the shared layouts re-render because we prefetch
+        // from the root. This will be addressed before GA.
+        isPPREnabledByDefault
+        ? it.skip
+        : it)(
         'should render the template that is a server component and rerender on navigation',
         async () => {
           const browser = await next.browser('/template/servercomponent')

--- a/test/e2e/app-dir/ppr-navigations/app/layout.tsx
+++ b/test/e2e/app-dir/ppr-navigations/app/layout.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function Root({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/ppr-navigations/app/loading-tsx-no-partial-rendering/[dataKey]/client.tsx
+++ b/test/e2e/app-dir/ppr-navigations/app/loading-tsx-no-partial-rendering/[dataKey]/client.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import React, { useState, use } from 'react'
+
+const never = new Promise(() => {})
+
+export function TriggerBadSuspenseFallback() {
+  const [shouldSuspend, setShouldSuspend] = useState(false)
+
+  if (shouldSuspend) {
+    use(never)
+  }
+
+  return (
+    <button
+      id="trigger-bad-suspense-fallback"
+      onClick={() => {
+        setShouldSuspend(true)
+      }}
+    >
+      Trigger Bad Suspense Fallback
+    </button>
+  )
+}

--- a/test/e2e/app-dir/ppr-navigations/app/loading-tsx-no-partial-rendering/[dataKey]/loading.tsx
+++ b/test/e2e/app-dir/ppr-navigations/app/loading-tsx-no-partial-rendering/[dataKey]/loading.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default async function LoadingInner() {
+  return <div id="loading-tsx">Loading [inner loading.tsx]...</div>
+}

--- a/test/e2e/app-dir/ppr-navigations/app/loading-tsx-no-partial-rendering/[dataKey]/page.tsx
+++ b/test/e2e/app-dir/ppr-navigations/app/loading-tsx-no-partial-rendering/[dataKey]/page.tsx
@@ -1,0 +1,33 @@
+import React, { Suspense } from 'react'
+import { TriggerBadSuspenseFallback } from './client'
+import { getDynamicTestData, getStaticTestData } from './test-data-service'
+
+async function Dynamic({ dataKey }) {
+  return (
+    <div id="dynamic">{await getDynamicTestData(`${dataKey} [dynamic]`)}</div>
+  )
+}
+
+async function Static({ dataKey }) {
+  return <div id="static">{await getStaticTestData(`${dataKey} [static]`)}</div>
+}
+
+export default async function Page({
+  params: { dataKey },
+}: {
+  params: { dataKey: string }
+}) {
+  return (
+    <>
+      <div id="container">
+        <Suspense fallback="Loading dynamic...">
+          <Dynamic dataKey={dataKey} />
+        </Suspense>
+        <Suspense fallback="Loading static...">
+          <Static dataKey={dataKey} />
+        </Suspense>
+      </div>
+      <TriggerBadSuspenseFallback />
+    </>
+  )
+}

--- a/test/e2e/app-dir/ppr-navigations/app/loading-tsx-no-partial-rendering/[dataKey]/test-data-service.ts
+++ b/test/e2e/app-dir/ppr-navigations/app/loading-tsx-no-partial-rendering/[dataKey]/test-data-service.ts
@@ -1,0 +1,40 @@
+// NOTE: I've intentionally not yet moved these helpers into a shared module, to
+// avoid early abstraction. I will if/when we start using them for other tests.
+// They are based on the testing patterns we use all over the React codebase, so
+// I'm reasonably confident in them.
+const TEST_DATA_SERVICE_URL = process.env.TEST_DATA_SERVICE_URL
+const ARTIFICIAL_DELAY = 200
+
+async function getTestData(key: string, isStatic: boolean): Promise<string> {
+  const searchParams = new URLSearchParams({
+    key,
+  })
+  if (!TEST_DATA_SERVICE_URL) {
+    // If environment variable is not set, resolve automatically after a delay.
+    // This is so you can run the test app locally without spinning up a
+    // data server.
+    await new Promise<void>((resolve) =>
+      setTimeout(() => resolve(), ARTIFICIAL_DELAY)
+    )
+    return key
+  }
+  const response = await fetch(
+    TEST_DATA_SERVICE_URL + '?' + searchParams.toString(),
+    {
+      cache: isStatic ? 'force-cache' : 'no-store',
+    }
+  )
+  const text = await response.text()
+  if (response.status !== 200) {
+    throw new Error(text)
+  }
+  return text
+}
+
+export async function getStaticTestData(key: string): Promise<string> {
+  return getTestData(key, true)
+}
+
+export async function getDynamicTestData(key: string): Promise<string> {
+  return getTestData(key, false)
+}

--- a/test/e2e/app-dir/ppr-navigations/app/loading-tsx-no-partial-rendering/start/page.tsx
+++ b/test/e2e/app-dir/ppr-navigations/app/loading-tsx-no-partial-rendering/start/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import React, { useState } from 'react'
+import Link from 'next/link'
+
+export default function Start() {
+  const [href, setHref] = useState('')
+  return (
+    <form>
+      <input
+        type="text"
+        name="href"
+        onChange={(e) => setHref(e.target.value)}
+        value={href}
+      />
+      {href === '' ? null : <Link href={href}>Navigate</Link>}
+    </form>
+  )
+}

--- a/test/e2e/app-dir/ppr-navigations/app/loading.tsx
+++ b/test/e2e/app-dir/ppr-navigations/app/loading.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default async function LoadingOuter() {
+  return <div id="loading-tsx">Loading [outer loading.tsx]...</div>
+}

--- a/test/e2e/app-dir/ppr-navigations/next.config.js
+++ b/test/e2e/app-dir/ppr-navigations/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/ppr-navigations/ppr-navigations.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/ppr-navigations.test.ts
@@ -1,0 +1,329 @@
+import { createNext } from 'e2e-utils'
+import { findPort } from 'next-test-utils'
+import http from 'http'
+
+describe('ppr-navigations', () => {
+  if ((global as any).isNextDev) {
+    test('prefetching is disabled in dev', () => {})
+    return
+  }
+
+  let server
+  let next
+  afterEach(async () => {
+    await next?.destroy()
+    server?.close()
+  })
+
+  test('when PPR is enabled, loading.tsx boundaries do not cause a partial prefetch', async () => {
+    const TestLog = createTestLog()
+    let pendingRequests = new Map()
+    server = createTestDataServer(async (key, res) => {
+      TestLog.log('REQUEST: ' + key)
+      if (pendingRequests.has(key)) {
+        throw new Error('Request already pending for ' + key)
+      }
+      pendingRequests.set(key, res)
+    })
+    const port = await findPort()
+    server.listen(port)
+    next = await createNext({
+      files: __dirname,
+      env: { TEST_DATA_SERVICE_URL: `http://localhost:${port}` },
+    })
+
+    // There should have been no data requests during build
+    TestLog.assert([])
+
+    const browser = await next.browser(
+      '/loading-tsx-no-partial-rendering/start'
+    )
+
+    // Use a text input to set the target URL.
+    const input = await browser.elementByCss('input')
+    await input.fill('/loading-tsx-no-partial-rendering/yay')
+
+    // This causes a <Link> to appear. (We create the Link after initial render
+    // so we can control when the prefetch happens.)
+    const link = await browser.elementByCss('a')
+    expect(await link.getAttribute('href')).toBe(
+      '/loading-tsx-no-partial-rendering/yay'
+    )
+
+    // The <Link> triggers a prefetch. Even though this route has a loading.tsx
+    // boundary, we're still able to prefetch the static data in the page.
+    // Without PPR, we would have stopped prefetching at the loading.tsx
+    // boundary. (The dynamic data is not fetched until navigation.)
+    await TestLog.waitFor(['REQUEST: yay [static]'])
+
+    // Navigate. This will trigger the dynamic fetch.
+    await link.click()
+
+    // TODO: Even though the prefetch request hasn't resolved yet, we should
+    // have already started fetching the dynamic data. Currently, the dynamic
+    // is fetched lazily during rendering, creating a waterfall. The plan is to
+    // remove this waterfall by initiating the fetch directly inside the
+    // router navigation handler, not during render.
+    TestLog.assert([])
+
+    // Finish loading the static data
+    pendingRequests.get('yay [static]').resolve()
+
+    // The static UI appears
+    await browser.elementById('static')
+    const container = await browser.elementById('container')
+    expect(await container.innerHTML()).toEqual(
+      'Loading dynamic...<div id="static">yay [static]</div>'
+    )
+
+    // The dynamic data is fetched
+    TestLog.assert(['REQUEST: yay [dynamic]'])
+
+    // Finish loading and render the full UI
+    pendingRequests.get('yay [dynamic]').resolve()
+    await browser.elementById('dynamic')
+    expect(await container.innerHTML()).toEqual(
+      '<div id="dynamic">yay [dynamic]</div><div id="static">yay [static]</div>'
+    )
+
+    // Now we'll demonstrate that even though loading.tsx wasn't activated
+    // during initial render, it still acts as a regular Suspense boundary.
+    // Trigger a "bad" Suspense fallback by intentionally suspending without
+    // startTransition.
+    await browser.elementById('trigger-bad-suspense-fallback').click()
+    const loading = await browser.elementById('loading-tsx')
+    expect(await loading.innerHTML()).toEqual('Loading [inner loading.tsx]...')
+  })
+})
+
+// NOTE: I've intentionally not yet moved these helpers into a separate
+// module, to avoid early abstraction. I will if/when we start using them for
+// other tests. They are based on the testing patterns we use all over the React
+// codebase, so I'm reasonably confident in them.
+
+type TestDataResponse = {
+  _res: http.ServerResponse
+  resolve: (value: string) => any
+  reject: (value: any) => any
+}
+
+type TestDataServer = {
+  _server: http.Server
+  listen: (port: number) => void
+  close: () => void
+}
+
+// Creates a lightweight HTTP server for use in e2e testing. This simulates the
+// data service that would be used in a real Next.js application, whether it's
+// direct database access, an ORM, or a higher-level data access layer. The e2e
+// test can observe when individual requests are received, and control the
+// timing of when the data is fulfilled, without needing to mock any lower
+// level I/O.
+//
+// Receives requests of the form: /?key=foo
+//
+// Responds in plain text. By default, the response is the key itself, but the
+// e2e test can respond with any text it wants.
+//
+// Examples:
+//   response.resolve() // Responds with the key itself
+//   response.resolve('custom') // Responds with custom text
+//   response.reject(new Error('oops!')) // Responds with a 500 error
+//
+// Based on the AsyncText pattern used in the React repo.
+function createTestDataServer(
+  onRequest: (key: string, response: TestDataResponse) => any
+): TestDataServer {
+  const httpServer = http.createServer(async (req, res) => {
+    const searchParams = new URL(req.url, 'http://n').searchParams
+    const key = searchParams.get('key')
+
+    if (typeof key !== 'string') {
+      res.statusCode = 400
+      const msg = 'Missing key parameter'
+      res.end(msg)
+      return
+    }
+
+    const response: TestDataResponse = {
+      _res: res,
+      resolve(value: string | void) {
+        res.end(value === undefined ? key : value)
+      },
+      reject(error: Error, status?: number) {
+        res.statusCode = status ?? 500
+        res.end(error.message ?? `Failed to fetch data for "${key}"`)
+      },
+    }
+
+    try {
+      const result = await onRequest(key, response)
+      if (typeof result === 'string') {
+        response.resolve(result)
+      }
+    } catch (error) {
+      response.reject(error)
+    }
+  })
+  return {
+    _server: httpServer,
+    listen(port: number) {
+      httpServer.listen(port)
+    },
+    close() {
+      httpServer.close()
+    },
+  }
+}
+
+// Creates an event log. You can write to this during testing and then assert
+// on the result.
+//
+// The main use case is for asynchronous e2e tests. It provides a `waitFor`
+// method that resolves when the log matches some expected asynchronous sequence
+// of events. This is an alternative to setting up a timer loop. It helps catch
+// subtle mistakes where the order of events is not expected, or the same
+// event happens more than it should.
+//
+// Based on the Scheduler.log pattern used in the React repo.
+function createTestLog() {
+  let events = []
+
+  // Represents a pending waitFor call.
+  let pendingExpectation: null | {
+    resolve: () => void
+    reject: (error: Error) => void
+    expectedEvents: Array<any>
+    error: Error
+  } = null
+
+  function log(value: any) {
+    // Add to the event log.
+    events.push(value)
+
+    // Check if we've reached the end of the expected log. If there's a
+    // pending waitFor, and we've reached the last of the expected events, this
+    // will resolve the promise.
+    pingExpectation()
+  }
+
+  function assert(expectedEvents: any[]) {
+    const actualEvents = events
+
+    if (pendingExpectation !== null) {
+      const error = new Error('Cannot assert while a waitFor() is pending.')
+      Error.captureStackTrace(error, assert)
+      throw error
+    }
+
+    if (!areLogsEqual(expectedEvents, actualEvents)) {
+      // Capture the stack trace of `assert` so that Jest will report the
+      // error as originating from the `assert` call instead of here.
+      const error = new Error(
+        'Expected sequence of events did not occur.\n\n' +
+          createDiff(expectedEvents, actualEvents)
+      )
+      Error.captureStackTrace(error, assert)
+      throw error
+    }
+  }
+
+  function waitFor(expectedEvents: any[], timeout: number = 5000) {
+    // Returns a promise that resolves when the event log matches the
+    // expected sequence.
+
+    // Capture the stack trace of `waitFor` so that if an inner assertion fails,
+    // Jest will report the error as originating from the `waitFor` call instead
+    // of inside this module's implementation.
+    const error = new Error()
+    Error.captureStackTrace(error, waitFor)
+
+    if (pendingExpectation !== null) {
+      error.message = 'A previous waitFor() is still pending.'
+      throw error
+    }
+
+    let resolve
+    let reject
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+
+    const thisExpectation = {
+      resolve,
+      reject,
+      expectedEvents,
+      error,
+    }
+    pendingExpectation = thisExpectation
+
+    setTimeout(() => {
+      if (pendingExpectation === thisExpectation) {
+        error.message = `waitFor timed out after ${timeout}ms`
+        reject(error)
+      }
+    }, timeout)
+
+    return promise
+  }
+
+  function pingExpectation() {
+    if (pendingExpectation !== null) {
+      const expectedEvents = pendingExpectation.expectedEvents
+      if (events.length < expectedEvents.length) {
+        return
+      }
+
+      if (areLogsEqual(expectedEvents, events)) {
+        // We've reached the end of the expected log. Resolve the promise and
+        // reset the log.
+        events = []
+        pendingExpectation.resolve()
+        pendingExpectation = null
+      } else {
+        // The log does not match what was expected by the test. Reject the
+        // promise and reset the log.
+
+        // Use the error object that we captured at the start of the `waitFor`
+        // call. Jest will show that the error originated from `waitFor` call
+        // instead of inside this internal function.
+        const error = pendingExpectation.error
+        error.message =
+          'Expected sequence of events did not occur.\n\n' +
+          createDiff(expectedEvents, events)
+
+        events = []
+        pendingExpectation.reject(error)
+        pendingExpectation = null
+      }
+    }
+  }
+
+  function createDiff(expected, actual) {
+    // TODO: Jest exposes the diffing utility that it uses for `expect`.
+    // We could use that here for nicer output.
+    return `
+Expected: ${JSON.stringify(expected)}
+Actual:   ${JSON.stringify(actual)}
+`
+  }
+
+  function areLogsEqual(a, b) {
+    if (a.length !== b.length) {
+      return false
+    }
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) {
+        return false
+      }
+    }
+    return true
+  }
+
+  return {
+    log,
+    waitFor,
+    assert,
+  }
+}


### PR DESCRIPTION
Before PPR, the way instant navigations work in Next.js is we prefetch everything up to the first route segment that defines a loading.js boundary. The rest of the tree is defered until the actual navigation. It does not take into account whether the data is dynamic — even if the tree is completely static, it will still defer everything inside the loading boundary.

The approach with PPR is different — we prefetch as deeply as possible, and only defer when dynamic data is accessed. If so, we only defer the nearest parent Suspense boundary of the dynamic data access, regardless of whether the boundary is defined by loading.js or a normal <Suspense> component in userspace.

This PR removes the partial behavior of loading.js when the PPR flag is enabled. In effect, loading.js now acts like a regular Suspense boundary with no additional special behavior.

Note that in practice this usually means we'll end up prefetching more than we were before PPR, which may or may not be considered a performance regression by some apps. The plan is to address this before General Availability of PPR by introducing granular per-segment fetching, so we can reuse as much of the tree as possible during both prefetches and dynamic navigations. But during the beta period, we should be clear about this trade off in our communications.

## Testing strategy

While I was writing a test, I noticed that it's currently pretty difficult to test all the scenarios that PPR is designed to handle, so I gave special attention to setting up a testing strategy that I hope will make this easier going forward. The overall pattern is based on how we've been testing concurrent rendering features in the React repo for many years:

- In the e2e test, spin up an HTTP server for responding to requests sent by the test app. This simulates the data service that would be used in a real Next.js application, whether it's direct db access, an ORM, or a higher-level data access layer. The e2e test can observe when individual requests are received, and control the timing of when the data is fulfilled, without needing to mock any lower level I/O. (We're already using a similar pattern to [test fetch deduping](https://github.com/vercel/next.js/blob/a3616d33edc40e7717b258f2636f280e30a3bccb/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts#L8-L29).)
- Each time a request is received, write to an event log. Then assert on the result of the log at different points throughout the test. This helps catch subtle mistakes where the order of events is not expected, or the same event happens more than it should.

(I wrote some test helpers, but to avoid early abstraction, I've intentionally not moved them into a separate module.)

Closes NEXT-1779