### PR TITLE
fix: correctly set x-forwarded-port in Middleware if there is no port

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -911,7 +911,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       }
 
       req.headers['x-forwarded-host'] ??= req.headers['host'] ?? this.hostname
-      req.headers['x-forwarded-port'] ??= this.port?.toString()
+      req.headers['x-forwarded-port'] ??= this.port? this.port.toString() : '80'
       const { originalRequest } = req as NodeNextRequest
       req.headers['x-forwarded-proto'] ??= (originalRequest.socket as TLSSocket)
         ?.encrypted


### PR DESCRIPTION
### What?
following this change https://github.com/vercel/next.js/pull/57815 `x-forwarded-port` header value is 'undefined' if the url has no port

### Why?
x-forwarded-port 'undefined' makes other http-proxy throw 405 error for invalid header value

### How?
Give default 80 port if the url has no port


