### PR TITLE
fix: rsc tests and run unit tests in CI again

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -119,29 +119,6 @@ jobs:
       mold: 'yes'
     secrets: inherit
 
-  test-cargo-integration:
-    name: test cargo integration
-    needs: ['changes', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
-
-    uses: ./.github/workflows/build_reusable.yml
-    with:
-      needsNextest: 'yes'
-      needsRust: 'yes'
-      skipNativeBuild: 'yes'
-      afterBuild: xvfb-run turbo run test-cargo-integration
-
-  test-cargo-bench:
-    name: test cargo benchmarks
-    needs: ['changes', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' || needs.changes.outputs.is-release == 'false' }}
-
-    uses: ./.github/workflows/build_reusable.yml
-    with:
-      needsRust: 'yes'
-      skipNativeBuild: 'yes'
-      afterBuild: xvfb-run turbo run test-cargo-bench
-
   rust-check:
     name: rust check
     needs: ['changes', 'build-next']
@@ -373,8 +350,6 @@ jobs:
         'test-ppr-prod',
         'test-ppr-integration',
         'test-cargo-unit',
-        'test-cargo-integration',
-        'test-cargo-bench',
         'rust-check',
         'test-next-swc-wasm',
         'test-turbopack-dev',

--- a/packages/next-swc/crates/core/tests/errors.rs
+++ b/packages/next-swc/crates/core/tests/errors.rs
@@ -3,13 +3,13 @@ use std::path::PathBuf;
 use next_swc::{
     disallow_re_export_all_in_page::disallow_re_export_all_in_page,
     next_ssg::next_ssg,
-    react_server_components::server_components,
     server_actions::{
         server_actions, {self},
     },
 };
 use next_transform_dynamic::{next_dynamic, NextDynamicMode};
 use next_transform_font::{next_font_loaders, Config as FontLoaderConfig};
+use next_transform_react_server_components::server_components;
 use turbopack_binding::swc::{
     core::{
         common::{chain, FileName, Mark},
@@ -94,8 +94,8 @@ fn react_server_components_server_graph_errors(input: PathBuf) {
         &|tr| {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/layout.js")),
-                next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options {
+                next_transform_react_server_components::Config::WithOptions(
+                    next_transform_react_server_components::Options {
                         is_react_server_layer: true,
                     },
                 ),
@@ -120,8 +120,8 @@ fn react_server_components_client_graph_errors(input: PathBuf) {
         &|tr| {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/page.js")),
-                next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options {
+                next_transform_react_server_components::Config::WithOptions(
+                    next_transform_react_server_components::Options {
                         is_react_server_layer: false,
                     },
                 ),
@@ -168,8 +168,8 @@ fn react_server_actions_server_errors(input: PathBuf) {
                 resolver(Mark::new(), Mark::new(), false),
                 server_components(
                     FileName::Real(PathBuf::from("/app/item.js")),
-                    next_swc::react_server_components::Config::WithOptions(
-                        next_swc::react_server_components::Options {
+                    next_transform_react_server_components::Config::WithOptions(
+                        next_transform_react_server_components::Options {
                             is_react_server_layer: true
                         },
                     ),
@@ -205,8 +205,8 @@ fn react_server_actions_client_errors(input: PathBuf) {
                 resolver(Mark::new(), Mark::new(), false),
                 server_components(
                     FileName::Real(PathBuf::from("/app/item.js")),
-                    next_swc::react_server_components::Config::WithOptions(
-                        next_swc::react_server_components::Options {
+                    next_transform_react_server_components::Config::WithOptions(
+                        next_transform_react_server_components::Options {
                             is_react_server_layer: false
                         },
                     ),

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -9,7 +9,6 @@ use next_swc::{
     optimize_server_react::optimize_server_react,
     page_config::page_config_test,
     pure::pure_magic,
-    react_server_components::server_components,
     server_actions::{
         server_actions, {self},
     },
@@ -17,6 +16,7 @@ use next_swc::{
 };
 use next_transform_dynamic::{next_dynamic, NextDynamicMode};
 use next_transform_font::{next_font_loaders, Config as FontLoaderConfig};
+use next_transform_react_server_components::server_components;
 use serde::de::DeserializeOwned;
 use turbopack_binding::swc::{
     core::{
@@ -311,8 +311,8 @@ fn react_server_components_server_graph_fixture(input: PathBuf) {
         &|tr| {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
-                next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options {
+                next_transform_react_server_components::Config::WithOptions(
+                    next_transform_react_server_components::Options {
                         is_react_server_layer: true,
                     },
                 ),
@@ -334,8 +334,8 @@ fn react_server_components_no_checks_server_graph_fixture(input: PathBuf) {
         &|tr| {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
-                next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options {
+                next_transform_react_server_components::Config::WithOptions(
+                    next_transform_react_server_components::Options {
                         is_react_server_layer: true,
                     },
                 ),
@@ -357,8 +357,8 @@ fn react_server_components_client_graph_fixture(input: PathBuf) {
         &|tr| {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
-                next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options {
+                next_transform_react_server_components::Config::WithOptions(
+                    next_transform_react_server_components::Options {
                         is_react_server_layer: false,
                     },
                 ),
@@ -380,8 +380,8 @@ fn react_server_components_no_checks_client_graph_fixture(input: PathBuf) {
         &|tr| {
             server_components(
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
-                next_swc::react_server_components::Config::WithOptions(
-                    next_swc::react_server_components::Options {
+                next_transform_react_server_components::Config::WithOptions(
+                    next_transform_react_server_components::Options {
                         is_react_server_layer: false,
                     },
                 ),

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -11,7 +11,10 @@
     "build-native-no-plugin-woa-release": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --release --cargo-flags=--no-default-features --features native-tls,image-webp,tracing/release_max_level_info --js false native",
     "build-wasm": "wasm-pack build crates/wasm --scope=next",
     "cache-build-native": "echo $(ls native)",
-    "rust-check": "cd ../../; cargo fmt -- --check && cargo clippy --all -- -D warnings -A deprecated && cargo check -p next-swc-napi --features=rustls-tls && rm -rf target"
+    "rust-check-fmt": "cd ../..; cargo fmt -- --check",
+    "rust-check-clippy": "cargo clippy --workspace --all-targets -- -D warnings -A deprecated",
+    "rust-check-napi-rustls": "cargo check -p next-swc-napi --features=rustls-tls",
+    "test-cargo-unit": "cargo nextest run --workspace --release --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",

--- a/turbo.json
+++ b/turbo.json
@@ -96,11 +96,41 @@
     "typescript": {},
     "//#typescript": {},
     "rust-check": {
+      "dependsOn": [
+        "^rust-check-fmt",
+        "^rust-check-clippy",
+        "^rust-check-napi-rustls"
+      ]
+    },
+    "rust-check-fmt": {
       "inputs": [
         "../../.cargo/**",
         "../../packages/next-swc/crates/**",
         "../../**/Cargo.toml",
-        "../../**/Cargo.lock"
+        "../../**/Cargo.lock",
+        "../../.github/workflows/build_and_deploy.yml",
+        "../../rust-toolchain"
+      ],
+      "cache": false
+    },
+    "rust-check-clippy": {
+      "inputs": [
+        "../../.cargo/**",
+        "../../packages/next-swc/crates/**",
+        "../../**/Cargo.toml",
+        "../../**/Cargo.lock",
+        "../../.github/workflows/build_and_deploy.yml",
+        "../../rust-toolchain"
+      ]
+    },
+    "rust-check-napi-rustls": {
+      "inputs": [
+        "../../.cargo/**",
+        "../../packages/next-swc/crates/**",
+        "../../**/Cargo.toml",
+        "../../**/Cargo.lock",
+        "../../.github/workflows/build_and_deploy.yml",
+        "../../rust-toolchain"
       ]
     },
     "test-cargo-unit": {
@@ -108,24 +138,9 @@
         "../../.cargo/**",
         "../../packages/next-swc/crates/**",
         "../../**/Cargo.toml",
-        "../../**/Cargo.lock"
-      ]
-    },
-    "test-cargo-integration": {
-      "inputs": [
-        "../../.cargo/**",
-        "../../packages/next-swc/crates/**",
-        "../../packages/next/**",
-        "../../**/Cargo.toml",
-        "../../**/Cargo.lock"
-      ]
-    },
-    "test-cargo-bench": {
-      "inputs": [
-        "../../.cargo/**",
-        "../../packages/next-swc/crates/**",
-        "../../**/Cargo.toml",
-        "../../**/Cargo.lock"
+        "../../**/Cargo.lock",
+        "../../.github/workflows/build_and_deploy.yml",
+        "../../rust-toolchain"
       ]
     },
     "//#get-test-timings": {


### PR DESCRIPTION
### What?

For some reason turbo skipped a rust task letting broken code get merged (we probably should not hack turbo into caching rust tasks).


Closes PACK-2202