### PR TITLE
Fix non bundler module resolution in ts for third-parties pkg

### DIFF
--- a/packages/third-parties/google.d.ts
+++ b/packages/third-parties/google.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types/index'

--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -6,9 +6,11 @@
     "directory": "packages/third-parties"
   },
   "exports": {
-    "./google": "./dist/google/index.js"
+    "./google": {
+      "types": "./dist/google/index.d.ts",
+      "default": "./dist/google/index.js"
+    }
   },
-  "types": "dist/types/google.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
tsconfig priovide few module resolution modes: value "bundler" can resolve the imports/exports fields but "node" will only work for commonjs require, adding a new type file to support when users specify module resolution as `"node"`.

Update the exports to make sure the types are also resolved properly when they use "bundler".

third-party package doesn't have main filed so we removed the "types" field

Tested against the reproduction provided in #58697 

Fixes #58697 

Closes NEXT-1790