### PR TITLE
Fix: should trigger hot update when canApplyUpdates is true

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
@@ -363,7 +363,7 @@ function processMessage(
       const isHotUpdate =
         obj.action !== HMR_ACTIONS_SENT_TO_BROWSER.SYNC &&
         (!window.__NEXT_DATA__ || window.__NEXT_DATA__.page !== '/_error') &&
-        isUpdateAvailable()
+        (isUpdateAvailable() || canApplyUpdates())
 
       // Attempt to apply hot updates or reload.
       if (isHotUpdate) {


### PR DESCRIPTION
When the dev overlay show up due to build errors, then you fixed the problem but it doesn't hide, or vise versa. There's a missing branch that we need to trigger the hot update when `built` event is triggered.

`isUpdateAvailable()` can return false at that and `canApplyUpdates()` is true, where we need to set isHotUpdate to `true`

Closes NEXT-2081