### PR TITLE
Ensure we validate revalidate configs properly

### DIFF
--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -54,6 +54,7 @@ import { isAppPageRoute } from '../lib/is-app-page-route'
 import isError from '../lib/is-error'
 import { needsExperimentalReact } from '../lib/needs-experimental-react'
 import { formatManifest } from '../build/manifests/formatter/format-manifest'
+import { validateRevalidate } from '../server/lib/patch-fetch'
 
 function divideSegments(number: number, segments: number): number[] {
   const result = []
@@ -741,7 +742,7 @@ export async function exportAppImpl(
       // Update path info by path.
       const info = collector.byPath.get(path) ?? {}
       if (typeof result.revalidate !== 'undefined') {
-        info.revalidate = result.revalidate
+        info.revalidate = validateRevalidate(result.revalidate, path)
       }
       if (typeof result.metadata !== 'undefined') {
         info.metadata = result.metadata

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -9,6 +9,7 @@ import type { CreateSegmentPath, AppRenderContext } from './app-render'
 import { createComponentStylesAndScripts } from './create-component-styles-and-scripts'
 import { getLayerAssets } from './get-layer-assets'
 import { hasLoadingComponentInTree } from './has-loading-component-in-tree'
+import { validateRevalidate } from '../lib/patch-fetch'
 
 type ComponentTree = {
   seedData: CacheNodeSeedData
@@ -187,6 +188,13 @@ export async function createComponentTree({
 
   if (typeof layoutOrPageMod?.fetchCache === 'string') {
     staticGenerationStore.fetchCache = layoutOrPageMod?.fetchCache
+  }
+
+  if (typeof layoutOrPageMod?.revalidate !== 'undefined') {
+    validateRevalidate(
+      layoutOrPageMod?.revalidate,
+      staticGenerationStore.urlPathname
+    )
   }
 
   if (typeof layoutOrPageMod?.revalidate === 'number') {

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -19,22 +19,34 @@ export function validateRevalidate(
   revalidateVal: unknown,
   pathname: string
 ): undefined | number | false {
-  let normalizedRevalidate: false | number | undefined = undefined
+  try {
+    let normalizedRevalidate: false | number | undefined = undefined
 
-  if (revalidateVal === false) {
-    normalizedRevalidate = revalidateVal
-  } else if (
-    typeof revalidateVal === 'number' &&
-    !isNaN(revalidateVal) &&
-    revalidateVal > -1
-  ) {
-    normalizedRevalidate = revalidateVal
-  } else if (typeof revalidateVal !== 'undefined') {
-    throw new Error(
-      `Invalid revalidate value "${revalidateVal}" on "${pathname}", must be a non-negative number or "false"`
-    )
+    if (revalidateVal === false) {
+      normalizedRevalidate = revalidateVal
+    } else if (
+      typeof revalidateVal === 'number' &&
+      !isNaN(revalidateVal) &&
+      revalidateVal > -1
+    ) {
+      normalizedRevalidate = revalidateVal
+    } else if (typeof revalidateVal !== 'undefined') {
+      throw new Error(
+        `Invalid revalidate value "${revalidateVal}" on "${pathname}", must be a non-negative number or "false"`
+      )
+    }
+    return normalizedRevalidate
+  } catch (err: any) {
+    // handle client component error from attempting to check revalidate value
+    if (
+      err &&
+      typeof err === 'object' &&
+      err.message?.includes('Invalid revalidate')
+    ) {
+      throw err
+    }
+    return undefined
   }
-  return normalizedRevalidate
 }
 
 export function validateTags(tags: any[], description: string) {

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -25,7 +25,7 @@ export function validateRevalidate(
     normalizedRevalidate = revalidateVal
   } else if (
     typeof revalidateVal === 'number' &&
-    !isNaN &&
+    !isNaN(revalidateVal) &&
     revalidateVal > -1
   ) {
     normalizedRevalidate = revalidateVal

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -402,8 +402,6 @@ export function patchFetch({
           cacheReason = `revalidate: ${revalidate}`
         }
 
-        validateRevalidate(revalidate, staticGenerationStore.urlPathname)
-
         if (
           // when force static is configured we don't bail from
           // `revalidate: 0` values

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -324,10 +324,10 @@ export function patchFetch({
           cacheReason = `cache: ${_cache}`
         }
 
-        if (typeof curRevalidate === 'number' || curRevalidate === false) {
-          revalidate = curRevalidate
-        }
-        validateRevalidate(curRevalidate, staticGenerationStore.urlPathname)
+        revalidate = validateRevalidate(
+          curRevalidate,
+          staticGenerationStore.urlPathname
+        )
 
         const _headers = getRequestMeta('headers')
         const initHeaders: Headers =

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -49,8 +49,7 @@ export function unstable_cache<T extends Callback>(
         // If revalidate was already set in the store before we should check if the new value is lower, set it to the lowest of the two.
       } else if (
         typeof store.revalidate === 'number' &&
-        typeof options.revalidate === 'number' &&
-        !isNaN(options.revalidate)
+        typeof options.revalidate === 'number'
       ) {
         if (store.revalidate > options.revalidate) {
           store.revalidate = options.revalidate

--- a/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
+++ b/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
@@ -8,7 +8,7 @@ createNextDescribe(
     skipStart: true,
     skipDeployment: true,
   },
-  ({ next }) => {
+  ({ next, isNextDev }) => {
     it('should error properly for invalid revalidate at layout', async () => {
       await next.stop().catch(() => {})
       const origText = await next.readFile('app/layout.tsx')
@@ -21,7 +21,7 @@ createNextDescribe(
         await next.start().catch(() => {})
 
         await check(async () => {
-          if ((global as any).isNextDev) {
+          if (isNextDev) {
             await next.fetch('/')
           }
           return next.cliOutput
@@ -43,7 +43,7 @@ createNextDescribe(
         await next.start().catch(() => {})
 
         await check(async () => {
-          if ((global as any).isNextDev) {
+          if (isNextDev) {
             await next.fetch('/')
           }
           return next.cliOutput
@@ -65,7 +65,7 @@ createNextDescribe(
         await next.start().catch(() => {})
 
         await check(async () => {
-          if ((global as any).isNextDev) {
+          if (isNextDev) {
             await next.fetch('/')
           }
           return next.cliOutput

--- a/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
+++ b/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
@@ -1,0 +1,78 @@
+import { createNextDescribe } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+createNextDescribe(
+  'app-invalid-revalidate',
+  {
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should error properly for invalid revalidate at layout', async () => {
+      await next.stop().catch(() => {})
+      const origText = await next.readFile('app/layout.tsx')
+
+      try {
+        await next.patchFile(
+          'app/layout.tsx',
+          origText.replace('// export', 'export')
+        )
+        await next.start().catch(() => {})
+
+        await check(async () => {
+          if ((global as any).isNextDev) {
+            await next.fetch('/')
+          }
+          return next.cliOutput
+        }, /Invalid revalidate value "1" on "\/", must be a non-negative number or "false"/)
+      } finally {
+        await next.patchFile('app/layout.tsx', origText)
+      }
+    })
+
+    it('should error properly for invalid revalidate at page', async () => {
+      await next.stop().catch(() => {})
+      const origText = await next.readFile('app/page.tsx')
+
+      try {
+        await next.patchFile(
+          'app/page.tsx',
+          origText.replace('// export', 'export')
+        )
+        await next.start().catch(() => {})
+
+        await check(async () => {
+          if ((global as any).isNextDev) {
+            await next.fetch('/')
+          }
+          return next.cliOutput
+        }, /Invalid revalidate value "1" on "\/", must be a non-negative number or "false"/)
+      } finally {
+        await next.patchFile('app/page.tsx', origText)
+      }
+    })
+
+    it('should error properly for invalid revalidate on fetch', async () => {
+      await next.stop().catch(() => {})
+      const origText = await next.readFile('app/page.tsx')
+
+      try {
+        await next.patchFile(
+          'app/page.tsx',
+          origText.replace('// await', 'await')
+        )
+        await next.start().catch(() => {})
+
+        await check(async () => {
+          if ((global as any).isNextDev) {
+            await next.fetch('/')
+          }
+          return next.cliOutput
+        }, /Invalid revalidate value "1" on "\/", must be a non-negative number or "false"/)
+      } finally {
+        await next.patchFile('app/page.tsx', origText)
+      }
+    })
+  }
+)

--- a/test/e2e/app-dir/app-invalid-revalidate/app/layout.tsx
+++ b/test/e2e/app-dir/app-invalid-revalidate/app/layout.tsx
@@ -1,0 +1,9 @@
+// export const revalidate = '1'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-invalid-revalidate/app/page.tsx
+++ b/test/e2e/app-dir/app-invalid-revalidate/app/page.tsx
@@ -1,0 +1,6 @@
+// export const revalidate = '1'
+
+export default async function Page() {
+  // await fetch('https://example.vercel.sh', { next: { revalidate: '1' } })
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/app-invalid-revalidate/next.config.js
+++ b/test/e2e/app-dir/app-invalid-revalidate/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/app-static/app/blog/[author]/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/blog/[author]/[slug]/page.js
@@ -1,7 +1,5 @@
 import { notFound } from 'next/navigation'
 
-export const revalidate = null
-
 export const dynamicParams = true
 
 export default function Page({ params }) {


### PR DESCRIPTION
If a user accidentally configures a non-valid `revalidate` value this ensures we show a proper error message instead of silently tolerating it. 

Closes: NEXT-1896

Closes NEXT-1915