### PR TITLE
Rename CacheNode.subTreeData -> .rsc 

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -149,7 +149,7 @@ function HistoryUpdater({
 
 export const createEmptyCacheNode = () => ({
   lazyData: null,
-  subTreeData: null,
+  rsc: null,
   parallelRoutes: new Map(),
 })
 
@@ -546,7 +546,7 @@ function Router({
   let content = (
     <RedirectBoundary>
       {head}
-      {cache.subTreeData}
+      {cache.rsc}
       <AppRouterAnnouncer tree={tree} />
     </RedirectBoundary>
   )

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -345,7 +345,7 @@ function InnerLayoutRouter({
     // data request.
     //
     // TODO: An eventual goal of PPR is to remove this case entirely.
-    (childNode.subTreeData === null && childNode.lazyData === null)
+    (childNode.rsc === null && childNode.lazyData === null)
   ) {
     /**
      * Router state with refetch marker added
@@ -360,7 +360,7 @@ function InnerLayoutRouter({
         context.nextUrl,
         buildId
       ),
-      subTreeData: null,
+      rsc: null,
       head: childNode ? childNode.head : undefined,
       parallelRoutes: childNode ? childNode.parallelRoutes : new Map(),
     }
@@ -377,8 +377,8 @@ function InnerLayoutRouter({
   }
 
   // This case should never happen so it throws an error. It indicates there's a bug in the Next.js.
-  if (childNode.subTreeData && childNode.lazyData) {
-    throw new Error('Child node should not have both subTreeData and lazyData')
+  if (childNode.rsc && childNode.lazyData) {
+    throw new Error('Child node should not have both rsc and lazyData')
   }
 
   // If cache node has a data request we have to unwrap response by `use` and update the cache.
@@ -402,9 +402,9 @@ function InnerLayoutRouter({
     use(createInfinitePromise())
   }
 
-  // If cache node has no subTreeData and no lazy data request we have to infinitely suspend as the data will likely flow in from another place.
+  // If cache node has no rsc and no lazy data request we have to infinitely suspend as the data will likely flow in from another place.
   // TODO-APP: double check users can't return null in a component that will kick in here.
-  if (!childNode.subTreeData) {
+  if (!childNode.rsc) {
     use(createInfinitePromise())
   }
 
@@ -418,7 +418,7 @@ function InnerLayoutRouter({
         url: url,
       }}
     >
-      {childNode.subTreeData}
+      {childNode.rsc}
     </LayoutRouterContext.Provider>
   )
   // Ensure root layout is not wrapped in a div as the root layout renders `<html>`

--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -18,8 +18,8 @@ export function applyFlightData(
   }
 
   if (flightDataPath.length === 3) {
-    const subTreeData = cacheNodeSeedData[2]
-    cache.subTreeData = subTreeData
+    const rsc = cacheNodeSeedData[2]
+    cache.rsc = rsc
     fillLazyItemsTillLeafWithHead(
       cache,
       existingCache,
@@ -29,10 +29,10 @@ export function applyFlightData(
       wasPrefetched
     )
   } else {
-    // Copy subTreeData for the root node of the cache.
-    cache.subTreeData = existingCache.subTreeData
+    // Copy rsc for the root node of the cache.
+    cache.rsc = existingCache.rsc
     cache.parallelRoutes = new Map(existingCache.parallelRoutes)
-    // Create a copy of the existing cache with the subTreeData applied.
+    // Create a copy of the existing cache with the rsc applied.
     fillCacheWithNewSubTreeData(
       cache,
       existingCache,

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -56,7 +56,7 @@ describe('createInitialRouterState', () => {
 
     const expectedCache: CacheNode = {
       lazyData: null,
-      subTreeData: children,
+      rsc: children,
       parallelRoutes: new Map([
         [
           'children',
@@ -72,7 +72,7 @@ describe('createInitialRouterState', () => {
                         '',
                         {
                           lazyData: null,
-                          subTreeData: null,
+                          rsc: null,
                           parallelRoutes: new Map(),
                           head: <title>Test</title>,
                         },
@@ -81,7 +81,7 @@ describe('createInitialRouterState', () => {
                   ],
                 ]),
                 lazyData: null,
-                subTreeData: null,
+                rsc: null,
               },
             ],
           ]),

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -30,11 +30,11 @@ export function createInitialRouterState({
   location,
   initialHead,
 }: InitialRouterStateParameters) {
-  const subTreeData = initialSeedData[2]
+  const rsc = initialSeedData[2]
 
   const cache: CacheNode = {
     lazyData: null,
-    subTreeData: subTreeData,
+    rsc: rsc,
     // The cache gets seeded during the first render. `initialParallelRoutes` ensures the cache from the first render is there during the second render.
     parallelRoutes: isServer ? new Map() : initialParallelRoutes,
   }

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.test.tsx
@@ -23,12 +23,12 @@ describe('fillCacheWithDataProperty', () => {
 
     const cache: CacheNode = {
       lazyData: null,
-      subTreeData: null,
+      rsc: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
       lazyData: null,
-      subTreeData: <>Root layout</>,
+      rsc: <>Root layout</>,
       parallelRoutes: new Map([
         [
           'children',
@@ -37,7 +37,7 @@ describe('fillCacheWithDataProperty', () => {
               'linking',
               {
                 lazyData: null,
-                subTreeData: <>Linking</>,
+                rsc: <>Linking</>,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -46,7 +46,7 @@ describe('fillCacheWithDataProperty', () => {
                         '',
                         {
                           lazyData: null,
-                          subTreeData: <>Page</>,
+                          rsc: <>Page</>,
                           parallelRoutes: new Map(),
                         },
                       ],
@@ -76,24 +76,24 @@ describe('fillCacheWithDataProperty', () => {
                   "" => {
                     "lazyData": null,
                     "parallelRoutes": Map {},
-                    "subTreeData": <React.Fragment>
+                    "rsc": <React.Fragment>
                       Page
                     </React.Fragment>,
                   },
                 },
               },
-              "subTreeData": <React.Fragment>
+              "rsc": <React.Fragment>
                 Linking
               </React.Fragment>,
             },
             "dashboard" => {
               "lazyData": Promise {},
               "parallelRoutes": Map {},
-              "subTreeData": null,
+              "rsc": null,
             },
           },
         },
-        "subTreeData": null,
+        "rsc": null,
       }
     `)
   })

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.ts
@@ -39,7 +39,7 @@ export function fillCacheWithDataProperty(
     ) {
       childSegmentMap.set(cacheKey, {
         lazyData: fetchResponse(),
-        subTreeData: null,
+        rsc: null,
         parallelRoutes: new Map(),
       })
     }
@@ -51,7 +51,7 @@ export function fillCacheWithDataProperty(
     if (!childCacheNode) {
       childSegmentMap.set(cacheKey, {
         lazyData: fetchResponse(),
-        subTreeData: null,
+        rsc: null,
         parallelRoutes: new Map(),
       })
     }
@@ -61,7 +61,7 @@ export function fillCacheWithDataProperty(
   if (childCacheNode === existingChildCacheNode) {
     childCacheNode = {
       lazyData: childCacheNode.lazyData,
-      subTreeData: childCacheNode.subTreeData,
+      rsc: childCacheNode.rsc,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
     } as CacheNode
     childSegmentMap.set(cacheKey, childCacheNode)

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -25,15 +25,15 @@ const getFlightData = (): FlightData => {
 }
 
 describe('fillCacheWithNewSubtreeData', () => {
-  it('should apply subTreeData and head property', () => {
+  it('should apply rsc and head property', () => {
     const cache: CacheNode = {
       lazyData: null,
-      subTreeData: null,
+      rsc: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
       lazyData: null,
-      subTreeData: <>Root layout</>,
+      rsc: <>Root layout</>,
       parallelRoutes: new Map([
         [
           'children',
@@ -42,7 +42,7 @@ describe('fillCacheWithNewSubtreeData', () => {
               'linking',
               {
                 lazyData: null,
-                subTreeData: <>Linking</>,
+                rsc: <>Linking</>,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -51,7 +51,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                         '',
                         {
                           lazyData: null,
-                          subTreeData: <>Page</>,
+                          rsc: <>Page</>,
                           parallelRoutes: new Map(),
                         },
                       ],
@@ -78,7 +78,7 @@ describe('fillCacheWithNewSubtreeData', () => {
 
     const expectedCache: CacheNode = {
       lazyData: null,
-      subTreeData: null,
+      rsc: null,
       parallelRoutes: new Map([
         [
           'children',
@@ -87,7 +87,7 @@ describe('fillCacheWithNewSubtreeData', () => {
               'linking',
               {
                 lazyData: null,
-                subTreeData: <>Linking</>,
+                rsc: <>Linking</>,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -97,7 +97,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                         '',
                         {
                           lazyData: null,
-                          subTreeData: <>Page</>,
+                          rsc: <>Page</>,
                           parallelRoutes: new Map(),
                         },
                       ],
@@ -113,7 +113,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                                   '',
                                   {
                                     lazyData: null,
-                                    subTreeData: null,
+                                    rsc: null,
                                     parallelRoutes: new Map(),
                                     head: (
                                       <>
@@ -125,7 +125,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                               ]),
                             ],
                           ]),
-                          subTreeData: <h1>SubTreeData Injected!</h1>,
+                          rsc: <h1>SubTreeData Injected!</h1>,
                         },
                       ],
                     ]),

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -8,7 +8,7 @@ import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-
 import { createRouterCacheKey } from './create-router-cache-key'
 
 /**
- * Fill cache with subTreeData based on flightDataPath
+ * Fill cache with rsc based on flightDataPath
  */
 export function fillCacheWithNewSubTreeData(
   newCache: CacheNode,
@@ -46,10 +46,10 @@ export function fillCacheWithNewSubTreeData(
       childCacheNode === existingChildCacheNode
     ) {
       const seedData: CacheNodeSeedData = flightDataPath[3]
-      const subTreeData = seedData[2]
+      const rsc = seedData[2]
       childCacheNode = {
         lazyData: null,
-        subTreeData,
+        rsc,
         // Ensure segments other than the one we got data for are preserved.
         parallelRoutes: existingChildCacheNode
           ? new Map(existingChildCacheNode.parallelRoutes)
@@ -87,7 +87,7 @@ export function fillCacheWithNewSubTreeData(
   if (childCacheNode === existingChildCacheNode) {
     childCacheNode = {
       lazyData: childCacheNode.lazyData,
-      subTreeData: childCacheNode.subTreeData,
+      rsc: childCacheNode.rsc,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
     } as CacheNode
     childSegmentMap.set(cacheKey, childCacheNode)

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -37,12 +37,12 @@ describe('fillLazyItemsTillLeafWithHead', () => {
   it('should fill lazy items till leaf with head', () => {
     const cache: CacheNode = {
       lazyData: null,
-      subTreeData: null,
+      rsc: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
       lazyData: null,
-      subTreeData: <>Root layout</>,
+      rsc: <>Root layout</>,
       parallelRoutes: new Map([
         [
           'children',
@@ -51,7 +51,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
               'linking',
               {
                 lazyData: null,
-                subTreeData: <>Linking</>,
+                rsc: <>Linking</>,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -60,7 +60,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                         '',
                         {
                           lazyData: null,
-                          subTreeData: <>Page</>,
+                          rsc: <>Page</>,
                           parallelRoutes: new Map(),
                         },
                       ],
@@ -93,7 +93,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
 
     const expectedCache: CacheNode = {
       lazyData: null,
-      subTreeData: null,
+      rsc: null,
       parallelRoutes: new Map([
         [
           'children',
@@ -102,7 +102,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
               'linking',
               {
                 lazyData: null,
-                subTreeData: null,
+                rsc: null,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -119,7 +119,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                                   '',
                                   {
                                     lazyData: null,
-                                    subTreeData: null,
+                                    rsc: null,
                                     parallelRoutes: new Map(),
                                     head: (
                                       <>
@@ -131,14 +131,14 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                               ]),
                             ],
                           ]),
-                          subTreeData: null,
+                          rsc: null,
                         },
                       ],
                       [
                         '',
                         {
                           lazyData: null,
-                          subTreeData: <>Page</>,
+                          rsc: <>Page</>,
                           parallelRoutes: new Map(),
                         },
                       ],

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -18,7 +18,7 @@ export function fillLazyItemsTillLeafWithHead(
     newCache.head = head
     return
   }
-  // Remove segment that we got data for so that it is filled in during rendering of subTreeData.
+  // Remove segment that we got data for so that it is filled in during rendering of rsc.
   for (const key in routerState[1]) {
     const parallelRouteState = routerState[1][key]
     const segmentForParallelRoute = parallelRouteState[0]
@@ -52,7 +52,7 @@ export function fillLazyItemsTillLeafWithHead(
           const seedNode = parallelSeedData[2]
           newCacheNode = {
             lazyData: null,
-            subTreeData: seedNode,
+            rsc: seedNode,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
           }
         } else if (wasPrefetched && existingCacheNode) {
@@ -60,7 +60,7 @@ export function fillLazyItemsTillLeafWithHead(
           // was prefetched, so we should reuse that.
           newCacheNode = {
             lazyData: existingCacheNode.lazyData,
-            subTreeData: existingCacheNode.subTreeData,
+            rsc: existingCacheNode.rsc,
             parallelRoutes: new Map(existingCacheNode.parallelRoutes),
           } as CacheNode
         } else {
@@ -68,7 +68,7 @@ export function fillLazyItemsTillLeafWithHead(
           // during render.
           newCacheNode = {
             lazyData: null,
-            subTreeData: null,
+            rsc: null,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
           }
         }
@@ -96,7 +96,7 @@ export function fillLazyItemsTillLeafWithHead(
       const seedNode = parallelSeedData[2]
       newCacheNode = {
         lazyData: null,
-        subTreeData: seedNode,
+        rsc: seedNode,
         parallelRoutes: new Map(),
       }
     } else {
@@ -104,7 +104,7 @@ export function fillLazyItemsTillLeafWithHead(
       // during render.
       newCacheNode = {
         lazyData: null,
-        subTreeData: null,
+        rsc: null,
         parallelRoutes: new Map(),
       }
     }

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -29,12 +29,12 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
   it('should invalidate cache below flight segment path', () => {
     const cache: CacheNode = {
       lazyData: null,
-      subTreeData: null,
+      rsc: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
       lazyData: null,
-      subTreeData: <>Root layout</>,
+      rsc: <>Root layout</>,
       parallelRoutes: new Map([
         [
           'children',
@@ -43,7 +43,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
               'linking',
               {
                 lazyData: null,
-                subTreeData: <>Linking</>,
+                rsc: <>Linking</>,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -52,7 +52,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                         '',
                         {
                           lazyData: null,
-                          subTreeData: <>Page</>,
+                          rsc: <>Page</>,
                           parallelRoutes: new Map(),
                         },
                       ],
@@ -76,9 +76,9 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
     const flightDataPath = flightData[0]
     const flightSegmentPath = flightDataPath.slice(0, -3)
 
-    // Copy subTreeData for the root node of the cache.
-    cache.subTreeData = existingCache.subTreeData
-    // Create a copy of the existing cache with the subTreeData applied.
+    // Copy rsc for the root node of the cache.
+    cache.rsc = existingCache.rsc
+    // Create a copy of the existing cache with the rsc applied.
     fillCacheWithNewSubTreeData(cache, existingCache, flightDataPath, false)
 
     // Invalidate the cache below the flight segment path. This should remove the 'about' node.
@@ -107,19 +107,19 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                         {
                           lazyData: null,
                           parallelRoutes: new Map(),
-                          subTreeData: <React.Fragment>Page</React.Fragment>,
+                          rsc: <React.Fragment>Page</React.Fragment>,
                         },
                       ],
                     ]),
                   ],
                 ]),
-                subTreeData: <React.Fragment>Linking</React.Fragment>,
+                rsc: <React.Fragment>Linking</React.Fragment>,
               },
             ],
           ]),
         ],
       ]),
-      subTreeData: <>Root layout</>,
+      rsc: <>Root layout</>,
     }
 
     expect(cache).toMatchObject(expectedCache)

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
@@ -48,7 +48,7 @@ export function invalidateCacheBelowFlightSegmentPath(
   if (childCacheNode === existingChildCacheNode) {
     childCacheNode = {
       lazyData: childCacheNode.lazyData,
-      subTreeData: childCacheNode.subTreeData,
+      rsc: childCacheNode.rsc,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
     } as CacheNode
     childSegmentMap.set(cacheKey, childCacheNode)

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
@@ -7,12 +7,12 @@ describe('invalidateCacheByRouterState', () => {
   it('should invalidate the cache by router state', () => {
     const cache: CacheNode = {
       lazyData: null,
-      subTreeData: null,
+      rsc: null,
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
       lazyData: null,
-      subTreeData: <>Root layout</>,
+      rsc: <>Root layout</>,
       parallelRoutes: new Map([
         [
           'children',
@@ -21,7 +21,7 @@ describe('invalidateCacheByRouterState', () => {
               'linking',
               {
                 lazyData: null,
-                subTreeData: <>Linking</>,
+                rsc: <>Linking</>,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -30,7 +30,7 @@ describe('invalidateCacheByRouterState', () => {
                         '',
                         {
                           lazyData: null,
-                          subTreeData: <>Page</>,
+                          rsc: <>Page</>,
                           parallelRoutes: new Map(),
                         },
                       ],
@@ -68,7 +68,7 @@ describe('invalidateCacheByRouterState', () => {
 
     const expectedCache: CacheNode = {
       lazyData: null,
-      subTreeData: null,
+      rsc: null,
       parallelRoutes: new Map([['children', new Map()]]),
     }
 

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.ts
@@ -10,7 +10,7 @@ export function invalidateCacheByRouterState(
   existingCache: CacheNode,
   routerState: FlightRouterState
 ): void {
-  // Remove segment that we got data for so that it is filled in during rendering of subTreeData.
+  // Remove segment that we got data for so that it is filled in during rendering of rsc.
   for (const key in routerState[1]) {
     const segmentForParallelRoute = routerState[1][key][0]
     const cacheKey = createRouterCacheKey(segmentForParallelRoute)

--- a/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
@@ -61,7 +61,7 @@ function fastRefreshReducerImpl(
           return state
         }
 
-        // Given the path can only have two items the items are only the router state and subTreeData for the root.
+        // Given the path can only have two items the items are only the router state and rsc for the root.
         const [treePatch] = flightDataPath
         const newTree = applyRouterStatePatchToTree(
           // TODO-APP: remove ''

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
@@ -27,7 +27,7 @@ describe('findHeadInCache', () => {
 
     const cache: CacheNode = {
       lazyData: null,
-      subTreeData: null,
+      rsc: null,
       parallelRoutes: new Map([
         [
           'children',
@@ -36,7 +36,7 @@ describe('findHeadInCache', () => {
               'linking',
               {
                 lazyData: null,
-                subTreeData: null,
+                rsc: null,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -53,7 +53,7 @@ describe('findHeadInCache', () => {
                                   '',
                                   {
                                     lazyData: null,
-                                    subTreeData: null,
+                                    rsc: null,
                                     parallelRoutes: new Map(),
                                     head: (
                                       <>
@@ -65,7 +65,7 @@ describe('findHeadInCache', () => {
                               ]),
                             ],
                           ]),
-                          subTreeData: null,
+                          rsc: null,
                         },
                       ],
                       // TODO-APP: this segment should be preserved when creating the new cache
@@ -73,7 +73,7 @@ describe('findHeadInCache', () => {
                       //   '',
                       //   {
                       //     lazyData: null,
-                      //     subTreeData: <>Page</>,
+                      //     rsc: <>Page</>,
                       //     parallelRoutes: new Map(),
                       //   },
                       // ],

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
@@ -140,7 +140,7 @@ describe('navigateReducer', () => {
                       '__PAGE__',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -148,7 +148,7 @@ describe('navigateReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -190,7 +190,7 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
@@ -206,23 +206,23 @@ describe('navigateReducer', () => {
                             </React.Fragment>,
                             "lazyData": null,
                             "parallelRoutes": Map {},
-                            "subTreeData": null,
+                            "rsc": null,
                           },
                         },
                       },
-                      "subTreeData": <h1>
+                      "rsc": <h1>
                         About Page!
                       </h1>,
                     },
                   },
                 },
-                "subTreeData": <React.Fragment>
+                "rsc": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "subTreeData": <html>
+          "rsc": <html>
             <head />
             <body>
               Root layout
@@ -326,7 +326,7 @@ describe('navigateReducer', () => {
                       '__PAGE__',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -334,7 +334,7 @@ describe('navigateReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -377,7 +377,7 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
@@ -393,23 +393,23 @@ describe('navigateReducer', () => {
                             </React.Fragment>,
                             "lazyData": null,
                             "parallelRoutes": Map {},
-                            "subTreeData": null,
+                            "rsc": null,
                           },
                         },
                       },
-                      "subTreeData": <h1>
+                      "rsc": <h1>
                         About Page!
                       </h1>,
                     },
                   },
                 },
-                "subTreeData": <React.Fragment>
+                "rsc": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "subTreeData": <html>
+          "rsc": <html>
             <head />
             <body>
               Root layout
@@ -513,7 +513,7 @@ describe('navigateReducer', () => {
                       '__PAGE__',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -521,7 +521,7 @@ describe('navigateReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -567,19 +567,19 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                   },
                 },
-                "subTreeData": <React.Fragment>
+                "rsc": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "subTreeData": <html>
+          "rsc": <html>
             <head />
             <body>
               Root layout
@@ -645,7 +645,7 @@ describe('navigateReducer', () => {
                       '__PAGE__',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -653,7 +653,7 @@ describe('navigateReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -699,19 +699,19 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                   },
                 },
-                "subTreeData": <React.Fragment>
+                "rsc": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "subTreeData": <html>
+          "rsc": <html>
             <head />
             <body>
               Root layout
@@ -777,7 +777,7 @@ describe('navigateReducer', () => {
                       '__PAGE__',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -785,7 +785,7 @@ describe('navigateReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -828,19 +828,19 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                   },
                 },
-                "subTreeData": <React.Fragment>
+                "rsc": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "subTreeData": <html>
+          "rsc": <html>
             <head />
             <body>
               Root layout
@@ -930,7 +930,7 @@ describe('navigateReducer', () => {
                       '__PAGE__',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -938,7 +938,7 @@ describe('navigateReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -1018,7 +1018,7 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
@@ -1034,23 +1034,23 @@ describe('navigateReducer', () => {
                             </React.Fragment>,
                             "lazyData": null,
                             "parallelRoutes": Map {},
-                            "subTreeData": null,
+                            "rsc": null,
                           },
                         },
                       },
-                      "subTreeData": <h1>
+                      "rsc": <h1>
                         About Page!
                       </h1>,
                     },
                   },
                 },
-                "subTreeData": <React.Fragment>
+                "rsc": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "subTreeData": <html>
+          "rsc": <html>
             <head />
             <body>
               Root layout
@@ -1170,7 +1170,7 @@ describe('navigateReducer', () => {
                       '__PAGE__',
                       {
                         lazyData: null,
-                        subTreeData: <>Audience Page</>,
+                        rsc: <>Audience Page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -1183,7 +1183,7 @@ describe('navigateReducer', () => {
                       '__PAGE__',
                       {
                         lazyData: null,
-                        subTreeData: <>Views Page</>,
+                        rsc: <>Views Page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -1196,7 +1196,7 @@ describe('navigateReducer', () => {
                       '__PAGE__',
                       {
                         lazyData: null,
-                        subTreeData: <>Children Page</>,
+                        rsc: <>Children Page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -1204,7 +1204,7 @@ describe('navigateReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Layout level</>,
+              rsc: <>Layout level</>,
             },
           ],
         ]),
@@ -1247,7 +1247,7 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Audience Page
                       </React.Fragment>,
                     },
@@ -1263,18 +1263,18 @@ describe('navigateReducer', () => {
                             </React.Fragment>,
                             "lazyData": null,
                             "parallelRoutes": Map {},
-                            "subTreeData": null,
+                            "rsc": null,
                           },
                         },
                       },
-                      "subTreeData": null,
+                      "rsc": null,
                     },
                   },
                   "views" => Map {
                     "__PAGE__" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Views Page
                       </React.Fragment>,
                     },
@@ -1283,17 +1283,17 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Children Page
                       </React.Fragment>,
                     },
                   },
                 },
-                "subTreeData": null,
+                "rsc": null,
               },
             },
           },
-          "subTreeData": <html>
+          "rsc": <html>
             <head />
             <body>
               Root layout from response
@@ -1413,7 +1413,7 @@ describe('navigateReducer', () => {
                       '__PAGE__',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -1421,7 +1421,7 @@ describe('navigateReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -1464,19 +1464,19 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
                   },
                 },
-                "subTreeData": <React.Fragment>
+                "rsc": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "subTreeData": <html>
+          "rsc": <html>
             <head />
             <body>
               Root layout
@@ -1542,7 +1542,7 @@ describe('navigateReducer', () => {
                       '__PAGE__',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -1550,7 +1550,7 @@ describe('navigateReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -1592,7 +1592,7 @@ describe('navigateReducer', () => {
                     "__PAGE__" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
@@ -1608,23 +1608,23 @@ describe('navigateReducer', () => {
                             </React.Fragment>,
                             "lazyData": null,
                             "parallelRoutes": Map {},
-                            "subTreeData": null,
+                            "rsc": null,
                           },
                         },
                       },
-                      "subTreeData": <h1>
+                      "rsc": <h1>
                         About Page!
                       </h1>,
                     },
                   },
                 },
-                "subTreeData": <React.Fragment>
+                "rsc": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "subTreeData": <html>
+          "rsc": <html>
             <head />
             <body>
               Root layout

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -77,7 +77,7 @@ function addRefetchToLeafSegments(
 ) {
   let appliedPatch = false
 
-  newCache.subTreeData = currentCache.subTreeData
+  newCache.rsc = currentCache.rsc
   newCache.parallelRoutes = new Map(currentCache.parallelRoutes)
 
   const segmentPathsToFill = generateSegmentsFromPatch(treePatch).map(
@@ -237,8 +237,8 @@ export function navigateReducer(
           )
 
           if (hardNavigate) {
-            // Copy subTreeData for the root node of the cache.
-            cache.subTreeData = currentCache.subTreeData
+            // Copy rsc for the root node of the cache.
+            cache.rsc = currentCache.rsc
 
             invalidateCacheBelowFlightSegmentPath(
               cache,

--- a/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.test.tsx
@@ -94,7 +94,7 @@ describe('prefetchReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -102,7 +102,7 @@ describe('prefetchReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -181,7 +181,7 @@ describe('prefetchReducer', () => {
       canonicalUrl: '/linking',
       cache: {
         lazyData: null,
-        subTreeData: (
+        rsc: (
           <html>
             <head></head>
             <body>Root layout</body>
@@ -233,7 +233,7 @@ describe('prefetchReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -241,7 +241,7 @@ describe('prefetchReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -334,7 +334,7 @@ describe('prefetchReducer', () => {
       canonicalUrl: '/linking',
       cache: {
         lazyData: null,
-        subTreeData: (
+        rsc: (
           <html>
             <head></head>
             <body>Root layout</body>

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.test.tsx
@@ -105,7 +105,7 @@ describe('refreshReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -113,7 +113,7 @@ describe('refreshReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -157,7 +157,7 @@ describe('refreshReducer', () => {
       nextUrl: '/linking',
       cache: {
         lazyData: null,
-        subTreeData: (
+        rsc: (
           <html>
             <head></head>
             <body>
@@ -180,7 +180,7 @@ describe('refreshReducer', () => {
                           '',
                           {
                             lazyData: null,
-                            subTreeData: null,
+                            rsc: null,
                             parallelRoutes: new Map(),
                             head: (
                               <>
@@ -193,7 +193,7 @@ describe('refreshReducer', () => {
                     ],
                   ]),
                   lazyData: null,
-                  subTreeData: null,
+                  rsc: null,
                 },
               ],
             ]),
@@ -243,7 +243,7 @@ describe('refreshReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -251,7 +251,7 @@ describe('refreshReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -309,7 +309,7 @@ describe('refreshReducer', () => {
       nextUrl: '/linking',
       cache: {
         lazyData: null,
-        subTreeData: (
+        rsc: (
           <html>
             <head></head>
             <body>
@@ -332,7 +332,7 @@ describe('refreshReducer', () => {
                           '',
                           {
                             lazyData: null,
-                            subTreeData: null,
+                            rsc: null,
                             parallelRoutes: new Map(),
                             head: (
                               <>
@@ -345,7 +345,7 @@ describe('refreshReducer', () => {
                     ],
                   ]),
                   lazyData: null,
-                  subTreeData: null,
+                  rsc: null,
                 },
               ],
             ]),
@@ -395,7 +395,7 @@ describe('refreshReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -403,7 +403,7 @@ describe('refreshReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
           [
@@ -417,7 +417,7 @@ describe('refreshReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>About page</>,
+                        rsc: <>About page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -425,7 +425,7 @@ describe('refreshReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>About layout level</>,
+              rsc: <>About layout level</>,
             },
           ],
         ]),
@@ -483,7 +483,7 @@ describe('refreshReducer', () => {
       nextUrl: '/linking',
       cache: {
         lazyData: null,
-        subTreeData: (
+        rsc: (
           <html>
             <head></head>
             <body>
@@ -506,7 +506,7 @@ describe('refreshReducer', () => {
                           '',
                           {
                             lazyData: null,
-                            subTreeData: null,
+                            rsc: null,
                             parallelRoutes: new Map(),
                             head: (
                               <>
@@ -519,7 +519,7 @@ describe('refreshReducer', () => {
                     ],
                   ]),
                   lazyData: null,
-                  subTreeData: null,
+                  rsc: null,
                 },
               ],
             ]),
@@ -569,7 +569,7 @@ describe('refreshReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -577,7 +577,7 @@ describe('refreshReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
           [
@@ -591,7 +591,7 @@ describe('refreshReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>About page</>,
+                        rsc: <>About page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -599,7 +599,7 @@ describe('refreshReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>About layout level</>,
+              rsc: <>About layout level</>,
             },
           ],
         ]),
@@ -706,7 +706,7 @@ describe('refreshReducer', () => {
       nextUrl: '/linking',
       cache: {
         lazyData: null,
-        subTreeData: (
+        rsc: (
           <html>
             <head></head>
             <body>
@@ -729,7 +729,7 @@ describe('refreshReducer', () => {
                           '',
                           {
                             lazyData: null,
-                            subTreeData: null,
+                            rsc: null,
                             parallelRoutes: new Map(),
                             head: (
                               <>
@@ -742,7 +742,7 @@ describe('refreshReducer', () => {
                     ],
                   ]),
                   lazyData: null,
-                  subTreeData: null,
+                  rsc: null,
                 },
               ],
             ]),

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -59,7 +59,7 @@ export function refreshReducer(
           return state
         }
 
-        // Given the path can only have two items the items are only the router state and subTreeData for the root.
+        // Given the path can only have two items the items are only the router state and rsc for the root.
         const [treePatch] = flightDataPath
         const newTree = applyRouterStatePatchToTree(
           // TODO-APP: remove ''
@@ -94,8 +94,8 @@ export function refreshReducer(
 
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (cacheNodeSeedData !== null) {
-          const subTreeData = cacheNodeSeedData[2]
-          cache.subTreeData = subTreeData
+          const rsc = cacheNodeSeedData[2]
+          cache.rsc = rsc
           fillLazyItemsTillLeafWithHead(
             cache,
             // Existing cache is not passed in as `router.refresh()` has to invalidate the entire cache.

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.test.tsx
@@ -61,7 +61,7 @@ describe('serverPatchReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -69,7 +69,7 @@ describe('serverPatchReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -132,7 +132,7 @@ describe('serverPatchReducer', () => {
       nextUrl: '/linking/about',
       cache: {
         lazyData: null,
-        subTreeData: (
+        rsc: (
           <html>
             <head></head>
             <body>Root layout</body>
@@ -153,7 +153,7 @@ describe('serverPatchReducer', () => {
                           '',
                           {
                             lazyData: null,
-                            subTreeData: <>Linking page</>,
+                            rsc: <>Linking page</>,
                             parallelRoutes: new Map(),
                           },
                         ],
@@ -161,7 +161,7 @@ describe('serverPatchReducer', () => {
                     ],
                   ]),
                   lazyData: null,
-                  subTreeData: <>Linking layout level</>,
+                  rsc: <>Linking layout level</>,
                 },
               ],
             ]),
@@ -211,7 +211,7 @@ describe('serverPatchReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -219,7 +219,7 @@ describe('serverPatchReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -295,7 +295,7 @@ describe('serverPatchReducer', () => {
       nextUrl: '/linking/about',
       cache: {
         lazyData: null,
-        subTreeData: (
+        rsc: (
           <html>
             <head></head>
             <body>Root layout</body>
@@ -316,7 +316,7 @@ describe('serverPatchReducer', () => {
                           '',
                           {
                             lazyData: null,
-                            subTreeData: <>Linking page</>,
+                            rsc: <>Linking page</>,
                             parallelRoutes: new Map(),
                           },
                         ],
@@ -324,7 +324,7 @@ describe('serverPatchReducer', () => {
                     ],
                   ]),
                   lazyData: null,
-                  subTreeData: <>Linking layout level</>,
+                  rsc: <>Linking layout level</>,
                 },
               ],
             ]),

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -214,7 +214,7 @@ export function serverActionReducer(
           return state
         }
 
-        // Given the path can only have two items the items are only the router state and subTreeData for the root.
+        // Given the path can only have two items the items are only the router state and rsc for the root.
         const [treePatch] = flightDataPath
         const newTree = applyRouterStatePatchToTree(
           // TODO-APP: remove ''
@@ -238,13 +238,12 @@ export function serverActionReducer(
 
         // The one before last item is the router state tree patch
         const [cacheNodeSeedData, head] = flightDataPath.slice(-2)
-        const subTreeData =
-          cacheNodeSeedData !== null ? cacheNodeSeedData[2] : null
+        const rsc = cacheNodeSeedData !== null ? cacheNodeSeedData[2] : null
 
         // Handles case where prefetch only returns the router tree patch without rendered components.
-        if (subTreeData !== null) {
+        if (rsc !== null) {
           const cache: CacheNode = createEmptyCacheNode()
-          cache.subTreeData = subTreeData
+          cache.rsc = rsc
           fillLazyItemsTillLeafWithHead(
             cache,
             // Existing cache is not passed in as `router.refresh()` has to invalidate the entire cache.

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
@@ -112,7 +112,7 @@ describe('serverPatchReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -120,7 +120,7 @@ describe('serverPatchReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -173,7 +173,7 @@ describe('serverPatchReducer', () => {
                     "" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
@@ -189,23 +189,23 @@ describe('serverPatchReducer', () => {
                             </React.Fragment>,
                             "lazyData": null,
                             "parallelRoutes": Map {},
-                            "subTreeData": null,
+                            "rsc": null,
                           },
                         },
                       },
-                      "subTreeData": <h1>
+                      "rsc": <h1>
                         Somewhere Page!
                       </h1>,
                     },
                   },
                 },
-                "subTreeData": <React.Fragment>
+                "rsc": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "subTreeData": <html>
+          "rsc": <html>
             <head />
             <body>
               Root layout
@@ -276,7 +276,7 @@ describe('serverPatchReducer', () => {
                       '',
                       {
                         lazyData: null,
-                        subTreeData: <>Linking page</>,
+                        rsc: <>Linking page</>,
                         parallelRoutes: new Map(),
                       },
                     ],
@@ -284,7 +284,7 @@ describe('serverPatchReducer', () => {
                 ],
               ]),
               lazyData: null,
-              subTreeData: <>Linking layout level</>,
+              rsc: <>Linking layout level</>,
             },
           ],
         ]),
@@ -349,7 +349,7 @@ describe('serverPatchReducer', () => {
                     "" => {
                       "lazyData": null,
                       "parallelRoutes": Map {},
-                      "subTreeData": <React.Fragment>
+                      "rsc": <React.Fragment>
                         Linking page
                       </React.Fragment>,
                     },
@@ -365,11 +365,11 @@ describe('serverPatchReducer', () => {
                             </React.Fragment>,
                             "lazyData": null,
                             "parallelRoutes": Map {},
-                            "subTreeData": null,
+                            "rsc": null,
                           },
                         },
                       },
-                      "subTreeData": <h1>
+                      "rsc": <h1>
                         About Page!
                       </h1>,
                     },
@@ -385,23 +385,23 @@ describe('serverPatchReducer', () => {
                             </React.Fragment>,
                             "lazyData": null,
                             "parallelRoutes": Map {},
-                            "subTreeData": null,
+                            "rsc": null,
                           },
                         },
                       },
-                      "subTreeData": <h1>
+                      "rsc": <h1>
                         Somewhere Page!
                       </h1>,
                     },
                   },
                 },
-                "subTreeData": <React.Fragment>
+                "rsc": <React.Fragment>
                   Linking layout level
                 </React.Fragment>,
               },
             },
           },
-          "subTreeData": <html>
+          "rsc": <html>
             <head />
             <body>
               Root layout

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -46,7 +46,7 @@ export interface ServerActionMutable extends Mutable {
 
 /**
  * Refresh triggers a refresh of the full page data.
- * - fetches the Flight data and fills subTreeData at the root of the cache.
+ * - fetches the Flight data and fills rsc at the root of the cache.
  * - The router state is updated at the root.
  */
 export interface RefreshAction {

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -20,7 +20,7 @@ export type CacheNode = ReadyCacheNode | LazyCacheNode
 
 export type LazyCacheNode = {
   /**
-   * When subtreeData is null, this is a lazily-initialized cache node.
+   * When rsc is null, this is a lazily-initialized cache node.
    *
    * If the app attempts to render it, it triggers a lazy data fetch,
    * postpones the render, and schedules an update to a new tree.
@@ -29,7 +29,10 @@ export type LazyCacheNode = {
    * currently is in some cases until we've implemented partial
    * segment fetching.
    */
-  subTreeData: null
+  rsc: null
+
+  // TODO: Add prefetchRsc field.
+  // prefetchRsc: null
 
   /**
    * A pending response for the lazy data fetch. If this is not present
@@ -46,7 +49,7 @@ export type LazyCacheNode = {
 
 export type ReadyCacheNode = {
   /**
-   * When subtreeData is not null, it represents the RSC data for the
+   * When rsc is not null, it represents the RSC data for the
    * corresponding segment.
    *
    * `null` is a valid React Node but because segment data is always a
@@ -54,9 +57,13 @@ export type ReadyCacheNode = {
    *
    * TODO: For additional type safety, update this type to
    * Exclude<React.ReactNode, null>. Need to update createEmptyCacheNode to
-   * accept subTreeData as an argument, or just inline the callers.
+   * accept rsc as an argument, or just inline the callers.
    */
-  subTreeData: React.ReactNode
+  rsc: React.ReactNode
+
+  // TODO: Add prefetchRsc field.
+  // prefetchRsc: React.ReactNode
+
   /**
    * There should never be a lazy data request in this case.
    */

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -224,7 +224,7 @@
   },
   "packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx": {
     "passed": [
-      "fillCacheWithNewSubtreeData should apply subTreeData and head property"
+      "fillCacheWithNewSubtreeData should apply rsc and head property"
     ],
     "failed": [],
     "pending": [],


### PR DESCRIPTION
I want to give this field a name that's bit less generic and distinguishes it from `lazyData` (because that one has a different type and is a special case we want to eventually remove).

I'm also about to add an optional `prefetchRsc` field that represents a prefetched version of the same value. The common suffix is meant to communicate how they are related.

Doing this rename in its own PR because it's a pure find-and-replace, whereas the later steps are not.

Closes NEXT-1846