### PR TITLE
(WIP) Remove extra top level not found boundary for parallel routes

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -64,7 +64,6 @@ export async function createComponentTree({
     staticGenerationStore,
     componentMod: {
       staticGenerationBailout,
-      NotFoundBoundary,
       LayoutRouter,
       RenderFromTemplateContext,
       StaticGenerationSearchParamsBailoutProvider,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -239,30 +239,6 @@ export async function createComponentTree({
    * The React Component to render.
    */
   let Component = LayoutOrPage
-  const parallelKeys = Object.keys(parallelRoutes)
-  const hasSlotKey = parallelKeys.length > 1
-
-  if (hasSlotKey && rootLayoutAtThisLevel) {
-    Component = (componentProps: any) => {
-      const NotFoundComponent = NotFound
-      const RootLayoutComponent = LayoutOrPage
-      return (
-        <NotFoundBoundary
-          notFound={
-            <>
-              {layerAssets}
-              <RootLayoutComponent>
-                {notFoundStyles}
-                <NotFoundComponent />
-              </RootLayoutComponent>
-            </>
-          }
-        >
-          <RootLayoutComponent {...componentProps} />
-        </NotFoundBoundary>
-      )
-    }
-  }
 
   if (process.env.NODE_ENV === 'development') {
     const { isValidElementType } = require('next/dist/compiled/react-is')


### PR DESCRIPTION
After landing #60186 we won't throw the notFound error when the slots are not properly configured.

Previously in #53703 we add an extra root not found boundary for app containing slots to display not found error properly due to bad structure of slots of parallel routes. Now it's not required anymore, this will help `RootLayout` get rendered twice due to passing it down in to root not-found boundary.

#### After this change
- root layout itself (1st)

#### Previous rendering
- root layout itself (1st)
- root layout render in root not found boundary (2nd)



Closes NEXT-1985