### PR TITLE
transpilePackages should override default settings for external packages

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -116,6 +116,9 @@ pub async fn get_server_resolve_options_context(
     )
     .await?;
 
+    let transpile_packages = next_config.transpile_packages().await?;
+    external_packages.retain(|item| !transpile_packages.contains(item));
+
     // Add the config's own list of external packages.
     external_packages.extend(
         (*next_config.server_component_externals().await?)

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -729,7 +729,10 @@ export default async function getBaseWebpackConfig(
 
   // The `serverComponentsExternalPackages` should not conflict with
   // the `transpilePackages`.
-  if (config.experimental.serverComponentsExternalPackages) {
+  if (
+    config.experimental.serverComponentsExternalPackages &&
+    config.transpilePackages
+  ) {
     const externalPackageConflicts = config.transpilePackages.filter((pkg) =>
       config.experimental.serverComponentsExternalPackages?.includes(pkg)
     )
@@ -745,7 +748,7 @@ export default async function getBaseWebpackConfig(
   // For original request, such as `package name`
   const optOutBundlingPackages = EXTERNAL_PACKAGES.concat(
     ...(config.experimental.serverComponentsExternalPackages || [])
-  ).filter((pkg) => !config.transpilePackages.includes(pkg))
+  ).filter((pkg) => !config.transpilePackages?.includes(pkg))
   // For resolved request, such as `absolute path/package name/foo/bar.js`
   const optOutBundlingPackageRegex = new RegExp(
     `[/\\\\]node_modules[/\\\\](${optOutBundlingPackages

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -727,6 +727,21 @@ export default async function getBaseWebpackConfig(
 
   const crossOrigin = config.crossOrigin
 
+  // The `serverComponentsExternalPackages` should not conflict with
+  // the `transpilePackages`.
+  if (config.experimental.serverComponentsExternalPackages) {
+    const externalPackageConflicts = config.transpilePackages.filter((pkg) =>
+      config.experimental.serverComponentsExternalPackages?.includes(pkg)
+    )
+    if (externalPackageConflicts.length > 0) {
+      throw new Error(
+        `The packages specified in the 'transpilePackages' conflict with the 'serverComponentsExternalPackages': ${externalPackageConflicts.join(
+          ', '
+        )}`
+      )
+    }
+  }
+
   // For original request, such as `package name`
   const optOutBundlingPackages = EXTERNAL_PACKAGES.concat(
     ...(config.experimental.serverComponentsExternalPackages || [])

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -730,7 +730,7 @@ export default async function getBaseWebpackConfig(
   // For original request, such as `package name`
   const optOutBundlingPackages = EXTERNAL_PACKAGES.concat(
     ...(config.experimental.serverComponentsExternalPackages || [])
-  )
+  ).filter((pkg) => !config.transpilePackages.includes(pkg))
   // For resolved request, such as `absolute path/package name/foo/bar.js`
   const optOutBundlingPackageRegex = new RegExp(
     `[/\\\\]node_modules[/\\\\](${optOutBundlingPackages

--- a/test/production/transpile-packages/app/layout.tsx
+++ b/test/production/transpile-packages/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/transpile-packages/app/page.tsx
+++ b/test/production/transpile-packages/app/page.tsx
@@ -1,0 +1,15 @@
+import { GetObjectCommand } from '@aws-sdk/client-s3'
+import { isObject } from 'lodash'
+
+export default function Page() {
+  const command = new GetObjectCommand({
+    Bucket: 'bucket',
+    Key: 'key1',
+  })
+  return (
+    <div>
+      <div id="key">Key: {command.input.Key}</div>
+      <div id="isObject">isObject: {String(isObject(command))}</div>
+    </div>
+  )
+}

--- a/test/production/transpile-packages/next.config.js
+++ b/test/production/transpile-packages/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  transpilePackages: ['@aws-sdk/client-s3'],
+}
+
+module.exports = nextConfig

--- a/test/production/transpile-packages/transpile-packages.test.ts
+++ b/test/production/transpile-packages/transpile-packages.test.ts
@@ -1,0 +1,29 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'app fetch build cache',
+  {
+    files: __dirname,
+    dependencies: {
+      '@aws-sdk/client-s3': 'latest',
+      lodash: 'latest',
+    },
+  },
+  ({ next }) => {
+    it('should render page with dependencies', async () => {
+      const $ = await next.render$('/')
+      expect($('#key').text()).toBe('Key: key1')
+      expect($('#isObject').text()).toBe('isObject: true')
+    })
+
+    it('should treat lodash as an external package', async () => {
+      const output = await next.readFile('.next/server/app/page.js')
+      expect(output).toContain('require("lodash')
+    })
+
+    it('should bundle @aws-sdk/client-s3 as a transpiled package', async () => {
+      const output = await next.readFile('.next/server/app/page.js')
+      expect(output).not.toContain('require("@aws-sdk/client-s3")')
+    })
+  }
+)


### PR DESCRIPTION
See related https://github.com/vercel/next.js/issues/51969. It should no longer apply.