### PR TITLE
Chore docs fix runon and definition of trailing slash redirect

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/11-middleware.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/11-middleware.mdx
@@ -361,7 +361,7 @@ export function middleware(req: NextRequest, event: NextFetchEvent) {
 
 In `v13.1` of Next.js two additional flags were introduced for middleware, `skipMiddlewareUrlNormalize` and `skipTrailingSlashRedirect` to handle advanced use cases.
 
-`skipTrailingSlashRedirect` allows disabling Next.js default redirects for adding or removing trailing slashes allowing custom handling inside middleware which can allow maintaining the trailing slash for some paths but not others allowing easier incremental migrations.
+`skipTrailingSlashRedirect` disables Next.js redirects for adding or removing trailing slashes. This allows custom handling inside middleware to maintain the trailing slash for some paths but not others, which can make incremental migrations easier.
 
 ```js filename="next.config.js"
 module.exports = {


### PR DESCRIPTION
Broke up a run-on sentence that's difficult to understand. Furthermore, the skipTrailingSlashRedirect as I understand it does not only disable "default redirects" as was stated. It disables slash redirecting altogether, whether the default behavior of removing them or the opposite behavior of keeping them when set by the trailingSlash flag. Thus, removed the word 'default'.