### PR TITLE
Extend screenshots member of manifest-types.ts

### DIFF
--- a/packages/next/src/lib/metadata/types/manifest-types.ts
+++ b/packages/next/src/lib/metadata/types/manifest-types.ts
@@ -52,9 +52,25 @@ export type Manifest = {
   }[]
   scope?: string
   screenshots?: {
+    label?: string
     src: string
     type?: string
     sizes?: string
+    platform?:
+      | 'android'
+      | 'chromeos'
+      | 'ipados'
+      | 'ios'
+      | 'kaios'
+      | 'macos'
+      | 'windows'
+      | 'xbox'
+      | 'chrome_web_store'
+      | 'itunes'
+      | 'microsoft-inbox'
+      | 'microsoft-store'
+      | 'play'
+    form_factor?: 'narrow' | 'wide'
   }[]
   serviceworker?: {
     src?: string


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


### What?

The `screenshots` member in the `Manifest` type has been extended (Relevant for the Web Application Manifest)

### Why?

1. The screenshot member already exists but a few fields are missing. That's why I've added all the missing `screenshot` fields to this PR.
2. Google Lighthouse currently displays a warning if the `form_factor` field is not configured for each screenshot. 

### How?

The fields were added based on this website.

https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots#browser_compatibility

Although the `screenshots` member is still experimental, it already exists in the file and therefore there is theoretically no reason why all the available fields in the type should not be used right away.