### PR TITLE
chore(docs): Remove `typesafe-i18n` from thrid-party i18n options

### DIFF
--- a/docs/03-pages/01-building-your-application/01-routing/08-internationalization.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/08-internationalization.mdx
@@ -13,7 +13,7 @@ description: Next.js has built-in support for internationalized routing and lang
 
 Next.js has built-in support for internationalized ([i18n](https://en.wikipedia.org/wiki/Internationalization_and_localization#Naming)) routing since `v10.0.0`. You can provide a list of locales, the default locale, and domain-specific locales and Next.js will automatically handle the routing.
 
-The i18n routing support is currently meant to complement existing i18n library solutions like [`react-intl`](https://formatjs.io/docs/getting-started/installation), [`react-i18next`](https://react.i18next.com/), [`lingui`](https://lingui.dev/), [`rosetta`](https://github.com/lukeed/rosetta), [`next-intl`](https://github.com/amannn/next-intl), [`next-translate`](https://github.com/aralroca/next-translate), [`next-multilingual`](https://github.com/Avansai/next-multilingual), [`typesafe-i18n`](https://github.com/ivanhofer/typesafe-i18n), [`tolgee`](https://tolgee.io/integrations/next), and others by streamlining the routes and locale parsing.
+The i18n routing support is currently meant to complement existing i18n library solutions like [`react-intl`](https://formatjs.io/docs/getting-started/installation), [`react-i18next`](https://react.i18next.com/), [`lingui`](https://lingui.dev/), [`rosetta`](https://github.com/lukeed/rosetta), [`next-intl`](https://github.com/amannn/next-intl), [`next-translate`](https://github.com/aralroca/next-translate), [`next-multilingual`](https://github.com/Avansai/next-multilingual), [`tolgee`](https://tolgee.io/integrations/next), and others by streamlining the routes and locale parsing.
 
 ## Getting started
 


### PR DESCRIPTION
This PR removes [typesafe-i18n](https://github.com/ivanhofer/typesafe-i18n) from the suggested community i18n solutions. 
The Maintainer of typesafe-i18n, Ivan Hofer, tragically passed away a few months ago. The library is no longer maintained. 