### PR TITLE
Use next.config.mjs for CNA templates

### DIFF
--- a/packages/create-next-app/templates/app-tw/js/next.config.mjs
+++ b/packages/create-next-app/templates/app-tw/js/next.config.mjs
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {}
 
-module.exports = nextConfig
+export default nextConfig

--- a/packages/create-next-app/templates/app-tw/ts/next.config.mjs
+++ b/packages/create-next-app/templates/app-tw/ts/next.config.mjs
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {}
 
-module.exports = nextConfig
+export default nextConfig

--- a/packages/create-next-app/templates/app/js/next.config.mjs
+++ b/packages/create-next-app/templates/app/js/next.config.mjs
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {}
 
-module.exports = nextConfig
+export default nextConfig

--- a/packages/create-next-app/templates/app/ts/next.config.mjs
+++ b/packages/create-next-app/templates/app/ts/next.config.mjs
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {}
 
-module.exports = nextConfig
+export default nextConfig

--- a/packages/create-next-app/templates/default-tw/js/next.config.mjs
+++ b/packages/create-next-app/templates/default-tw/js/next.config.mjs
@@ -3,4 +3,4 @@ const nextConfig = {
   reactStrictMode: true,
 }
 
-module.exports = nextConfig
+export default nextConfig

--- a/packages/create-next-app/templates/default-tw/ts/next.config.mjs
+++ b/packages/create-next-app/templates/default-tw/ts/next.config.mjs
@@ -3,4 +3,4 @@ const nextConfig = {
   reactStrictMode: true,
 }
 
-module.exports = nextConfig
+export default nextConfig

--- a/packages/create-next-app/templates/default/js/next.config.mjs
+++ b/packages/create-next-app/templates/default/js/next.config.mjs
@@ -3,4 +3,4 @@ const nextConfig = {
   reactStrictMode: true,
 }
 
-module.exports = nextConfig
+export default nextConfig

--- a/packages/create-next-app/templates/default/ts/next.config.mjs
+++ b/packages/create-next-app/templates/default/ts/next.config.mjs
@@ -3,4 +3,4 @@ const nextConfig = {
   reactStrictMode: true,
 }
 
-module.exports = nextConfig
+export default nextConfig


### PR DESCRIPTION
As `.mjs` support for `next.config` is stable now we can swap our default to use it instead. 

Closes NEXT-2052