### PR TITLE
Fix bug sitemap() without generateSitemaps fails

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -152,7 +152,7 @@ function getDynamicSiteMapRouteCode(resourcePath: string, page: string) {
   ) {
     staticGenerationCode = `\
 export async function generateStaticParams() {
-  const sitemaps = await generateSitemaps()
+  const sitemaps = generateSitemaps ? await generateSitemaps() : [{ id: 0 }]
   const params = []
 
   for (const item of sitemaps) {


### PR DESCRIPTION
### What?

In https://github.com/vercel/next.js/issues/59698 , sitemap() without generateSitemaps fails.
I looked for the `.next/server/app/sitemap/[__metadata_id__]/route.js` and next-metadata-route-loader to find that there are no condition to deal with the case not having `generateSitemaps`. ( there is condition in [ImageMetaData](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts#L124) )
So I add this condition in `next-metadata-route-loader`.
Since I can't understand the case sitemaps returns empty array so I just add `[{id: 0}]` if there is no `generateSitemaps`.