### PR TITLE
Rename CacheNode.data → .lazyData 

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -148,7 +148,7 @@ function HistoryUpdater({
 }
 
 export const createEmptyCacheNode = () => ({
-  data: null,
+  lazyData: null,
   subTreeData: null,
   parallelRoutes: new Map(),
 })

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -345,7 +345,7 @@ function InnerLayoutRouter({
     // data request.
     //
     // TODO: An eventual goal of PPR is to remove this case entirely.
-    (childNode.subTreeData === null && childNode.data === null)
+    (childNode.subTreeData === null && childNode.lazyData === null)
   ) {
     /**
      * Router state with refetch marker added
@@ -354,7 +354,7 @@ function InnerLayoutRouter({
     const refetchTree = walkAddRefetch(['', ...segmentPath], fullTree)
 
     childNode = {
-      data: fetchServerResponse(
+      lazyData: fetchServerResponse(
         new URL(url, location.origin),
         refetchTree,
         context.nextUrl,
@@ -377,20 +377,20 @@ function InnerLayoutRouter({
   }
 
   // This case should never happen so it throws an error. It indicates there's a bug in the Next.js.
-  if (childNode.subTreeData && childNode.data) {
-    throw new Error('Child node should not have both subTreeData and data')
+  if (childNode.subTreeData && childNode.lazyData) {
+    throw new Error('Child node should not have both subTreeData and lazyData')
   }
 
   // If cache node has a data request we have to unwrap response by `use` and update the cache.
-  if (childNode.data) {
+  if (childNode.lazyData) {
     /**
      * Flight response data
      */
     // When the data has not resolved yet `use` will suspend here.
-    const [flightData, overrideCanonicalUrl] = use(childNode.data)
+    const [flightData, overrideCanonicalUrl] = use(childNode.lazyData)
 
     // segmentPath from the server does not match the layout's segmentPath
-    childNode.data = null
+    childNode.lazyData = null
 
     // setTimeout is used to start a new transition during render, this is an intentional hack around React.
     setTimeout(() => {
@@ -402,7 +402,7 @@ function InnerLayoutRouter({
     use(createInfinitePromise())
   }
 
-  // If cache node has no subTreeData and no data request we have to infinitely suspend as the data will likely flow in from another place.
+  // If cache node has no subTreeData and no lazy data request we have to infinitely suspend as the data will likely flow in from another place.
   // TODO-APP: double check users can't return null in a component that will kick in here.
   if (!childNode.subTreeData) {
     use(createInfinitePromise())

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -55,7 +55,7 @@ describe('createInitialRouterState', () => {
     })
 
     const expectedCache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: children,
       parallelRoutes: new Map([
         [
@@ -71,7 +71,7 @@ describe('createInitialRouterState', () => {
                       [
                         '',
                         {
-                          data: null,
+                          lazyData: null,
                           subTreeData: null,
                           parallelRoutes: new Map(),
                           head: <title>Test</title>,
@@ -80,7 +80,7 @@ describe('createInitialRouterState', () => {
                     ]),
                   ],
                 ]),
-                data: null,
+                lazyData: null,
                 subTreeData: null,
               },
             ],

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -33,7 +33,7 @@ export function createInitialRouterState({
   const subTreeData = initialSeedData[2]
 
   const cache: CacheNode = {
-    data: null,
+    lazyData: null,
     subTreeData: subTreeData,
     // The cache gets seeded during the first render. `initialParallelRoutes` ensures the cache from the first render is there during the second render.
     parallelRoutes: isServer ? new Map() : initialParallelRoutes,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.test.tsx
@@ -22,12 +22,12 @@ describe('fillCacheWithDataProperty', () => {
       .flat()
 
     const cache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: <>Root layout</>,
       parallelRoutes: new Map([
         [
@@ -36,7 +36,7 @@ describe('fillCacheWithDataProperty', () => {
             [
               'linking',
               {
-                data: null,
+                lazyData: null,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -45,7 +45,7 @@ describe('fillCacheWithDataProperty', () => {
                       [
                         '',
                         {
-                          data: null,
+                          lazyData: null,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -66,15 +66,15 @@ describe('fillCacheWithDataProperty', () => {
 
     expect(cache).toMatchInlineSnapshot(`
       {
-        "data": null,
+        "lazyData": null,
         "parallelRoutes": Map {
           "children" => Map {
             "linking" => {
-              "data": null,
+              "lazyData": null,
               "parallelRoutes": Map {
                 "children" => Map {
                   "" => {
-                    "data": null,
+                    "lazyData": null,
                     "parallelRoutes": Map {},
                     "subTreeData": <React.Fragment>
                       Page
@@ -87,7 +87,7 @@ describe('fillCacheWithDataProperty', () => {
               </React.Fragment>,
             },
             "dashboard" => {
-              "data": Promise {},
+              "lazyData": Promise {},
               "parallelRoutes": Map {},
               "subTreeData": null,
             },

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.ts
@@ -34,11 +34,11 @@ export function fillCacheWithDataProperty(
   if (isLastEntry) {
     if (
       !childCacheNode ||
-      !childCacheNode.data ||
+      !childCacheNode.lazyData ||
       childCacheNode === existingChildCacheNode
     ) {
       childSegmentMap.set(cacheKey, {
-        data: fetchResponse(),
+        lazyData: fetchResponse(),
         subTreeData: null,
         parallelRoutes: new Map(),
       })
@@ -50,7 +50,7 @@ export function fillCacheWithDataProperty(
     // Start fetch in the place where the existing cache doesn't have the data yet.
     if (!childCacheNode) {
       childSegmentMap.set(cacheKey, {
-        data: fetchResponse(),
+        lazyData: fetchResponse(),
         subTreeData: null,
         parallelRoutes: new Map(),
       })
@@ -60,7 +60,7 @@ export function fillCacheWithDataProperty(
 
   if (childCacheNode === existingChildCacheNode) {
     childCacheNode = {
-      data: childCacheNode.data,
+      lazyData: childCacheNode.lazyData,
       subTreeData: childCacheNode.subTreeData,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
     } as CacheNode

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -27,12 +27,12 @@ const getFlightData = (): FlightData => {
 describe('fillCacheWithNewSubtreeData', () => {
   it('should apply subTreeData and head property', () => {
     const cache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: <>Root layout</>,
       parallelRoutes: new Map([
         [
@@ -41,7 +41,7 @@ describe('fillCacheWithNewSubtreeData', () => {
             [
               'linking',
               {
-                data: null,
+                lazyData: null,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -50,7 +50,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                       [
                         '',
                         {
-                          data: null,
+                          lazyData: null,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -77,7 +77,7 @@ describe('fillCacheWithNewSubtreeData', () => {
     fillCacheWithNewSubTreeData(cache, existingCache, flightDataPath, false)
 
     const expectedCache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: null,
       parallelRoutes: new Map([
         [
@@ -86,7 +86,7 @@ describe('fillCacheWithNewSubtreeData', () => {
             [
               'linking',
               {
-                data: null,
+                lazyData: null,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -96,7 +96,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                       [
                         '',
                         {
-                          data: null,
+                          lazyData: null,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -104,7 +104,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                       [
                         'about',
                         {
-                          data: null,
+                          lazyData: null,
                           parallelRoutes: new Map([
                             [
                               'children',
@@ -112,7 +112,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                                 [
                                   '',
                                   {
-                                    data: null,
+                                    lazyData: null,
                                     subTreeData: null,
                                     parallelRoutes: new Map(),
                                     head: (

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -42,13 +42,13 @@ export function fillCacheWithNewSubTreeData(
   if (isLastEntry) {
     if (
       !childCacheNode ||
-      !childCacheNode.data ||
+      !childCacheNode.lazyData ||
       childCacheNode === existingChildCacheNode
     ) {
       const seedData: CacheNodeSeedData = flightDataPath[3]
       const subTreeData = seedData[2]
       childCacheNode = {
-        data: null,
+        lazyData: null,
         subTreeData,
         // Ensure segments other than the one we got data for are preserved.
         parallelRoutes: existingChildCacheNode
@@ -86,7 +86,7 @@ export function fillCacheWithNewSubTreeData(
 
   if (childCacheNode === existingChildCacheNode) {
     childCacheNode = {
-      data: childCacheNode.data,
+      lazyData: childCacheNode.lazyData,
       subTreeData: childCacheNode.subTreeData,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
     } as CacheNode

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -36,12 +36,12 @@ const getFlightData = (): FlightData => {
 describe('fillLazyItemsTillLeafWithHead', () => {
   it('should fill lazy items till leaf with head', () => {
     const cache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: <>Root layout</>,
       parallelRoutes: new Map([
         [
@@ -50,7 +50,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
             [
               'linking',
               {
-                data: null,
+                lazyData: null,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -59,7 +59,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                       [
                         '',
                         {
-                          data: null,
+                          lazyData: null,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -92,7 +92,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
     )
 
     const expectedCache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: null,
       parallelRoutes: new Map([
         [
@@ -101,7 +101,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
             [
               'linking',
               {
-                data: null,
+                lazyData: null,
                 subTreeData: null,
                 parallelRoutes: new Map([
                   [
@@ -110,7 +110,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                       [
                         'about',
                         {
-                          data: null,
+                          lazyData: null,
                           parallelRoutes: new Map([
                             [
                               'children',
@@ -118,7 +118,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                                 [
                                   '',
                                   {
-                                    data: null,
+                                    lazyData: null,
                                     subTreeData: null,
                                     parallelRoutes: new Map(),
                                     head: (
@@ -137,7 +137,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                       [
                         '',
                         {
-                          data: null,
+                          lazyData: null,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -51,7 +51,7 @@ export function fillLazyItemsTillLeafWithHead(
           // New data was sent from the server.
           const seedNode = parallelSeedData[2]
           newCacheNode = {
-            data: null,
+            lazyData: null,
             subTreeData: seedNode,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
           }
@@ -59,7 +59,7 @@ export function fillLazyItemsTillLeafWithHead(
           // No new data was sent from the server, but the existing cache node
           // was prefetched, so we should reuse that.
           newCacheNode = {
-            data: existingCacheNode.data,
+            lazyData: existingCacheNode.lazyData,
             subTreeData: existingCacheNode.subTreeData,
             parallelRoutes: new Map(existingCacheNode.parallelRoutes),
           } as CacheNode
@@ -67,7 +67,7 @@ export function fillLazyItemsTillLeafWithHead(
           // No data available for this node. This will trigger a lazy fetch
           // during render.
           newCacheNode = {
-            data: null,
+            lazyData: null,
             subTreeData: null,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
           }
@@ -95,7 +95,7 @@ export function fillLazyItemsTillLeafWithHead(
       // New data was sent from the server.
       const seedNode = parallelSeedData[2]
       newCacheNode = {
-        data: null,
+        lazyData: null,
         subTreeData: seedNode,
         parallelRoutes: new Map(),
       }
@@ -103,7 +103,7 @@ export function fillLazyItemsTillLeafWithHead(
       // No data available for this node. This will trigger a lazy fetch
       // during render.
       newCacheNode = {
-        data: null,
+        lazyData: null,
         subTreeData: null,
         parallelRoutes: new Map(),
       }

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -28,12 +28,12 @@ const getFlightData = (): FlightData => {
 describe('invalidateCacheBelowFlightSegmentPath', () => {
   it('should invalidate cache below flight segment path', () => {
     const cache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: <>Root layout</>,
       parallelRoutes: new Map([
         [
@@ -42,7 +42,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
             [
               'linking',
               {
-                data: null,
+                lazyData: null,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -51,7 +51,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                       [
                         '',
                         {
-                          data: null,
+                          lazyData: null,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -89,7 +89,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
     )
 
     const expectedCache: CacheNode = {
-      data: null,
+      lazyData: null,
       parallelRoutes: new Map([
         [
           'children',
@@ -97,7 +97,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
             [
               'linking',
               {
-                data: null,
+                lazyData: null,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -105,7 +105,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                       [
                         '',
                         {
-                          data: null,
+                          lazyData: null,
                           parallelRoutes: new Map(),
                           subTreeData: <React.Fragment>Page</React.Fragment>,
                         },

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
@@ -47,7 +47,7 @@ export function invalidateCacheBelowFlightSegmentPath(
 
   if (childCacheNode === existingChildCacheNode) {
     childCacheNode = {
-      data: childCacheNode.data,
+      lazyData: childCacheNode.lazyData,
       subTreeData: childCacheNode.subTreeData,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
     } as CacheNode

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
@@ -6,12 +6,12 @@ import type { FlightRouterState } from '../../../server/app-render/types'
 describe('invalidateCacheByRouterState', () => {
   it('should invalidate the cache by router state', () => {
     const cache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: <>Root layout</>,
       parallelRoutes: new Map([
         [
@@ -20,7 +20,7 @@ describe('invalidateCacheByRouterState', () => {
             [
               'linking',
               {
-                data: null,
+                lazyData: null,
                 subTreeData: <>Linking</>,
                 parallelRoutes: new Map([
                   [
@@ -29,7 +29,7 @@ describe('invalidateCacheByRouterState', () => {
                       [
                         '',
                         {
-                          data: null,
+                          lazyData: null,
                           subTreeData: <>Page</>,
                           parallelRoutes: new Map(),
                         },
@@ -67,7 +67,7 @@ describe('invalidateCacheByRouterState', () => {
     invalidateCacheByRouterState(cache, existingCache, routerState)
 
     const expectedCache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: null,
       parallelRoutes: new Map([['children', new Map()]]),
     }

--- a/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
@@ -28,14 +28,14 @@ function fastRefreshReducerImpl(
   const cache: CacheNode = createEmptyCacheNode()
   // TODO-APP: verify that `href` is not an external url.
   // Fetch data from the root of the tree.
-  cache.data = fetchServerResponse(
+  cache.lazyData = fetchServerResponse(
     new URL(href, origin),
     [state.tree[0], state.tree[1], state.tree[2], 'refetch'],
     state.nextUrl,
     state.buildId
   )
 
-  return cache.data.then(
+  return cache.lazyData.then(
     ([flightData, canonicalUrlOverride]) => {
       // Handle case when navigating to page in `pages` from `app`
       if (typeof flightData === 'string') {
@@ -47,8 +47,8 @@ function fastRefreshReducerImpl(
         )
       }
 
-      // Remove cache.data as it has been resolved at this point.
-      cache.data = null
+      // Remove cache.lazyData as it has been resolved at this point.
+      cache.lazyData = null
 
       let currentTree = state.tree
       let currentCache = state.cache

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
@@ -26,7 +26,7 @@ describe('findHeadInCache', () => {
     ]
 
     const cache: CacheNode = {
-      data: null,
+      lazyData: null,
       subTreeData: null,
       parallelRoutes: new Map([
         [
@@ -35,7 +35,7 @@ describe('findHeadInCache', () => {
             [
               'linking',
               {
-                data: null,
+                lazyData: null,
                 subTreeData: null,
                 parallelRoutes: new Map([
                   [
@@ -44,7 +44,7 @@ describe('findHeadInCache', () => {
                       [
                         'about',
                         {
-                          data: null,
+                          lazyData: null,
                           parallelRoutes: new Map([
                             [
                               'children',
@@ -52,7 +52,7 @@ describe('findHeadInCache', () => {
                                 [
                                   '',
                                   {
-                                    data: null,
+                                    lazyData: null,
                                     subTreeData: null,
                                     parallelRoutes: new Map(),
                                     head: (
@@ -72,7 +72,7 @@ describe('findHeadInCache', () => {
                       // [
                       //   '',
                       //   {
-                      //     data: null,
+                      //     lazyData: null,
                       //     subTreeData: <>Page</>,
                       //     parallelRoutes: new Map(),
                       //   },

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
@@ -139,7 +139,7 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -147,7 +147,7 @@ describe('navigateReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -180,31 +180,31 @@ describe('navigateReducer', () => {
       {
         "buildId": "development",
         "cache": {
-          "data": null,
+          "lazyData": null,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
-                "data": null,
+                "lazyData": null,
                 "parallelRoutes": Map {
                   "children" => Map {
                     "__PAGE__" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                     "about" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {
                         "children" => Map {
                           "__PAGE__" => {
-                            "data": null,
                             "head": <React.Fragment>
                               <title>
                                 About page!
                               </title>
                             </React.Fragment>,
+                            "lazyData": null,
                             "parallelRoutes": Map {},
                             "subTreeData": null,
                           },
@@ -325,7 +325,7 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -333,7 +333,7 @@ describe('navigateReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -367,31 +367,31 @@ describe('navigateReducer', () => {
       {
         "buildId": "development",
         "cache": {
-          "data": null,
+          "lazyData": null,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
-                "data": null,
+                "lazyData": null,
                 "parallelRoutes": Map {
                   "children" => Map {
                     "__PAGE__" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                     "about" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {
                         "children" => Map {
                           "__PAGE__" => {
-                            "data": null,
                             "head": <React.Fragment>
                               <title>
                                 About page!
                               </title>
                             </React.Fragment>,
+                            "lazyData": null,
                             "parallelRoutes": Map {},
                             "subTreeData": null,
                           },
@@ -512,7 +512,7 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -520,7 +520,7 @@ describe('navigateReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -557,15 +557,15 @@ describe('navigateReducer', () => {
       {
         "buildId": "development",
         "cache": {
-          "data": null,
+          "lazyData": null,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
-                "data": null,
+                "lazyData": null,
                 "parallelRoutes": Map {
                   "children" => Map {
                     "__PAGE__" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Linking page
@@ -644,7 +644,7 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -652,7 +652,7 @@ describe('navigateReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -689,15 +689,15 @@ describe('navigateReducer', () => {
       {
         "buildId": "development",
         "cache": {
-          "data": null,
+          "lazyData": null,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
-                "data": null,
+                "lazyData": null,
                 "parallelRoutes": Map {
                   "children" => Map {
                     "__PAGE__" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Linking page
@@ -776,7 +776,7 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -784,7 +784,7 @@ describe('navigateReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -818,15 +818,15 @@ describe('navigateReducer', () => {
       {
         "buildId": "development",
         "cache": {
-          "data": null,
+          "lazyData": null,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
-                "data": null,
+                "lazyData": null,
                 "parallelRoutes": Map {
                   "children" => Map {
                     "__PAGE__" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Linking page
@@ -929,7 +929,7 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -937,7 +937,7 @@ describe('navigateReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -1008,31 +1008,31 @@ describe('navigateReducer', () => {
       {
         "buildId": "development",
         "cache": {
-          "data": null,
+          "lazyData": null,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
-                "data": null,
+                "lazyData": null,
                 "parallelRoutes": Map {
                   "children" => Map {
                     "__PAGE__" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                     "about" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {
                         "children" => Map {
                           "__PAGE__" => {
-                            "data": null,
                             "head": <React.Fragment>
                               <title>
                                 About page!
                               </title>
                             </React.Fragment>,
+                            "lazyData": null,
                             "parallelRoutes": Map {},
                             "subTreeData": null,
                           },
@@ -1169,7 +1169,7 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Audience Page</>,
                         parallelRoutes: new Map(),
                       },
@@ -1182,7 +1182,7 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Views Page</>,
                         parallelRoutes: new Map(),
                       },
@@ -1195,7 +1195,7 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Children Page</>,
                         parallelRoutes: new Map(),
                       },
@@ -1203,7 +1203,7 @@ describe('navigateReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Layout level</>,
             },
           ],
@@ -1237,31 +1237,31 @@ describe('navigateReducer', () => {
       {
         "buildId": "development",
         "cache": {
-          "data": null,
+          "lazyData": null,
           "parallelRoutes": Map {
             "children" => Map {
               "parallel-tab-bar" => {
-                "data": null,
+                "lazyData": null,
                 "parallelRoutes": Map {
                   "audience" => Map {
                     "__PAGE__" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Audience Page
                       </React.Fragment>,
                     },
                     "demographics" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {
                         "children" => Map {
                           "__PAGE__" => {
-                            "data": null,
                             "head": <React.Fragment>
                               <title>
                                 Demographics Head
                               </title>
                             </React.Fragment>,
+                            "lazyData": null,
                             "parallelRoutes": Map {},
                             "subTreeData": null,
                           },
@@ -1272,7 +1272,7 @@ describe('navigateReducer', () => {
                   },
                   "views" => Map {
                     "__PAGE__" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Views Page
@@ -1281,7 +1281,7 @@ describe('navigateReducer', () => {
                   },
                   "children" => Map {
                     "__PAGE__" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Children Page
@@ -1412,7 +1412,7 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -1420,7 +1420,7 @@ describe('navigateReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -1454,15 +1454,15 @@ describe('navigateReducer', () => {
       {
         "buildId": "development",
         "cache": {
-          "data": null,
+          "lazyData": null,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
-                "data": null,
+                "lazyData": null,
                 "parallelRoutes": Map {
                   "children" => Map {
                     "__PAGE__" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Linking page
@@ -1541,7 +1541,7 @@ describe('navigateReducer', () => {
                     [
                       '__PAGE__',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -1549,7 +1549,7 @@ describe('navigateReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -1582,31 +1582,31 @@ describe('navigateReducer', () => {
       {
         "buildId": "development",
         "cache": {
-          "data": null,
+          "lazyData": null,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
-                "data": null,
+                "lazyData": null,
                 "parallelRoutes": Map {
                   "children" => Map {
                     "__PAGE__" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                     "about" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {
                         "children" => Map {
                           "__PAGE__" => {
-                            "data": null,
                             "head": <React.Fragment>
                               <title>
                                 About page!
                               </title>
                             </React.Fragment>,
+                            "lazyData": null,
                             "parallelRoutes": Map {},
                             "subTreeData": null,
                           },

--- a/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
@@ -93,7 +93,7 @@ describe('prefetchReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -101,7 +101,7 @@ describe('prefetchReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -180,7 +180,7 @@ describe('prefetchReducer', () => {
       },
       canonicalUrl: '/linking',
       cache: {
-        data: null,
+        lazyData: null,
         subTreeData: (
           <html>
             <head></head>
@@ -232,7 +232,7 @@ describe('prefetchReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -240,7 +240,7 @@ describe('prefetchReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -333,7 +333,7 @@ describe('prefetchReducer', () => {
       },
       canonicalUrl: '/linking',
       cache: {
-        data: null,
+        lazyData: null,
         subTreeData: (
           <html>
             <head></head>

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
@@ -104,7 +104,7 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -112,7 +112,7 @@ describe('refreshReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -156,7 +156,7 @@ describe('refreshReducer', () => {
       canonicalUrl: '/linking',
       nextUrl: '/linking',
       cache: {
-        data: null,
+        lazyData: null,
         subTreeData: (
           <html>
             <head></head>
@@ -179,7 +179,7 @@ describe('refreshReducer', () => {
                         [
                           '',
                           {
-                            data: null,
+                            lazyData: null,
                             subTreeData: null,
                             parallelRoutes: new Map(),
                             head: (
@@ -192,7 +192,7 @@ describe('refreshReducer', () => {
                       ]),
                     ],
                   ]),
-                  data: null,
+                  lazyData: null,
                   subTreeData: null,
                 },
               ],
@@ -242,7 +242,7 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -250,7 +250,7 @@ describe('refreshReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -308,7 +308,7 @@ describe('refreshReducer', () => {
       canonicalUrl: '/linking',
       nextUrl: '/linking',
       cache: {
-        data: null,
+        lazyData: null,
         subTreeData: (
           <html>
             <head></head>
@@ -331,7 +331,7 @@ describe('refreshReducer', () => {
                         [
                           '',
                           {
-                            data: null,
+                            lazyData: null,
                             subTreeData: null,
                             parallelRoutes: new Map(),
                             head: (
@@ -344,7 +344,7 @@ describe('refreshReducer', () => {
                       ]),
                     ],
                   ]),
-                  data: null,
+                  lazyData: null,
                   subTreeData: null,
                 },
               ],
@@ -394,7 +394,7 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -402,7 +402,7 @@ describe('refreshReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -416,7 +416,7 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>About page</>,
                         parallelRoutes: new Map(),
                       },
@@ -424,7 +424,7 @@ describe('refreshReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>About layout level</>,
             },
           ],
@@ -482,7 +482,7 @@ describe('refreshReducer', () => {
       canonicalUrl: '/linking',
       nextUrl: '/linking',
       cache: {
-        data: null,
+        lazyData: null,
         subTreeData: (
           <html>
             <head></head>
@@ -505,7 +505,7 @@ describe('refreshReducer', () => {
                         [
                           '',
                           {
-                            data: null,
+                            lazyData: null,
                             subTreeData: null,
                             parallelRoutes: new Map(),
                             head: (
@@ -518,7 +518,7 @@ describe('refreshReducer', () => {
                       ]),
                     ],
                   ]),
-                  data: null,
+                  lazyData: null,
                   subTreeData: null,
                 },
               ],
@@ -568,7 +568,7 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -576,7 +576,7 @@ describe('refreshReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -590,7 +590,7 @@ describe('refreshReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>About page</>,
                         parallelRoutes: new Map(),
                       },
@@ -598,7 +598,7 @@ describe('refreshReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>About layout level</>,
             },
           ],
@@ -705,7 +705,7 @@ describe('refreshReducer', () => {
       canonicalUrl: '/linking',
       nextUrl: '/linking',
       cache: {
-        data: null,
+        lazyData: null,
         subTreeData: (
           <html>
             <head></head>
@@ -728,7 +728,7 @@ describe('refreshReducer', () => {
                         [
                           '',
                           {
-                            data: null,
+                            lazyData: null,
                             subTreeData: null,
                             parallelRoutes: new Map(),
                             head: (
@@ -741,7 +741,7 @@ describe('refreshReducer', () => {
                       ]),
                     ],
                   ]),
-                  data: null,
+                  lazyData: null,
                   subTreeData: null,
                 },
               ],

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -29,14 +29,14 @@ export function refreshReducer(
   const cache: CacheNode = createEmptyCacheNode()
   // TODO-APP: verify that `href` is not an external url.
   // Fetch data from the root of the tree.
-  cache.data = fetchServerResponse(
+  cache.lazyData = fetchServerResponse(
     new URL(href, origin),
     [currentTree[0], currentTree[1], currentTree[2], 'refetch'],
     state.nextUrl,
     state.buildId
   )
 
-  return cache.data.then(
+  return cache.lazyData.then(
     ([flightData, canonicalUrlOverride]) => {
       // Handle case when navigating to page in `pages` from `app`
       if (typeof flightData === 'string') {
@@ -48,8 +48,8 @@ export function refreshReducer(
         )
       }
 
-      // Remove cache.data as it has been resolved at this point.
-      cache.data = null
+      // Remove cache.lazyData as it has been resolved at this point.
+      cache.lazyData = null
 
       for (const flightDataPath of flightData) {
         // FlightDataPath with more than two items means unexpected Flight data was returned

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.test.tsx
@@ -60,7 +60,7 @@ describe('serverPatchReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -68,7 +68,7 @@ describe('serverPatchReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -131,7 +131,7 @@ describe('serverPatchReducer', () => {
       canonicalUrl: '/linking/about',
       nextUrl: '/linking/about',
       cache: {
-        data: null,
+        lazyData: null,
         subTreeData: (
           <html>
             <head></head>
@@ -152,7 +152,7 @@ describe('serverPatchReducer', () => {
                         [
                           '',
                           {
-                            data: null,
+                            lazyData: null,
                             subTreeData: <>Linking page</>,
                             parallelRoutes: new Map(),
                           },
@@ -160,7 +160,7 @@ describe('serverPatchReducer', () => {
                       ]),
                     ],
                   ]),
-                  data: null,
+                  lazyData: null,
                   subTreeData: <>Linking layout level</>,
                 },
               ],
@@ -210,7 +210,7 @@ describe('serverPatchReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -218,7 +218,7 @@ describe('serverPatchReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -294,7 +294,7 @@ describe('serverPatchReducer', () => {
       canonicalUrl: '/linking/about',
       nextUrl: '/linking/about',
       cache: {
-        data: null,
+        lazyData: null,
         subTreeData: (
           <html>
             <head></head>
@@ -315,7 +315,7 @@ describe('serverPatchReducer', () => {
                         [
                           '',
                           {
-                            data: null,
+                            lazyData: null,
                             subTreeData: <>Linking page</>,
                             parallelRoutes: new Map(),
                           },
@@ -323,7 +323,7 @@ describe('serverPatchReducer', () => {
                       ]),
                     ],
                   ]),
-                  data: null,
+                  lazyData: null,
                   subTreeData: <>Linking layout level</>,
                 },
               ],

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
@@ -111,7 +111,7 @@ describe('serverPatchReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -119,7 +119,7 @@ describe('serverPatchReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -163,31 +163,31 @@ describe('serverPatchReducer', () => {
       {
         "buildId": "development",
         "cache": {
-          "data": null,
+          "lazyData": null,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
-                "data": null,
+                "lazyData": null,
                 "parallelRoutes": Map {
                   "children" => Map {
                     "" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                     "somewhere-else" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {
                         "children" => Map {
                           "" => {
-                            "data": null,
                             "head": <React.Fragment>
                               <title>
                                 Somewhere page!
                               </title>
                             </React.Fragment>,
+                            "lazyData": null,
                             "parallelRoutes": Map {},
                             "subTreeData": null,
                           },
@@ -275,7 +275,7 @@ describe('serverPatchReducer', () => {
                     [
                       '',
                       {
-                        data: null,
+                        lazyData: null,
                         subTreeData: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
@@ -283,7 +283,7 @@ describe('serverPatchReducer', () => {
                   ]),
                 ],
               ]),
-              data: null,
+              lazyData: null,
               subTreeData: <>Linking layout level</>,
             },
           ],
@@ -339,31 +339,31 @@ describe('serverPatchReducer', () => {
       {
         "buildId": "development",
         "cache": {
-          "data": null,
+          "lazyData": null,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
-                "data": null,
+                "lazyData": null,
                 "parallelRoutes": Map {
                   "children" => Map {
                     "" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {},
                       "subTreeData": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                     "about" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {
                         "children" => Map {
                           "" => {
-                            "data": null,
                             "head": <React.Fragment>
                               <title>
                                 About page!
                               </title>
                             </React.Fragment>,
+                            "lazyData": null,
                             "parallelRoutes": Map {},
                             "subTreeData": null,
                           },
@@ -374,16 +374,16 @@ describe('serverPatchReducer', () => {
                       </h1>,
                     },
                     "somewhere-else" => {
-                      "data": null,
+                      "lazyData": null,
                       "parallelRoutes": Map {
                         "children" => Map {
                           "" => {
-                            "data": null,
                             "head": <React.Fragment>
                               <title>
                                 Somewhere page!
                               </title>
                             </React.Fragment>,
+                            "lazyData": null,
                             "parallelRoutes": Map {},
                             "subTreeData": null,
                           },

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -35,7 +35,7 @@ export type LazyCacheNode = {
    * A pending response for the lazy data fetch. If this is not present
    * during render, it is lazily created.
    */
-  data: Promise<FetchServerResponseResult> | null
+  lazyData: Promise<FetchServerResponseResult> | null
 
   head?: React.ReactNode
   /**
@@ -58,9 +58,9 @@ export type ReadyCacheNode = {
    */
   subTreeData: React.ReactNode
   /**
-   * There should never be a pending data request in this case.
+   * There should never be a lazy data request in this case.
    */
-  data: null
+  lazyData: null
   head?: React.ReactNode
   parallelRoutes: Map<string, ChildSegmentMap>
 }


### PR DESCRIPTION
`CacheNode.data` is used to lazily kick off a request during render, and represents the result of the entire Flight response. It doesn't correspond directly to the RSC data of the cache node itself — that's `subTreeData`. To complicate things further, I'm about to add another field to CacheNode that represents prefetched RSC data.

To make it a little less confusing, I've renamed the `data` field to `lazyData`. Still not perfectly clear on first glance, but it's at least more specific. With PPR, the goal is to remove the lazy data fetching mechanism in favor of initiating the request immediately upon navigation. So this field will eventually go away.

In the next PR, I will rename `subTreeData`, too. Perhaps something with "rsc" in the name so it's less generic than "data".

Closes NEXT-1843