### PR TITLE
[Docs] Updates references for styled-components configuration in next.config.js

### DIFF
--- a/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
+++ b/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
@@ -131,7 +131,18 @@ export default function RootLayout({ children }) {
 
 Below is an example of how to configure `styled-components@6` or newer:
 
-First, use the `styled-components` API to create a global registry component to collect all CSS style rules generated during a render, and a function to return those rules. Then use the `useServerInsertedHTML` hook to inject the styles collected in the registry into the `<head>` HTML tag in the root layout.
+First, enable styled-components in `next.config.js`.
+
+```js filename="next.config.js"
+module.exports = {
+  compiler: {
+    styledComponents: true,
+    },
+  },
+}
+```
+
+Then, use the `styled-components` API to create a global registry component to collect all CSS style rules generated during a render, and a function to return those rules. Then use the `useServerInsertedHTML` hook to inject the styles collected in the registry into the `<head>` HTML tag in the root layout.
 
 ```tsx filename="lib/registry.tsx" switcher
 'use client'
@@ -234,6 +245,7 @@ export default function RootLayout({ children }) {
 > - During server rendering, styles will be extracted to a global registry and flushed to the `<head>` of your HTML. This ensures the style rules are placed before any content that might use them. In the future, we may use an upcoming React feature to determine where to inject the styles.
 > - During streaming, styles from each chunk will be collected and appended to existing styles. After client-side hydration is complete, `styled-components` will take over as usual and inject any further dynamic styles.
 > - We specifically use a Client Component at the top level of the tree for the style registry because it's more efficient to extract CSS rules this way. It avoids re-generating styles on subsequent server renders, and prevents them from being sent in the Server Component payload.
+> - For advanced use cases where you need to configure individual properties of styled-components compilation, you can read our [Next.js styled-components API reference](/docs/architecture/nextjs-compiler#styled-components) to learn more.
 
 </AppOnly>
 

--- a/docs/04-architecture/nextjs-compiler.mdx
+++ b/docs/04-architecture/nextjs-compiler.mdx
@@ -31,8 +31,21 @@ First, update to the latest version of Next.js: `npm install next@latest`. Then,
 ```js filename="next.config.js"
 module.exports = {
   compiler: {
+    styledComponents: true,
+    },
+  },
+}
+```
+
+For advanced use cases, you can configure individual properties for styled-components compilation.
+
+> Note: `minify`, `transpileTemplateLiterals` and `pure` are not yet implemented. You can follow the progress [here](https://github.com/vercel/next.js/issues/30802). `ssr` and `displayName` transforms are the main requirement for using `styled-components` in Next.js.
+
+```js filename="next.config.js"
+module.exports = {
+  compiler: {
     // see https://styled-components.com/docs/tooling#babel-plugin for more info on the options.
-    styledComponents: boolean | {
+    styledComponents: {
       // Enabled by default in development, disabled in production to reduce file size,
       // setting this will override the default for all environments.
       displayName?: boolean,
@@ -58,8 +71,6 @@ module.exports = {
   },
 }
 ```
-
-`minify`, `transpileTemplateLiterals` and `pure` are not yet implemented. You can follow the progress [here](https://github.com/vercel/next.js/issues/30802). `ssr` and `displayName` transforms are the main requirement for using `styled-components` in Next.js.
 
 ### Jest
 


### PR DESCRIPTION
styled-component references were missing how to configure it in `next.config.js`.