### PR TITLE
Change color of output bundle size

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -28,7 +28,7 @@ import '../server/require-hook'
 import '../server/node-polyfill-crypto'
 import '../server/node-environment'
 
-import { green, yellow, red, cyan, bold, underline } from '../lib/picocolors'
+import { green, yellow, cyan, bold, underline } from '../lib/picocolors'
 import getGzipSize from 'next/dist/compiled/gzip-size'
 import textTable from 'next/dist/compiled/text-table'
 import path from 'path'
@@ -387,12 +387,7 @@ export async function printTreeView(
 ) {
   const getPrettySize = (_size: number): string => {
     const size = prettyBytes(_size)
-    // green for 0-130kb
-    if (_size < 130 * 1000) return green(size)
-    // yellow for 130-170kb
-    if (_size < 170 * 1000) return yellow(size)
-    // red for >= 170kb
-    return red(bold(size))
+    return bold(size)
   }
 
   const MIN_DURATION = 300
@@ -403,7 +398,7 @@ export async function printTreeView(
     // yellow for 1000-2000ms
     if (_duration < 2000) return yellow(duration)
     // red for >= 2000ms
-    return red(bold(duration))
+    return yellow(bold(duration))
   }
 
   const getCleanName = (fileName: string) =>

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -28,7 +28,15 @@ import '../server/require-hook'
 import '../server/node-polyfill-crypto'
 import '../server/node-environment'
 
-import { green, yellow, cyan, bold, underline } from '../lib/picocolors'
+import {
+  green,
+  yellow,
+  red,
+  cyan,
+  white,
+  bold,
+  underline,
+} from '../lib/picocolors'
 import getGzipSize from 'next/dist/compiled/gzip-size'
 import textTable from 'next/dist/compiled/text-table'
 import path from 'path'
@@ -387,7 +395,7 @@ export async function printTreeView(
 ) {
   const getPrettySize = (_size: number): string => {
     const size = prettyBytes(_size)
-    return bold(size)
+    return white(bold(size))
   }
 
   const MIN_DURATION = 300
@@ -398,7 +406,7 @@ export async function printTreeView(
     // yellow for 1000-2000ms
     if (_duration < 2000) return yellow(duration)
     // red for >= 2000ms
-    return yellow(bold(duration))
+    return red(bold(duration))
   }
 
   const getCleanName = (fileName: string) =>


### PR DESCRIPTION
When you have a gaint code base of next.js app, the output client side loaded js bundle size could be large since most of them are functional, it might not make sense to display yellow or red color to warn you that your bundle is too large since they conatin the basic functionality.

We display the previous colored ones with opinionless bold white color to highlight them 
![image](https://github.com/vercel/next.js/assets/4800338/34814f2f-ff83-48b4-bad8-989031eff49e)

Closes NEXT-2017
Closes NEXT-2015