### PR TITLE
chore: indicate staleness more prominently in `next info` output

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -40,13 +40,6 @@ body:
       placeholder: 'Following the steps from the previous section, I expected A to happen, but I observed B instead'
     validations:
       required: true
-  - type: checkboxes
-    attributes:
-      label: Verify canary release
-      description: 'Please run `npm install next@canary` to try the canary version of Next.js that ships daily. It includes all features and fixes that have not been released to the stable version yet. Some issues may already be fixed in the canary version, so please verify that your issue reproduces before opening a new issue.'
-      options:
-        - label: I verified that the issue exists in the latest Next.js canary release
-          required: true
   - type: textarea
     attributes:
       label: Provide environment information

--- a/packages/next/src/cli/next-info.ts
+++ b/packages/next/src/cli/next-info.ts
@@ -108,7 +108,7 @@ async function printDefaultInfo() {
   const installedRelease = getPackageVersion('next')
   const nextConfig = await getNextConfig()
 
-  let staleness = ''
+  let stalenessWithTitle = ''
   let title = ''
   let versionInfo
   try {
@@ -123,7 +123,7 @@ async function printDefaultInfo() {
       canary: tags.canary,
     })
     title = getStaleness(versionInfo).title
-    if (title) staleness = ` // ${title}`
+    if (title) stalenessWithTitle = ` // ${title}`
   } catch (e) {
     console.warn(
       `${yellow(
@@ -148,7 +148,7 @@ Binaries:
   Yarn: ${getBinaryVersion('yarn')}
   pnpm: ${getBinaryVersion('pnpm')}
 Relevant Packages:
-  next: ${installedRelease}${staleness}
+  next: ${installedRelease}${stalenessWithTitle}
   eslint-config-next: ${getPackageVersion('eslint-config-next')}
   react: ${getPackageVersion('react')}
   react-dom: ${getPackageVersion('react-dom')}

--- a/packages/next/src/cli/next-info.ts
+++ b/packages/next/src/cli/next-info.ts
@@ -7,6 +7,10 @@ import { bold, cyan, yellow } from '../lib/picocolors'
 import type { CliCommand } from '../lib/commands'
 import { PHASE_INFO } from '../shared/lib/constants'
 import loadConfig from '../server/config'
+import { getRegistry } from '../lib/helpers/get-registry'
+import { parseVersionInfo } from '../server/dev/parse-version-info'
+import { getStaleness } from '../client/components/react-dev-overlay/internal/components/VersionStalenessInfo/VersionStalenessInfo'
+import { warn } from '../build/output/log'
 
 const dir = process.cwd()
 
@@ -104,43 +108,22 @@ async function printDefaultInfo() {
   const installedRelease = getPackageVersion('next')
   const nextConfig = await getNextConfig()
 
-  console.log(`
-Operating System:
-  Platform: ${os.platform()}
-  Arch: ${os.arch()}
-  Version: ${os.version()}
-Binaries:
-  Node: ${process.versions.node}
-  npm: ${getBinaryVersion('npm')}
-  Yarn: ${getBinaryVersion('yarn')}
-  pnpm: ${getBinaryVersion('pnpm')}
-Relevant Packages:
-  next: ${installedRelease}
-  eslint-config-next: ${getPackageVersion('eslint-config-next')}
-  react: ${getPackageVersion('react')}
-  react-dom: ${getPackageVersion('react-dom')}
-  typescript: ${getPackageVersion('typescript')}
-Next.js Config:
-  output: ${nextConfig.output}
-
-`)
-
+  let staleness = ''
+  let title = ''
+  let versionInfo
   try {
-    const res = await fetch(
-      'https://api.github.com/repos/vercel/next.js/releases'
-    )
-    const releases = await res.json()
-    const newestRelease = releases[0].tag_name.replace(/^v/, '')
+    const registry = getRegistry()
+    const res = await fetch(`${registry}-/package/next/dist-tags`)
 
-    if (installedRelease !== newestRelease) {
-      console.warn(
-        `${yellow(
-          bold('warn')
-        )}  - Latest canary version not detected, detected: "${installedRelease}", newest: "${newestRelease}".
-        Please try the latest canary version (\`npm install next@canary\`) to confirm the issue still exists before creating a new issue.
-        Read more - https://nextjs.org/docs/messages/opening-an-issue`
-      )
-    }
+    const tags = await res.json()
+
+    versionInfo = parseVersionInfo({
+      installed: installedRelease,
+      latest: tags.latest,
+      canary: tags.canary,
+    })
+    title = getStaleness(versionInfo).title
+    if (title) staleness = ` // ${title}`
   } catch (e) {
     console.warn(
       `${yellow(
@@ -152,6 +135,33 @@ Next.js Config:
       Make sure to try the latest canary version (eg.: \`npm install next@canary\`) to confirm the issue still exists before creating a new issue.
       Read more - https://nextjs.org/docs/messages/opening-an-issue`
     )
+  }
+
+  console.log(`
+Operating System:
+  Platform: ${os.platform()}
+  Arch: ${os.arch()}
+  Version: ${os.version()}
+Binaries:
+  Node: ${process.versions.node}
+  npm: ${getBinaryVersion('npm')}
+  Yarn: ${getBinaryVersion('yarn')}
+  pnpm: ${getBinaryVersion('pnpm')}
+Relevant Packages:
+  next: ${installedRelease}${staleness}
+  eslint-config-next: ${getPackageVersion('eslint-config-next')}
+  react: ${getPackageVersion('react')}
+  react-dom: ${getPackageVersion('react-dom')}
+  typescript: ${getPackageVersion('typescript')}
+Next.js Config:
+  output: ${nextConfig.output}
+
+`)
+
+  if (versionInfo?.staleness.startsWith('stale')) {
+    warn(`${title}
+   Please try the latest canary version (\`npm install next@canary\`) to confirm the issue still exists before creating a new issue.
+   Read more - https://nextjs.org/docs/messages/opening-an-issue`)
   }
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/VersionStalenessInfo/VersionStalenessInfo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/VersionStalenessInfo/VersionStalenessInfo.tsx
@@ -3,7 +3,34 @@ import type { VersionInfo } from '../../../../../../server/dev/parse-version-inf
 
 export function VersionStalenessInfo(props: VersionInfo) {
   if (!props) return null
-  const { staleness, installed, expected } = props
+  const { staleness } = props
+  let { text, indicatorClass, title } = getStaleness(props)
+
+  if (!text) return null
+
+  return (
+    <small className="nextjs-container-build-error-version-status">
+      <span className={indicatorClass} />
+      <small
+        className="nextjs-container-build-error-version-status"
+        title={title}
+      >
+        {text}
+      </small>{' '}
+      {staleness === 'fresh' || staleness === 'unknown' ? null : (
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://nextjs.org/docs/messages/version-staleness"
+        >
+          (learn more)
+        </a>
+      )}
+    </small>
+  )
+}
+
+export function getStaleness({ installed, staleness, expected }: VersionInfo) {
   let text = ''
   let title = ''
   let indicatorClass = ''
@@ -37,27 +64,5 @@ export function VersionStalenessInfo(props: VersionInfo) {
     default:
       break
   }
-
-  if (!text) return null
-
-  return (
-    <small className="nextjs-container-build-error-version-status">
-      <span className={indicatorClass} />
-      <small
-        className="nextjs-container-build-error-version-status"
-        title={title}
-      >
-        {text}
-      </small>{' '}
-      {staleness === 'fresh' || staleness === 'unknown' ? null : (
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://nextjs.org/docs/messages/version-staleness"
-        >
-          (learn more)
-        </a>
-      )}
-    </small>
-  )
+  return { text, indicatorClass, title }
 }


### PR DESCRIPTION
### What?

Improve the `next info` output.

<details>
<summary>Before:
</summary>
<img src="https://github.com/vercel/next.js/assets/18369201/735da72f-6746-42a0-838d-e10db78b2db3">
</details>

<details>
<summary>After:
</summary>
<img src="https://github.com/vercel/next.js/assets/18369201/d72c0027-71d9-494c-bb98-dd0fed99c8d9">
</details>

### Why?

People have been ignoring the ask to check `next@canary` before opening a new issue, which results in triaging overhead. This PR inlines the warning into `next info` that would make it an extra effort to remove the warning without reading the message, hopefully leading to not ignoring the message anymore.

### How?

Reusing the same logic from the version staleness indicator from Error Overlay.

[Slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1704364764719949)
