### PR TITLE
chore(font): enable minification

### DIFF
--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "cd ../../ && turbo run build",
     "dev": "pnpm ncc-fontkit && tsc -d -w -p tsconfig.json",
     "typescript": "tsec --noEmit -p tsconfig.json",
-    "ncc-fontkit": "ncc build ./fontkit.js -o dist/fontkit"
+    "ncc-fontkit": "ncc build ./fontkit.js --minify -o dist/fontkit"
   },
   "devDependencies": {
     "@types/fontkit": "2.0.0",


### PR DESCRIPTION
Per @styfle suggestion, #58038 has been split into multiple PRs for easier review.

- Enable minification of `@next/font`
  - Currently, the `@next/font` is built separately (without minification) and then copied to the `dist` folder of the Next.js.
