### PR TITLE
chore: skip flaky turbopack navigation test

### DIFF
--- a/test/build-turbopack-tests-manifest.js
+++ b/test/build-turbopack-tests-manifest.js
@@ -72,6 +72,9 @@ const SKIPPED_TEST_SUITES = {
     'app dir - metadata twitter should support twitter card summary_large_image when image present',
     'app dir - metadata viewport should support dynamic viewport export',
   ],
+  'test/e2e/app-dir/navigation/navigation.test.ts': [
+    'app dir - navigation query string useParams identity between renders should be stable in pages',
+  ],
   'test/e2e/basepath.test.ts': [
     'basePath should 404 when manually adding basePath with router.push',
     'basePath should 404 when manually adding basePath with router.replace',

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -3729,7 +3729,6 @@
       "app dir - navigation query string should not reset shallow url updates on prefetch",
       "app dir - navigation query string should set query correctly",
       "app dir - navigation query string useParams identity between renders should be stable in app",
-      "app dir - navigation query string useParams identity between renders should be stable in pages",
       "app dir - navigation redirect components should redirect client-side",
       "app dir - navigation redirect components should redirect in a client component",
       "app dir - navigation redirect components should redirect in a server component",
@@ -3750,7 +3749,9 @@
     ],
     "failed": [],
     "pending": [],
-    "flakey": [],
+    "flakey": [
+      "app dir - navigation query string useParams identity between renders should be stable in pages"
+    ],
     "runtimeError": false
   },
   "test/e2e/app-dir/next-config/index.test.ts": {


### PR DESCRIPTION
Tracking issue for fixing the test: https://linear.app/vercel/issue/PACK-2203/fix-flaky-navigation-e2e-test

Closes PACK-2204