### PR TITLE
Partial Pre Rendering Headers

### DIFF
--- a/test/e2e/app-dir/ppr-full/app/dynamic/force-dynamic/nested/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/dynamic/force-dynamic/nested/[slug]/page.jsx
@@ -1,0 +1,20 @@
+import React, { Suspense } from 'react'
+import { Dynamic } from '../../../../../components/dynamic'
+
+export const dynamic = 'force-dynamic'
+
+export function generateStaticParams() {
+  return []
+}
+
+export default ({ params: { slug } }) => {
+  return (
+    <Suspense
+      fallback={
+        <Dynamic pathname={`/dynamic/force-dynamic/nested/${slug}`} fallback />
+      }
+    >
+      <Dynamic pathname={`/dynamic/force-dynamic/nested/${slug}`} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/dynamic/force-dynamic/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/dynamic/force-dynamic/page.jsx
@@ -3,14 +3,10 @@ import { Dynamic } from '../../../components/dynamic'
 
 export const dynamic = 'force-dynamic'
 
-export default ({ params: { slug } }) => {
+export default () => {
   return (
-    <Suspense
-      fallback={
-        <Dynamic pathname={`/dynamic/force-dynamic/${slug}`} fallback />
-      }
-    >
-      <Dynamic pathname={`/dynamic/force-dynamic/${slug}`} />
+    <Suspense fallback={<Dynamic pathname="/dynamic/force-dynamic" fallback />}>
+      <Dynamic pathname="/dynamic/force-dynamic" />
     </Suspense>
   )
 }

--- a/test/e2e/app-dir/ppr-full/app/dynamic/force-static/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/dynamic/force-static/page.jsx
@@ -4,12 +4,10 @@ import { Dynamic } from '../../../components/dynamic'
 export const dynamic = 'force-static'
 export const revalidate = 60
 
-export default ({ params: { slug } }) => {
+export default () => {
   return (
-    <Suspense
-      fallback={<Dynamic pathname={`/dynamic/force-static/${slug}`} fallback />}
-    >
-      <Dynamic pathname={`/dynamic/force-static/${slug}`} />
+    <Suspense fallback={<Dynamic pathname="/dynamic/force-static" fallback />}>
+      <Dynamic pathname="/dynamic/force-static" />
     </Suspense>
   )
 }

--- a/test/e2e/app-dir/ppr-full/app/layout.jsx
+++ b/test/e2e/app-dir/ppr-full/app/layout.jsx
@@ -1,18 +1,10 @@
-import { Links } from '../components/links'
+import { Layout } from '../components/layout'
 
 export default ({ children }) => {
   return (
     <html>
       <body>
-        <h1>Partial Prerendering</h1>
-        <p>
-          Below are links that are associated with different pages that all will
-          partially prerender
-        </p>
-        <aside>
-          <Links />
-        </aside>
-        <main>{children}</main>
+        <Layout>{children}</Layout>
       </body>
     </html>
   )

--- a/test/e2e/app-dir/ppr-full/app/static/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/static/page.jsx
@@ -1,6 +1,8 @@
-import React from 'react'
-import { Dynamic } from '../../components/dynamic'
-
 export default () => {
-  return <Dynamic pathname="/static" fallback />
+  return (
+    <dl>
+      <dt>Pathname</dt>
+      <dd data-pathname="/static">/static</dd>
+    </dl>
+  )
 }

--- a/test/e2e/app-dir/ppr-full/components/dynamic.jsx
+++ b/test/e2e/app-dir/ppr-full/components/dynamic.jsx
@@ -1,37 +1,38 @@
-import React from 'react'
-import { headers } from 'next/headers'
+import React, { use } from 'react'
+import * as next from 'next/headers'
 
 export const Dynamic = ({ pathname, fallback }) => {
   if (fallback) {
-    return <div>Loading...</div>
+    return <div>Dynamic Loading...</div>
   }
 
+  const headers = next.headers()
   const messages = []
-  const names = ['x-test-input', 'user-agent']
-  const list = headers()
+  for (const name of ['x-test-input', 'user-agent']) {
+    messages.push({ name, value: headers.get(name) })
+  }
 
-  for (const name of names) {
-    messages.push({ name, value: list.get(name) })
+  const delay = headers.get('x-delay')
+  if (delay) {
+    use(new Promise((resolve) => setTimeout(resolve, parseInt(delay, 10))))
   }
 
   return (
-    <div id="needle">
-      <dl>
-        {pathname && (
-          <>
-            <dt>Pathname</dt>
-            <dd>{pathname}</dd>
-          </>
-        )}
-        {messages.map(({ name, value }) => (
-          <React.Fragment key={name}>
-            <dt>
-              Header: <code>{name}</code>
-            </dt>
-            <dd>{value ?? 'null'}</dd>
-          </React.Fragment>
-        ))}
-      </dl>
-    </div>
+    <dl>
+      {pathname && (
+        <>
+          <dt>Pathname</dt>
+          <dd data-pathname={pathname}>{pathname}</dd>
+        </>
+      )}
+      {messages.map(({ name, value }) => (
+        <React.Fragment key={name}>
+          <dt>
+            Header: <code>{name}</code>
+          </dt>
+          <dd>{value ?? `MISSING:${name.toUpperCase()}`}</dd>
+        </React.Fragment>
+      ))}
+    </dl>
   )
 }

--- a/test/e2e/app-dir/ppr-full/components/layout.jsx
+++ b/test/e2e/app-dir/ppr-full/components/layout.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Links } from './links'
+
+export const Layout = ({ children }) => {
+  return (
+    <>
+      <h1>Partial Prerendering</h1>
+      <p>
+        Below are links that are associated with different pages that all will
+        partially prerender
+      </p>
+      <aside>
+        <Links />
+      </aside>
+      <main>{children}</main>
+    </>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/components/links.jsx
+++ b/test/e2e/app-dir/ppr-full/components/links.jsx
@@ -18,6 +18,18 @@ const links = [
   { href: '/no-suspense/nested/b', tag: 'no suspense, on-demand' },
   { href: '/no-suspense/nested/c', tag: 'no suspense, on-demand' },
   { href: '/dynamic/force-dynamic', tag: "dynamic = 'force-dynamic'" },
+  {
+    href: '/dynamic/force-dynamic/nested/a',
+    tag: "dynamic = 'force-dynamic', on-demand, no-gsp",
+  },
+  {
+    href: '/dynamic/force-dynamic/nested/b',
+    tag: "dynamic = 'force-dynamic', on-demand, no-gsp",
+  },
+  {
+    href: '/dynamic/force-dynamic/nested/c',
+    tag: "dynamic = 'force-dynamic', on-demand, no-gsp",
+  },
   { href: '/dynamic/force-static', tag: "dynamic = 'force-static'" },
   { href: '/edge/suspense', tag: 'edge, pre-generated' },
   { href: '/edge/suspense/a', tag: 'edge, pre-generated' },
@@ -27,6 +39,7 @@ const links = [
   { href: '/edge/no-suspense/a', tag: 'edge, no suspense, pre-generated' },
   { href: '/edge/no-suspense/b', tag: 'edge, no suspense, on-demand' },
   { href: '/edge/no-suspense/c', tag: 'edge, no suspense, on-demand' },
+  { href: '/pages', tag: 'pages' },
 ]
 
 export const Links = () => {

--- a/test/e2e/app-dir/ppr-full/pages/pages.jsx
+++ b/test/e2e/app-dir/ppr-full/pages/pages.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Layout } from '../components/layout'
+
+export default () => {
+  return (
+    <Layout>
+      <dl>
+        <dt>Pathname</dt>
+        <dd data-pathname="/pages">/pages</dd>
+      </dl>
+    </Layout>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/ppr-full.test.ts
+++ b/test/e2e/app-dir/ppr-full/ppr-full.test.ts
@@ -1,6 +1,55 @@
 import { createNextDescribe } from 'e2e-utils'
 
-const pages = [
+async function measure(stream: NodeJS.ReadableStream) {
+  let streamFirstChunk = 0
+  let streamEnd = 0
+
+  const data: {
+    chunk: string
+    emittedAt: number
+  }[] = []
+
+  await new Promise<void>((resolve, reject) => {
+    stream.on('data', (chunk: Buffer | string) => {
+      if (!streamFirstChunk) {
+        streamFirstChunk = Date.now()
+      }
+
+      if (typeof chunk !== 'string') {
+        chunk = chunk.toString()
+      }
+
+      data.push({ chunk, emittedAt: Date.now() })
+    })
+
+    stream.on('end', () => {
+      streamEnd = Date.now()
+      resolve()
+    })
+
+    stream.on('error', reject)
+  })
+
+  return {
+    streamFirstChunk,
+    streamEnd,
+    data,
+  }
+}
+
+type Page = {
+  pathname: string
+  dynamic: boolean | 'force-dynamic' | 'force-static'
+  revalidate?: number
+
+  /**
+   * If true, this indicates that the test case should not expect any content
+   * to be sent as the static part.
+   */
+  emptyStaticPart?: boolean
+}
+
+const pages: Page[] = [
   { pathname: '/', dynamic: true },
   { pathname: '/nested/a', dynamic: true, revalidate: 60 },
   { pathname: '/nested/b', dynamic: true, revalidate: 60 },
@@ -12,12 +61,14 @@ const pages = [
   { pathname: '/loading/b', dynamic: true, revalidate: 60 },
   { pathname: '/loading/c', dynamic: true, revalidate: 60 },
   { pathname: '/static', dynamic: false },
-  { pathname: '/no-suspense', dynamic: true },
-  { pathname: '/no-suspense/nested/a', dynamic: true },
-  { pathname: '/no-suspense/nested/b', dynamic: true },
-  { pathname: '/no-suspense/nested/c', dynamic: true },
-  // TODO: uncomment when we've fixed the 404 case for force-dynamic pages
-  // { pathname: '/dynamic/force-dynamic', dynamic: 'force-dynamic' },
+  { pathname: '/no-suspense', dynamic: true, emptyStaticPart: true },
+  { pathname: '/no-suspense/nested/a', dynamic: true, emptyStaticPart: true },
+  { pathname: '/no-suspense/nested/b', dynamic: true, emptyStaticPart: true },
+  { pathname: '/no-suspense/nested/c', dynamic: true, emptyStaticPart: true },
+  { pathname: '/dynamic/force-dynamic', dynamic: 'force-dynamic' },
+  { pathname: '/dynamic/force-dynamic/nested/a', dynamic: 'force-dynamic' },
+  { pathname: '/dynamic/force-dynamic/nested/b', dynamic: 'force-dynamic' },
+  { pathname: '/dynamic/force-dynamic/nested/c', dynamic: 'force-dynamic' },
   {
     pathname: '/dynamic/force-static',
     dynamic: 'force-static',
@@ -30,31 +81,209 @@ createNextDescribe(
   {
     files: __dirname,
   },
-  ({ next, isNextDev, isNextStart, isNextDeploy }) => {
-    describe('dynamic pages should resume', () => {
-      it.each(pages.filter((p) => p.dynamic === true))(
-        'should resume $pathname',
-        async ({ pathname }) => {
-          const expected = `${Date.now()}:${Math.random()}`
-          const res = await next.fetch(pathname, {
-            headers: { 'X-Test-Input': expected },
+  ({ next, isNextDev, isNextDeploy }) => {
+    describe('HTML Response', () => {
+      describe.each(pages)(
+        'for $pathname',
+        ({ pathname, dynamic, revalidate, emptyStaticPart }) => {
+          beforeEach(async () => {
+            // Hit the page once to populate the cache.
+            const res = await next.fetch(pathname)
+
+            // Consume the response body to ensure the cache is populated.
+            await res.text()
           })
-          expect(res.status).toEqual(200)
-          expect(res.headers.get('content-type')).toEqual(
-            'text/html; charset=utf-8'
-          )
-          const html = await res.text()
-          expect(html).toContain(expected)
-          expect(html).toContain('</html>')
+
+          it('should allow navigations to and from a pages/ page', async () => {
+            const browser = await next.browser(pathname)
+
+            try {
+              await browser.waitForElementByCss(`[data-pathname="${pathname}"]`)
+
+              // Add a window var so we can detect if there was a full navigation.
+              const now = Date.now()
+              await browser.eval(`window.beforeNav = ${now.toString()}`)
+
+              // Navigate to the pages page and wait for the page to load.
+              await browser.elementByCss(`a[href="/pages"]`).click()
+              await browser.waitForElementByCss('[data-pathname="/pages"]')
+
+              // Ensure we did a full page navigation, and not a client navigation.
+              let beforeNav = await browser.eval('window.beforeNav')
+              expect(beforeNav).not.toBe(now)
+
+              await browser.eval(`window.beforeNav = ${now.toString()}`)
+
+              // Navigate back and wait for the page to load.
+              await browser.elementByCss(`a[href="${pathname}"]`).click()
+              await browser.waitForElementByCss(`[data-pathname="${pathname}"]`)
+
+              // Ensure we did a full page navigation, and not a client navigation.
+              beforeNav = await browser.eval('window.beforeNav')
+              expect(beforeNav).not.toBe(now)
+            } finally {
+              await browser.close()
+            }
+          })
+
+          it('should have correct headers', async () => {
+            const res = await next.fetch(pathname)
+            expect(res.status).toEqual(200)
+            expect(res.headers.get('content-type')).toEqual(
+              'text/html; charset=utf-8'
+            )
+
+            const cacheControl = res.headers.get('cache-control')
+            if (isNextDeploy) {
+              expect(cacheControl).toEqual('public, max-age=0, must-revalidate')
+            } else if (isNextDev) {
+              expect(cacheControl).toEqual('no-store, must-revalidate')
+            } else if (dynamic === false || dynamic === 'force-static') {
+              expect(cacheControl).toEqual(
+                `s-maxage=${revalidate || '31536000'}, stale-while-revalidate`
+              )
+            } else {
+              expect(cacheControl).toEqual(
+                'private, no-cache, no-store, max-age=0, must-revalidate'
+              )
+            }
+
+            // The cache header is not relevant in development and is not
+            // deterministic enough for this table test to verify.
+            if (isNextDev) return
+
+            if (
+              !isNextDeploy &&
+              (dynamic === false || dynamic === 'force-static')
+            ) {
+              expect(res.headers.get('x-nextjs-cache')).toEqual('HIT')
+            } else {
+              expect(res.headers.get('x-nextjs-cache')).toEqual(null)
+            }
+          })
+
+          if (dynamic === true) {
+            it('should cache the static part', async () => {
+              const delay = 500
+
+              const dynamicValue = `${Date.now()}:${Math.random()}`
+              const start = Date.now()
+              const res = await next.fetch(pathname, {
+                headers: {
+                  'X-Delay': delay.toString(),
+                  'X-Test-Input': dynamicValue,
+                },
+              })
+              expect(res.status).toBe(200)
+
+              const result = await measure(res.body)
+              if (emptyStaticPart) {
+                expect(result.streamFirstChunk - start).toBeGreaterThanOrEqual(
+                  delay
+                )
+              } else {
+                expect(result.streamFirstChunk - start).toBeLessThan(delay)
+              }
+              expect(result.streamEnd - start).toBeGreaterThanOrEqual(delay)
+
+              // Find all the chunks that arrived before the delay, and split
+              // it into the static and dynamic parts.
+              const chunks = result.data.reduce(
+                (acc, { chunk, emittedAt }) => {
+                  if (emittedAt < start + delay) {
+                    acc.static.push(chunk)
+                  } else {
+                    acc.dynamic.push(chunk)
+                  }
+                  return acc
+                },
+                { static: [], dynamic: [] }
+              )
+
+              const parts = {
+                static: chunks.static.join(''),
+                dynamic: chunks.dynamic.join(''),
+              }
+
+              // The static part should not contain the dynamic input.
+              expect(parts.dynamic).toContain(dynamicValue)
+
+              // Ensure static part contains what we expect.
+              if (emptyStaticPart) {
+                expect(parts.static).toBe('')
+              } else {
+                expect(parts.static).toContain('Dynamic Loading...')
+                expect(parts.static).not.toContain(dynamicValue)
+              }
+            })
+          }
+
+          if (dynamic === true || dynamic === 'force-dynamic') {
+            it('should resume with dynamic content', async () => {
+              const expected = `${Date.now()}:${Math.random()}`
+              const res = await next.fetch(pathname, {
+                headers: { 'X-Test-Input': expected },
+              })
+              expect(res.status).toEqual(200)
+              expect(res.headers.get('content-type')).toEqual(
+                'text/html; charset=utf-8'
+              )
+              const html = await res.text()
+              expect(html).toContain(expected)
+              expect(html).not.toContain('MISSING:USER-AGENT')
+              expect(html).toContain('</html>')
+            })
+          } else {
+            it('should not contain dynamic content', async () => {
+              const unexpected = `${Date.now()}:${Math.random()}`
+              const res = await next.fetch(pathname, {
+                headers: { 'X-Test-Input': unexpected },
+              })
+              expect(res.status).toEqual(200)
+              expect(res.headers.get('content-type')).toEqual(
+                'text/html; charset=utf-8'
+              )
+              const html = await res.text()
+              expect(html).not.toContain(unexpected)
+              if (dynamic !== false) {
+                expect(html).toContain('MISSING:USER-AGENT')
+                expect(html).toContain('MISSING:X-TEST-INPUT')
+              }
+              expect(html).toContain('</html>')
+            })
+          }
         }
       )
     })
 
     if (!isNextDev) {
-      describe('prefetch RSC payloads should return', () => {
-        it.each(pages)(
-          'should prefetch $pathname',
-          async ({ pathname, dynamic, revalidate }) => {
+      describe('Prefetch RSC Response', () => {
+        describe.each(pages)('for $pathname', ({ pathname, revalidate }) => {
+          it('should have correct headers', async () => {
+            const res = await next.fetch(pathname, {
+              headers: { RSC: '1', 'Next-Router-Prefetch': '1' },
+            })
+            expect(res.status).toEqual(200)
+            expect(res.headers.get('content-type')).toEqual('text/x-component')
+
+            // cache header handling is different when in minimal mode
+            const cache = res.headers.get('cache-control')
+            if (isNextDeploy) {
+              expect(cache).toEqual('public, max-age=0, must-revalidate')
+            } else {
+              expect(cache).toEqual(
+                `s-maxage=${revalidate || '31536000'}, stale-while-revalidate`
+              )
+            }
+
+            if (!isNextDeploy) {
+              expect(res.headers.get('x-nextjs-cache')).toEqual('HIT')
+            } else {
+              expect(res.headers.get('x-nextjs-cache')).toEqual(null)
+            }
+          })
+
+          it('should not contain dynamic content', async () => {
             const unexpected = `${Date.now()}:${Math.random()}`
             const res = await next.fetch(pathname, {
               headers: {
@@ -65,80 +294,57 @@ createNextDescribe(
             })
             expect(res.status).toEqual(200)
             expect(res.headers.get('content-type')).toEqual('text/x-component')
-
-            const cache = res.headers.get('cache-control')
-
-            // cache header handling is different when in minimal mode
-            if (isNextDeploy) {
-              expect(cache).toContain('public')
-              expect(cache).toContain('must-revalidate')
-            } else {
-              expect(cache).toContain(`s-maxage=${revalidate || '31536000'}`)
-              expect(cache).toContain('stale-while-revalidate')
-            }
-
-            // Expect that static RSC prefetches do not contain the dynamic text.
             const text = await res.text()
             expect(text).not.toContain(unexpected)
-
-            if (dynamic === true) {
-              // The dynamic component will contain the text "needle" if it was
-              // rendered using dynamic content.
-              expect(text).not.toContain('needle')
-              expect(res.headers.get('X-NextJS-Postponed')).toEqual('1')
-            } else {
-              if (dynamic !== false) {
-                expect(text).toContain('needle')
-              }
-
-              expect(res.headers.has('X-NextJS-Postponed')).toEqual(false)
-            }
-          }
-        )
+          })
+        })
       })
 
-      describe('dynamic RSC payloads should return', () => {
-        it.each(pages)(
-          'should fetch $pathname',
-          async ({ pathname, dynamic }) => {
-            const expected = `${Date.now()}:${Math.random()}`
+      describe('Dynamic RSC Response', () => {
+        describe.each(pages)('for $pathname', ({ pathname, dynamic }) => {
+          it('should have correct headers', async () => {
             const res = await next.fetch(pathname, {
-              headers: { RSC: '1', 'X-Test-Input': expected },
+              headers: { RSC: '1' },
             })
             expect(res.status).toEqual(200)
             expect(res.headers.get('content-type')).toEqual('text/x-component')
-            expect(res.headers.has('X-NextJS-Postponed')).toEqual(false)
+            expect(res.headers.get('cache-control')).toEqual(
+              'private, no-cache, no-store, max-age=0, must-revalidate'
+            )
+            expect(res.headers.get('x-nextjs-cache')).toEqual(null)
+          })
 
-            const cache = res.headers.get('cache-control')
-
-            // cache header handling is different when in minimal mode
-            if (isNextDeploy) {
-              expect(cache).toContain('private')
-              expect(cache).toContain('no-store')
-              expect(cache).toContain('no-cache')
-              expect(cache).toContain('max-age=0')
-              expect(cache).toContain('must-revalidate')
-            } else {
-              expect(cache).toContain('s-maxage=1')
-              expect(cache).toContain('stale-while-revalidate')
-            }
-
-            const text = await res.text()
-
-            if (dynamic !== false) {
-              expect(text).toContain('needle')
-            }
-
-            if (dynamic === true) {
-              // Expect that dynamic RSC prefetches do contain the dynamic text.
+          if (dynamic === true || dynamic === 'force-dynamic') {
+            it('should contain dynamic content', async () => {
+              const expected = `${Date.now()}:${Math.random()}`
+              const res = await next.fetch(pathname, {
+                headers: { RSC: '1', 'X-Test-Input': expected },
+              })
+              expect(res.status).toEqual(200)
+              expect(res.headers.get('content-type')).toEqual(
+                'text/x-component'
+              )
+              const text = await res.text()
               expect(text).toContain(expected)
-            } else {
-              // Expect that dynamic RSC prefetches do not contain the dynamic text
-              // when we're forced static.
-              expect(text).not.toContain(expected)
-            }
+            })
+          } else {
+            it('should not contain dynamic content', async () => {
+              const unexpected = `${Date.now()}:${Math.random()}`
+              const res = await next.fetch(pathname, {
+                headers: {
+                  RSC: '1',
+                  'X-Test-Input': unexpected,
+                },
+              })
+              expect(res.status).toEqual(200)
+              expect(res.headers.get('content-type')).toEqual(
+                'text/x-component'
+              )
+              const text = await res.text()
+              expect(text).not.toContain(unexpected)
+            })
           }
-        )
+        })
       })
     }
   }

--- a/test/e2e/app-dir/ppr/ppr.test.ts
+++ b/test/e2e/app-dir/ppr/ppr.test.ts
@@ -70,21 +70,6 @@ createNextDescribe(
           expect($('#container > #dynamic > #state').length).toBe(0)
         })
       }
-
-      if (!isNextDev) {
-        it('should cache the static part', async () => {
-          // First, render the page to populate the cache.
-          let res = await next.fetch(pathname)
-          expect(res.status).toBe(200)
-          expect(res.headers.get('x-nextjs-postponed')).toBe('1')
-
-          // Then, render the page again.
-          res = await next.fetch(pathname)
-          expect(res.status).toBe(200)
-          expect(res.headers.get('x-nextjs-cache')).toBe('HIT')
-          expect(res.headers.get('x-nextjs-postponed')).toBe('1')
-        })
-      }
     })
 
     describe.each([

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -79,6 +79,7 @@
       "test/integration/app-dir-export/**/*",
       "test/e2e/app-dir/next-font/**/*",
       "test/e2e/app-dir/ppr/**/*",
+      "test/e2e/app-dir/ppr-*/**/*",
       "test/e2e/app-dir/app-prefetch*/**/*",
       "test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts",
       "test/e2e/app-dir/searchparams-static-bailout/searchparams-static-bailout.test.ts"


### PR DESCRIPTION
This fixes some of headers (and adds associated tests) for pages when PPR is enabled. Namely, the `Cache-Control` headers are now returning correctly, reflecting the non-cachability of some requests:

- Requests that postpone (dynamic data is streamed after the initial static shell is streamed)
- Requests for the Dynamic RSC payload

Additionally, the `X-NextJS-Cache` header has been updated for better support for PPR:

- Requests that postpone no longer return this header as it doesn't reflect the cache state of the request (because it streams)
- Requests for the Prefetch RSC now returns the correct cache headers depending on the segment and pre-postpone state

This also enables the other pathnames in the test suites 🙌🏻 

Closes NEXT-1840