### PR TITLE
Remove path normalization logic when uploading .next/trace traces

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1720,7 +1720,7 @@ export default async function getBaseWebpackConfig(
           exportRuntime: true,
           appDirEnabled: hasAppDir,
         }),
-      new ProfilingPlugin({ runWebpackSpan }),
+      new ProfilingPlugin({ runWebpackSpan, rootDir: dir }),
       config.optimizeFonts &&
         !dev &&
         isNodeServer &&

--- a/packages/next/src/trace/trace-uploader.ts
+++ b/packages/next/src/trace/trace-uploader.ts
@@ -110,17 +110,6 @@ interface TraceMetadata {
         shouldUploadFullTrace ||
         EVENT_FILTER.has(event.name)
       ) {
-        if (
-          typeof event.tags.trigger === 'string' &&
-          path.isAbsolute(event.tags.trigger)
-        ) {
-          event.tags.trigger =
-            '[project]/' +
-            path
-              .relative(projectDir, event.tags.trigger)
-              .replaceAll(path.sep, '/')
-        }
-
         let trace = traces.get(event.traceId)
         if (trace === undefined) {
           trace = []


### PR DESCRIPTION
When uploading traces from `.next/trace`, target paths that trigger compilations were being normalized to paths like `[project]/../../../../../middleware`. This PR removes the normalization logic so that the triggers appear as `/middleware` which is easier to understand.