### PR TITLE
Telemetry: allow disabling of fetch tracing

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
@@ -276,6 +276,8 @@ Attributes:
 - `next.span_name`
 - `next.span_type`
 
+This span can be turned off by setting `NEXT_OTEL_FETCH_DISABLED=1` in your environment. This is useful when you want to use a custom fetch instrumentation library.
+
 ### `executing api route (app) [next.route]`
 
 - `next.span_type`: `AppRouteRouteHandlers.runHandler`.

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -211,10 +211,12 @@ export function patchFetch({
     // Do create a new span trace for internal fetches in the
     // non-verbose mode.
     const isInternal = (init?.next as any)?.internal === true
+    const hideSpan = process.env.NEXT_OTEL_FETCH_DISABLED === '1'
 
     return await getTracer().trace(
       isInternal ? NextNodeServerSpan.internalFetch : AppRenderSpan.fetch,
       {
+        hideSpan,
         kind: SpanKind.CLIENT,
         spanName: ['fetch', method, fetchUrl].filter(Boolean).join(' '),
         attributes: {

--- a/test/e2e/opentelemetry/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/opentelemetry.test.ts
@@ -102,7 +102,8 @@ createNextDescribe(
         },
       },
     ]) {
-      describe(env.name, () => {
+      // turbopack does not support experimental.instrumentationHook
+      ;(process.env.TURBOPACK ? describe.skip : describe)(env.name, () => {
         describe('app router', () => {
           it('should handle RSC with fetch', async () => {
             await next.fetch('/app/param/rsc-fetch', env.fetchInit)
@@ -528,7 +529,8 @@ createNextDescribe(
       await cleanTraces()
     })
 
-    describe('root context', () => {
+    // turbopack does not support experimental.instrumentationHook
+    ;(process.env.TURBOPACK ? describe.skip : describe)('root context', () => {
       describe('app router', () => {
         it('should handle RSC with fetch', async () => {
           await next.fetch('/app/param/rsc-fetch')

--- a/test/e2e/opentelemetry/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/opentelemetry.test.ts
@@ -103,7 +103,9 @@ createNextDescribe(
       },
     ]) {
       // turbopack does not support experimental.instrumentationHook
-      ;(process.env.TURBOPACK ? describe.skip : describe)(env.name, () => {
+      ;(process.env.TURBOPACK || process.env.__NEXT_EXPERIMENTAL_PPR
+        ? describe.skip
+        : describe)(env.name, () => {
         describe('app router', () => {
           it('should handle RSC with fetch', async () => {
             await next.fetch('/app/param/rsc-fetch', env.fetchInit)
@@ -530,7 +532,9 @@ createNextDescribe(
     })
 
     // turbopack does not support experimental.instrumentationHook
-    ;(process.env.TURBOPACK ? describe.skip : describe)('root context', () => {
+    ;(process.env.TURBOPACK || process.env.__NEXT_EXPERIMENTAL_PPR
+      ? describe.skip
+      : describe)('root context', () => {
       describe('app router with disabled fetch', () => {
         it('should handle RSC with disabled fetch', async () => {
           await next.fetch('/app/param/rsc-fetch')

--- a/test/e2e/opentelemetry/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/opentelemetry.test.ts
@@ -531,8 +531,8 @@ createNextDescribe(
 
     // turbopack does not support experimental.instrumentationHook
     ;(process.env.TURBOPACK ? describe.skip : describe)('root context', () => {
-      describe('app router', () => {
-        it('should handle RSC with fetch', async () => {
+      describe('app router with disabled fetch', () => {
+        it('should handle RSC with disabled fetch', async () => {
           await next.fetch('/app/param/rsc-fetch')
 
           await check(async () => {


### PR DESCRIPTION
This would allow different apps to setup fetch instrumentation similar to `@opentelemetry/instrumentation-http` and `@opentelemetry/instrumentation-fetch` without duplicating fetch spans and avoiding confusion with context propagation.