### PR TITLE
Allow NODE_OPTIONS to container a host and port combination

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -6,6 +6,7 @@ import {
   RESTART_EXIT_CODE,
   checkNodeDebugType,
   getDebugPort,
+  getDebugHost,
   getMaxOldSpaceSize,
   getNodeOptionsWithoutInspect,
   getPort,
@@ -238,7 +239,7 @@ const nextDev: CliCommand = async (args) => {
       }
 
       if (nodeDebugType) {
-        NODE_OPTIONS = `${NODE_OPTIONS} --${nodeDebugType}=${
+        NODE_OPTIONS = `${NODE_OPTIONS} --${nodeDebugType}=${getDebugHost()}:${
           getDebugPort() + 1
         }`
       }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -17,7 +17,7 @@ import os from 'os'
 import Watchpack from 'watchpack'
 import * as Log from '../../build/output/log'
 import setupDebug from 'next/dist/compiled/debug'
-import { RESTART_EXIT_CODE, checkNodeDebugType, getDebugPort } from './utils'
+import { RESTART_EXIT_CODE, checkNodeDebugType, getDebugPort, getDebugHost } from './utils'
 import { formatHostname } from './format-hostname'
 import { initialize } from './router-server'
 import { CONFIG_FILES } from '../../shared/lib/constants'
@@ -239,8 +239,9 @@ export async function startServer(
 
       if (nodeDebugType) {
         const debugPort = getDebugPort()
+        const debugHost = getDebugHost();
         Log.info(
-          `the --${nodeDebugType} option was detected, the Next.js router server should be inspected at port ${debugPort}.`
+          `the --${nodeDebugType} option was detected, the Next.js router server should be inspected at ${debugHost}:${debugPort}.`
         )
       }
 

--- a/packages/next/src/server/lib/utils.ts
+++ b/packages/next/src/server/lib/utils.ts
@@ -10,17 +10,25 @@ export function printAndExit(message: string, code = 1) {
   process.exit(code)
 }
 
-export const getDebugPort = () => {
-  const debugPortStr =
-    process.execArgv
+const getDebugStr = () => {
+  return process.execArgv
       .find(
         (localArg) =>
           localArg.startsWith('--inspect') ||
           localArg.startsWith('--inspect-brk')
       )
-      ?.split('=', 2)[1] ??
-    process.env.NODE_OPTIONS?.match?.(/--inspect(-brk)?(=(\S+))?( |$)/)?.[3]
+      ?.split('=', 2)[1].split(":").pop() ??
+    process.env.NODE_OPTIONS?.match?.(/--inspect(-brk)?(=(\S+))?( |$)/)?.[3] ?? ""
+}
+
+export const getDebugPort = () => {
+  const debugPortStr = getDebugStr().split(":").pop()
   return debugPortStr ? parseInt(debugPortStr, 10) : 9229
+}
+
+export const getDebugHost = () => {
+  const debugStr = getDebugStr();
+  return debugStr.includes(":") ? debugStr.split(":")[0] : '127.0.0.1';
 }
 
 const NODE_INSPECT_RE = /--inspect(-brk)?(=\S+)?( |$)/

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -556,6 +556,37 @@ describe('CLI Usage', () => {
       }
     })
 
+    test("NODE_OPTIONS='--inspect=<host>:<port>'", async () => {
+      const hostsWithPort = [
+        '0.0.0.0:1234',
+        '127.0.0.1:1235',
+        'localhost:1236',
+        '192.168.18.90:1237',
+        'app.barcos.co:1238',
+      ]
+      for (const someHost of hostsWithPort) {
+        const [host, debugPort] = someHost.split(':');
+        const port = await findPort()
+        let output = ''
+        const app = await runNextCommandDev(
+          [dirBasic, '--port', port],
+          undefined,
+          {
+            onStdout(msg) {
+              output += stripAnsi(msg)
+            },
+            env: { NODE_OPTIONS: `--inspect=${host}:${debugPort}` },
+          }
+        )
+        try {
+          await check(() => output, new RegExp(`at ${host}:${parseInt(debugPort,10)+1}`))
+          await check(() => output, new RegExp(`http://localhost:${port}`))
+        } finally {
+          await killApp(app)
+        }
+      }
+    })
+
     test('-p', async () => {
       const port = await findPort()
       let output = ''


### PR DESCRIPTION
### What?

This allows debugging sessions from a remote host such as a docker container. For example in package.json:

`"debug": "NODE_OPTIONS='--inspect=0.0.0.0:5433' next dev",`

This follows the inspect options as they are specified by NodeJs - https://nodejs.org/api/cli.html#--inspecthostport

Fixes:

*  #53127 
*  #53757

### Why?

If you're using docker containers for development, it's impossible to attach a debugger, and this more closely follows the spec outlined by NodeJS
