### PR TITLE
ci(workflow): restore publish wasm binary

### DIFF
--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -73,60 +73,55 @@ const cwd = process.cwd()
     )
 
     // Update name/version of wasm packages and publish
-    // const pkgDirectory = 'packages/next-swc/crates/wasm'
-    // let wasmDir = path.join(cwd, pkgDirectory)
-
-    // await Promise.all(
-    //   ['web', 'nodejs'].map(async (wasmTarget) => {
-    //     await publishSema.acquire()
-
-    //     let wasmPkg = JSON.parse(
-    //       await readFile(path.join(wasmDir, `pkg-${wasmTarget}/package.json`))
-    //     )
-    //     wasmPkg.name = `@next/swc-wasm-${wasmTarget}`
-    //     wasmPkg.version = version
-    //     wasmPkg.repository = {
-    //       type: 'git',
-    //       url: 'https://github.com/vercel/next.js',
-    //       directory: pkgDirectory,
-    //     }
-
-    //     await writeFile(
-    //       path.join(wasmDir, `pkg-${wasmTarget}/package.json`),
-    //       JSON.stringify(wasmPkg, null, 2)
-    //     )
-
-    //     try {
-    //       await execa(
-    //         `npm`,
-    //         [
-    //           'publish',
-    //           `${path.join(wasmDir, `pkg-${wasmTarget}`)}`,
-    //           '--access',
-    //           'public',
-    //           ...(version.includes('canary') ? ['--tag', 'canary'] : []),
-    //         ],
-    //         { stdio: 'inherit' }
-    //       )
-    //     } catch (err) {
-    //       // don't block publishing other versions on single platform error
-    //       console.error(`Failed to publish`, wasmTarget, err)
-
-    //       if (
-    //         err.message &&
-    //         err.message.includes(
-    //           'You cannot publish over the previously published versions'
-    //         )
-    //       ) {
-    //         console.error('Ignoring already published error', wasmTarget)
-    //       } else {
-    //         // throw err
-    //       }
-    //     } finally {
-    //       publishSema.release()
-    //     }
-    //   })
-    // )
+    const pkgDirectory = 'packages/next-swc/crates/wasm'
+    let wasmDir = path.join(cwd, pkgDirectory)
+    await Promise.all(
+      ['web', 'nodejs'].map(async (wasmTarget) => {
+        await publishSema.acquire()
+        let wasmPkg = JSON.parse(
+          await readFile(path.join(wasmDir, `pkg-${wasmTarget}/package.json`))
+        )
+        wasmPkg.name = `@next/swc-wasm-${wasmTarget}`
+        wasmPkg.version = version
+        wasmPkg.repository = {
+          type: 'git',
+          url: 'https://github.com/vercel/next.js',
+          directory: pkgDirectory,
+        }
+        await writeFile(
+          path.join(wasmDir, `pkg-${wasmTarget}/package.json`),
+          JSON.stringify(wasmPkg, null, 2)
+        )
+        try {
+          await execa(
+            `npm`,
+            [
+              'publish',
+              `${path.join(wasmDir, `pkg-${wasmTarget}`)}`,
+              '--access',
+              'public',
+              ...(version.includes('canary') ? ['--tag', 'canary'] : []),
+            ],
+            { stdio: 'inherit' }
+          )
+        } catch (err) {
+          // don't block publishing other versions on single platform error
+          console.error(`Failed to publish`, wasmTarget, err)
+          if (
+            err.message &&
+            err.message.includes(
+              'You cannot publish over the previously published versions'
+            )
+          ) {
+            console.error('Ignoring already published error', wasmTarget)
+          } else {
+            // throw err
+          }
+        } finally {
+          publishSema.release()
+        }
+      })
+    )
 
     // Update optional dependencies versions
     let nextPkg = JSON.parse(


### PR DESCRIPTION
### What?

Looks like publishing step was missing when we restored wasm binary build.

Closes PACK-2127