### PR TITLE
docs: Add Chakra UI setup guide

### DIFF
--- a/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
+++ b/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
@@ -13,6 +13,7 @@ description: Use CSS-in-JS libraries with Next.js
 
 The following libraries are supported in Client Components in the `app` directory (alphabetical):
 
+- [`chakra-ui`](https://chakra-ui.com/getting-started/nextjs-guide)
 - [`kuma-ui`](https://kuma-ui.com)
 - [`@mui/material`](https://mui.com/material-ui/guides/next-js-app-router/)
 - [`pandacss`](https://panda-css.com)

--- a/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
+++ b/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
@@ -13,7 +13,7 @@ description: Use CSS-in-JS libraries with Next.js
 
 The following libraries are supported in Client Components in the `app` directory (alphabetical):
 
-- [`chakra-ui`](https://chakra-ui.com/getting-started/nextjs-guide)
+- [`chakra-ui`](https://chakra-ui.com/getting-started/nextjs-app-guide)
 - [`kuma-ui`](https://kuma-ui.com)
 - [`@mui/material`](https://mui.com/material-ui/guides/next-js-app-router/)
 - [`pandacss`](https://panda-css.com)


### PR DESCRIPTION
This PR adds Chakra UI setup guide to CSS-in-JS libraries list supported in Client Components in the app directory.
If there’s a reason chakraui is missing or it’s not suit here, I will close this PR.