### PR TITLE
Transpile all code on app browser layer

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -142,14 +142,14 @@ const devtoolRevertWarning = execOnce(
 
 let loggedSwcDisabled = false
 let loggedIgnoredCompilerOptions = false
+const reactRefreshLoaderName =
+  'next/dist/compiled/@next/react-refresh-utils/dist/loader'
 
 export function attachReactRefresh(
   webpackConfig: webpack.Configuration,
   targetLoader: webpack.RuleSetUseItem
 ) {
   let injections = 0
-  const reactRefreshLoaderName =
-    'next/dist/compiled/@next/react-refresh-utils/dist/loader'
   const reactRefreshLoader = require.resolve(reactRefreshLoaderName)
   webpackConfig.module?.rules?.forEach((rule) => {
     if (rule && typeof rule === 'object' && 'use' in rule) {
@@ -491,15 +491,12 @@ export default async function getBaseWebpackConfig(
         }),
       ]
 
+  const reactRefreshLoaders =
+    dev && isClient ? [require.resolve(reactRefreshLoaderName)] : []
+
   // client components layers: SSR + browser
   const swcLoaderForClientLayer = [
-    ...(dev && isClient
-      ? [
-          require.resolve(
-            'next/dist/compiled/@next/react-refresh-utils/dist/loader'
-          ),
-        ]
-      : []),
+    ...reactRefreshLoaders,
     {
       // This loader handles actions and client entries
       // in the client layer.
@@ -1412,15 +1409,7 @@ export default async function getBaseWebpackConfig(
               : []),
             {
               ...codeCondition,
-              use:
-                dev && isClient
-                  ? [
-                      require.resolve(
-                        'next/dist/compiled/@next/react-refresh-utils/dist/loader'
-                      ),
-                      defaultLoaders.babel,
-                    ]
-                  : defaultLoaders.babel,
+              use: [...reactRefreshLoaders, defaultLoaders.babel],
             },
           ],
         },

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1394,7 +1394,6 @@ export default async function getBaseWebpackConfig(
                   },
                   {
                     test: codeCondition.test,
-                    exclude: codeCondition.exclude,
                     issuerLayer: [WEBPACK_LAYERS.appPagesBrowser],
                     use: swcLoaderForClientLayer,
                     resolve: {

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -495,14 +495,14 @@ export default async function getBaseWebpackConfig(
     dev && isClient ? [require.resolve(reactRefreshLoaderName)] : []
 
   // client components layers: SSR or browser
-  const createSwcLoaderForClientLayer = (isBrowserLayer: boolean) => [
-    ...(dev && isClient
-      ? [
-          require.resolve(
-            'next/dist/compiled/@next/react-refresh-utils/dist/loader'
-          ),
-        ]
-      : []),
+  const createSwcLoaderForClientLayer = ({
+    isBrowserLayer,
+    reactRefresh,
+  }: {
+    isBrowserLayer: boolean
+    reactRefresh: boolean
+  }) => [
+    ...(reactRefresh ? reactRefreshLoaders : []),
     {
       // This loader handles actions and client entries
       // in the client layer.
@@ -520,8 +520,15 @@ export default async function getBaseWebpackConfig(
       : []),
   ]
 
-  const swcLoaderForBrowserLayer = createSwcLoaderForClientLayer(true)
-  const swcLoaderForSSRLayer = createSwcLoaderForClientLayer(false)
+  const swcLoaderForBrowserLayer = createSwcLoaderForClientLayer({
+    isBrowserLayer: true,
+    // reactRefresh for browser layer is applied conditionally to user-land source
+    reactRefresh: false,
+  })
+  const swcLoaderForSSRLayer = createSwcLoaderForClientLayer({
+    isBrowserLayer: false,
+    reactRefresh: true,
+  })
 
   // Loader for API routes needs to be differently configured as it shouldn't
   // have RSC transpiler enabled, so syntax checks such as invalid imports won't

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -496,7 +496,6 @@ export default async function getBaseWebpackConfig(
 
   // client components layers: SSR + browser
   const swcLoaderForClientLayer = [
-    ...reactRefreshLoaders,
     {
       // This loader handles actions and client entries
       // in the client layer.
@@ -1391,15 +1390,29 @@ export default async function getBaseWebpackConfig(
                   },
                   {
                     test: codeCondition.test,
-                    issuerLayer: [WEBPACK_LAYERS.appPagesBrowser],
+                    issuerLayer: WEBPACK_LAYERS.appPagesBrowser,
                     use: swcLoaderForClientLayer,
                     resolve: {
                       mainFields: getMainField(compilerType, true),
                     },
                   },
+                  // Do not apply react-refresh-loader to node_modules for app router browser layer
+                  ...(dev && isClient
+                    ? [
+                        {
+                          test: codeCondition.test,
+                          exclude: codeCondition.exclude,
+                          issuerLayer: WEBPACK_LAYERS.appPagesBrowser,
+                          use: reactRefreshLoaders,
+                          resolve: {
+                            mainFields: getMainField(compilerType, true),
+                          },
+                        },
+                      ]
+                    : []),
                   {
                     test: codeCondition.test,
-                    issuerLayer: [WEBPACK_LAYERS.serverSideRendering],
+                    issuerLayer: WEBPACK_LAYERS.serverSideRendering,
                     use: swcLoaderForClientLayer,
                     resolve: {
                       mainFields: getMainField(compilerType, true),

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1406,12 +1406,11 @@ export default async function getBaseWebpackConfig(
                   },
                 ]
               : []),
+            {
+              ...codeCondition,
+              use: [...reactRefreshLoaders, defaultLoaders.babel],
+            },
           ],
-        },
-        {
-          ...codeCondition,
-          issuerLayer: isWebpackDefaultLayer,
-          use: [...reactRefreshLoaders, defaultLoaders.babel],
         },
         // Do not apply react-refresh-loader to node_modules for app router browser layer
         ...(hasAppDir && dev && isClient

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1396,20 +1396,6 @@ export default async function getBaseWebpackConfig(
                       mainFields: getMainField(compilerType, true),
                     },
                   },
-                  // Do not apply react-refresh-loader to node_modules for app router browser layer
-                  ...(dev && isClient
-                    ? [
-                        {
-                          test: codeCondition.test,
-                          exclude: codeCondition.exclude,
-                          issuerLayer: WEBPACK_LAYERS.appPagesBrowser,
-                          use: reactRefreshLoaders,
-                          resolve: {
-                            mainFields: getMainField(compilerType, true),
-                          },
-                        },
-                      ]
-                    : []),
                   {
                     test: codeCondition.test,
                     issuerLayer: WEBPACK_LAYERS.serverSideRendering,
@@ -1420,12 +1406,27 @@ export default async function getBaseWebpackConfig(
                   },
                 ]
               : []),
-            {
-              ...codeCondition,
-              use: [...reactRefreshLoaders, defaultLoaders.babel],
-            },
           ],
         },
+        {
+          ...codeCondition,
+          issuerLayer: isWebpackDefaultLayer,
+          use: [...reactRefreshLoaders, defaultLoaders.babel],
+        },
+        // Do not apply react-refresh-loader to node_modules for app router browser layer
+        ...(hasAppDir && dev && isClient
+          ? [
+              {
+                test: codeCondition.test,
+                exclude: codeCondition.exclude,
+                issuerLayer: WEBPACK_LAYERS.appPagesBrowser,
+                use: reactRefreshLoaders,
+                resolve: {
+                  mainFields: getMainField(compilerType, true),
+                },
+              },
+            ]
+          : []),
         ...(!config.images.disableStaticImages
           ? [
               {

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1357,6 +1357,20 @@ export default async function getBaseWebpackConfig(
               },
             ]
           : []),
+        // Do not apply react-refresh-loader to node_modules for app router browser layer
+        ...(hasAppDir && dev && isClient
+          ? [
+              {
+                test: codeCondition.test,
+                exclude: codeCondition.exclude,
+                issuerLayer: WEBPACK_LAYERS.appPagesBrowser,
+                use: reactRefreshLoaders,
+                resolve: {
+                  mainFields: getMainField(compilerType, true),
+                },
+              },
+            ]
+          : []),
         {
           oneOf: [
             {
@@ -1412,20 +1426,7 @@ export default async function getBaseWebpackConfig(
             },
           ],
         },
-        // Do not apply react-refresh-loader to node_modules for app router browser layer
-        ...(hasAppDir && dev && isClient
-          ? [
-              {
-                test: codeCondition.test,
-                exclude: codeCondition.exclude,
-                issuerLayer: WEBPACK_LAYERS.appPagesBrowser,
-                use: reactRefreshLoaders,
-                resolve: {
-                  mainFields: getMainField(compilerType, true),
-                },
-              },
-            ]
-          : []),
+
         ...(!config.images.disableStaticImages
           ? [
               {

--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.
 */
 
 import type { NextConfig } from '../../../../types'
+import type { WebpackLayerName } from '../../../lib/constants'
 import { isWasm, transform } from '../../swc'
 import { getLoaderSWCOptions } from '../../swc/options'
 import path, { isAbsolute } from 'path'
@@ -43,7 +44,7 @@ export interface SWCLoaderOptions {
   supportedBrowsers: string[] | undefined
   swcCacheDir: string
   serverComponents?: boolean
-  isReactServerLayer?: boolean
+  bundleLayer?: WebpackLayerName
   esm?: boolean
 }
 
@@ -69,7 +70,7 @@ async function loaderTransform(
     supportedBrowsers,
     swcCacheDir,
     serverComponents,
-    isReactServerLayer,
+    bundleLayer,
     esm,
   } = loaderOptions
   const isPageFile = filename.startsWith(pagesDir)
@@ -93,7 +94,7 @@ async function loaderTransform(
     swcCacheDir,
     relativeFilePathFromRoot,
     serverComponents,
-    isReactServerLayer,
+    bundleLayer,
     esm,
   })
 

--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -51,7 +51,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     )
     expect(await session.hasRedbox(true)).toBe(true)
     expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-      "./node_modules/my-package/index.js:1:0
+      "./node_modules/my-package/index.js:1:12
       Module not found: Can't resolve 'dns'
 
       https://nextjs.org/docs/messages/module-not-found

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -269,19 +269,17 @@ createNextDescribe(
         }, /success/)
       })
 
-      if (!process.env.TURBOPACK) {
-        it('should compile server actions from node_modules in client components', async () => {
-          // before action there's no action log
-          expect(next.cliOutput).not.toContain('action-log:server:action1')
-          const browser = await next.browser('/action/client')
-          await browser.elementByCss('#action').click()
+      it('should compile server actions from node_modules in client components', async () => {
+        // before action there's no action log
+        expect(next.cliOutput).not.toContain('action-log:server:action1')
+        const browser = await next.browser('/action/client')
+        await browser.elementByCss('#action').click()
 
-          await check(() => {
-            expect(next.cliOutput).toContain('action-log:server:action1')
-            return 'success'
-          }, /success/)
-        })
-      }
+        await check(() => {
+          expect(next.cliOutput).toContain('action-log:server:action1')
+          return 'success'
+        }, /success/)
+      })
     })
   }
 )

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -269,17 +269,19 @@ createNextDescribe(
         }, /success/)
       })
 
