### PR TITLE
docs: add bun usage example to 04-ci-build-caching.mdx

### DIFF
--- a/docs/03-pages/01-building-your-application/08-deploying/04-ci-build-caching.mdx
+++ b/docs/03-pages/01-building-your-application/08-deploying/04-ci-build-caching.mdx
@@ -87,6 +87,20 @@ with:
     ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
 ```
 
+If you'd prefer to use bun instead of npm or node:
+
+```yaml
+uses: actions/cache@v3
+with:
+  path: |
+    ${{ github.workspace }}/.next/cache
+  # Generate a new cache whenever packages or source files change.
+  key: ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lockb.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+  # If source files changed but packages didn't, rebuild from a prior cache.
+  restore-keys: |
+    ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lockb.json') }}-
+```
+
 ## Bitbucket Pipelines
 
 Add or merge the following into your `bitbucket-pipelines.yml` at the top level (same level as `pipelines`):


### PR DESCRIPTION
fixes #57079

This adds how to use github actions/cache@v3 with bun by hashing bun's lockfile instead of package-lock.json or yarn.lock.

This does add a whole new paragraph of text, so it might be necessary or preferable to instead change the first example instead. I just thought it'd get messy to keep adding comments to the original code block.

I have a proof of concept for using this build step here https://github.com/JCharante/nextjs-github-actions-bun

and it can be seen [in the latest build](https://github.com/JCharante/nextjs-github-actions-bun/actions/runs/7434846626/job/20229494808) that the error message `No build cache found.` does not occur because Next.js is using the cache.