### PR TITLE
(WIP) DX: Filter out Nextjs internal error trace frames

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/CallStackFrame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/CallStackFrame.tsx
@@ -7,13 +7,14 @@ import {
 import { useOpenInEditor } from '../../helpers/use-open-in-editor'
 
 const frameworkInternalRegex = /[\\/]next[\\/]dist[\\/]/
-const reactNodeModulesRegex = /[\\/]node_modules[\\/]react(-dom)?[\\/]/
+const nodeModulesRegex = /node_modules[\\/]/
 
-export function isNextInternalStackFrame(frame: StackFrame): boolean {
+export function isUserCode(frame: StackFrame) {
+  // Is not either next.js internal or from node_modules
   return !!(
     frame.file &&
-    (frameworkInternalRegex.test(frame.file) ||
-      reactNodeModulesRegex.test(frame.file))
+    !frameworkInternalRegex.test(frame.file) &&
+    !nodeModulesRegex.test(frame.file)
   )
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/CallStackFrame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/CallStackFrame.tsx
@@ -6,20 +6,32 @@ import {
 } from '../../helpers/stack-frame'
 import { useOpenInEditor } from '../../helpers/use-open-in-editor'
 
+const frameworkInternalRegex = /[\\/]next[\\/]dist[\\/]/
+const reactNodeModulesRegex = /[\\/]node_modules[\\/]react(-dom)?[\\/]/
+
+export function isNextInternalStackFrame(frame: StackFrame): boolean {
+  return !!(
+    frame.file &&
+    (frameworkInternalRegex.test(frame.file) ||
+      reactNodeModulesRegex.test(frame.file))
+  )
+}
+
 export const CallStackFrame: React.FC<{
   frame: OriginalStackFrame
 }> = function CallStackFrame({ frame }) {
   // TODO: ability to expand resolved frames
   // TODO: render error or external indicator
 
-  const f: StackFrame = frame.originalStackFrame ?? frame.sourceStackFrame
+  const stackFrame: StackFrame =
+    frame.originalStackFrame ?? frame.sourceStackFrame
   const hasSource = Boolean(frame.originalCodeFrame)
   const open = useOpenInEditor(
     hasSource
       ? {
-          file: f.file,
-          lineNumber: f.lineNumber,
-          column: f.column,
+          file: stackFrame.file,
+          lineNumber: stackFrame.lineNumber,
+          column: stackFrame.column,
         }
       : undefined
   )
@@ -27,7 +39,7 @@ export const CallStackFrame: React.FC<{
   return (
     <div data-nextjs-call-stack-frame>
       <h3 data-nextjs-frame-expanded={Boolean(frame.expanded)}>
-        {f.methodName}
+        {stackFrame.methodName}
       </h3>
       <div
         data-has-source={hasSource ? 'true' : undefined}
@@ -36,7 +48,7 @@ export const CallStackFrame: React.FC<{
         onClick={open}
         title={hasSource ? 'Click to open in your editor' : undefined}
       >
-        <span>{getFrameSource(f)}</span>
+        <span>{getFrameSource(stackFrame)}</span>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/GroupedStackFrames.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/GroupedStackFrames.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import type { StackFramesGroup } from '../../helpers/group-stack-frames-by-framework'
 import { CallStackFrame } from './CallStackFrame'
 import { FrameworkIcon } from './FrameworkIcon'

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -21,11 +21,11 @@ const RuntimeError: React.FC<RuntimeErrorProps> = function RuntimeError({
   }, [error.frames])
 
   const firstFirstPartyFrameIndex = React.useMemo<number>(() => {
-    return userlandSourceStackFrames.findIndex(
-      (entry) =>
-        entry.expanded &&
-        Boolean(entry.originalCodeFrame) &&
-        Boolean(entry.originalStackFrame)
+    return (
+      userlandSourceStackFrames.findIndex(
+        (entry) =>
+          Boolean(entry.originalCodeFrame) && Boolean(entry.originalStackFrame)
+      ) ?? -1
     )
   }, [userlandSourceStackFrames])
   const firstFrame = React.useMemo<OriginalStackFrame | null>(() => {
@@ -46,7 +46,7 @@ const RuntimeError: React.FC<RuntimeErrorProps> = function RuntimeError({
   }, [])
 
   const leadingFrames = React.useMemo(
-    () => allLeadingFrames.filter((f) => f.expanded || all),
+    () => (all ? allLeadingFrames : []),
     [all, allLeadingFrames]
   )
   const allCallStackFrames = React.useMemo<OriginalStackFrame[]>(
@@ -54,7 +54,7 @@ const RuntimeError: React.FC<RuntimeErrorProps> = function RuntimeError({
     [userlandSourceStackFrames, firstFirstPartyFrameIndex]
   )
   const visibleCallStackFrames = React.useMemo<OriginalStackFrame[]>(
-    () => allCallStackFrames.filter((f) => f.expanded || all),
+    () => (all ? allCallStackFrames : []),
     [all, allCallStackFrames]
   )
 

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -1,5 +1,5 @@
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
-// import type { OriginalStackFrameResponse } from '../../middleware'
+import { isUserCode } from '../container/RuntimeError/CallStackFrame'
 
 export type OriginalStackFrame =
   | {
@@ -71,12 +71,7 @@ export function getOriginalStackFrame(
       error: false,
       reason: null,
       external: false,
-      expanded: !Boolean(
-        /* collapsed */
-        (source.file?.includes('node_modules') ||
-          body.originalStackFrame?.file?.includes('node_modules')) ??
-          true
-      ),
+      expanded: isUserCode(source) || isUserCode(body.originalStackFrame),
       sourceStackFrame: source,
       originalStackFrame: body.originalStackFrame,
       originalCodeFrame: body.originalCodeFrame || null,

--- a/packages/next/src/experimental/testmode/fetch.ts
+++ b/packages/next/src/experimental/testmode/fetch.ts
@@ -18,6 +18,8 @@ export const reader: TestRequestReader<Request> = {
   },
 }
 
+const nextInternalRegex = /[\\/]next[\\/]dist[\\/]/
+
 function getTestStack(): string {
   let stack = (new Error().stack ?? '').split('\n')
   // Skip the first line and find first non-empty line.
@@ -27,12 +29,14 @@ function getTestStack(): string {
       break
     }
   }
-  // Filter out franmework lines.
-  stack = stack.filter((f) => !f.includes('/next/dist/'))
+  // Filter out nextjs framework lines.
+  stack = stack.filter((f) => !nextInternalRegex.test(f))
   // At most 5 lines.
   stack = stack.slice(0, 5)
   // Cleanup some internal info and trim.
-  stack = stack.map((s) => s.replace('webpack-internal:///(rsc)/', '').trim())
+  stack = stack.map((s) =>
+    s.replace(/webpack-internal:\/\/\/(\w+)\//, '').trim()
+  )
   return stack.join('    ')
 }
 

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -222,7 +222,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     expect(next.normalizeTestDirContent(source)).toMatchInlineSnapshot(
       next.normalizeSnapshot(`
         "./index.js
-        Error:
+        Error: 
           x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
            ,-[TEST_DIR/index.js:4:1]
          4 |       <p>lol</p>
@@ -800,15 +800,24 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
       expect(await session.hasRedbox(true)).toBe(true)
 
-      // Open full Call Stack
-      await browser
-        .elementByCss('[data-nextjs-data-runtime-error-collapsed-action]')
-        .click()
+      if (pageType === 'server') {
+        // Open full Call Stack
+        await browser
+          .elementByCss('[data-nextjs-data-runtime-error-collapsed-action]')
+          .click()
 
-      // Expect more than the default amount of frames:
-      // The default stackTraceLimit results in max 3 [data-nextjs-call-stack-frame] elements
-      // after filter out the framework traces.
-      expect(await getCallStackCount()).toBeGreaterThan(3)
+        // Expect more than the default amount of frames:
+        // The default stackTraceLimit results in max 3 [data-nextjs-call-stack-frame] elements
+        // after filter out the framework traces.
+        expect(await getCallStackCount()).toBeGreaterThanOrEqual(3)
+      } else {
+        // Client errors should not have a collapsed action
+        expect(
+          await browser.hasElementByCssSelector(
+            '[data-nextjs-data-runtime-error-collapsed-action]'
+          )
+        ).toBeFalse()
+      }
 
       await cleanup()
     }

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -222,7 +222,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     expect(next.normalizeTestDirContent(source)).toMatchInlineSnapshot(
       next.normalizeSnapshot(`
         "./index.js
-        Error: 
+        Error:
           x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
            ,-[TEST_DIR/index.js:4:1]
          4 |       <p>lol</p>
@@ -805,9 +805,10 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         .elementByCss('[data-nextjs-data-runtime-error-collapsed-action]')
         .click()
 
-      // Expect more than the default amount of frames
-      // The default stackTraceLimit results in max 9 [data-nextjs-call-stack-frame] elements
-      expect(await getCallStackCount()).toBeGreaterThan(9)
+      // Expect more than the default amount of frames:
+      // The default stackTraceLimit results in max 3 [data-nextjs-call-stack-frame] elements
+      // after filter out the framework traces.
+      expect(await getCallStackCount()).toBeGreaterThan(3)
 
       await cleanup()
     }


### PR DESCRIPTION
<!--
## Invalid Hook Call

### After
Collapsed and Expanded
<img width="300" src="https://github.com/vercel/next.js/assets/4800338/454efb39-6b05-4be1-b9c7-1138ffcf4b9c">
<img width="300" src="https://github.com/vercel/next.js/assets/4800338/0c9a9707-f4e9-4a67-babc-73ce725a65ff">

### Before

Collapsed and Expanded
<img width="300" src="https://github.com/vercel/next.js/assets/4800338/7a0fafaf-662f-408d-a980-6f291d28a2e6">

### Client Components Error

<img width="300" src="https://github.com/vercel/next.js/assets/4800338/9f9a22d6-aea7-4127-8cde-9cded3aede02">
<img width="300" src="https://github.com/vercel/next.js/assets/4800338/8550b8d7-2fff-48ea-87a3-9eaa3be38b86">



Closes NEXT-1983
-->