### PR TITLE
Update flakey test from port re-use

### DIFF
--- a/test/integration/edge-runtime-configurable-guards/test/index.test.js
+++ b/test/integration/edge-runtime-configurable-guards/test/index.test.js
@@ -312,6 +312,7 @@ describe('Edge runtime configurable guards', () => {
           })
           expect(output.stderr).not.toContain(`Build failed`)
           expect(output.stderr).toContain(TELEMETRY_EVENT_NAME)
+          context.appPort = await findPort()
           context.app = await nextStart(
             context.appDir,
             context.appPort,
@@ -453,6 +454,7 @@ describe('Edge runtime configurable guards', () => {
             stderr: true,
           })
           expect(output.stderr).not.toContain(`Build failed`)
+          context.appPort = await findPort()
           context.app = await nextStart(
             context.appDir,
             context.appPort,


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/actions/runs/7427293982/job/20213797689

Closes NEXT-2002