### PR TITLE
docs: fix broken backtick for link

### DIFF
--- a/docs/03-pages/02-api-reference/03-next-config-js/runtime-configuration.mdx
+++ b/docs/03-pages/02-api-reference/03-next-config-js/runtime-configuration.mdx
@@ -6,7 +6,7 @@ description: Add client and server runtime configuration to your Next.js app.
 > **Warning:**
 >
 > - **This feature is deprecated.** We recommend using [environment variables](/docs/pages/building-your-application/configuring/environment-variables) instead, which also can support reading runtime values.
-> - You can run code on server startup using the `[register` function](/docs/app/building-your-application/optimizing/instrumentation).
+> - You can run code on server startup using the [`register` function](/docs/app/building-your-application/optimizing/instrumentation).
 > - This feature does not work with [Automatic Static Optimization](/docs/pages/building-your-application/rendering/automatic-static-optimization), [Output File Tracing](/docs/pages/api-reference/next-config-js/output#automatically-copying-traced-files), or [React Server Components](/docs/app/building-your-application/rendering/server-components).
 
 To add runtime configuration to your app, open `next.config.js` and add the `publicRuntimeConfig` and `serverRuntimeConfig` configs:


### PR DESCRIPTION
<img width="764" alt="CleanShot 2023-12-17 at 11 25 10@2x" src="https://github.com/vercel/next.js/assets/9113740/437a8a0d-0f56-4199-9629-b767569349de">
