### PR TITLE
chore: include required Next.js stages to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -103,6 +103,16 @@ body:
         - 'TypeScript (plugin, built-in types)'
     validations:
       required: true
+  - type: dropdown
+    attributes:
+      label: Which stage(s) are affected? (Select all that apply)
+      multiple: true
+      options:
+        - 'next dev'
+        - 'next build'
+        - 'next start'
+    validations:
+      required: true
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -108,9 +108,11 @@ body:
       label: Which stage(s) are affected? (Select all that apply)
       multiple: true
       options:
-        - 'next dev'
-        - 'next build'
-        - 'next start'
+        - 'next dev (local)'
+        - 'next build (local)'
+        - 'next start (local)'
+        - 'Vercel (Deployed)'
+        - 'Other (Deployed)'
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
Include an additional requirement in the [Issue Template](https://github.com/vercel/next.js/blob/canary/.github/ISSUE_TEMPLATE/1.bug_report.yml) for adding information about which <picture data-single-emoji=":nextjs:" title=":nextjs:"><img class="emoji" width="20" height="auto" src="https://emoji.slack-edge.com/T0CAQ00TU/nextjs/2a85d633ae594556.png" alt=":nextjs:" align="absmiddle"></picture> stage (e.g, `next dev`, `next build`, & `next start`) is affected in an issue.

