### PR TITLE
Fix typo in generate-sitemaps.mdx docs

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-sitemaps.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-sitemaps.mdx
@@ -45,7 +45,7 @@ export default async function sitemap({
     `SELECT id, date FROM products WHERE id BETWEEN ${start} AND ${end}`
   )
   return products.map((product) => ({
-    url: `${BASE_URL}/product/${id}`
+    url: `${BASE_URL}/product/${product.id}`
     lastModified: product.date,
   }))
 }


### PR DESCRIPTION
In the existing docs, the `id` was for the sitemap page (file)

<img width="704" alt="image" src="https://github.com/vercel/next.js/assets/60820021/c803a25a-2743-4a8f-bd57-900e32538a25">


But in the list of products for this sitemap file, we should use `product.id` (in a similar way to using `product.date` for lastModified)
