### PR TITLE
Updating the caching process

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -557,10 +557,7 @@ export class IncrementalCache implements IncrementalCacheType {
     if (this.dev && !ctx.fetchCache) return
     // fetchCache has upper limit of 2MB per-entry currently
     if (ctx.fetchCache && JSON.stringify(data).length > 2 * 1024 * 1024) {
-      if (this.dev) {
-        throw new Error(`fetch for over 2MB of data can not be cached`)
-      }
-      return
+      throw new Error(`fetch for over 2MB of data can not be cached`)
     }
 
     pathname = this._getPathname(pathname, ctx.fetchCache)

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -28,6 +28,7 @@ export interface CachedFetchValue {
     body: string
     url: string
     status?: number
+    archived?: boolean
   }
   // tags are only present with file-system-cache
   // fetch cache stores tags outside of cache entry


### PR DESCRIPTION
### Fixing a bug

### What?

In case of cache write errors, it will be impossible to retrieve up-to-date data until the cache can be written. However, requests for up-to-date data will continue to be made.

### Why?
Example:

We load a blog. All articles are loaded immediately. At some point, an additional batch of articles is added, but they are not displayed on the service. There are no errors, requests are being made, and the backend returns the correct data.

Why? The answer is that the data was initially 1.9MB and became over 2MB. Next.js (*for some reason*) did not display this error in production.

### How?

In case of cache write errors, I mark the last written cache as archived. The next request no longer immediately returns archived data, but goes for new data.

This solution is somewhat controversial as it violates the described logic of incrementality, but both the current option and the situation that has arisen are, in my opinion, a bug. That's why I started a discussion - #60129 .

Repository with the bug - https://github.com/vordgi/next-fetch-cache-bug

I will return to finalizing the solution and conducting tests based on the results of the discussion (*if it's needed at all*).