### PR TITLE
chore: test against latest sharp

### DIFF
--- a/test/integration/image-optimizer/test/old-sharp.test.ts
+++ b/test/integration/image-optimizer/test/old-sharp.test.ts
@@ -11,17 +11,17 @@ describe('with outdated sharp', () => {
     await fs.writeFile(
       join(appDir, 'package.json'),
       JSON.stringify({
-        packageManager: 'yarn@1.22.19',
+        packageManager: 'npm@10.2.5',
       })
     )
-    await execa('yarn', ['add', 'sharp@0.26.3'], {
+    await execa('npm', ['add', 'sharp@0.26.3'], {
       cwd: appDir,
       stdio: 'inherit',
     })
   })
   afterAll(async () => {
     await fs.remove(join(appDir, 'node_modules'))
-    await fs.remove(join(appDir, 'yarn.lock'))
+    await fs.remove(join(appDir, 'package-lock.json'))
     await fs.remove(join(appDir, 'package.json'))
   })
 

--- a/test/integration/image-optimizer/test/sharp.test.ts
+++ b/test/integration/image-optimizer/test/sharp.test.ts
@@ -11,17 +11,17 @@ describe('with latest sharp', () => {
     await fs.writeFile(
       join(appDir, 'package.json'),
       JSON.stringify({
-        packageManager: 'yarn@1.22.19',
+        packageManager: 'npm@10.2.5',
       })
     )
-    await execa('yarn', ['add', 'sharp@^0.32.0'], {
+    await execa('npm', ['add', 'sharp@latest'], {
       cwd: appDir,
       stdio: 'inherit',
     })
   })
   afterAll(async () => {
     await fs.remove(join(appDir, 'node_modules'))
-    await fs.remove(join(appDir, 'yarn.lock'))
+    await fs.remove(join(appDir, 'package-lock.json'))
     await fs.remove(join(appDir, 'package.json'))
   })
 

--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -163,9 +163,7 @@ export function runTests(ctx) {
           'custom-sharp.js.nft.json'
         )
       )
-      expect(traceFile.files.some((file) => file.includes('sharp/build'))).toBe(
-        true
-      )
+      expect(traceFile.files.some((file) => file.includes('sharp/'))).toBe(true)
     })
   }
 


### PR DESCRIPTION
This test was changed in https://github.com/vercel/next.js/pull/59074 because the latest sharp stopped working with yarn. However, we can update these tests to use npm instead and continue testing the latest sharp.
 
Closes NEXT-1986

Closes #57007 