### PR TITLE
fix: fail build when `dynamic="error"` is set

### DIFF
--- a/test/production/app-dir/dynamic/app/layout.tsx
+++ b/test/production/app-dir/dynamic/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/dynamic/app/page.tsx
+++ b/test/production/app-dir/dynamic/app/page.tsx
@@ -1,5 +1,6 @@
-export default function Page({ searchParams }) {
-  return <p>{searchParams.get('foo')}</p>
+import { cookies } from 'next/headers'
+export default function Page() {
+  return <p>{cookies().get('foo')?.value}</p>
 }
 
 export const dynamic = 'error'

--- a/test/production/app-dir/dynamic/app/page.tsx
+++ b/test/production/app-dir/dynamic/app/page.tsx
@@ -1,0 +1,5 @@
+export default function Page({ searchParams }) {
+  return <p>{searchParams.get('foo')}</p>
+}
+
+export const dynamic = 'error'

--- a/test/production/app-dir/dynamic/fail-build-on-dynamic-error.test.ts
+++ b/test/production/app-dir/dynamic/fail-build-on-dynamic-error.test.ts
@@ -1,0 +1,16 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'When dynamic=error set',
+  { files: __dirname, skipStart: true },
+  ({ next }) => {
+    it('should fail to build', async () => {
+      await expect(next.build()).resolves.toEqual({
+        exitCode: 1,
+        cliOutput: expect.stringContaining(
+          'Error: Page with `dynamic = "error"` couldn\'t be rendered statically because it used `searchParams.get`.'
+        ),
+      })
+    })
+  }
+)

--- a/test/production/app-dir/dynamic/fail-build-on-dynamic-error.test.ts
+++ b/test/production/app-dir/dynamic/fail-build-on-dynamic-error.test.ts
@@ -8,7 +8,7 @@ createNextDescribe(
       await expect(next.build()).resolves.toEqual({
         exitCode: 1,
         cliOutput: expect.stringContaining(
-          'Error: Page with `dynamic = "error"` couldn\'t be rendered statically because it used `searchParams.get`.'
+          'Error: Page with `dynamic = "error"` couldn\'t be rendered statically because it used `cookies`.'
         ),
       })
     })

--- a/test/production/app-dir/dynamic/next.config.js
+++ b/test/production/app-dir/dynamic/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/app-dir/dynamic/tsconfig.json
+++ b/test/production/app-dir/dynamic/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### What?

### Why?

### How?

Closes NEXT-1969
Fixes #

[Slack thread](https://vercel.slack.com/archives/C043CGHSZLH/p1704239899202249?thread_ts=1704229807.158689&cid=C043CGHSZLH)