### PR TITLE
test(runner): preserve browser tracing if test fails

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -178,6 +178,7 @@ jobs:
         with:
           name: test-reports
           path: |
+            test/traces
             test/test-junit-report
             test/turbopack-test-junit-report
           if-no-files-found: ignore

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -390,7 +390,9 @@ export class NextInstance {
               `next-trace`
             )
           )
-          .catch(() => {})
+          .catch((e) => {
+            require('console').error(e)
+          })
       }
 
       if (!process.env.NEXT_TEST_SKIP_CLEANUP) {


### PR DESCRIPTION
### Description

I was tinkering an idea for debugging flaky tests, `if we could attach brwoser side tracing with playwright`?

then I found

1. We already have it configured
2. But it actually doesn't do anything, since 1. trace never stops to teardown 2. `run-tests` wipes out after run

PR adjusts the logics for the tracing

1. Calls the `context.tracing.stop` when page closes or context is being closed
2. Preserve files under `test/traces` under certain conditions - if it's in the CI, and it's retry, and the test is failed after retry

So we can download it and audit to get some more context to debug.

Closes PACK-2129