### PR TITLE
Tracing: attach Turbopack session value to root span

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -95,7 +95,6 @@ const handleSessionStop = async (signal: string | null) => {
     uploadTrace({
       traceUploadUrl,
       mode: 'dev',
-      isTurboSession,
       projectDir: dir,
       distDir: config.distDir,
     })
@@ -283,7 +282,6 @@ const nextDev: CliCommand = async (args) => {
             uploadTrace({
               traceUploadUrl,
               mode: 'dev',
-              isTurboSession,
               projectDir: dir,
               distDir: config.distDir,
               sync: true,

--- a/packages/next/src/trace/trace-uploader.ts
+++ b/packages/next/src/trace/trace-uploader.ts
@@ -35,9 +35,7 @@ const {
 const isDebugEnabled = !!NEXT_TRACE_UPLOAD_DEBUG || !!NEXT_TRACE_UPLOAD_FULL
 const shouldUploadFullTrace = !!NEXT_TRACE_UPLOAD_FULL
 
-const [, , traceUploadUrl, mode, _isTurboSession, projectDir, distDir] =
-  process.argv
-const isTurboSession = _isTurboSession === 'true'
+const [, , traceUploadUrl, mode, projectDir, distDir] = process.argv
 
 type TraceRequestBody = {
   metadata: TraceMetadata
@@ -100,6 +98,7 @@ interface TraceMetadata {
     crlfDelay: Infinity,
   })
 
+  let isTurboSession = false
   const traces = new Map<string, TraceEvent[]>()
   for await (const line of readLineInterface) {
     const lineEvents: TraceEvent[] = JSON.parse(line)
@@ -114,6 +113,9 @@ interface TraceMetadata {
         if (trace === undefined) {
           trace = []
           traces.set(event.traceId, trace)
+        }
+        if (typeof event.tags.isTurbopack === 'boolean') {
+          isTurboSession = event.tags.isTurbopack
         }
         trace.push(event)
       }

--- a/packages/next/src/trace/trace.ts
+++ b/packages/next/src/trace/trace.ts
@@ -47,6 +47,11 @@ export class Span {
     this.name = name
     this.parentId = parentId ?? defaultParentSpanId
     this.attrs = attrs ? { ...attrs } : {}
+    if (this.parentId === undefined) {
+      // Attach additional information to root spans
+      this.attrs.isTurbopack = Boolean(process.env.TURBOPACK)
+    }
+
     this.status = SpanStatus.Started
     this.id = getId()
     this._start = startTime || process.hrtime.bigint()

--- a/packages/next/src/trace/upload-trace.ts
+++ b/packages/next/src/trace/upload-trace.ts
@@ -1,14 +1,12 @@
 export default function uploadTrace({
   traceUploadUrl,
   mode,
-  isTurboSession,
   projectDir,
   distDir,
   sync,
 }: {
   traceUploadUrl: string
   mode: 'dev'
-  isTurboSession: boolean
   projectDir: string
   distDir: string
   sync?: boolean
@@ -33,7 +31,6 @@ export default function uploadTrace({
       require.resolve('./trace-uploader'),
       traceUploadUrl,
       mode,
-      String(isTurboSession),
       projectDir,
       distDir,
     ],


### PR DESCRIPTION
This allows us to more accurately attribute whether a trace was created in a Turbopack session by doing so at trace creation time rather than trace upload time.

Test Plan: Configured next to send traces to a local server and verified this information is attached to the top-level of the trace.


Closes PACK-2233