### PR TITLE
fix(turbopack): prevent edge entrypoint from becoming an async module

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_edge/entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/entry.rs
@@ -18,12 +18,17 @@ pub async fn wrap_edge_entry(
     entry: Vc<Box<dyn Module>>,
     pathname: String,
 ) -> Result<Vc<Box<dyn Module>>> {
+    // The wrapped module could be an async module, we handle that with the proxy
+    // here. The comma expression makes sure we don't call the function with the
+    // module as the "this" arg.
     let source = formatdoc!(
         r#"
-            import * as module from "MODULE"
-
             self._ENTRIES ||= {{}}
-            self._ENTRIES[{}] = module
+            self._ENTRIES[{}] = new Proxy(Promise.resolve(require('MODULE')), {{
+              get(modProm, name) {{
+                return (...args) => modProm.then(mod => (0, mod[name])(...args))
+              }}
+            }})
         "#,
         StringifyJs(&format_args!("middleware_{}", pathname))
     );


### PR DESCRIPTION
### Why?

We can't await the entrypoint of the edge bundle, so it has to not be async.

Closes PACK-2171

