### PR TITLE
Fix useOptimistic in server components bug. Add tests for invalid React server APIs

### DIFF
--- a/packages/next-swc/crates/core/src/react_server_components.rs
+++ b/packages/next-swc/crates/core/src/react_server_components.rs
@@ -627,7 +627,7 @@ pub fn server_components<C: Comments>(
             JsWord::from("useState"),
             JsWord::from("useSyncExternalStore"),
             JsWord::from("useTransition"),
-            JsWord::from("experimental_useOptimistic"),
+            JsWord::from("useOptimistic"),
         ],
     })
 }

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/component/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/component/page.js
@@ -1,0 +1,7 @@
+import { Component } from 'react'
+
+console.log({ Component })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/createcontext/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/createcontext/page.js
@@ -1,0 +1,7 @@
+import { createContext } from 'react'
+
+console.log({ createContext })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/createfactory/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/createfactory/page.js
@@ -1,0 +1,7 @@
+import { createFactory } from 'react'
+
+console.log({ createFactory })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/purecomponent/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/purecomponent/page.js
@@ -1,0 +1,7 @@
+import { PureComponent } from 'react'
+
+console.log({ PureComponent })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/usedeferredvalue/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/usedeferredvalue/page.js
@@ -1,0 +1,7 @@
+import { useDeferredValue } from 'react'
+
+console.log({ useDeferredValue })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useeffect/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useeffect/page.js
@@ -1,0 +1,7 @@
+import { useEffect } from 'react'
+
+console.log({ useEffect })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useimperativehandle/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useimperativehandle/page.js
@@ -1,0 +1,7 @@
+import { useImperativeHandle } from 'react'
+
+console.log({ useImperativeHandle })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useinsertioneffect/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useinsertioneffect/page.js
@@ -1,0 +1,7 @@
+import { useInsertionEffect } from 'react'
+
+console.log({ useInsertionEffect })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/uselayouteffect/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/uselayouteffect/page.js
@@ -1,0 +1,7 @@
+import { useLayoutEffect } from 'react'
+
+console.log({ useLayoutEffect })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useoptimistic/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useoptimistic/page.js
@@ -1,0 +1,7 @@
+import { useOptimistic } from 'react'
+
+console.log({ useOptimistic })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/usereducer/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/usereducer/page.js
@@ -1,0 +1,7 @@
+import { useReducer } from 'react'
+
+console.log({ useReducer })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useref/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useref/page.js
@@ -1,0 +1,7 @@
+import { useRef } from 'react'
+
+console.log({ useRef })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/usestate/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/usestate/page.js
@@ -1,0 +1,7 @@
+import { useState } from 'react'
+
+console.log({ useState })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/usesyncexternalstore/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/usesyncexternalstore/page.js
@@ -1,0 +1,7 @@
+import { useSyncExternalStore } from 'react'
+
+console.log({ useSyncExternalStore })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/usetransition/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/usetransition/page.js
@@ -1,0 +1,7 @@
+import { useTransition } from 'react'
+
+console.log({ useTransition })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -226,6 +226,43 @@ describe('Error overlay - RSC build errors', () => {
     await cleanup()
   })
 
+  const invalidReactServerApis = [
+    'Component',
+    'createContext',
+    'createFactory',
+    'PureComponent',
+    'useDeferredValue',
+    'useEffect',
+    'useImperativeHandle',
+    'useInsertionEffect',
+    'useLayoutEffect',
+    'useReducer',
+    'useRef',
+    'useState',
+    'useSyncExternalStore',
+    'useTransition',
+    'useOptimistic',
+  ]
+  for (const api of invalidReactServerApis) {
+    it(`should error when ${api} from react is used in server component`, async () => {
+      const { session, cleanup } = await sandbox(
+        next,
+        undefined,
+        `/server-with-errors/react-apis/${api.toLowerCase()}`
+      )
+
+      expect(await session.hasRedbox(true)).toBe(true)
+      expect(await session.getRedboxSource()).toInclude(
+        // `Component` has a custom error message
+        api === 'Component'
+          ? `You’re importing a class component. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.`
+          : `You're importing a component that needs ${api}. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.`
+      )
+
+      await cleanup()
+    })
+  }
+
   it('should allow to use and handle rsc poisoning server-only', async () => {
     const { session, cleanup } = await sandbox(
       next,

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1122,7 +1122,22 @@
       "Error overlay - RSC build errors should throw an error when error file is a server component with empty error file",
       "Error overlay - RSC build errors should throw an error when getServerSideProps is used",
       "Error overlay - RSC build errors should throw an error when metadata export is used in client components",
-      "Error overlay - RSC build errors should throw an error when metadata exports are used together in server components"
+      "Error overlay - RSC build errors should throw an error when metadata exports are used together in server components",
+      "Error overlay - RSC build errors should error when Component from react is used in server component",
+      "Error overlay - RSC build errors should error when createContext from react is used in server component",
+      "Error overlay - RSC build errors should error when createFactory from react is used in server component",
+      "Error overlay - RSC build errors should error when PureComponent from react is used in server component",
+      "Error overlay - RSC build errors should error when useDeferredValue from react is used in server component",
+      "Error overlay - RSC build errors should error when useEffect from react is used in server component",
+      "Error overlay - RSC build errors should error when useImperativeHandle from react is used in server component",
+      "Error overlay - RSC build errors should error when useInsertionEffect from react is used in server component",
+      "Error overlay - RSC build errors should error when useLayoutEffect from react is used in server component",
+      "Error overlay - RSC build errors should error when useReducer from react is used in server component",
+      "Error overlay - RSC build errors should error when useRef from react is used in server component",
+      "Error overlay - RSC build errors should error when useState from react is used in server component",
+      "Error overlay - RSC build errors should error when useSyncExternalStore from react is used in server component",
+      "Error overlay - RSC build errors should error when useTransition from react is used in server component",
+      "Error overlay - RSC build errors should error when useOptimistic from react is used in server component"
     ],
     "pending": [
       "Error overlay - RSC build errors should throw an error when getStaticProps is used"


### PR DESCRIPTION
## What?

Fixes a bug where `useOptimistic` wouldn't trigger a compiler error when imported in Server Components.

Adds tests for the following `import { x } from 'react'` in Server Components, where `x` is the value: 

- Component
- createContext
- createFactory
- PureComponent
- useDeferredValue
- useEffect
- useImperativeHandle
- useInsertionEffect
- useLayoutEffect
- useReducer
- useRef
- useState
- useSyncExternalStore
- useTransition
- useOptimistic

These show a particular error explaining how to add `"use client"`:

![CleanShot 2023-12-14 at 14 49 37@2x](https://github.com/vercel/next.js/assets/6324199/e47eab71-b2a2-4c14-bec0-0d5cdd720e80)





<!-- Thanks for opening a PR! Your contribution is much appreciated.i:
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
