### PR TITLE
Add text-wrap: balance to CNA template for card descriptions

### DIFF
--- a/examples/app-dir-mdx/app/page.module.css
+++ b/examples/app-dir-mdx/app/page.module.css
@@ -70,6 +70,7 @@
   font-size: 0.9rem;
   line-height: 1.5;
   max-width: 34ch;
+  text-wrap: pretty;
 }
 
 .center {

--- a/examples/app-dir-mdx/app/page.module.css
+++ b/examples/app-dir-mdx/app/page.module.css
@@ -70,7 +70,7 @@
   font-size: 0.9rem;
   line-height: 1.5;
   max-width: 34ch;
-  text-wrap: pretty;
+  text-wrap: balance;
 }
 
 .center {

--- a/examples/with-storybook/app/page.module.css
+++ b/examples/with-storybook/app/page.module.css
@@ -70,7 +70,7 @@
   font-size: 0.9rem;
   line-height: 1.5;
   max-width: 30ch;
-  text-wrap: pretty;
+  text-wrap: balance;
 }
 
 .center {

--- a/examples/with-storybook/app/page.module.css
+++ b/examples/with-storybook/app/page.module.css
@@ -70,6 +70,7 @@
   font-size: 0.9rem;
   line-height: 1.5;
   max-width: 30ch;
+  text-wrap: pretty;
 }
 
 .center {

--- a/packages/create-next-app/templates/app-tw/js/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/js/app/globals.css
@@ -27,7 +27,7 @@ body {
 }
 
 @layer utilities {
-  .text-pretty {
-    text-wrap: pretty;
+  .text-balance {
+    text-wrap: balance;
   }
 }

--- a/packages/create-next-app/templates/app-tw/js/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/js/app/globals.css
@@ -25,3 +25,9 @@ body {
     )
     rgb(var(--background-start-rgb));
 }
+
+@layer utilities {
+  .text-pretty {
+    text-wrap: pretty;
+  }
+}

--- a/packages/create-next-app/templates/app-tw/js/app/page.js
+++ b/packages/create-next-app/templates/app-tw/js/app/page.js
@@ -103,7 +103,7 @@ export default function Home() {
               -&gt;
             </span>
           </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
+          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-pretty`}>
             Instantly deploy your Next.js site to a shareable URL with Vercel.
           </p>
         </a>

--- a/packages/create-next-app/templates/app-tw/js/app/page.js
+++ b/packages/create-next-app/templates/app-tw/js/app/page.js
@@ -103,7 +103,7 @@ export default function Home() {
               -&gt;
             </span>
           </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-pretty`}>
+          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-balance`}>
             Instantly deploy your Next.js site to a shareable URL with Vercel.
           </p>
         </a>

--- a/packages/create-next-app/templates/app-tw/ts/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/ts/app/globals.css
@@ -27,7 +27,7 @@ body {
 }
 
 @layer utilities {
-  .text-pretty {
-    text-wrap: pretty;
+  .text-balance {
+    text-wrap: balance;
   }
 }

--- a/packages/create-next-app/templates/app-tw/ts/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/ts/app/globals.css
@@ -25,3 +25,9 @@ body {
     )
     rgb(var(--background-start-rgb));
 }
+
+@layer utilities {
+  .text-pretty {
+    text-wrap: pretty;
+  }
+}

--- a/packages/create-next-app/templates/app-tw/ts/app/page.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/page.tsx
@@ -103,7 +103,7 @@ export default function Home() {
               -&gt;
             </span>
           </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
+          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-pretty`}>
             Instantly deploy your Next.js site to a shareable URL with Vercel.
           </p>
         </a>

--- a/packages/create-next-app/templates/app-tw/ts/app/page.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/page.tsx
@@ -103,7 +103,7 @@ export default function Home() {
               -&gt;
             </span>
           </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-pretty`}>
+          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-balance`}>
             Instantly deploy your Next.js site to a shareable URL with Vercel.
           </p>
         </a>

--- a/packages/create-next-app/templates/app/js/app/page.module.css
+++ b/packages/create-next-app/templates/app/js/app/page.module.css
@@ -70,7 +70,7 @@
   font-size: 0.9rem;
   line-height: 1.5;
   max-width: 30ch;
