### PR TITLE
docs: Add docs for `next dev --experimental-https`

### DIFF
--- a/docs/02-app/02-api-reference/08-next-cli.mdx
+++ b/docs/02-app/02-api-reference/08-next-cli.mdx
@@ -91,6 +91,22 @@ You can also set the hostname to be different from the default of `0.0.0.0`, thi
 npx next dev -H 192.168.1.2
 ```
 
+### HTTPS for Local Development
+
+For certain use cases like webhooks or authentication, it may be required to use HTTPS to have a secure environment on `localhost`. Next.js can generate a self-signed certificate with `next dev` as follows:
+
+```bash filename="Terminal"
+next dev --experimental-https
+```
+
+You can also provide a custom certificate and key with `--experimental-https-key` and `--experimental-https-cert`. Optionally, you can provide a custom CA certificate with `--experimental-https-ca` as well.
+
+```bash filename="Terminal"
+next dev --experimental-https --experimental-https-key ./certificates/localhost-key.pem --experimental-https-cert ./certificates/localhost.pem
+```
+
+`next dev --experimental-https` is only intended for development and creates a locally-trusted certificate with `mkcert`. In production, use properly issued certificates from trusted authorities. When deploying to Vercel, HTTPS is [automatically configured](https://vercel.com/docs/security/encryption) for your Next.js application.
+
 ## Production
 
 `next start` starts the application in production mode. The application should be compiled with [`next build`](#build) first.

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -125,10 +125,14 @@ const nextDev: CliCommand = async (args) => {
       If no directory is provided, the current directory will be used.
 
       Options
-        --port, -p      A port number on which to start the application
-        --hostname, -H  Hostname on which to start the application (default: 0.0.0.0)
-        --experimental-upload-trace=<trace-url>  [EXPERIMENTAL] Report a subset of the debugging trace to a remote http url. Includes sensitive data. Disabled by default and url must be provided.
-        --help, -h      Displays this message
+        --port, -p                              A port number to start the application on
+        --hostname, -H                          Hostname start the application on (default: 0.0.0.0)
+        --experimental-https                    Start the server with HTTPS and generate a self-signed certificate
+        --experimental-https-key <path>         Path to a HTTPS key file
+        --experimental-https-cert <path>        Path to a HTTPS certificate file
+        --experimental-https-ca <path>          Path to a HTTPS certificate authority file
+        --experimental-upload-trace=<trace-url> Report a subset of the debugging trace to a remote http url. Includes sensitive data. Disabled by default and url must be provided.
+        --help, -h                              Displays this message
     `)
     process.exit(0)
   }


### PR DESCRIPTION
Closes https://linear.app/vercel/issue/DX-2096/document-next-dev-experimental-https-when-stable.