### PR TITLE
docs: fix bad closed tag

### DIFF
--- a/docs/02-app/01-building-your-application/08-testing/02-jest.mdx
+++ b/docs/02-app/01-building-your-application/08-testing/02-jest.mdx
@@ -331,7 +331,7 @@ describe('Page', () => {
 
 </AppOnly>
 
-<PagesOnly>
+</PagesOnly>
 
 Optionally, add a [snapshot test](https://jestjs.io/docs/snapshot-testing) to keep track of any unexpected changes in your component:
 


### PR DESCRIPTION
Found this from build error trace while testing the change in #59569 

```
docs/02-app/01-building-your-application/08-testing/02-jest.mdx": UnexpectedMDXError: Error: Build failed with 1 error:
--
  _mdx_bundler_entry_point-776983b1-6900-47c0-98cc-0c35882e9532.mdx:297:0: ERROR: [plugin: @mdx-js/esbuild] Unexpected closing tag `</PageOnly>`, expected corresponding closing tag for `<PagesOnly>
```



Closes NEXT-1863