### PR TITLE
feat(next-core): port remaining next.js custom transforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,6 +3445,7 @@ dependencies = [
  "once_cell",
  "qstring",
  "regex",
+ "rustc-hash",
  "serde",
  "serde_json",
  "swc_core",

--- a/packages/next-swc/crates/next-core/Cargo.toml
+++ b/packages/next-swc/crates/next-core/Cargo.toml
@@ -33,6 +33,7 @@ futures = { workspace = true }
 lazy_static = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+rustc-hash = { workspace = true }
 turbopack-binding = { workspace = true, features = [
   "__swc_transform_modularize_imports",
   "__swc_transform_relay",

--- a/packages/next-swc/crates/next-core/src/next_client/transforms.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/transforms.rs
@@ -10,7 +10,11 @@ use crate::{
     next_shared::transforms::{
         get_next_dynamic_transform_rule, get_next_font_transform_rule, get_next_image_rule,
         get_next_modularize_imports_rule, get_next_pages_transforms_rule,
-        get_server_actions_transform_rule, server_actions::ActionsTransform,
+        get_server_actions_transform_rule, next_amp_attributes::get_next_amp_attr_rule,
+        next_cjs_optimizer::get_next_cjs_optimizer_rule,
+        next_disallow_re_export_all_in_page::get_next_disallow_export_all_in_page_rule,
+        next_page_config::get_next_page_config_rule, next_pure::get_next_pure_rule,
+        server_actions::ActionsTransform,
     },
 };
 
@@ -51,6 +55,15 @@ pub async fn get_next_client_transforms_rules(
         }
         ClientContextType::Fallback | ClientContextType::Other => None,
     };
+
+    rules.push(get_next_amp_attr_rule(mdx_rs));
+    rules.push(get_next_cjs_optimizer_rule(mdx_rs));
+    rules.push(get_next_disallow_export_all_in_page_rule(
+        mdx_rs,
+        pages_dir.is_some(),
+    ));
+    rules.push(get_next_page_config_rule(mdx_rs, pages_dir.is_some()));
+    rules.push(get_next_pure_rule(mdx_rs));
 
     rules.push(get_next_dynamic_transform_rule(false, false, pages_dir, mode, mdx_rs).await?);
 

--- a/packages/next-swc/crates/next-core/src/next_server/transforms.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/transforms.rs
@@ -11,7 +11,10 @@ use crate::{
     next_shared::transforms::{
         get_next_dynamic_transform_rule, get_next_font_transform_rule, get_next_image_rule,
         get_next_modularize_imports_rule, get_next_pages_transforms_rule,
-        get_server_actions_transform_rule,
+        get_server_actions_transform_rule, next_amp_attributes::get_next_amp_attr_rule,
+        next_cjs_optimizer::get_next_cjs_optimizer_rule,
+        next_disallow_re_export_all_in_page::get_next_disallow_export_all_in_page_rule,
+        next_pure::get_next_pure_rule,
         next_react_server_components::get_next_react_server_components_transform_rule,
         server_actions::ActionsTransform,
     },
@@ -84,6 +87,19 @@ pub async fn get_next_server_transforms_rules(
         get_next_dynamic_transform_rule(true, is_server_components, pages_dir, mode, mdx_rs)
             .await?,
     );
+
+    rules.push(get_next_amp_attr_rule(mdx_rs));
+    rules.push(get_next_cjs_optimizer_rule(mdx_rs));
+    rules.push(get_next_disallow_export_all_in_page_rule(
+        mdx_rs,
+        pages_dir.is_some(),
+    ));
+    rules.push(get_next_pure_rule(mdx_rs));
+
+    // [NOTE]: this rule only works in prod config
+    // https://github.com/vercel/next.js/blob/a1d0259ea06592c5ca6df882e9b1d0d0121c5083/packages/next/src/build/swc/options.ts#L409
+    // rules.push(get_next_optimize_server_react_rule(enable_mdx_rs,
+    // optimize_use_state))
 
     rules.push(get_next_image_rule());
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
@@ -1,8 +1,15 @@
 pub(crate) mod emotion;
 pub(crate) mod modularize_imports;
+pub(crate) mod next_amp_attributes;
+pub(crate) mod next_cjs_optimizer;
+pub(crate) mod next_disallow_re_export_all_in_page;
 pub(crate) mod next_dynamic;
 pub(crate) mod next_font;
+pub(crate) mod next_optimize_server_react;
+pub(crate) mod next_page_config;
+pub(crate) mod next_pure;
 pub(crate) mod next_react_server_components;
+pub(crate) mod next_shake_exports;
 pub(crate) mod next_strip_page_exports;
 pub(crate) mod relay;
 pub(crate) mod server_actions;

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use next_custom_transforms::transforms::amp_attributes::amp_attributes;
+use turbo_tasks::Vc;
+use turbopack_binding::{
+    swc::core::{
+        common::util::take::Take,
+        ecma::{ast::*, visit::FoldWith},
+    },
+    turbopack::{
+        ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
+        turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+    },
+};
+
+use super::module_rule_match_js_no_url;
+
+pub fn get_next_amp_attr_rule(enable_mdx_rs: bool) -> ModuleRule {
+    let transformer =
+        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextAmpAttributes {}) as _));
+    ModuleRule::new(
+        module_rule_match_js_no_url(enable_mdx_rs),
+        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
+            transformer,
+        ]))],
+    )
+}
+
+#[derive(Debug)]
+struct NextAmpAttributes {}
+
+#[async_trait]
+impl CustomTransformer for NextAmpAttributes {
+    async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
+        let p = std::mem::replace(program, Program::Module(Module::dummy()));
+        *program = p.fold_with(&mut amp_attributes());
+        Ok(())
+    }
+}

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use next_custom_transforms::transforms::cjs_optimizer::{cjs_optimizer, Config};
+use turbo_tasks::Vc;
+use turbopack_binding::{
+    swc::core::{
+        common::SyntaxContext,
+        ecma::{ast::*, visit::VisitMutWith},
+    },
+    turbopack::{
+        ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
+        turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+    },
+};
+
+use super::module_rule_match_js_no_url;
+
+pub fn get_next_cjs_optimizer_rule(enable_mdx_rs: bool, config: Config) -> ModuleRule {
+    let transformer =
+        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextCjsOptimizer { config }) as _));
+    ModuleRule::new(
+        module_rule_match_js_no_url(enable_mdx_rs),
+        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
+            transformer,
+        ]))],
+    )
+}
+
+#[derive(Debug)]
+struct NextCjsOptimizer {
+    config: Config,
+}
+
+#[async_trait]
+impl CustomTransformer for NextCjsOptimizer {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
+        let mut visitor = cjs_optimizer(
+            self.config.clone(),
+            SyntaxContext::empty().apply_mark(ctx.unresolved_mark),
+        );
+
+        program.visit_mut_with(&mut visitor);
+        Ok(())
+    }
+}

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use next_custom_transforms::transforms::cjs_optimizer::{cjs_optimizer, Config};
+use next_custom_transforms::transforms::cjs_optimizer::{cjs_optimizer, Config, PackageConfig};
+use rustc_hash::FxHashMap;
 use turbo_tasks::Vc;
 use turbopack_binding::{
     swc::core::{
@@ -15,7 +16,40 @@ use turbopack_binding::{
 
 use super::module_rule_match_js_no_url;
 
-pub fn get_next_cjs_optimizer_rule(enable_mdx_rs: bool, config: Config) -> ModuleRule {
+pub fn get_next_cjs_optimizer_rule(enable_mdx_rs: bool) -> ModuleRule {
+    // [NOTE]: This isn't user configurable config
+    // (https://github.com/vercel/next.js/blob/a1d0259ea06592c5ca6df882e9b1d0d0121c5083/packages/next/src/build/swc/options.ts#L395)
+    // build it internally without accepting customization.
+    let config = Config {
+        packages: FxHashMap::from_iter([(
+            "next/server".to_string(),
+            PackageConfig {
+                transforms: FxHashMap::from_iter([
+                    (
+                        "NextRequest".into(),
+                        "next/dist/server/web/spec-extension/request".into(),
+                    ),
+                    (
+                        "NextResponse".into(),
+                        "next/dist/server/web/spec-extension/response".into(),
+                    ),
+                    (
+                        "ImageResponse".into(),
+                        "next/dist/server/web/spec-extension/image-response".into(),
+                    ),
+                    (
+                        "userAgentFromString".into(),
+                        "next/dist/server/web/spec-extension/user-agent".into(),
+                    ),
+                    (
+                        "userAgent".into(),
+                        "next/dist/server/web/spec-extension/user-agent".into(),
+                    ),
+                ]),
+            },
+        )]),
+    };
+
     let transformer =
         EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextCjsOptimizer { config }) as _));
     ModuleRule::new(

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use next_custom_transforms::transforms::disallow_re_export_all_in_page::disallow_re_export_all_in_page;
+use turbo_tasks::Vc;
+use turbopack_binding::{
+    swc::core::{
+        common::util::take::Take,
+        ecma::{ast::*, visit::FoldWith},
+    },
+    turbopack::{
+        ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
+        turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+    },
+};
+
+use super::module_rule_match_js_no_url;
+
+pub fn get_next_disallow_export_all_in_page_rule(
+    enable_mdx_rs: bool,
+    is_page_file: bool,
+) -> ModuleRule {
+    let transformer =
+        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextDisallowReExportAllInPage {
+            is_page_file,
+        }) as _));
+    ModuleRule::new(
+        module_rule_match_js_no_url(enable_mdx_rs),
+        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
+            transformer,
+        ]))],
+    )
+}
+
+#[derive(Debug)]
+struct NextDisallowReExportAllInPage {
+    is_page_file: bool,
+}
+
+#[async_trait]
+impl CustomTransformer for NextDisallowReExportAllInPage {
+    async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
+        let p = std::mem::replace(program, Program::Module(Module::dummy()));
+        *program = p.fold_with(&mut disallow_re_export_all_in_page(self.is_page_file));
+        Ok(())
+    }
+}

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
@@ -1,0 +1,50 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use next_custom_transforms::transforms::optimize_server_react::{optimize_server_react, Config};
+use turbo_tasks::Vc;
+use turbopack_binding::{
+    swc::core::{
+        common::util::take::Take,
+        ecma::{ast::*, visit::FoldWith},
+    },
+    turbopack::{
+        ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
+        turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+    },
+};
+
+use super::module_rule_match_js_no_url;
+
+#[allow(dead_code)]
+pub fn get_next_optimize_server_react_rule(
+    enable_mdx_rs: bool,
+    optimize_use_state: bool,
+) -> ModuleRule {
+    let transformer =
+        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextOptimizeServerReact {
+            optimize_use_state,
+        }) as _));
+    ModuleRule::new(
+        module_rule_match_js_no_url(enable_mdx_rs),
+        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
+            transformer,
+        ]))],
+    )
+}
+
+#[derive(Debug)]
+struct NextOptimizeServerReact {
+    optimize_use_state: bool,
+}
+
+#[async_trait]
+impl CustomTransformer for NextOptimizeServerReact {
+    async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
+        let p = std::mem::replace(program, Program::Module(Module::dummy()));
+
+        *program = p.fold_with(&mut optimize_server_react(Config {
+            optimize_use_state: self.optimize_use_state,
+        }));
+        Ok(())
+    }
+}

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_page_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_page_config.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use next_custom_transforms::transforms::page_config::page_config;
+use turbo_tasks::Vc;
+use turbopack_binding::{
+    swc::core::{
+        common::util::take::Take,
+        ecma::{ast::*, visit::FoldWith},
+    },
+    turbopack::{
+        ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
+        turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+    },
+};
+
+use super::module_rule_match_js_no_url;
+
+pub fn get_next_page_config_rule(enable_mdx_rs: bool, is_page_file: bool) -> ModuleRule {
+    let transformer = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextPageConfig {
+        // [TODO]: update once turbopack build works
+        is_development: true,
+        is_page_file,
+    }) as _));
+    ModuleRule::new(
+        module_rule_match_js_no_url(enable_mdx_rs),
+        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
+            transformer,
+        ]))],
+    )
+}
+
+#[derive(Debug)]
+struct NextPageConfig {
+    is_development: bool,
+    is_page_file: bool,
+}
+
+#[async_trait]
+impl CustomTransformer for NextPageConfig {
+    async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
+        let p = std::mem::replace(program, Program::Module(Module::dummy()));
+
+        *program = p.fold_with(&mut page_config(self.is_development, self.is_page_file));
+        Ok(())
+    }
+}

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_pure.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_pure.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use next_custom_transforms::transforms::pure::pure_magic;
+use turbo_tasks::Vc;
+use turbopack_binding::{
+    swc::core::ecma::{ast::*, visit::VisitMutWith},
+    turbopack::{
+        ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
+        turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+    },
+};
+
+use super::module_rule_match_js_no_url;
+
+pub fn get_next_pure_rule(enable_mdx_rs: bool) -> ModuleRule {
+    let transformer = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextPure {}) as _));
+    ModuleRule::new(
+        module_rule_match_js_no_url(enable_mdx_rs),
+        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
+            transformer,
+        ]))],
+    )
+}
+
+#[derive(Debug)]
+struct NextPure {}
+
+#[async_trait]
+impl CustomTransformer for NextPure {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
+        program.visit_mut_with(&mut pure_magic(ctx.comments.clone()));
+        Ok(())
+    }
+}

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use next_custom_transforms::transforms::shake_exports::{shake_exports, Config};
+use turbo_tasks::Vc;
+use turbopack_binding::{
+    swc::core::{
+        common::util::take::Take,
+        ecma::{ast::*, visit::FoldWith},
+    },
+    turbopack::{
+        ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
+        turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+    },
+};
+
+use super::module_rule_match_js_no_url;
+
+#[allow(dead_code)]
+pub fn get_next_shake_exports_rule(enable_mdx_rs: bool, ignore: Vec<String>) -> ModuleRule {
+    let transformer =
+        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextShakeExports { ignore }) as _));
+    ModuleRule::new(
+        module_rule_match_js_no_url(enable_mdx_rs),
+        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
+            transformer,
+        ]))],
+    )
+}
+
+#[derive(Debug)]
+struct NextShakeExports {
+    ignore: Vec<String>,
+}
+
+#[async_trait]
+impl CustomTransformer for NextShakeExports {
+    async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
+        let p = std::mem::replace(program, Program::Module(Module::dummy()));
+
+        *program = p.fold_with(&mut shake_exports(Config {
+            ignore: self.ignore.iter().map(|s| s.clone().into()).collect(),
+        }));
+        Ok(())
+    }
+}

