### PR TITLE
chore(cms-contentfu): fix contentful instructions

### DIFF
--- a/examples/cms-contentful/README.md
+++ b/examples/cms-contentful/README.md
@@ -73,7 +73,7 @@ This project includes a setup script which you can use to set up the content mod
 
 In your Contentful dashboard go to **Settings > General Settings** and copy the **Space ID**.
 
-Next, go to **Settings > API > Content management tokens** and create a new token by clicking **Generate personal token**. This token has the same access rights as the logged in user. **Do not share it publicly**, you will only use it to set up your space and can delete it afterwards.
+Next, go to **Settings > CMA tokens** and create a new token by clicking **Create personal access token**. This token has the same access rights as the logged in user. **Do not share it publicly**, you will only use it to set up your space and can delete it afterwards.
 
 With the space ID and management access token at hand run the following command:
 


### PR DESCRIPTION
### What?

Updating the contentful template readme.

### Why?

Contentful has updated the menu structure and it took me a while to find the refenced personal access token creation menu.


![image](https://github.com/vercel/next.js/assets/342688/31b728fb-819c-4c61-bc77-4f7633a10c43)

