### PR TITLE
Refactor: Separate RSC renderer from SSR wrapping component

### DIFF
--- a/packages/next/src/server/app-render/create-server-components-renderer.tsx
+++ b/packages/next/src/server/app-render/create-server-components-renderer.tsx
@@ -3,54 +3,61 @@ import type { FlightResponseRef } from './flight-response-ref'
 import type { AppPageModule } from '../future/route-modules/app-page/module'
 import type { createErrorHandler } from './create-error-handler'
 
-import React, { use } from 'react'
+import { use } from 'react'
 import { useFlightResponse } from './use-flight-response'
-
-export type ServerComponentRendererOptions = {
-  ComponentMod: AppPageModule
-  inlinedDataTransformStream: TransformStream<Uint8Array, Uint8Array>
-  clientReferenceManifest: NonNullable<RenderOpts['clientReferenceManifest']>
-  formState: null | any
-  serverComponentsErrorHandler: ReturnType<typeof createErrorHandler>
-  nonce?: string
-}
 
 /**
  * Create a component that renders the Flight stream.
  * This is only used for renderToHTML, the Flight response does not need additional wrappers.
  */
-export function createServerComponentRenderer<Props>(
-  ComponentToRender: (props: Props) => any,
+export function createReactServerRenderer(
+  children: React.ReactNode,
+  ComponentMod: AppPageModule,
+  clientReferenceManifest: NonNullable<RenderOpts['clientReferenceManifest']>,
+  onError: ReturnType<typeof createErrorHandler>,
+  onPostpone: (reason: unknown) => void
+): () => ReadableStream<Uint8Array> {
+  let flightStream: ReadableStream<Uint8Array>
+  return function renderToReactServerStream() {
+    if (flightStream) {
+      return flightStream
+    } else {
+      flightStream = ComponentMod.renderToReadableStream(
+        children,
+        clientReferenceManifest.clientModules,
+        {
+          onError,
+          onPostpone,
+        }
+      )
+      return flightStream
+    }
+  }
+}
+
+export type ServerComponentEntrypointOptions = {
+  inlinedDataTransformStream: TransformStream<Uint8Array, Uint8Array>
+  clientReferenceManifest: NonNullable<RenderOpts['clientReferenceManifest']>
+  formState: null | any
+  nonce?: string
+}
+export function createReactServerEntrypoint<Props>(
+  reactServerRenderer: () => ReadableStream<Uint8Array>,
   {
-    ComponentMod,
     inlinedDataTransformStream,
     clientReferenceManifest,
     formState,
     nonce,
-    serverComponentsErrorHandler,
-  }: ServerComponentRendererOptions
+  }: ServerComponentEntrypointOptions
 ): (props: Props) => JSX.Element {
-  let flightStream: ReadableStream<Uint8Array>
-  const createFlightStream = (props: Props) => {
-    if (!flightStream) {
-      flightStream = ComponentMod.renderToReadableStream(
-        <ComponentToRender {...(props as any)} />,
-        clientReferenceManifest.clientModules,
-        {
-          onError: serverComponentsErrorHandler,
-        }
-      )
-    }
-    return flightStream
-  }
-
   const flightResponseRef: FlightResponseRef = { current: null }
 
   const writable = inlinedDataTransformStream.writable
-  return function ServerComponentWrapper(props: Props): JSX.Element {
+  return function ServerComponentWrapper(): JSX.Element {
+    const reactServerStream = reactServerRenderer()
     const response = useFlightResponse(
       writable,
-      createFlightStream(props),
+      reactServerStream,
       clientReferenceManifest,
       flightResponseRef,
       formState,

--- a/packages/next/src/server/app-render/create-server-components-renderer.tsx
+++ b/packages/next/src/server/app-render/create-server-components-renderer.tsx
@@ -1,10 +1,6 @@
 import type { RenderOpts } from './types'
-import type { FlightResponseRef } from './flight-response-ref'
 import type { AppPageModule } from '../future/route-modules/app-page/module'
 import type { createErrorHandler } from './create-error-handler'
-
-import { use } from 'react'
-import { useFlightResponse } from './use-flight-response'
 
 /**
  * Create a component that renders the Flight stream.
@@ -32,37 +28,5 @@ export function createReactServerRenderer(
       )
       return flightStream
     }
-  }
-}
-
-export type ServerComponentEntrypointOptions = {
-  inlinedDataTransformStream: TransformStream<Uint8Array, Uint8Array>
-  clientReferenceManifest: NonNullable<RenderOpts['clientReferenceManifest']>
-  formState: null | any
-  nonce?: string
-}
-export function createReactServerEntrypoint<Props>(
-  reactServerRenderer: () => ReadableStream<Uint8Array>,
-  {
-    inlinedDataTransformStream,
-    clientReferenceManifest,
-    formState,
-    nonce,
-  }: ServerComponentEntrypointOptions
-): (props: Props) => JSX.Element {
-  const flightResponseRef: FlightResponseRef = { current: null }
-
-  const writable = inlinedDataTransformStream.writable
-  return function ServerComponentWrapper(): JSX.Element {
-    const reactServerStream = reactServerRenderer()
-    const response = useFlightResponse(
-      writable,
-      reactServerStream,
-      clientReferenceManifest,
-      flightResponseRef,
-      formState,
-      nonce
-    )
-    return use(response)
   }
 }

--- a/packages/next/src/server/app-render/flight-response-ref.tsx
+++ b/packages/next/src/server/app-render/flight-response-ref.tsx
@@ -1,3 +1,0 @@
-export interface FlightResponseRef {
-  current: Promise<JSX.Element> | null
-}

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -82,19 +82,23 @@ export function useFlightResponse(
   })
   flightResponseRef.current = res
 
-  forwardStream
+  pipeFlightDataToInlinedStream(forwardStream, writable, nonce, formState)
+
+  return res
+}
+
+export function pipeFlightDataToInlinedStream(
+  flightStream: ReadableStream<Uint8Array>,
+  writable: WritableStream<Uint8Array>,
+  nonce: string | undefined,
+  formState: unknown | null
+): void {
+  flightStream
     .pipeThrough(createDecodeTransformStream())
     .pipeThrough(createFlightTransformer(nonce, formState))
     .pipeThrough(createEncodeTransformStream())
     .pipeTo(writable)
-    .finally(() => {
-      // Once the last encoding stream has flushed, then unset the flight
-      // response ref.
-      flightResponseRef.current = null
-    })
     .catch((err) => {
       console.error('Unexpected error while rendering Flight stream', err)
     })
-
-  return res
 }

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -1,5 +1,4 @@
 import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
-import type { FlightResponseRef } from './flight-response-ref'
 
 import { htmlEscapeJsonString } from '../htmlescape'
 import {
@@ -42,6 +41,11 @@ function createFlightTransformer(
   })
 }
 
+const flightResponses = new WeakMap<
+  ReadableStream<Uint8Array>,
+  Promise<JSX.Element>
+>()
+
 /**
  * Render Flight stream.
  * This is only used for renderToHTML, the Flight response does not need additional wrappers.
@@ -50,13 +54,15 @@ export function useFlightResponse(
   writable: WritableStream<Uint8Array>,
   flightStream: ReadableStream<Uint8Array>,
   clientReferenceManifest: ClientReferenceManifest,
-  flightResponseRef: FlightResponseRef,
   formState: null | any,
   nonce?: string
 ): Promise<JSX.Element> {
-  if (flightResponseRef.current !== null) {
-    return flightResponseRef.current
+  const response = flightResponses.get(flightStream)
+
+  if (response) {
+    return response
   }
+
   // react-server-dom-webpack/client.edge must not be hoisted for require cache clearing to work correctly
   let createFromReadableStream
   // @TODO: investigate why the aliasing for turbopack doesn't pick this up, requiring this runtime check
@@ -80,14 +86,14 @@ export function useFlightResponse(
     },
     nonce,
   })
-  flightResponseRef.current = res
+  flightResponses.set(flightStream, res)
 
   pipeFlightDataToInlinedStream(forwardStream, writable, nonce, formState)
 
   return res
 }
 
-export function pipeFlightDataToInlinedStream(
+function pipeFlightDataToInlinedStream(
   flightStream: ReadableStream<Uint8Array>,
   writable: WritableStream<Uint8Array>,
   nonce: string | undefined,


### PR DESCRIPTION
This commit updates some of the code organization in app-render in preparation for supporting dynamic RSC repsonses on top of static SSR responses for PPR. The main change to notice is the separation of creating the server component renderer which initiates the RSC render and executes in the RSC layer with the consuming component which lives in the SSR layer. By organizing the code this way we can later only call the server render in certain cases, omitting the SSR render entirely.

This is different than just using the generaetFlight pathway because that pathway serves client navs and does not actually render the same output that the intial render does.

Closes NEXT-1889