### PR TITLE
Change server actions cache default to no-store

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -299,6 +299,9 @@ export async function handleAction({
     )
   }
 
+  // When running actions the default is no-store, you can still `cache: 'force-cache'`
+  staticGenerationStore.fetchCache = 'default-no-store'
+
   const originDomain =
     typeof req.headers['origin'] === 'string'
       ? new URL(req.headers['origin']).host

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1115,27 +1115,76 @@ createNextDescribe(
       })
     })
 
-    it('should use no-store as default for server action', async () => {
-      const browser = await next.browser('/no-caching-in-actions')
-      await browser
-        .waitForElementByCss('#trigger-fetch')
-        .click()
-        .waitForElementByCss('#fetched-data')
+    describe('caching disabled by default', () => {
+      it('should use no-store as default for server action', async () => {
+        const browser = await next.browser('/no-caching-in-actions')
+        await browser
+          .waitForElementByCss('#trigger-fetch')
+          .click()
+          .waitForElementByCss('#fetched-data')
 
-      const getNumber = async () =>
-        JSON.parse(await browser.elementByCss('#fetched-data').text())
+        const getNumber = async () =>
+          JSON.parse(await browser.elementByCss('#fetched-data').text())
 
-      const firstNumber = await getNumber()
+        const firstNumber = await getNumber()
 
-      await browser.waitForElementByCss('#trigger-fetch').click()
+        await browser.waitForElementByCss('#trigger-fetch').click()
 
-      await check(async () => {
-        const newNumber = await getNumber()
-        // Expect that the number changes on each click
-        expect(newNumber).not.toBe(firstNumber)
+        await check(async () => {
+          const newNumber = await getNumber()
+          // Expect that the number changes on each click
+          expect(newNumber).not.toBe(firstNumber)
 
-        return 'success'
-      }, 'success')
+          return 'success'
+        }, 'success')
+      })
+
+      it('should not override force-cache in server action', async () => {
+        const browser = await next.browser('/no-caching-in-actions/force-cache')
+        await browser
+          .waitForElementByCss('#trigger-fetch')
+          .click()
+          .waitForElementByCss('#fetched-data')
+
+        const getNumber = async () =>
+          JSON.parse(await browser.elementByCss('#fetched-data').text())
+
+        const firstNumber = await getNumber()
+
+        await browser.waitForElementByCss('#trigger-fetch').click()
+
+        await check(async () => {
+          const newNumber = await getNumber()
+          // Expect that the number changes on each click
+          expect(newNumber).toBe(firstNumber)
+
+          return 'success'
+        }, 'success')
+      })
+
+      // Implicit force-cache
+      it('should not override revalidate in server action', async () => {
+        const browser = await next.browser('/no-caching-in-actions/revalidate')
+        await browser
+          .waitForElementByCss('#trigger-fetch')
+          .click()
+          .waitForElementByCss('#fetched-data')
+
+        const getNumber = async () =>
+          JSON.parse(await browser.elementByCss('#fetched-data').text())
+
+        const firstNumber = await getNumber()
+
+        await browser.waitForElementByCss('#trigger-fetch').click()
+
+        await check(async () => {
+          const newNumber = await getNumber()
+          // Expect that the number changes on each click
+          expect(newNumber).toBe(firstNumber)
+
+          return 'success'
+        }, 'success')
+      })
     })
   }
 )

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1155,7 +1155,7 @@ createNextDescribe(
 
         await check(async () => {
           const newNumber = await getNumber()
-          // Expect that the number changes on each click
+          // Expect that the number is the same on each click
           expect(newNumber).toBe(firstNumber)
 
           return 'success'

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1179,7 +1179,7 @@ createNextDescribe(
 
         await check(async () => {
           const newNumber = await getNumber()
-          // Expect that the number changes on each click
+          // Expect that the number is the same on each click
           expect(newNumber).toBe(firstNumber)
 
           return 'success'

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1114,5 +1114,28 @@ createNextDescribe(
         })
       })
     })
+
+    it('should use no-store as default for server action', async () => {
+      const browser = await next.browser('/no-caching-in-actions')
+      await browser
+        .waitForElementByCss('#trigger-fetch')
+        .click()
+        .waitForElementByCss('#fetched-data')
+
+      const getNumber = async () =>
+        JSON.parse(await browser.elementByCss('#fetched-data').text())
+
+      const firstNumber = await getNumber()
+
+      await browser.waitForElementByCss('#trigger-fetch').click()
+
+      await check(async () => {
+        const newNumber = await getNumber()
+        // Expect that the number changes on each click
+        expect(newNumber).not.toBe(firstNumber)
+
+        return 'success'
+      }, 'success')
+    })
   }
 )

