### PR TITLE
Navigation Signals in PPR

### DIFF
--- a/packages/next/src/client/components/redirect.ts
+++ b/packages/next/src/client/components/redirect.ts
@@ -129,7 +129,7 @@ export function isRedirectError<U extends string>(
 export function getURLFromRedirectError<U extends string>(
   error: RedirectError<U>
 ): U
-export function getURLFromRedirectError(error: any): string | null {
+export function getURLFromRedirectError(error: unknown): string | null {
   if (!isRedirectError(error)) return null
 
   // Slices off the beginning of the digest that contains the code and the

--- a/packages/next/src/export/helpers/is-dynamic-usage-error.ts
+++ b/packages/next/src/export/helpers/is-dynamic-usage-error.ts
@@ -1,10 +1,8 @@
 import { isDynamicServerError } from '../../client/components/hooks-server-context'
-import { isNotFoundError } from '../../client/components/not-found'
-import { isRedirectError } from '../../client/components/redirect'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
+import { isNavigationSignalError } from './is-navigation-signal-error'
 
 export const isDynamicUsageError = (err: unknown) =>
   isDynamicServerError(err) ||
   isBailoutToCSRError(err) ||
-  isNotFoundError(err) ||
-  isRedirectError(err)
+  isNavigationSignalError(err)

--- a/packages/next/src/export/helpers/is-navigation-signal-error.ts
+++ b/packages/next/src/export/helpers/is-navigation-signal-error.ts
@@ -1,0 +1,10 @@
+import { isNotFoundError } from '../../client/components/not-found'
+import { isRedirectError } from '../../client/components/redirect'
+
+/**
+ * Returns true if the error is a navigation signal error. These errors are
+ * thrown by user code to perform navigation operations and interrupt the React
+ * render.
+ */
+export const isNavigationSignalError = (err: unknown) =>
+  isNotFoundError(err) || isRedirectError(err)

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -1,3 +1,4 @@
+import type { OutgoingHttpHeaders } from 'node:http'
 import type { ExportRouteResult, FileWriter } from '../types'
 import type { RenderOpts } from '../../server/app-render/types'
 import type { NextParsedUrlQuery } from '../../server/request-meta'
@@ -106,7 +107,15 @@ export async function exportAppPage(
       )
     }
 
-    const headers = { ...metadata.headers }
+    const headers: OutgoingHttpHeaders = { ...metadata.headers }
+
+    // When PPR is enabled, we should grab the headers from the mocked response
+    // and add it to the headers.
+    if (renderOpts.experimental.ppr) {
+      for (const [key, value] of Object.entries(res.getHeaders())) {
+        headers[key] = value
+      }
+    }
 
     if (fetchTags) {
       headers[NEXT_CACHE_TAGS_HEADER] = fetchTags
@@ -122,7 +131,10 @@ export async function exportAppPage(
 
     // Writing the request metadata to a file.
     const meta: RouteMetadata = {
-      status: undefined,
+      // When PPR is enabled, we don't always send 200 for routes that have been
+      // pregenerated, so we should grab the status code from the mocked
+      // response.
+      status: renderOpts.experimental.ppr ? res.statusCode : undefined,
       headers,
       postponed,
     }

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -112,9 +112,7 @@ export async function exportAppPage(
     // When PPR is enabled, we should grab the headers from the mocked response
     // and add it to the headers.
     if (renderOpts.experimental.ppr) {
-      for (const [key, value] of Object.entries(res.getHeaders())) {
-        headers[key] = value
-      }
+      Object.assign(headers, res.getHeaders())
     }
 
     if (fetchTags) {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -725,9 +725,6 @@ async function renderToHTMLOrFlightImpl(
     isRSCRequest &&
     req.headers[NEXT_ROUTER_PREFETCH_HEADER.toLowerCase()] !== undefined
 
-  // TODO: this should be moved to a higher point in the stack
-  const isInterceptionRoute = isInterceptionRouteAppPath(pagePath)
-
   /**
    * Router state provided from the client-side router. Used to handle rendering
    * from the common layout down. This value will be undefined if the request
@@ -735,12 +732,13 @@ async function renderToHTMLOrFlightImpl(
    * request (except when it's a prefetch request for an interception route
    * which is always dynamic).
    */
-
   const shouldProvideFlightRouterState =
     isRSCRequest &&
     (!isPrefetchRSCRequest ||
       !renderOpts.experimental.ppr ||
-      isInterceptionRoute)
+      // Interception routes currently depend on the flight router state to
+      // extract dynamic params.
+      isInterceptionRouteAppPath(pagePath))
 
   let providedFlightRouterState = shouldProvideFlightRouterState
     ? parseAndValidateFlightRouterState(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -725,16 +725,22 @@ async function renderToHTMLOrFlightImpl(
     isRSCRequest &&
     req.headers[NEXT_ROUTER_PREFETCH_HEADER.toLowerCase()] !== undefined
 
+  // TODO: this should be moved to a higher point in the stack
+  const isInterceptionRoute = isInterceptionRouteAppPath(pagePath)
+
   /**
-   * Router state provided from the client-side router. Used to handle rendering from the common layout down.
+   * Router state provided from the client-side router. Used to handle rendering
+   * from the common layout down. This value will be undefined if the request
+   * is not a client-side navigation request or if the request is a prefetch
+   * request (except when it's a prefetch request for an interception route
+   * which is always dynamic).
    */
 
   const shouldProvideFlightRouterState =
     isRSCRequest &&
     (!isPrefetchRSCRequest ||
       !renderOpts.experimental.ppr ||
-      // interception routes currently depend on the flight router state to extract dynamic params
-      isInterceptionRouteAppPath(pagePath))
+      isInterceptionRoute)
 
   let providedFlightRouterState = shouldProvideFlightRouterState
     ? parseAndValidateFlightRouterState(

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2801,7 +2801,10 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         )
       }
 
-      if (cachedData.status) {
+      // If the request is a data request, then we shouldn't set the status code
+      // from the response because it should always be 200. This should be gated
+      // behind the experimental PPR flag.
+      if (cachedData.status && (!isDataReq || !opts.experimental.ppr)) {
         res.statusCode = cachedData.status
       }
 

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -71,69 +71,71 @@ createNextDescribe(
       })
 
       describe('useParams identity between renders', () => {
-        async function runTests(page: string, waitForNEffects: number) {
-          const browser = await next.browser(page)
+        it.each([
+          {
+            router: 'app',
+            pathname: '/search-params/foo',
+            // App Router doesn't re-render on initial load (the params are baked
+            // server side). In development, effects will render twice.
+            waitForNEffects: isNextDev ? 2 : 1,
+          },
+          {
+            router: 'pages',
+            pathname: '/search-params-pages/foo',
+            // Pages Router re-renders on initial load and after hydration, the
+            // params when initially loaded are null.
+            waitForNEffects: 2,
+          },
+        ])(
+          'should be stable in $router',
+          async ({ pathname, waitForNEffects }) => {
+            const browser = await next.browser(pathname)
 
-          // Expect to see the params changed message at least twice.
-          let lastLogIndex = await retry(async () => {
-            const logs: Array<{ message: string }> = await browser.log()
+            // Expect to see the params changed message at least twice.
+            let lastLogIndex = await retry(async () => {
+              const logs: Array<{ message: string }> = await browser.log()
 
-            expect(
-              logs.filter(({ message }) => message === 'params changed')
-            ).toHaveLength(waitForNEffects)
+              expect(
+                logs.filter(({ message }) => message === 'params changed')
+              ).toHaveLength(waitForNEffects)
 
-            return logs.length
-          })
-
-          await browser.elementById('rerender-button').click()
-          await browser.elementById('rerender-button').click()
-          await browser.elementById('rerender-button').click()
-
-          await retry(async () => {
-            const rerender = await browser.elementById('rerender-button').text()
-
-            expect(rerender).toBe('Re-Render 3')
-          })
-
-          let logs: Array<{ message: string }> = await browser.log()
-          expect(logs.slice(lastLogIndex)).not.toContainEqual(
-            expect.objectContaining({
-              message: 'params changed',
+              return logs.length
             })
-          )
 
-          lastLogIndex = logs.length
+            await browser.elementById('rerender-button').click()
+            await browser.elementById('rerender-button').click()
+            await browser.elementById('rerender-button').click()
 
-          await browser.elementById('change-params-button').click()
+            await retry(async () => {
+              const rerender = await browser
+                .elementById('rerender-button')
+                .text()
 
-          await retry(async () => {
-            logs = await browser.log()
+              expect(rerender).toBe('Re-Render 3')
+            })
 
-            expect(logs.slice(lastLogIndex)).toContainEqual(
+            let logs: Array<{ message: string }> = await browser.log()
+            expect(logs.slice(lastLogIndex)).not.toContainEqual(
               expect.objectContaining({
                 message: 'params changed',
               })
             )
-          })
-        }
 
-        it('should be stable in app', async () => {
-          await runTests(
-            '/search-params/foo',
-            // App Router doesn't re-render on initial load (the params are baked
-            // server side). In development, effects will render twice.
-            isNextDev ? 2 : 1
-          )
-        })
+            lastLogIndex = logs.length
 
-        it('should be stable in pages', async () => {
-          await runTests(
-            '/search-params-pages/foo',
-            // Pages Router re-renders on initial load and after hydration, the
-            // params when initially loaded are null.
-            2
-          )
-        })
+            await browser.elementById('change-params-button').click()
+
+            await retry(async () => {
+              logs = await browser.log()
+
+              expect(logs.slice(lastLogIndex)).toContainEqual(
+                expect.objectContaining({
+                  message: 'params changed',
+                })
+              )
+            })
+          }
+        )
       })
     })
 

--- a/test/e2e/app-dir/ppr-full/app/navigation/not-found/dynamic/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/navigation/not-found/dynamic/page.jsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
+
+import { Dynamic } from '../../../../components/dynamic'
+
+const NotFound = () => {
+  notFound()
+}
+
+export default function NotFoundPage() {
+  return (
+    <>
+      <Suspense
+        fallback={<Dynamic pathname="/navigation/not-found/dynamic" fallback />}
+      >
+        <Dynamic pathname="/navigation/not-found/dynamic" />
+      </Suspense>
+      <NotFound />
+    </>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/navigation/not-found/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/navigation/not-found/page.jsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function NotFoundPage() {
+  notFound()
+}

--- a/test/e2e/app-dir/ppr-full/app/navigation/redirect/dynamic/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/navigation/redirect/dynamic/page.jsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+import { redirect } from 'next/navigation'
+
+import { Dynamic } from '../../../../components/dynamic'
+
+const Redirect = () => {
+  redirect('/navigation/redirect/location')
+}
+
+export default function RedirectPage() {
+  return (
+    <>
+      <Suspense
+        fallback={<Dynamic pathname="/navigation/redirect/dynamic" fallback />}
+      >
+        <Dynamic pathname="/navigation/redirect/dynamic" />
+      </Suspense>
+      <Redirect />
+    </>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/navigation/redirect/location/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/navigation/redirect/location/page.jsx
@@ -1,0 +1,5 @@
+export default function RedirectTargetPage() {
+  return (
+    <div data-pathname="/navigation/redirect/location">Redirect Target</div>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/navigation/redirect/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/navigation/redirect/page.jsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function RedirectPage() {
+  redirect('/navigation/redirect/location')
+}

--- a/test/e2e/app-dir/ppr-full/app/not-found.jsx
+++ b/test/e2e/app-dir/ppr-full/app/not-found.jsx
@@ -1,0 +1,3 @@
+export default function NotFoundPage() {
+  return <div id="not-found-page">Not Found</div>
+}

--- a/test/e2e/app-dir/ppr-full/components/links.jsx
+++ b/test/e2e/app-dir/ppr-full/components/links.jsx
@@ -39,6 +39,10 @@ const links = [
   { href: '/edge/no-suspense/a', tag: 'edge, no suspense, pre-generated' },
   { href: '/edge/no-suspense/b', tag: 'edge, no suspense, on-demand' },
   { href: '/edge/no-suspense/c', tag: 'edge, no suspense, on-demand' },
+  { href: '/navigation/not-found', tag: 'not-found' },
+  { href: '/navigation/not-found/no-store', tag: 'not-found, dynamic' },
+  { href: '/navigation/redirect', tag: 'redirect' },
+  { href: '/navigation/redirect/no-store', tag: 'redirect, dynamic' },
   { href: '/pages', tag: 'pages' },
 ]
 

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -47,8 +47,7 @@
         "app dir - navigation redirect status code should respond with 308 status code if permanent flag is set",
         "app dir - navigation redirect status code should respond with 307 status code in client component",
         "app dir - navigation redirect status code should respond with 307 status code in server component",
-        "app dir - navigation bots should block rendering for bots and return 404 status",
-        "app dir - navigation navigation between pages and app should not continously initiate a mpa navigation to the same URL when router state changes"
+        "app dir - navigation bots should block rendering for bots and return 404 status"
       ]
     },
     "test/e2e/app-dir/app-static/app-static-custom-handler.test.ts": {

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -1,9 +1,6 @@
 {
   "version": 2,
   "suites": {
-    "test/e2e/app-dir/actions/app-action.test.ts": {
-      "failed": ["app-dir action handling should work with interception routes"]
-    },
     "test/e2e/app-dir/app-static/app-static.test.ts": {
       "failed": [
         "app-dir static/dynamic handling usePathname should have values from canonical url on rewrite",

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -1,6 +1,9 @@
 {
   "version": 2,
   "suites": {
+    "test/e2e/app-dir/actions/app-action.test.ts": {
+      "failed": ["app-dir action handling should work with interception routes"]
+    },
     "test/e2e/app-dir/app-static/app-static.test.ts": {
       "failed": [
         "app-dir static/dynamic handling usePathname should have values from canonical url on rewrite",


### PR DESCRIPTION
### What

This adds support for navigation signals like `notFound()` and `redirect(url)` when Partial Prerendering has been enabled.

### Why

Navigation API's like `notFound()` and `redirect(url)` throw errors in order to interrupt the rendering of components. When a page both invokes API's that cause the render to be marked as dynamic (like `unstable_noStore()`) and also a navigation API, these errors may race to the end. In the case where the navigation error does not beat out the error emitted by dynamic API's will still trigger the detection warning that's present to warn you about situations where you may have accidentally caught the error.

### How

This resolves this issue by explicitly checking for navigation signals (errors) thrown during the render, and not displaying the "caught dynamic API" error and console warning.

Closes NEXT-2037