### PR TITLE
Add test for importing client components from server actions

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1081,5 +1081,38 @@ createNextDescribe(
         }
       )
     })
+
+    describe('server actions render client components', () => {
+      describe('server component imported action', () => {
+        it('should support importing client components from actions', async () => {
+          const browser = await next.browser(
+            '/server/action-return-client-component'
+          )
+          expect(
+            await browser
+              .elementByCss('#trigger-component-load')
+              .click()
+              .waitForElementByCss('#client-component')
+              .text()
+          ).toBe('Hello World')
+        })
+      })
+
+      // Server Component -> Client Component -> Server Action (imported from client component) -> Import Client Component is not not supported yet.
+      describe.skip('client component imported action', () => {
+        it('should support importing client components from actions', async () => {
+          const browser = await next.browser(
+            '/client/action-return-client-component'
+          )
+          expect(
+            await browser
+              .elementByCss('#trigger-component-load')
+              .click()
+              .waitForElementByCss('#client-component')
+              .text()
+          ).toBe('Hello World')
+        })
+      })
+    })
   }
 )

--- a/test/e2e/app-dir/actions/app/client/action-return-client-component/actions.js
+++ b/test/e2e/app-dir/actions/app/client/action-return-client-component/actions.js
@@ -1,0 +1,8 @@
+'use server'
+import { Hello } from './client-component'
+
+export async function getComponent() {
+  return {
+    component: <Hello />,
+  }
+}

--- a/test/e2e/app-dir/actions/app/client/action-return-client-component/client-component.js
+++ b/test/e2e/app-dir/actions/app/client/action-return-client-component/client-component.js
@@ -1,0 +1,5 @@
+'use client'
+
+export function Hello() {
+  return <p id="client-component">Hello World</p>
+}

--- a/test/e2e/app-dir/actions/app/client/action-return-client-component/form.js
+++ b/test/e2e/app-dir/actions/app/client/action-return-client-component/form.js
@@ -1,0 +1,16 @@
+'use client'
+import { useFormState } from 'react-dom'
+
+export function Form({ action }) {
+  const [state, formAction] = useFormState(action, null)
+  return (
+    <>
+      <form action={formAction}>
+        <button id="trigger-component-load" type="submit">
+          Trigger Component Load
+        </button>
+      </form>
+      {state?.component}
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions/app/client/action-return-client-component/page.js
+++ b/test/e2e/app-dir/actions/app/client/action-return-client-component/page.js
@@ -1,0 +1,12 @@
+'use client'
+import { getComponent } from './actions'
+import { Form } from './form'
+
+export default function Page() {
+  return (
+    <>
+      <h1>Server Component loading client component through action</h1>
+      <Form action={getComponent} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions/app/server/action-return-client-component/actions.js
+++ b/test/e2e/app-dir/actions/app/server/action-return-client-component/actions.js
@@ -1,0 +1,8 @@
+'use server'
+import { Hello } from './client-component'
+
+export async function getComponent() {
+  return {
+    component: <Hello />,
+  }
+}

--- a/test/e2e/app-dir/actions/app/server/action-return-client-component/client-component.js
+++ b/test/e2e/app-dir/actions/app/server/action-return-client-component/client-component.js
@@ -1,0 +1,5 @@
+'use client'
+
+export function Hello() {
+  return <p id="client-component">Hello World</p>
+}

--- a/test/e2e/app-dir/actions/app/server/action-return-client-component/form.js
+++ b/test/e2e/app-dir/actions/app/server/action-return-client-component/form.js
@@ -1,0 +1,16 @@
+'use client'
+import { useFormState } from 'react-dom'
+
+export function Form({ action }) {
+  const [state, formAction] = useFormState(action, null)
+  return (
+    <>
+      <form action={formAction}>
+        <button id="trigger-component-load" type="submit">
+          Trigger Component Load
+        </button>
+      </form>
+      {state?.component}
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions/app/server/action-return-client-component/page.js
+++ b/test/e2e/app-dir/actions/app/server/action-return-client-component/page.js
@@ -1,0 +1,11 @@
+import { getComponent } from './actions'
+import { Form } from './form'
+
+export default function Page() {
+  return (
+    <>
+      <h1>Server Component loading client component through action</h1>
+      <Form action={getComponent} />
+    </>
+  )
+}


### PR DESCRIPTION
## What?

Adds two tests for server actions returning client components:

- (supported) Importing a server action from a server component. That server action imports a client component and returns it.
- (not supported yet) Importing a server action from a client component. The server action imports a client component and returns it.

The second case is not supported yet as it would effectively mean a compilation loop:

`server` -> `client` -> `server` -> `client`

and if that last client component includes another server action it goes even further:

`server` -> `client` -> `server` -> `client` -> `server` (and if that server action includes anothe client component it goes further and further)


Whereas currently it's only `server` -> `client` -> `server`, so it's limited to that.

In the future we should be able to support this server->client->server->client loop in Turbopack specifically because Turbopack has a single module graph. 

Importing the client component in a server action that is defined in the server compiler (i.e. when created inline or when imported from a server component) it does work correctly already.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-1873