### PR TITLE
 feat(turbopack): support named client references properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "serde",
  "smallvec",
@@ -3515,7 +3515,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "serde",
@@ -7635,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7667,7 +7667,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7708,7 +7708,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7725,7 +7725,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7756,7 +7756,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "base16",
  "hex",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7782,7 +7782,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "mimalloc",
 ]
@@ -7800,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7825,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7857,7 +7857,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7898,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7922,7 +7922,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7940,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7970,7 +7970,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8021,7 +8021,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8058,7 +8058,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8093,7 +8093,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "serde",
  "serde_json",
@@ -8104,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8127,7 +8127,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8144,7 +8144,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8160,7 +8160,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8180,7 +8180,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "serde",
@@ -8195,7 +8195,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8210,7 +8210,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8245,7 +8245,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "serde",
@@ -8261,7 +8261,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.3#05b59b2502e259837020e531659e33aa8d9c9f8e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240110.4#35ade4e85b17a076fb4e6287e519c26b087d0bef"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.87.16", features = [
 testing = { version = "0.35.14" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240110.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240110.4" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240110.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240110.4" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240110.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240110.4" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -1,6 +1,7 @@
 use std::{io::Write, iter::once};
 
 use anyhow::{bail, Context, Result};
+use indexmap::IndexSet;
 use indoc::writedoc;
 use turbo_tasks::{Value, ValueToString, Vc};
 use turbo_tasks_fs::File;
@@ -65,18 +66,17 @@ impl EcmascriptClientReferenceProxyModule {
     }
 
     #[turbo_tasks::function]
-    async fn proxy_module(self: Vc<Self>) -> Result<Vc<EcmascriptModuleAsset>> {
-        let this = self.await?;
+    async fn proxy_module(&self) -> Result<Vc<EcmascriptModuleAsset>> {
         let mut code = CodeBuilder::default();
 
-        // Adapted from
-        // next.js/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+        let server_module_path = &*self.server_module_ident.path().to_string().await?;
+
         writedoc!(
             code,
             r#"
-                import {{ createProxy }} from 'next/dist/build/webpack/loaders/next-flight-loader/module-proxy'
+                import {{ createProxy }} from 'next/dist/build/webpack/loaders/next-flight-loader/module-proxy';
 
-                const proxy = createProxy({server_module_path})
+                const proxy = createProxy({server_module_path});
 
                 // Accessing the __esModule property and exporting $$typeof are required here.
                 // The __esModule getter forces the proxy target to create the default export
@@ -84,22 +84,54 @@ impl EcmascriptClientReferenceProxyModule {
                 // is a client boundary.
                 const {{ __esModule, $$typeof }} = proxy;
 
-                export {{ __esModule, $$typeof }};
                 export default proxy;
             "#,
-            server_module_path = StringifyJs(&this.server_module_ident.path().to_string().await?)
+            server_module_path = StringifyJs(server_module_path),
         )?;
+
+        // Adapted from
+        // next.js/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+        if let EcmascriptExports::EsmExports(exports) = &*self.client_module.get_exports().await? {
+            let mut exported_names = exports
+                .await?
+                .exports
+                .keys()
+                .cloned()
+                .collect::<IndexSet<_>>();
+
+            for result in exports.expand_star_exports().await? {
+                let export_info = result.await?;
+
+                exported_names.extend(export_info.star_exports.iter().cloned());
+
+                if export_info.has_dynamic_exports {
+                    // TODO: throw? warn?
+                }
+            }
+
+            for (i, client_ref) in exported_names.into_iter().enumerate() {
+                writedoc!(
+                    code,
+                    r#"
+                        // Initialize export.
+                        const _e{cnt} = proxy[{client_ref}];
+                    "#,
+                    client_ref = StringifyJs(&client_ref),
+                    cnt = i,
+                )?;
+            }
+        };
 
         let code = code.build();
         let proxy_module_content =
             AssetContent::file(File::from(code.source_code().clone()).into());
 
         let proxy_source = VirtualSource::new(
-            this.server_module_ident.path().join("proxy.ts".to_string()),
+            self.server_module_ident.path().join("proxy.ts".to_string()),
             proxy_module_content,
         );
 
-        let proxy_module = this
+        let proxy_module = self
             .server_asset_context
             .process(
                 Vc::upcast(proxy_source),

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -194,7 +194,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.2",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.3",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.4",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1083,8 +1083,8 @@ importers:
         specifier: 0.26.2
         version: 0.26.2
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.3
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.3(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.4
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.4(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25688,9 +25688,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.3(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.3}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.3'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.4(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.4}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240110.4'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?
Makes sure `import * as mod from 'client-mod'` works properly by actually adding the exports to the emitted module.

Depends on: https://github.com/vercel/turbo/pull/6787

### Turbopack Updates

* https://github.com/vercel/turbo/pull/6965 <!-- Tobias Koppers - recycle trace buffers  -->
* https://github.com/vercel/turbo/pull/6974 <!-- Chris Olszewski - feat(lockfiles): support Yarn 4 patches  -->
* https://github.com/vercel/turbo/pull/6787 <!-- Leah - feat(turbopack-ecmascript): support named client references  -->


Closes PACK-2110

