### PR TITLE
makes `env` values optional

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -446,7 +446,7 @@ export interface NextConfig extends Record<string, any> {
    *
    * @see [Environment Variables documentation](https://nextjs.org/docs/api-reference/next.config.js/environment-variables)
    */
-  env?: Record<string, string>
+  env?: Record<string, string | undefined>
 
   /**
    * Destination directory (defaults to `.next`)


### PR DESCRIPTION
### What?

Allows `env` values in next.config.* to be optional.

### Why?

Because `process.env.` values are optional and typed as such.

```
// should be valid but will not transpile under its current TypeScript definition:
export default {
  env: {
    SOMETHING: process.env.SOMETHING, // error `string | undefined` does not satisfy `string`
  },
}
```

### How?

Existing definition is `Record<string, string>` when it should simply be `Record<string, string | undefined>`