### PR TITLE
fix nextConfig headers not applying to static resources with i18n

### DIFF
--- a/packages/next/src/lib/load-custom-routes.ts
+++ b/packages/next/src/lib/load-custom-routes.ts
@@ -547,9 +547,10 @@ function processRoutes<T>(
         })
       }
 
-      r.source = `/:nextInternalLocale(${config.i18n.locales
-        .map((locale: string) => escapeStringRegexp(locale))
-        .join('|')})${
+      const locales = config.i18n.locales.map(escapeStringRegexp).join('|')
+      // locale is intentionally marked optional here so that custom route headers
+      // are applied to static resources (which don't have a locale prefix)
+      r.source = `/:nextInternalLocale(${locales})?${
         r.source === '/' && !config.trailingSlash ? '' : r.source
       }`
 

--- a/test/integration/custom-routes-i18n/next.config.js
+++ b/test/integration/custom-routes-i18n/next.config.js
@@ -81,4 +81,17 @@ module.exports = {
       },
     ]
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Custom-Header',
+            value: 'my custom header value',
+          },
+        ],
+      },
+    ]
+  },
 }

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -755,6 +755,15 @@ module.exports = {
           },
         ],
       },
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Global-Custom-Header',
+            value: 'my custom header value',
+          },
+        ],
+      },
     ]
   },
 }


### PR DESCRIPTION
Closed in favor of `nextConfig.headers.locale` being set to `false`. https://nextjs.org/docs/app/api-reference/next-config-js/headers#headers-with-i18n-support