### PR TITLE
fix(next-core): adjust edge entry path

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_pages/page_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_pages/page_entry.rs
@@ -182,7 +182,7 @@ async fn wrap_edge_page(
         project_root,
         indexmap! {
             "VAR_USERLAND" => INNER.to_string(),
-            "VAR_PAGE" => page.clone(),
+            "VAR_PAGE" => pathname.clone(),
             "VAR_BUILD_ID" => build_id.to_string(),
             "VAR_MODULE_DOCUMENT" => "@vercel/turbopack-next/pages/_document".to_string(),
             "VAR_MODULE_APP" => "@vercel/turbopack-next/pages/_app".to_string(),


### PR DESCRIPTION
### What

Minor fix to edge entry for the pages, currently there are misaligned entry between manifest (request and manifest builds to the `/` pathname, then turbopack embeds its entry to `/something`) results edge rendering fails.

Closes PACK-2079