### PR TITLE
Fix webpack chunks handling in traces

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -305,6 +305,10 @@ export async function collectBuildTraces({
 
       const routesIgnores = [
         ...sharedIgnores,
+        // server chunks are provided via next-trace-entrypoints-plugin plugin
+        // as otherwise all chunks are traced here and included for all pages
+        // whether they are needed or not
+        '**/.next/server/chunks/**',
         '**/next/dist/server/optimize-amp.js',
         '**/next/dist/server/post-process.js',
       ].filter(nonNullable)

--- a/test/integration/build-trace-extra-entries/app/lib/my-component.js
+++ b/test/integration/build-trace-extra-entries/app/lib/my-component.js
@@ -1,0 +1,3 @@
+export function Button() {
+  return <button>click me</button>
+}

--- a/test/integration/build-trace-extra-entries/app/pages/index.js
+++ b/test/integration/build-trace-extra-entries/app/pages/index.js
@@ -1,5 +1,9 @@
 import { fetchData } from '../lib/fetch-data'
 
+import('../lib/my-component').then((mod) => {
+  console.log(mod.Button)
+})
+
 export default function Page() {
   return 'index page'
 }

--- a/test/integration/build-trace-extra-entries/test/index.test.js
+++ b/test/integration/build-trace-extra-entries/test/index.test.js
@@ -51,6 +51,22 @@ describe('build trace with extra entries', () => {
         true
       )
       expect(
+        appTrace.files.filter(
+          (file) => file.includes('chunks') && file.endsWith('.js')
+        ).length
+      ).toBe(0)
+
+      expect(
+        indexTrace.files.filter(
+          (file) => file.includes('chunks') && file.endsWith('.js')
+        ).length
+      ).toBeGreaterThan(
+        anotherTrace.files.filter(
+          (file) => file.includes('chunks') && file.endsWith('.js')
+        ).length
+      )
+
+      expect(
         appTrace.files.some((file) => file.endsWith('lib/get-data.js'))
       ).toBe(true)
       expect(


### PR DESCRIPTION
This ensures we don't include all chunks in `nft` traces un-necessarily as our webpack plugin already tracks which are needed per-entry. 

x-ref: [slack thread](https://vercel.slack.com/archives/C0591D8EN4C/p1702318184832319?thread_ts=1701815919.923639&cid=C0591D8EN4C)

Closes NEXT-1847