### PR TITLE
Improves generateViewport documentation

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-viewport.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-viewport.mdx
@@ -19,7 +19,7 @@ You can customize the initial viewport of the page with the static `viewport` ob
 
 ## The `viewport` object
 
-To define the viewport options, export a `viewport` object from a `layout.js` or `page.js` file.
+To define the viewport options, export a `viewport` object from a `layout.jsx` or `page.jsx` file.
 
 ```tsx filename="layout.tsx | page.tsx" switcher
 import type { Viewport } from 'next'
@@ -71,16 +71,16 @@ Learn more about [`theme-color`](https://developer.mozilla.org/docs/Web/HTML/Ele
 
 **Simple theme color**
 
-```jsx filename="layout.jsx | page.jsx" switcher
-export const viewport = {
-  themeColor: 'black',
-}
-```
-
 ```tsx filename="layout.tsx | page.tsx" switcher
 import type { Viewport } from 'next'
 
 export const viewport: Viewport = {
+  themeColor: 'black',
+}
+```
+
+```jsx filename="layout.jsx | page.jsx" switcher
+export const viewport = {
   themeColor: 'black',
 }
 ```
@@ -91,8 +91,10 @@ export const viewport: Viewport = {
 
 **With media attribute**
 
-```jsx filename="layout.jsx | page.jsx" switcher
-export const viewport = {
+```tsx filename="layout.tsx | page.tsx" switcher
+import type { Viewport } from 'next'
+
+export const viewport: Viewport = {
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: 'cyan' },
     { media: '(prefers-color-scheme: dark)', color: 'black' },
@@ -100,10 +102,8 @@ export const viewport = {
 }
 ```
 
-```tsx filename="layout.tsx | page.tsx" switcher
-import type { Viewport } from 'next'
-
-export const viewport: Viewport = {
+```jsx filename="layout.jsx | page.jsx" switcher
+export const viewport = {
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: 'cyan' },
     { media: '(prefers-color-scheme: dark)', color: 'black' },
@@ -120,8 +120,10 @@ export const viewport: Viewport = {
 
 > **Good to know**: The `viewport` meta tag is automatically set with the following default values. Usually, manual configuration is unnecessary as the default is sufficient. However, the information is provided for completeness.
 
-```jsx filename="layout.jsx | page.jsx" switcher
-export const viewport = {
+```tsx filename="layout.tsx | page.tsx" switcher
+import type { Viewport } from 'next'
+
+export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
@@ -131,10 +133,8 @@ export const viewport = {
 }
 ```
 
-```tsx filename="layout.tsx | page.tsx" switcher
-import type { Viewport } from 'next'
-
-export const viewport: Viewport = {
+```jsx filename="layout.jsx | page.jsx" switcher
+export const viewport = {
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
@@ -155,16 +155,16 @@ export const viewport: Viewport = {
 
 Learn more about [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name#:~:text=color%2Dscheme%3A%20specifies,of%20the%20following%3A).
 
-```jsx filename="layout.jsx | page.jsx" switcher
-export const viewport = {
-  colorScheme: 'dark',
-}
-```
-
 ```tsx filename="layout.tsx | page.tsx" switcher
 import type { Viewport } from 'next'
 
 export const viewport: Viewport = {
+  colorScheme: 'dark',
+}
+```
+
+```jsx filename="layout.jsx | page.jsx" switcher
+export const viewport = {
   colorScheme: 'dark',
 }
 ```

--- a/docs/02-app/02-api-reference/04-functions/generate-viewport.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-viewport.mdx
@@ -31,7 +31,7 @@ export const viewport: Viewport = {
 export default function Page() {}
 ```
 
-```jsx filename="layout.js | page.js" switcher
+```jsx filename="layout.jsx | page.jsx" switcher
 export const viewport = {
   themeColor: 'black',
 }
@@ -67,12 +67,20 @@ export function generateViewport({ params }) {
 
 ### `themeColor`
 
-Learn more about [theme-color](https://developer.mozilla.org/docs/Web/HTML/Element/meta/name/theme-color).
+Learn more about [`theme-color`](https://developer.mozilla.org/docs/Web/HTML/Element/meta/name/theme-color).
 
 **Simple theme color**
 
-```jsx filename="layout.js | page.js"
+```jsx filename="layout.jsx | page.jsx" switcher
 export const viewport = {
+  themeColor: 'black',
+}
+```
+
+```tsx filename="layout.tsx | page.tsx" switcher
+import type { Viewport } from 'next'
+
+export const viewport: Viewport = {
   themeColor: 'black',
 }
 ```
@@ -83,8 +91,19 @@ export const viewport = {
 
 **With media attribute**
 
-```jsx filename="layout.js | page.js"
+```jsx filename="layout.jsx | page.jsx" switcher
 export const viewport = {
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: 'cyan' },
+    { media: '(prefers-color-scheme: dark)', color: 'black' },
+  ],
+}
+```
+
+```tsx filename="layout.tsx | page.tsx" switcher
+import type { Viewport } from 'next'
+
+export const viewport: Viewport = {
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: 'cyan' },
     { media: '(prefers-color-scheme: dark)', color: 'black' },
@@ -97,16 +116,29 @@ export const viewport = {
 <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black" />
 ```
 
-### `width`, `initialScale`, `maximumScale` and 'userScalable'
+### `width`, `initialScale`, `maximumScale` and `userScalable`
 
 > **Good to know**: The `viewport` meta tag is automatically set with the following default values. Usually, manual configuration is unnecessary as the default is sufficient. However, the information is provided for completeness.
 
-```jsx filename="layout.js | page.js"
+```jsx filename="layout.jsx | page.jsx" switcher
 export const viewport = {
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
-  userScalable: 1,
+  userScalable: 'no',
+  // Also supported by less commonly used
+  // interactiveWidget: 'resizes-visual',
+}
+```
+
+```tsx filename="layout.tsx | page.tsx" switcher
+import type { Viewport } from 'next'
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: 'no',
   // Also supported by less commonly used
   // interactiveWidget: 'resizes-visual',
 }
@@ -123,8 +155,16 @@ export const viewport = {
 
 Learn more about [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name#:~:text=color%2Dscheme%3A%20specifies,of%20the%20following%3A).
 
-```jsx filename="layout.js | page.js"
+```jsx filename="layout.jsx | page.jsx" switcher
 export const viewport = {
+  colorScheme: 'dark',
+}
+```
+
+```tsx filename="layout.tsx | page.tsx" switcher
+import type { Viewport } from 'next'
+
+export const viewport: Viewport = {
   colorScheme: 'dark',
 }
 ```


### PR DESCRIPTION
This PR introduces 2 changes to the `generateViewport` documentation.
-  Adds more **TypeScript** examples
- Changes the line that says `userScalable: 'no'` to `userScalable: false` because according to **TypeScript** `userScalable` is of type `boolean | undefined` _because it's an optional property._
     - Whenever a **string** is used this error message is shown: `Type 'string' is not assignable to type 'boolean | undefined'.`