### PR TITLE
Skip webpack loader test in Turbopack

### DIFF
--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -335,11 +335,14 @@ describe('ReactRefreshRegression app', () => {
   })
 
   // https://github.com/vercel/next.js/issues/13574
-  test('custom loader mdx should have Fast Refresh enabled', async () => {
-    const files = new Map()
-    files.set(
-      'next.config.js',
-      outdent`
+  // Test is skipped with Turbopack as the package uses webpack loaders
+  ;(process.env.TURBOPACK ? test.skip : test)(
+    'custom loader mdx should have Fast Refresh enabled',
+    async () => {
+      const files = new Map()
+      files.set(
+        'next.config.js',
+        outdent`
         const withMDX = require("@next/mdx")({
           extension: /\\.mdx?$/,
         });
@@ -347,44 +350,45 @@ describe('ReactRefreshRegression app', () => {
           pageExtensions: ["js", "mdx"],
         });
       `
-    )
-    files.set('app/content.mdx', `Hello World!`)
-    files.set(
-      'app/page.js',
-      outdent`
+      )
+      files.set('app/content.mdx', `Hello World!`)
+      files.set(
+        'app/page.js',
+        outdent`
         'use client'
         import MDX from './content.mdx'
         export default function Page() {
           return <div id="content"><MDX /></div>
         }
       `
-    )
-
-    const { session, cleanup } = await sandbox(next, files)
-    expect(
-      await session.evaluate(
-        () => document.querySelector('#content').textContent
       )
-    ).toBe('Hello World!')
 
-    let didNotReload = await session.patch('app/content.mdx', `Hello Foo!`)
-    expect(didNotReload).toBe(true)
-    expect(await session.hasRedbox(false)).toBe(false)
-    expect(
-      await session.evaluate(
-        () => document.querySelector('#content').textContent
-      )
-    ).toBe('Hello Foo!')
+      const { session, cleanup } = await sandbox(next, files)
+      expect(
+        await session.evaluate(
+          () => document.querySelector('#content').textContent
+        )
+      ).toBe('Hello World!')
 
-    didNotReload = await session.patch('app/content.mdx', `Hello Bar!`)
-    expect(didNotReload).toBe(true)
-    expect(await session.hasRedbox(false)).toBe(false)
-    expect(
-      await session.evaluate(
-        () => document.querySelector('#content').textContent
-      )
-    ).toBe('Hello Bar!')
+      let didNotReload = await session.patch('app/content.mdx', `Hello Foo!`)
+      expect(didNotReload).toBe(true)
+      expect(await session.hasRedbox(false)).toBe(false)
+      expect(
+        await session.evaluate(
+          () => document.querySelector('#content').textContent
+        )
+      ).toBe('Hello Foo!')
 
-    await cleanup()
-  })
+      didNotReload = await session.patch('app/content.mdx', `Hello Bar!`)
+      expect(didNotReload).toBe(true)
+      expect(await session.hasRedbox(false)).toBe(false)
+      expect(
+        await session.evaluate(
+          () => document.querySelector('#content').textContent
+        )
+      ).toBe('Hello Bar!')
+
+      await cleanup()
+    }
+  )
 })

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -295,13 +295,16 @@ describe('ReactRefreshRegression', () => {
   })
 
   // https://github.com/vercel/next.js/issues/13574
-  test('custom loader (mdx) should have Fast Refresh enabled', async () => {
-    const { session, cleanup } = await sandbox(
-      next,
-      new Map([
-        [
-          'next.config.js',
-          outdent`
+  // Test is skipped with Turbopack as the package uses webpack loaders
+  ;(process.env.TURBOPACK ? test.skip : test)(
+    'custom loader (mdx) should have Fast Refresh enabled',
+    async () => {
+      const { session, cleanup } = await sandbox(
+        next,
+        new Map([
+          [
+            'next.config.js',
+            outdent`
             const withMDX = require("@next/mdx")({
               extension: /\\.mdx?$/,
             });
@@ -309,35 +312,36 @@ describe('ReactRefreshRegression', () => {
               pageExtensions: ["js", "mdx"],
             });
           `,
-        ],
-        ['pages/mdx.mdx', `Hello World!`],
-      ]),
-      '/mdx'
-    )
-    expect(
-      await session.evaluate(
-        () => document.querySelector('#__next').textContent
+          ],
+          ['pages/mdx.mdx', `Hello World!`],
+        ]),
+        '/mdx'
       )
-    ).toBe('Hello World!')
+      expect(
+        await session.evaluate(
+          () => document.querySelector('#__next').textContent
+        )
+      ).toBe('Hello World!')
 
-    let didNotReload = await session.patch('pages/mdx.mdx', `Hello Foo!`)
-    expect(didNotReload).toBe(true)
-    expect(await session.hasRedbox(false)).toBe(false)
-    expect(
-      await session.evaluate(
-        () => document.querySelector('#__next').textContent
-      )
-    ).toBe('Hello Foo!')
+      let didNotReload = await session.patch('pages/mdx.mdx', `Hello Foo!`)
+      expect(didNotReload).toBe(true)
+      expect(await session.hasRedbox(false)).toBe(false)
+      expect(
+        await session.evaluate(
+          () => document.querySelector('#__next').textContent
+        )
+      ).toBe('Hello Foo!')
 
-    didNotReload = await session.patch('pages/mdx.mdx', `Hello Bar!`)
-    expect(didNotReload).toBe(true)
-    expect(await session.hasRedbox(false)).toBe(false)
-    expect(
-      await session.evaluate(
-        () => document.querySelector('#__next').textContent
-      )
-    ).toBe('Hello Bar!')
+      didNotReload = await session.patch('pages/mdx.mdx', `Hello Bar!`)
+      expect(didNotReload).toBe(true)
+      expect(await session.hasRedbox(false)).toBe(false)
+      expect(
+        await session.evaluate(
+          () => document.querySelector('#__next').textContent
+        )
+      ).toBe('Hello Bar!')
 
-    await cleanup()
-  })
+      await cleanup()
+    }
+  )
 })


### PR DESCRIPTION
## What?

This test can be skipped as it checks a webpack loader. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2054