### PR TITLE
Remove unused target: es5 from tsconfig.json in create-next-app

### DIFF
--- a/packages/create-next-app/templates/app-tw/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app-tw/ts/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/create-next-app/templates/app/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app/ts/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/create-next-app/templates/default-tw/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default-tw/ts/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/create-next-app/templates/default/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default/ts/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
fixes #58640

When there is no tsconfig.json, `npm run dev` generates `tsconfig.json`, which has no `target` option.
But create-next-app generates `tsconfig.json` with `"target": "es5"`

Related to: #44567
Related to: #14390