### PR TITLE
fix typo in daily turbopack integration test reporting

### DIFF
--- a/.github/workflows/nextjs-integration-test.yml
+++ b/.github/workflows/nextjs-integration-test.yml
@@ -194,4 +194,4 @@ jobs:
       - name: Upload to datadog
         run: |
           # We'll tag this to the "Turbopack" datadog service, not "nextjs"
-          DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:turbopack.daily --service Turbopack ./test/report
+          DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:turbopack.daily --service Turbopack ./test/reports


### PR DESCRIPTION
### What?

Test reports are downloaded into `test/reports`, not `test/report`

Closes PACK-2073