### PR TITLE
log a dev warning when a missing parallel slot results in a 404

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -31,6 +31,7 @@ import {
 import { getFilesInDir } from '../../../lib/get-files-in-dir'
 import { normalizeAppPath } from '../../../shared/lib/router/utils/app-paths'
 import type { PageExtensions } from '../../page-extensions-type'
+import { PARALLEL_ROUTE_DEFAULT_PATH } from '../../../client/components/parallel-route-default'
 
 export type AppLoaderOptions = {
   name: string
@@ -424,8 +425,6 @@ async function createTreeCodeFromPath(
       if (!props[normalizeParallelKey(adjacentParallelSegment)]) {
         const actualSegment =
           adjacentParallelSegment === 'children' ? '' : adjacentParallelSegment
-        const fallbackDefault =
-          'next/dist/client/components/parallel-route-default'
         let defaultPath = await resolver(
           `${appDirPrefix}${segmentPath}/${actualSegment}/default`
         )
@@ -440,7 +439,7 @@ async function createTreeCodeFromPath(
           )
 
           // if a default is found, use that. Otherwise use the fallback, which will trigger a `notFound()`
-          defaultPath = normalizedDefault ?? fallbackDefault
+          defaultPath = normalizedDefault ?? PARALLEL_ROUTE_DEFAULT_PATH
         }
 
         props[normalizeParallelKey(adjacentParallelSegment)] = `[

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -14,6 +14,7 @@ import {
   AppRouterContext,
   LayoutRouterContext,
   GlobalLayoutRouterContext,
+  MissingSlotContext,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import type {
   CacheNode,
@@ -104,6 +105,7 @@ type AppRouterProps = Omit<
   buildId: string
   initialHead: ReactNode
   assetPrefix: string
+  missingSlots: Set<string>
 }
 
 function isExternalURL(url: URL) {
@@ -266,6 +268,7 @@ function Router({
   initialCanonicalUrl,
   initialSeedData,
   assetPrefix,
+  missingSlots,
 }: AppRouterProps) {
   const initialState = useMemo(
     () =>
@@ -598,7 +601,13 @@ function Router({
     if (typeof window !== 'undefined') {
       const DevRootNotFoundBoundary: typeof import('./dev-root-not-found-boundary').DevRootNotFoundBoundary =
         require('./dev-root-not-found-boundary').DevRootNotFoundBoundary
-      content = <DevRootNotFoundBoundary>{content}</DevRootNotFoundBoundary>
+      content = (
+        <DevRootNotFoundBoundary>
+          <MissingSlotContext.Provider value={missingSlots}>
+            {content}
+          </MissingSlotContext.Provider>
+        </DevRootNotFoundBoundary>
+      )
     }
     const HotReloader: typeof import('./react-dev-overlay/hot-reloader-client').default =
       require('./react-dev-overlay/hot-reloader-client').default

--- a/packages/next/src/client/components/parallel-route-default.tsx
+++ b/packages/next/src/client/components/parallel-route-default.tsx
@@ -1,5 +1,8 @@
 import { notFound } from './not-found'
 
-export default function NoopParallelRouteDefault() {
+export const PARALLEL_ROUTE_DEFAULT_PATH =
+  'next/dist/client/components/parallel-route-default'
+
+export default function ParallelRouteDefault() {
   notFound()
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -352,6 +352,7 @@ async function ReactServerApp({
   const injectedCSS = new Set<string>()
   const injectedJS = new Set<string>()
   const injectedFontPreloadTags = new Set<string>()
+  const missingSlots = new Set<string>()
   const {
     getDynamicParamFromSegment,
     query,
@@ -387,6 +388,7 @@ async function ReactServerApp({
     rootLayoutIncluded: false,
     asNotFound: asNotFound,
     metadataOutlet: <MetadataOutlet />,
+    missingSlots,
   })
 
   return (
@@ -410,6 +412,9 @@ async function ReactServerApp({
           </>
         }
         globalErrorComponent={GlobalError}
+        // This is used to provide debug information (when in development mode)
+        // about which slots were not filled by page components while creating the component tree.
+        missingSlots={missingSlots}
       />
     </>
   )
@@ -485,6 +490,7 @@ async function ReactServerError({
       initialHead={head}
       globalErrorComponent={GlobalError}
       initialSeedData={initialSeedData}
+      missingSlots={new Set()}
     />
   )
 }

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -34,6 +34,8 @@ export function createErrorHandler({
   return (err) => {
     if (allCapturedErrors) allCapturedErrors.push(err)
 
+    // These errors are expected. We return the digest
+    // so that they can be properly handled.
     if (isDynamicUsageError(err)) {
       return err.digest
     }

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -161,3 +161,5 @@ if (process.env.NODE_ENV !== 'production') {
   GlobalLayoutRouterContext.displayName = 'GlobalLayoutRouterContext'
   TemplateContext.displayName = 'TemplateContext'
 }
+
+export const MissingSlotContext = React.createContext<Set<string>>(new Set())

--- a/test/e2e/app-dir/parallel-route-not-found/app/@bar/has-both-slots/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/@bar/has-both-slots/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>@bar slot</div>
+}

--- a/test/e2e/app-dir/parallel-route-not-found/app/@bar/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/@bar/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>@bar slot</div>
+}

--- a/test/e2e/app-dir/parallel-route-not-found/app/@foo/has-both-slots/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/@foo/has-both-slots/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>@foo slot</div>
+}

--- a/test/e2e/app-dir/parallel-route-not-found/app/@foo/no-bar-slot/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/@foo/no-bar-slot/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>@foo slot</div>
+}

--- a/test/e2e/app-dir/parallel-route-not-found/app/@foo/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/@foo/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>@foo slot</div>
+}

--- a/test/e2e/app-dir/parallel-route-not-found/app/both-slots-missing/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/both-slots-missing/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Both Slots Missing</div>
+}

--- a/test/e2e/app-dir/parallel-route-not-found/app/has-both-slots/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/has-both-slots/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Has Both Slots</div>
+}

--- a/test/e2e/app-dir/parallel-route-not-found/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/layout.tsx
@@ -1,0 +1,15 @@
+export default function Layout(props: {
+  children: React.ReactNode
+  foo: React.ReactNode
+  bar: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <div id="children">{props.children}</div>
+        {props.foo}
+        {props.bar}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-route-not-found/app/no-bar-slot/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/no-bar-slot/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>No @bar Slot</div>
+}

--- a/test/e2e/app-dir/parallel-route-not-found/app/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/nested">To /nested</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-route-not-found/parallel-route-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-route-not-found/parallel-route-not-found.test.ts
@@ -1,0 +1,73 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'parallel-route-not-found',
+  {
+    files: __dirname,
+  },
+  ({ next, isNextDev }) => {
+    it('should handle a layout that attempts to render a missing parallel route', async () => {
+      const browser = await next.browser('/no-bar-slot')
+      const logs = await browser.log()
+      expect(await browser.elementByCss('body').text()).toContain(
+        'This page could not be found'
+      )
+      const warnings = logs.filter((log) => log.source === 'warning')
+      if (isNextDev) {
+        expect(warnings.length).toBe(1)
+        expect(warnings[0].message).toContain(
+          'No default component was found for a parallel route rendered on this page'
+        )
+        expect(warnings[0].message).toContain('Missing slots: @bar')
+      } else {
+        expect(warnings.length).toBe(0)
+      }
+    })
+
+    it('should handle multiple missing parallel routes', async () => {
+      const browser = await next.browser('/both-slots-missing')
+      const logs = await browser.log()
+
+      expect(await browser.elementByCss('body').text()).toContain(
+        'This page could not be found'
+      )
+
+      const warnings = logs.filter((log) => log.source === 'warning')
+      if (isNextDev) {
+        expect(warnings.length).toBe(1)
+        expect(warnings[0].message).toContain(
+          'No default component was found for a parallel route rendered on this page'
+        )
+        expect(warnings[0].message).toContain('Missing slots: @bar, @foo')
+      } else {
+        expect(warnings.length).toBe(0)
+      }
+    })
+
+    it('should render the page & slots if all parallel routes are found', async () => {
+      const browser = await next.browser('/has-both-slots')
+      const logs = await browser.log()
+
+      expect(await browser.elementByCss('body').text()).toContain(
+        'Has Both Slots'
+      )
+      expect(await browser.elementByCss('body').text()).toContain('@foo slot')
+      expect(await browser.elementByCss('body').text()).toContain('@bar slot')
+
+      const warnings = logs.filter((log) => log.source === 'warning')
+      expect(warnings.length).toBe(0)
+    })
+
+    if (isNextDev) {
+      it('should not log any warnings for a regular not found page', async () => {
+        const browser = await next.browser('/this-page-doesnt-exist')
+        const logs = await browser.log()
+        expect(await browser.elementByCss('body').text()).toContain(
+          'This page could not be found'
+        )
+        const warnings = logs.filter((log) => log.source === 'warning')
+        expect(warnings.length).toBe(0)
+      })
+    }
+  }
+)


### PR DESCRIPTION
### What & Why?
When visiting a route that attempts to render a slot with no page & no default, the fallback behavior is to trigger a 404. However this can lead to a confusing development experience for complex parallel routing cases as you might not realize a default is missing, or which slot is causing the error.

Previous issues where this caused confusion:
- https://github.com/vercel/next.js/issues/51805
- https://github.com/vercel/next.js/issues/49569


### How?
This is a dev-only modification to track parallel slots that are using the default fallback (aka missing). When the `NotFoundBoundary` is triggered in development mode, this will log a warning about why it 404ed, along with a list of slot(s) that were determined to be missing.

![CleanShot 2024-01-03 at 14 34 30@2x](https://github.com/vercel/next.js/assets/1939140/1a00ea49-24b6-4ba0-9bac-8773c7e10a75)

### Future
We should eventually lift this into some sort of dev-only UI to help catch it when not monitoring the browser console (similar to the error overlay). However, this will require some design thought and isn't necessary for the first iteration.

Closes NEXT-1798
