### PR TITLE
docs: update broken link in UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,1 +1,1 @@
-This document has been moved to [nextjs.org/docs/upgrading](https://nextjs.org/docs/upgrading). It's also available in this repository on [/docs/02-app/01-building-your-application/09-upgrading/index.mdx](/docs/02-app/01-building-your-application/09-upgrading/index.mdx).
+This document has been moved to [nextjs.org/docs/upgrading](https://nextjs.org/docs/upgrading). It's also available in this repository on [/docs/02-app/01-building-your-application/10-upgrading](/docs/02-app/01-building-your-application/10-upgrading).


### PR DESCRIPTION
This link → [/docs/02-app/01-building-your-application/09-upgrading/index.mdx](https://github.com/vercel/next.js/blob/21452921c055421ec8a44dae6e0e5f311c503337/docs/02-app/01-building-your-application/09-upgrading/index.mdx) doesn't exist.

Fixing it to link to the correct directory.

Closes NEXT-2006