-      it('should compile server actions from node_modules in client components', async () => {
-        // before action there's no action log
-        expect(next.cliOutput).not.toContain('action-log:server:action1')
-        const browser = await next.browser('/action/client')
-        await browser.elementByCss('#action').click()
+      if (!process.env.TURBOPACK) {
+        it('should compile server actions from node_modules in client components', async () => {
+          // before action there's no action log
+          expect(next.cliOutput).not.toContain('action-log:server:action1')
+          const browser = await next.browser('/action/client')
+          await browser.elementByCss('#action').click()
 
-        await check(() => {
-          expect(next.cliOutput).toContain('action-log:server:action1')
-          return 'success'
-        }, /success/)
-      })
+          await check(() => {
+            expect(next.cliOutput).toContain('action-log:server:action1')
+            return 'success'
+          }, /success/)
+        })
+      }
     })
   }
 )

--- a/test/e2e/app-dir/app-external/app/action/client/page.js
+++ b/test/e2e/app-dir/app-external/app/action/client/page.js
@@ -1,0 +1,16 @@
+'use client'
+
+import { action1 } from 'server-action-mod'
+
+export default function Page() {
+  return (
+    <button
+      id="action"
+      onClick={() => {
+        action1()
+      }}
+    >
+      action
+    </button>
+  )
+}

