### PR TITLE
Fix test/tsconfig.json alias for internal test utils

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -13,11 +13,11 @@
     "baseUrl": ".",
     "types": ["react", "jest", "node", "trusted-types", "jest-extended"],
     "paths": {
-      "development-sandbox": ["test/lib/development-sandbox"],
-      "next-test-utils": ["test/lib/next-test-utils"],
-      "amp-test-utils": ["test/lib/amp-test-utils"],
-      "next-webdriver": ["test/lib/next-webdriver"],
-      "e2e-utils": ["test/lib/e2e-utils"]
+      "development-sandbox": ["./lib/development-sandbox"],
+      "next-test-utils": ["./lib/next-test-utils"],
+      "amp-test-utils": ["./lib/amp-test-utils"],
+      "next-webdriver": ["./lib/next-webdriver"],
+      "e2e-utils": ["./lib/e2e-utils"]
     }
   }
 }


### PR DESCRIPTION
Inside `test/` folder we should use different path for alias paths
Follow up #59550 
