### PR TITLE
Update tests for Turbopack

### DIFF
--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -69,6 +69,7 @@ const supportedTurbopackNextConfigOptions = [
   'experimental.useLightningcss',
   'experimental.windowHistorySupport',
   'experimental.instrumentationHook',
+  'experimental.externalDir',
 
   // Experimental options that don't affect compilation
   'experimental.ppr',
@@ -131,7 +132,6 @@ const supportedTurbopackNextConfigOptions = [
   // 'experimental.craCompat',
   // 'experimental.disablePostcssPresetEnv',
   // 'experimental.esmExternals',
-  // 'experimental.externalDir',
   // This is used to force swc-loader to run regardless of finding Babel.
   // 'experimental.forceSwcTransforms',
   // 'experimental.fullySpecified',

--- a/test/e2e/app-dir/with-babel/with-babel.test.ts
+++ b/test/e2e/app-dir/with-babel/with-babel.test.ts
@@ -1,23 +1,26 @@
 import { createNextDescribe } from 'e2e-utils'
 
-createNextDescribe(
-  'with babel',
-  {
-    files: __dirname,
-    skipDeployment: true,
-  },
-  ({ next, isNextStart }) => {
-    it('should support babel in app dir', async () => {
-      const $ = await next.render$('/')
-      expect($('h1').text()).toBe('hello')
-    })
-
-    if (isNextStart) {
-      it('should contain og package files in middleware', async () => {
-        const middleware = await next.readFile('.next/server/middleware.js')
-        // @vercel/og default font should be bundled
-        expect(middleware).not.toContain('noto-sans-v27-latin-regular.ttf')
+// Tests Babel, not needed for Turbopack
+;(process.env.TURBOPACK ? describe.skip : describe)('with babel', () => {
+  createNextDescribe(
+    'with babel',
+    {
+      files: __dirname,
+      skipDeployment: true,
+    },
+    ({ next, isNextStart }) => {
+      it('should support babel in app dir', async () => {
+        const $ = await next.render$('/')
+        expect($('h1').text()).toBe('hello')
       })
+
+      if (isNextStart) {
+        it('should contain og package files in middleware', async () => {
+          const middleware = await next.readFile('.next/server/middleware.js')
+          // @vercel/og default font should be bundled
+          expect(middleware).not.toContain('noto-sans-v27-latin-regular.ttf')
+        })
+      }
     }
-  }
-)
+  )
+})

--- a/test/e2e/swc-warnings/index.test.ts
+++ b/test/e2e/swc-warnings/index.test.ts
@@ -2,35 +2,39 @@ import { createNext } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { renderViaHTTP } from 'next-test-utils'
 
-describe('swc warnings by default', () => {
-  let next: NextInstance
+// Tests Babel, not needed for Turbopack
+;(process.env.TURBOPACK ? describe.skip : describe)(
+  'swc warnings by default',
+  () => {
+    let next: NextInstance
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
+    beforeAll(async () => {
+      next = await createNext({
+        files: {
+          'pages/index.js': `
           export default function Page() { 
             return <p>hello world</p>
           } 
         `,
-        '.babelrc': `
+          '.babelrc': `
           {
             "presets": ["next/babel"]
           }
         `,
-      },
-      dependencies: {},
+        },
+        dependencies: {},
+      })
     })
-  })
-  afterAll(() => next.destroy())
+    afterAll(() => next.destroy())
 
-  it('should have warning', async () => {
-    await renderViaHTTP(next.url, '/')
-    expect(next.cliOutput).toContain(
-      'Disabled SWC as replacement for Babel because of custom Babel configuration'
-    )
-  })
-})
+    it('should have warning', async () => {
+      await renderViaHTTP(next.url, '/')
+      expect(next.cliOutput).toContain(
+        'Disabled SWC as replacement for Babel because of custom Babel configuration'
+      )
+    })
+  }
+)
 
 describe('can force swc', () => {
   let next: NextInstance

--- a/test/integration/config-resolve-alias/test/index.test.js
+++ b/test/integration/config-resolve-alias/test/index.test.js
@@ -3,14 +3,21 @@
 import { join } from 'path'
 import { runNextCommand } from 'next-test-utils'
 
-describe('Invalid resolve alias', () => {
-  it('should show relevant error when webpack resolve alias is wrong', async () => {
-    const { stderr } = await runNextCommand(['build', join(__dirname, '..')], {
-      stderr: true,
-    })
+// Skip in Turbopack as it does not support `config.resolve.alias` from webpack.
+;(process.env.TURBOPACK ? describe.skip : describe)(
+  'Invalid resolve alias',
+  () => {
+    it('should show relevant error when webpack resolve alias is wrong', async () => {
+      const { stderr } = await runNextCommand(
+        ['build', join(__dirname, '..')],
+        {
+          stderr: true,
+        }
+      )
 
-    expect(stderr).toMatch(
-      'webpack config.resolve.alias was incorrectly overridden. https://'
-    )
-  })
-})
+      expect(stderr).toMatch(
+        'webpack config.resolve.alias was incorrectly overridden. https://'
+      )
+    })
+  }
+)

--- a/test/integration/undefined-webpack-config/test/index.test.js
+++ b/test/integration/undefined-webpack-config/test/index.test.js
@@ -7,29 +7,36 @@ const appDir = join(__dirname, '../')
 const expectedErr =
   /Webpack config is undefined. You may have forgot to return properly from within the "webpack" method of your next.config.js/
 
-describe('undefined webpack config error', () => {
-  ;(process.env.TURBOPACK ? describe.skip : describe)('production mode', () => {
-    it.skip('should show in production mode', async () => {
-      const result = await nextBuild(appDir, [], {
-        stdout: true,
-        stderr: true,
+// Tests webpack, not needed for Turbopack
+;(process.env.TURBOPACK ? describe.skip : describe)(
+  'undefined webpack config error',
+  () => {
+    ;(process.env.TURBOPACK ? describe.skip : describe)(
+      'production mode',
+      () => {
+        it.skip('should show in production mode', async () => {
+          const result = await nextBuild(appDir, [], {
+            stdout: true,
+            stderr: true,
+          })
+          expect(result.stderr || '' + result.stdout || '').toMatch(expectedErr)
+        })
+      }
+    )
+
+    it('should show in dev mode', async () => {
+      let output = ''
+
+      await launchApp(appDir, await findPort(), {
+        onStderr(msg) {
+          output += msg || ''
+        },
+        ontStdout(msg) {
+          output += msg || ''
+        },
       })
-      expect(result.stderr || '' + result.stdout || '').toMatch(expectedErr)
+
+      expect(output).toMatch(expectedErr)
     })
-  })
-
-  it('should show in dev mode', async () => {
-    let output = ''
-
-    await launchApp(appDir, await findPort(), {
-      onStderr(msg) {
-        output += msg || ''
-      },
-      ontStdout(msg) {
-        output += msg || ''
-      },
-    })
-
-    expect(output).toMatch(expectedErr)
-  })
-})
+  }
+)


### PR DESCRIPTION
## What?

- Add support for `experimental.externalDir` -- Was already supported, just makes Turbopack not fail on that config option
- Skipped `with-babel` test because it tests Babel
- Skipped `swc-warnings` test because it tests Babel
- Skipped `config-resolve-alias` as it tests webpack config
- Skipped `undefined-webpack-config` as it tests webpack config

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-1817