### PR TITLE
chore: fix postinstall when using tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "next-no-sourcemaps": "cross-env NEXT_TELEMETRY_DISABLED=1 node --trace-deprecation packages/next/dist/bin/next",
     "clean-trace-jaeger": "node scripts/rm.mjs test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",
     "debug": "cross-env NEXT_TELEMETRY_DISABLED=1 node --inspect packages/next/dist/bin/next",
-    "postinstall": "git config index.skipHash false && node scripts/install-native.mjs",
+    "postinstall": "node scripts/git-configure.mjs && node scripts/install-native.mjs",
     "version": "pnpm install --no-frozen-lockfile && IS_PUBLISH=yes ./scripts/check-pre-compiled.sh && git add .",
     "prepare": "husky install",
     "sync-react": "node ./scripts/sync-react.js",

--- a/scripts/git-configure.mjs
+++ b/scripts/git-configure.mjs
@@ -1,0 +1,12 @@
+import execa from 'execa'
+
+// See https://github.com/vercel/next.js/pull/47375
+const { stdout, stderr } = await execa(
+  'git',
+  ['config', 'index.skipHash', 'false'],
+  {
+    reject: false,
+  }
+)
+
+console.log(stderr + stdout)


### PR DESCRIPTION
The postinstall script was failing In the case when you download [a zip](https://codeload.github.com/vercel/next.js/zip/refs/heads/canary) of the repo.

This PR fixes it so that `git config` can fail silently in that case when the repo is not using git.

- Related to https://github.com/nodejs/citgm/pull/1044

Closes NEXT-2036