### PR TITLE
Page Info Cleanup v2

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -15,10 +15,10 @@ import {
 import path from 'path'
 import fs from 'fs/promises'
 import {
-  deserializePageInfos,
   type PageInfos,
   type SerializedPageInfos,
-} from './utils'
+  deserializePageInfos,
+} from './page-info'
 import { loadBindings } from './swc'
 import { nonNullable } from '../lib/non-nullable'
 import * as ciEnvironment from '../telemetry/ci-info'

--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -78,7 +78,7 @@ export async function collectBuildTraces({
   staticPages: string[]
   hasSsrAmpPages: boolean
   outputFileTracingRoot: string
-  edgeRoutes: readonly string[] | undefined
+  edgeRoutes: Readonly<Record<string, boolean>> | undefined
   nextBuildSpan?: Span
   config: NextConfigComplete
   buildTraceContext?: BuildTraceContext
@@ -642,7 +642,7 @@ export async function collectBuildTraces({
         }
 
         // Edge routes have no trace files.
-        if (edgeRoutes && edgeRoutes.includes(route)) {
+        if (edgeRoutes && route in edgeRoutes) {
           return
         }
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1946,15 +1946,11 @@ export default async function build(
       if (!isGenerateMode && config.outputFileTracing && !buildTracesPromise) {
         // Get all the edge routes from the pageInfos. If the runtime is set as
         // edge, then we know it's an edge route.
-        const edgeRoutes: ReadonlyArray<string> = Array.from(
-          pageInfos.entries()
-        ).reduce<string[]>((acc, [route, { runtime }]) => {
-          if (runtime === 'edge') {
-            acc.push(route)
-          }
-
-          return acc
-        }, [])
+        const edgeRoutes: Record<string, boolean> = {}
+        pageInfos.forEach((pageInfo, route) => {
+          if (pageInfo.runtime !== 'edge') return
+          edgeRoutes[route] = true
+        })
 
         buildTracesPromise = collectBuildTraces({
           dir,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -6,6 +6,7 @@ import type { MiddlewareManifest } from './webpack/plugins/middleware-plugin'
 import type { ActionManifest } from './webpack/plugins/flight-client-entry-plugin'
 import type { ExportAppOptions, ExportAppWorker } from '../export/types'
 import type { Revalidate } from '../server/lib/revalidate'
+import { serializePageInfos, type PageInfo, type PageInfos } from './page-info'
 
 import '../lib/setup-exception-listeners'
 
@@ -114,9 +115,8 @@ import {
   copyTracedFiles,
   isReservedPage,
   isAppBuiltinNotFoundPage,
-  serializePageInfos,
 } from './utils'
-import type { PageInfo, PageInfos, AppConfig } from './utils'
+import type { AppConfig } from './utils'
 import { writeBuildId } from './write-build-id'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import isError from '../lib/is-error'
@@ -162,6 +162,7 @@ import { formatManifest } from './manifests/formatter/format-manifest'
 import { getStartServerInfo, logStartInfo } from '../server/lib/app-info-log'
 import type { NextEnabledDirectories } from '../server/base-server'
 import { hasCustomExportOutput } from '../export/utils'
+import { RouteKind } from '../server/future/route-kind'
 
 interface ExperimentalBypassForInfo {
   experimentalBypassFor?: RouteHas[]
@@ -2283,22 +2284,30 @@ export default async function build(
               appConfig.revalidate === 0 ||
               exportResult.byPath.get(page)?.revalidate === 0
 
-            if (hasDynamicData && pageInfos.get(page)?.isStatic) {
-              // if the page was marked as being static, but it contains dynamic data
-              // (ie, in the case of a static generation bailout), then it should be marked dynamic
-              pageInfos.set(page, {
-                ...(pageInfos.get(page) as PageInfo),
-                isStatic: false,
-                isSSG: false,
-              })
+            const pageInfo = pageInfos.get(page)
+            if (!pageInfo) {
+              throw new Error(
+                `Invariant: page info for ${page} is missing from registry`
+              )
             }
 
-            const isRouteHandler = isAppRouteRoute(originalAppPath)
+            if (hasDynamicData && pageInfo.isStatic) {
+              // If the page was marked as being static, but it contains dynamic
+              // data (ie, in the case of a static generation bailout), then it
+              // should be marked dynamic.
+              pageInfo.isStatic = false
+              pageInfo.isSSG = false
+            }
+
+            const isDynamic = isDynamicRoute(page)
+            const kind = isAppRouteRoute(originalAppPath)
+              ? RouteKind.APP_ROUTE
+              : RouteKind.APP_PAGE
 
             // When this is an app page and PPR is enabled, the route supports
             // partial pre-rendering.
             const experimentalPPR =
-              !isRouteHandler && config.experimental.ppr === true
+              kind === RouteKind.APP_PAGE && config.experimental.ppr === true
                 ? true
                 : undefined
 
@@ -2324,34 +2333,27 @@ export default async function build(
                 hasPostponed,
               } = exportResult.byPath.get(route) ?? {}
 
-              pageInfos.set(route, {
-                ...(pageInfos.get(route) as PageInfo),
-                hasPostponed,
-                hasEmptyPrelude,
-              })
+              // If this route postponed and/or had an empty prelude, then
+              // mark the page as having postponed and/or an empty prelude.
+              pageInfo.hasPostponed ||= hasPostponed
+              pageInfo.hasEmptyPrelude ||= hasEmptyPrelude
 
-              // update the page (eg /blog/[slug]) to also have the postpone metadata
-              pageInfos.set(page, {
-                ...(pageInfos.get(page) as PageInfo),
-                hasPostponed,
-                hasEmptyPrelude,
-              })
+              // Link the same pageInfo used for the `page` to this specific
+              // `route` as they should all share the same characteristics.
+              pageInfos.set(route, pageInfo)
 
               if (revalidate !== 0) {
-                const normalizedRoute = normalizePagePath(route)
+                let dataRoute: string | null = null
+                let prefetchDataRoute: string | undefined
 
-                let dataRoute: string | null
-                if (isRouteHandler) {
-                  dataRoute = null
-                } else {
-                  dataRoute = path.posix.join(`${normalizedRoute}${RSC_SUFFIX}`)
-                }
-
-                let prefetchDataRoute: string | null | undefined
-                if (experimentalPPR) {
-                  prefetchDataRoute = path.posix.join(
-                    `${normalizedRoute}${RSC_PREFETCH_SUFFIX}`
-                  )
+                // If this is for an app page, then we should associate a data
+                // route (and prefetch if PPR is enabled) for it.
+                if (kind === RouteKind.APP_PAGE) {
+                  const normalized = normalizePagePath(route)
+                  dataRoute = `${normalized}${RSC_SUFFIX}`
+                  if (experimentalPPR) {
+                    prefetchDataRoute = `${normalized}${RSC_PREFETCH_SUFFIX}`
+                  }
                 }
 
                 const routeMeta: Partial<SsgRoute> = {}
@@ -2398,34 +2400,30 @@ export default async function build(
                 hasDynamicData = true
                 // we might have determined during prerendering that this page
                 // used dynamic data
-                pageInfos.set(route, {
-                  ...(pageInfos.get(route) as PageInfo),
-                  isSSG: false,
-                  isStatic: false,
-                })
+                pageInfo.isStatic = false
+                pageInfo.isSSG = false
               }
             })
 
-            if (!hasDynamicData && isDynamicRoute(originalAppPath)) {
-              const normalizedRoute = normalizePagePath(page)
-              const dataRoute = path.posix.join(
-                `${normalizedRoute}${RSC_SUFFIX}`
-              )
+            if (!hasDynamicData && isDynamic) {
+              let dataRoute: string | null = null
+              let prefetchDataRoute: string | undefined
 
-              let prefetchDataRoute: string | null | undefined
-              if (experimentalPPR) {
-                prefetchDataRoute = path.posix.join(
-                  `${normalizedRoute}${RSC_PREFETCH_SUFFIX}`
-                )
+              // If this is for an app page, then we should associate a data
+              // route (and prefetch if PPR is enabled) for it.
+              if (kind === RouteKind.APP_PAGE) {
+                const normalized = normalizePagePath(page)
+                dataRoute = `${normalized}${RSC_SUFFIX}`
+                if (experimentalPPR) {
+                  prefetchDataRoute = `${normalized}${RSC_PREFETCH_SUFFIX}`
+                }
               }
 
-              pageInfos.set(page, {
-                ...(pageInfos.get(page) as PageInfo),
-                isDynamicAppRoute: true,
-                // if PPR is turned on and the route contains a dynamic segment,
-                // we assume it'll be partially prerendered
-                hasPostponed: experimentalPPR,
-              })
+              pageInfo.isDynamicAppRoute = true
+
+              // If PPR is turned on and the route contains a dynamic segment,
+              // we assume it'll be partially prerendered
+              pageInfo.hasPostponed = experimentalPPR
 
               // TODO: create a separate manifest to allow enforcing
               // dynamicParams for non-static paths?
@@ -2435,33 +2433,32 @@ export default async function build(
                 routeRegex: normalizeRouteRegex(
                   getNamedRouteRegex(page, false).re.source
                 ),
-                dataRoute,
                 // if dynamicParams are enabled treat as fallback:
                 // 'blocking' if not it's fallback: false
                 fallback: appDynamicParamPaths.has(originalAppPath)
                   ? null
                   : false,
-                dataRouteRegex: isRouteHandler
-                  ? null
-                  : normalizeRouteRegex(
+                dataRoute,
+                dataRouteRegex: dataRoute
+                  ? normalizeRouteRegex(
                       getNamedRouteRegex(
                         dataRoute.replace(/\.rsc$/, ''),
                         false
                       ).re.source.replace(/\(\?:\\\/\)\?\$$/, '\\.rsc$')
-                    ),
+                    )
+                  : null,
                 prefetchDataRoute,
-                prefetchDataRouteRegex:
-                  isRouteHandler || !prefetchDataRoute
-                    ? undefined
-                    : normalizeRouteRegex(
-                        getNamedRouteRegex(
-                          prefetchDataRoute.replace(/\.prefetch\.rsc$/, ''),
-                          false
-                        ).re.source.replace(
-                          /\(\?:\\\/\)\?\$$/,
-                          '\\.prefetch\\.rsc$'
-                        )
-                      ),
+                prefetchDataRouteRegex: prefetchDataRoute
+                  ? normalizeRouteRegex(
+                      getNamedRouteRegex(
+                        prefetchDataRoute.replace(/\.prefetch\.rsc$/, ''),
+                        false
+                      ).re.source.replace(
+                        /\(\?:\\\/\)\?\$$/,
+                        '\\.prefetch\\.rsc$'
+                      )
+                    )
+                  : undefined,
               }
             }
           }

--- a/packages/next/src/build/page-info.ts
+++ b/packages/next/src/build/page-info.ts
@@ -1,0 +1,30 @@
+import type { ServerRuntime } from '../../types'
+
+export interface PageInfo {
+  isHybridAmp?: boolean
+  size: number
+  totalSize: number
+  isStatic: boolean
+  isSSG: boolean
+  isPPR: boolean
+  ssgPageRoutes: string[] | null
+  initialRevalidateSeconds: number | false
+  pageDuration: number | undefined
+  ssgPageDurations: number[] | undefined
+  runtime: ServerRuntime
+  hasEmptyPrelude?: boolean
+  hasPostponed?: boolean
+  isDynamicAppRoute?: boolean
+}
+
+export type PageInfos = Map<string, PageInfo>
+
+export type SerializedPageInfos = [string, PageInfo][]
+
+export function serializePageInfos(input: PageInfos): SerializedPageInfos {
+  return Array.from(input.entries())
+}
+
+export function deserializePageInfos(input: SerializedPageInfos): PageInfos {
+  return new Map(input)
+}

--- a/packages/next/src/build/page-info.ts
+++ b/packages/next/src/build/page-info.ts
@@ -16,15 +16,3 @@ export interface PageInfo {
   hasPostponed?: boolean
   isDynamicAppRoute?: boolean
 }
-
-export type PageInfos = Map<string, PageInfo>
-
-export type SerializedPageInfos = [string, PageInfo][]
-
-export function serializePageInfos(input: PageInfos): SerializedPageInfos {
-  return Array.from(input.entries())
-}
-
-export function deserializePageInfos(input: SerializedPageInfos): PageInfos {
-  return new Map(input)
-}

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -23,6 +23,7 @@ import type { AppPageModule } from '../server/future/route-modules/app-page/modu
 import type { RouteModule } from '../server/future/route-modules/route-module'
 import type { LoaderTree } from '../server/lib/app-dir-module'
 import type { NextComponentType } from '../shared/lib/utils'
+import type { PageInfo } from './page-info'
 
 import '../server/require-hook'
 import '../server/node-polyfill-crypto'
@@ -324,35 +325,6 @@ const filterAndSortList = (
       )
   }
   return pages.sort((a, b) => a.localeCompare(b))
-}
-
-export interface PageInfo {
-  isHybridAmp?: boolean
-  size: number
-  totalSize: number
-  isStatic: boolean
-  isSSG: boolean
-  isPPR: boolean
-  ssgPageRoutes: string[] | null
-  initialRevalidateSeconds: number | false
-  pageDuration: number | undefined
-  ssgPageDurations: number[] | undefined
-  runtime: ServerRuntime
-  hasEmptyPrelude?: boolean
-  hasPostponed?: boolean
-  isDynamicAppRoute?: boolean
-}
-
-export type PageInfos = Map<string, PageInfo>
-
-export type SerializedPageInfos = [string, PageInfo][]
-
-export function serializePageInfos(input: PageInfos): SerializedPageInfos {
-  return Array.from(input.entries())
-}
-
-export function deserializePageInfos(input: SerializedPageInfos): PageInfos {
-  return new Map(input)
 }
 
 export async function printTreeView(
@@ -659,10 +631,15 @@ export async function printTreeView(
     messages.push(['', '', ''])
   }
 
-  pageInfos.set('/404', {
-    ...(pageInfos.get('/404') || pageInfos.get('/_error'))!,
-    isStatic: useStaticPages404,
-  })
+  // We should update the `isStatic` part of the pageInfo for the /404 page.
+  // When we're using experimental compile, this won't be available.
+  const pageInfo = pageInfos.get('/404') || pageInfos.get('/_error')
+  if (pageInfo) {
+    pageInfos.set('/404', {
+      ...pageInfo,
+      isStatic: useStaticPages404,
+    })
+  }
 
   // If there's no app /_notFound page present, then the 404 is still using the pages/404
   if (!lists.pages.includes('/404') && !lists.app?.includes('/_not-found')) {


### PR DESCRIPTION
This is a followup to #59430 which re-introduces the refactor changes. The bug discovered with this that caused the revert is addressed in the following pull request https://github.com/vercel/vercel/pull/10978. Once merged, a test will be added to https://github.com/vercel/vercel that verifies that this doesn't regress.

This also removes the leaky abstraction [detailed here](https://github.com/vercel/next.js/pull/59157/files#r1428097252) which resolves the issue of passing higher ordered objects across the worker boundary.

Closes NEXT-1903