### PR TITLE
Remove CacheNode.status field

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -13,7 +13,6 @@ import {
   AppRouterContext,
   LayoutRouterContext,
   GlobalLayoutRouterContext,
-  CacheStates,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import type {
   CacheNode,
@@ -149,7 +148,6 @@ function HistoryUpdater({
 }
 
 export const createEmptyCacheNode = () => ({
-  status: CacheStates.LAZY_INITIALIZED,
   data: null,
   subTreeData: null,
   parallelRoutes: new Map(),

--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -1,4 +1,3 @@
-import { CacheStates } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { FlightDataPath } from '../../../server/app-render/types'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
@@ -20,7 +19,6 @@ export function applyFlightData(
 
   if (flightDataPath.length === 3) {
     const subTreeData = cacheNodeSeedData[2]
-    cache.status = CacheStates.READY
     cache.subTreeData = subTreeData
     fillLazyItemsTillLeafWithHead(
       cache,
@@ -32,7 +30,6 @@ export function applyFlightData(
     )
   } else {
     // Copy subTreeData for the root node of the cache.
-    cache.status = CacheStates.READY
     cache.subTreeData = existingCache.subTreeData
     cache.parallelRoutes = new Map(existingCache.parallelRoutes)
     // Create a copy of the existing cache with the subTreeData applied.

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import type { FlightRouterState } from '../../../server/app-render/types'
-import { CacheStates } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import { createInitialRouterState } from './create-initial-router-state'
 
@@ -56,7 +55,6 @@ describe('createInitialRouterState', () => {
     })
 
     const expectedCache: CacheNode = {
-      status: CacheStates.READY,
       data: null,
       subTreeData: children,
       parallelRoutes: new Map([
@@ -66,7 +64,6 @@ describe('createInitialRouterState', () => {
             [
               'linking',
               {
-                status: CacheStates.LAZY_INITIALIZED,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -74,7 +71,6 @@ describe('createInitialRouterState', () => {
                       [
                         '',
                         {
-                          status: CacheStates.LAZY_INITIALIZED,
                           data: null,
                           subTreeData: null,
                           parallelRoutes: new Map(),

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -5,7 +5,6 @@ import type {
   CacheNodeSeedData,
 } from '../../../server/app-render/types'
 
-import { CacheStates } from '../../../shared/lib/app-router-context.shared-runtime'
 import { createHrefFromUrl } from './create-href-from-url'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { extractPathFromFlightRouterState } from './compute-changed-path'
@@ -34,7 +33,6 @@ export function createInitialRouterState({
   const subTreeData = initialSeedData[2]
 
   const cache: CacheNode = {
-    status: CacheStates.READY,
     data: null,
     subTreeData: subTreeData,
     // The cache gets seeded during the first render. `initialParallelRoutes` ensures the cache from the first render is there during the second render.

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import type { FetchServerResponseResult } from './fetch-server-response'
 import { fillCacheWithDataProperty } from './fill-cache-with-data-property'
-import { CacheStates } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 
 describe('fillCacheWithDataProperty', () => {
@@ -23,14 +22,12 @@ describe('fillCacheWithDataProperty', () => {
       .flat()
 
     const cache: CacheNode = {
-      status: CacheStates.LAZY_INITIALIZED,
       data: null,
       subTreeData: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
       data: null,
-      status: CacheStates.READY,
       subTreeData: <>Root layout</>,
       parallelRoutes: new Map([
         [
@@ -40,7 +37,6 @@ describe('fillCacheWithDataProperty', () => {
               'linking',
               {
                 data: null,
-                status: CacheStates.READY,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -50,7 +46,6 @@ describe('fillCacheWithDataProperty', () => {
                         '',
                         {
                           data: null,
-                          status: CacheStates.READY,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -81,14 +76,12 @@ describe('fillCacheWithDataProperty', () => {
                   "" => {
                     "data": null,
                     "parallelRoutes": Map {},
-                    "status": "READY",
                     "subTreeData": <React.Fragment>
                       Page
                     </React.Fragment>,
                   },
                 },
               },
-              "status": "READY",
               "subTreeData": <React.Fragment>
                 Linking
               </React.Fragment>,
@@ -96,12 +89,10 @@ describe('fillCacheWithDataProperty', () => {
             "dashboard" => {
               "data": Promise {},
               "parallelRoutes": Map {},
-              "status": "DATAFETCH",
               "subTreeData": null,
             },
           },
         },
-        "status": "LAZYINITIALIZED",
         "subTreeData": null,
       }
     `)

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.ts
@@ -1,6 +1,5 @@
 import type { FetchServerResponseResult } from './fetch-server-response'
 import type { FlightSegmentPath } from '../../../server/app-render/types'
-import { CacheStates } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import { createRouterCacheKey } from './create-router-cache-key'
 
@@ -39,7 +38,6 @@ export function fillCacheWithDataProperty(
       childCacheNode === existingChildCacheNode
     ) {
       childSegmentMap.set(cacheKey, {
-        status: CacheStates.DATA_FETCH,
         data: fetchResponse(),
         subTreeData: null,
         parallelRoutes: new Map(),
@@ -52,7 +50,6 @@ export function fillCacheWithDataProperty(
     // Start fetch in the place where the existing cache doesn't have the data yet.
     if (!childCacheNode) {
       childSegmentMap.set(cacheKey, {
-        status: CacheStates.DATA_FETCH,
         data: fetchResponse(),
         subTreeData: null,
         parallelRoutes: new Map(),
@@ -63,7 +60,6 @@ export function fillCacheWithDataProperty(
 
   if (childCacheNode === existingChildCacheNode) {
     childCacheNode = {
-      status: childCacheNode.status,
       data: childCacheNode.data,
       subTreeData: childCacheNode.subTreeData,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { fillCacheWithNewSubTreeData } from './fill-cache-with-new-subtree-data'
-import { CacheStates } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { FlightData } from '../../../server/app-render/types'
 
@@ -28,14 +27,12 @@ const getFlightData = (): FlightData => {
 describe('fillCacheWithNewSubtreeData', () => {
   it('should apply subTreeData and head property', () => {
     const cache: CacheNode = {
-      status: CacheStates.LAZY_INITIALIZED,
       data: null,
       subTreeData: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
       data: null,
-      status: CacheStates.READY,
       subTreeData: <>Root layout</>,
       parallelRoutes: new Map([
         [
@@ -45,7 +42,6 @@ describe('fillCacheWithNewSubtreeData', () => {
               'linking',
               {
                 data: null,
-                status: CacheStates.READY,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -55,7 +51,6 @@ describe('fillCacheWithNewSubtreeData', () => {
                         '',
                         {
                           data: null,
-                          status: CacheStates.READY,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -83,7 +78,6 @@ describe('fillCacheWithNewSubtreeData', () => {
 
     const expectedCache: CacheNode = {
       data: null,
-      status: CacheStates.LAZY_INITIALIZED,
       subTreeData: null,
       parallelRoutes: new Map([
         [
@@ -93,7 +87,6 @@ describe('fillCacheWithNewSubtreeData', () => {
               'linking',
               {
                 data: null,
-                status: CacheStates.READY,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -104,7 +97,6 @@ describe('fillCacheWithNewSubtreeData', () => {
                         '',
                         {
                           data: null,
-                          status: CacheStates.READY,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -121,7 +113,6 @@ describe('fillCacheWithNewSubtreeData', () => {
                                   '',
                                   {
                                     data: null,
-                                    status: CacheStates.LAZY_INITIALIZED,
                                     subTreeData: null,
                                     parallelRoutes: new Map(),
                                     head: (
@@ -135,7 +126,6 @@ describe('fillCacheWithNewSubtreeData', () => {
                             ],
                           ]),
                           subTreeData: <h1>SubTreeData Injected!</h1>,
-                          status: CacheStates.READY,
                         },
                       ],
                     ]),

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -1,4 +1,3 @@
-import { CacheStates } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import type {
   FlightDataPath,
@@ -49,7 +48,6 @@ export function fillCacheWithNewSubTreeData(
       const seedData: CacheNodeSeedData = flightDataPath[3]
       const subTreeData = seedData[2]
       childCacheNode = {
-        status: CacheStates.READY,
         data: null,
         subTreeData,
         // Ensure segments other than the one we got data for are preserved.
@@ -88,7 +86,6 @@ export function fillCacheWithNewSubTreeData(
 
   if (childCacheNode === existingChildCacheNode) {
     childCacheNode = {
-      status: childCacheNode.status,
       data: childCacheNode.data,
       subTreeData: childCacheNode.subTreeData,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
-import { CacheStates } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { FlightData } from '../../../server/app-render/types'
 
@@ -37,14 +36,12 @@ const getFlightData = (): FlightData => {
 describe('fillLazyItemsTillLeafWithHead', () => {
   it('should fill lazy items till leaf with head', () => {
     const cache: CacheNode = {
-      status: CacheStates.LAZY_INITIALIZED,
       data: null,
       subTreeData: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
       data: null,
-      status: CacheStates.READY,
       subTreeData: <>Root layout</>,
       parallelRoutes: new Map([
         [
@@ -54,7 +51,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
               'linking',
               {
                 data: null,
-                status: CacheStates.READY,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -64,7 +60,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                         '',
                         {
                           data: null,
-                          status: CacheStates.READY,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -98,7 +93,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
 
     const expectedCache: CacheNode = {
       data: null,
-      status: CacheStates.LAZY_INITIALIZED,
       subTreeData: null,
       parallelRoutes: new Map([
         [
@@ -108,7 +102,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
               'linking',
               {
                 data: null,
-                status: CacheStates.LAZY_INITIALIZED,
                 subTreeData: null,
                 parallelRoutes: new Map([
                   [
@@ -126,7 +119,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                                   '',
                                   {
                                     data: null,
-                                    status: CacheStates.LAZY_INITIALIZED,
                                     subTreeData: null,
                                     parallelRoutes: new Map(),
                                     head: (
@@ -140,14 +132,12 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                             ],
                           ]),
                           subTreeData: null,
-                          status: CacheStates.LAZY_INITIALIZED,
                         },
                       ],
                       [
                         '',
                         {
                           data: null,
-                          status: CacheStates.READY,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -1,4 +1,3 @@
-import { CacheStates } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import type {
   FlightRouterState,
@@ -52,7 +51,6 @@ export function fillLazyItemsTillLeafWithHead(
           // New data was sent from the server.
           const seedNode = parallelSeedData[2]
           newCacheNode = {
-            status: CacheStates.READY,
             data: null,
             subTreeData: seedNode,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
@@ -61,7 +59,6 @@ export function fillLazyItemsTillLeafWithHead(
           // No new data was sent from the server, but the existing cache node
           // was prefetched, so we should reuse that.
           newCacheNode = {
-            status: existingCacheNode.status,
             data: existingCacheNode.data,
             subTreeData: existingCacheNode.subTreeData,
             parallelRoutes: new Map(existingCacheNode.parallelRoutes),
@@ -70,7 +67,6 @@ export function fillLazyItemsTillLeafWithHead(
           // No data available for this node. This will trigger a lazy fetch
           // during render.
           newCacheNode = {
-            status: CacheStates.LAZY_INITIALIZED,
             data: null,
             subTreeData: null,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
@@ -99,7 +95,6 @@ export function fillLazyItemsTillLeafWithHead(
       // New data was sent from the server.
       const seedNode = parallelSeedData[2]
       newCacheNode = {
-        status: CacheStates.READY,
         data: null,
         subTreeData: seedNode,
         parallelRoutes: new Map(),
@@ -108,7 +103,6 @@ export function fillLazyItemsTillLeafWithHead(
       // No data available for this node. This will trigger a lazy fetch
       // during render.
       newCacheNode = {
-        status: CacheStates.LAZY_INITIALIZED,
         data: null,
         subTreeData: null,
         parallelRoutes: new Map(),

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import type { FlightData } from '../../../server/app-render/types'
 import { invalidateCacheBelowFlightSegmentPath } from './invalidate-cache-below-flight-segmentpath'
-import { CacheStates } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import { fillCacheWithNewSubTreeData } from './fill-cache-with-new-subtree-data'
 
@@ -29,14 +28,12 @@ const getFlightData = (): FlightData => {
 describe('invalidateCacheBelowFlightSegmentPath', () => {
   it('should invalidate cache below flight segment path', () => {
     const cache: CacheNode = {
-      status: CacheStates.LAZY_INITIALIZED,
       data: null,
       subTreeData: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
       data: null,
-      status: CacheStates.READY,
       subTreeData: <>Root layout</>,
       parallelRoutes: new Map([
         [
@@ -46,7 +43,6 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
               'linking',
               {
                 data: null,
-                status: CacheStates.READY,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -56,7 +52,6 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                         '',
                         {
                           data: null,
-                          status: CacheStates.READY,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -81,10 +76,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
     const flightDataPath = flightData[0]
     const flightSegmentPath = flightDataPath.slice(0, -3)
 
-    // @ts-expect-error TODO-APP: investigate why this is not a TS error in router-reducer.
-    cache.status = CacheStates.READY
     // Copy subTreeData for the root node of the cache.
-    // @ts-expect-error TODO-APP: investigate why this is not a TS error in router-reducer.
     cache.subTreeData = existingCache.subTreeData
     // Create a copy of the existing cache with the subTreeData applied.
     fillCacheWithNewSubTreeData(cache, existingCache, flightDataPath, false)
@@ -115,21 +107,18 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                         {
                           data: null,
                           parallelRoutes: new Map(),
-                          status: CacheStates.READY,
                           subTreeData: <React.Fragment>Page</React.Fragment>,
                         },
                       ],
                     ]),
                   ],
                 ]),
-                status: CacheStates.READY,
                 subTreeData: <React.Fragment>Linking</React.Fragment>,
               },
             ],
           ]),
         ],
       ]),
-      status: CacheStates.READY,
       subTreeData: <>Root layout</>,
     }
 

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
@@ -47,7 +47,6 @@ export function invalidateCacheBelowFlightSegmentPath(
 
   if (childCacheNode === existingChildCacheNode) {
     childCacheNode = {
-      status: childCacheNode.status,
       data: childCacheNode.data,
       subTreeData: childCacheNode.subTreeData,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
@@ -1,20 +1,17 @@
 import React from 'react'
 import { invalidateCacheByRouterState } from './invalidate-cache-by-router-state'
-import { CacheStates } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { FlightRouterState } from '../../../server/app-render/types'
 
 describe('invalidateCacheByRouterState', () => {
   it('should invalidate the cache by router state', () => {
     const cache: CacheNode = {
-      status: CacheStates.LAZY_INITIALIZED,
       data: null,
       subTreeData: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
       data: null,
-      status: CacheStates.READY,
       subTreeData: <>Root layout</>,
       parallelRoutes: new Map([
         [
@@ -24,7 +21,6 @@ describe('invalidateCacheByRouterState', () => {
               'linking',
               {
                 data: null,
-                status: CacheStates.READY,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -34,7 +30,6 @@ describe('invalidateCacheByRouterState', () => {
                         '',
                         {
                           data: null,
-                          status: CacheStates.READY,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -73,7 +68,6 @@ describe('invalidateCacheByRouterState', () => {
 
     const expectedCache: CacheNode = {
       data: null,
-      status: CacheStates.LAZY_INITIALIZED,
       subTreeData: null,
       parallelRoutes: new Map([['children', new Map()]]),
     }

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import type { FlightRouterState } from '../../../../server/app-render/types'
-import { CacheStates } from '../../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { findHeadInCache } from './find-head-in-cache'
 
@@ -28,7 +27,6 @@ describe('findHeadInCache', () => {
 
     const cache: CacheNode = {
       data: null,
-      status: CacheStates.LAZY_INITIALIZED,
       subTreeData: null,
       parallelRoutes: new Map([
         [
@@ -38,7 +36,6 @@ describe('findHeadInCache', () => {
               'linking',
               {
                 data: null,
-                status: CacheStates.LAZY_INITIALIZED,
                 subTreeData: null,
                 parallelRoutes: new Map([
                   [
@@ -56,7 +53,6 @@ describe('findHeadInCache', () => {
                                   '',
                                   {
                                     data: null,
-                                    status: CacheStates.LAZY_INITIALIZED,
                                     subTreeData: null,
                                     parallelRoutes: new Map(),
                                     head: (
@@ -70,7 +66,6 @@ describe('findHeadInCache', () => {
                             ],
                           ]),
                           subTreeData: null,
-                          status: CacheStates.LAZY_INITIALIZED,
                         },
                       ],
                       // TODO-APP: this segment should be preserved when creating the new cache
@@ -78,7 +73,6 @@ describe('findHeadInCache', () => {
                       //   '',
                       //   {
                       //     data: null,
-                      //     status: CacheStates.READY,
                       //     subTreeData: <>Page</>,
                       //     parallelRoutes: new Map(),
                       //   },

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import type { fetchServerResponse as fetchServerResponseType } from '../fetch-server-response'
 import type { FlightData } from '../../../../server/app-render/types'
 import type { FlightRouterState } from '../../../../server/app-render/types'
-import { CacheStates } from '../../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { createInitialRouterState } from '../create-initial-router-state'
 import {
@@ -133,7 +132,6 @@ describe('navigateReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -141,7 +139,6 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -193,7 +190,6 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
@@ -210,26 +206,22 @@ describe('navigateReducer', () => {
                               </title>
                             </React.Fragment>,
                             "parallelRoutes": Map {},
-                            "status": "LAZYINITIALIZED",
                             "subTreeData": null,
                           },
                         },
                       },
-                      "status": "READY",
                       "subTreeData": <h1>
                         About Page!
                       </h1>,
                     },
                   },
                 },
-                "status": "READY",
                 "subTreeData": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "status": "READY",
           "subTreeData": <html>
             <head />
             <body>
@@ -326,7 +318,6 @@ describe('navigateReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -334,7 +325,6 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -387,7 +377,6 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
@@ -404,26 +393,22 @@ describe('navigateReducer', () => {
                               </title>
                             </React.Fragment>,
                             "parallelRoutes": Map {},
-                            "status": "LAZYINITIALIZED",
                             "subTreeData": null,
                           },
                         },
                       },
-                      "status": "READY",
                       "subTreeData": <h1>
                         About Page!
                       </h1>,
                     },
                   },
                 },
-                "status": "READY",
                 "subTreeData": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "status": "READY",
           "subTreeData": <html>
             <head />
             <body>
@@ -520,7 +505,6 @@ describe('navigateReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -528,7 +512,6 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -584,21 +567,18 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                   },
                 },
-                "status": "READY",
                 "subTreeData": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "status": "READY",
           "subTreeData": <html>
             <head />
             <body>
@@ -657,7 +637,6 @@ describe('navigateReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -665,7 +644,6 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -721,21 +699,18 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                   },
                 },
-                "status": "READY",
                 "subTreeData": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "status": "READY",
           "subTreeData": <html>
             <head />
             <body>
@@ -794,7 +769,6 @@ describe('navigateReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -802,7 +776,6 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -855,21 +828,18 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                   },
                 },
-                "status": "READY",
                 "subTreeData": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "status": "READY",
           "subTreeData": <html>
             <head />
             <body>
@@ -952,7 +922,6 @@ describe('navigateReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -960,7 +929,6 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -1050,7 +1018,6 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
@@ -1067,26 +1034,22 @@ describe('navigateReducer', () => {
                               </title>
                             </React.Fragment>,
                             "parallelRoutes": Map {},
-                            "status": "LAZYINITIALIZED",
                             "subTreeData": null,
                           },
                         },
                       },
-                      "status": "READY",
                       "subTreeData": <h1>
                         About Page!
                       </h1>,
                     },
                   },
                 },
-                "status": "READY",
                 "subTreeData": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "status": "READY",
           "subTreeData": <html>
             <head />
             <body>
@@ -1199,7 +1162,6 @@ describe('navigateReducer', () => {
           [
             'parallel-tab-bar',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'audience',
@@ -1207,7 +1169,6 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Audience Page</>,
                         parallelRoutes: new Map(),
@@ -1221,7 +1182,6 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Views Page</>,
                         parallelRoutes: new Map(),
@@ -1235,7 +1195,6 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Children Page</>,
                         parallelRoutes: new Map(),
@@ -1288,7 +1247,6 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Audience Page
                       </React.Fragment>,
@@ -1305,12 +1263,10 @@ describe('navigateReducer', () => {
                               </title>
                             </React.Fragment>,
                             "parallelRoutes": Map {},
-                            "status": "LAZYINITIALIZED",
                             "subTreeData": null,
                           },
                         },
                       },
-                      "status": "LAZYINITIALIZED",
                       "subTreeData": null,
                     },
                   },
@@ -1318,7 +1274,6 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Views Page
                       </React.Fragment>,
@@ -1328,19 +1283,16 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Children Page
                       </React.Fragment>,
                     },
                   },
                 },
-                "status": "LAZYINITIALIZED",
                 "subTreeData": null,
               },
             },
           },
-          "status": "READY",
           "subTreeData": <html>
             <head />
             <body>
@@ -1453,7 +1405,6 @@ describe('navigateReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -1461,7 +1412,6 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -1514,21 +1464,18 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                   },
                 },
-                "status": "READY",
                 "subTreeData": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "status": "READY",
           "subTreeData": <html>
             <head />
             <body>
@@ -1587,7 +1534,6 @@ describe('navigateReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -1595,7 +1541,6 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -1647,7 +1592,6 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
@@ -1664,26 +1608,22 @@ describe('navigateReducer', () => {
                               </title>
                             </React.Fragment>,
                             "parallelRoutes": Map {},
-                            "status": "LAZYINITIALIZED",
                             "subTreeData": null,
                           },
                         },
                       },
-                      "status": "READY",
                       "subTreeData": <h1>
                         About Page!
                       </h1>,
                     },
                   },
                 },
-                "status": "READY",
                 "subTreeData": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "status": "READY",
           "subTreeData": <html>
             <head />
             <body>

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -1,4 +1,3 @@
-import { CacheStates } from '../../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import type {
   FlightRouterState,
@@ -78,7 +77,6 @@ function addRefetchToLeafSegments(
 ) {
   let appliedPatch = false
 
-  newCache.status = CacheStates.READY
   newCache.subTreeData = currentCache.subTreeData
   newCache.parallelRoutes = new Map(currentCache.parallelRoutes)
 
@@ -239,7 +237,6 @@ export function navigateReducer(
           )
 
           if (hardNavigate) {
-            cache.status = CacheStates.READY
             // Copy subTreeData for the root node of the cache.
             cache.subTreeData = currentCache.subTreeData
 

--- a/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import type { fetchServerResponse as fetchServerResponseType } from '../fetch-server-response'
 import type { FlightData } from '../../../../server/app-render/types'
 import type { FlightRouterState } from '../../../../server/app-render/types'
-import { CacheStates } from '../../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { createInitialRouterState } from '../create-initial-router-state'
 import { ACTION_PREFETCH, PrefetchKind } from '../router-reducer-types'
@@ -87,7 +86,6 @@ describe('prefetchReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -95,7 +93,6 @@ describe('prefetchReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -183,7 +180,6 @@ describe('prefetchReducer', () => {
       },
       canonicalUrl: '/linking',
       cache: {
-        status: CacheStates.READY,
         data: null,
         subTreeData: (
           <html>
@@ -229,7 +225,6 @@ describe('prefetchReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -237,7 +232,6 @@ describe('prefetchReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -339,7 +333,6 @@ describe('prefetchReducer', () => {
       },
       canonicalUrl: '/linking',
       cache: {
-        status: CacheStates.READY,
         data: null,
         subTreeData: (
           <html>

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import type { fetchServerResponse } from '../fetch-server-response'
 import type { FlightData } from '../../../../server/app-render/types'
 import type { FlightRouterState } from '../../../../server/app-render/types'
-import { CacheStates } from '../../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { createInitialRouterState } from '../create-initial-router-state'
 import { ACTION_REFRESH } from '../router-reducer-types'
@@ -98,7 +97,6 @@ describe('refreshReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -106,7 +104,6 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -159,7 +156,6 @@ describe('refreshReducer', () => {
       canonicalUrl: '/linking',
       nextUrl: '/linking',
       cache: {
-        status: CacheStates.READY,
         data: null,
         subTreeData: (
           <html>
@@ -176,7 +172,6 @@ describe('refreshReducer', () => {
               [
                 'linking',
                 {
-                  status: CacheStates.LAZY_INITIALIZED,
                   parallelRoutes: new Map([
                     [
                       'children',
@@ -184,7 +179,6 @@ describe('refreshReducer', () => {
                         [
                           '',
                           {
-                            status: CacheStates.LAZY_INITIALIZED,
                             data: null,
                             subTreeData: null,
                             parallelRoutes: new Map(),
@@ -241,7 +235,6 @@ describe('refreshReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -249,7 +242,6 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -316,7 +308,6 @@ describe('refreshReducer', () => {
       canonicalUrl: '/linking',
       nextUrl: '/linking',
       cache: {
-        status: CacheStates.READY,
         data: null,
         subTreeData: (
           <html>
@@ -333,7 +324,6 @@ describe('refreshReducer', () => {
               [
                 'linking',
                 {
-                  status: CacheStates.LAZY_INITIALIZED,
                   parallelRoutes: new Map([
                     [
                       'children',
@@ -341,7 +331,6 @@ describe('refreshReducer', () => {
                         [
                           '',
                           {
-                            status: CacheStates.LAZY_INITIALIZED,
                             data: null,
                             subTreeData: null,
                             parallelRoutes: new Map(),
@@ -398,7 +387,6 @@ describe('refreshReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -406,7 +394,6 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -422,7 +409,6 @@ describe('refreshReducer', () => {
           [
             'about',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -430,7 +416,6 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>About page</>,
                         parallelRoutes: new Map(),
@@ -497,7 +482,6 @@ describe('refreshReducer', () => {
       canonicalUrl: '/linking',
       nextUrl: '/linking',
       cache: {
-        status: CacheStates.READY,
         data: null,
         subTreeData: (
           <html>
@@ -514,7 +498,6 @@ describe('refreshReducer', () => {
               [
                 'linking',
                 {
-                  status: CacheStates.LAZY_INITIALIZED,
                   parallelRoutes: new Map([
                     [
                       'children',
@@ -522,7 +505,6 @@ describe('refreshReducer', () => {
                         [
                           '',
                           {
-                            status: CacheStates.LAZY_INITIALIZED,
                             data: null,
                             subTreeData: null,
                             parallelRoutes: new Map(),
@@ -579,7 +561,6 @@ describe('refreshReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -587,7 +568,6 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -603,7 +583,6 @@ describe('refreshReducer', () => {
           [
             'about',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -611,7 +590,6 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>About page</>,
                         parallelRoutes: new Map(),
@@ -727,7 +705,6 @@ describe('refreshReducer', () => {
       canonicalUrl: '/linking',
       nextUrl: '/linking',
       cache: {
-        status: CacheStates.READY,
         data: null,
         subTreeData: (
           <html>
@@ -744,7 +721,6 @@ describe('refreshReducer', () => {
               [
                 'linking',
                 {
-                  status: CacheStates.LAZY_INITIALIZED,
                   parallelRoutes: new Map([
                     [
                       'children',
@@ -752,7 +728,6 @@ describe('refreshReducer', () => {
                         [
                           '',
                           {
-                            status: CacheStates.LAZY_INITIALIZED,
                             data: null,
                             subTreeData: null,
                             parallelRoutes: new Map(),

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -10,10 +10,7 @@ import type {
 } from '../router-reducer-types'
 import { handleExternalUrl } from './navigate-reducer'
 import { handleMutable } from '../handle-mutable'
-import {
-  CacheStates,
-  type CacheNode,
-} from '../../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { fillLazyItemsTillLeafWithHead } from '../fill-lazy-items-till-leaf-with-head'
 import { createEmptyCacheNode } from '../../app-router'
 
@@ -98,7 +95,6 @@ export function refreshReducer(
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (cacheNodeSeedData !== null) {
           const subTreeData = cacheNodeSeedData[2]
-          cache.status = CacheStates.READY
           cache.subTreeData = subTreeData
           fillLazyItemsTillLeafWithHead(
             cache,

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import type { FlightRouterState } from '../../../../server/app-render/types'
-import { CacheStates } from '../../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { createInitialRouterState } from '../create-initial-router-state'
 import { ACTION_RESTORE } from '../router-reducer-types'
@@ -54,7 +53,6 @@ describe('serverPatchReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -62,7 +60,6 @@ describe('serverPatchReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -134,7 +131,6 @@ describe('serverPatchReducer', () => {
       canonicalUrl: '/linking/about',
       nextUrl: '/linking/about',
       cache: {
-        status: CacheStates.READY,
         data: null,
         subTreeData: (
           <html>
@@ -149,7 +145,6 @@ describe('serverPatchReducer', () => {
               [
                 'linking',
                 {
-                  status: CacheStates.READY,
                   parallelRoutes: new Map([
                     [
                       'children',
@@ -157,7 +152,6 @@ describe('serverPatchReducer', () => {
                         [
                           '',
                           {
-                            status: CacheStates.READY,
                             data: null,
                             subTreeData: <>Linking page</>,
                             parallelRoutes: new Map(),
@@ -209,7 +203,6 @@ describe('serverPatchReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -217,7 +210,6 @@ describe('serverPatchReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -302,7 +294,6 @@ describe('serverPatchReducer', () => {
       canonicalUrl: '/linking/about',
       nextUrl: '/linking/about',
       cache: {
-        status: CacheStates.READY,
         data: null,
         subTreeData: (
           <html>
@@ -317,7 +308,6 @@ describe('serverPatchReducer', () => {
               [
                 'linking',
                 {
-                  status: CacheStates.READY,
                   parallelRoutes: new Map([
                     [
                       'children',
@@ -325,7 +315,6 @@ describe('serverPatchReducer', () => {
                         [
                           '',
                           {
-                            status: CacheStates.READY,
                             data: null,
                             subTreeData: <>Linking page</>,
                             parallelRoutes: new Map(),

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -33,10 +33,7 @@ import { createHrefFromUrl } from '../create-href-from-url'
 import { handleExternalUrl } from './navigate-reducer'
 import { applyRouterStatePatchToTree } from '../apply-router-state-patch-to-tree'
 import { isNavigatingToNewRootLayout } from '../is-navigating-to-new-root-layout'
-import {
-  CacheStates,
-  type CacheNode,
-} from '../../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { handleMutable } from '../handle-mutable'
 import { fillLazyItemsTillLeafWithHead } from '../fill-lazy-items-till-leaf-with-head'
 import { createEmptyCacheNode } from '../../app-router'
@@ -247,7 +244,6 @@ export function serverActionReducer(
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (subTreeData !== null) {
           const cache: CacheNode = createEmptyCacheNode()
-          cache.status = CacheStates.READY
           cache.subTreeData = subTreeData
           fillLazyItemsTillLeafWithHead(
             cache,

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
@@ -4,7 +4,6 @@ import type {
   FlightData,
   FlightRouterState,
 } from '../../../../server/app-render/types'
-import { CacheStates } from '../../../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { createInitialRouterState } from '../create-initial-router-state'
 import { ACTION_SERVER_PATCH, ACTION_NAVIGATE } from '../router-reducer-types'
@@ -105,7 +104,6 @@ describe('serverPatchReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -113,7 +111,6 @@ describe('serverPatchReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -176,7 +173,6 @@ describe('serverPatchReducer', () => {
                     "" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
@@ -193,26 +189,22 @@ describe('serverPatchReducer', () => {
                               </title>
                             </React.Fragment>,
                             "parallelRoutes": Map {},
-                            "status": "LAZYINITIALIZED",
                             "subTreeData": null,
                           },
                         },
                       },
-                      "status": "READY",
                       "subTreeData": <h1>
                         Somewhere Page!
                       </h1>,
                     },
                   },
                 },
-                "status": "READY",
                 "subTreeData": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "status": "READY",
           "subTreeData": <html>
             <head />
             <body>
@@ -276,7 +268,6 @@ describe('serverPatchReducer', () => {
           [
             'linking',
             {
-              status: CacheStates.READY,
               parallelRoutes: new Map([
                 [
                   'children',
@@ -284,7 +275,6 @@ describe('serverPatchReducer', () => {
                     [
                       '',
                       {
-                        status: CacheStates.READY,
                         data: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
@@ -359,7 +349,6 @@ describe('serverPatchReducer', () => {
                     "" => {
                       "data": null,
                       "parallelRoutes": Map {},
-                      "status": "READY",
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
@@ -376,12 +365,10 @@ describe('serverPatchReducer', () => {
                               </title>
                             </React.Fragment>,
                             "parallelRoutes": Map {},
-                            "status": "LAZYINITIALIZED",
                             "subTreeData": null,
                           },
                         },
                       },
-                      "status": "READY",
                       "subTreeData": <h1>
                         About Page!
                       </h1>,
@@ -398,26 +385,22 @@ describe('serverPatchReducer', () => {
                               </title>
                             </React.Fragment>,
                             "parallelRoutes": Map {},
-                            "status": "LAZYINITIALIZED",
                             "subTreeData": null,
                           },
                         },
                       },
-                      "status": "READY",
                       "subTreeData": <h1>
                         Somewhere Page!
                       </h1>,
                     },
                   },
                 },
-                "status": "READY",
                 "subTreeData": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "status": "READY",
           "subTreeData": <html>
             <head />
             <body>


### PR DESCRIPTION
I'm about to make some changes to the CacheNode data structure, and before I add more complexity, I noticed an opportunity to remove some — the `status` field isn't logically necessary:

- The `DATA_FETCH` and `LAZY_INITIALIZED` states are already treated as equivalent; in either case, they will cause the render to suspend during render, trigger a lazy data fetch (if one hasn't been triggered already), and then update the router with the result of the response.
- `subTreeData` is null if and only if the node is in the `DATA_FETCH` or `LAZY_INITIALIZED` states, and it always causes the render to suspend. So rather than check if the status is one of those, we can check if `subTreeData` is null.

The most important changes are to CacheNode type in app-router-context.shared-runtime and the lazy fetching logic in LayoutRouter. Everything else in the diff is related to deleting the `status` field wherever a CacheNode is referenced, like in the reducer unit tests.

Closes NEXT-1842