### PR TITLE
Add process.env.__NEXT_PPR to build config

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -98,6 +98,7 @@ export function getDefineEnv({
     'process.env.__NEXT_WINDOW_HISTORY_SUPPORT': JSON.stringify(
       config.experimental.windowHistorySupport
     ),
+    'process.env.__NEXT_PPR': JSON.stringify(config.experimental.ppr === true),
     'process.env.__NEXT_ACTIONS_DEPLOYMENT_ID': JSON.stringify(
       config.experimental.useDeploymentIdServerActions
     ),


### PR DESCRIPTION
Adds process.env.__NEXT_PPR as static flag that it gets inlined by DefinePlugin during build.

This matches what we do for other experiments, but I do wonder, why do we bother with process.env at all instead of a global __NEXT_PPR symbol? I'll leave that for later discussion.

Closes NEXT-1792