--- a/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
@@ -3,6 +3,7 @@ use std::{cell::RefCell, path::PathBuf, rc::Rc, sync::Arc};
 use either::Either;
 use fxhash::FxHashSet;
 use serde::Deserialize;
+use swc_core::ecma::visit::as_folder;
 use turbopack_binding::swc::{
     core::{
         common::{
@@ -275,11 +276,11 @@ where
         },
         match &opts.cjs_require_optimizer {
             Some(config) => {
-                Either::Left(crate::transforms::cjs_optimizer::cjs_optimizer(config.clone(), SyntaxContext::empty().apply_mark(unresolved_mark)))
+                Either::Left(as_folder(crate::transforms::cjs_optimizer::cjs_optimizer(config.clone(), SyntaxContext::empty().apply_mark(unresolved_mark))))
             },
             None => Either::Right(noop()),
         },
-        crate::transforms::pure::pure_magic(comments),
+        as_folder(crate::transforms::pure::pure_magic(comments)),
     )
 }
 

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/cjs_optimizer.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/cjs_optimizer.rs
@@ -9,19 +9,16 @@ use turbopack_binding::swc::core::{
         },
         atoms::{Atom, JsWord},
         utils::{prepend_stmts, private_ident, ExprFactory, IdentRenamer},
-        visit::{
-            as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith,
-            VisitWith,
-        },
+        visit::{noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith},
     },
 };
 
