### PR TITLE
docs: typo fix in compression page

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/compress.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/compress.mdx
@@ -5,7 +5,7 @@ description: Next.js provides gzip compression to compress rendered content and 
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
 
-By default, Next.js uses `gzip` to compress rendered content and static files when using `next start` or a custom server. This is an optmization for application's that do not have compression configured. If compression is _already_ configured in your application via a custom server, Next.js will not add compression.
+By default, Next.js uses `gzip` to compress rendered content and static files when using `next start` or a custom server. This is an optimization for applications that do not have compression configured. If compression is _already_ configured in your application via a custom server, Next.js will not add compression.
 
 > **Good to know:**
 >


### PR DESCRIPTION
Fixes typo introduced in #60268

Was looking at recently merged PRs to understand the project more in depth and spotted this. I promise I won't just submit this typo fix and call myself a "contributor".
