### PR TITLE
Start typechecking at the same time between pages and app router

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -796,25 +796,6 @@ export default async function build(
       const ignoreESLint = Boolean(config.eslint.ignoreDuringBuilds)
       const shouldLint = !ignoreESLint && runLint
 
-      const typeCheckingOptions: Parameters<typeof startTypeChecking>[0] = {
-        dir,
-        appDir,
-        pagesDir,
-        runLint,
-        shouldLint,
-        ignoreESLint,
-        telemetry,
-        nextBuildSpan,
-        config,
-        cacheDir,
-      }
-
-      // For app directory, we run type checking after build. That's because
-      // we dynamically generate types for each layout and page in the app
-      // directory.
-      if (!appDir && !isCompileMode)
-        await startTypeChecking(typeCheckingOptions)
-
       if (appDir && 'exportPathMap' in config) {
         Log.error(
           'The "exportPathMap" configuration cannot be used with the "app" directory. Please use generateStaticParams() instead.'
@@ -1461,9 +1442,20 @@ export default async function build(
         }
       }
 
-      // For app directory, we run type checking after build.
-      if (appDir && !isCompileMode && !isGenerateMode) {
-        await startTypeChecking(typeCheckingOptions)
+      // Run type checking after the build as the build writes additional types.
+      if (!isCompileMode && !isGenerateMode) {
+        await startTypeChecking({
+          dir,
+          appDir,
+          pagesDir,
+          runLint,
+          shouldLint,
+          ignoreESLint,
+          telemetry,
+          nextBuildSpan,
+          config,
+          cacheDir,
+        })
       }
 
       const postCompileSpinner = createSpinner('Collecting page data')


### PR DESCRIPTION
## What?

This makes sure there is only one place that typechecking starts, simplifies reasoning about when it starts as otherwise adding `app` is enough to change the order.

While looking at this I noticed that the experimental generateMode seems to run typechecking (if enabled) which seems unexpected to me. This PR solves that because the line is removed, but would be good to double check if this is expected as I'd expected experimental-compile to run typechecking.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-1993