### PR TITLE
fix: Mark file as ESM if it has an export from `auto-cjs` pass

### DIFF
--- a/packages/next-swc/crates/core/src/auto_cjs/mod.rs
+++ b/packages/next-swc/crates/core/src/auto_cjs/mod.rs
@@ -6,12 +6,13 @@ use turbopack_binding::swc::core::ecma::{
 pub(crate) fn contains_cjs(m: &Module) -> bool {
     let mut v = CjsFinder::default();
     m.visit_with(&mut v);
-    v.found
+    v.found && !v.is_esm
 }
 
 #[derive(Copy, Clone, Default)]
 struct CjsFinder {
     found: bool,
+    is_esm: bool,
 }
 
 impl CjsFinder {
@@ -113,5 +114,9 @@ impl Visit for CjsFinder {
         }
 
         n.visit_children_with(self);
+    }
+
+    fn visit_mut_module_decl(&mut self, _: &mut ModuleDecl) {
+        self.is_esm = true;
     }
 }

--- a/packages/next-swc/crates/core/src/auto_cjs/mod.rs
+++ b/packages/next-swc/crates/core/src/auto_cjs/mod.rs
@@ -116,7 +116,12 @@ impl Visit for CjsFinder {
         n.visit_children_with(self);
     }
 
-    fn visit_module_decl(&mut self, _: &ModuleDecl) {
-        self.is_esm = true;
+    fn visit_module_decl(&mut self, n: &ModuleDecl) {
+        match n {
+            ModuleDecl::Import(_) => {}
+            _ => {
+                self.is_esm = true;
+            }
+        }
     }
 }

--- a/packages/next-swc/crates/core/src/auto_cjs/mod.rs
+++ b/packages/next-swc/crates/core/src/auto_cjs/mod.rs
@@ -116,7 +116,7 @@ impl Visit for CjsFinder {
         n.visit_children_with(self);
     }
 
-    fn visit_mut_module_decl(&mut self, _: &mut ModuleDecl) {
+    fn visit_module_decl(&mut self, _: &ModuleDecl) {
         self.is_esm = true;
     }
 }

--- a/packages/next-swc/crates/core/tests/loader/auto-cjs/2/output.js
+++ b/packages/next-swc/crates/core/tests/loader/auto-cjs/2/output.js
@@ -1,14 +1,4 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
-Object.defineProperty(exports, "default", {
-    enumerable: true,
-    get: function() {
-        return _default;
-    }
-});
-var _default = 1;
+export default 1;
 Object.defineProperty(exports, "__esModule", {
     value: true
 });

--- a/packages/next-swc/crates/core/tests/loader/auto-cjs/issue-60197/input.js
+++ b/packages/next-swc/crates/core/tests/loader/auto-cjs/issue-60197/input.js
@@ -1,13 +1,16 @@
-var module = {};
+var module = {}
 
-(function main(global, module) {
-  module.exports = function() {}
+;(function main(global, module) {
+  module.exports = function () {}
 
   module.exports.create = () => {}
-}((function () {
-  return this || {};
-})(), module, false));
+})(
+  (function () {
+    return this || {}
+  })(),
+  module,
+  false
+)
 
-
-export default module.exports;
-export var create = module.exports.create;
+export default module.exports
+export var create = module.exports.create

--- a/packages/next-swc/crates/core/tests/loader/auto-cjs/issue-60197/input.js
+++ b/packages/next-swc/crates/core/tests/loader/auto-cjs/issue-60197/input.js
@@ -1,0 +1,13 @@
+var module = {};
+
+(function main(global, module) {
+  module.exports = function() {}
+
+  module.exports.create = () => {}
+}((function () {
+  return this || {};
+})(), module, false));
+
+
+export default module.exports;
+export var create = module.exports.create;

--- a/packages/next-swc/crates/core/tests/loader/auto-cjs/issue-60197/output.js
+++ b/packages/next-swc/crates/core/tests/loader/auto-cjs/issue-60197/output.js
@@ -1,0 +1,9 @@
+var module = {};
+(function main(global, module) {
+    module.exports = function() {};
+    module.exports.create = function() {};
+})(function() {
+    return this || {};
+}(), module, false);
+export default module.exports;
+export var create = module.exports.create;


### PR DESCRIPTION
### What?

Improve `auto-cjs` pass to consider `export` statements.

### Why?

The previous code caused some problems.

### How?

Fixes #60197


Closes PACK-2195