### PR TITLE
Update `swc_core` to `v0.86.98` and turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "serde",
  "smallvec",
@@ -3236,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b4169048f6d77763229901de98307369bd96e901ec496eb095bf9c82943608"
+checksum = "4559444eabc75096e7655a1a0bbd4a5b7f00e22e58fa860d2273e1ea48999f08"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "serde",
@@ -5652,9 +5652,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.89.0"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98db15f396dabd0f53988952ad682b957b5d310ebb0a0106f8d93f20303c378d"
+checksum = "ddb45c257489ad9439cd5c9ecc4b17b1b43dde147ec0c857393b10226948364b"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -5670,9 +5670,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.66.0"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d4222bde4e3ee9d454b8e8e7585ddd9ff8f5a7c98e960b434b9c9822e625e2"
+checksum = "65e068120264b52af6da6766b840029394955f8eaf2b2ae7c535a35e4b5934aa"
 dependencies = [
  "easy-error",
  "lightningcss",
@@ -6826,9 +6826,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.65.0"
+version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e658f35b695f0dc8152088a03c7678dcf6702bf7a0bacc4b7727499f7d5db454"
+checksum = "82d6da43f8db4ca99b277d7d830d79001bc83e559ee6d295c938a5c03b57fae4"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -6986,9 +6986,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faede0a001c4f29cd912954334b9940b57f89bc844f46aafb8d6c304f6acc211"
+checksum = "693c62bf6468383f780551dbd43f9c7ca7abaa7eac2a9eb0a5f191bfb428a360"
 dependencies = [
  "once_cell",
  "regex",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7711,7 +7711,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7723,7 +7723,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7738,7 +7738,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7752,7 +7752,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7769,7 +7769,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7800,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "base16",
  "hex",
@@ -7812,7 +7812,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7826,7 +7826,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7836,7 +7836,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "mimalloc",
 ]
@@ -7844,7 +7844,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7869,7 +7869,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7901,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7942,7 +7942,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7966,7 +7966,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7984,7 +7984,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8014,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8041,7 +8041,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8065,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8102,7 +8102,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8136,7 +8136,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "serde",
  "serde_json",
@@ -8147,7 +8147,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8170,7 +8170,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8187,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8203,7 +8203,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8223,7 +8223,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "serde",
@@ -8238,7 +8238,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8253,7 +8253,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8288,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "serde",
@@ -8304,7 +8304,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8315,7 +8315,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8330,7 +8330,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231207.2#d168d850a3eda771477886171f2014a0c167aab6"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-231208.1#943f856354fcd45af869b0dab56ec51144eb81cc"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.60.80"
+version = "0.60.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad347930aa10cdc234781028009ccb8ebf4ee5055463fe473c055fc6e92ca90"
+checksum = "ddb1c61e6cb276b4c763d85d3d983a4bd02da9073bf2433740b06769555d6e54"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2479,7 +2479,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "rayon",
  "serde",
 ]
 
@@ -2491,6 +2490,8 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -4497,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2278d333c3a8172c77876b33c5f48115a9e36f59204b922b0b60d6d92281c"
+checksum = "9d14d7294f88a465e9025bd187929631e9ed0bd40141c4a583256f1f7129f620"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -4640,9 +4641,9 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a94a77158b6033a4cb7491e701477e6636ad3e764885dacd9088a6c887ab67"
+checksum = "7b29b3228590b8e93cfab323cad1a7f47a3b31b79da5ad39f35296536cb36318"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5730,15 +5731,15 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.269.72"
+version = "0.269.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08210450ab29ec98733f71ac457d45d4355ef166a4a21d669bf79f7d1cfe5ab"
+checksum = "c0b8b2b29de3721582970d08e33b5af55b86ce246f5d1367dddc76275d1b7d45"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.4",
  "dashmap",
  "either",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "jsonc-parser",
  "lru",
  "napi",
