### PR TITLE
docs: Fix typo on generate-sitemaps.mdx

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-sitemaps.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-sitemaps.mdx
@@ -9,7 +9,7 @@ related:
     - app/api-reference/file-conventions/metadata/sitemap
 ---
 
-You can use the `generateSiteMaps` function to generate multiple sitemaps for your application.
+You can use the `generateSitemaps` function to generate multiple sitemaps for your application.
 
 ## Returns
 


### PR DESCRIPTION
### Improving Documentation
Fix typo for the function `generateSitemaps`. 

It had incorrect casing: `generateSiteMaps` in the docs page.