### PR TITLE
Ensure NextBuildContext is only used during build

### DIFF
--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -28,7 +28,6 @@ import { traceGlobals } from '../../../trace/shared'
 import { EVENT_BUILD_FEATURE_USAGE } from '../../../telemetry/events'
 import { normalizeAppPath } from '../../../shared/lib/router/utils/app-paths'
 import { INSTRUMENTATION_HOOK_FILENAME } from '../../../lib/constants'
-import { NextBuildContext } from '../../build-context'
 
 const KNOWN_SAFE_DYNAMIC_PACKAGES =
   require('../../../lib/known-edge-safe-packages.json') as string[]
@@ -91,6 +90,7 @@ function isUsingIndirectEvalAndUsedByExports(args: {
 function getEntryFiles(
   entryFiles: string[],
   meta: EntryMetadata,
+  hasInstrumentationHook: boolean,
   opts: {
     sriEnabled: boolean
   }
@@ -124,7 +124,7 @@ function getEntryFiles(
     files.push(`server/${NEXT_FONT_MANIFEST}.js`)
   }
 
-  if (NextBuildContext!.hasInstrumentationHook) {
+  if (hasInstrumentationHook) {
     files.push(`server/edge-${INSTRUMENTATION_HOOK_FILENAME}.js`)
   }
 
@@ -156,6 +156,11 @@ function getCreateAssets(params: {
       functions: {},
       version: 2,
     }
+
+    const hasInstrumentationHook = compilation.entrypoints.has(
+      INSTRUMENTATION_HOOK_FILENAME
+    )
+
     for (const entrypoint of compilation.entrypoints.values()) {
       if (!entrypoint.name) {
         continue
@@ -188,7 +193,12 @@ function getCreateAssets(params: {
       ]
 
       const edgeFunctionDefinition: EdgeFunctionDefinition = {
-        files: getEntryFiles(entrypoint.getFiles(), metadata, opts),
+        files: getEntryFiles(
+          entrypoint.getFiles(),
+          metadata,
+          hasInstrumentationHook,
+          opts
+        ),
         name: entrypoint.name,
         page: page,
         matchers,

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -58,7 +58,6 @@ import { DevAppRouteRouteMatcherProvider } from '../future/route-matcher-provide
 import { NodeManifestLoader } from '../future/route-matcher-providers/helpers/manifest-loaders/node-manifest-loader'
 import { BatchedFileReader } from '../future/route-matcher-providers/dev/helpers/file-reader/batched-file-reader'
 import { DefaultFileReader } from '../future/route-matcher-providers/dev/helpers/file-reader/default-file-reader'
-import { NextBuildContext } from '../../build/build-context'
 import LRUCache from 'next/dist/compiled/lru-cache'
 import { getMiddlewareRouteMatcher } from '../../shared/lib/router/utils/middleware-route-matcher'
 import { DetachedPromise } from '../../lib/detached-promise'
@@ -580,8 +579,6 @@ export default class DevServer extends Server {
         .then(() => true)
         .catch(() => false))
     ) {
-      NextBuildContext!.hasInstrumentationHook = true
-
       try {
         const instrumentationHook = await require(pathJoin(
           this.distDir,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -89,7 +89,6 @@ import {
 } from '../../../shared/lib/constants'
 
 import { getMiddlewareRouteMatcher } from '../../../shared/lib/router/utils/middleware-route-matcher'
-import { NextBuildContext } from '../../../build/build-context'
 
 import {
   isMiddlewareFile,
@@ -1180,14 +1179,12 @@ async function startWatcher(opts: SetupOpts) {
             await loadMiddlewareManifest('instrumentation', 'instrumentation')
             await writeManifests()
 
-            NextBuildContext.hasInstrumentationHook = true
             serverFields.actualInstrumentationHookFile = '/instrumentation'
             await propagateServerField(
               'actualInstrumentationHookFile',
               serverFields.actualInstrumentationHookFile
             )
           } else {
-            NextBuildContext.hasInstrumentationHook = false
             serverFields.actualInstrumentationHookFile = undefined
             await propagateServerField(
               'actualInstrumentationHookFile',
@@ -1948,7 +1945,6 @@ async function startWatcher(opts: SetupOpts) {
           isInstrumentationHookFile(rootFile) &&
           nextConfig.experimental.instrumentationHook
         ) {
-          NextBuildContext.hasInstrumentationHook = true
           serverFields.actualInstrumentationHookFile = rootFile
           await propagateServerField(
             'actualInstrumentationHookFile',

--- a/test/e2e/instrumentation-hook/general/next.config.js
+++ b/test/e2e/instrumentation-hook/general/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
+++ b/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
@@ -10,11 +10,6 @@ const describeCase = (
     caseName,
     {
       files: path.join(__dirname, caseName),
-      nextConfig: {
-        experimental: {
-          instrumentationHook: true,
-        },
-      },
       skipDeployment: true,
     },
     callback

--- a/test/e2e/instrumentation-hook/with-async-edge-page/next.config.js
+++ b/test/e2e/instrumentation-hook/with-async-edge-page/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-hook/with-async-node-page/next.config.js
+++ b/test/e2e/instrumentation-hook/with-async-node-page/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-hook/with-edge-api/next.config.js
+++ b/test/e2e/instrumentation-hook/with-edge-api/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-hook/with-edge-page/next.config.js
+++ b/test/e2e/instrumentation-hook/with-edge-page/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-hook/with-esm-import/next.config.js
+++ b/test/e2e/instrumentation-hook/with-esm-import/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-hook/with-middleware/next.config.js
+++ b/test/e2e/instrumentation-hook/with-middleware/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-hook/with-node-api/next.config.js
+++ b/test/e2e/instrumentation-hook/with-node-api/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-hook/with-node-page/next.config.js
+++ b/test/e2e/instrumentation-hook/with-node-page/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}


### PR DESCRIPTION
## What?

While looking into some refactors for `next build` I noticed that `NextBuildContext` was used to propagate if instrumentation.js exists or not, however that information can be inferred by checking if the entrypoint exists in the compiler. Applied that change.

I've updated the test fixtures to include the `next.config.js` so that you can run them using `pnpm next`.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-1931