### PR TITLE
Fix: Enable manifest.json file in app directory to success next build

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1262,6 +1262,7 @@ export default async function getBaseWebpackConfig(
                   WEBPACK_RESOURCE_QUERIES.metadataRoute
                 ),
                 layer: WEBPACK_LAYERS.appMetadataRoute,
+                type: 'javascript/auto'
               },
               {
                 // Ensure that the app page module is in the client layers, this


### PR DESCRIPTION
### What?

In this issue https://github.com/vercel/next.js/issues/59923 , you cannot success `next build` if any manifest.json file in root of app directory are exist.
I research for this and find since you are importing `json` format, webpack parse this JSON file using JSON parser, not Javascript parser and failed ([code1](https://github.com/webpack/webpack/blob/228fc69f40c3e9ec6d99a5105fdc85b5bca4ce43/lib/NormalModule.js#L1093), [code2](https://github.com/vercel/next.js/blob/43410c992684670bc95dad25873f1ec89fed2f25/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts#L60) they are using Javascript) .
So I read [this article](https://webpack.js.org/guides/asset-modules/) and [this article](https://stackoverflow.com/questions/71304739/need-for-json-loader-in-webpack-5) and imitate the code and get fixed.

Since I am new to webpack and next.js, My solution may not be good enough, if you have any advices or opinions, I am welcome.