--- a/test/e2e/app-dir/actions/app/no-caching-in-actions/actions.js
+++ b/test/e2e/app-dir/actions/app/no-caching-in-actions/actions.js
@@ -1,0 +1,9 @@
+'use server'
+
+export async function getNumber() {
+  const res = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?no-caching-actions'
+  )
+
+  return res.text()
+}

--- a/test/e2e/app-dir/actions/app/no-caching-in-actions/force-cache/actions.js
+++ b/test/e2e/app-dir/actions/app/no-caching-in-actions/force-cache/actions.js
@@ -1,0 +1,12 @@
+'use server'
+
+export async function getNumber() {
+  const res = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?no-caching-actions',
+    {
+      cache: 'force-cache',
+    }
+  )
+
+  return res.text()
+}

--- a/test/e2e/app-dir/actions/app/no-caching-in-actions/force-cache/page.js
+++ b/test/e2e/app-dir/actions/app/no-caching-in-actions/force-cache/page.js
@@ -1,0 +1,27 @@
+'use client'
+import { useState, useTransition } from 'react'
+import { getNumber } from './actions'
+
+export default function Page() {
+  const [isPending, startTransition] = useTransition()
+  const [result, setResult] = useState(null)
+  return (
+    <>
+      <h1>No Caching in Actions: {isPending ? 'pending' : 'not pending'}</h1>
+      {result !== null ? (
+        <pre id="fetched-data">{JSON.stringify(result)}</pre>
+      ) : null}
+      <button
+        id="trigger-fetch"
+        onClick={() =>
+          startTransition(async () => {
+            const result = await getNumber()
+            setResult(result)
+          })
+        }
+      >
+        Trigger fetch
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions/app/no-caching-in-actions/page.js
+++ b/test/e2e/app-dir/actions/app/no-caching-in-actions/page.js
@@ -1,0 +1,27 @@
+'use client'
+import { useState, useTransition } from 'react'
+import { getNumber } from './actions'
+
+export default function Page() {
+  const [isPending, startTransition] = useTransition()
+  const [result, setResult] = useState(null)
+  return (
+    <>
+      <h1>No Caching in Actions: {isPending ? 'pending' : 'not pending'}</h1>
+      {result !== null ? (
+        <pre id="fetched-data">{JSON.stringify(result)}</pre>
+      ) : null}
+      <button
+        id="trigger-fetch"
+        onClick={() =>
+          startTransition(async () => {
+            const result = await getNumber()
+            setResult(result)
+          })
+        }
+      >
+        Trigger fetch
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions/app/no-caching-in-actions/revalidate/actions.js
+++ b/test/e2e/app-dir/actions/app/no-caching-in-actions/revalidate/actions.js
@@ -1,0 +1,14 @@
+'use server'
+
+export async function getNumber() {
+  const res = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?no-caching-actions',
+    {
+      next: {
+        revalidate: 100,
+      },
+    }
+  )
+
+  return res.text()
+}

--- a/test/e2e/app-dir/actions/app/no-caching-in-actions/revalidate/page.js
+++ b/test/e2e/app-dir/actions/app/no-caching-in-actions/revalidate/page.js
@@ -1,0 +1,27 @@
+'use client'
+import { useState, useTransition } from 'react'
+import { getNumber } from './actions'
+
+export default function Page() {
+  const [isPending, startTransition] = useTransition()
+  const [result, setResult] = useState(null)
+  return (
+    <>
+      <h1>No Caching in Actions: {isPending ? 'pending' : 'not pending'}</h1>
+      {result !== null ? (
+        <pre id="fetched-data">{JSON.stringify(result)}</pre>
+      ) : null}
+      <button
+        id="trigger-fetch"
+        onClick={() =>
+          startTransition(async () => {
+            const result = await getNumber()
+            setResult(result)
+          })
+        }
+      >
+        Trigger fetch
+      </button>
+    </>
+  )
+}


### PR DESCRIPTION
## What?


Currently there is a bug in Server Actions when you `fetch` as it uses the same defaults (caching when not specified) as rendering, this causes some issues as you want to read your writes in Server Actions.

This change adds the `no-store` default for Server Actions, you can still override it by specifying `cache: 'force-cache'` for example, but it defaults to `cache: 'no-store'`.

Fixes NEXT-1926

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
