### PR TITLE
fix(playwright): another teardown path

### DIFF
--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -192,6 +192,12 @@ export class Playwright extends BrowserInterface {
     await page.goto(url)
   }
 
+  async close(): Promise<void> {
+    await teardown(this.teardownTracing.bind(this))
+    await Promise.all(pendingTeardown.map((fn) => fn()))
+    await super.close()
+  }
+
   async loadPage(
     url: string,
     opts?: {


### PR DESCRIPTION
### What?

Other than global `quit`, there is another teardown interface which should handle tracing.

Closes PACK-2151