### PR TITLE
update turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "serde",
  "smallvec",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "serde",
@@ -7678,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7710,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7737,7 +7737,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7751,7 +7751,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7799,7 +7799,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "base16",
  "hex",
@@ -7811,7 +7811,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7825,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7835,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "mimalloc",
 ]
@@ -7843,7 +7843,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7868,7 +7868,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7879,6 +7879,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-env",
@@ -7899,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7940,7 +7941,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7950,6 +7951,7 @@ dependencies = [
  "serde_qs",
  "sourcemap",
  "swc_core",
+ "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -7963,7 +7965,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7981,7 +7983,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8011,7 +8013,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8037,7 +8039,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8061,7 +8063,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8098,7 +8100,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8132,7 +8134,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "serde",
  "serde_json",
@@ -8143,7 +8145,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8166,7 +8168,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8183,7 +8185,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8199,7 +8201,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8219,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "serde",
@@ -8234,7 +8236,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8249,7 +8251,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8284,7 +8286,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "serde",
@@ -8300,7 +8302,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8311,7 +8313,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8326,7 +8328,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231204.2#51a9522cd235fabdae619fd92d5d912baacd1ea8"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231205.2#8cb1c34181948ea6e85584d05eb9f69e86e11859"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ swc_core = { version = "0.86.81", features = [
 testing = { version = "0.35.11" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231204.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231205.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231204.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231205.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231204.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231205.2" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -195,7 +195,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.24.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231205.2",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.24.4
         version: 0.24.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231205.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231205.2(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -24647,9 +24647,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231204.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231205.2(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231205.2}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231205.2'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
* https://github.com/vercel/turbo/pull/6588 <!-- Leah - ci: remove daily turbopack next.js integration test workflow  -->
* https://github.com/vercel/turbo/pull/6666 <!-- Will Binns-Smith - Turbopack css: treat `composes` and `@import` as urls when resolving  -->
* https://github.com/vercel/turbo/pull/6701 <!-- Tobias Koppers - add user level tracing  -->
* https://github.com/vercel/turbo/pull/6616 <!-- Leah - feat(turbopack): support "loading" WebAssembly injected as global varables in edge runtime  -->

Closes PACK-2086