### PR TITLE
examples: improve typings for i18n app dir

### DIFF
--- a/examples/app-dir-i18n-routing/app/[lang]/components/counter.tsx
+++ b/examples/app-dir-i18n-routing/app/[lang]/components/counter.tsx
@@ -1,14 +1,12 @@
 'use client'
 
 import { useState } from 'react'
+import { type getDictionary } from '../../../get-dictionary'
 
 export default function Counter({
   dictionary,
 }: {
-  dictionary: {
-    increment: string
-    decrement: string
-  }
+  dictionary: Awaited<ReturnType<typeof getDictionary>>['counter']
 }) {
   const [count, setCount] = useState(0)
   return (

--- a/examples/app-dir-i18n-routing/app/[lang]/components/locale-switcher.tsx
+++ b/examples/app-dir-i18n-routing/app/[lang]/components/locale-switcher.tsx
@@ -2,11 +2,11 @@
 
 import { usePathname } from 'next/navigation'
 import Link from 'next/link'
-import { i18n } from '../../../i18n-config'
+import { i18n, type Locale } from '../../../i18n-config'
 
 export default function LocaleSwitcher() {
   const pathName = usePathname()
-  const redirectedPathName = (locale: string) => {
+  const redirectedPathName = (locale: Locale) => {
     if (!pathName) return '/'
     const segments = pathName.split('/')
     segments[1] = locale

--- a/examples/app-dir-i18n-routing/app/[lang]/layout.tsx
+++ b/examples/app-dir-i18n-routing/app/[lang]/layout.tsx
@@ -1,4 +1,4 @@
-import { i18n } from '../../i18n-config'
+import { i18n, type Locale } from '../../i18n-config'
 
 export async function generateStaticParams() {
   return i18n.locales.map((locale) => ({ lang: locale }))
@@ -9,7 +9,7 @@ export default function Root({
   params,
 }: {
   children: React.ReactNode
-  params: { lang: string }
+  params: { lang: Locale }
 }) {
   return (
     <html lang={params.lang}>


### PR DESCRIPTION
Adds some minor types changes for the `app-dir-i18n-routing` example. It basically adds more type safety and avoid creating types for the dictionary contents when creating a new client React component by extracting the types from the `getDictionary` function instead of writing it by hand.