### PR TITLE
Add ppr test for using redirect functions on PPR

### DIFF
--- a/test/production/app-dir/ppr-root-redirections/app/layout.tsx
+++ b/test/production/app-dir/ppr-root-redirections/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/ppr-root-redirections/app/page.tsx
+++ b/test/production/app-dir/ppr-root-redirections/app/page.tsx
@@ -1,0 +1,24 @@
+import { cookies } from 'next/headers'
+import { notFound } from 'next/navigation'
+import { Suspense } from 'react'
+
+function NameLogger() {
+  return <span>{cookies().get('my-name-is')?.value ?? 'what'}</span>
+}
+
+function NothingHere() {
+  notFound()
+
+  return <span>nothing here</span>
+}
+
+export default async function Page() {
+  return (
+    <>
+      <Suspense fallback={<span>Loading...</span>}>
+        <NameLogger />
+      </Suspense>
+      <NothingHere />
+    </>
+  )
+}

--- a/test/production/app-dir/ppr-root-redirections/next.config.js
+++ b/test/production/app-dir/ppr-root-redirections/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/ppr-root-redirections/ppr-root-redirections.test.ts
+++ b/test/production/app-dir/ppr-root-redirections/ppr-root-redirections.test.ts
@@ -1,0 +1,13 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'ppr-root-redirections',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should not bail out', async () => {
+      expect(next.cliOutput).not.toContain('bail out')
+    })
+  }
+)


### PR DESCRIPTION
Using a redirect function (or any Next.js function that throws an error) fails if used outside a Suspense Boundary when ppr is enabled