### PR TITLE
fix: add `node-web-audio-api` to server-external-packages.json

### DIFF
--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -32,6 +32,7 @@
   "next-mdx-remote",
   "next-seo",
   "node-pty",
+  "node-web-audio-api",
   "payload",
   "pg",
   "playwright",


### PR DESCRIPTION
The package [`node-web-audio-api`](https://unpkg.com/browse/node-web-audio-api@0.14.0/) contains native `.node` files that cannot be bundled (similar to https://github.com/vercel/next.js/pull/57640)

Closes NEXT-1974

