### PR TITLE
Introduce cache version history in cache API

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/unstable_cache.mdx
+++ b/docs/02-app/02-api-reference/04-functions/unstable_cache.mdx
@@ -37,3 +37,9 @@ const data = unstable_cache(fetchData, keyParts, options)()
 ## Returns
 
 `unstable_cache` returns a function that when invoked, returns a Promise that resolves to the cached data. If the data is not in the cache, the provided function will be invoked, and its result will be cached and returned.
+
+## Version History
+
+| Version   | Changes                      |
+| --------- | ---------------------------- |
+| `v14.0.0` | `unstable_cache` introduced. |


### PR DESCRIPTION
### Improving Documentation
I'm fixing the cache version history in the [unstable cache](https://nextjs.org/docs/app/api-reference/functions/unstable_cache) documentation.