### PR TITLE
types: cover the tests with root tsconfig.json

### DIFF
--- a/test/e2e/app-dir/metadata-edge/app/page.tsx
+++ b/test/e2e/app-dir/metadata-edge/app/page.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export default function Page() {
   return <>hello index</>
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,3 +1,4 @@
+// Make development mode typescript module resolving and jsx parsing correct for all tests
 {
   "compilerOptions": {
     "strict": false,
@@ -18,7 +19,5 @@
       "next-webdriver": ["test/lib/next-webdriver"],
       "e2e-utils": ["test/lib/e2e-utils"]
     }
-  },
-  "include": ["test/**/*.test.ts", "test/**/*.test.tsx"],
-  "exclude": ["node_modules"]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,9 +22,8 @@
   "include": [
     "test/**/*.test.ts",
     "test/**/*.test.tsx",
-    "test/**/test/*",
-    "packages/next/types/compiled.d.ts",
-    "test/e2e/pages-dir/client-navigation/index.test.js",
-    "test/e2e/pages-dir/client-navigation/rendering.js"
+    "test/**/*.ts",
+    "test/**/*.tsx",
+    "packages/next/types/compiled.d.ts"
   ]
 }


### PR DESCRIPTION
We're using react automatic transform now, tsconfig.json `jsx` will be aligned as `react-jsx`. Some tests files are showing `'React' refers to a UMD global, but the current file is a module` if there's no react import, cause they're not being covered by  jsx config in `tsconfig.json`. Update the `jsx` config in root tsconfig.json to cover test ts/tsx files.

Adding a new `test/tsconfig.json` to resolve the modules and parsing jsx correctly

Closes NEXT-1859