### PR TITLE
Invoke preinitScripts during SSR render

### DIFF
--- a/packages/next/src/server/app-render/required-scripts.tsx
+++ b/packages/next/src/server/app-render/required-scripts.tsx
@@ -10,10 +10,10 @@ export function getRequiredScripts(
   qs: string,
   nonce: string | undefined
 ): [
-  () => void,
+  () => null,
   { src: string; integrity?: string; crossOrigin?: string | undefined }
 ] {
-  let preinitScripts: () => void
+  let PreinitScripts: () => null
   let preinitScriptCommands: string[] = []
   const bootstrapScript: {
     src: string
@@ -39,7 +39,7 @@ export function getRequiredScripts(
       const integrity = SRIManifest[files[i]]
       preinitScriptCommands.push(src, integrity)
     }
-    preinitScripts = () => {
+    PreinitScripts = () => {
       // preinitScriptCommands is a double indexed array of src/integrity pairs
       for (let i = 0; i < preinitScriptCommands.length; i += 2) {
         ReactDOM.preinit(preinitScriptCommands[i], {
@@ -49,6 +49,7 @@ export function getRequiredScripts(
           nonce,
         })
       }
+      return null
     }
   } else {
     bootstrapScript.src = `${assetPrefix}/_next/` + files[0] + qs
@@ -57,7 +58,7 @@ export function getRequiredScripts(
       const src = `${assetPrefix}/_next/` + files[i] + qs
       preinitScriptCommands.push(src)
     }
-    preinitScripts = () => {
+    PreinitScripts = () => {
       // preinitScriptCommands is a singled indexed array of src values
       for (let i = 0; i < preinitScriptCommands.length; i++) {
         ReactDOM.preinit(preinitScriptCommands[i], {
@@ -66,8 +67,9 @@ export function getRequiredScripts(
           crossOrigin,
         })
       }
+      return null
     }
   }
 
-  return [preinitScripts, bootstrapScript]
+  return [PreinitScripts, bootstrapScript]
 }


### PR DESCRIPTION
preinitScripts is currently called during the RSC render pass. This works because the function is bound to the SSR react instances but it's confusing and unecesssary. I will be doing further refactors to the SSR codepaths for app rendering and this clears the way for some more dramatic movements and simplifies the implementation

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:


Closes NEXT-1871