--- a/test/e2e/app-dir/app-external/node_modules_bak/server-action-mod/index.js
+++ b/test/e2e/app-dir/app-external/node_modules_bak/server-action-mod/index.js
@@ -1,0 +1,7 @@
+'use server'
+
+export async function action1() {
+  console.log(
+    `action-log:${typeof window === 'undefined' ? 'server' : 'client'}:action1`
+  )
+}

--- a/test/e2e/app-dir/app-external/node_modules_bak/server-action-mod/package.json
+++ b/test/e2e/app-dir/app-external/node_modules_bak/server-action-mod/package.json
@@ -1,0 +1,3 @@
+{
+  "exports": "./index.js"
+}

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -2452,12 +2452,12 @@
       "app dir - external dependency should support exporting multiple star re-exports",
       "app dir - external dependency should transpile specific external packages with the `transpilePackages` option",
       "app dir - external dependency should use the same async storages if imported directly",
-      "app dir - external dependency should use the same export type for packages in both ssr and client",
-      "app dir - external dependency server actions should compile server actions from node_modules in client components"
+      "app dir - external dependency should use the same export type for packages in both ssr and client"
     ],
     "failed": [
       "app dir - external dependency should be able to opt-out 3rd party packages being bundled in server components",
-      "app dir - external dependency should have proper tree-shaking for known modules in CJS"
+      "app dir - external dependency should have proper tree-shaking for known modules in CJS",
+      "app dir - external dependency server actions should compile server actions from node_modules in client components"
     ],
     "pending": [],
     "flakey": [],

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -2452,7 +2452,8 @@
       "app dir - external dependency should support exporting multiple star re-exports",
       "app dir - external dependency should transpile specific external packages with the `transpilePackages` option",
       "app dir - external dependency should use the same async storages if imported directly",
-      "app dir - external dependency should use the same export type for packages in both ssr and client"
+      "app dir - external dependency should use the same export type for packages in both ssr and client",
+      "app dir - external dependency server actions should compile server actions from node_modules in client components"
     ],
     "failed": [
       "app dir - external dependency should be able to opt-out 3rd party packages being bundled in server components",


### PR DESCRIPTION
### What

Include modules from `node_modules` into swc transform, this will help discover server actions from node_modules.

### Why

We didn't transform the code from node_modules in app router browser layer, if you're using server actions in client components from node_modules, it's not going to act properly.

### How

- Remove the `exclude` condition for `node_modules` in app router browser layer
- Change react refresh loader to only apply for userland code (non node_modules) in app router browser layer to avoid broken

There's perf concern that all transform applying to node_modules might cause too much overhead. We're passing down webpack bundling layer to swc loader, to determine when to disable the unnecessary transforms. In this PR we disabled few server specific transform for browser layer.

Closes NEXT-1848
Closes NEXT-1861