### PR TITLE
fix tsconfig alias cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "serde",
  "smallvec",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "serde",
@@ -7678,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7710,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7737,7 +7737,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7751,7 +7751,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7799,7 +7799,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "base16",
  "hex",
@@ -7811,7 +7811,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7825,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7835,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "mimalloc",
 ]
@@ -7843,7 +7843,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7868,7 +7868,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7899,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7940,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7963,7 +7963,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7981,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8037,7 +8037,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8061,7 +8061,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8098,7 +8098,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8132,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "serde",
  "serde_json",
@@ -8143,7 +8143,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8166,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8183,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8199,7 +8199,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8219,7 +8219,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "serde",
@@ -8234,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8249,7 +8249,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8284,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "serde",
@@ -8300,7 +8300,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8311,7 +8311,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "serde",
  "smallvec",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "serde",
@@ -7678,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7710,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7737,7 +7737,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7751,7 +7751,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7793,12 +7793,13 @@ dependencies = [
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-hash",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "base16",
  "hex",
@@ -7810,7 +7811,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7824,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7834,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "mimalloc",
 ]
@@ -7842,7 +7843,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7867,7 +7868,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7898,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7939,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7962,7 +7963,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7980,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8010,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8036,7 +8037,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8060,7 +8061,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8097,7 +8098,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8131,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "serde",
  "serde_json",
@@ -8142,7 +8143,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8165,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8182,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8198,7 +8199,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8218,7 +8219,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "serde",
@@ -8233,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8248,7 +8249,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8283,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "serde",
@@ -8299,7 +8300,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8310,7 +8311,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8325,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231128.2#0f828c5744c17c19235fe3a6cb4006a3102183bb"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/bugfix-tsconfig-alias-cycle#39119741a7a02549a46b1610da6745c22febbc9a"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ swc_core = { version = "0.86.81", features = [
 testing = { version = "0.35.11" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231128.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "sokra/bugfix-tsconfig-alias-cycle" } # last tag: "turbopack-231128.2"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231128.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "sokra/bugfix-tsconfig-alias-cycle" } # last tag: "turbopack-231128.2"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231128.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "sokra/bugfix-tsconfig-alias-cycle" } # last tag: "turbopack-231128.2"
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ swc_core = { version = "0.86.81", features = [
 testing = { version = "0.35.11" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "sokra/bugfix-tsconfig-alias-cycle" } # last tag: "turbopack-231128.2"
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231204.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "sokra/bugfix-tsconfig-alias-cycle" } # last tag: "turbopack-231128.2"
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231204.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "sokra/bugfix-tsconfig-alias-cycle" } # last tag: "turbopack-231128.2"
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231204.2" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -195,7 +195,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.24.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -195,7 +195,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.24.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.24.4
         version: 0.24.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -24647,9 +24647,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231128.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.24.4
         version: 0.24.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -24647,9 +24647,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?39119741a7a02549a46b1610da6745c22febbc9a'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -12139,11 +12139,11 @@
     "runtimeError": false
   },
   "test/integration/jsconfig-paths-wildcard/test/index.test.js": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "jsconfig paths wildcard default behavior should resolve a wildcard alias",
       "jsconfig paths without baseurl wildcard default behavior should resolve a wildcard alias"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -5696,6 +5696,16 @@
     "flakey": [],
     "runtimeError": false
   },
+  "test/e2e/react-dnd-compile/react-dnd-compile.test.ts": {
+    "passed": [
+      "react-dnd-compile should work",
+      "react-dnd-compile should work on react-dnd import page"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
   "test/e2e/reload-scroll-backforward-restoration/index.test.ts": {
     "passed": [
       "reload-scroll-back-restoration should restore the scroll position on navigating back",


### PR DESCRIPTION
### What?

fixes https://github.com/vercel/next.js/issues/59195
fixes PACK-450

### Why?

### How?

see https://github.com/vercel/turbo/pull/6687

### Turbopack Changes

* https://github.com/vercel/turbo/pull/6627 <!-- Tobias Koppers - fix stack trace of errors  -->
* https://github.com/vercel/turbo/pull/6646 <!-- OJ Kwon - fix(turbo-tasks-fs): support unicode segment for glob  -->
* https://github.com/vercel/turbo/pull/6672 <!-- OJ Kwon - fix(ecmascript): dbg assert for the globals  -->
* https://github.com/vercel/turbo/pull/6687 <!-- Tobias Koppers - fix tsconfig alias cycle  -->