### PR TITLE
Docs: Mention that cookies will encode/decode on a user's behalf

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/cookies.mdx
+++ b/docs/02-app/02-api-reference/04-functions/cookies.mdx
@@ -12,6 +12,8 @@ The `cookies` function allows you to read the HTTP incoming request cookies from
 
 > **Good to know**: `cookies()` is a **[Dynamic Function](/docs/app/building-your-application/rendering/server-components#server-rendering-strategies#dynamic-functions)** whose returned values cannot be known ahead of time. Using it in a layout or page will opt a route into **[dynamic rendering](/docs/app/building-your-application/rendering/server-components#dynamic-rendering)** at request time.
 
+> **Good to know**: `cookies()` uses the [jshttp/cookie](https://github.com/jshttp/cookie) package to manage cookies. `jshttp/cookie` will `encodeURIComponent` and `decodeURIComponent` your cookie values for you, so you don't need to do this.
+
 ## `cookies().get(name)`
 
 A method that takes a cookie name and returns an object with name and value. If a cookie with `name` isn't found, it returns `undefined`. If multiple cookies match, it will only return the first match.


### PR DESCRIPTION
My team was manually encoding and decoding our cookie values and then wondering why they were double-encoded when the raw cookie values were inspected in the browser.

I don't know if this is giving too much info, but we wouldn't have made this mistake if the docs page either mentioned that https://github.com/jshttp/cookie was being used by Next, or explicitly mentioned that the cookie values will be encoded and decoded on our behalf. This PR does both, but feel free to edit the text or tone-of-voice.