### PR TITLE
Fix bundle analyzer NPM package name in documentation

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/06-bundle-analyzer.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/06-bundle-analyzer.mdx
@@ -14,7 +14,7 @@ related:
 Install the plugin by running the following command:
 
 ```bash
-npm i @next/bundle-analyzers
+npm i @next/bundle-analyzer
 # or
 yarn add @next/bundle-analyzer
 # or


### PR DESCRIPTION
This fixes a typo in the Next.js documentation.