### PR TITLE
improve next/image not found error

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -569,6 +569,13 @@ export async function imageOptimizer(
         )
       }
 
+      if (mocked.res.statusCode === 404) {
+        throw new ImageError(
+          404,
+          `The requested resource was not found. ${href}`
+        )
+      }
+
       upstreamBuffer = Buffer.concat(mocked.res.buffers)
       upstreamType =
         detectContentType(upstreamBuffer) ||
@@ -576,6 +583,10 @@ export async function imageOptimizer(
       const cacheControl = mocked.res.getHeader('Cache-Control')
       maxAge = cacheControl ? getMaxAge(cacheControl) : 0
     } catch (err) {
+      if (err instanceof ImageError) {
+        throw err
+      }
+
       Log.error('upstream image response failed for', href, err)
       throw new ImageError(
         500,

--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -1217,11 +1217,14 @@ export function runTests(ctx) {
   })
 
   it('should error if the image file does not exist', async () => {
-    const query = { url: '/does_not_exist.jpg', w: ctx.w, q: 80 }
+    const filepath = '/does_not_exist.jpg'
+    const query = { url: filepath, w: ctx.w, q: 80 }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(400)
-    expect(await res.text()).toBe("The requested resource isn't a valid image.")
+    expect(await res.text()).toBe(
+      `The requested resource was not found. ${filepath}`
+    )
   })
 
   if (domains.length > 0) {


### PR DESCRIPTION
### What?
I have updated nextImage to return a `404: The requested resource was not found.` error when a non-existent relative 
 filepath is specified.

### Why?
see the issue

Closes NEXT-
Fixes #60304

-->
