### PR TITLE
Telemetry code load

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
@@ -337,3 +337,27 @@ Attributes:
 - `next.span_name`
 - `next.span_type`
 - `next.page`
+
+### `resolve page components`
+
+- `next.span_type`: `NextNodeServer.findPageComponents`.
+
+This span represents the process of resolving page components for a specific page.
+
+Attributes:
+
+- `next.span_name`
+- `next.span_type`
+- `next.route`
+
+### `resolve segment modules`
+
+- `next.span_type`: `NextNodeServer.getLayoutOrPageModule`.
+
+This span represents loading of code modules for a layout or a page.
+
+Attributes:
+
+- `next.span_name`
+- `next.span_type`
+- `next.segment`

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -136,11 +136,9 @@ export async function createComponentTree({
   const [layoutOrPageMod] = await getTracer().trace(
     NextNodeServerSpan.getLayoutOrPageModule,
     {
-      spanName: 'resolve page modules',
-      attributes: {
-        'next.page': page?.[1],
-        'next.layout': layout?.[1],
-      },
+      hideSpan: !(isLayout || isPage),
+      spanName: 'resolve segment modules',
+      attributes: { 'next.segment': segment },
     },
     () => getLayoutOrPageModule(tree)
   )

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -138,7 +138,9 @@ export async function createComponentTree({
     {
       hideSpan: !(isLayout || isPage),
       spanName: 'resolve segment modules',
-      attributes: { 'next.segment': segment },
+      attributes: {
+        'next.segment': segment,
+      },
     },
     () => getLayoutOrPageModule(tree)
   )

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -38,6 +38,7 @@ enum NextServerSpan {
 enum NextNodeServerSpan {
   compression = 'NextNodeServer.compression',
   getBuildId = 'NextNodeServer.getBuildId',
+  getLayoutOrPageModule = 'NextNodeServer.getLayoutOrPageModule',
   generateStaticRoutes = 'NextNodeServer.generateStaticRoutes',
   generateFsStaticRoutes = 'NextNodeServer.generateFsStaticRoutes',
   generatePublicRoutes = 'NextNodeServer.generatePublicRoutes',
@@ -127,6 +128,8 @@ export const NextVanillaSpanAllowlist = [
   AppRouteRouteHandlersSpan.runHandler,
   ResolveMetadataSpan.generateMetadata,
   ResolveMetadataSpan.generateViewport,
+  NextNodeServerSpan.findPageComponents,
+  NextNodeServerSpan.getLayoutOrPageModule,
 ]
 
 export {

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -141,7 +141,7 @@ interface NextTracer {
 type NextAttributeNames =
   | 'next.route'
   | 'next.page'
-  | 'next.layout'
+  | 'next.segment'
   | 'next.span_name'
   | 'next.span_type'
 type OTELAttributeNames = `http.${string}` | `net.${string}`

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -141,6 +141,7 @@ interface NextTracer {
 type NextAttributeNames =
   | 'next.route'
   | 'next.page'
+  | 'next.layout'
   | 'next.span_name'
   | 'next.span_type'
 type OTELAttributeNames = `http.${string}` | `net.${string}`

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -658,7 +658,7 @@ export default class NextNodeServer extends BaseServer {
     return getTracer().trace(
       NextNodeServerSpan.findPageComponents,
       {
-        spanName: `resolving page into components`,
+        spanName: 'resolve page components',
         attributes: {
           'next.route': isAppPath ? normalizeAppPath(page) : page,
         },

--- a/test/e2e/opentelemetry/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/opentelemetry.test.ts
@@ -114,8 +114,8 @@ createNextDescribe(
               const numberOfRootTraces =
                 env.span.rootParentId === undefined ? 1 : 0
               const traces = await getSanitizedTraces(numberOfRootTraces)
-              if (traces.length < 5) {
-                return `not enough traces, expected 5, but got ${traces.length}`
+              if (traces.length < 8) {
+                return `not enough traces, expected 8, but got ${traces.length}`
               }
               expect(traces).toMatchInlineSnapshot(`
                 [
@@ -173,6 +173,48 @@ createNextDescribe(
                   },
                   {
                     "attributes": {
+                      "next.route": "/app/[param]/rsc-fetch",
+                      "next.span_name": "resolve page components",
+                      "next.span_type": "NextNodeServer.findPageComponents",
+                    },
+                    "kind": 0,
+                    "name": "resolve page components",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.segment": "[param]",
+                      "next.span_name": "resolve segment modules",
+                      "next.span_type": "NextNodeServer.getLayoutOrPageModule",
+                    },
+                    "kind": 0,
+                    "name": "resolve segment modules",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.segment": "__PAGE__",
+                      "next.span_name": "resolve segment modules",
+                      "next.span_type": "NextNodeServer.getLayoutOrPageModule",
+                    },
+                    "kind": 0,
+                    "name": "resolve segment modules",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
                       "next.page": "/app/[param]/layout",
                       "next.span_name": "generateMetadata /app/[param]/layout",
                       "next.span_type": "ResolveMetadata.generateMetadata",
@@ -212,8 +254,8 @@ createNextDescribe(
               const numberOfRootTraces =
                 env.span.rootParentId === undefined ? 1 : 0
               const traces = await getSanitizedTraces(numberOfRootTraces)
-              if (traces.length < 2) {
-                return `not enough traces, expected 2, but got ${traces.length}`
+              if (traces.length < 3) {
+                return `not enough traces, expected 3, but got ${traces.length}`
               }
               expect(traces).toMatchInlineSnapshot(`
                 [
@@ -253,6 +295,20 @@ createNextDescribe(
                     },
                     "traceId": "${env.span.traceId}",
                   },
+                  {
+                    "attributes": {
+                      "next.route": "/api/app/[param]/data",
+                      "next.span_name": "resolve page components",
+                      "next.span_type": "NextNodeServer.findPageComponents",
+                    },
+                    "kind": 0,
+                    "name": "resolve page components",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
                 ]
               `)
               return 'success'
@@ -268,8 +324,8 @@ createNextDescribe(
               const numberOfRootTraces =
                 env.span.rootParentId === undefined ? 1 : 0
               const traces = await getSanitizedTraces(numberOfRootTraces)
-              if (traces.length < 3) {
-                return `not enough traces, expected 3, but got ${traces.length}`
+              if (traces.length < 4) {
+                return `not enough traces, expected 4, but got ${traces.length}`
               }
               expect(traces).toMatchInlineSnapshot(`
                 [
@@ -290,6 +346,20 @@ createNextDescribe(
                         ? `"${env.span.rootParentId}"`
                         : undefined
                     },
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.route": "/pages/[param]/getServerSideProps",
+                      "next.span_name": "resolve page components",
+                      "next.span_type": "NextNodeServer.findPageComponents",
+                    },
+                    "kind": 0,
+                    "name": "resolve page components",
+                    "parentId": "[parent-id]",
                     "status": {
                       "code": 0,
                     },
@@ -337,8 +407,8 @@ createNextDescribe(
               const numberOfRootTraces =
                 env.span.rootParentId === undefined ? 1 : 0
               const traces = await getSanitizedTraces(numberOfRootTraces)
-              if (traces.length < 3) {
-                return `not enough traces, expected 3, but got ${traces.length}`
+              if (traces.length < 4) {
+                return `not enough traces, expected 4, but got ${traces.length}`
               }
               expect(traces).toMatchInlineSnapshot(`
                 [
@@ -359,6 +429,20 @@ createNextDescribe(
                         ? `"${env.span.rootParentId}"`
                         : undefined
                     },
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.route": "/pages/[param]/getStaticProps${v}",
+                      "next.span_name": "resolve page components",
+                      "next.span_type": "NextNodeServer.findPageComponents",
+                    },
+                    "kind": 0,
+                    "name": "resolve page components",
+                    "parentId": "[parent-id]",
                     "status": {
                       "code": 0,
                     },
@@ -573,6 +657,48 @@ createNextDescribe(
                     "kind": 1,
                     "name": "GET /app/[param]/rsc-fetch",
                     "parentId": undefined,
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "[trace-id]",
+                  },
+                  {
+                    "attributes": {
+                      "next.route": "/app/[param]/rsc-fetch",
+                      "next.span_name": "resolve page components",
+                      "next.span_type": "NextNodeServer.findPageComponents",
+                    },
+                    "kind": 0,
+                    "name": "resolve page components",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "[trace-id]",
+                  },
+                  {
+                    "attributes": {
+                      "next.segment": "[param]",
+                      "next.span_name": "resolve segment modules",
+                      "next.span_type": "NextNodeServer.getLayoutOrPageModule",
+                    },
+                    "kind": 0,
+                    "name": "resolve segment modules",
+                    "parentId": "[parent-id]",
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "[trace-id]",
+                  },
+                  {
+                    "attributes": {
+                      "next.segment": "__PAGE__",
+                      "next.span_name": "resolve segment modules",
+                      "next.span_type": "NextNodeServer.getLayoutOrPageModule",
+                    },
+                    "kind": 0,
+                    "name": "resolve segment modules",
+                    "parentId": "[parent-id]",
                     "status": {
                       "code": 0,
                     },


### PR DESCRIPTION
The following spans are either added or displayed by default:

* `NextNodeServer.findPageComponents` - page components resolution/require
* `NextNodeServer.getLayoutOrPageModule` - load modules (webpack or turbopack)
