### PR TITLE
chore(docs): Add `inlang` to list of thrid-party i18n solutions

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/13-internationalization.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/13-internationalization.mdx
@@ -150,3 +150,4 @@ export default function Root({ children, params }) {
 - [`next-intl`](https://next-intl-docs.vercel.app/docs/next-13)
 - [`next-international`](https://github.com/QuiiBz/next-international)
 - [`next-i18n-router`](https://github.com/i18nexus/next-i18n-router)
+- [`inlang`](https://inlang.com/c/nextjs)

--- a/docs/03-pages/01-building-your-application/01-routing/08-internationalization.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/08-internationalization.mdx
@@ -13,7 +13,7 @@ description: Next.js has built-in support for internationalized routing and lang
 
 Next.js has built-in support for internationalized ([i18n](https://en.wikipedia.org/wiki/Internationalization_and_localization#Naming)) routing since `v10.0.0`. You can provide a list of locales, the default locale, and domain-specific locales and Next.js will automatically handle the routing.
 
-The i18n routing support is currently meant to complement existing i18n library solutions like [`react-intl`](https://formatjs.io/docs/getting-started/installation), [`react-i18next`](https://react.i18next.com/), [`lingui`](https://lingui.dev/), [`rosetta`](https://github.com/lukeed/rosetta), [`next-intl`](https://github.com/amannn/next-intl), [`next-translate`](https://github.com/aralroca/next-translate), [`next-multilingual`](https://github.com/Avansai/next-multilingual), [`typesafe-i18n`](https://github.com/ivanhofer/typesafe-i18n), [`tolgee`](https://tolgee.io/integrations/next), and others by streamlining the routes and locale parsing.
+The i18n routing support is currently meant to complement existing i18n library solutions like [`react-intl`](https://formatjs.io/docs/getting-started/installation), [`react-i18next`](https://react.i18next.com/), [`lingui`](https://lingui.dev/), [`rosetta`](https://github.com/lukeed/rosetta), [`next-intl`](https://github.com/amannn/next-intl), [`next-translate`](https://github.com/aralroca/next-translate), [`next-multilingual`](https://github.com/Avansai/next-multilingual), [`inlang`](https://inlang.com/c/nextjs), [`typesafe-i18n`](https://github.com/ivanhofer/typesafe-i18n), [`tolgee`](https://tolgee.io/integrations/next), and others by streamlining the routes and locale parsing.
 
 ## Getting started
 


### PR DESCRIPTION
This PR adds [inlang](https://inlang.com/c/nextjs) to the list of third-party i18n solutions. Inlang is an ecosystem of i18n tools, guides & infrastructure that integrates well with NextJS, as-well as most other Frameworks. It aims to offer a successor to `typesafe-i18n`, which is unfortunately no longer maintained. 