### PR TITLE
Update Deployment Testing

### DIFF
--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -34,11 +34,30 @@ export class NextDeployInstance extends NextInstance {
         stdio: 'inherit',
       })
     }
-    const vercelFlags = ['--scope', TEST_TEAM_NAME]
-    const vercelEnv = { ...process.env, TOKEN: TEST_TOKEN }
+
+    const vercelFlags = []
+
+    // If the team name is available in the environment, use it as the scope.
+    if (TEST_TEAM_NAME) {
+      vercelFlags.push('--scope', TEST_TEAM_NAME)
+    }
+
+    const vercelEnv = { ...process.env }
+
+    // If the token is available in the environment, use it as the token in the
+    // environment.
+    if (TEST_TOKEN) {
+      vercelEnv.TOKEN = TEST_TOKEN
+    }
 
     // create auth file in CI
     if (process.env.NEXT_TEST_JOB) {
+      if (!TEST_TOKEN && !TEST_TEAM_NAME) {
+        throw new Error(
+          'Missing TEST_TOKEN and TEST_TEAM_NAME environment variables for CI'
+        )
+      }
+
       const vcConfigDir = path.join(os.homedir(), '.vercel')
       await fs.ensureDir(vcConfigDir)
       await fs.writeFile(
@@ -125,25 +144,21 @@ export class NextDeployInstance extends NextInstance {
 
     require('console').log(`Got buildId: ${this._buildId}`)
 
-    const cliOutputRes = await fetch(
-      `https://vercel.com/api/v1/deployments/${this._parsedUrl.hostname}/events?builds=1&direction=backward`,
+    // Use the vercel logs command to get the CLI output from the build.
+    const logs = await execa(
+      'vercel',
+      ['logs', this._url, '--output', 'raw', ...vercelFlags],
       {
-        headers: {
-          Authorization: `Bearer ${TEST_TOKEN}`,
-        },
+        env: vercelEnv,
       }
     )
-
-    if (!cliOutputRes.ok) {
-      throw new Error(
-        `Failed to get build output: ${await cliOutputRes.text()} (${
-          cliOutputRes.status
-        })`
-      )
+    if (logs.exitCode !== 0) {
+      throw new Error(`Failed to get build output logs: ${logs.stderr}`)
     }
-    this._cliOutput = (await cliOutputRes.json())
-      .map((line) => line.text || '')
-      .join('\n')
+
+    // Use the stdout from the logs command as the CLI output. The CLI will
+    // output other unrelated logs to stderr.
+    this._cliOutput = logs.stdout
   }
 
   public get cliOutput() {


### PR DESCRIPTION
Previously when running deployment tests, the testing infrastructure used the Vercel REST API to manage and work with deployments to perform the actual testing. This now utilizes the Vercel CLI instead (while maintaining the same beheviour as before) to simplifiy the implementation.

In cases where testing is performed against a locally configured Vercel CLI that's already authenticated it will now use those pre-configured credentials.

Closes NEXT-1841