### PR TITLE
chore: add myself to created-by: Next.js team

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -24,6 +24,7 @@
       { "type": "user", "pattern": "ijjk" },
       { "type": "user", "pattern": "javivelasco" },
       { "type": "user", "pattern": "kikobeats" },
+      { "type": "user", "pattern": "samcx" },
       { "type": "user", "pattern": "schniz" },
       { "type": "user", "pattern": "sebmarkbage" },
       { "type": "user", "pattern": "shuding" },


### PR DESCRIPTION
Quick <picture data-single-emoji=":pr:" title=":pr:"><img class="emoji" width="20" height="auto" src="https://emoji.slack-edge.com/T0CAQ00TU/pr/876af7e7d65e1595.png" alt=":pr:" align="absmiddle"></picture> so the `created-by: Next.js team` label automatically gets added to my <picture data-single-emoji=":pr:" title=":pr:"><img class="emoji" width="20" height="auto" src="https://emoji.slack-edge.com/T0CAQ00TU/pr/876af7e7d65e1595.png" alt=":pr:" align="absmiddle"></picture>s.