### PR TITLE
ci: only run release commit check on canary releases

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -58,7 +58,7 @@ jobs:
         run: echo "LATEST_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Check if new commits since last tag
-        if: ${{ github.event.inputs.releaseType == 'canary' }}
+        if: ${{ github.event.inputs.releaseType != 'stable' }}
         run: |
           if [ "$LATEST_TAG_COMMIT" = "$LATEST_COMMIT" ]; then
             echo "No new commits. Exiting..."

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -58,6 +58,7 @@ jobs:
         run: echo "LATEST_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Check if new commits since last tag
+        if: ${{ github.event.inputs.releaseType == 'canary' }}
         run: |
           if [ "$LATEST_TAG_COMMIT" = "$LATEST_COMMIT" ]; then
             echo "No new commits. Exiting..."


### PR DESCRIPTION
We don't want to perform this check for stable releases since those are never initiated by the cron task, as otherwise it would fail when going from canary -> stable as no commits would land in-between.

Closes NEXT-1836