### PR TITLE
Disable more Turbopack build tests

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -360,11 +360,6 @@ export default async function build(
   turboNextBuildRoot = null,
   buildMode: 'default' | 'experimental-compile' | 'experimental-generate'
 ): Promise<void> {
-  if (process.env.TURBOPACK) {
-    console.error('Testing if some test were not disabled yet.')
-    process.exit(1)
-  }
-
   const isCompile = buildMode === 'experimental-compile'
   const isGenerate = buildMode === 'experimental-generate'
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -360,6 +360,11 @@ export default async function build(
   turboNextBuildRoot = null,
   buildMode: 'default' | 'experimental-compile' | 'experimental-generate'
 ): Promise<void> {
+  if (process.env.TURBOPACK) {
+    console.error('Testing if some test were not disabled yet.')
+    process.exit(1)
+  }
+
   const isCompile = buildMode === 'experimental-compile'
   const isGenerate = buildMode === 'experimental-generate'
 

--- a/test/e2e/app-dir/ppr-errors/ppr-errors.test.ts
+++ b/test/e2e/app-dir/ppr-errors/ppr-errors.test.ts
@@ -1,96 +1,98 @@
 import { nextBuild } from 'next-test-utils'
 
 describe('ppr build errors', () => {
-  let stderr: string
-  let stdout: string
+  ;(process.env.TURBOPACK ? describe.skip : describe)('production mode', () => {
+    let stderr: string
+    let stdout: string
 
-  beforeAll(async () => {
-    const output = await nextBuild(__dirname, [], {
-      stderr: true,
-      stdout: true,
-    })
-    stderr = output.stderr
-    stdout = output.stdout
-  })
-
-  describe('within a suspense boundary', () => {
-    it('should fail the build for uncaught prerender errors', async () => {
-      expect(stderr).toContain(
-        'Error occurred prerendering page "/regular-error-suspense-boundary".'
-      )
+    beforeAll(async () => {
+      const output = await nextBuild(__dirname, [], {
+        stderr: true,
+        stdout: true,
+      })
+      stderr = output.stderr
+      stdout = output.stdout
     })
 
-    describe('when a postpone call was made but missing postpone data', () => {
-      it('should fail the build', async () => {
+    describe('within a suspense boundary', () => {
+      it('should fail the build for uncaught prerender errors', async () => {
         expect(stderr).toContain(
-          'Prerendering / needs to partially bail out because something dynamic was used. '
+          'Error occurred prerendering page "/regular-error-suspense-boundary".'
         )
       })
 
-      it('should fail the build & surface any errors that were thrown by user code', async () => {
-        // in the case of catching a postpone and throwing a new error, we log the error that the user threw to help with debugging
-        expect(stderr).toContain(
-          'Prerendering /re-throwing-error needs to partially bail out because something dynamic was used. '
-        )
-        expect(stderr).toContain(
-          'The following error was thrown during build, and may help identify the source of the issue:'
-        )
-        expect(stderr).toContain(
-          'Error: The original error was caught and rethrown.'
-        )
+      describe('when a postpone call was made but missing postpone data', () => {
+        it('should fail the build', async () => {
+          expect(stderr).toContain(
+            'Prerendering / needs to partially bail out because something dynamic was used. '
+          )
+        })
 
-        // the regular pre-render error should not be thrown as well, as we've already logged a more specific error
-        expect(stderr).not.toContain(
-          'Error occurred prerendering page "/re-throwing-error"'
-        )
+        it('should fail the build & surface any errors that were thrown by user code', async () => {
+          // in the case of catching a postpone and throwing a new error, we log the error that the user threw to help with debugging
+          expect(stderr).toContain(
+            'Prerendering /re-throwing-error needs to partially bail out because something dynamic was used. '
+          )
+          expect(stderr).toContain(
+            'The following error was thrown during build, and may help identify the source of the issue:'
+          )
+          expect(stderr).toContain(
+            'Error: The original error was caught and rethrown.'
+          )
+
+          // the regular pre-render error should not be thrown as well, as we've already logged a more specific error
+          expect(stderr).not.toContain(
+            'Error occurred prerendering page "/re-throwing-error"'
+          )
+        })
       })
     })
-  })
 
-  describe('outside of a suspense boundary', () => {
-    it('should fail the build for uncaught errors', async () => {
-      expect(stderr).toContain(
-        'Error occurred prerendering page "/regular-error".'
-      )
-    })
-
-    describe('when a postpone call was made but missing postpone data', () => {
-      it('should fail the build', async () => {
+    describe('outside of a suspense boundary', () => {
+      it('should fail the build for uncaught errors', async () => {
         expect(stderr).toContain(
-          'Prerendering /no-suspense-boundary needs to partially bail out because something dynamic was used. '
-        )
-
-        // the regular pre-render error should not be thrown as well, as we've already logged a more specific error
-        expect(stderr).not.toContain(
-          'Error occurred prerendering page "/no-suspense-boundary"'
+          'Error occurred prerendering page "/regular-error".'
         )
       })
 
-      it('should fail the build & surface any errors that were thrown by user code', async () => {
-        // in the case of catching a postpone and throwing a new error, we log the error that the user threw to help with debugging
-        expect(stderr).toContain(
-          'Prerendering /no-suspense-boundary-re-throwing-error needs to partially bail out because something dynamic was used. '
-        )
-        expect(stderr).toContain(
-          'The following error was thrown during build, and may help identify the source of the issue:'
-        )
-        expect(stderr).toContain(
-          "Error: Throwing a new error from 'no-suspense-boundary-re-throwing-error'"
-        )
+      describe('when a postpone call was made but missing postpone data', () => {
+        it('should fail the build', async () => {
+          expect(stderr).toContain(
+            'Prerendering /no-suspense-boundary needs to partially bail out because something dynamic was used. '
+          )
 
-        // the regular pre-render error should not be thrown as well, as we've already logged a more specific error
-        expect(stderr).not.toContain(
-          'Error occurred prerendering page "/no-suspense-boundary-re-throwing-error"'
-        )
+          // the regular pre-render error should not be thrown as well, as we've already logged a more specific error
+          expect(stderr).not.toContain(
+            'Error occurred prerendering page "/no-suspense-boundary"'
+          )
+        })
+
+        it('should fail the build & surface any errors that were thrown by user code', async () => {
+          // in the case of catching a postpone and throwing a new error, we log the error that the user threw to help with debugging
+          expect(stderr).toContain(
+            'Prerendering /no-suspense-boundary-re-throwing-error needs to partially bail out because something dynamic was used. '
+          )
+          expect(stderr).toContain(
+            'The following error was thrown during build, and may help identify the source of the issue:'
+          )
+          expect(stderr).toContain(
+            "Error: Throwing a new error from 'no-suspense-boundary-re-throwing-error'"
+          )
+
+          // the regular pre-render error should not be thrown as well, as we've already logged a more specific error
+          expect(stderr).not.toContain(
+            'Error occurred prerendering page "/no-suspense-boundary-re-throwing-error"'
+          )
+        })
       })
     })
-  })
 
-  describe('when a postpone call is caught and logged it should', () => {
-    it('should include a message telling why', async () => {
-      expect(stdout).toContain(
-        'Logged error: This page needs to bail out of prerendering at this point because it used cookies.'
-      )
+    describe('when a postpone call is caught and logged it should', () => {
+      it('should include a message telling why', async () => {
+        expect(stdout).toContain(
+          'Logged error: This page needs to bail out of prerendering at this point because it used cookies.'
+        )
+      })
     })
   })
 })

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -310,6 +310,56 @@ describe('CLI Usage', () => {
         expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
       })
     })
+
+    describe('build', () => {
+      test('--help', async () => {
+        const help = await runNextCommand(['build', '--help'], {
+          stdout: true,
+        })
+        expect(help.stdout).toMatch(
+          /Compiles the application for production deployment/
+        )
+      })
+
+      test('-h', async () => {
+        const help = await runNextCommand(['build', '-h'], {
+          stdout: true,
+        })
+        expect(help.stdout).toMatch(
+          /Compiles the application for production deployment/
+        )
+      })
+
+      test('should warn when unknown argument provided', async () => {
+        const { stderr } = await runNextCommand(['build', '--random'], {
+          stderr: true,
+        })
+        expect(stderr).toEqual('Unknown or unexpected option: --random\n')
+      })
+      test('should not throw UnhandledPromiseRejectionWarning', async () => {
+        const { stderr } = await runNextCommand(['build', '--random'], {
+          stderr: true,
+        })
+        expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
+      })
+
+      test('should exit when SIGINT is signalled', async () => {
+        await testExitSignal('SIGINT', ['build', dirBasic])
+      })
+
+      test('should exit when SIGTERM is signalled', async () => {
+        await testExitSignal('SIGTERM', ['build', dirBasic])
+      })
+
+      test('invalid directory', async () => {
+        const output = await runNextCommand(['build', 'non-existent'], {
+          stderr: true,
+        })
+        expect(output.stderr).toContain(
+          'Invalid project directory provided, no such directory'
+        )
+      })
+    })
   })
 
   describe('no command', () => {
@@ -371,56 +421,6 @@ describe('CLI Usage', () => {
           `"next ${check[0]}" does not exist. Did you mean "next ${check[1]}"?`
         )
       }
-    })
-  })
-
-  describe('build', () => {
-    test('--help', async () => {
-      const help = await runNextCommand(['build', '--help'], {
-        stdout: true,
-      })
-      expect(help.stdout).toMatch(
-        /Compiles the application for production deployment/
-      )
-    })
-
-    test('-h', async () => {
-      const help = await runNextCommand(['build', '-h'], {
-        stdout: true,
-      })
-      expect(help.stdout).toMatch(
-        /Compiles the application for production deployment/
-      )
-    })
-
-    test('should warn when unknown argument provided', async () => {
-      const { stderr } = await runNextCommand(['build', '--random'], {
-        stderr: true,
-      })
-      expect(stderr).toEqual('Unknown or unexpected option: --random\n')
-    })
-    test('should not throw UnhandledPromiseRejectionWarning', async () => {
-      const { stderr } = await runNextCommand(['build', '--random'], {
-        stderr: true,
-      })
-      expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
-    })
-
-    test('should exit when SIGINT is signalled', async () => {
-      await testExitSignal('SIGINT', ['build', dirBasic])
-    })
-
-    test('should exit when SIGTERM is signalled', async () => {
-      await testExitSignal('SIGTERM', ['build', dirBasic])
-    })
-
-    test('invalid directory', async () => {
-      const output = await runNextCommand(['build', 'non-existent'], {
-        stderr: true,
-      })
-      expect(output.stderr).toContain(
-        'Invalid project directory provided, no such directory'
-      )
     })
   })
 

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -128,78 +128,81 @@ describe('Config Experimental Warning', () => {
     expect(stdout).toContain(' · workerThreads')
     expect(stdout).toContain(' · scrollRestoration')
   })
-
-  it('should not show next app info in next start', async () => {
-    configFile.write(`
-      module.exports = {
-        experimental: {
-          workerThreads: true,
-          scrollRestoration: true,
-          instrumentationHook: true,
-          cpus: 2,
+  ;(process.env.TURBOPACK ? describe.skip : describe)('production mode', () => {
+    it('should not show next app info in next start', async () => {
+      configFile.write(`
+        module.exports = {
+          experimental: {
+            workerThreads: true,
+            scrollRestoration: true,
+            instrumentationHook: true,
+            cpus: 2,
+          }
         }
-      }
-    `)
+      `)
 
-    await collectStdoutFromBuild(appDir)
-    const port = await findPort()
-    let stdout = ''
-    app = await nextStart(appDir, port, {
-      onStdout(msg) {
-        stdout += msg
-      },
-    })
-    expect(stdout).not.toMatch(' - Experiments (use at your own risk):')
-  })
-
-  it('should show next app info with all experimental features in next build', async () => {
-    configFile.write(`
-      module.exports = {
-        experimental: {
-          workerThreads: true,
-          scrollRestoration: true,
-          instrumentationHook: true,
-          cpus: 2,
-        }
-      }
-    `)
-    const stdout = await collectStdoutFromBuild(appDir)
-    expect(stdout).toMatch(' - Experiments (use at your own risk):')
-    expect(stdout).toMatch(' · cpus')
-    expect(stdout).toMatch(' · workerThreads')
-    expect(stdout).toMatch(' · scrollRestoration')
-    expect(stdout).toMatch(' · instrumentationHook')
-  })
-
-  it('should show unrecognized experimental features in warning but not in start log experiments section', async () => {
-    configFile.write(`
-      module.exports = {
-        experimental: {
-          appDir: true
-        }
-      }
-    `)
-
-    await collectStdoutFromBuild(appDir)
-    const port = await findPort()
-    let stdout = ''
-    let stderr = ''
-    app = await nextStart(appDir, port, {
-      onStdout(msg) {
-        stdout += msg
-      },
-      onStderr(msg) {
-        stderr += msg
-      },
+      await collectStdoutFromBuild(appDir)
+      const port = await findPort()
+      let stdout = ''
+      app = await nextStart(appDir, port, {
+        onStdout(msg) {
+          stdout += msg
+        },
+      })
+      expect(stdout).not.toMatch(' - Experiments (use at your own risk):')
     })
 
-    await check(() => {
-      const cliOutput = stripAnsi(stdout)
-      const cliOutputErr = stripAnsi(stderr)
-      expect(cliOutput).not.toContain(' - Experiments (use at your own risk):')
-      expect(cliOutputErr).toContain(
-        `Unrecognized key(s) in object: 'appDir' at "experimental"`
-      )
+    it('should show next app info with all experimental features in next build', async () => {
+      configFile.write(`
+        module.exports = {
+          experimental: {
+            workerThreads: true,
+            scrollRestoration: true,
+            instrumentationHook: true,
+            cpus: 2,
+          }
+        }
+      `)
+      const stdout = await collectStdoutFromBuild(appDir)
+      expect(stdout).toMatch(' - Experiments (use at your own risk):')
+      expect(stdout).toMatch(' · cpus')
+      expect(stdout).toMatch(' · workerThreads')
+      expect(stdout).toMatch(' · scrollRestoration')
+      expect(stdout).toMatch(' · instrumentationHook')
+    })
+
+    it('should show unrecognized experimental features in warning but not in start log experiments section', async () => {
+      configFile.write(`
+        module.exports = {
+          experimental: {
+            appDir: true
+          }
+        }
+      `)
+
+      await collectStdoutFromBuild(appDir)
+      const port = await findPort()
+      let stdout = ''
+      let stderr = ''
+      app = await nextStart(appDir, port, {
+        onStdout(msg) {
+          stdout += msg
+        },
+        onStderr(msg) {
+          stderr += msg
+        },
+      })
+
+      await check(() => {
+        const cliOutput = stripAnsi(stdout)
+        const cliOutputErr = stripAnsi(stderr)
+        expect(cliOutput).not.toContain(
+          ' - Experiments (use at your own risk):'
+        )
+        expect(cliOutputErr).toContain(
+          `Unrecognized key(s) in object: 'appDir' at "experimental"`
+        )
+      })
     })
   })
 })

--- a/test/integration/page-extensions/test/index.test.js
+++ b/test/integration/page-extensions/test/index.test.js
@@ -8,56 +8,66 @@ const appDir = join(__dirname, '..')
 const nextConfig = join(appDir, 'next.config.js')
 
 describe('Page Extensions', () => {
-  it('should use the default pageExtensions if set to undefined', async () => {
-    await fs.writeFile(
-      nextConfig,
-      `module.exports = { pageExtensions: undefined }`
-    )
+  ;(process.env.TURBOPACK ? describe.skip : describe)('production mode', () => {
+    it('should use the default pageExtensions if set to undefined', async () => {
+      await fs.writeFile(
+        nextConfig,
+        `module.exports = { pageExtensions: undefined }`
+      )
 
-    const { stdout } = await runNextCommand(['build', appDir], { stdout: true })
+      const { stdout } = await runNextCommand(['build', appDir], {
+        stdout: true,
+      })
 
-    await fs.remove(nextConfig)
+      await fs.remove(nextConfig)
 
-    expect(stdout).toContain('Compiled successfully')
-  })
+      expect(stdout).toContain('Compiled successfully')
+    })
 
-  it('should throw if pageExtensions is an empty array', async () => {
-    await fs.writeFile(nextConfig, `module.exports = { pageExtensions: [] }`)
+    it('should throw if pageExtensions is an empty array', async () => {
+      await fs.writeFile(nextConfig, `module.exports = { pageExtensions: [] }`)
 
-    const { stderr } = await runNextCommand(['build', appDir], { stderr: true })
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+      })
 
-    await fs.remove(nextConfig)
+      await fs.remove(nextConfig)
 
-    expect(stderr).toContain(
-      'Specified pageExtensions is an empty array. Please update it with the relevant extensions or remove it'
-    )
-  })
+      expect(stderr).toContain(
+        'Specified pageExtensions is an empty array. Please update it with the relevant extensions or remove it'
+      )
+    })
 
-  it('should throw if pageExtensions has invalid extensions', async () => {
-    await fs.writeFile(
-      nextConfig,
-      `module.exports = { pageExtensions: ['js', 123] }`
-    )
+    it('should throw if pageExtensions has invalid extensions', async () => {
+      await fs.writeFile(
+        nextConfig,
+        `module.exports = { pageExtensions: ['js', 123] }`
+      )
 
-    const { stderr } = await runNextCommand(['build', appDir], { stderr: true })
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+      })
 
-    await fs.remove(nextConfig)
+      await fs.remove(nextConfig)
 
-    expect(stderr).toContain(
-      'Specified pageExtensions is not an array of strings, found "123" of type "number". Please update this config or remove it'
-    )
-  })
+      expect(stderr).toContain(
+        'Specified pageExtensions is not an array of strings, found "123" of type "number". Please update this config or remove it'
+      )
+    })
 
-  it('should not throw if .d.ts file inside the pages folder', async () => {
-    await fs.writeFile(
-      nextConfig,
-      `module.exports = { pageExtensions: ['js', 'ts', 'tsx'] }`
-    )
+    it('should not throw if .d.ts file inside the pages folder', async () => {
+      await fs.writeFile(
+        nextConfig,
+        `module.exports = { pageExtensions: ['js', 'ts', 'tsx'] }`
+      )
 
-    const { stdout } = await runNextCommand(['build', appDir], { stdout: true })
+      const { stdout } = await runNextCommand(['build', appDir], {
+        stdout: true,
+      })
 
-    await fs.remove(nextConfig)
+      await fs.remove(nextConfig)
 
-    expect(stdout).toContain('Compiled successfully')
+      expect(stdout).toContain('Compiled successfully')
+    })
   })
 })

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -98,247 +98,250 @@ describe('Telemetry CLI', () => {
     })
     expect(stdout).toMatch(/Status: Disabled/)
   })
-
-  it('detects isSrcDir dir correctly for `next build`', async () => {
-    // must clear cache for GSSP imports to be detected correctly
-    await fs.remove(path.join(appDir, '.next'))
-    const { stderr } = await runNextCommand(['build', appDir], {
-      stderr: true,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-
-    expect(stderr).toMatch(/isSrcDir.*?false/)
-    expect(stderr).toMatch(/package.*?"fs"/)
-    expect(stderr).toMatch(/package.*?"path"/)
-    expect(stderr).toMatch(/package.*?"http"/)
-    expect(stderr).toMatch(/NEXT_PACKAGE_USED_IN_GET_SERVER_SIDE_PROPS/)
-
-    await fs.move(path.join(appDir, 'pages'), path.join(appDir, 'src/pages'))
-    const { stderr: stderr2 } = await runNextCommand(['build', appDir], {
-      stderr: true,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-    await fs.move(path.join(appDir, 'src/pages'), path.join(appDir, 'pages'))
-
-    expect(stderr2).toMatch(/isSrcDir.*?true/)
-  })
-
-  it('emits event when swc fails to load', async () => {
-    await fs.remove(path.join(appDir, '.next'))
-    const { stderr } = await runNextCommand(['build', appDir], {
-      stderr: true,
-      env: {
-        // block swc from loading
-        NODE_OPTIONS: '--no-addons',
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-    expect(stderr).toMatch(/NEXT_SWC_LOAD_FAILURE/)
-    expect(stderr).toContain(
-      `"nextVersion": "${require('next/package.json').version}"`
-    )
-    expect(stderr).toContain(`"arch": "${process.arch}"`)
-    expect(stderr).toContain(`"platform": "${process.platform}"`)
-    expect(stderr).toContain(`"nodeVersion": "${process.versions.node}"`)
-  })
-
-  it('logs completed `next build` with warnings', async () => {
-    await fs.rename(
-      path.join(appDir, 'pages', 'warning.skip'),
-      path.join(appDir, 'pages', 'warning.js')
-    )
-    const { stderr } = await runNextCommand(['build', appDir], {
-      stderr: true,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-    await fs.rename(
-      path.join(appDir, 'pages', 'warning.js'),
-      path.join(appDir, 'pages', 'warning.skip')
-    )
-
-    expect(stderr).toMatch(/Compiled with warnings/)
-    expect(stderr).toMatch(/NEXT_BUILD_COMPLETED/)
-  })
-
-  it('detects tests correctly for `next build`', async () => {
-    await fs.rename(
-      path.join(appDir, 'pages', 'hello.test.skip'),
-      path.join(appDir, 'pages', 'hello.test.js')
-    )
-    const { stderr } = await runNextCommand(['build', appDir], {
-      stderr: true,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-    await fs.rename(
-      path.join(appDir, 'pages', 'hello.test.js'),
-      path.join(appDir, 'pages', 'hello.test.skip')
-    )
-
-    const event1 = /NEXT_BUILD_COMPLETED[\s\S]+?{([\s\S]+?)}/.exec(stderr).pop()
-    expect(event1).toMatch(/hasDunderPages.*?true/)
-    expect(event1).toMatch(/hasTestPages.*?true/)
-
-    const event2 = /NEXT_BUILD_OPTIMIZED[\s\S]+?{([\s\S]+?)}/.exec(stderr).pop()
-    expect(event2).toMatch(/hasDunderPages.*?true/)
-    expect(event2).toMatch(/hasTestPages.*?true/)
-  })
-
-  it('detects correct cli session defaults', async () => {
-    const { stderr } = await runNextCommand(['build', appDir], {
-      stderr: true,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-
-    const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
-      .exec(stderr)
-      .pop()
-
-    expect(event).toMatch(/"hasNextConfig": false/)
-    expect(event).toMatch(/"buildTarget": "default"/)
-    expect(event).toMatch(/"hasWebpackConfig": false/)
-    expect(event).toMatch(/"hasBabelConfig": false/)
-  })
-
-  it('cli session: babel tooling config', async () => {
-    await fs.rename(
-      path.join(appDir, '.babelrc.default'),
-      path.join(appDir, '.babelrc')
-    )
-    const { stderr } = await runNextCommand(['build', appDir], {
-      stderr: true,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-    await fs.rename(
-      path.join(appDir, '.babelrc'),
-      path.join(appDir, '.babelrc.default')
-    )
-
-    const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
-      .exec(stderr)
-      .pop()
-
-    expect(event).toMatch(/"hasNextConfig": false/)
-    expect(event).toMatch(/"buildTarget": "default"/)
-    expect(event).toMatch(/"hasWebpackConfig": false/)
-    expect(event).toMatch(/"hasBabelConfig": false/)
-  })
-
-  it('cli session: custom babel config (plugin)', async () => {
-    await fs.rename(
-      path.join(appDir, '.babelrc.plugin'),
-      path.join(appDir, '.babelrc')
-    )
-    const { stderr } = await runNextCommand(['build', appDir], {
-      stderr: true,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-    await fs.rename(
-      path.join(appDir, '.babelrc'),
-      path.join(appDir, '.babelrc.plugin')
-    )
-
-    const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
-      .exec(stderr)
-      .pop()
-
-    expect(event).toMatch(/"hasNextConfig": false/)
-    expect(event).toMatch(/"buildTarget": "default"/)
-    expect(event).toMatch(/"hasWebpackConfig": false/)
-    expect(event).toMatch(/"hasBabelConfig": true/)
-  })
-
-  it('cli session: package.json custom babel config (plugin)', async () => {
-    await fs.rename(
-      path.join(appDir, 'package.babel'),
-      path.join(appDir, 'package.json')
-    )
-    const { stderr } = await runNextCommand(['build', appDir], {
-      stderr: true,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-    await fs.rename(
-      path.join(appDir, 'package.json'),
-      path.join(appDir, 'package.babel')
-    )
-
-    const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
-      .exec(stderr)
-      .pop()
-
-    expect(event).toMatch(/"hasNextConfig": false/)
-    expect(event).toMatch(/"buildTarget": "default"/)
-    expect(event).toMatch(/"hasWebpackConfig": false/)
-    expect(event).toMatch(/"hasBabelConfig": true/)
-  })
-
-  it('cli session: custom babel config (preset)', async () => {
-    await fs.rename(
-      path.join(appDir, '.babelrc.preset'),
-      path.join(appDir, '.babelrc')
-    )
-    const { stderr } = await runNextCommand(['build', appDir], {
-      stderr: true,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-    await fs.rename(
-      path.join(appDir, '.babelrc'),
-      path.join(appDir, '.babelrc.preset')
-    )
-
-    const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
-      .exec(stderr)
-      .pop()
-
-    expect(event).toMatch(/"hasNextConfig": false/)
-    expect(event).toMatch(/"buildTarget": "default"/)
-    expect(event).toMatch(/"hasWebpackConfig": false/)
-    expect(event).toMatch(/"hasBabelConfig": true/)
-  })
-
-  it('cli session: next config with webpack', async () => {
-    await fs.rename(
-      path.join(appDir, 'next.config.webpack'),
-      path.join(appDir, 'next.config.js')
-    )
-    const { stderr } = await runNextCommand(['build', appDir], {
-      stderr: true,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-    await fs.rename(
-      path.join(appDir, 'next.config.js'),
-      path.join(appDir, 'next.config.webpack')
-    )
-
-    const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
-      .exec(stderr)
-      .pop()
-
-    expect(event).toMatch(/"hasNextConfig": true/)
-    expect(event).toMatch(/"buildTarget": "default"/)
-    expect(event).toMatch(/"hasWebpackConfig": true/)
-    expect(event).toMatch(/"hasBabelConfig": false/)
-  })
   ;(process.env.TURBOPACK ? describe.skip : describe)('production mode', () => {
+    it('detects isSrcDir dir correctly for `next build`', async () => {
+      // must clear cache for GSSP imports to be detected correctly
+      await fs.remove(path.join(appDir, '.next'))
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+        env: {
+          NEXT_TELEMETRY_DEBUG: 1,
+        },
+      })
+
+      expect(stderr).toMatch(/isSrcDir.*?false/)
+      expect(stderr).toMatch(/package.*?"fs"/)
+      expect(stderr).toMatch(/package.*?"path"/)
+      expect(stderr).toMatch(/package.*?"http"/)
+      expect(stderr).toMatch(/NEXT_PACKAGE_USED_IN_GET_SERVER_SIDE_PROPS/)
+
+      await fs.move(path.join(appDir, 'pages'), path.join(appDir, 'src/pages'))
+      const { stderr: stderr2 } = await runNextCommand(['build', appDir], {
+        stderr: true,
+        env: {
+          NEXT_TELEMETRY_DEBUG: 1,
+        },
+      })
+      await fs.move(path.join(appDir, 'src/pages'), path.join(appDir, 'pages'))
+
+      expect(stderr2).toMatch(/isSrcDir.*?true/)
+    })
+
+    it('emits event when swc fails to load', async () => {
+      await fs.remove(path.join(appDir, '.next'))
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+        env: {
+          // block swc from loading
+          NODE_OPTIONS: '--no-addons',
+          NEXT_TELEMETRY_DEBUG: 1,
+        },
+      })
+      expect(stderr).toMatch(/NEXT_SWC_LOAD_FAILURE/)
+      expect(stderr).toContain(
+        `"nextVersion": "${require('next/package.json').version}"`
+      )
+      expect(stderr).toContain(`"arch": "${process.arch}"`)
+      expect(stderr).toContain(`"platform": "${process.platform}"`)
+      expect(stderr).toContain(`"nodeVersion": "${process.versions.node}"`)
+    })
+
+    it('logs completed `next build` with warnings', async () => {
+      await fs.rename(
+        path.join(appDir, 'pages', 'warning.skip'),
+        path.join(appDir, 'pages', 'warning.js')
+      )
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+        env: {
+          NEXT_TELEMETRY_DEBUG: 1,
+        },
+      })
+      await fs.rename(
+        path.join(appDir, 'pages', 'warning.js'),
+        path.join(appDir, 'pages', 'warning.skip')
+      )
+
+      expect(stderr).toMatch(/Compiled with warnings/)
+      expect(stderr).toMatch(/NEXT_BUILD_COMPLETED/)
+    })
+
+    it('detects tests correctly for `next build`', async () => {
+      await fs.rename(
+        path.join(appDir, 'pages', 'hello.test.skip'),
+        path.join(appDir, 'pages', 'hello.test.js')
+      )
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+        env: {
+          NEXT_TELEMETRY_DEBUG: 1,
+        },
+      })
+      await fs.rename(
+        path.join(appDir, 'pages', 'hello.test.js'),
+        path.join(appDir, 'pages', 'hello.test.skip')
+      )
+
+      const event1 = /NEXT_BUILD_COMPLETED[\s\S]+?{([\s\S]+?)}/
+        .exec(stderr)
+        .pop()
+      expect(event1).toMatch(/hasDunderPages.*?true/)
+      expect(event1).toMatch(/hasTestPages.*?true/)
+
+      const event2 = /NEXT_BUILD_OPTIMIZED[\s\S]+?{([\s\S]+?)}/
+        .exec(stderr)
+        .pop()
+      expect(event2).toMatch(/hasDunderPages.*?true/)
+      expect(event2).toMatch(/hasTestPages.*?true/)
+    })
+
+    it('detects correct cli session defaults', async () => {
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+        env: {
+          NEXT_TELEMETRY_DEBUG: 1,
+        },
+      })
+
+      const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
+        .exec(stderr)
+        .pop()
+
+      expect(event).toMatch(/"hasNextConfig": false/)
+      expect(event).toMatch(/"buildTarget": "default"/)
+      expect(event).toMatch(/"hasWebpackConfig": false/)
+      expect(event).toMatch(/"hasBabelConfig": false/)
+    })
+
+    it('cli session: babel tooling config', async () => {
+      await fs.rename(
+        path.join(appDir, '.babelrc.default'),
+        path.join(appDir, '.babelrc')
+      )
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+        env: {
+          NEXT_TELEMETRY_DEBUG: 1,
+        },
+      })
+      await fs.rename(
+        path.join(appDir, '.babelrc'),
+        path.join(appDir, '.babelrc.default')
+      )
+
+      const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
+        .exec(stderr)
+        .pop()
+
+      expect(event).toMatch(/"hasNextConfig": false/)
+      expect(event).toMatch(/"buildTarget": "default"/)
+      expect(event).toMatch(/"hasWebpackConfig": false/)
+      expect(event).toMatch(/"hasBabelConfig": false/)
+    })
+
+    it('cli session: custom babel config (plugin)', async () => {
+      await fs.rename(
+        path.join(appDir, '.babelrc.plugin'),
+        path.join(appDir, '.babelrc')
+      )
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+        env: {
+          NEXT_TELEMETRY_DEBUG: 1,
+        },
+      })
+      await fs.rename(
+        path.join(appDir, '.babelrc'),
+        path.join(appDir, '.babelrc.plugin')
+      )
+
+      const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
+        .exec(stderr)
+        .pop()
+
+      expect(event).toMatch(/"hasNextConfig": false/)
+      expect(event).toMatch(/"buildTarget": "default"/)
+      expect(event).toMatch(/"hasWebpackConfig": false/)
+      expect(event).toMatch(/"hasBabelConfig": true/)
+    })
+
+    it('cli session: package.json custom babel config (plugin)', async () => {
+      await fs.rename(
+        path.join(appDir, 'package.babel'),
+        path.join(appDir, 'package.json')
+      )
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+        env: {
+          NEXT_TELEMETRY_DEBUG: 1,
+        },
+      })
+      await fs.rename(
+        path.join(appDir, 'package.json'),
+        path.join(appDir, 'package.babel')
+      )
+
+      const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
+        .exec(stderr)
+        .pop()
+
+      expect(event).toMatch(/"hasNextConfig": false/)
+      expect(event).toMatch(/"buildTarget": "default"/)
+      expect(event).toMatch(/"hasWebpackConfig": false/)
+      expect(event).toMatch(/"hasBabelConfig": true/)
+    })
+
+    it('cli session: custom babel config (preset)', async () => {
+      await fs.rename(
+        path.join(appDir, '.babelrc.preset'),
+        path.join(appDir, '.babelrc')
+      )
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+        env: {
+          NEXT_TELEMETRY_DEBUG: 1,
+        },
+      })
+      await fs.rename(
+        path.join(appDir, '.babelrc'),
+        path.join(appDir, '.babelrc.preset')
+      )
+
+      const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
+        .exec(stderr)
+        .pop()
+
+      expect(event).toMatch(/"hasNextConfig": false/)
+      expect(event).toMatch(/"buildTarget": "default"/)
+      expect(event).toMatch(/"hasWebpackConfig": false/)
+      expect(event).toMatch(/"hasBabelConfig": true/)
+    })
+
+    it('cli session: next config with webpack', async () => {
+      await fs.rename(
+        path.join(appDir, 'next.config.webpack'),
+        path.join(appDir, 'next.config.js')
+      )
+      const { stderr } = await runNextCommand(['build', appDir], {
+        stderr: true,
+        env: {
+          NEXT_TELEMETRY_DEBUG: 1,
+        },
+      })
+      await fs.rename(
+        path.join(appDir, 'next.config.js'),
+        path.join(appDir, 'next.config.webpack')
+      )
+
+      const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
+        .exec(stderr)
+        .pop()
+
+      expect(event).toMatch(/"hasNextConfig": true/)
+      expect(event).toMatch(/"buildTarget": "default"/)
+      expect(event).toMatch(/"hasWebpackConfig": true/)
+      expect(event).toMatch(/"hasBabelConfig": false/)
+    })
     it('detect static 404 correctly for `next build`', async () => {
       const { stderr } = await nextBuild(appDir, [], {
         stderr: true,


### PR DESCRIPTION
## What?

Skips more tests that are running `next build` which is not supported by Turbopack yet.

## How?

Used an approach where all `next build` tests would fail if `TURBOPACK=1` is set, which is how the tests run. This highlighted the cases `next build` was still running.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-1791