### PR TITLE
[PPR Nav] Fix: Page data should always be applied

### DIFF
--- a/test/e2e/app-dir/ppr-navigations/ppr-navigations.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/ppr-navigations.test.ts
@@ -176,6 +176,27 @@ describe('ppr-navigations', () => {
       expect(await dynamicContainer.innerText()).toBe('Some data [dynamic]')
     }
   )
+
+  test(
+    'updates page data during a nav even if no shared layouts have changed ' +
+      '(e.g. updating a search param on the current page)',
+    async () => {
+      next = await createNext({
+        files: __dirname + '/search-params',
+      })
+      const browser = await next.browser('/')
+
+      // Click a link that updates the current page's search params.
+      const link = await browser.elementByCss('a')
+      await link.click()
+
+      // Confirm that the page re-rendered with the new search params.
+      const searchParamsContainer = await browser.elementById('search-params')
+      expect(await searchParamsContainer.innerText()).toBe(
+        'Search params: {"blazing":"good"}'
+      )
+    }
+  )
 })
 
 // NOTE: I've intentionally not yet moved these helpers into a separate

--- a/test/e2e/app-dir/ppr-navigations/search-params/app/layout.tsx
+++ b/test/e2e/app-dir/ppr-navigations/search-params/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/ppr-navigations/search-params/app/page.tsx
+++ b/test/e2e/app-dir/ppr-navigations/search-params/app/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined }
+}) {
+  const hasParams = Object.keys(searchParams).length > 0
+  return (
+    <>
+      <Link href="/?blazing=good">Go</Link>
+      {hasParams ? (
+        <div id="search-params">
+          Search params: {JSON.stringify(searchParams)}
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/test/e2e/app-dir/ppr-navigations/search-params/next.config.js
+++ b/test/e2e/app-dir/ppr-navigations/search-params/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
This fixes a case in the PPR navigations implementation where page data was not being applied.

During a navigation, we compare the route trees of the old and new pages to determine which layouts are shared. If the segment keys of two layouts are the same, they are reused.

However, the server doesn't bother to assign segment keys to the leaf segments (which we refer to as "page" segments) because they are never part of a shared layout. It assigns all of them a special constant (`__PAGE__`).

In the PPR implementation, I overlooked this and compared the segment keys of all segments, including pages, not just shared layouts. So if the only thing that changed during a navigation was the page data, and not any parent layout, the client would fail to apply the navigation.

The fix is to add a special case for page segments before comparing nested layouts. I also moved an existing special case for default pages, since those are also leaf segments and are conceptually similar.