### PR TITLE
chore(docs): fix 14 upgrade guide mentioning export

### DIFF
--- a/docs/02-app/01-building-your-application/10-upgrading/03-version-14.mdx
+++ b/docs/02-app/01-building-your-application/10-upgrading/03-version-14.mdx
@@ -30,7 +30,7 @@ bun add next@latest react@latest react-dom@latest eslint-config-next@latest
 ### v14 Summary
 
 - The minimum Node.js version has been bumped from 16.14 to 18.17, since 16.x has reached end-of-life.
-- The `next export` command is deprecated in favor of `output: 'export'`. Please see the [docs](https://nextjs.org/docs/app/building-your-application/deploying/static-exports) for more information.
+- The `next export` command has been removed in favor of `output: 'export'` config. Please see the [docs](https://nextjs.org/docs/app/building-your-application/deploying/static-exports) for more information.
 - The `next/server` import for `ImageResponse` was renamed to `next/og`. A [codemod is available](/docs/app/building-your-application/upgrading/codemods#next-og-import) to safely and automatically rename your imports.
 - The `@next/font` package has been fully removed in favor of the built-in `next/font`. A [codemod is available](/docs/app/building-your-application/upgrading/codemods#built-in-next-font) to safely and automatically rename your imports.
 - The WASM target for `next-swc` has been removed.


### PR DESCRIPTION
This was actually deprecated in a previous version 13.x and removed in Next.js 14.0.0

- See original PR: https://github.com/vercel/next.js/pull/57085