### PR TITLE
docs: add optional catch-all segments typescript example

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/05-dynamic-routes.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/05-dynamic-routes.mdx
@@ -120,6 +120,7 @@ export default function Page({ params }) {
 | ----------------------------------- | ---------------------------------------- |
 | `app/blog/[slug]/page.js`           | `{ slug: string }`                       |
 | `app/shop/[...slug]/page.js`        | `{ slug: string[] }`                     |
+| `app/shop/[[...slug]]/page.js`      | `{ slug?: string[] }`                    |
 | `app/[categoryId]/[itemId]/page.js` | `{ categoryId: string, itemId: string }` |
 
 > **Good to know**: This may be done automatically by the [TypeScript plugin](/docs/app/building-your-application/configuring/typescript#typescript-plugin) in the future.


### PR DESCRIPTION
Closes https://github.com/vercel/next.js/issues/60235

This PR adds a TypeScript example for optional catch-all segments. I think it's worth to be added because there's a section about this right above the TypeScript section.