### PR TITLE
Fix dynamic transform ssr:false case for pages router with ESM

### DIFF
--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -98,6 +98,9 @@ pub struct TransformOptions {
     pub is_server_compiler: bool,
 
     #[serde(default)]
+    pub prefer_esm: bool,
+
+    #[serde(default)]
     pub server_components: Option<react_server_components::Config>,
 
     #[serde(default)]
@@ -238,6 +241,7 @@ where
                 },
                 _ => false,
             },
+            opts.prefer_esm,
             NextDynamicMode::Webpack,
             file.name.clone(),
             opts.pages_dir.clone()

--- a/packages/next-swc/crates/core/tests/errors.rs
+++ b/packages/next-swc/crates/core/tests/errors.rs
@@ -56,6 +56,7 @@ fn next_dynamic_errors(input: PathBuf) {
                 true,
                 false,
                 false,
+                false,
                 NextDynamicMode::Webpack,
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 Some("/some-project/src".into()),

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -65,6 +65,7 @@ fn next_dynamic_fixture(input: PathBuf) {
                 true,
                 false,
                 false,
+                false,
                 NextDynamicMode::Webpack,
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 Some("/some-project/src".into()),
@@ -78,6 +79,7 @@ fn next_dynamic_fixture(input: PathBuf) {
         syntax(),
         &|_tr| {
             next_dynamic(
+                false,
                 false,
                 false,
                 false,
@@ -96,6 +98,7 @@ fn next_dynamic_fixture(input: PathBuf) {
             next_dynamic(
                 false,
                 true,
+                false,
                 false,
                 NextDynamicMode::Webpack,
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
@@ -124,6 +127,7 @@ fn app_dir_next_dynamic_fixture(input: PathBuf) {
                 true,
                 false,
                 true,
+                false,
                 NextDynamicMode::Webpack,
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 Some("/some-project/src".into()),
@@ -140,6 +144,7 @@ fn app_dir_next_dynamic_fixture(input: PathBuf) {
                 false,
                 false,
                 true,
+                false,
                 NextDynamicMode::Webpack,
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 Some("/some-project/src".into()),
@@ -156,6 +161,7 @@ fn app_dir_next_dynamic_fixture(input: PathBuf) {
                 false,
                 true,
                 true,
+                false,
                 NextDynamicMode::Webpack,
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 Some("/some-project/src".into()),
@@ -171,6 +177,7 @@ fn app_dir_next_dynamic_fixture(input: PathBuf) {
             next_dynamic(
                 false,
                 true,
+                false,
                 false,
                 NextDynamicMode::Webpack,
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic-app-dir/no-ssr/output-server-client-layer.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic-app-dir/no-ssr/output-server-client-layer.js
@@ -1,7 +1,5 @@
 import dynamic from 'next/dynamic';
-export const NextDynamicNoSSRServerComponent = dynamic(async ()=>{
-    typeof require.resolveWeak !== "undefined" && require.resolveWeak("../text-dynamic-no-ssr-server");
-}, {
+export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server'), {
     loadableGenerated: {
         modules: [
             "some-file.js -> " + "../text-dynamic-no-ssr-server"

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/issue-48098/output-server.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/issue-48098/output-server.js
@@ -1,7 +1,5 @@
 import dynamic from 'next/dynamic';
-export const NextDynamicNoSSRServerComponent = dynamic(async ()=>{
-    typeof require.resolveWeak !== "undefined" && require.resolveWeak("../text-dynamic-no-ssr-server");
-}, {
+export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server'), {
     loadableGenerated: {
         modules: [
             "some-file.js -> " + "../text-dynamic-no-ssr-server"

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/output-server.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/output-server.js
@@ -7,9 +7,7 @@ const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hell
     },
     loading: ()=><p>...</p>
 });
-const DynamicClientOnlyComponent = dynamic(async ()=>{
-    typeof require.resolveWeak !== "undefined" && require.resolveWeak("../components/hello");
-}, {
+const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello'), {
     loadableGenerated: {
         modules: [
             "some-file.js -> " + "../components/hello"
@@ -17,9 +15,7 @@ const DynamicClientOnlyComponent = dynamic(async ()=>{
     },
     ssr: false
 });
-const DynamicClientOnlyComponentWithSuspense = dynamic(async ()=>{
-    typeof require.resolveWeak !== "undefined" && require.resolveWeak("../components/hello");
-}, {
+const DynamicClientOnlyComponentWithSuspense = dynamic(()=>import('../components/hello'), {
     loadableGenerated: {
         modules: [
             "some-file.js -> " + "../components/hello"

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/wrapped-import/output-server.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/wrapped-import/output-server.js
@@ -1,7 +1,5 @@
 import dynamic from 'next/dynamic';
-const DynamicComponent = dynamic(async ()=>{
-    typeof require.resolveWeak !== "undefined" && require.resolveWeak("./components/hello");
-}, {
+const DynamicComponent = dynamic(()=>handleImport(import('./components/hello')), {
     loadableGenerated: {
         modules: [
             "some-file.js -> " + "./components/hello"

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -66,6 +66,7 @@ impl CustomTransformer for NextJsDynamic {
             },
             self.is_server_compiler,
             self.is_react_server_layer,
+            false,
             NextDynamicMode::Webpack,
             FileName::Real(ctx.file_path_str.into()),
             self.pages_dir.clone(),

--- a/packages/next-swc/crates/next-transform-dynamic/src/lib.rs
+++ b/packages/next-swc/crates/next-transform-dynamic/src/lib.rs
@@ -28,6 +28,7 @@ pub fn next_dynamic(
     is_development: bool,
     is_server_compiler: bool,
     is_react_server_layer: bool,
+    prefer_esm: bool,
     mode: NextDynamicMode,
     filename: FileName,
     pages_dir: Option<PathBuf>,
@@ -36,6 +37,7 @@ pub fn next_dynamic(
         is_development,
         is_server_compiler,
         is_react_server_layer,
+        prefer_esm,
         pages_dir,
         filename,
         dynamic_bindings: vec![],
@@ -81,6 +83,7 @@ struct NextDynamicPatcher {
     is_development: bool,
     is_server_compiler: bool,
     is_react_server_layer: bool,
+    prefer_esm: bool,
     pages_dir: Option<PathBuf>,
     filename: FileName,
     dynamic_bindings: Vec<Id>,
@@ -368,7 +371,10 @@ impl Fold for NextDynamicPatcher {
                     if has_ssr_false
                         && self.is_server_compiler
                         && !self.is_react_server_layer
-                        && !self.pages_dir.is_none()
+                        // When it's not prefer to picking up ESM, as it's in the pages router, we don't need to do it as it doesn't need to enter the non-ssr module.
+                        // Also transforming it to `require.resolveWeak` and with ESM import, like require.resolveWeak(esm asset) is not available as it's commonjs importing ESM.
+                        && self.prefer_esm
+
                         // Only use `require.resolveWebpack` to decouple modules for webpack,
                         // turbopack doesn't need this
                         && self.state == NextDynamicPatcherState::Webpack

--- a/packages/next-swc/crates/next-transform-dynamic/src/lib.rs
+++ b/packages/next-swc/crates/next-transform-dynamic/src/lib.rs
@@ -368,6 +368,7 @@ impl Fold for NextDynamicPatcher {
                     if has_ssr_false
                         && self.is_server_compiler
                         && !self.is_react_server_layer
+                        && !self.pages_dir.is_none()
                         // Only use `require.resolveWebpack` to decouple modules for webpack,
                         // turbopack doesn't need this
                         && self.state == NextDynamicPatcherState::Webpack

--- a/packages/next-swc/crates/next-transform-dynamic/tests/errors.rs
+++ b/packages/next-swc/crates/next-transform-dynamic/tests/errors.rs
@@ -39,6 +39,7 @@ fn next_dynamic_errors_run(input: &Path, output: &str, mode: NextDynamicMode) {
                 true,
                 false,
                 false,
+                false,
                 mode.clone(),
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 Some("/some-project/src".into()),

--- a/packages/next-swc/crates/next-transform-dynamic/tests/fixture.rs
+++ b/packages/next-swc/crates/next-transform-dynamic/tests/fixture.rs
@@ -25,11 +25,13 @@ fn next_dynamic_fixture(input: PathBuf) {
         true,
         false,
         false,
+        false,
         NextDynamicMode::Webpack,
     );
     next_dynamic_fixture_run(
         &input,
         "output-webpack-prod.js",
+        false,
         false,
         false,
         false,
@@ -41,6 +43,7 @@ fn next_dynamic_fixture(input: PathBuf) {
         false,
         true,
         false,
+        false,
         NextDynamicMode::Webpack,
     );
 
@@ -48,6 +51,7 @@ fn next_dynamic_fixture(input: PathBuf) {
         &input,
         "output-turbo-dev-client.js",
         true,
+        false,
         false,
         false,
         NextDynamicMode::Turbopack {
@@ -60,6 +64,7 @@ fn next_dynamic_fixture(input: PathBuf) {
         true,
         true,
         false,
+        false,
         NextDynamicMode::Turbopack {
             dynamic_transition_name: "next-client-chunks".into(),
         },
@@ -67,6 +72,7 @@ fn next_dynamic_fixture(input: PathBuf) {
     next_dynamic_fixture_run(
         &input,
         "output-turbo-build-client.js",
+        false,
         false,
         false,
         false,
@@ -80,6 +86,7 @@ fn next_dynamic_fixture(input: PathBuf) {
         false,
         true,
         false,
+        false,
         NextDynamicMode::Turbopack {
             dynamic_transition_name: "next-dynamic".into(),
         },
@@ -88,6 +95,7 @@ fn next_dynamic_fixture(input: PathBuf) {
         &input,
         "output-turbo-build-rsc.js",
         false,
+        true,
         true,
         true,
         NextDynamicMode::Turbopack {
@@ -102,6 +110,7 @@ fn next_dynamic_fixture_run(
     is_development: bool,
     is_server_compiler: bool,
     is_react_server_layer: bool,
+    prefer_esm: bool,
     mode: NextDynamicMode,
 ) {
     let output = input.parent().unwrap().join(output);
@@ -112,6 +121,7 @@ fn next_dynamic_fixture_run(
                 is_development,
                 is_server_compiler,
                 is_react_server_layer,
+                prefer_esm,
                 mode.clone(),
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 Some("/some-project/src".into()),

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -44,12 +44,14 @@ function getBaseSWCOptions({
   swcCacheDir,
   serverComponents,
   isReactServerLayer,
+  esm,
 }: {
   filename: string
   jest?: boolean
   development: boolean
   hasReactRefresh: boolean
   globalWindow: boolean
+  esm: boolean
   modularizeImports?: NextConfig['modularizeImports']
   compilerOptions: NextConfig['compiler']
   swcPlugins: ExperimentalConfig['swcPlugins']
@@ -188,6 +190,9 @@ function getBaseSWCOptions({
             isReactServerLayer: !!isReactServerLayer,
           }
         : undefined,
+    // For app router we prefer to bundle ESM,
+    // On server side of pages router we prefer CJS.
+    preferEsm: esm,
   }
 }
 
@@ -289,6 +294,7 @@ export function getJestSWCOptions({
     compilerOptions,
     jsConfig,
     resolvedBaseUrl,
+    esm,
     // Don't apply server layer transformations for Jest
     isReactServerLayer: false,
     // Disable server / client graph assertions for Jest
@@ -423,6 +429,7 @@ export function getLoaderSWCOptions({
       isServerCompiler: isServer,
       pagesDir,
       appDir,
+      preferEsm: !!esm,
       isPageFile,
       env: {
         targets: {

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -36,6 +36,7 @@ function getBaseSWCOptions({
   development,
   hasReactRefresh,
   globalWindow,
+  esm,
   modularizeImports,
   swcPlugins,
   compilerOptions,
@@ -44,7 +45,6 @@ function getBaseSWCOptions({
   swcCacheDir,
   serverComponents,
   isReactServerLayer,
-  esm,
 }: {
   filename: string
   jest?: boolean
@@ -378,6 +378,7 @@ export function getLoaderSWCOptions({
     swcCacheDir,
     isReactServerLayer,
     serverComponents,
+    esm: !!esm,
   })
   baseOptions.fontLoaders = {
     fontLoaders: [

--- a/test/development/basic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic.test.ts
@@ -199,6 +199,25 @@ describe.each([
                 }
               }
             })
+
+            it('should import and render the ESM module correctly on client side', async () => {
+              let browser
+              try {
+                browser = await webdriver(
+                  next.url,
+                  basePath + '/dynamic/no-ssr-esm'
+                )
+                await check(
+                  () => browser.elementByCss('body').text(),
+                  /esm.mjs/
+                )
+                expect(await hasRedbox(browser, false)).toBe(false)
+              } finally {
+                if (browser) {
+                  await browser.close()
+                }
+              }
+            })
           })
 
           describe('ssr:true option', () => {

--- a/test/development/basic/next-dynamic/components/esm.mjs
+++ b/test/development/basic/next-dynamic/components/esm.mjs
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Component() {
+  return <p>esm.mjs</p>
+}

--- a/test/development/basic/next-dynamic/components/esm.mjs
+++ b/test/development/basic/next-dynamic/components/esm.mjs
@@ -1,5 +1,7 @@
 import React from 'react'
 
+window.ua = navigator.userAgent
+
 export default function Component() {
   return <p>esm.mjs</p>
 }

--- a/test/development/basic/next-dynamic/pages/dynamic/no-ssr-esm.js
+++ b/test/development/basic/next-dynamic/pages/dynamic/no-ssr-esm.js
@@ -1,0 +1,5 @@
+import dynamic from 'next/dynamic'
+
+const Page = dynamic(() => import('../../components/esm.mjs'), { ssr: false })
+
+export default Hello

--- a/test/development/basic/next-dynamic/pages/dynamic/no-ssr-esm.js
+++ b/test/development/basic/next-dynamic/pages/dynamic/no-ssr-esm.js
@@ -2,4 +2,4 @@ import dynamic from 'next/dynamic'
 
 const Page = dynamic(() => import('../../components/esm.mjs'), { ssr: false })
 
-export default Hello
+export default Page


### PR DESCRIPTION
We introduced a new transform (#56761) for non-SSR `next/dynamic` to always "weakly" linked the non-SSR module, so that in app router we can still enter the module to discover the server actions, but in edge runtime we also won't bundle it in the server bundle.

For app router since we bundle all it works well. But when you import a ESM in pages router it doesn't work as it become the path of "commonjs require (ESM path)"

### Solution

Leveraging the `esm` option for next swc loader, which means if we really prefer the esm asset for bundling, in pages router it's false and we won't apply the new transform.

Closes #59235
Closes NEXT-1788
