### PR TITLE
doc: add example with useFormState hook and additional arguments

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/02-server-actions-and-mutations.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/02-server-actions-and-mutations.mdx
@@ -474,8 +474,6 @@ export async function editUser(userId, prevState, formData) {
 }
 ```
 
-Then, you can pass your action to the `useFormState` hook and use the returned `state` to display an error message.
-
 ```tsx filename="app/ui/user-details.tsx" switcher
 'use client'
 
@@ -492,7 +490,7 @@ export function UserDetails({ userId }: { userId: string }) {
 
   return (
     <form action={formAction}>
-      <label htmlFor="username">username</label>
+      <label htmlFor="username">Username</label>
       <input type="text" id="username" name="username" required />
       {/* ... */}
       <p aria-live="polite" className="sr-only">
@@ -520,7 +518,7 @@ export function UserDetails({ userId }) {
 
   return (
     <form action={formAction}>
-      <label htmlFor="username">username</label>
+      <label htmlFor="username">Username</label>
       <input type="text" id="username" name="username" required />
       {/* ... */}
       <p aria-live="polite" className="sr-only">

--- a/docs/02-app/01-building-your-application/02-data-fetching/02-server-actions-and-mutations.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/02-server-actions-and-mutations.mdx
@@ -444,6 +444,94 @@ export function Signup() {
 >
 > - Before mutating data, you should always ensure a user is also authorized to perform the action. See [Authentication and Authorization](#authentication-and-authorization).
 
+#### Using `useFormState` with [additional arguments](#passing-additional-arguments)
+
+Sometimes, you may want to benefits the advantages of the React [`useFormState`](https://react.dev/reference/react-dom/hooks/useFormState) hook with a Server Action that has additional arguments. For example, to edit a user:
+
+```tsx filename="app/actions.ts" switcher
+'use server'
+
+export async function editUser(
+  userId: string,
+  prevState: any,
+  formData: FormData
+) {
+  // ...
+  return {
+    message: 'The user has been updated',
+  }
+}
+```
+
+```jsx filename="app/actions.js" switcher
+'use server'
+
+export async function editUser(userId, prevState, formData) {
+  // ...
+  return {
+    message: 'The user has been updated',
+  }
+}
+```
+
+Then, you can pass your action to the `useFormState` hook and use the returned `state` to display an error message.
+
+```tsx filename="app/ui/user-details.tsx" switcher
+'use client'
+
+import { useFormState } from 'react-dom'
+import { editUser } from '@/app/actions'
+
+const initialState = {
+  message: '',
+}
+
+export function UserDetails({ userId }: { userId: string }) {
+  const editUserWithId = editUser.bind(null, userId)
+  const [state, formAction] = useFormState(editUserWithId, initialState)
+
+  return (
+    <form action={formAction}>
+      <label htmlFor="username">username</label>
+      <input type="text" id="username" name="username" required />
+      {/* ... */}
+      <p aria-live="polite" className="sr-only">
+        {state?.message}
+      </p>
+      <button>Edit</button>
+    </form>
+  )
+}
+```
+
+```jsx filename="app/ui/user-details.js" switcher
+'use client'
+
+import { useFormState } from 'react-dom'
+import { editUser } from '@/app/actions'
+
+const initialState = {
+  message: '',
+}
+
+export function UserDetails({ userId }) {
+  const editUserWithId = editUser.bind(null, userId)
+  const [state, formAction] = useFormState(editUserWithId, initialState)
+
+  return (
+    <form action={formAction}>
+      <label htmlFor="username">username</label>
+      <input type="text" id="username" name="username" required />
+      {/* ... */}
+      <p aria-live="polite" className="sr-only">
+        {state?.message}
+      </p>
+      <button>Edit</button>
+    </form>
+  )
+}
+```
+
 #### Optimistic updates
 
 You can use the React [`useOptimistic`](https://react.dev/reference/react/useOptimistic) hook to optimistically update the UI before the Server Action finishes, rather than waiting for the response:


### PR DESCRIPTION
I hesitated to create a new section or add the "Good to know" section from the "Server-side validation and error handling" section, but I wanted to have some code blocks to show a common use case.

### What?
This PR adds an example where we use `useFormState` and `additional arguments` together.

### Why?
The TypeScript error is unclear and this case is not yet documented