### PR TITLE
Fix start build log being overwritten by logs from page

### DIFF
--- a/packages/next/src/build/build-context.ts
+++ b/packages/next/src/build/build-context.ts
@@ -1,5 +1,4 @@
 import type { LoadedEnvFiles } from '@next/env'
-import type { Ora } from 'next/dist/compiled/ora'
 import type { Rewrite, Redirect } from '../lib/load-custom-routes'
 import type { __ApiPreviewProps } from '../server/api-utils'
 import type { NextConfigComplete } from '../server/config-shared'
@@ -79,7 +78,6 @@ export const NextBuildContext: Partial<{
   // misc fields
   telemetry: Telemetry
   telemetryState: TelemetryPluginState
-  buildSpinner: Ora
   nextBuildSpan: Span
 
   // cli fields

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -518,11 +518,6 @@ export default async function build(
         eventName: EVENT_BUILD_FEATURE_USAGE,
         payload: buildLintEvent,
       })
-      let buildSpinner: ReturnType<typeof createSpinner> = {
-        stopAndPersist() {
-          return this
-        },
-      } as any
 
       const { envInfo, expFeatureInfo } = await getStartServerInfo(dir)
       logStartInfo({
@@ -531,12 +526,6 @@ export default async function build(
         envInfo,
         expFeatureInfo,
       })
-
-      if (!isGenerateMode) {
-        buildSpinner = createSpinner('Creating an optimized production build')
-      }
-
-      NextBuildContext.buildSpinner = buildSpinner
 
       const validFileMatcher = createValidFileMatcher(
         config.pageExtensions,
@@ -1115,6 +1104,8 @@ export default async function build(
         )
       }
 
+      Log.info('Creating an optimized production build ...')
+
       if (!isGenerateMode) {
         if (isCompileMode && useBuildWorker) {
           let durationInSeconds = 0
@@ -1156,7 +1147,6 @@ export default async function build(
             durationInSeconds += res.duration
           })
 
-          buildSpinner?.stopAndPersist()
           Log.event('Compiled successfully')
 
           telemetry.record(

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -327,7 +327,6 @@ export async function webpackBuildImpl(
       console.warn(result.warnings.filter(Boolean).join('\n\n'))
       console.warn()
     } else if (!compilerName) {
-      NextBuildContext.buildSpinner?.stopAndPersist()
       Log.event('Compiled successfully')
     }
 

--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -34,8 +34,7 @@ async function webpackBuildWithWorker(
   compilerNamesArg: typeof ORDERED_COMPILER_NAMES | null
 ) {
   const compilerNames = compilerNamesArg || ORDERED_COMPILER_NAMES
-  const { buildSpinner, nextBuildSpan, ...prunedBuildContext } =
-    NextBuildContext
+  const { nextBuildSpan, ...prunedBuildContext } = NextBuildContext
 
   prunedBuildContext.pluginState = pluginState
 
@@ -127,7 +126,6 @@ async function webpackBuildWithWorker(
   }
 
   if (compilerNames.length === 3) {
-    buildSpinner?.stopAndPersist()
     Log.event('Compiled successfully')
   }
 


### PR DESCRIPTION
The start line of build logging `Creating an optimized production build ...` was logged by spinner, and when all build is finished we stop that spinner. But the problem is all the logs from a page such as warnings will be also leaded by it since they interrupted the spinner.

We changed the spinner to a one-line log now that will make the warning logs more clear and let the page-level build logs print without messed with app-level build logs.

#### After

```
   ▲ Next.js 14.0.5-canary.34

   Creating an optimized production build ...
 ⚠ Next.js can't recognize the exported `runtime` field in "/Users/huozhi/workspace/next.js/test/e2e/app-dir/app-edge/app/expo
rt/inherit/page.tsx" as it was not assigned to a string literal.
The default runtime will be used instead.
 ⚠ Next.js can't recognize the exported `preferredRegion` field in "/Users/huozhi/workspace/next.js/test/e2e/app-dir/app-edge/
app/export/inherit/page.tsx" as it was not assigned to a string literal or an array of string literals.
The default runtime will be used instead.
```

#### Before

```
   ▲ Next.js 14.0.5-canary.34

   Creating an optimized production build  ... ⚠ Next.js can't recognize the exported `runtime` field in "/Users/huozhi/worksp
ace/next.js/test/e2e/app-dir/app-edge/app/export/inherit/page.tsx" as it was not assigned to a string literal.
The default runtime will be used instead.
 ⚠ Next.js can't recognize the exported `preferredRegion` field in "/Users/huozhi/workspace/next.js/test/e2e/app-dir/app-edge/
app/export/inherit/page.tsx" as it was not assigned to a string literal or an array of string literals.
The default runtime will be used instead.
   Creating an optimized production build  ... ⚠ Next.js can't recognize the exported `runtime` field in "/Users/huozhi/worksp
ace/next.js/test/e2e/app-dir/app-edge/app/export/inherit/page.tsx" as it was not assigned to a string literal.
The default runtime will be used instead.
 ⚠ Next.js can't recognize the exported `preferredRegion` field in "/Users/huozhi/workspace/next.js/test/e2e/app-dir/app-edge/
app/export/inherit/page.tsx" as it was not assigned to a string literal or an array of string literals.
The default runtime will be used instead.
```   

Closes NEXT-1939
Closes NEXT-1947