### PR TITLE
networkUrl isn't showing correct protocol when using selfSignedCertificate.

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -232,10 +232,10 @@ export async function startServer(
 
       port = typeof addr === 'object' ? addr?.port || port : port
 
-      const networkUrl = hostname ? `http://${actualHostname}:${port}` : null
-      const appUrl = `${
-        selfSignedCertificate ? 'https' : 'http'
-      }://${formattedHostname}:${port}`
+      const protocol = selfSignedCertificate ? 'https' : 'http'
+
+      const networkUrl = hostname ? `${protocol}://${actualHostname}:${port}` : null
+      const appUrl = `${protocol}://${formattedHostname}:${port}`
 
       if (nodeDebugType) {
         const debugPort = getDebugPort()


### PR DESCRIPTION
Currently server logs prints `http` on network address, even if using certificates that allow ssl on that address.
![image](https://github.com/vercel/next.js/assets/6390605/f7880313-6d1c-49b5-bb99-34cf28d3aad9)
