### PR TITLE
fix parallel catch-all route normalization

### DIFF
--- a/packages/next/src/build/normalize-catchall-routes.test.ts
+++ b/packages/next/src/build/normalize-catchall-routes.test.ts
@@ -1,0 +1,99 @@
+import { normalizeCatchAllRoutes } from './normalize-catchall-routes'
+
+describe('normalizeCatchallRoutes', () => {
+  it('should not add the catch-all to the interception route', () => {
+    const appPaths = {
+      '/': ['/page'],
+      '/[...slug]': ['/[...slug]/page'],
+      '/things/[...ids]': ['/things/[...ids]/page'],
+      '/(.)things/[...ids]': ['/@modal/(.)things/[...ids]/page'],
+    }
+
+    const initialAppPaths = JSON.parse(JSON.stringify(appPaths))
+
+    normalizeCatchAllRoutes(appPaths)
+
+    expect(appPaths).toMatchObject(initialAppPaths)
+  })
+
+  it('should add the catch-all route to all matched paths when nested', () => {
+    const appPaths = {
+      '/parallel-nested-catchall': ['/parallel-nested-catchall/page'],
+      '/parallel-nested-catchall/[...catchAll]': [
+        '/parallel-nested-catchall/[...catchAll]/page',
+        '/parallel-nested-catchall/@slot/[...catchAll]/page',
+      ],
+      '/parallel-nested-catchall/bar': ['/parallel-nested-catchall/bar/page'],
+      '/parallel-nested-catchall/foo': [
+        '/parallel-nested-catchall/foo/page',
+        '/parallel-nested-catchall/@slot/foo/page',
+      ],
+      '/parallel-nested-catchall/foo/[id]': [
+        '/parallel-nested-catchall/foo/[id]/page',
+      ],
+      '/parallel-nested-catchall/foo/[...catchAll]': [
+        '/parallel-nested-catchall/@slot/foo/[...catchAll]/page',
+      ],
+    }
+
+    normalizeCatchAllRoutes(appPaths)
+
+    expect(appPaths).toMatchObject({
+      '/parallel-nested-catchall': ['/parallel-nested-catchall/page'],
+      '/parallel-nested-catchall/[...catchAll]': [
+        '/parallel-nested-catchall/[...catchAll]/page',
+        '/parallel-nested-catchall/@slot/[...catchAll]/page',
+      ],
+      '/parallel-nested-catchall/bar': [
+        '/parallel-nested-catchall/bar/page',
+        '/parallel-nested-catchall/@slot/[...catchAll]/page', // inserted
+      ],
+      '/parallel-nested-catchall/foo': [
+        '/parallel-nested-catchall/foo/page',
+        '/parallel-nested-catchall/@slot/foo/page',
+      ],
+      '/parallel-nested-catchall/foo/[id]': [
+        '/parallel-nested-catchall/foo/[id]/page',
+        '/parallel-nested-catchall/@slot/foo/[...catchAll]/page', // inserted
+      ],
+      '/parallel-nested-catchall/foo/[...catchAll]': [
+        '/parallel-nested-catchall/@slot/foo/[...catchAll]/page',
+        '/parallel-nested-catchall/[...catchAll]/page', // inserted
+      ],
+    })
+  })
+
+  it('should add the catch-all route to all matched paths at the root', () => {
+    const appPaths = {
+      '/': ['/page'],
+      '/[...catchAll]': ['/[...catchAll]/page', '/@slot/[...catchAll]/page'],
+      '/bar': ['/bar/page'],
+      '/foo': ['/foo/page', '/@slot/foo/page'],
+      '/foo/[id]': ['/foo/[id]/page'],
+      '/foo/[...catchAll]': ['/@slot/foo/[...catchAll]/page'],
+    }
+
+    normalizeCatchAllRoutes(appPaths)
+
+    expect(appPaths).toMatchObject({
+      '/': [
+        '/page',
+        '/@slot/[...catchAll]/page', // inserted
+      ],
+      '/[...catchAll]': ['/[...catchAll]/page', '/@slot/[...catchAll]/page'],
+      '/bar': [
+        '/bar/page',
+        '/@slot/[...catchAll]/page', // inserted
+      ],
+      '/foo': ['/foo/page', '/@slot/foo/page'],
+      '/foo/[id]': [
+        '/foo/[id]/page',
+        '/@slot/foo/[...catchAll]/page', // inserted
+      ],
+      '/foo/[...catchAll]': [
+        '/@slot/foo/[...catchAll]/page',
+        '/[...catchAll]/page', //inserted
+      ],
+    })
+  })
+})

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -546,12 +546,27 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
           continue
         }
 
