### PR TITLE
Fix dynamic sitemap detection

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -459,12 +459,12 @@ export async function isDynamicMetadataRoute(
   pageFilePath: string
 ): Promise<boolean> {
   const fileContent = (await tryToReadFile(pageFilePath, true)) || ''
-  if (!/generateImageMetadata|generateSitemaps/.test(fileContent)) return false
-
-  const swcAST = await parseModule(pageFilePath, fileContent)
-  const exportsInfo = checkExports(swcAST, pageFilePath)
-
-  return !exportsInfo.generateImageMetadata || !exportsInfo.generateSitemaps
+  if (/generateImageMetadata|generateSitemaps/.test(fileContent)) {
+    const swcAST = await parseModule(pageFilePath, fileContent)
+    const exportsInfo = checkExports(swcAST, pageFilePath)
+    return !!(exportsInfo.generateImageMetadata || exportsInfo.generateSitemaps)
+  }
+  return false
 }
 
 /**

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -23,9 +23,46 @@ interface Options {
   basePath: string
 }
 
+export async function getNamedExports(
+  resourcePath: string,
+  context: webpack.LoaderContext<any>
+): Promise<string[]> {
+  const mod = await new Promise<webpack.NormalModule>((res, rej) => {
+    context.loadModule(
+      resourcePath,
+      (err: null | Error, _source: any, _sourceMap: any, module: any) => {
+        if (err) {
+          return rej(err)
+        }
+        res(module)
+      }
+    )
+  })
+
+  const exportNames =
+    mod.dependencies
+      ?.filter((dep) => {
+        return (
+          [
+            'HarmonyExportImportedSpecifierDependency',
+            'HarmonyExportSpecifierDependency',
+          ].includes(dep.constructor.name) &&
+          'name' in dep &&
+          dep.name !== 'default'
+        )
+      })
+      .map((dep: any) => {
+        return dep.name
+      }) || []
+  return exportNames
+}
+
 // [NOTE] For turbopack
 // refer loader_tree's write_static|dynamic_metadata for corresponding features
-async function nextMetadataImageLoader(this: any, content: Buffer) {
+async function nextMetadataImageLoader(
+  this: webpack.LoaderContext<Options>,
+  content: Buffer
+) {
   const options: Options = this.getOptions()
   const { type, segment, pageExtensions, basePath } = options
   const { resourcePath, rootContext: context } = this
@@ -57,33 +94,9 @@ async function nextMetadataImageLoader(this: any, content: Buffer) {
   const pathnamePrefix = normalizePathSep(path.join(basePath, segment))
 
   if (isDynamicResource) {
-    const mod = await new Promise<webpack.NormalModule>((res, rej) => {
-      this.loadModule(
-        resourcePath,
-        (err: null | Error, _source: any, _sourceMap: any, module: any) => {
-          if (err) {
-            return rej(err)
-          }
-          res(module)
-        }
-      )
-    })
-
-    const exportedFieldsExcludingDefault =
-      mod.dependencies
-        ?.filter((dep) => {
-          return (
-            [
-              'HarmonyExportImportedSpecifierDependency',
-              'HarmonyExportSpecifierDependency',
-            ].includes(dep.constructor.name) &&
-            'name' in dep &&
-            dep.name !== 'default'
-          )
-        })
-        .map((dep: any) => {
-          return dep.name
-        }) || []
+    const exportedFieldsExcludingDefault = (
+      await getNamedExports(resourcePath, this)
+    ).filter((name) => name !== 'default')
 
     // re-export and spread as `exportedImageData` to avoid non-exported error
     return `\

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/opengraph-image.tsx
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/opengraph-image.tsx
@@ -2,6 +2,7 @@ import { ImageResponse } from 'next/og'
 
 export const alt = 'Open Graph'
 
+/* without generateImageMetadata */
 export default function og() {
   return new ImageResponse(
     (

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/sitemap.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/sitemap.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 import { MetadataRoute } from 'next'
 
+/* without generateSitemaps */
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {


### PR DESCRIPTION
### What

Fix bad detection of dynamic route of sitemap metadata route, the swc AST check should process when the text are detected. But prevuious if there's text with `generateSitemap` such as comment but not the actual export it will fail.

### How
Add both checks on metadata loader side and detection helper side

* Only call `generateSitemaps` helper when the export existed
* Fix the helper detection logic (major part of this PR)

Fixes #59698
Closes #60344
Closes NEXT-2007
