### PR TITLE
Group small chunks in shared js section of output

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -628,7 +628,7 @@ export async function printTreeView(
       '',
     ])
     const sharedCssFiles: string[] = []
-    ;[
+    const sharedJsChunks = [
       ...sharedFiles
         .filter((file) => {
           if (file.endsWith('.css')) {
@@ -640,19 +640,36 @@ export async function printTreeView(
         .map((e) => e.replace(buildId, '<buildId>'))
         .sort(),
       ...sharedCssFiles.map((e) => e.replace(buildId, '<buildId>')).sort(),
-    ].forEach((fileName, index, { length }) => {
-      const innerSymbol = index === length - 1 ? '└' : '├'
+    ]
+
+    // if the some chunk are less than 10kb or we don't know the size, we don't show them
+    const tenKbLimit = 10 * 1000
+    let restChunkSize = 0
+    sharedJsChunks.forEach((fileName, index, { length }) => {
+      const innerSymbol =
+        index === length - 1 && restChunkSize < tenKbLimit ? '└' : '├'
 
       const originalName = fileName.replace('<buildId>', buildId)
       const cleanName = getCleanName(fileName)
       const size = stats.sizes.get(originalName)
 
+      if (!size || size < tenKbLimit) {
+        if (typeof size === 'number') {
+          restChunkSize += size
+        }
+        return
+      }
+
+      messages.push([`  ${innerSymbol} ${cleanName}`, prettyBytes(size), ''])
+    })
+
+    if (restChunkSize > tenKbLimit) {
       messages.push([
-        `  ${innerSymbol} ${cleanName}`,
-        typeof size === 'number' ? prettyBytes(size) : '',
+        `  └ Other shared modules`,
+        prettyBytes(restChunkSize),
         '',
       ])
-    })
+    }
   }
 
   // If enabled, then print the tree for the app directory.

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -642,30 +642,29 @@ export async function printTreeView(
       ...sharedCssFiles.map((e) => e.replace(buildId, '<buildId>')).sort(),
     ]
 
-    // if the some chunk are less than 10kb or we don't know the size, we don't show them
+    // if the some chunk are less than 10kb or we don't know the size, we only show the total size of the rest
     const tenKbLimit = 10 * 1000
     let restChunkSize = 0
+    let restChunkCount = 0
     sharedJsChunks.forEach((fileName, index, { length }) => {
-      const innerSymbol =
-        index === length - 1 && restChunkSize < tenKbLimit ? '└' : '├'
+      const innerSymbol = index + restChunkCount === length - 1 ? '└' : '├'
 
       const originalName = fileName.replace('<buildId>', buildId)
       const cleanName = getCleanName(fileName)
       const size = stats.sizes.get(originalName)
 
       if (!size || size < tenKbLimit) {
-        if (typeof size === 'number') {
-          restChunkSize += size
-        }
+        restChunkCount++
+        restChunkSize += size || 0
         return
       }
 
       messages.push([`  ${innerSymbol} ${cleanName}`, prettyBytes(size), ''])
     })
 
-    if (restChunkSize > tenKbLimit) {
+    if (restChunkCount > 0) {
       messages.push([
-        `  └ Other shared modules`,
+        `  └ other shared chunks (total)`,
         prettyBytes(restChunkSize),
         '',
       ])

--- a/test/production/app-dir/build-output/index.test.ts
+++ b/test/production/app-dir/build-output/index.test.ts
@@ -1,4 +1,5 @@
 import { createNextDescribe } from 'e2e-utils'
+import stripAnsi from 'strip-ansi'
 
 createNextDescribe(
   'production - app dir - build output',
@@ -18,6 +19,17 @@ createNextDescribe(
       expect(output).toContain('Route (app)')
       expect(output).not.toContain('Route (pages)')
       expect(output).not.toContain('/favicon.ico')
+    })
+
+    it('should match the expected output format', async () => {
+      const output = stripAnsi(next.cliOutput)
+      expect(output).toContain('Size')
+      expect(output).toContain('First Load JS')
+      expect(output).toContain('+ First Load JS shared by all')
+      expect(output).toContain('└ other shared chunks (total)')
+
+      // output type
+      expect(output).toContain('○  (Static)  prerendered as static content')
     })
   }
 )


### PR DESCRIPTION
In the output shared js chunks section we're showing all shared chunks atm, some of them might be too small (few bytes) due to code split. e.g. in the below example, main-app is only `218B`, we're going to group all the chunks below 10KB together into one item line

#### Before

```
+ First Load JS shared by all            81.9 kB
  ├ chunks/381-ffe155bc1c63f064.js       26.7 kB
  ├ chunks/8766613a-1f3d501627fe8359.js  53.3 kB
  ├ chunks/main-app-80d2c0fe59f30ae2.js  218 B
  └ chunks/webpack-e6edcd8ebd35b832.js   1.68 kB
```

#### After 
```
+ First Load JS shared by all            83.7 kB
  ├ chunks/4921c021-73266f862a05e4e2.js  53.3 kB
  ├ chunks/596-73310d23ef824244.js       28.6 kB
  └ other shared chunks (total)          1.83 kB
```

Closes NEXT-2046
Closes NEXT-1970