-        // avoid clobbering existing page segments
-        // if it's a valid parallel segment, the `children` property will be set appropriately
         if (existingChildrenPath && matched.children !== rest[0]) {
-          throw new Error(
-            `You cannot have two parallel pages that resolve to the same path. Please check ${existingChildrenPath} and ${appPath}. Refer to the route group docs for more information: https://nextjs.org/docs/app/building-your-application/routing/route-groups`
-          )
+          // If we get here, it means we already set a `page` segment earlier in the loop,
+          // meaning we already matched a page to the `children` parallel segment.
+          const isIncomingParallelPage = appPath.includes('@')
+          const hasCurrentParallelPage = existingChildrenPath.includes('@')
+
+          if (isIncomingParallelPage) {
+            // The duplicate segment was for a parallel slot. In this case,
+            // rather than throwing an error, we can ignore it since this can happen for valid reasons.
+            // For example, when we attempt to normalize catch-all routes, we'll push potential slot matches so
+            // that they are available in the loader tree when we go to render the page.
+            // We only need to throw an error if the duplicate segment was for a regular page.
+            // For example, /app/(groupa)/page & /app/(groupb)/page is an error since it corresponds
+            // with the same path.
+            continue
+          } else if (!hasCurrentParallelPage && !isIncomingParallelPage) {
+            // Both the current `children` and the incoming `children` are regular pages.
+            throw new Error(
+              `You cannot have two parallel pages that resolve to the same path. Please check ${existingChildrenPath} and ${appPath}. Refer to the route group docs for more information: https://nextjs.org/docs/app/building-your-application/routing/route-groups`
+            )
+          }
         }
 
         existingChildrenPath = appPath

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-app-page-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-app-page-route-matcher-provider.ts
@@ -34,7 +34,7 @@ export class DevAppPageRouteMatcherProvider extends FileCacheRouteMatcherProvide
       { page: string; pathname: string; bundlePath: string }
     >()
     const routeFilenames = new Array<string>()
-    const appPaths: Record<string, string[]> = {}
+    let appPaths: Record<string, string[]> = {}
     for (const filename of files) {
       // If the file isn't a match for this matcher, then skip it.
       if (!this.expression.test(filename)) continue
@@ -58,6 +58,11 @@ export class DevAppPageRouteMatcherProvider extends FileCacheRouteMatcherProvide
     }
 
     normalizeCatchAllRoutes(appPaths)
