### PR TITLE
fix: gracefully shutdown server

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -34,17 +34,20 @@ import {
 } from '../lib/helpers/get-reserved-port'
 import os from 'os'
 
+type Child = ReturnType<typeof fork>
+type ExitCode = Parameters<Child['kill']>[0]
+
 let dir: string
-let child: undefined | ReturnType<typeof fork>
+let child: undefined | Child
 let config: NextConfigComplete
 let isTurboSession = false
 let traceUploadUrl: string
 let sessionStopHandled = false
 let sessionStarted = Date.now()
 
-const handleSessionStop = async (signal: string | null) => {
+const handleSessionStop = async (signal: ExitCode | null) => {
   if (child) {
-    child.kill((signal as any) || 0)
+    child.kill(signal ?? 0)
   }
   if (sessionStopHandled) return
   sessionStopHandled = true
@@ -108,8 +111,11 @@ const handleSessionStop = async (signal: string | null) => {
   process.exit(0)
 }
 
-process.on('SIGINT', () => handleSessionStop('SIGINT'))
-process.on('SIGTERM', () => handleSessionStop('SIGTERM'))
+process.on('SIGINT', () => handleSessionStop('SIGKILL'))
+process.on('SIGTERM', () => handleSessionStop('SIGKILL'))
+
+// exit event must be synchronous
+process.on('exit', () => child?.kill('SIGKILL'))
 
 const nextDev: CliCommand = async (args) => {
   if (args['--help']) {
@@ -332,17 +338,5 @@ const nextDev: CliCommand = async (args) => {
 
   await runDevServer(false)
 }
-
-function cleanup() {
-  if (!child) {
-    return
-  }
-
-  child.kill('SIGTERM')
-}
-
-process.on('exit', cleanup)
-process.on('SIGINT', cleanup)
-process.on('SIGTERM', cleanup)
 
 export { nextDev }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -264,10 +264,9 @@ export async function startServer(
       })
 
       try {
-        const cleanup = (code: number | null) => {
+        const cleanup = () => {
           debug('start-server process cleanup')
-          server.close()
-          process.exit(code ?? 0)
+          server.close(() => process.exit(0))
         }
         const exception = (err: Error) => {
           if (isPostpone(err)) {
@@ -279,11 +278,11 @@ export async function startServer(
           // This is the render worker, we keep the process alive
           console.error(err)
         }
-        process.on('exit', (code) => cleanup(code))
+        // Make sure commands gracefully respect termination signals (e.g. from Docker)
+        // Allow the graceful termination to be manually configurable
         if (!process.env.NEXT_MANUAL_SIG_HANDLE) {
-          // callback value is signal string, exit with 0
-          process.on('SIGINT', () => cleanup(0))
-          process.on('SIGTERM', () => cleanup(0))
+          process.on('SIGINT', cleanup)
+          process.on('SIGTERM', cleanup)
         }
         process.on('rejectionHandled', () => {
           // It is ok to await a Promise late in Next.js as it allows for better

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -526,7 +526,7 @@ export async function killProcess(
 // Kill a launched app
 export async function killApp(instance: ChildProcess) {
   if (instance && instance.pid) {
-    await killProcess(instance.pid)
+    await killProcess(instance.pid, 'SIGKILL')
   }
 }
 


### PR DESCRIPTION
- Both the standalone server and the `startServer` function it calls attempt to stop the server on `SIGINT` and `SIGTERM` in different ways. This lets `server.js` yield to `startServer`
- The cleanup function in `startServer` was not waiting for the server to close before calling `process.exit`. This lets it wait for any in-flight requests to finish processing before exiting the process

fixes: #53661

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
