### PR TITLE
fix(turbopack): Apply aliases for `react` and `react-dom` for client pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "serde",
  "smallvec",
@@ -3548,7 +3548,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "serde",
@@ -7668,7 +7668,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7700,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7712,7 +7712,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7727,7 +7727,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7741,7 +7741,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7758,7 +7758,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7789,7 +7789,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "base16",
  "hex",
@@ -7801,7 +7801,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7815,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7825,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "mimalloc",
 ]
@@ -7833,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7858,7 +7858,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7890,7 +7890,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7931,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7955,7 +7955,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7973,7 +7973,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8003,7 +8003,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8030,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8054,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8091,7 +8091,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "serde",
  "serde_json",
@@ -8137,7 +8137,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8160,7 +8160,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8177,7 +8177,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8193,7 +8193,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8213,7 +8213,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "serde",
@@ -8228,7 +8228,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8243,7 +8243,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8278,7 +8278,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "serde",
@@ -8294,7 +8294,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8305,7 +8305,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8320,7 +8320,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240102.1#5933c1cc0d6d974573f3efaf8016a4a8136d0b20"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/issue-2149#e75429d8fdd4b8dbef69030f89dadd747c04a591"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8342,7 +8342,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8342,7 +8342,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ swc_core = { version = "0.87.10", features = [
 testing = { version = "0.35.14" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240102.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/issue-2149" } # last tag: "turbopack-240102.1"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240102.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/issue-2149" } # last tag: "turbopack-240102.1"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240102.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/issue-2149" } # last tag: "turbopack-240102.1"
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -827,8 +827,6 @@ async fn insert_next_shared_aliases(
     import_map.insert_singleton_alias("@swc/helpers", get_next_package(project_path));
     import_map.insert_singleton_alias("styled-jsx", get_next_package(project_path));
     import_map.insert_singleton_alias("next", project_path);
-    // import_map.insert_singleton_alias("react", project_path);
-    // import_map.insert_singleton_alias("react-dom", project_path);
 
     let ppr = *next_config.enable_ppr().await?;
     let taint = *next_config.enable_taint().await?;
@@ -846,14 +844,6 @@ async fn insert_next_shared_aliases(
         "react-dom/server" => format!("next/dist/compiled/react-dom{react_channel}/server"),
         "react-dom/server.edge" => format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
         "react-dom/server.browser" => format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
-        "react-server-dom-webpack/client" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client"),
-        "react-server-dom-webpack/client.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
-        "react-server-dom-webpack/server.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
-        "react-server-dom-webpack/server.node" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
-        "react-server-dom-turbopack/client" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client"),
-        "react-server-dom-turbopack/client.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
-        "react-server-dom-turbopack/server.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
-        "react-server-dom-turbopack/server.node" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
     };
 
     for (key, value) in alias.iter_mut() {

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -7,6 +7,7 @@ use turbopack_binding::{
     turbo::tasks_fs::{glob::Glob, FileSystem, FileSystemPath},
     turbopack::{
         core::{
+            chunk::ChunkingContext,
             reference_type::{CommonJsReferenceSubType, ReferenceType},
             resolve::{
                 options::{ConditionValue, ImportMap, ImportMapping, ResolveOptions, ResolvedMap},
@@ -92,39 +93,44 @@ pub async fn get_next_client_import_map(
                 ],
             );
 
+            let chunking_context = execution_context.chunking_context();
+            let is_browser = *chunking_context.environment().is_browser().await?;
+
             let ppr = *next_config.enable_ppr().await?;
             let taint = *next_config.enable_taint().await?;
             let react_channel = if ppr || taint { "-experimental" } else { "" };
 
-            import_map.insert_exact_alias(
-                "react",
-                request_to_import_mapping(
-                    project_path,
-                    &format!("next/dist/compiled/react{react_channel}"),
-                ),
-            );
-            import_map.insert_wildcard_alias(
-                "react/",
-                request_to_import_mapping(
-                    project_path,
-                    &format!("next/dist/compiled/react{react_channel}/*"),
-                ),
-            );
+            if is_browser {
+                import_map.insert_exact_alias(
+                    "react",
+                    request_to_import_mapping(
+                        project_path,
+                        &format!("next/dist/compiled/react{react_channel}"),
+                    ),
+                );
+                import_map.insert_wildcard_alias(
+                    "react/",
+                    request_to_import_mapping(
+                        project_path,
+                        &format!("next/dist/compiled/react{react_channel}/*"),
+                    ),
+                );
 
-            import_map.insert_exact_alias(
-                "react-dom",
-                request_to_import_mapping(
-                    project_path,
-                    &format!("next/dist/compiled/react-dom{react_channel}"),
-                ),
-            );
-            import_map.insert_wildcard_alias(
-                "react-dom/",
-                request_to_import_mapping(
-                    project_path,
-                    &format!("next/dist/compiled/react-dom{react_channel}/*"),
-                ),
-            );
+                import_map.insert_exact_alias(
+                    "react-dom",
+                    request_to_import_mapping(
+                        project_path,
+                        &format!("next/dist/compiled/react-dom{react_channel}"),
+                    ),
+                );
+                import_map.insert_wildcard_alias(
+                    "react-dom/",
+                    request_to_import_mapping(
+                        project_path,
+                        &format!("next/dist/compiled/react-dom{react_channel}/*"),
+                    ),
+                );
+            }
         }
         ClientContextType::App { app_dir } => {
             let react_flavor =

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -92,40 +92,6 @@ pub async fn get_next_client_import_map(
                     request_to_import_mapping(pages_dir, "next/error"),
                 ],
             );
-
-            let ppr = *next_config.enable_ppr().await?;
-            let taint = *next_config.enable_taint().await?;
-            let react_channel = if ppr || taint { "-experimental" } else { "" };
-
-            import_map.insert_exact_alias(
-                "react",
-                request_to_import_mapping(
-                    project_path,
-                    &format!("next/dist/compiled/react{react_channel}"),
-                ),
-            );
-            import_map.insert_wildcard_alias(
-                "react/",
-                request_to_import_mapping(
-                    project_path,
-                    &format!("next/dist/compiled/react{react_channel}/*"),
-                ),
-            );
-
-            import_map.insert_exact_alias(
-                "react-dom",
-                request_to_import_mapping(
-                    project_path,
-                    &format!("next/dist/compiled/react-dom{react_channel}"),
-                ),
-            );
-            import_map.insert_wildcard_alias(
-                "react-dom/",
-                request_to_import_mapping(
-                    project_path,
-                    &format!("next/dist/compiled/react-dom{react_channel}/*"),
-                ),
-            );
         }
         ClientContextType::App { app_dir } => {
             let react_flavor =

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -836,15 +836,6 @@ async fn insert_next_shared_aliases(
         import_map.insert_exact_alias(key, request_to_import_mapping(project_path, &value));
     };
 
-    precompiled("react", format!("next/dist/compiled/react{react_channel}"));
-    precompiled(
-        "react/jsx-runtime",
-        format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
-    );
-    precompiled(
-        "react/jsx-dev-runtime",
-        format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
-    );
     precompiled(
         "react-dom",
         format!("next/dist/compiled/react-dom{react_channel}"),

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -122,6 +122,13 @@ pub async fn get_next_client_import_map(
                 ),
             );
             import_map.insert_exact_alias(
+                "react-dom/server",
+                request_to_import_mapping(
+                    app_dir,
+                    "next/dist/compiled/react-dom-experimental/server",
+                ),
+            );
+            import_map.insert_exact_alias(
                 "react-dom/static",
                 request_to_import_mapping(
                     app_dir,

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -172,20 +172,6 @@ pub async fn get_next_client_import_map(
                 ),
             );
             import_map.insert_exact_alias(
-                "react-dom/server",
-                request_to_import_mapping(
-                    app_dir,
-                    "next/dist/compiled/react-dom-experimental/server",
-                ),
-            );
-            import_map.insert_exact_alias(
-                "react-dom/server.browser",
-                request_to_import_mapping(
-                    app_dir,
-                    "next/dist/compiled/react-dom-experimental/server.browser",
-                ),
-            );
-            import_map.insert_exact_alias(
                 "react-dom/static",
                 request_to_import_mapping(
                     app_dir,

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -94,13 +94,13 @@ pub async fn get_next_client_import_map(
             );
 
             let chunking_context = execution_context.chunking_context();
-            let is_browser = *chunking_context.environment().is_browser().await?;
+            let alias_react = *chunking_context.environment().alias_react().await?;
 
             let ppr = *next_config.enable_ppr().await?;
             let taint = *next_config.enable_taint().await?;
             let react_channel = if ppr || taint { "-experimental" } else { "" };
 
-            if is_browser {
+            if alias_react {
                 import_map.insert_exact_alias(
                     "react",
                     request_to_import_mapping(

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -832,23 +832,51 @@ async fn insert_next_shared_aliases(
     let taint = *next_config.enable_taint().await?;
     let react_channel = if ppr || taint { "-experimental" } else { "" };
 
-    let mut alias = indexmap! {
-        "react" => format!("next/dist/compiled/react{react_channel}"),
-        "react-dom" => format!("next/dist/compiled/react-dom{react_channel}"),
-        "react/jsx-runtime" => format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
-        "react/jsx-dev-runtime" => format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
-        "react-dom/client" => format!("next/dist/compiled/react-dom{react_channel}/client"),
-        "react-dom/static" => format!("next/dist/compiled/react-dom-experimental/static"),
-        "react-dom/static.edge" => format!("next/dist/compiled/react-dom-experimental/static.edge"),
-        "react-dom/static.browser" => format!("next/dist/compiled/react-dom-experimental/static.browser"),
-        "react-dom/server" => format!("next/dist/compiled/react-dom{react_channel}/server"),
-        "react-dom/server.edge" => format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
-        "react-dom/server.browser" => format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
+    let mut precompiled = |key, value: String| {
+        import_map.insert_exact_alias(key, request_to_import_mapping(project_path, &value));
     };
 
-    for (key, value) in alias.iter_mut() {
-        import_map.insert_exact_alias(*key, request_to_import_mapping(project_path, value));
-    }
+    precompiled("react", format!("next/dist/compiled/react{react_channel}"));
+    precompiled(
+        "react/jsx-runtime",
+        format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
+    );
+    precompiled(
+        "react/jsx-dev-runtime",
+        format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
+    );
+    precompiled(
+        "react-dom",
+        format!("next/dist/compiled/react-dom{react_channel}"),
+    );
+    precompiled(
+        "react-dom/server",
+        format!("next/dist/compiled/react-dom{react_channel}/server"),
+    );
+    precompiled(
+        "react-dom/server.browser",
+        format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
+    );
+    precompiled(
+        "react-dom/server.edge",
+        format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
+    );
+    precompiled(
+        "react-dom/client",
+        format!("next/dist/compiled/react-dom{react_channel}/client"),
+    );
+    precompiled(
+        "react-dom/static",
+        format!("next/dist/compiled/react-dom-experimental/static"),
+    );
+    precompiled(
+        "react-dom/static.edge",
+        format!("next/dist/compiled/react-dom-experimental/static.edge"),
+    );
+    precompiled(
+        "react-dom/static.browser",
+        format!("next/dist/compiled/react-dom-experimental/static.browser"),
+    );
 
     //https://github.com/vercel/next.js/blob/f94d4f93e4802f951063cfa3351dd5a2325724b3/packages/next/src/build/webpack-config.ts#L1196
     import_map.insert_exact_alias(

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -836,6 +836,15 @@ async fn insert_next_shared_aliases(
         import_map.insert_exact_alias(key, request_to_import_mapping(project_path, &value));
     };
 
+    precompiled("react", format!("next/dist/compiled/react{react_channel}"));
+    precompiled(
+        "react/jsx-runtime",
+        format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
+    );
+    precompiled(
+        "react/jsx-dev-runtime",
+        format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
+    );
     precompiled(
         "react-dom",
         format!("next/dist/compiled/react-dom{react_channel}"),

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -55,6 +55,56 @@ pub async fn get_next_client_import_map(
     )
     .await?;
 
+    let ppr = *next_config.enable_ppr().await?;
+    let taint = *next_config.enable_taint().await?;
+    let react_channel = if ppr || taint { "-experimental" } else { "" };
+
+    let mut precompiled = |key, value: String| {
+        import_map.insert_exact_alias(key, request_to_import_mapping(project_path, &value));
+    };
+
+    precompiled("react", format!("next/dist/compiled/react{react_channel}"));
+    precompiled(
+        "react/jsx-runtime",
+        format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
+    );
+    precompiled(
+        "react/jsx-dev-runtime",
+        format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
+    );
+    precompiled(
+        "react-dom",
+        format!("next/dist/compiled/react-dom{react_channel}"),
+    );
+    precompiled(
+        "react-dom/server",
+        format!("next/dist/compiled/react-dom{react_channel}/server"),
+    );
+    precompiled(
+        "react-dom/server.browser",
+        format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
+    );
+    precompiled(
+        "react-dom/server.edge",
+        format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
+    );
+    precompiled(
+        "react-dom/client",
+        format!("next/dist/compiled/react-dom{react_channel}/client"),
+    );
+    precompiled(
+        "react-dom/static",
+        format!("next/dist/compiled/react-dom-experimental/static"),
+    );
+    precompiled(
+        "react-dom/static.edge",
+        format!("next/dist/compiled/react-dom-experimental/static.edge"),
+    );
+    precompiled(
+        "react-dom/static.browser",
+        format!("next/dist/compiled/react-dom-experimental/static.browser"),
+    );
+
     insert_optimized_module_aliases(&mut import_map, project_path).await?;
 
     insert_alias_option(
@@ -126,6 +176,13 @@ pub async fn get_next_client_import_map(
                 request_to_import_mapping(
                     app_dir,
                     "next/dist/compiled/react-dom-experimental/server",
+                ),
+            );
+            import_map.insert_exact_alias(
+                "react-dom/server.browser",
+                request_to_import_mapping(
+                    app_dir,
+                    "next/dist/compiled/react-dom-experimental/server.browser",
                 ),
             );
             import_map.insert_exact_alias(
@@ -827,56 +884,8 @@ async fn insert_next_shared_aliases(
     import_map.insert_singleton_alias("@swc/helpers", get_next_package(project_path));
     import_map.insert_singleton_alias("styled-jsx", get_next_package(project_path));
     import_map.insert_singleton_alias("next", project_path);
-
-    let ppr = *next_config.enable_ppr().await?;
-    let taint = *next_config.enable_taint().await?;
-    let react_channel = if ppr || taint { "-experimental" } else { "" };
-
-    let mut precompiled = |key, value: String| {
-        import_map.insert_exact_alias(key, request_to_import_mapping(project_path, &value));
-    };
-
-    precompiled("react", format!("next/dist/compiled/react{react_channel}"));
-    precompiled(
-        "react/jsx-runtime",
-        format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
-    );
-    precompiled(
-        "react/jsx-dev-runtime",
-        format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
-    );
-    precompiled(
-        "react-dom",
-        format!("next/dist/compiled/react-dom{react_channel}"),
-    );
-    precompiled(
-        "react-dom/server",
-        format!("next/dist/compiled/react-dom{react_channel}/server"),
-    );
-    precompiled(
-        "react-dom/server.browser",
-        format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
-    );
-    precompiled(
-        "react-dom/server.edge",
-        format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
-    );
-    precompiled(
-        "react-dom/client",
-        format!("next/dist/compiled/react-dom{react_channel}/client"),
-    );
-    precompiled(
-        "react-dom/static",
-        format!("next/dist/compiled/react-dom-experimental/static"),
-    );
-    precompiled(
-        "react-dom/static.edge",
-        format!("next/dist/compiled/react-dom-experimental/static.edge"),
-    );
-    precompiled(
-        "react-dom/static.browser",
-        format!("next/dist/compiled/react-dom-experimental/static.browser"),
-    );
+    import_map.insert_singleton_alias("react", project_path);
+    import_map.insert_singleton_alias("react-dom", project_path);
 
     //https://github.com/vercel/next.js/blob/f94d4f93e4802f951063cfa3351dd5a2325724b3/packages/next/src/build/webpack-config.ts#L1196
     import_map.insert_exact_alias(

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -55,56 +55,6 @@ pub async fn get_next_client_import_map(
     )
     .await?;
 
-    let ppr = *next_config.enable_ppr().await?;
-    let taint = *next_config.enable_taint().await?;
-    let react_channel = if ppr || taint { "-experimental" } else { "" };
-
-    let mut precompiled = |key, value: String| {
-        import_map.insert_exact_alias(key, request_to_import_mapping(project_path, &value));
-    };
-
-    precompiled("react", format!("next/dist/compiled/react{react_channel}"));
-    precompiled(
-        "react/jsx-runtime",
-        format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
-    );
-    precompiled(
-        "react/jsx-dev-runtime",
-        format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
-    );
-    precompiled(
-        "react-dom",
-        format!("next/dist/compiled/react-dom{react_channel}"),
-    );
-    precompiled(
-        "react-dom/server",
-        format!("next/dist/compiled/react-dom{react_channel}/server"),
-    );
-    precompiled(
-        "react-dom/server.browser",
-        format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
-    );
-    precompiled(
-        "react-dom/server.edge",
-        format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
-    );
-    precompiled(
-        "react-dom/client",
-        format!("next/dist/compiled/react-dom{react_channel}/client"),
-    );
-    precompiled(
-        "react-dom/static",
-        format!("next/dist/compiled/react-dom-experimental/static"),
-    );
-    precompiled(
-        "react-dom/static.edge",
-        format!("next/dist/compiled/react-dom-experimental/static.edge"),
-    );
-    precompiled(
-        "react-dom/static.browser",
-        format!("next/dist/compiled/react-dom-experimental/static.browser"),
-    );
-
     insert_optimized_module_aliases(&mut import_map, project_path).await?;
 
     insert_alias_option(
@@ -140,6 +90,56 @@ pub async fn get_next_client_import_map(
                     request_to_import_mapping(pages_dir, "./_error"),
                     request_to_import_mapping(pages_dir, "next/error"),
                 ],
+            );
+
+            let ppr = *next_config.enable_ppr().await?;
+            let taint = *next_config.enable_taint().await?;
+            let react_channel = if ppr || taint { "-experimental" } else { "" };
+
+            let mut precompiled = |key, value: String| {
+                import_map.insert_exact_alias(key, request_to_import_mapping(project_path, &value));
+            };
+
+            precompiled("react", format!("next/dist/compiled/react{react_channel}"));
+            precompiled(
+                "react/jsx-runtime",
+                format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
+            );
+            precompiled(
+                "react/jsx-dev-runtime",
+                format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
+            );
+            precompiled(
+                "react-dom",
+                format!("next/dist/compiled/react-dom{react_channel}"),
+            );
+            precompiled(
+                "react-dom/server",
+                format!("next/dist/compiled/react-dom{react_channel}/server"),
+            );
+            precompiled(
+                "react-dom/server.browser",
+                format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
+            );
+            precompiled(
+                "react-dom/server.edge",
+                format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
+            );
+            precompiled(
+                "react-dom/client",
+                format!("next/dist/compiled/react-dom{react_channel}/client"),
+            );
+            precompiled(
+                "react-dom/static",
+                format!("next/dist/compiled/react-dom-experimental/static"),
+            );
+            precompiled(
+                "react-dom/static.edge",
+                format!("next/dist/compiled/react-dom-experimental/static.edge"),
+            );
+            precompiled(
+                "react-dom/static.browser",
+                format!("next/dist/compiled/react-dom-experimental/static.browser"),
             );
         }
         ClientContextType::App { app_dir } => {

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -93,44 +93,39 @@ pub async fn get_next_client_import_map(
                 ],
             );
 
-            let chunking_context = execution_context.chunking_context();
-            let alias_react = *chunking_context.environment().alias_react().await?;
-
             let ppr = *next_config.enable_ppr().await?;
             let taint = *next_config.enable_taint().await?;
             let react_channel = if ppr || taint { "-experimental" } else { "" };
 
-            if alias_react {
-                import_map.insert_exact_alias(
-                    "react",
-                    request_to_import_mapping(
-                        project_path,
-                        &format!("next/dist/compiled/react{react_channel}"),
-                    ),
-                );
-                import_map.insert_wildcard_alias(
-                    "react/",
-                    request_to_import_mapping(
-                        project_path,
-                        &format!("next/dist/compiled/react{react_channel}/*"),
-                    ),
-                );
+            import_map.insert_exact_alias(
+                "react",
+                request_to_import_mapping(
+                    project_path,
+                    &format!("next/dist/compiled/react{react_channel}"),
+                ),
+            );
+            import_map.insert_wildcard_alias(
+                "react/",
+                request_to_import_mapping(
+                    project_path,
+                    &format!("next/dist/compiled/react{react_channel}/*"),
+                ),
+            );
 
-                import_map.insert_exact_alias(
-                    "react-dom",
-                    request_to_import_mapping(
-                        project_path,
-                        &format!("next/dist/compiled/react-dom{react_channel}"),
-                    ),
-                );
-                import_map.insert_wildcard_alias(
-                    "react-dom/",
-                    request_to_import_mapping(
-                        project_path,
-                        &format!("next/dist/compiled/react-dom{react_channel}/*"),
-                    ),
-                );
-            }
+            import_map.insert_exact_alias(
+                "react-dom",
+                request_to_import_mapping(
+                    project_path,
+                    &format!("next/dist/compiled/react-dom{react_channel}"),
+                ),
+            );
+            import_map.insert_wildcard_alias(
+                "react-dom/",
+                request_to_import_mapping(
+                    project_path,
+                    &format!("next/dist/compiled/react-dom{react_channel}/*"),
+                ),
+            );
         }
         ClientContextType::App { app_dir } => {
             let react_flavor =

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -7,7 +7,6 @@ use turbopack_binding::{
     turbo::tasks_fs::{glob::Glob, FileSystem, FileSystemPath},
     turbopack::{
         core::{
-            chunk::ChunkingContext,
             reference_type::{CommonJsReferenceSubType, ReferenceType},
             resolve::{
                 options::{ConditionValue, ImportMap, ImportMapping, ResolveOptions, ResolvedMap},

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -96,50 +96,34 @@ pub async fn get_next_client_import_map(
             let taint = *next_config.enable_taint().await?;
             let react_channel = if ppr || taint { "-experimental" } else { "" };
 
-            let mut precompiled = |key, value: String| {
-                import_map.insert_exact_alias(key, request_to_import_mapping(project_path, &value));
-            };
+            import_map.insert_exact_alias(
+                "react",
+                request_to_import_mapping(
+                    project_path,
+                    &format!("next/dist/compiled/react{react_channel}"),
+                ),
+            );
+            import_map.insert_wildcard_alias(
+                "react/",
+                request_to_import_mapping(
+                    project_path,
+                    &format!("next/dist/compiled/react{react_channel}/*"),
+                ),
+            );
 
-            precompiled("react", format!("next/dist/compiled/react{react_channel}"));
-            precompiled(
-                "react/jsx-runtime",
-                format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
-            );
-            precompiled(
-                "react/jsx-dev-runtime",
-                format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
-            );
-            precompiled(
+            import_map.insert_exact_alias(
                 "react-dom",
-                format!("next/dist/compiled/react-dom{react_channel}"),
+                request_to_import_mapping(
+                    project_path,
+                    &format!("next/dist/compiled/react-dom{react_channel}"),
+                ),
             );
-            precompiled(
-                "react-dom/server",
-                format!("next/dist/compiled/react-dom{react_channel}/server"),
-            );
-            precompiled(
-                "react-dom/server.browser",
-                format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
-            );
-            precompiled(
-                "react-dom/server.edge",
-                format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
-            );
-            precompiled(
-                "react-dom/client",
-                format!("next/dist/compiled/react-dom{react_channel}/client"),
-            );
-            precompiled(
-                "react-dom/static",
-                format!("next/dist/compiled/react-dom-experimental/static"),
-            );
-            precompiled(
-                "react-dom/static.edge",
-                format!("next/dist/compiled/react-dom-experimental/static.edge"),
-            );
-            precompiled(
-                "react-dom/static.browser",
-                format!("next/dist/compiled/react-dom-experimental/static.browser"),
+            import_map.insert_wildcard_alias(
+                "react-dom/",
+                request_to_import_mapping(
+                    project_path,
+                    &format!("next/dist/compiled/react-dom{react_channel}/*"),
+                ),
             );
         }
         ClientContextType::App { app_dir } => {

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -827,8 +827,38 @@ async fn insert_next_shared_aliases(
     import_map.insert_singleton_alias("@swc/helpers", get_next_package(project_path));
     import_map.insert_singleton_alias("styled-jsx", get_next_package(project_path));
     import_map.insert_singleton_alias("next", project_path);
-    import_map.insert_singleton_alias("react", project_path);
-    import_map.insert_singleton_alias("react-dom", project_path);
+    // import_map.insert_singleton_alias("react", project_path);
+    // import_map.insert_singleton_alias("react-dom", project_path);
+
+    let ppr = *next_config.enable_ppr().await?;
+    let taint = *next_config.enable_taint().await?;
+    let react_channel = if ppr || taint { "-experimental" } else { "" };
+
+    let mut alias = indexmap! {
+        "react" => format!("next/dist/compiled/react{react_channel}"),
+        "react-dom" => format!("next/dist/compiled/react-dom{react_channel}"),
+        "react/jsx-runtime" => format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
+        "react/jsx-dev-runtime" => format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
+        "react-dom/client" => format!("next/dist/compiled/react-dom{react_channel}/client"),
+        "react-dom/static" => format!("next/dist/compiled/react-dom-experimental/static"),
+        "react-dom/static.edge" => format!("next/dist/compiled/react-dom-experimental/static.edge"),
+        "react-dom/static.browser" => format!("next/dist/compiled/react-dom-experimental/static.browser"),
+        "react-dom/server" => format!("next/dist/compiled/react-dom{react_channel}/server"),
+        "react-dom/server.edge" => format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
+        "react-dom/server.browser" => format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
+        "react-server-dom-webpack/client" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client"),
+        "react-server-dom-webpack/client.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+        "react-server-dom-webpack/server.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
+        "react-server-dom-webpack/server.node" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
+        "react-server-dom-turbopack/client" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client"),
+        "react-server-dom-turbopack/client.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+        "react-server-dom-turbopack/server.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
+        "react-server-dom-turbopack/server.node" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
+    };
+
+    for (key, value) in alias.iter_mut() {
+        import_map.insert_exact_alias(*key, request_to_import_mapping(project_path, value));
+    }
 
     //https://github.com/vercel/next.js/blob/f94d4f93e4802f951063cfa3351dd5a2325724b3/packages/next/src/build/webpack-config.ts#L1196
     import_map.insert_exact_alias(

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -195,7 +195,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.2",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240102.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e75429d8fdd4b8dbef69030f89dadd747c04a591",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.26.2
         version: 0.26.2
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240102.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240102.1(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e75429d8fdd4b8dbef69030f89dadd747c04a591
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e75429d8fdd4b8dbef69030f89dadd747c04a591(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -24678,9 +24678,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240102.1(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240102.1}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240102.1'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e75429d8fdd4b8dbef69030f89dadd747c04a591(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e75429d8fdd4b8dbef69030f89dadd747c04a591}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?e75429d8fdd4b8dbef69030f89dadd747c04a591'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

Apply important aliases like

 - `react` => `next/dist/compiled/react`
 - `react-dom/server` => `next/dist/compiled/react-dom-experimental/server`

correctly.

### Why?

We should already be using compiled versions.


I wrote down all debugging steps in the linear issue.

https://linear.app/vercel/issue/PACK-2149/[vercel-site]-turbopack-mistakes-some-client-components-for-server

### How?

Closes PACK-2149
Turbopack counterpart: https://github.com/vercel/turbo/pull/6846