### PR TITLE
add user-level tracing

### DIFF
--- a/packages/next-swc/crates/core/tests/full.rs
+++ b/packages/next-swc/crates/core/tests/full.rs
@@ -81,6 +81,7 @@ fn test(input: &Path, minify: bool) {
                 auto_modularize_imports: None,
                 optimize_barrel_exports: None,
                 optimize_server_react: None,
+                prefer_esm: false,
             };
 
             let unresolved_mark = Mark::new();

--- a/packages/next-swc/crates/napi/src/next_api/project.rs
+++ b/packages/next-swc/crates/napi/src/next_api/project.rs
@@ -217,7 +217,7 @@ pub async fn project_new(
     let guard = if let Some(mut trace) = trace {
         // Trace presets
         match trace.as_str() {
-            "overview" => {
+            "overview" | "1" => {
                 trace = TRACING_NEXT_OVERVIEW_TARGETS.join(",");
             }
             "next" => {

--- a/packages/next-swc/crates/next-api/src/middleware.rs
+++ b/packages/next-swc/crates/next-api/src/middleware.rs
@@ -7,6 +7,7 @@ use next_core::{
     next_server::{get_server_runtime_entries, ServerContextType},
     util::parse_config_from_source,
 };
+use tracing::Instrument;
 use turbo_tasks::{Completion, TryJoinIterExt, Value, Vc};
 use turbopack_binding::{
     turbo::tasks_fs::{File, FileContent},
@@ -167,18 +168,23 @@ impl MiddlewareEndpoint {
 impl Endpoint for MiddlewareEndpoint {
     #[turbo_tasks::function]
     async fn write_to_disk(self: Vc<Self>) -> Result<Vc<WrittenEndpoint>> {
-        let this = self.await?;
-        let output_assets = self.output_assets();
-        this.project
-            .emit_all_output_assets(Vc::cell(output_assets))
-            .await?;
+        let span = tracing::info_span!("middleware endpoint");
+        async move {
+            let this = self.await?;
+            let output_assets = self.output_assets();
+            this.project
+                .emit_all_output_assets(Vc::cell(output_assets))
+                .await?;
 
-        let node_root = this.project.node_root();
-        let server_paths = all_server_paths(output_assets, node_root)
-            .await?
-            .clone_value();
+            let node_root = this.project.node_root();
+            let server_paths = all_server_paths(output_assets, node_root)
+                .await?
+                .clone_value();
 
-        Ok(WrittenEndpoint::Edge { server_paths }.cell())
+            Ok(WrittenEndpoint::Edge { server_paths }.cell())
+        }
+        .instrument(span)
+        .await
     }
 
     #[turbo_tasks::function]

--- a/packages/next-swc/crates/next-api/src/pages.rs
+++ b/packages/next-swc/crates/next-api/src/pages.rs
@@ -28,6 +28,7 @@ use next_core::{
     PageLoaderAsset,
 };
 use serde::{Deserialize, Serialize};
+use tracing::Instrument;
 use turbo_tasks::{
     trace::TraceRawVcs, Completion, TaskInput, TryFlatJoinIterExt, TryJoinIterExt, Value, Vc,
 };
@@ -560,66 +561,71 @@ impl PageEndpoint {
 
     #[turbo_tasks::function]
     async fn client_chunks(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
-        let this = self.await?;
+        async move {
+            let this = self.await?;
 
-        let client_module_context = this.pages_project.client_module_context();
-        let client_module =
-            create_page_loader_entry_module(client_module_context, self.source(), this.pathname);
-
-        let Some(client_module) =
-            Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(client_module).await?
-        else {
-            bail!("expected an ECMAScript module asset");
-        };
-
-        let Some(client_main_module) = *esm_resolve(
-            Vc::upcast(PlainResolveOrigin::new(
+            let client_module_context = this.pages_project.client_module_context();
+            let client_module = create_page_loader_entry_module(
                 client_module_context,
-                this.pages_project
-                    .project()
-                    .project_path()
-                    .join("_".to_string()),
-            )),
-            Request::parse(Value::new(Pattern::Constant(
-                "next/dist/client/next-dev-turbopack.js".to_string(),
-            ))),
-            Value::new(EcmaScriptModulesReferenceSubType::Undefined),
-            IssueSeverity::Error.cell(),
-            None,
-        )
-        .first_module()
-        .await?
-        else {
-            bail!("expected next/dist/client/next-dev-turbopack.js to resolve to a module");
-        };
+                self.source(),
+                this.pathname,
+            );
 
-        let Some(client_main_module) =
-            Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(client_main_module).await?
-        else {
-            bail!("expected an ECMAScript module asset");
-        };
+            let Some(client_module) =
+                Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(client_module).await?
+            else {
+                bail!("expected an ECMAScript module asset");
+            };
 
-        let client_chunking_context = this.pages_project.project().client_chunking_context();
-
-        let mut client_chunks = client_chunking_context
-            .evaluated_chunk_group(
-                client_module.ident(),
-                this.pages_project
-                    .client_runtime_entries()
-                    .with_entry(Vc::upcast(client_main_module))
-                    .with_entry(Vc::upcast(client_module)),
+            let client_main_module = esm_resolve(
+                Vc::upcast(PlainResolveOrigin::new(
+                    client_module_context,
+                    this.pages_project
+                        .project()
+                        .project_path()
+                        .join("_".to_string()),
+                )),
+                Request::parse(Value::new(Pattern::Constant(
+                    "next/dist/client/next-dev-turbopack.js".to_string(),
+                ))),
+                Value::new(EcmaScriptModulesReferenceSubType::Undefined),
+                IssueSeverity::Error.cell(),
+                None,
             )
+            .first_module()
             .await?
-            .clone_value();
+            .context("expected next/dist/client/next-dev-turbopack.js to resolve to a module")?;
 
-        client_chunks.push(Vc::upcast(PageLoaderAsset::new(
-            this.pages_project.project().client_root(),
-            this.pathname,
-            self.client_relative_path(),
-            Vc::cell(client_chunks.clone()),
-        )));
+            let Some(client_main_module) =
+                Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(client_main_module).await?
+            else {
+                bail!("expected an ECMAScript module asset");
+            };
 
-        Ok(Vc::cell(client_chunks))
+            let client_chunking_context = this.pages_project.project().client_chunking_context();
+
+            let mut client_chunks = client_chunking_context
+                .evaluated_chunk_group(
+                    client_module.ident(),
+                    this.pages_project
+                        .client_runtime_entries()
+                        .with_entry(Vc::upcast(client_main_module))
+                        .with_entry(Vc::upcast(client_module)),
+                )
+                .await?
+                .clone_value();
+
+            client_chunks.push(Vc::upcast(PageLoaderAsset::new(
+                this.pages_project.project().client_root(),
+                this.pathname,
+                self.client_relative_path(),
+                Vc::cell(client_chunks.clone()),
+            )));
+
+            Ok(Vc::cell(client_chunks))
+        }
+        .instrument(tracing::info_span!("page client side rendering"))
+        .await
     }
 
     #[turbo_tasks::function]
@@ -635,81 +641,90 @@ impl PageEndpoint {
         runtime_entries: Vc<EvaluatableAssets>,
         edge_runtime_entries: Vc<EvaluatableAssets>,
     ) -> Result<Vc<SsrChunk>> {
-        let this = self.await?;
+        async move {
+            let this = self.await?;
 
-        let ssr_module = module_context.process(self.source(), reference_type.clone());
+            let ssr_module = module_context.process(self.source(), reference_type.clone());
 
-        let config = parse_config_from_source(ssr_module).await?;
-        let is_edge = matches!(config.runtime, NextRuntime::Edge);
+            let config = parse_config_from_source(ssr_module).await?;
+            let is_edge = matches!(config.runtime, NextRuntime::Edge);
 
-        if is_edge {
-            let ssr_module = create_page_ssr_entry_module(
-                this.pathname,
-                reference_type,
-                project_root,
-                Vc::upcast(edge_module_context),
-                self.source(),
-                this.original_name,
-                config.runtime,
-                this.pages_project.project().next_config(),
-            );
+            if is_edge {
+                let ssr_module = create_page_ssr_entry_module(
+                    this.pathname,
+                    reference_type,
+                    project_root,
+                    Vc::upcast(edge_module_context),
+                    self.source(),
+                    this.original_name,
+                    config.runtime,
+                    this.pages_project.project().next_config(),
+                );
 
-            let mut evaluatable_assets = edge_runtime_entries.await?.clone_value();
-            let Some(evaluatable) = Vc::try_resolve_sidecast(ssr_module).await? else {
-                bail!("Entry module must be evaluatable");
-            };
-            evaluatable_assets.push(evaluatable);
+                let mut evaluatable_assets = edge_runtime_entries.await?.clone_value();
+                let Some(evaluatable) = Vc::try_resolve_sidecast(ssr_module).await? else {
+                    bail!("Entry module must be evaluatable");
+                };
+                evaluatable_assets.push(evaluatable);
 
-            let edge_files = edge_chunking_context
-                .evaluated_chunk_group(ssr_module.ident(), Vc::cell(evaluatable_assets.clone()));
+                let edge_files = edge_chunking_context.evaluated_chunk_group(
+                    ssr_module.ident(),
+                    Vc::cell(evaluatable_assets.clone()),
+                );
 
-            let dynamic_import_modules = collect_next_dynamic_imports(ssr_module).await?;
-            let dynamic_import_entries = collect_evaluated_chunk_group(
-                edge_chunking_context,
-                dynamic_import_modules,
-                Vc::cell(evaluatable_assets.clone()),
-            )
-            .await?;
+                let dynamic_import_modules = collect_next_dynamic_imports(ssr_module).await?;
+                let dynamic_import_entries = collect_evaluated_chunk_group(
+                    edge_chunking_context,
+                    dynamic_import_modules,
+                    Vc::cell(evaluatable_assets.clone()),
+                )
+                .await?;
 
-            Ok(SsrChunk::Edge {
-                files: edge_files,
-                dynamic_import_entries,
+                Ok(SsrChunk::Edge {
+                    files: edge_files,
+                    dynamic_import_entries,
+                }
+                .cell())
+            } else {
+                let ssr_module = create_page_ssr_entry_module(
+                    this.pathname,
+                    reference_type,
+                    project_root,
+                    Vc::upcast(module_context),
+                    self.source(),
+                    this.original_name,
+                    config.runtime,
+                    this.pages_project.project().next_config(),
+                );
+
+                let asset_path = get_asset_path_from_pathname(&this.pathname.await?, ".js");
+
+                let ssr_entry_chunk_path_string = format!("pages{asset_path}");
+                let ssr_entry_chunk_path = node_path.join(ssr_entry_chunk_path_string);
+                let ssr_entry_chunk = chunking_context.entry_chunk_group(
+                    ssr_entry_chunk_path,
+                    ssr_module,
+                    runtime_entries,
+                );
+
+                let availability_info = Value::new(AvailabilityInfo::Root);
+                let dynamic_import_modules = collect_next_dynamic_imports(ssr_module).await?;
+                let dynamic_import_entries = collect_chunk_group(
+                    chunking_context,
+                    dynamic_import_modules,
+                    availability_info,
+                )
+                .await?;
+
+                Ok(SsrChunk::NodeJs {
+                    entry: ssr_entry_chunk,
+                    dynamic_import_entries,
+                }
+                .cell())
             }
-            .cell())
-        } else {
-            let ssr_module = create_page_ssr_entry_module(
-                this.pathname,
-                reference_type,
-                project_root,
-                Vc::upcast(module_context),
-                self.source(),
-                this.original_name,
-                config.runtime,
-                this.pages_project.project().next_config(),
-            );
-
-            let asset_path = get_asset_path_from_pathname(&this.pathname.await?, ".js");
-
-            let ssr_entry_chunk_path_string = format!("pages{asset_path}");
-            let ssr_entry_chunk_path = node_path.join(ssr_entry_chunk_path_string);
-            let ssr_entry_chunk = chunking_context.entry_chunk_group(
-                ssr_entry_chunk_path,
-                ssr_module,
-                runtime_entries,
-            );
-
-            let availability_info = Value::new(AvailabilityInfo::Root);
-            let dynamic_import_modules = collect_next_dynamic_imports(ssr_module).await?;
-            let dynamic_import_entries =
-                collect_chunk_group(chunking_context, dynamic_import_modules, availability_info)
-                    .await?;
-
-            Ok(SsrChunk::NodeJs {
-                entry: ssr_entry_chunk,
-                dynamic_import_entries,
-            }
-            .cell())
         }
+        .instrument(tracing::info_span!("page server side rendering"))
+        .await
     }
 
     #[turbo_tasks::function]
@@ -1055,36 +1070,56 @@ impl PageEndpoint {
 impl Endpoint for PageEndpoint {
     #[turbo_tasks::function]
     async fn write_to_disk(self: Vc<Self>) -> Result<Vc<WrittenEndpoint>> {
-        let output = self.output();
-        // Must use self.output_assets() instead of output.output_assets() to make it a
-        // single operation
-        let output_assets = self.output_assets();
-
         let this = self.await?;
-
-        this.pages_project
-            .project()
-            .emit_all_output_assets(Vc::cell(output_assets))
-            .await?;
-
-        let node_root = this.pages_project.project().node_root();
-        let server_paths = all_server_paths(output_assets, node_root)
-            .await?
-            .clone_value();
-
-        let node_root = &node_root.await?;
-        let written_endpoint = match *output.await? {
-            PageEndpointOutput::NodeJs { entry_chunk, .. } => WrittenEndpoint::NodeJs {
-                server_entry_path: node_root
-                    .get_path_to(&*entry_chunk.ident().path().await?)
-                    .context("ssr chunk entry path must be inside the node root")?
-                    .to_string(),
-                server_paths,
-            },
-            PageEndpointOutput::Edge { .. } => WrittenEndpoint::Edge { server_paths },
+        let span = {
+            let original_name = this.original_name.await?;
+            match this.ty {
+                PageEndpointType::Html => {
+                    tracing::info_span!("page endpoint HTML", name = *original_name)
+                }
+                PageEndpointType::Data => {
+                    tracing::info_span!("page endpoint data", name = *original_name)
+                }
+                PageEndpointType::Api => {
+                    tracing::info_span!("page endpoint API", name = *original_name)
+                }
+                PageEndpointType::SsrOnly => {
+                    tracing::info_span!("page endpoint SSR", name = *original_name)
+                }
+            }
         };
+        async move {
+            let output = self.output();
+            // Must use self.output_assets() instead of output.output_assets() to make it a
+            // single operation
+            let output_assets = self.output_assets();
 
-        Ok(written_endpoint.cell())
+            this.pages_project
+                .project()
+                .emit_all_output_assets(Vc::cell(output_assets))
+                .await?;
+
+            let node_root = this.pages_project.project().node_root();
+            let server_paths = all_server_paths(output_assets, node_root)
+                .await?
+                .clone_value();
+
+            let node_root = &node_root.await?;
+            let written_endpoint = match *output.await? {
+                PageEndpointOutput::NodeJs { entry_chunk, .. } => WrittenEndpoint::NodeJs {
+                    server_entry_path: node_root
+                        .get_path_to(&*entry_chunk.ident().path().await?)
+                        .context("ssr chunk entry path must be inside the node root")?
+                        .to_string(),
+                    server_paths,
+                },
+                PageEndpointOutput::Edge { .. } => WrittenEndpoint::Edge { server_paths },
+            };
+
+            Ok(written_endpoint.cell())
+        }
+        .instrument(span)
+        .await
     }
 
     #[turbo_tasks::function]

--- a/packages/next-swc/crates/next-core/src/app_structure.rs
+++ b/packages/next-swc/crates/next-core/src/app_structure.rs
@@ -284,7 +284,7 @@ async fn get_directory_tree(
 ) -> Result<Vc<DirectoryTree>> {
     let span = {
         let dir = dir.to_string().await?;
-        tracing::info_span!("read app directory tree", name = ?dir)
+        tracing::info_span!("read app directory tree", name = *dir)
     };
     async move {
         let DirectoryContent::Entries(entries) = &*dir.read_dir().await? else {

--- a/packages/next-swc/crates/next-core/src/tracing_presets.rs
+++ b/packages/next-swc/crates/next-core/src/tracing_presets.rs
@@ -3,14 +3,32 @@ use turbopack_binding::turbopack::trace_utils::tracing_presets::{
     TRACING_OVERVIEW_TARGETS, TRACING_TURBOPACK_TARGETS, TRACING_TURBO_TASKS_TARGETS,
 };
 
-pub static TRACING_NEXT_TARGETS: Lazy<Vec<&str>> = Lazy::new(|| {
+pub static TRACING_NEXT_OVERVIEW_TARGETS: Lazy<Vec<&str>> = Lazy::new(|| {
     [
         &TRACING_OVERVIEW_TARGETS[..],
         &[
+            "next_swc_napi=info",
+            "next_swc=info",
+            "next_api=info",
+            "next_dev=info",
+            "next_core=info",
+            "next_font=info",
+            "turbopack_node=info",
+        ],
+    ]
+    .concat()
+});
+
+pub static TRACING_NEXT_TARGETS: Lazy<Vec<&str>> = Lazy::new(|| {
+    [
+        &TRACING_NEXT_OVERVIEW_TARGETS[..],
+        &[
+            "next_swc_napi=trace",
+            "next_swc=trace",
+            "next_api=trace",
             "next_dev=trace",
             "next_core=trace",
             "next_font=trace",
-            "turbopack_node=trace",
         ],
     ]
     .concat()
@@ -19,7 +37,7 @@ pub static TRACING_NEXT_TURBOPACK_TARGETS: Lazy<Vec<&str>> =
     Lazy::new(|| [&TRACING_NEXT_TARGETS[..], &TRACING_TURBOPACK_TARGETS[..]].concat());
 pub static TRACING_NEXT_TURBO_TASKS_TARGETS: Lazy<Vec<&str>> = Lazy::new(|| {
     [
-        &TRACING_TURBOPACK_TARGETS[..],
+        &TRACING_NEXT_TURBOPACK_TARGETS[..],
         &TRACING_TURBO_TASKS_TARGETS[..],
     ]
     .concat()


### PR DESCRIPTION
### What?

add a few user-focused info-level spans to allow high-level tracing on a normal build.

`NEXT_TURBOPACK_TRACING=1` can be used to generate a `.next/trace.log` file

### Why?

Gain insight into build performance and module cost 



Closes PACK-2083