### PR TITLE
Expand hydration error test to check recovery

### DIFF
--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -17,7 +17,7 @@ describe('Error overlay for hydration errors', () => {
   })
 
   it('should show correct hydration error when client and server render different text', async () => {
-    const { cleanup, session } = await sandbox(
+    const { cleanup, session, browser } = await sandbox(
       next,
       new Map([
         [
@@ -47,6 +47,25 @@ describe('Error overlay for hydration errors', () => {
       See more info here: https://nextjs.org/docs/messages/react-hydration-error"
     `)
 
+    await session.patch(
+      'app/page.js',
+      outdent`
+      'use client'
+      const isClient = typeof window !== 'undefined'
+      export default function Mismatch() {
+        return (
+          <div className="parent">
+            <main className="child">Value</main>
+          </div>
+        );
+      }
+    `
+    )
+
+    expect(await session.hasRedbox()).toBe(false)
+
+    expect(await browser.elementByCss('.child').text()).toBe('Value')
+
     await cleanup()
   })
 
@@ -58,7 +77,6 @@ describe('Error overlay for hydration errors', () => {
           'app/page.js',
           outdent`
             'use client'
-            const isClient = typeof window !== 'undefined'
             export default function Mismatch() {
               return (
                 <div className="parent">

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -51,7 +51,6 @@ describe('Error overlay for hydration errors', () => {
       'app/page.js',
       outdent`
       'use client'
-      const isClient = typeof window !== 'undefined'
       export default function Mismatch() {
         return (
           <div className="parent">
@@ -77,6 +76,7 @@ describe('Error overlay for hydration errors', () => {
           'app/page.js',
           outdent`
             'use client'
+            const isClient = typeof window !== 'undefined'
             export default function Mismatch() {
               return (
                 <div className="parent">

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -15,7 +15,7 @@ describe('Error overlay for hydration errors', () => {
   })
 
   it('should show correct hydration error when client and server render different text', async () => {
-    const { cleanup, session } = await sandbox(
+    const { cleanup, session, browser } = await sandbox(
       next,
       new Map([
         [
@@ -43,6 +43,23 @@ describe('Error overlay for hydration errors', () => {
 
       See more info here: https://nextjs.org/docs/messages/react-hydration-error"
     `)
+
+    await session.patch(
+      'index.js',
+      outdent`
+      export default function Mismatch() {
+          return (
+            <div className="parent">
+              <main className="child">Value</main>
+            </div>
+          );
+        }
+    `
+    )
+
+    expect(await session.hasRedbox()).toBe(false)
+
+    expect(await browser.elementByCss('.child').text()).toBe('Value')
 
     await cleanup()
   })


### PR DESCRIPTION
## What?

Adds an additional condition to the hydration error test to check if it recovers correctly when making a change that removes the hydration error.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2033