-  text-wrap: pretty;
+  text-wrap: balance;
 }
 
 .center {

--- a/packages/create-next-app/templates/app/js/app/page.module.css
+++ b/packages/create-next-app/templates/app/js/app/page.module.css
@@ -70,6 +70,7 @@
   font-size: 0.9rem;
   line-height: 1.5;
   max-width: 30ch;
+  text-wrap: pretty;
 }
 
 .center {

--- a/packages/create-next-app/templates/app/ts/app/page.module.css
+++ b/packages/create-next-app/templates/app/ts/app/page.module.css
@@ -70,7 +70,7 @@
   font-size: 0.9rem;
   line-height: 1.5;
   max-width: 30ch;
-  text-wrap: pretty;
+  text-wrap: balance;
 }
 
 .center {

--- a/packages/create-next-app/templates/app/ts/app/page.module.css
+++ b/packages/create-next-app/templates/app/ts/app/page.module.css
@@ -70,6 +70,7 @@
   font-size: 0.9rem;
   line-height: 1.5;
   max-width: 30ch;
+  text-wrap: pretty;
 }
 
 .center {

--- a/packages/create-next-app/templates/default-tw/js/pages/index.js
+++ b/packages/create-next-app/templates/default-tw/js/pages/index.js
@@ -108,7 +108,7 @@ export default function Home() {
               -&gt;
             </span>
           </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
+          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-pretty`}>
             Instantly deploy your Next.js site to a shareable URL with Vercel.
           </p>
         </a>

--- a/packages/create-next-app/templates/default-tw/js/pages/index.js
+++ b/packages/create-next-app/templates/default-tw/js/pages/index.js
@@ -108,7 +108,7 @@ export default function Home() {
               -&gt;
             </span>
           </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-pretty`}>
+          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-balance`}>
             Instantly deploy your Next.js site to a shareable URL with Vercel.
           </p>
         </a>

--- a/packages/create-next-app/templates/default-tw/js/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/js/styles/globals.css
@@ -27,7 +27,7 @@ body {
 }
 
 @layer utilities {
-  .text-pretty {
-    text-wrap: pretty;
+  .text-balance {
+    text-wrap: balance;
   }
 }

--- a/packages/create-next-app/templates/default-tw/js/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/js/styles/globals.css
@@ -25,3 +25,9 @@ body {
     )
     rgb(var(--background-start-rgb));
 }
+
+@layer utilities {
+  .text-pretty {
+    text-wrap: pretty;
+  }
+}

--- a/packages/create-next-app/templates/default-tw/ts/pages/index.tsx
+++ b/packages/create-next-app/templates/default-tw/ts/pages/index.tsx
@@ -108,7 +108,7 @@ export default function Home() {
               -&gt;
             </span>
           </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
+          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-pretty`}>
             Instantly deploy your Next.js site to a shareable URL with Vercel.
           </p>
         </a>

--- a/packages/create-next-app/templates/default-tw/ts/pages/index.tsx
+++ b/packages/create-next-app/templates/default-tw/ts/pages/index.tsx
@@ -108,7 +108,7 @@ export default function Home() {
               -&gt;
             </span>
           </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-pretty`}>
+          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-balance`}>
             Instantly deploy your Next.js site to a shareable URL with Vercel.
           </p>
         </a>

--- a/packages/create-next-app/templates/default-tw/ts/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/ts/styles/globals.css
@@ -27,7 +27,7 @@ body {
 }
 
 @layer utilities {
-  .text-pretty {
-    text-wrap: pretty;
+  .text-balance {
+    text-wrap: balance;
   }
 }

--- a/packages/create-next-app/templates/default-tw/ts/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/ts/styles/globals.css
@@ -25,3 +25,9 @@ body {
     )
     rgb(var(--background-start-rgb));
 }
+
+@layer utilities {
+  .text-pretty {
+    text-wrap: pretty;
+  }
+}


### PR DESCRIPTION
### What?
This prevents the descriptions from having orphans at different viewport widths.

### Why?

| Default | Pretty | Balance |
|--------|-------| --- |
|  ![image](https://github.com/vercel/next.js/assets/16027268/66c8eac4-b995-4c30-9bdc-fd44a4a7fdda)     |  ![image](https://github.com/vercel/next.js/assets/16027268/07a2e45a-728b-438f-a4e5-98f7c1c5c33a)   | ![image](https://github.com/vercel/next.js/assets/16027268/153fe94a-2b10-4e39-bb19-b1ca702bcea8) |
