### PR TITLE
Refactor `unstable_cache` implementation

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -295,7 +295,6 @@ export class IncrementalCache implements IncrementalCacheType {
     // that should bust the cache
     const MAIN_KEY_PREFIX = 'v3'
 
-    let cacheKey: string
     const bodyChunks: string[] = []
 
     const encoder = new TextEncoder()
@@ -398,12 +397,11 @@ export class IncrementalCache implements IncrementalCacheType {
           .join('')
       }
       const buffer = encoder.encode(cacheString)
-      cacheKey = bufferToHex(await crypto.subtle.digest('SHA-256', buffer))
+      return bufferToHex(await crypto.subtle.digest('SHA-256', buffer))
     } else {
       const crypto = require('crypto') as typeof import('crypto')
-      cacheKey = crypto.createHash('sha256').update(cacheString).digest('hex')
+      return crypto.createHash('sha256').update(cacheString).digest('hex')
     }
-    return cacheKey
   }
 
   // get data from cache if available

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -2,6 +2,7 @@ import type {
   StaticGenerationStore,
   StaticGenerationAsyncStorage,
 } from '../../../client/components/static-generation-async-storage.external'
+import type { IncrementalCache } from '../../lib/incremental-cache'
 
 import { staticGenerationAsyncStorage as _staticGenerationAsyncStorage } from '../../../client/components/static-generation-async-storage.external'
 import { CACHE_ONE_YEAR } from '../../../lib/constants'
@@ -12,6 +13,35 @@ import {
 } from '../../lib/patch-fetch'
 
 type Callback = (...args: any[]) => Promise<any>
+
+async function cacheNewResult<T>(
+  result: T,
+  incrementalCache: IncrementalCache,
+  cacheKey: string,
+  tags: string[],
+  revalidate: number | false | undefined
+): Promise<unknown> {
+  await incrementalCache.set(
+    cacheKey,
+    {
+      kind: 'FETCH',
+      data: {
+        headers: {},
+        // TODO: handle non-JSON values?
+        body: JSON.stringify(result),
+        status: 200,
+        url: '',
+      },
+      revalidate: typeof revalidate !== 'number' ? CACHE_ONE_YEAR : revalidate,
+    },
+    {
+      revalidate,
+      fetchCache: true,
+      tags,
+    }
+  )
+  return
+}
 
 export function unstable_cache<T extends Callback>(
   cb: T,
@@ -30,164 +60,245 @@ export function unstable_cache<T extends Callback>(
     )
   }
 
