### PR TITLE
chore: add github bug report item type module resolution

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -90,6 +90,7 @@ body:
         - 'MDX (@next/mdx)'
         - 'Metadata (metadata, generateMetadata, next/head)'
         - 'Middleware / Edge (API routes, runtime)'
+        - 'Module resolution (CJS / ESM, module resolving)'
         - 'Operating System (Windows, MacOS, Linux)'
         - 'Package manager (npm, pnpm, Yarn)'
         - 'Routing (next/router, next/navigation, next/link)'


### PR DESCRIPTION
Add new bug report type of module resolution in GH yml config file

Closes NEXT-1946