### PR TITLE
chore: extends from shared base tsconfig

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,23 +1,6 @@
-// Make development mode typescript module resolving and jsx parsing correct for all tests
+// Make development mode typescript module resolving and jsx parsing correct for all tests.
+// We want to apply the compiler options to the testing app, but we don't want to do strict type checking for them.
+// e.g. testing app could have import a from '3rd-lib-nextjs-ws-doesnt-have'
 {
-  "compilerOptions": {
-    "strict": false,
-    "noEmit": true,
-    "allowJs": true,
-    "resolveJsonModule": true,
-    "jsx": "react-jsx",
-    "module": "esnext",
-    "target": "ESNext",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "baseUrl": ".",
-    "types": ["react", "jest", "node", "trusted-types", "jest-extended"],
-    "paths": {
-      "development-sandbox": ["./lib/development-sandbox"],
-      "next-test-utils": ["./lib/next-test-utils"],
-      "amp-test-utils": ["./lib/amp-test-utils"],
-      "next-webdriver": ["./lib/next-webdriver"],
-      "e2e-utils": ["./lib/e2e-utils"]
-    }
-  }
+  "extends": "../tsconfig.base.json"
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "strict": false,
+    "noEmit": true,
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "target": "ESNext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "types": ["react", "jest", "node", "trusted-types", "jest-extended"],
+    "paths": {
+      "development-sandbox": ["test/lib/development-sandbox"],
+      "next-test-utils": ["test/lib/next-test-utils"],
+      "amp-test-utils": ["test/lib/amp-test-utils"],
+      "next-webdriver": ["test/lib/next-webdriver"],
+      "e2e-utils": ["test/lib/e2e-utils"]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,5 @@
 {
-  "compilerOptions": {
-    "strict": false,
-    "noEmit": true,
-    "allowJs": true,
-    "resolveJsonModule": true,
-    "jsx": "react-jsx",
-    "module": "esnext",
-    "target": "ESNext",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "baseUrl": ".",
-    "types": ["react", "jest", "node", "trusted-types", "jest-extended"],
-    "paths": {
-      "development-sandbox": ["test/lib/development-sandbox"],
-      "next-test-utils": ["test/lib/next-test-utils"],
-      "amp-test-utils": ["test/lib/amp-test-utils"],
-      "next-webdriver": ["test/lib/next-webdriver"],
-      "e2e-utils": ["test/lib/e2e-utils"]
-    }
-  },
+  "extends": "./tsconfig.base.json",
   "include": ["test/**/*.test.ts", "test/**/*.test.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Previously the `baseUrl` is not aligned in root and test tsconfig, which is causing the direct import from  `test/*` not resolved properly 

e.g. https://github.com/vercel/next.js/blob/25e0988e7c9033cb1503cbe0c62ba5de2e97849c/test/production/typescript-basic/index.test.ts#L4

Using `extends` to align the config and fix them


Closes NEXT-1902