+  // Validate the tags provided are valid
+  const tags = options.tags
+    ? validateTags(options.tags, `unstable_cache ${cb.toString()}`)
+    : []
+
+  // Validate the revalidate options
+  validateRevalidate(
+    options.revalidate,
+    `unstable_cache ${cb.name || cb.toString()}`
+  )
+
+  // Stash the fixed part of the key at construction time. The invocation key will combine
+  // the fixed key with the arguments when actually called
+  // @TODO if cb.toString() is long we should hash it
+  // @TODO come up with a collision-free way to combine keyParts
+  // @TODO consider validating the keyParts are all strings. TS can't provide runtime guarantees
+  // and the error produced by accidentally using something that cannot be safely coerced is likely
+  // hard to debug
+  const fixedKey = `${cb.toString()}-${
+    Array.isArray(keyParts) && keyParts.join(',')
+  }`
+
   const cachedCb = async (...args: any[]) => {
     const store: undefined | StaticGenerationStore =
       staticGenerationAsyncStorage?.getStore()
 
-    if (store && typeof options.revalidate !== 'undefined') {
-      validateRevalidate(
-        options.revalidate,
-        `unstable_cache ${cb.name || cb.toString()}`
-      )
-      // Revalidate 0 is a special case, it means opt-out of static generation.
-      if (options.revalidate === 0) {
-        // If postpone is supported we should postpone the render.
-        store.postpone?.('revalidate: 0')
-
-        // Set during dynamic rendering
-        store.revalidate = 0
-        // If revalidate was already set in the store before we should check if the new value is lower, set it to the lowest of the two.
-      } else if (
-        typeof store.revalidate === 'number' &&
-        typeof options.revalidate === 'number'
-      ) {
-        if (store.revalidate > options.revalidate) {
-          store.revalidate = options.revalidate
-        }
-        // All other cases we set the value from the option.
-      } else {
-        store.revalidate = options.revalidate
-      }
-    }
-
-    const incrementalCache:
+    // We must be able to find the incremental cache otherwise we throw
+    const maybeIncrementalCache:
       | import('../../lib/incremental-cache').IncrementalCache
       | undefined =
       store?.incrementalCache || (globalThis as any).__incrementalCache
 
-    if (!incrementalCache) {
+    if (!maybeIncrementalCache) {
       throw new Error(
         `Invariant: incrementalCache missing in unstable_cache ${cb.toString()}`
       )
     }
+    const incrementalCache = maybeIncrementalCache
 
-    const joinedKey = `${cb.toString()}-${
-      Array.isArray(keyParts) && keyParts.join(',')
-    }-${JSON.stringify(args)}`
+    // Construct the complete cache key for this function invocation
+    // @TODO stringify is likely not safe here. We will coerce undefined to null which will make
+    // the keyspace smaller than the execution space
+    const invocationKey = `${fixedKey}-${JSON.stringify(args)}`
+    const cacheKey = await incrementalCache.fetchCacheKey(invocationKey)
 
-    // We override the default fetch cache handling inside of the
-    // cache callback so that we only cache the specific values returned
-    // from the callback instead of also caching any fetches done inside
-    // of the callback as well
-    return staticGenerationAsyncStorage.run(
-      {
-        ...store,
-        // force any nested fetches to bypass cache so they revalidate
-        // when the unstable_cache call is revalidated
-        fetchCache: 'force-no-store',
-        urlPathname: store?.urlPathname || '/',
-        isUnstableCacheCallback: true,
-        isStaticGeneration: store?.isStaticGeneration === true,
-        postpone: store?.postpone,
-      },
-      async () => {
-        const tags = validateTags(
-          options.tags || [],
-          `unstable_cache ${cb.toString()}`
-        )
+    if (store) {
+      // We are in an App Router context. We try to return the cached entry if it exists and is valid
+      // If the entry is fresh we return it. If the entry is stale we return it but revalidate the entry in
+      // the background. If the entry is missing or invalid we generate a new entry and return it.
 
-        if (Array.isArray(tags) && store) {
-          if (!store.tags) {
-            store.tags = []
-          }
-          for (const tag of tags) {
-            if (!store.tags.includes(tag)) {
-              store.tags.push(tag)
-            }
-          }
+      // We update the store's revalidate property if the option.revalidate is a higher precedence
+      if (typeof options.revalidate === 'number') {
+        if (
+          typeof store.revalidate === 'number' &&
+          store.revalidate < options.revalidate
+        ) {
+          // The store is already revalidating on a shorter time interval, leave it alone
+        } else {
+          store.revalidate = options.revalidate
         }
-        const implicitTags = store ? addImplicitTags(store) : []
-
-        const cacheKey = await incrementalCache?.fetchCacheKey(joinedKey)
-        const cacheEntry =
-          cacheKey &&
-          // when we are nested inside of other unstable_cache's
-          // we should bypass cache similar to fetches
-          store?.fetchCache !== 'force-no-store' &&
-          !(
-            store?.isOnDemandRevalidate || incrementalCache.isOnDemandRevalidate
-          ) &&
-          (await incrementalCache?.get(cacheKey, {
-            kindHint: 'fetch',
-            revalidate: options.revalidate,
-            tags,
-            softTags: implicitTags,
-          }))
-
-        const invokeCallback = async () => {
-          const result = await cb(...args)
-
-          if (cacheKey && incrementalCache) {
-            await incrementalCache.set(
-              cacheKey,
-              {
-                kind: 'FETCH',
-                data: {
-                  headers: {},
-                  // TODO: handle non-JSON values?
-                  body: JSON.stringify(result),
-                  status: 200,
-                  url: '',
-                },
-                revalidate:
-                  typeof options.revalidate !== 'number'
-                    ? CACHE_ONE_YEAR
-                    : options.revalidate,
-              },
-              {
-                revalidate: options.revalidate,
-                fetchCache: true,
-                tags,
-              }
-            )
-          }
-          return result
-        }
-
-        if (!cacheEntry || !cacheEntry.value) {
-          return invokeCallback()
-        }
-
-        if (cacheEntry.value.kind !== 'FETCH') {
-          console.error(
-            `Invariant invalid cacheEntry returned for ${joinedKey}`
-          )
-          return invokeCallback()
-        }
-        let cachedValue: any
-        const isStale = cacheEntry.isStale
-
-        if (cacheEntry) {
-          const resData = cacheEntry.value.data
-          cachedValue = JSON.parse(resData.body)
-        }
-
-        if (isStale) {
-          if (!store) {
-            return invokeCallback()
-          } else {
-            if (!store.pendingRevalidates) {
-              store.pendingRevalidates = {}
-            }
-            store.pendingRevalidates[joinedKey] = invokeCallback().catch(
-              (err) =>
-                console.error(`revalidating cache with key: ${joinedKey}`, err)
-            )
-          }
-        }
-        return cachedValue
+      } else if (
+        options.revalidate === false &&
+        typeof store.revalidate === 'undefined'
+      ) {
+        // The store has not defined revalidate type so we can use the false option
+        store.revalidate = options.revalidate
       }
-    )
+
+      // We need to accumulate the tags for this invocation within the store
+      if (!store.tags) {
+        store.tags = tags.slice()
+      } else {
+        for (const tag of tags) {
+          // @TODO refactor tags to be a set to avoid this O(n) lookup
+          if (!store.tags.includes(tag)) {
+            store.tags.push(tag)
+          }
+        }
+      }
+      // @TODO check on this API. addImplicitTags mutates the store and returns the implicit tags. The naming
+      // of this function is potentially a little confusing
+      const implicitTags = addImplicitTags(store)
+
+      if (
+        // when we are nested inside of other unstable_cache's
+        // we should bypass cache similar to fetches
+        store.fetchCache !== 'force-no-store' &&
+        !store.isOnDemandRevalidate &&
+        !incrementalCache.isOnDemandRevalidate
+      ) {
+        // We attempt to get the current cache entry from the incremental cache.
+        const cacheEntry = await incrementalCache.get(cacheKey, {
+          kindHint: 'fetch',
+          revalidate: options.revalidate,
+          tags,
+          softTags: implicitTags,
+        })
+
+        if (cacheEntry && cacheEntry.value) {
+          // The entry exists and has a value
+          if (cacheEntry.value.kind !== 'FETCH') {
+            // The entry is invalid and we need a special warning
+            // @TODO why do we warn this way? Should this just be an error? How are these errors surfaced
+            // so bugs can be reported
+            // @TODO the invocation key can have sensitive data in it. we should not log this entire object
+            console.error(
+              `Invariant invalid cacheEntry returned for ${invocationKey}`
+            )
+            // will fall through to generating a new cache entry below
+          } else {
+            // We have a valid cache entry so we will be returning it. We also check to see if we need
+            // to background revalidate it by checking if it is stale.
+            const cachedResponse = JSON.parse(cacheEntry.value.data.body)
+            if (cacheEntry.isStale) {
+              // In App Router we return the stale result and revalidate in the background
+              if (!store.pendingRevalidates) {
+                store.pendingRevalidates = {}
+              }
+              // We run the cache function asynchronously and save the result when it completes
+              store.pendingRevalidates[invocationKey] =
+                staticGenerationAsyncStorage
+                  .run(
+                    {
+                      ...store,
+                      // force any nested fetches to bypass cache so they revalidate
+                      // when the unstable_cache call is revalidated
+                      fetchCache: 'force-no-store',
+                      isUnstableCacheCallback: true,
+                    },
+                    cb,
+                    ...args
+                  )
+                  .then((result) => {
+                    return cacheNewResult(
+                      result,
+                      incrementalCache,
+                      cacheKey,
+                      tags,
+                      options.revalidate
+                    )
+                  })
+                  // @TODO This error handling seems wrong. We swallow the error?
+                  .catch((err) =>
+                    console.error(
+                      `revalidating cache with key: ${invocationKey}`,
+                      err
+                    )
+                  )
+            }
+            // We had a valid cache entry so we return it here
+            return cachedResponse
+          }
+        }
+      }
+
+      // If we got this far then we had an invalid cache entry and need to generate a new one
+      const result = await staticGenerationAsyncStorage.run(
+        {
+          ...store,
+          // force any nested fetches to bypass cache so they revalidate
+          // when the unstable_cache call is revalidated
+          fetchCache: 'force-no-store',
+          isUnstableCacheCallback: true,
+        },
+        cb,
+        ...args
+      )
+      cacheNewResult(
+        result,
+        incrementalCache,
+        cacheKey,
+        tags,
+        options.revalidate
+      )
+      return result
+    } else {
+      // We are in Pages Router or were called outside of a render. We don't have a store
+      // so we just call the callback directly when it needs to run.
+      // If the entry is fresh we return it. If the entry is stale we return it but revalidate the entry in
+      // the background. If the entry is missing or invalid we generate a new entry and return it.
+
+      if (!incrementalCache.isOnDemandRevalidate) {
+        // We aren't doing an on demand revalidation so we check use the cache if valid
+
+        const cacheEntry = await incrementalCache.get(cacheKey, {
+          kindHint: 'fetch',
+          revalidate: options.revalidate,
+          tags,
+        })
+
+        if (cacheEntry && cacheEntry.value) {
+          // The entry exists and has a value
+          if (cacheEntry.value.kind !== 'FETCH') {
+            // The entry is invalid and we need a special warning
+            // @TODO why do we warn this way? Should this just be an error? How are these errors surfaced
+            // so bugs can be reported
+            console.error(
+              `Invariant invalid cacheEntry returned for ${invocationKey}`
+            )
+            // will fall through to generating a new cache entry below
+          } else if (!cacheEntry.isStale) {
+            // We have a valid cache entry and it is fresh so we return it
+            return JSON.parse(cacheEntry.value.data.body)
+          }
+        }
+      }
+
+      // If we got this far then we had an invalid cache entry and need to generate a new one
+      // @TODO this storage wrapper is included here because it existed prior to the latest refactor
+      // however it is incorrect logic because it causes any internal cache calls to follow the App Router
+      // path rather than Pages router path. This may mean there is existing buggy behavior however no specific
+      // issues are known at this time. The whole static generation storage pathways should be reworked
+      // to allow tracking which "mode" we are in without the presence of a store or not. For now I have
+      // maintained the existing behavior to limit the impact of the current refactor
+      const result = await staticGenerationAsyncStorage.run(
+        // We are making a fake store that is useful for scoping fetchCache: 'force-no-store' and isUnstableCacheCallback: true
+        // The fact that we need to construct this kind of fake store indicates the code is not factored correctly
+        // @TODO refactor to not require this fake store object
+        {
+          // force any nested fetches to bypass cache so they revalidate
+          // when the unstable_cache call is revalidated
+          fetchCache: 'force-no-store',
+          isUnstableCacheCallback: true,
+          urlPathname: '/',
+          isStaticGeneration: false,
+          postpone: undefined,
+        },
+        cb,
+        ...args
+      )
+      cacheNewResult(
+        result,
+        incrementalCache,
+        cacheKey,
+        tags,
+        options.revalidate
+      )
+      return result
+    }
   }
   // TODO: once AsyncLocalStorage.run() returns the correct types this override will no longer be necessary
   return cachedCb as unknown as T


### PR DESCRIPTION
The original motivation of this PR is to get `unstable_cache` into a state where I can more easily change the implementation of postpone to be more akin to "dynamic rendering APIs". the existing approach made typing the staticGenerationStore in a way I wanted to for the planned changes would have been hard to implement with the current approach. At the same time this was an opportunity to make the implementation more efficient and easier to reason about.

reorganizes unstable_cache to improve performance and potentially fix latent bugs related to nest cache calls

In the original implementation there are repeated defined checks for the store and relatively complex logic around gathering the cache entry. In my refactor I fork the implementation based on whether we have a store or not. Loosely this translates to whether the cache call is for App Router vs Pages Router however due to a quirk in how we scope inner cache calls there is an existing and unchanged case where a Pages Router cached callback runs with a "fake" store that is used to scope some cache values to prevent inner caching when one cached function calls another. It should be noted that this fake store technique means that inner cache calls inside Pages Router will hit the App Router pathway in unstable cache. This is not great but it is the current behavior and while I have made some changes that might fix some bugs changing this felt like a much bigger lift to do in a primarily refactor PR.

This "fake" store can be replaced by a different async store for Pages Router which we can use to scope the inner environment to not be cached eventually though it may make more sense to just generalize the staticGenerationStore into a kind of RenderStore and have it run for Pages Router too.

I moved as much computation that can be done in the closure around the cached function out of the cached function and I narrowed the scope of the run call to make it clear that we really only need to scope the callback.

I removed function allocations per invocation

I probably fixed a bug in how the revalidate property was refined on the static generation store. Previously it would be possible to go from number to false and back again but this doesn't make sense as false is more like INFINITY in terms of refining to shorter values. This PR updates this logic to be apparently

Closes NEXT-2028