### PR TITLE
fix NODE_OPTIONS=inspect

### DIFF
--- a/packages/next/src/lib/helpers/get-registry.ts
+++ b/packages/next/src/lib/helpers/get-registry.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process'
 import { getPkgManager } from './get-pkg-manager'
+import { getNodeOptionsWithoutInspect } from '../../server/lib/utils'
 
 /**
  * Returns the package registry using the user's package manager.
@@ -10,7 +11,12 @@ export function getRegistry(baseDir: string = process.cwd()) {
   let registry = `https://registry.npmjs.org/`
   try {
     const pkgManager = getPkgManager(baseDir)
-    const output = execSync(`${pkgManager} config get registry`)
+    const output = execSync(`${pkgManager} config get registry`, {
+      env: {
+        ...process.env,
+        NODE_OPTIONS: getNodeOptionsWithoutInspect(),
+      },
+    })
       .toString()
       .trim()
 

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -547,8 +547,10 @@ describe('CLI Usage', () => {
       try {
         await check(() => output, new RegExp(`http://localhost:${port}`))
         await check(() => errOutput, /Debugger listening on/)
-        // TODO: This should work, but is currently failing.
-        // expect(errOutput).not.toContain('address already in use')
+        expect(errOutput).not.toContain('address already in use')
+        expect(output).toContain(
+          'the --inspect option was detected, the Next.js router server should be inspected at port'
+        )
       } finally {
         await killApp(app)
       }


### PR DESCRIPTION
Passing `NODE_OPTIONS='--inspect'` was failing because a sub-process was getting created (`getRegistry()`) which would trigger a "address already in use" error when the process inherited the same debugger port from the parent process. 

I had to disable this test in https://github.com/vercel/next.js/pull/59508 because it wasn't passing, CI was just skipping it. This PR fixes the behavior and re-enables the test.

Fixes #55862

Closes NEXT-1854