### PR TITLE
fix interception routes with dynamic segments

### DIFF
--- a/packages/next/src/shared/lib/router/utils/route-regex.test.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.test.ts
@@ -24,6 +24,18 @@ describe('getNamedRouteRegex', () => {
     expect(regex.re.test('/photos/(.)next/123')).toBe(true)
   })
 
+  it('should match named routes correctly when interception markers are adjacent to dynamic segments', () => {
+    let regex = getNamedRouteRegex('/(.)[author]/[id]', true)
+    let namedRegexp = new RegExp(regex.namedRegex)
+    expect(namedRegexp.test('/[author]/[id]')).toBe(false)
+    expect(namedRegexp.test('/(.)[author]/[id]')).toBe(true)
+
+    regex = getNamedRouteRegex('/(..)(..)[author]/[id]', true)
+    namedRegexp = new RegExp(regex.namedRegex)
+    expect(namedRegexp.test('/[author]/[id]')).toBe(false)
+    expect(namedRegexp.test('/(..)(..)[author]/[id]')).toBe(true)
+  })
+
   it('should handle multi-level interception markers', () => {
     const regex = getNamedRouteRegex('/photos/(..)(..)[author]/[id]', true)
 

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)[username]/[id]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)[username]/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'intercepted'
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/default.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/default.tsx
@@ -1,0 +1,1 @@
+export default () => null

--- a/test/e2e/app-dir/interception-dynamic-segment/app/[username]/[id]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/[username]/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'not intercepted'
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/default.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/layout.tsx
@@ -1,0 +1,13 @@
+export default function Layout(props: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <div id="children">{props.children}</div>
+        <div id="modal">{props.modal}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/foo/1">Foo</Link> <Link href="/bar/1">Foo</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
@@ -1,0 +1,23 @@
+import { createNextDescribe } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+createNextDescribe(
+  'interception-dynamic-segment',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should work when interception route is paired with a dynamic segment', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('[href="/foo/1"]').click()
+      await check(() => browser.elementById('modal').text(), /intercepted/)
+      await browser.refresh()
+      await check(() => browser.elementById('modal').text(), '')
+      await check(
+        () => browser.elementById('children').text(),
+        /not intercepted/
+      )
+    })
+  }
+)

--- a/test/e2e/app-dir/interception-dynamic-segment/next.config.js
+++ b/test/e2e/app-dir/interception-dynamic-segment/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What?
Using an interception marker next to a dynamic segment does not behave properly when deployed to Vercel

### Why?
The named route regex that gets created is not accounting for the interception marker, which is causing the non-intercepted route to match the intercepted serverless function.

### How?
This factors in the interception marker when building the named route regex so that the non-intercepted route regex properly matches when loading the non-intercepted page. 

Deployment verified here: https://test-intercept-mu.vercel.app/

Closes NEXT-1786
Fixes #54650