@@ -5782,9 +5783,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a9e1b6d97f27b6abe5571f8fe3bdbd2fa987299fc2126450c7cde6214896ef"
+checksum = "7d538eaaa6f085161d088a04cf0a3a5a52c5a7f2b3bd9b83f73f058b0ed357c0"
 dependencies = [
  "bytecheck",
  "hstr",
@@ -5796,14 +5797,14 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.222.68"
+version = "0.222.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ee0a3735b686dbf5819f739d969fc51932db5dbf766dd845b114d0da0aaa6"
+checksum = "7620532a2e85cb4bd88e1d8382f2a3f8b147a331058a5af6a19185fb8177f913"
 dependencies = [
  "anyhow",
  "crc",
  "dashmap",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "is-macro",
  "once_cell",
  "parking_lot",
@@ -5842,9 +5843,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.33.9"
+version = "0.33.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccb656cd57c93614e4e8b33a60e75ca095383565c1a8d2bbe6a1103942831e0"
+checksum = "e4874cb70fc4d77cf9069b00a3167b32a8394916371ed053297fcfa0b0ddbf13"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
@@ -5875,12 +5876,12 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.3.76"
+version = "0.3.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "febebd8b41806960c8ac3e00f6702eb4cecfa4c60e8cc38ce94fa1e5d8b87269"
+checksum = "f945f7afdee7fbf9875175d17bef81b10e8c0f0ac1161f7d6e4c3fe6014dd725"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.4",
  "napi",
  "napi-derive",
  "pathdiff",
@@ -5899,11 +5900,11 @@ dependencies = [
 
 [[package]]
 name = "swc_config"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba1c7a40d38f9dd4e9a046975d3faf95af42937b34b2b963be4d8f01239584b"
+checksum = "c820294225e8e7fe381cc34235d7f485b87a90d3bf6c0ebfd7b16ed100a6d4ee"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "serde",
  "serde_json",
  "swc_config_macro",
@@ -5924,9 +5925,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.86.81"
+version = "0.86.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862dfc1749e2b0ddfba5431a9001c9727c7349606b4aaa571f784232b122ff0d"
+checksum = "e287849b5e0a2b3696630cf2a76facf475d731e0aa196949b0a9dce73cedbd86"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5965,9 +5966,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.140.10"
+version = "0.140.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f17c30ef639db1d8ad3df3a23391f0ede477cd7f51cfa7bc9d4e6d8e0429849"
+checksum = "c6bb729eb47dd15d9e5ef2176cbe07976655961514b0611641cf124358a7b17c"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -5977,9 +5978,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.151.16"
+version = "0.151.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268ca93260524544652a53c61120c2d08bfd8e61868219cc7a2d4a16e2ad96de"
+checksum = "7c16cd94ee47a29ecb5f56062b54c1bcbc4ddec02e6319aca81caf60b513cce7"
 dependencies = [
  "auto_impl",
  "bitflags 2.4.0",
@@ -6007,9 +6008,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.27.16"
+version = "0.27.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7f172cd29cffebad877373d6d8e0978a195371940e84afb1e95d70dc3780d3"
+checksum = "9b65e9eb357aec10e7e761c4669db3d87cb612ce933c63033100288c1acd49b8"
 dependencies = [
  "bitflags 2.4.0",
  "once_cell",
@@ -6038,9 +6039,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.29.17"
+version = "0.29.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb16b1bf99683064b366434bd1ece6880829b01af8c77b38f2f0f06e21805b2"
+checksum = "53a8789130a6cbcc7903a397d7cd488cdaf6c644bb968361c6be591778971ec1"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -6054,9 +6055,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.150.16"
+version = "0.150.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258304ed3eab3fc7bae96158eb51cd32900bac706413604de13cb9483b9e259a"
+checksum = "c45f0298b478389423bfdfcd59a7a929758403980cc4418d07db292b11f3de3e"
 dependencies = [
  "lexical",
  "serde",
@@ -6084,9 +6085,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.137.10"
+version = "0.137.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c187c251c81f8b9f45b4b58d5eaec24a31dfac66c4cd196e4dd7330a71b44"
+checksum = "8820fefb540817a43958a787a8b9bd75711830648f876e2bd65e43a48cc4e1a2"
 dependencies = [
  "once_cell",
  "serde",
@@ -6099,9 +6100,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.139.10"
+version = "0.139.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a65238a42e8cb07dbfff82211867dd868b1ff4ce310209eb9d4b8c63807944"
+checksum = "0778e8c8f8ca40d840a284fae0de6c8d1dd196bda2fec4d6d2b69cd4f5c66d4b"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6112,9 +6113,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.110.10"
+version = "0.110.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3d416121da2d56bcbd1b1623725a68890af4552fef0c6d1e4bfa92776ccd6a"
+checksum = "6e8b1b4760728709b51dde8b7fab13d49f1f00905ea9b923d51c2bee6c20b60d"
 dependencies = [
  "bitflags 2.4.0",
  "bytecheck",
@@ -6132,9 +6133,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.146.34"
+version = "0.146.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6b9e2e703bab3cc0f484eaf32c8081792460beb64860c2950fb7e56ff67ed8"
+checksum = "12e7a29b8546220fe1ec8587dc82bfd6a45bface7c8da0a78fe2f54c2181f79e"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -6164,9 +6165,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.1.46"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23c256c5729096df0635bd1fc727e6e34c804882478805ab3820c824060017c"
+checksum = "826e45469dd36ad600fbaaa240f5f811eb1c4a37f57ff0fb2c2f7ca9eb519f46"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6181,9 +6182,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "0.1.31"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5abed404c9425bf0d1f44da426f9fec6fe1833b696275ed4dff85550376a32d4"
+checksum = "78a7b23dc75703f456c2caae6745c6adff850182ae6311b84db89f7583ff8dd8"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6194,12 +6195,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.1.46"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139b44e5de713a690003040c1068d52f4cc400fa623887d84e29fc7a5cf01b23"
+checksum = "bcaf05cd7721d4856c78c475220a4acb7ed18a55411d1d7ff1839618bae07743"
 dependencies = [
  "arrayvec",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "is-macro",
  "serde",
  "serde_derive",
@@ -6220,9 +6221,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.1.44"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4130f981d7f216116feb9b01a878fea161b19494834e7fc9ddf4ab550839ec97"
+checksum = "f4e821ffeec4f21131ff9b4809cbaaab9ba2361f2c021c0e34b977b84db6ce93"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6237,9 +6238,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.1.45"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b25eb792480f28c5ef7d37cf3db3a4d6241a7b64e068435586d806922eac84"
+checksum = "7e034b087d5fbda812db376f8e300372c6ed8c857d0e6bee5191b9791e8fcb1e"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6255,9 +6256,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.1.45"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24abad70f29e945544994e4977cd986f5fc6579cd8b0dc16230faff2c7b14f0e"
+checksum = "ab8e997b7fcbd7f6cbbbe90a544f25bfff9a1b7d315f1a21d1b23ca28f4366a7"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6274,9 +6275,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.1.45"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d7d78648bc37adc80f24941a6b84027d78aa6916638633e2f271a611d6bf0f"
+checksum = "df71dade962eae54277f6cb53272ed6a236164af7261822d665594a24180e409"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6290,9 +6291,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.1.43"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10e70a88c91a60cae3ccc9513db46e83ee05dcadbe06e41fbddf72f66537e7d0"
+checksum = "3a767c865694d21ab768a496493367b662c1f858339095dcd717feb42d344d6d"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6308,9 +6309,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.1.43"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7e5dbd76ce0ef560086aa5a34a8c2901095724c6d3cf4e1bc193c91d40ed25"
+checksum = "98099602241d83afb4e656355dc55c4b3847c7ef50b6cc323ec95bcf0f6d899b"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6324,9 +6325,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.1.44"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bc635b5029c48b92723e10af44e4710e5c42963bfd52b1d1fd8e78835b4601"
+checksum = "08bef1d7861cf65a666ebf418bc3aab4abd7d5a01ed3a94a1ee4a15193adc723"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6343,9 +6344,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.1.44"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e9dcb092ae019ee6cb54abcab7659ea8469e3f0808916895cebc465c79adb1"
+checksum = "a0aa876a7c4fc5b634fd8bec3d22557cf7fff7391b4ee5df35723a0edfa823fb"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6358,9 +6359,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.110.35"
+version = "0.110.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc0000e38d2c67772c632f3e0fe1d8c2a63479bcb9d2746b8042af6f65f42c7"
+checksum = "87ccd4018d0d8f8b589d0ffa692cddec4fb6521f20e41f6f1b64d37f800bd6bb"
 dependencies = [
  "phf 0.11.2",
  "swc_atoms",
@@ -6372,9 +6373,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.89.44"
+version = "0.89.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac15ed364f2a72ba02f7ecd5add9745c7713b919c8826d147b549ffea1554196"
+checksum = "96370822c767e52d8c4dc338000200128aa43aeb0d11f205cfa80e2064b74a24"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -6392,9 +6393,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.45.10"
+version = "0.45.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31cf7549feec3698d0110a0a71ae547f31ae272dc92db3285ce126d6dcbdadf3"
+checksum = "15f97280ec2cc9ca804355d1cb4419326ca36ab06655422362aafa510a44e0d0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6413,12 +6414,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.189.70"
+version = "0.189.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5adc7f226679e7371d794b54155bf0b4afe095486c5316ed3760897e1e56045c"
+checksum = "7c78ed56e905af1858331343810f0d4ccdd9b763453ce25a949e0e5a277c2361"
 dependencies = [
  "arrayvec",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "num-bigint",
  "num_cpus",
  "once_cell",
@@ -6448,9 +6449,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.141.28"
+version = "0.141.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8436a58ac9f31068e9bf871e2ce7f3a18fe1d7e3fe8d54abe4896673eae20c"
+checksum = "f3377d76614957cbb9985e2b6ae7175f504636024e9548ab156c0555e8471a23"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -6470,13 +6471,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.203.58"
+version = "0.203.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1f8c17f6231387150aa69d62c1ebba3e1d55dc2a858e9bdf40f9f6e2adef8"
+checksum = "4035339557fc2e0a508d280989588a6c067f888ce1ae13eb563bec13ba05e7d8"
 dependencies = [
  "anyhow",
  "dashmap",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "once_cell",
  "preset_env_base",
  "rustc-hash",
@@ -6495,9 +6496,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.52.28"
+version = "0.52.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b017bb7d94219d36c2647f927a3937c5d578ee90630aff74f4fbc0e345341e"
+checksum = "1bc37285fa2413e91c4659693151982e3e8d7a00a3bc4649bef1185b68883dd9"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -6513,22 +6514,22 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.22.11"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ae9e4a7deca72765c1d63fa6b0b3b41919187e4dd4ce99d57e348a2411b57f"
+checksum = "72760f28d6d43b5fc6883ce86685aa2bb2410acc4de065ad821348152b99e4b5"
 dependencies = [
  "anyhow",
  "hex",
- "sha-1",
+ "sha2",
  "testing",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.226.58"
+version = "0.226.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5bfa68b9931abbf582fa08aa427e74089036ffdfb1efa5624059fb3caecd9b3"
+checksum = "fb35e3dfb667fe370502de35777572d143f3ddc8fdae0499b07ec1ddf6331f21"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6546,13 +6547,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.134.45"
+version = "0.134.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3b8393c86d0ea8ccc7aab30696fae48b8ec7edd69b450318bb7930ca448817"
+checksum = "e923c96fc523bbecd54b81e436c16f8c2fd9ed0ad3563965e23ca313d132b3c6"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "once_cell",
  "phf 0.11.2",
  "rayon",
@@ -6570,9 +6571,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.123.46"
+version = "0.123.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b718100ae10d0790bb867197e648d505a1f849f830edf25e0f0f30cdbafae0d"
+checksum = "cd1244df050f3eab7ceeeb6b2e30ca57a6013b8547caf15f8385cbe94741bb93"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6584,12 +6585,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.160.51"
+version = "0.160.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e9596160b85bd29a0ad12294add8436555b35a1624fb294931e61378c4059b"
+checksum = "543b847e251123442d408e43ea32f933ad572d33a9fdc52479b63f916d948c54"
 dependencies = [
  "arrayvec",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "is-macro",
  "num-bigint",
  "rayon",
@@ -6634,14 +6635,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.177.54"
+version = "0.177.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2326820487674180acee95ed55f3386e6555fe39b0ac25df13097f57c4a6bb2"
+checksum = "386d70749d6cb0f25877ac9ba94df975172a5c56cb2d17b96983827867d91a33"
 dependencies = [
  "Inflector",
  "anyhow",
  "bitflags 2.4.0",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "is-macro",
  "path-clean",
  "pathdiff",
@@ -6661,12 +6662,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.195.58"
+version = "0.195.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaf94134146830012488f6bee2b89f0675fd742611c326c2b2c1bb49f59714e"
+checksum = "4666fae166ddac71631ffdde3567a82e65962c25786fc1120a5c7dc382ae8d85"
 dependencies = [
  "dashmap",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "once_cell",
  "petgraph",
  "rayon",
@@ -6686,9 +6687,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.168.55"
+version = "0.168.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6abb14f7198481c85bd1cf69ece8ed9a72c49d77260b107d0fcfdf0a12717885"
+checksum = "ee223978d0878bf22172778b02fba9acb7fff3f0bc8403a4638479b565fb1137"
 dependencies = [
  "either",
  "rustc-hash",
@@ -6706,13 +6707,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.180.56"
+version = "0.180.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02424cc787df6f5a37cc0c45fc159141a78f4a713dd1f394ef787f3147c4edbf"
+checksum = "246740603e38d86d8b21c623508942461814a8bec7b7f251a402bb44ea177074"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.4",
  "dashmap",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "once_cell",
  "rayon",
  "serde",
@@ -6731,17 +6732,17 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.137.47"
+version = "0.137.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b282c0fe89bc6bc2ce0c76211fcaf89e2472edc2b87e8f8353278be625bec7"
+checksum = "8fdfd2f4bdb193630c776ba2053da413fe693ff5c6dea99c2c426af3f477fa5d"
 dependencies = [
  "ansi_term",
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.4",
  "hex",
  "serde",
  "serde_json",
- "sha-1",
+ "sha2",
  "sourcemap",
  "swc_common",
  "swc_ecma_ast",
@@ -6757,9 +6758,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.185.56"
+version = "0.185.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401d899c11ca688f62a0b28bfd5c129d58d7cb838e22072aa86a54f03d8cac73"
+checksum = "54b35884f49f034ae1a73aa04598dae77e8489d95c33649f71d1fc64451ca4ca"
 dependencies = [
  "ryu-js",
  "serde",
@@ -6774,11 +6775,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.20.35"
+version = "0.20.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa8d5dc775d4bf35967a0216783058b13ffe5423b807927aa5dbc92251f6839"
+checksum = "9858dff60f5af64cbd8edd55cde6a2a2c11e49591a132ccaff19308002c124d3"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "rustc-hash",
  "swc_atoms",
  "swc_common",
@@ -6791,11 +6792,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.124.34"
+version = "0.124.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad013c92a6e05a850db088ae7a17dc667209780b2a1a313544540111f33b5233"
+checksum = "57baa288197bcf32f40efd324c15b57947a06277e9ef3fed80dbab2826570a98"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "num_cpus",
  "once_cell",
  "rayon",
@@ -6810,9 +6811,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.96.10"
+version = "0.96.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba962f0becf83bab12a17365dface5a4f636c9e1743d479e292b96910a753743"
+checksum = "da131f01faa7df2ec55703cd154e0d155bd9cb30964bf47db086da0c05799f03"
 dependencies = [
  "num-bigint",
  "serde",
@@ -6861,9 +6862,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29add35412af288be50e1012bbb825a66871bb2b4d960d1c456917ec3ccea32"
+checksum = "27e04af603c8d9ec4f9f35bdb9e56d96ac478991fb3365fda6cea68c9edcff38"
 dependencies = [
  "anyhow",
  "miette",
@@ -6874,11 +6875,11 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.21.9"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8117f6d10bbcb30cb3e549d6fa7637cb6d7c713cb71b2ce1808105a6825c788d"
+checksum = "905c4f09b54cc799fd6cfb9b71dce5b7e32d0e068dacf1d3885c499bec20a378"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "petgraph",
  "rustc-hash",
  "swc_common",
@@ -6886,9 +6887,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.22.11"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de8f0ac33ef7486723a3acdd9c4541dac79f0433bf878b9075826bca1163d83e"
+checksum = "49cf3e61896bbe45538ce23c11233f446c7ff141909b54dec98199dc451aa66e"
 dependencies = [
  "auto_impl",
  "petgraph",
@@ -6911,9 +6912,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.20.9"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282ef548f602694c4eaa36a1d704282fd9713b9725b58bce7fb41630feefc4f7"
+checksum = "3bdb6cd2c3ea5f93b284499e1fdc3caaeae3d6691a2de5d46ebee43e847eeb6f"
 dependencies = [
  "dashmap",
  "swc_atoms",
@@ -6947,9 +6948,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.39.10"
+version = "0.39.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10904ed792a38bae2810ed9ca781a2e5d62c369b2f83843255bde1141a32502"
+checksum = "ff9b09606e02e5f27d2cb5761357951b4b3e7ba04b13bdf5e5f95c034d682321"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -6961,9 +6962,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.104.30"
+version = "0.104.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650a138a519e67dd9b85c37bf807c311be009f68267d767da6989f428d715037"
+checksum = "d44bef4b862c1f1a61d19c6672a4d406b1506ae14251b22d32a7eebcca026913"
 dependencies = [
  "anyhow",
  "enumset",
@@ -7003,9 +7004,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.21.11"
+version = "0.21.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a200243f3c296f74f52a562342ec0e972376377f4c202b0fa84a0e860a3bff7"
+checksum = "1cca6a9bb7102c89eb78fe3a3f2409981c995cf91e990b8f52154dbf35ca64d9"
 dependencies = [
  "tracing",
 ]
@@ -7171,9 +7172,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.35.11"
+version = "0.35.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528fe2b00056f8a214476c599708f70a09c8b6634d4f6e2f9d78e0d1d37f4057"
+checksum = "a784b2b2b524ea9a0286ed1e33671a916a728633df8c0837e2db54984b56f50b"
 dependencies = [
  "ansi_term",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ swc_core = { version = "0.86.98", features = [
 testing = { version = "0.35.13" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231207.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231208.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231207.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231208.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231207.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231208.1" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ next-transform-dynamic = { path = "packages/next-swc/crates/next-transform-dynam
 next-transform-strip-page-exports = { path = "packages/next-swc/crates/next-transform-strip-page-exports" }
 
 # SWC crates
-swc_core = { version = "0.86.81", features = [
+swc_core = { version = "0.86.98", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
-testing = { version = "0.35.11" }
+testing = { version = "0.35.13" }
 
 # Turbo crates
 turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-231207.2" }

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -38,8 +38,8 @@ turbopack-binding = { workspace = true, features = [
   "__swc_transform_modularize_imports",
   "__swc_transform_relay",
 ] }
-react_remove_properties = "0.17.0"
-remove_console = "0.18.0"
+react_remove_properties = "0.18.0"
+remove_console = "0.19.0"
 
 [dev-dependencies]
 turbopack-binding = { workspace = true, features = [

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -195,7 +195,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.24.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231207.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231208.1",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.24.4
         version: 0.24.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231207.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231207.2(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231208.1
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231208.1(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -24647,9 +24647,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231207.2(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231207.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231207.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231208.1(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231208.1}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-231208.1'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

Update SWC crates.

### Why?

To fix OOM bug of `inputSourceMap`.

Patch: https://github.com/swc-project/swc/pull/8402

### How?

Closes PACK-2123



# Turbopack updates

* https://github.com/vercel/turbo/pull/6733 <!-- Thomas Knickman - chore(ignore): exclude rustic-ice files  -->
* https://github.com/vercel/turbo/pull/6731 <!-- Leah - fix(turbopack-ecmascript-runtime): don't use `path.relative` for absolute paths  -->
* https://github.com/vercel/turbo/pull/6745 <!-- Donny/강동윤 - Update `swc_core` to `v0.86.98`  -->