### PR TITLE
fix hmr in multi-zone handling

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -582,8 +582,14 @@ export async function initialize(opts: {
         // console.error(_err);
       })
 
-      if (opts.dev && developmentBundler) {
-        if (req.url?.includes(`/_next/webpack-hmr`)) {
+      if (opts.dev && developmentBundler && req.url) {
+        const isHMRRequest = req.url.includes('/_next/webpack-hmr')
+        // only handle HMR requests if the basePath in the request
+        // matches the basePath for the handler responding to the request
+        const isRequestForCurrentBasepath =
+          !config.basePath || pathHasPrefix(req.url, config.basePath)
+
+        if (isHMRRequest && isRequestForCurrentBasepath) {
           return developmentBundler.hotReloader.onHMR(req, socket, head)
         }
       }

--- a/test/e2e/multi-zone/app/apps/first/pages/index.tsx
+++ b/test/e2e/multi-zone/app/apps/first/pages/index.tsx
@@ -1,3 +1,11 @@
 export default function Page() {
-  return <p>hello from first app</p>
+  // this variable is edited by the test to verify HMR
+  const editedContent = ''
+  return (
+    <>
+      <p>hello from first app</p>
+      <div>{editedContent}</div>
+      <div id="now">{Date.now()}</div>
+    </>
+  )
 }

--- a/test/e2e/multi-zone/app/apps/second/pages/index.tsx
+++ b/test/e2e/multi-zone/app/apps/second/pages/index.tsx
@@ -1,3 +1,11 @@
 export default function Page() {
-  return <p>hello from second app</p>
+  // this variable is edited by the test to verify HMR
+  const editedContent = ''
+  return (
+    <>
+      <p>hello from second app</p>
+      <div>{editedContent}</div>
+      <div id="now">{Date.now()}</div>
+    </>
+  )
 }


### PR DESCRIPTION
### What?
When running a [multi-zone](https://github.com/vercel/next.js/tree/canary/examples/with-zones) app in dev, app pages would infinitely reload

### Why?
The HMR upgrade request would fail and get caught into a retry loop. In the multi-zone case, they fail because the upgrade request would be sent again for a request that had already been upgraded. This resulted in a "server.handleUpgrade() was called more than once with the same socket" error, causing the upgrade request to fail. 

Every time a retry occurred, the page would trigger a full refresh since certain HMR errors cause the browser to reload.

### How?
This ensures the upgrade handler only responds to requests that match the configured basePath. 

Closes NEXT-1797
Fixes #59161
Fixes #56615
Fixes #54454
