### PR TITLE
Always send postpone header when PPR is enabled

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -111,7 +111,7 @@ export async function fetchServerResponse(
     const canonicalUrl = res.redirected ? responseUrl : undefined
 
     const contentType = res.headers.get('content-type') || ''
-    const postponed = !!res.headers.get(NEXT_DID_POSTPONE_HEADER)
+    const postponed = res.headers.get(NEXT_DID_POSTPONE_HEADER) === '1'
     let isFlightResponse = contentType === RSC_CONTENT_TYPE_HEADER
 
     if (process.env.NODE_ENV === 'production') {

--- a/packages/next/src/server/app-render/static/create-static-headers-adapter.ts
+++ b/packages/next/src/server/app-render/static/create-static-headers-adapter.ts
@@ -1,0 +1,37 @@
+import type { OutgoingHttpHeader } from 'http'
+import type { AppPageRenderResultMetadata } from '../../render-result'
+
+/**
+ * This adapter is used to set headers in the `AppPageRenderResultMetadata`
+ * object.
+ */
+export type StaticHeadersAdapter = {
+  appendHeader: (name: string, value: string) => void
+  setHeader: (name: string, value: OutgoingHttpHeader) => void
+}
+
+/**
+ * Creates a static headers adapter that can be used to set headers in the
+ * `AppPageRenderResultMetadata` object.
+ */
+export const createStaticHeadersAdapter = (
+  metadata: AppPageRenderResultMetadata
+): StaticHeadersAdapter => ({
+  appendHeader: (name, value) => {
+    metadata.headers ??= {}
+    const existing = metadata.headers[name]
+    if (Array.isArray(existing)) {
+      metadata.headers[name] = [...existing, value]
+    } else if (typeof existing === 'string') {
+      metadata.headers[name] = [existing, value]
+    } else if (typeof existing === 'number') {
+      metadata.headers[name] = [existing.toString(), value]
+    } else {
+      metadata.headers[name] = value
+    }
+  },
+  setHeader: (name, value) => {
+    metadata.headers ??= {}
+    metadata.headers[name] = value
+  },
+})


### PR DESCRIPTION
When PPR is enabled, determining if the page has postponed is difficult to do in production without diving deep into the source code of the page. This adds the `x-nextjs-postponed` header to all pages in the `app/` directory when PPR is enabled. When the page has postponed, the value will be `1`, otherwise it'll be `0` if the page did not postpone.


Closes NEXT-1991