### PR TITLE
chore(examples): fix image-component example viewsource paths, shimmer page filename

### DIFF
--- a/examples/image-component/app/background/page.tsx
+++ b/examples/image-component/app/background/page.tsx
@@ -5,7 +5,7 @@ import mountains from '../../public/mountains.jpg'
 
 const BackgroundPage = () => (
   <div>
-    <ViewSource pathname="pages/background.tsx" />
+    <ViewSource pathname="app/background/page.tsx" />
     <div className={styles.bgWrap}>
       <Image
         alt="Mountains"

--- a/examples/image-component/app/color/page.tsx
+++ b/examples/image-component/app/color/page.tsx
@@ -18,7 +18,7 @@ const rgbDataURL = (r: number, g: number, b: number) =>
 
 const Color = () => (
   <div>
-    <ViewSource pathname="pages/color.tsx" />
+    <ViewSource pathname="app/color/page.tsx" />
     <h1>Image Component With Color Data URL</h1>
     <Image
       alt="Dog"

--- a/examples/image-component/app/fill/page.tsx
+++ b/examples/image-component/app/fill/page.tsx
@@ -4,7 +4,7 @@ import mountains from '../../public/mountains.jpg'
 
 const Fill = () => (
   <div>
-    <ViewSource pathname="pages/fill.tsx" />
+    <ViewSource pathname="app/fill/page.tsx" />
     <h1>Image Component With Layout Fill</h1>
     <div style={{ position: 'relative', width: '300px', height: '500px' }}>
       <Image

--- a/examples/image-component/app/page.tsx
+++ b/examples/image-component/app/page.tsx
@@ -11,7 +11,7 @@ const Code = (props: PropsWithChildren<{}>) => (
 
 const Index = () => (
   <div className={styles.container}>
-    <ViewSource pathname="pages/index.tsx" />
+    <ViewSource pathname="app/page.tsx" />
     <div className={styles.card}>
       <h1>Image Component with Next.js</h1>
       <p>

--- a/examples/image-component/app/placeholder/page.tsx
+++ b/examples/image-component/app/placeholder/page.tsx
@@ -4,7 +4,7 @@ import mountains from '../../public/mountains.jpg'
 
 const PlaceholderBlur = () => (
   <div>
-    <ViewSource pathname="pages/placeholder.tsx" />
+    <ViewSource pathname="app/placeholder/page.tsx" />
     <h1>Image Component With Placeholder Blur</h1>
     <Image
       alt="Mountains"

--- a/examples/image-component/app/responsive/page.tsx
+++ b/examples/image-component/app/responsive/page.tsx
@@ -4,7 +4,7 @@ import mountains from '../../public/mountains.jpg'
 
 const Responsive = () => (
   <div>
-    <ViewSource pathname="pages/responsive.tsx" />
+    <ViewSource pathname="app/responsive/page.tsx" />
     <h1>Image Component With Layout Responsive</h1>
     <Image
       alt="Mountains"

--- a/examples/image-component/app/shimmer/page.tsx
+++ b/examples/image-component/app/shimmer/page.tsx
@@ -22,7 +22,7 @@ const toBase64 = (str: string) =>
 
 const Shimmer = () => (
   <div>
-    <ViewSource pathname="pages/shimmer.tsx" />
+    <ViewSource pathname="app/shimmer/page.tsx" />
     <h1>Image Component With Shimmer Data URL</h1>
     <Image
       alt="Mountains"

--- a/examples/image-component/app/theme/page.tsx
+++ b/examples/image-component/app/theme/page.tsx
@@ -23,7 +23,7 @@ const ThemeImage = (props: Props) => {
 
 const Page = () => (
   <div>
-    <ViewSource pathname="pages/theme.tsx" />
+    <ViewSource pathname="app/theme/page.tsx" />
     <h1>Image With Light/Dark Theme Detection</h1>
     <ThemeImage
       alt="Next.js Streaming"


### PR DESCRIPTION
This PR fix `image-component` example viewsource paths and shimmer page filename. Which would result a Github 404 page in the current live example.

A flow up fix on this PR #60289