### PR TITLE
fix: 500 error when POSTing a multipart/form-data to a non-existent route

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "find-up": "4.1.0",
     "firebase": "7.14.5",
     "flat": "5.0.2",
+    "form-data": "4.0.0",
     "fs-extra": "9.0.0",
     "get-port": "5.1.1",
     "get-port-please": "3.1.1",

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -417,6 +417,11 @@ export async function handleAction({
             bound = await decodeReply(formData, serverModuleMap)
           } else {
             const action = await decodeAction(formData, serverModuleMap)
+            if (action === null) {
+              return {
+                type: 'not-found',
+              }
+            }
             const actionReturnedState = await action()
             formState = decodeFormState(actionReturnedState, formData)
 
@@ -495,6 +500,11 @@ export async function handleAction({
             })
             const formData = await fakeRequest.formData()
             const action = await decodeAction(formData, serverModuleMap)
+            if (action === null) {
+              return {
+                type: 'not-found',
+              }
+            }
             const actionReturnedState = await action()
             formState = await decodeFormState(actionReturnedState, formData)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,6 +284,9 @@ importers:
       flat:
         specifier: 5.0.2
         version: 5.0.2
+      form-data:
+        specifier: 4.0.0
+        version: 4.0.0
       fs-extra:
         specifier: 9.0.0
         version: 9.0.0

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -409,32 +409,48 @@ createNextDescribe(
       )
     })
 
-    it('should 404 when POSTing an invalid server action', async () => {
-      const res = await next.fetch('/non-existent-route', {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-        },
-        body: 'foo=bar',
+    describe('invalid server actions', () => {
+      it('should 404 when POSTing a x-www-form-urlencoded to a non-existent route', async () => {
+        const res = await next.fetch('/non-existent-route', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+          body: 'foo=bar',
+        })
+
+        expect(res.status).toBe(404)
       })
 
-      expect(res.status).toBe(404)
-    })
+      it('should 404 when POSTing a multipart/form-data to a non-existent route', async () => {
+        // `form-data` must be used with `node-fetch` otherwise the content-type won't be properly
+        // set as multipart/form-data
+        const FormData = require('form-data') as typeof import('form-data')
+        const data = new FormData()
+        data.append('foo', 'bar')
+        const res = await next.fetch('/non-existent-route', {
+          method: 'POST',
+          body: data,
+        })
 
-    it('should log a warning when a server action is not found but an id is provided', async () => {
-      await next.fetch('/server', {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-          'next-action': 'abc123',
-        },
-        body: 'foo=bar',
+        expect(res.status).toBe(404)
       })
 
-      await check(
-        () => next.cliOutput,
-        /Failed to find Server Action "abc123". This request might be from an older or newer deployment./
-      )
+      it('should log a warning when a server action is not found but an id is provided', async () => {
+        await next.fetch('/server', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+            'next-action': 'abc123',
+          },
+          body: 'foo=bar',
+        })
+
+        await check(
+          () => next.cliOutput,
+          /Failed to find Server Action "abc123". This request might be from an older or newer deployment./
+        )
+      })
     })
 
     if (isNextStart) {


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/59846

### What?

When a POST (`multipart/form-data`) is sent to a non-existent route, applications return a 500 error instead of a 404.

This can be reproduced by sending said request to any app,

Here is the log from my production app,

<img width="597" alt="Screenshot 2023-12-25 at 7 34 56 PM" src="https://github.com/vercel/next.js/assets/762112/d1bd2aae-0734-4881-9845-671d4dd673bc">

And this is the response from [Next.js Commerce app (ACME store)](https://demo.vercel.store/),

<img width="895" alt="Screenshot 2023-12-26 at 7 56 20 PM" src="https://github.com/vercel/next.js/assets/762112/367b0a46-e2b7-4b33-8b65-3ab41b3fe2dd">



### Why?

The problem seems to be in the `handleAction` function (`action-handler.ts`), when form data is sent `handleAction` flags it with `isMultipartAction`, which then tries to use `decodeAction` to eventually handle the action, the problem is that at that point there is no guarantee that the action exists and [React's `decodeAction` returns `null` ](https://github.com/facebook/react/blob/c5b9375767e2c4102d7e5559d383523736f1c902/packages/react-server/src/ReactFlightActionServer.js#L113-L115).

### How?

Validating that the action actually exists, and bailing out if it doesn't, solves the problem of the app breaking and the network request eventually becoming a 500 (returning the expected 404).

I noticed that this does NOT happen with `x-www-form-urlencoded` since `getActionModIdOrError` handles it, but for `multipart/form-data` relying on the logic already implemented by React's `decodeAction` seems to be the way to go, but I'm not 100% sure if it is the right approach. I'm also just returning `not-found`, similar to how `x-www-form-urlencoded` is handled, but I could log an error if needed.

Also, I added a test to cover this case, but I had to explicitly add the `form-data` lib since that's how `node-fetch` expects you to send a properly formed `multipart/form-data` (with the boundary).