-pub fn cjs_optimizer(config: Config, unresolved_ctxt: SyntaxContext) -> impl Fold + VisitMut {
-    as_folder(CjsOptimizer {
+pub fn cjs_optimizer(config: Config, unresolved_ctxt: SyntaxContext) -> CjsOptimizer {
+    CjsOptimizer {
         data: State::default(),
         packages: config.packages,
         unresolved_ctxt,
-    })
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -35,7 +32,7 @@ pub struct PackageConfig {
     pub transforms: FxHashMap<JsWord, JsWord>,
 }
 
-struct CjsOptimizer {
+pub struct CjsOptimizer {
     data: State,
     packages: FxHashMap<String, PackageConfig>,
     unresolved_ctxt: SyntaxContext,

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/mod.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/mod.rs
@@ -5,9 +5,7 @@ pub mod disallow_re_export_all_in_page;
 pub mod dynamic;
 pub mod fonts;
 pub mod import_analyzer;
-pub mod named_import_transform;
 pub mod next_ssg;
-pub mod optimize_barrel;
 pub mod optimize_server_react;
 pub mod page_config;
 pub mod pure;
@@ -15,3 +13,7 @@ pub mod react_server_components;
 pub mod server_actions;
 pub mod shake_exports;
 pub mod strip_page_exports;
+
+//[TODO] PACK-1564: need to decide reuse vs. turbopack specific
+pub mod named_import_transform;
+pub mod optimize_barrel;

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/pure.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/pure.rs
@@ -2,23 +2,23 @@ use turbopack_binding::swc::core::{
     common::{comments::Comments, errors::HANDLER, util::take::Take, Span, Spanned, DUMMY_SP},
     ecma::{
         ast::{CallExpr, Callee, EmptyStmt, Expr, Module, ModuleDecl, ModuleItem, Stmt},
-        visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith},
+        visit::{noop_visit_mut_type, VisitMut, VisitMutWith},
     },
 };
 
 use crate::transforms::import_analyzer::ImportMap;
 
-pub fn pure_magic<C>(comments: C) -> impl Fold
+pub fn pure_magic<C>(comments: C) -> PureTransform<C>
 where
     C: Comments,
 {
-    as_folder(PureTransform {
+    PureTransform {
         imports: Default::default(),
         comments,
-    })
+    }
 }
 
-struct PureTransform<C>
+pub struct PureTransform<C>
 where
     C: Comments,
 {

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture.rs
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture.rs
@@ -22,6 +22,7 @@ use next_custom_transforms::transforms::{
     strip_page_exports::{next_transform_strip_page_exports, ExportFilter},
 };
 use serde::de::DeserializeOwned;
+use swc_core::ecma::visit::as_folder;
 use turbopack_binding::swc::{
     core::{
         common::{chain, comments::SingleThreadedComments, FileName, Mark, SyntaxContext},
@@ -429,7 +430,7 @@ fn cjs_optimize_fixture(input: PathBuf) {
 
             chain!(
                 resolver(unresolved_mark, top_level_mark, false),
-                cjs_optimizer(
+                as_folder(cjs_optimizer(
                     json(
                         r#"
                         {
@@ -444,7 +445,7 @@ fn cjs_optimize_fixture(input: PathBuf) {
                         "#
                     ),
                     unresolved_ctxt
-                )
+                ))
             )
         },
         &input,
@@ -571,7 +572,7 @@ fn pure(input: PathBuf) {
 
             chain!(
                 resolver(unresolved_mark, top_level_mark, false),
-                pure_magic(tr.comments.clone())
+                as_folder(pure_magic(tr.comments.clone()))
             )
         },
         &input,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?



-->

This PR ports over all of the remaining custom transforms for next-swc into turbopack, and apply it into client / server rules accordingly.

Closes PACK-2225

