### PR TITLE
docs: remove Next 13 mention for App Router

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
@@ -128,10 +128,10 @@ function Card<T extends string>({ href }: { href: Route<T> | URL }) {
 
 ## End-to-End Type Safety
 
-Next.js 13 has **enhanced type safety**. This includes:
+The Next.js App Router has **enhanced type safety**. This includes:
 
 1. **No serialization of data between fetching function and page**: You can `fetch` directly in components, layouts, and pages on the server. This data _does not_ need to be serialized (converted to a string) to be passed to the client side for consumption in React. Instead, since `app` uses Server Components by default, we can use values like `Date`, `Map`, `Set`, and more without any extra steps. Previously, you needed to manually type the boundary between server and client with Next.js-specific types.
-2. **Streamlined data flow between components**: With the removal of `_app` in favor of root layouts, it is now easier to visualize the data flow between components and pages. Previously, data flowing between individual `pages` and `_app` were difficult to type and could introduce confusing bugs. With [colocated data fetching](/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating) in Next.js 13, this is no longer an issue.
+2. **Streamlined data flow between components**: With the removal of `_app` in favor of root layouts, it is now easier to visualize the data flow between components and pages. Previously, data flowing between individual `pages` and `_app` were difficult to type and could introduce confusing bugs. With [colocated data fetching](/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating) in the App Router, this is no longer an issue.
 
 [Data Fetching in Next.js](/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating) now provides as close to end-to-end type safety as possible without being prescriptive about your database or content provider selection.
 


### PR DESCRIPTION
We're on 14 now, silly goose.