### PR TITLE
Docs: Update note on `@next/third-parties` being experimental

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/11-third-party-libraries.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/11-third-party-libraries.mdx
@@ -9,19 +9,20 @@ description: Optimize the performance of third-party libraries in your applicati
 improve the performance and developer experience of loading popular third-party libraries in your
 Next.js application.
 
-> **Good to know**: `@next/third-parties` is a new **experimental** library that is still under
-> active development. We're currently working on adding more third-party integrations.
-
 All third-party integrations provided by `@next/third-parties` have been optimized for performance
 and ease of use.
 
 ## Getting Started
 
-To get started, you must install the `@next/third-parties` library:
+To get started, install the `@next/third-parties` library:
 
 ```bash filename="Terminal"
-npm install @next/third-parties
+npm install @next/third-parties next@latest
 ```
+
+{/* To do: Remove this paragraph once package becomes stable */}
+
+`@next/third-parties` is currently an **experimental** library under active development. We recommend installing it with the **latest** or **canary** flags while we work on adding more third-party integrations.
 
 ## Google Third-Parties
 

--- a/docs/02-app/01-building-your-application/06-optimizing/11-third-party-libraries.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/11-third-party-libraries.mdx
@@ -17,7 +17,7 @@ and ease of use.
 To get started, install the `@next/third-parties` library:
 
 ```bash filename="Terminal"
-npm install @next/third-parties next@latest
+npm install @next/third-parties@latest next@latest
 ```
 
 {/* To do: Remove this paragraph once package becomes stable */}


### PR DESCRIPTION
At the moment, `@next/third-parties` is only working on canary. This can be a blocker for those trying it out on `latest`. This updates the experimental note to recommend installing canary. 

The note should be removed once the package is stable.  

Closes: https://github.com/vercel/feedback/issues/51035