### PR TITLE
Fix force-static and fetch no-store cases

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -201,6 +201,7 @@ export async function createComponentTree({
     }
 
     if (
+      !staticGenerationStore.forceStatic &&
       staticGenerationStore.isStaticGeneration &&
       ctx.defaultRevalidate === 0 &&
       // If the postpone API isn't available, we can't postpone the render and

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -621,10 +621,8 @@ export function patchFetch({
               (typeof staticGenerationStore.revalidate === 'number' &&
                 next.revalidate < staticGenerationStore.revalidate))
           ) {
-            const forceDynamic = staticGenerationStore.forceDynamic
-
             if (
-              !forceDynamic &&
+              !staticGenerationStore.forceDynamic &&
               !staticGenerationStore.forceStatic &&
               next.revalidate === 0
             ) {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -45,6 +45,12 @@ createNextDescribe(
           'unstable_cache_tag1'
         )
       })
+
+      it('should honor force-static with fetch cache: no-store correctly', async () => {
+        const res = await next.fetch('/force-static-fetch-no-store')
+        expect(res.status).toBe(200)
+        expect(res.headers.get('x-nextjs-cache').toLowerCase()).toBe('hit')
+      })
     }
 
     it('should correctly include headers instance in cache key', async () => {
@@ -519,6 +525,10 @@ createNextDescribe(
             'default-cache/page.js',
             'fetch-no-cache/page.js',
             'force-no-store/page.js',
+            'force-static-fetch-no-store.html',
+            'force-static-fetch-no-store.rsc',
+            'force-static-fetch-no-store/page.js',
+            'force-static-fetch-no-store/page_client-reference-manifest.js',
             'force-static/first.rsc',
             'api/draft-mode/route.js',
             'blog/tim/first-post.rsc',
@@ -901,6 +911,22 @@ createNextDescribe(
               ],
               "initialRevalidateSeconds": 3,
               "srcRoute": "/force-cache",
+            },
+            "/force-static-fetch-no-store": {
+              "dataRoute": "/force-static-fetch-no-store.rsc",
+              "experimentalBypassFor": [
+                {
+                  "key": "Next-Action",
+                  "type": "header",
+                },
+                {
+                  "key": "content-type",
+                  "type": "header",
+                  "value": "multipart/form-data",
+                },
+              ],
+              "initialRevalidateSeconds": false,
+              "srcRoute": "/force-static-fetch-no-store",
             },
             "/force-static/first": {
               "dataRoute": "/force-static/first.rsc",

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -46,11 +46,13 @@ createNextDescribe(
         )
       })
 
-      it('should honor force-static with fetch cache: no-store correctly', async () => {
-        const res = await next.fetch('/force-static-fetch-no-store')
-        expect(res.status).toBe(200)
-        expect(res.headers.get('x-nextjs-cache').toLowerCase()).toBe('hit')
-      })
+      if (!process.env.CUSTOM_CACHE_HANDLER) {
+        it('should honor force-static with fetch cache: no-store correctly', async () => {
+          const res = await next.fetch('/force-static-fetch-no-store')
+          expect(res.status).toBe(200)
+          expect(res.headers.get('x-nextjs-cache').toLowerCase()).toBe('hit')
+        })
+      }
     }
 
     it('should correctly include headers instance in cache key', async () => {

--- a/test/e2e/app-dir/app-static/app/force-static-fetch-no-store/page.js
+++ b/test/e2e/app-dir/app-static/app/force-static-fetch-no-store/page.js
@@ -1,0 +1,36 @@
+export const dynamic = 'force-static'
+
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?page',
+    {
+      cache: 'no-store',
+    }
+  ).then((res) => res.text())
+
+  const data2 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?page',
+    {
+      next: {
+        revalidate: 0,
+      },
+    }
+  ).then((res) => res.text())
+
+  const data3 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?page',
+    {
+      cache: 'no-cache',
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="page">/force-static-fetch-no-store</p>
+      <p id="page-data">{data}</p>
+      <p id="page-data2">{data2}</p>
+      <p id="page-data3">{data3}</p>
+      <p id="now">{Date.now()}</p>
+    </>
+  )
+}


### PR DESCRIPTION
This ensures that `export const dynamic = 'force-static'` is properly honored when a page contains fetches with `cache: 'no-store'`, `cache: 'no-cache'` or `next: { revalidate: 0 }`. 

Closes NEXT-1858