### PR TITLE
fix: Allow start turbopack dev server for a project using middleware

### DIFF
--- a/packages/next-swc/crates/next-core/src/util.rs
+++ b/packages/next-swc/crates/next-core/src/util.rs
@@ -239,7 +239,7 @@ pub async fn parse_config_from_source(module: Vc<Box<dyn Module>>) -> Result<Vc<
                             .unwrap_or_default()
                         {
                             if let Some(init) = decl.init.as_ref() {
-                                return GLOBALS.set(&globals, || {
+                                return GLOBALS.set(globals, || {
                                     let value = eval_context.eval(init);
                                     Ok(parse_config_from_js_value(module, &value).cell())
                                 });

--- a/packages/next-swc/crates/next-core/src/util.rs
+++ b/packages/next-swc/crates/next-core/src/util.rs
@@ -241,7 +241,7 @@ pub async fn parse_config_from_source(module: Vc<Box<dyn Module>>) -> Result<Vc<
                             if let Some(init) = decl.init.as_ref() {
                                 return GLOBALS.set(&globals, || {
                                     let value = eval_context.eval(init);
-                                    return Ok(parse_config_from_js_value(module, &value).cell());
+                                    Ok(parse_config_from_js_value(module, &value).cell())
                                 });
                             } else {
                                 NextSourceConfigParsingIssue {


### PR DESCRIPTION
### What?

Configures `scoped_tls` (in `swc_common`) correctly.

### Why?

One of the company website fails to **start**.

https://vercel.slack.com/archives/C03EWR7LGEN/p1702970892605989

### How?



Closes PACK-2165