### PR TITLE
Add params prop for not-found page [have questions]

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -250,7 +250,7 @@ export async function createComponentTree({
               {layerAssets}
               <RootLayoutComponent>
                 {notFoundStyles}
-                <NotFoundComponent />
+                <NotFoundComponent params={currentParams} />
               </RootLayoutComponent>
             </>
           }
@@ -327,7 +327,9 @@ export async function createComponentTree({
         const parallelRoute = parallelRoutes[parallelRouteKey]
 
         const notFoundComponent =
-          NotFound && isChildrenRouteKey ? <NotFound /> : undefined
+          NotFound && isChildrenRouteKey ? (
+            <NotFound params={currentParams} />
+          ) : undefined
 
         // if we're prefetching and that there's a Loading component, we bail out
         // otherwise we keep rendering for the prefetch.
@@ -486,7 +488,7 @@ export async function createComponentTree({
             <meta name="next-error" content="not-found" />
           )}
           {notFoundStyles}
-          <NotFound />
+          <NotFound params={currentParams} />
         </>
       ),
     }


### PR DESCRIPTION
### Adding a feature

### What?

Passing parameters for not-found errors

### Why?

Dynamic 404 errors are needed. The most vivid example is a localized error within the [lang] directory (which is suggested in the next.js documentation for internationalization).

In any case, the 404 page in this directory should be localized (*for example, if a user from Germany stumbles upon a deleted post or FAQ*).

Currently, to achieve this, either all translations and data need to be passed to the client or the language needs to be determined from the headers (after adding it to the middleware), thus making the page dynamic.

### How?

I simply pass the parameters of the current segment to the NotFound component. It worked as expected during manual tests.

### Questions

Can you explain why this was not done initially?

If this solution is acceptable, I will write tests and finalize the pull request. Otherwise, please describe the cases, and I might be able to come up with a solution.

Fixes #43179