### PR TITLE
Refactor AppRouter

### DIFF
--- a/packages/next/src/server/app-render/create-server-components-renderer.tsx
+++ b/packages/next/src/server/app-render/create-server-components-renderer.tsx
@@ -1,10 +1,6 @@
 import type { RenderOpts } from './types'
-import type { FlightResponseRef } from './flight-response-ref'
 import type { AppPageModule } from '../future/route-modules/app-page/module'
 import type { createErrorHandler } from './create-error-handler'
-
-import React, { use } from 'react'
-import { useFlightResponse } from './use-flight-response'
 
 export type ServerComponentRendererOptions = {
   ComponentMod: AppPageModule
@@ -13,49 +9,4 @@ export type ServerComponentRendererOptions = {
   formState: null | any
   serverComponentsErrorHandler: ReturnType<typeof createErrorHandler>
   nonce?: string
-}
-
-/**
- * Create a component that renders the Flight stream.
- * This is only used for renderToHTML, the Flight response does not need additional wrappers.
- */
-export function createServerComponentRenderer<Props>(
-  ComponentToRender: (props: Props) => any,
-  {
-    ComponentMod,
-    inlinedDataTransformStream,
-    clientReferenceManifest,
-    formState,
-    nonce,
-    serverComponentsErrorHandler,
-  }: ServerComponentRendererOptions
-): (props: Props) => JSX.Element {
-  let flightStream: ReadableStream<Uint8Array>
-  const createFlightStream = (props: Props) => {
-    if (!flightStream) {
-      flightStream = ComponentMod.renderToReadableStream(
-        <ComponentToRender {...(props as any)} />,
-        clientReferenceManifest.clientModules,
-        {
-          onError: serverComponentsErrorHandler,
-        }
-      )
-    }
-    return flightStream
-  }
-
-  const flightResponseRef: FlightResponseRef = { current: null }
-
-  const writable = inlinedDataTransformStream.writable
-  return function ServerComponentWrapper(props: Props): JSX.Element {
-    const response = useFlightResponse(
-      writable,
-      createFlightStream(props),
-      clientReferenceManifest,
-      flightResponseRef,
-      formState,
-      nonce
-    )
-    return use(response)
-  }
 }

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -6,7 +6,6 @@ export {
   // eslint-disable-next-line import/no-extraneous-dependencies
 } from 'react-server-dom-webpack/server.edge'
 
-import AppRouter from '../../client/components/app-router'
 import LayoutRouter from '../../client/components/layout-router'
 import RenderFromTemplateContext from '../../client/components/render-from-template-context'
 import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
@@ -36,7 +35,6 @@ function patchFetch() {
 }
 
 export {
-  AppRouter,
   LayoutRouter,
   RenderFromTemplateContext,
   staticGenerationAsyncStorage,

--- a/packages/next/src/server/app-render/flight-response-ref.tsx
+++ b/packages/next/src/server/app-render/flight-response-ref.tsx
@@ -1,3 +1,0 @@
-export interface FlightResponseRef {
-  current: Promise<JSX.Element> | null
-}

--- a/packages/next/src/server/app-render/required-scripts.tsx
+++ b/packages/next/src/server/app-render/required-scripts.tsx
@@ -10,10 +10,10 @@ export function getRequiredScripts(
   qs: string,
   nonce: string | undefined
 ): [
-  () => void,
+  () => null,
   { src: string; integrity?: string; crossOrigin?: string | undefined }
 ] {
-  let preinitScripts: () => void
+  let PreinitScripts: () => null
   let preinitScriptCommands: string[] = []
   const bootstrapScript: {
     src: string
@@ -39,7 +39,7 @@ export function getRequiredScripts(
       const integrity = SRIManifest[files[i]]
       preinitScriptCommands.push(src, integrity)
     }
-    preinitScripts = () => {
+    PreinitScripts = () => {
       // preinitScriptCommands is a double indexed array of src/integrity pairs
       for (let i = 0; i < preinitScriptCommands.length; i += 2) {
         ReactDOM.preinit(preinitScriptCommands[i], {
@@ -49,6 +49,7 @@ export function getRequiredScripts(
           nonce,
         })
       }
+      return null
     }
   } else {
     bootstrapScript.src = `${assetPrefix}/_next/` + files[0] + qs
@@ -57,7 +58,7 @@ export function getRequiredScripts(
       const src = `${assetPrefix}/_next/` + files[i] + qs
       preinitScriptCommands.push(src)
     }
-    preinitScripts = () => {
+    PreinitScripts = () => {
       // preinitScriptCommands is a singled indexed array of src values
       for (let i = 0; i < preinitScriptCommands.length; i++) {
         ReactDOM.preinit(preinitScriptCommands[i], {
@@ -66,8 +67,9 @@ export function getRequiredScripts(
           crossOrigin,
         })
       }
+      return null
     }
   }
 
-  return [preinitScripts, bootstrapScript]
+  return [PreinitScripts, bootstrapScript]
 }

--- a/packages/next/src/server/app-render/required-scripts.tsx
+++ b/packages/next/src/server/app-render/required-scripts.tsx
@@ -10,10 +10,10 @@ export function getRequiredScripts(
   qs: string,
   nonce: string | undefined
 ): [
-  () => null,
+  () => void,
   { src: string; integrity?: string; crossOrigin?: string | undefined }
 ] {
-  let PreinitScripts: () => null
+  let preinitScripts: () => void
   let preinitScriptCommands: string[] = []
   const bootstrapScript: {
     src: string
@@ -39,7 +39,7 @@ export function getRequiredScripts(
       const integrity = SRIManifest[files[i]]
       preinitScriptCommands.push(src, integrity)
     }
-    PreinitScripts = () => {
+    preinitScripts = () => {
       // preinitScriptCommands is a double indexed array of src/integrity pairs
       for (let i = 0; i < preinitScriptCommands.length; i += 2) {
         ReactDOM.preinit(preinitScriptCommands[i], {
@@ -49,7 +49,6 @@ export function getRequiredScripts(
           nonce,
         })
       }
-      return null
     }
   } else {
     bootstrapScript.src = `${assetPrefix}/_next/` + files[0] + qs
@@ -58,7 +57,7 @@ export function getRequiredScripts(
       const src = `${assetPrefix}/_next/` + files[i] + qs
       preinitScriptCommands.push(src)
     }
-    PreinitScripts = () => {
+    preinitScripts = () => {
       // preinitScriptCommands is a singled indexed array of src values
       for (let i = 0; i < preinitScriptCommands.length; i++) {
         ReactDOM.preinit(preinitScriptCommands[i], {
@@ -67,9 +66,8 @@ export function getRequiredScripts(
           crossOrigin,
         })
       }
-      return null
     }
   }
 
-  return [PreinitScripts, bootstrapScript]
+  return [preinitScripts, bootstrapScript]
 }

--- a/packages/next/webpack.config.js
+++ b/packages/next/webpack.config.js
@@ -46,6 +46,8 @@ function makeAppAliases(reactChannel = '') {
     // optimisations to ignore the legacy build of react-dom/server
     './cjs/react-dom-server-legacy.browser.production.min.js': `next/dist/build/noop-react-dom-server-legacy`,
     './cjs/react-dom-server-legacy.browser.development.js': `next/dist/build/noop-react-dom-server-legacy`,
+    // test
+    '@vercel/turbopack-ecmascript-runtime/dev/client/hmr-client.ts': `next/dist/client/dev/noop-turbopack-hmr`,
   }
 }
 


### PR DESCRIPTION
The current composition of RSC and client layers is a little awkward. In particular the AppRouter component is a client component but it is rendered by RSC which makes the intial data load format for RSC different than what you would get on a navigation. This change moves around some implementations to lift AppRouter out of the RSC tree and make it render as part of the Client entrypoint directly.

Closes NEXT-1872