+
+    // Make sure to sort parallel routes to make the result deterministic.
+    appPaths = Object.fromEntries(
+      Object.entries(appPaths).map(([k, v]) => [k, v.sort()])
+    )
 
     const matchers: Array<AppPageRouteMatcher> = []
     for (const filename of routeFilenames) {

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -86,11 +86,11 @@ async function loadClientReferenceManifest(
   manifestPath: string,
   entryName: string
 ): Promise<ClientReferenceManifest | undefined> {
-  process.env.NEXT_MINIMAL
-    ? // @ts-ignore
-      __non_webpack_require__(manifestPath)
-    : require(manifestPath)
   try {
+    process.env.NEXT_MINIMAL
+      ? // @ts-ignore
+        __non_webpack_require__(manifestPath)
+      : require(manifestPath)
     return (globalThis as any).__RSC_MANIFEST[
       entryName
     ] as ClientReferenceManifest

--- a/test/e2e/app-dir/conflicting-page-segments/app/(group-a)/page.tsx
+++ b/test/e2e/app-dir/conflicting-page-segments/app/(group-a)/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      Home <Link href="/foo">To /foo</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/conflicting-page-segments/app/(group-b)/page.tsx
+++ b/test/e2e/app-dir/conflicting-page-segments/app/(group-b)/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      Home <Link href="/foo">To /foo</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/conflicting-page-segments/app/layout.tsx
+++ b/test/e2e/app-dir/conflicting-page-segments/app/layout.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <div id="children">{children}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
+++ b/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
@@ -1,0 +1,31 @@
+import { createNextDescribe } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+createNextDescribe(
+  'conflicting-page-segments',
+  {
+    files: __dirname,
+    // we skip start because the build will fail and we won't be able to catch it
+    // start is re-triggered but caught in the assertions below
+    skipStart: true,
+  },
+  ({ next, isNextDev }) => {
+    it('should throw an error when a route groups causes a conflict with a parallel segment', async () => {
+      if (isNextDev) {
+        await next.start()
+        const html = await next.render('/')
+
+        expect(html).toContain(
+          'You cannot have two parallel pages that resolve to the same path.'
+        )
+      } else {
+        await expect(next.start()).rejects.toThrow('next build failed')
+
+        await check(
+          () => next.cliOutput,
+          /You cannot have two parallel pages that resolve to the same path\. Please check \/\(group-a\)\/page and \/\(group-b\)\/page\./i
+        )
+      }
+    })
+  }
+)

--- a/test/e2e/app-dir/conflicting-page-segments/next.config.js
+++ b/test/e2e/app-dir/conflicting-page-segments/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/interception-routes-root-catchall/app/@modal/(.)items/[...ids]/page.tsx
+++ b/test/e2e/app-dir/interception-routes-root-catchall/app/@modal/(.)items/[...ids]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page({ params }: { params: { ids: string[] } }) {
+  return <div>Intercepted Modal Page. Id: {params.ids}</div>
+}

--- a/test/e2e/app-dir/interception-routes-root-catchall/app/@modal/default.tsx
+++ b/test/e2e/app-dir/interception-routes-root-catchall/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <div>default @modal</div>
+}

--- a/test/e2e/app-dir/interception-routes-root-catchall/app/[...slug]/page.tsx
+++ b/test/e2e/app-dir/interception-routes-root-catchall/app/[...slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Root Catch-All Page</div>
+}

--- a/test/e2e/app-dir/interception-routes-root-catchall/app/default.tsx
+++ b/test/e2e/app-dir/interception-routes-root-catchall/app/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <div>default root</div>
+}

--- a/test/e2e/app-dir/interception-routes-root-catchall/app/items/[...ids]/page.tsx
+++ b/test/e2e/app-dir/interception-routes-root-catchall/app/items/[...ids]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page({ params }: { params: { ids: string[] } }) {
+  return <div>Regular Item Page. Id: {params.ids}</div>
+}

--- a/test/e2e/app-dir/interception-routes-root-catchall/app/layout.tsx
+++ b/test/e2e/app-dir/interception-routes-root-catchall/app/layout.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default function Root({
+  children,
+  modal,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <div id="children">{children}</div>
+        <div id="slot">{modal}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/interception-routes-root-catchall/app/page.tsx
+++ b/test/e2e/app-dir/interception-routes-root-catchall/app/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default async function Home() {
+  return (
+    <div>
+      <Link href="/items/1">Open Items #1 (Intercepted)</Link>
+      <Link href="/foobar">Go to Catch-All Page</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-routes-root-catchall/interception-routes-root-catchall.test.ts
+++ b/test/e2e/app-dir/interception-routes-root-catchall/interception-routes-root-catchall.test.ts
@@ -1,0 +1,41 @@
+import { createNextDescribe } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+createNextDescribe(
+  'interception-routes-root-catchall',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should support having a root catch-all and a catch-all in a parallel route group', async () => {
+      const browser = await next.browser('/')
+      await browser.elementByCss('[href="/items/1"]').click()
+
+      // this triggers the /items route interception handling
+      await check(
+        () => browser.elementById('slot').text(),
+        /Intercepted Modal Page. Id: 1/
+      )
+      await browser.refresh()
+
+      // no longer intercepted, using the page
+      await check(() => browser.elementById('slot').text(), /default @modal/)
+      await check(
+        () => browser.elementById('children').text(),
+        /Regular Item Page. Id: 1/
+      )
+    })
+
+    it('should handle non-intercepted catch-all pages', async () => {
+      const browser = await next.browser('/')
+
+      // there's no explicit page for /foobar. This will trigger the catchall [...slug] page
+      await browser.elementByCss('[href="/foobar"]').click()
+      await check(() => browser.elementById('slot').text(), /default @modal/)
+      await check(
+        () => browser.elementById('children').text(),
+        /Root Catch-All Page/
+      )
+    })
+  }
+)

--- a/test/e2e/app-dir/interception-routes-root-catchall/next.config.js
+++ b/test/e2e/app-dir/interception-routes-root-catchall/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -187,7 +187,7 @@ createNextDescribe(
         expect(pageText).toContain('parallel/(new)/@baz/nested/page')
       })
 
-      it('should throw an error when a route groups causes a conflict with a parallel segment', async () => {
+      it('should gracefully handle when two page segments match the `children` parallel slot', async () => {
         await next.stop()
         await next.patchFile(
           'app/parallel/nested-2/page.js',
@@ -198,22 +198,21 @@ createNextDescribe(
             `
         )
 
-        if (isNextDev) {
-          await next.start()
+        await next.start()
 
-          const html = await next.render('/parallel/nested-2')
+        const html = await next.render('/parallel/nested-2')
 
-          expect(html).toContain(
-            'You cannot have two parallel pages that resolve to the same path.'
-          )
+        // before adding this file, the page would have matched `/app/parallel/(new)/@baz/nested-2/page`
+        // but we've added a more specific page, so it should match that instead
+        if (process.env.TURBOPACK) {
+          // TODO: this matches differently in Turbopack because the Webpack loader does some sorting on the paths
+          // Investigate the discrepancy in a follow-up. For now, since no errors are being thrown (and since this test was previously ignored in Turbopack),
+          // we'll just verify that the page is rendered and some content was matched.
+          expect(html).toContain('parallel/(new)/@baz/nested/page')
         } else {
-          await expect(next.start()).rejects.toThrow('next build failed')
-
-          await check(
-            () => next.cliOutput,
-            /You cannot have two parallel pages that resolve to the same path\. Please check \/parallel\/\(new\)\/@baz\/nested-2\/page and \/parallel\/nested-2\/page\./i
-          )
+          expect(html).toContain('hello world')
         }
+
         await next.stop()
         await next.deleteFile('app/parallel/nested-2/page.js')
         await next.start()
@@ -339,7 +338,7 @@ createNextDescribe(
         )
       })
 
-      it('Should match the catch-all routes of the more specific path, If there is more than one catch-all route', async () => {
+      it('should match the catch-all routes of the more specific path, if there is more than one catch-all route', async () => {
         const browser = await next.browser('/parallel-nested-catchall')
 
         await browser

--- a/test/e2e/app-dir/parallel-routes-catchall-groups/app/(group-a)/@parallel/[...catcher]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-groups/app/(group-a)/@parallel/[...catcher]/page.tsx
@@ -1,0 +1,3 @@
+export default function Catcher() {
+  return <div>Catcher</div>
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-groups/app/(group-a)/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-groups/app/(group-a)/layout.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function Root({ parallel }: { parallel: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <div id="children">{parallel}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-groups/app/(group-b)/foo/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-groups/app/(group-b)/foo/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Foo Page</div>
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-groups/app/(group-b)/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-groups/app/(group-b)/layout.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <div id="children">{children}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-groups/app/(group-b)/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-groups/app/(group-b)/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      Home
+      <div>
+        <Link href="/foo">To /foo </Link>
+      </div>
+      <div>
+        <Link href="/bar">To /bar</Link>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-groups/next.config.js
+++ b/test/e2e/app-dir/parallel-routes-catchall-groups/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-catchall-groups/parallel-routes-catchall-groups.test.ts
+++ b/test/e2e/app-dir/parallel-routes-catchall-groups/parallel-routes-catchall-groups.test.ts
@@ -1,0 +1,25 @@
+import { createNextDescribe } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+createNextDescribe(
+  'parallel-routes-catchall-groups',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should work without throwing any errors about conflicting paths', async () => {
+      const browser = await next.browser('/')
+
+      await check(() => browser.elementByCss('body').text(), /Home/)
+      await browser.elementByCss('[href="/foo"]').click()
+      // Foo has a page route defined, so we'd expect to see the page content
+      await check(() => browser.elementByCss('body').text(), /Foo Page/)
+      await browser.back()
+
+      // /bar doesn't have an explicit page path. (group-a) defines a catch-all slot with a separate root layout
+      // that only renders a slot (ie no children). So we'd expect to see the fallback slot content
+      await browser.elementByCss('[href="/bar"]').click()
+      await check(() => browser.elementByCss('body').text(), /Catcher/)
+    })
+  }
+)

--- a/test/e2e/app-dir/parallel-routes-catchall/app/@slot/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall/app/@slot/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'slot catchall'
+}

--- a/test/e2e/app-dir/parallel-routes-catchall/app/@slot/baz/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall/app/@slot/baz/page.tsx
@@ -1,0 +1,3 @@
+export default function Baz() {
+  return 'baz slot'
+}

--- a/test/e2e/app-dir/parallel-routes-catchall/app/@slot/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall/app/@slot/default.tsx
@@ -1,0 +1,7 @@
+export default function Default() {
+  return (
+    <div>
+      <div>Default</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-catchall/app/@slot/foo/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall/app/@slot/foo/page.tsx
@@ -1,0 +1,3 @@
+export default function Foo() {
+  return 'foo slot'
+}

--- a/test/e2e/app-dir/parallel-routes-catchall/app/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall/app/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'main catchall'
+}

--- a/test/e2e/app-dir/parallel-routes-catchall/app/bar/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall/app/bar/page.tsx
@@ -1,0 +1,3 @@
+export default function Foo() {
+  return 'bar'
+}

--- a/test/e2e/app-dir/parallel-routes-catchall/app/foo/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall/app/foo/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'foo'
+}

--- a/test/e2e/app-dir/parallel-routes-catchall/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall/app/layout.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default function Root({
+  children,
+  slot,
+}: {
+  children: React.ReactNode
+  slot: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <div id="children">{children}</div>
+        <div id="slot">{slot}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-catchall/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall/app/page.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export default async function Home() {
+  return (
+    <div>
+      <div>
+        <Link href="/foo">Go to /foo (page & slot)</Link>
+      </div>
+      <div>
+        <Link href="/bar">Go to /bar (page & no slot)</Link>
+      </div>
+      <div>
+        <Link href="/baz">Go to /baz (no page & slot)</Link>
+      </div>
+      <div>
+        <Link href="/quux">Go to /quux (no page & no slot)</Link>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-catchall/next.config.js
+++ b/test/e2e/app-dir/parallel-routes-catchall/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-catchall/parallel-routes-catchall.test.ts
+++ b/test/e2e/app-dir/parallel-routes-catchall/parallel-routes-catchall.test.ts
@@ -1,0 +1,57 @@
+import { createNextDescribe } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+createNextDescribe(
+  'parallel-routes-catchall',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should match correctly when defining an explicit page & slot', async () => {
+      const browser = await next.browser('/')
+      await check(() => browser.elementById('slot').text(), /slot catchall/)
+
+      await browser.elementByCss('[href="/foo"]').click()
+
+      // foo has defined a page route and a corresponding parallel slot
+      // so we'd expect to see the custom slot content & the page content
+      await check(() => browser.elementById('children').text(), /foo/)
+      await check(() => browser.elementById('slot').text(), /foo slot/)
+    })
+
+    it('should match correctly when defining an explicit page but no slot', async () => {
+      const browser = await next.browser('/')
+      await check(() => browser.elementById('slot').text(), /slot catchall/)
+
+      await browser.elementByCss('[href="/bar"]').click()
+
+      // bar has defined a slot but no page route
+      // so we'd expect to see the catch-all slot & the page content
+      await check(() => browser.elementById('children').text(), /bar/)
+      await check(() => browser.elementById('slot').text(), /slot catchall/)
+    })
+
+    it('should match correctly when defining an explicit slot but no page', async () => {
+      const browser = await next.browser('/')
+      await check(() => browser.elementById('slot').text(), /slot catchall/)
+
+      await browser.elementByCss('[href="/baz"]').click()
+
+      // baz has defined a page route and a corresponding parallel slot
+      // so we'd expect to see the custom slot content & the page content
+      await check(() => browser.elementById('children').text(), /main catchall/)
+      await check(() => browser.elementById('slot').text(), /baz slot/)
+    })
+
+    it('should match both the catch-all page & slot', async () => {
+      const browser = await next.browser('/')
+      await check(() => browser.elementById('slot').text(), /slot catchall/)
+
+      await browser.elementByCss('[href="/quux"]').click()
+
+      // quux doesn't have a page or slot defined. It should use the catch-all for both
+      await check(() => browser.elementById('children').text(), /main catchall/)
+      await check(() => browser.elementById('slot').text(), /slot catchall/)
+    })
+  }
+)

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -3838,8 +3838,7 @@
     ],
     "failed": [
       "parallel-routes-and-interception parallel routes Should match the catch-all routes of the more specific path, If there is more than one catch-all route",
-      "parallel-routes-and-interception parallel routes should apply the catch-all route to the parallel route if no matching route is found",
-      "parallel-routes-and-interception parallel routes should throw an error when a route groups causes a conflict with a parallel segment"
+      "parallel-routes-and-interception parallel routes should apply the catch-all route to the parallel route if no matching route is found"
     ],
     "pending": [],
     "flakey": [],


### PR DESCRIPTION
### What?
Catch-all routes are being matched to parallel routes which causes issues like an interception route being handled by the wrong page component, or a page component being associated with multiple pages resulting in a "You cannot have two parallel pages that resolve to the same path" build error.

### Why?
#58215 fixed a bug that caused catchall paths to not properly match when used with parallel routes. In other words, a catchall slot wouldn't render on a page that could match that catch all. Or a catchall page wouldn't match a slot. At build time, a normalization step was introduced to take application paths and attempt to perform this matching behavior.

However in it's current form, this causes the errors mentioned above to manifest. To better illustrate the problem, here are a few examples:

Given:
```
{
  '/': [ '/page' ],
  '/[...slug]': [ '/[...slug]/page' ],
  '/items/[...ids]': [ '/items/[...ids]/page' ],
  '/(.)items/[...ids]': [ '/@modal/(.)items/[...ids]/page' ]
}
```

The normalization logic would produce:
```
{
  '/': [ '/page' ],
  '/[...slug]': [ '/[...slug]/page' ],
  '/items/[...ids]': [ '/items/[...ids]/page' ],
  '/(.)items/[...ids]': [ '/@modal/(.)items/[...ids]/page', '/[...slug]/page' ]
}
```
The interception route will now be improperly handled by `[...slug]/page` rather than the interception handler.

Another example, which rather than incorrectly handling a match, will produce a build error:

Given:
```
{
  '/': [ '/(group-b)/page' ],
  '/[...catcher]': [ '/(group-a)/@parallel/[...catcher]/page' ]
}
```

The normalization logic would produce:

```
{
  '/': [ '/(group-b)/page', '/(group-a)/@parallel/[...catcher]/page' ],
  '/[...catcher]': [ '/(group-a)/@parallel/[...catcher]/page' ]
}
```
The parallel catch-all slot is now part of `/`. This means when building the loader tree, two `children` parallel segments (aka page components) will be found when hitting `/`, which is an error. 

The error that was added here was originally intended to help catch scenarios like:
`/app/(group-a)/page` and `/app/(group-b)/page`. However it also throws for parallel slots, which isn't necessarily an error (especially since the normalization logic will push potential matches). 

### How?
There are two small fixes in this PR, the rest are an abundance of e2e tests to help prevent regressions. 

- When normalizing catch-all routes, we will not attempt to push any page entrypoints for interception routes. These should already have all the information they need in `appPaths`.
- Before throwing the error about duplicate page segments in `next-app-loader`, we check to see if it's because we already matched a page component but we also detected a parallel slot that would have matched the page slot. In this case, we don't error, since the app can recover from this. 
- Loading a client reference manifest shouldn't throw a cryptic require error. `loadClientReferenceManifest` is already potentially returning undefined, so this case should already be handled gracefully

Separately, we'll need to follow-up on the Turbopack side to:
- Make sure the duplicate matching matches the Webpack implementation (I believe Webpack is sorting, but Turbopack isn't)
- Implement #58215 in Turbopack. Once this is done, we should expect the tests added in this PR to start failing.

Fixes #58272
Fixes #58660
Fixes #58312
Fixes #59782
Fixes #59784

Closes NEXT-1809
