### PR TITLE
fix(docs): add missing docs on external packages

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
@@ -23,6 +23,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@aws-sdk/client-s3`
 - `@aws-sdk/s3-presigned-post`
 - `@blockfrost/blockfrost-js`
+- `@highlight-run/node`
 - `@libsql/client`
 - `@jpg-store/lucid-cardano`
 - `@mikro-orm/core`
@@ -51,6 +52,8 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `mongoose`
 - `next-mdx-remote`
 - `next-seo`
+- `node-pty`
+- `node-web-audio-api`
 - `payload`
 - `pg`
 - `playwright`
@@ -67,3 +70,4 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `typescript`
 - `vscode-oniguruma`
 - `webpack`
+- `websocket`


### PR DESCRIPTION
In the future, we should make this automatically fetch the json from https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/server-external-packages.json

Closes NEXT-1990