### PR TITLE
Turbopack test updates

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -50,15 +50,28 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
       `
     )
     expect(await session.hasRedbox()).toBe(true)
-    expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-      "./node_modules/my-package/index.js:1:12
-      Module not found: Can't resolve 'dns'
-      > 1 | const dns = require('dns')
-          |             ^^^^^^^^^^^^^^
-        2 | module.exports = dns
+    if (process.env.TURBOPACK) {
+      expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
+        "./node_modules/my-package/index.js:1:12
+        Module not found: Can't resolve 'dns'
+        > 1 | const dns = require('dns')
+            |             ^^^^^^^^^^^^^^
+          2 | module.exports = dns
 
-      https://nextjs.org/docs/messages/module-not-found"
-    `)
+        https://nextjs.org/docs/messages/module-not-found"
+      `)
+    } else {
+      expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
+        "./node_modules/my-package/index.js:1:12
+        Module not found: Can't resolve 'dns'
+
+        https://nextjs.org/docs/messages/module-not-found
+
+        Import trace for requested module:
+        ./index.js
+        ./app/page.js"
+      `)
+    }
 
     await cleanup()
   })
@@ -83,17 +96,33 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     expect(await session.hasRedbox()).toBe(true)
 
     const source = await session.getRedboxSource()
-    expect(source).toMatchInlineSnapshot(`
-      "./index.js:1:0
-      Module not found: Can't resolve 'b'
-      > 1 | import Comp from 'b'
-          | ^^^^^^^^^^^^^^^^^^^^
-        2 | export default function Oops() {
-        3 |   return (
-        4 |     <div>
+    if (process.env.TURBOPACK) {
+      expect(source).toMatchInlineSnapshot(`
+        "./index.js:1:0
+        Module not found: Can't resolve 'b'
+        > 1 | import Comp from 'b'
+            | ^^^^^^^^^^^^^^^^^^^^
+          2 | export default function Oops() {
+          3 |   return (
+          4 |     <div>
 
-      https://nextjs.org/docs/messages/module-not-found"
-    `)
+        https://nextjs.org/docs/messages/module-not-found"
+      `)
+    } else {
+      expect(source).toMatchInlineSnapshot(`
+        "./index.js:1:0
+        Module not found: Can't resolve 'b'
+        > 1 | import Comp from 'b'
+          2 | export default function Oops() {
+          3 |   return (
+          4 |     <div>
+
+        https://nextjs.org/docs/messages/module-not-found
+
+        Import trace for requested module:
+        ./app/page.js"
+      `)
+    }
 
     await cleanup()
   })
@@ -134,16 +163,16 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
       `)
     } else {
       expect(source).toMatchInlineSnapshot(`
-              "./app/page.js:2:0
-              Module not found: Can't resolve 'b'
-                1 | 'use client'
-              > 2 | import Comp from 'b'
-                3 | export default function Oops() {
-                4 |   return (
-                5 |     <div>
+        "./app/page.js:2:0
+        Module not found: Can't resolve 'b'
+          1 | 'use client'
+        > 2 | import Comp from 'b'
+          3 | export default function Oops() {
+          4 |   return (
+          5 |     <div>
 
-              https://nextjs.org/docs/messages/module-not-found"
-          `)
+        https://nextjs.org/docs/messages/module-not-found"
+      `)
     }
 
     await cleanup()
@@ -183,16 +212,16 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
       `)
     } else {
       expect(source).toMatchInlineSnapshot(`
-              "./app/page.js:2:0
-              Module not found: Can't resolve './non-existent.css'
-                1 | 'use client'
-              > 2 | import './non-existent.css'
-                3 | export default function Page(props) {
-                4 |   return <p>index page</p>
-                5 | }
+        "./app/page.js:2:0
+        Module not found: Can't resolve './non-existent.css'
+          1 | 'use client'
+        > 2 | import './non-existent.css'
+          3 | export default function Page(props) {
+          4 |   return <p>index page</p>
+          5 | }
 
-              https://nextjs.org/docs/messages/module-not-found"
-          `)
+        https://nextjs.org/docs/messages/module-not-found"
+      `)
     }
     await session.patch(
       'app/page.js',

--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -53,12 +53,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
       "./node_modules/my-package/index.js:1:12
       Module not found: Can't resolve 'dns'
+      > 1 | const dns = require('dns')
+          |             ^^^^^^^^^^^^^^
+        2 | module.exports = dns
 
-      https://nextjs.org/docs/messages/module-not-found
-
-      Import trace for requested module:
-      ./index.js
-      ./app/page.js"
+      https://nextjs.org/docs/messages/module-not-found"
     `)
 
     await cleanup()
@@ -88,14 +87,12 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
       "./index.js:1:0
       Module not found: Can't resolve 'b'
       > 1 | import Comp from 'b'
+          | ^^^^^^^^^^^^^^^^^^^^
         2 | export default function Oops() {
         3 |   return (
         4 |     <div>
 
-      https://nextjs.org/docs/messages/module-not-found
-
-      Import trace for requested module:
-      ./app/page.js"
+      https://nextjs.org/docs/messages/module-not-found"
     `)
 
     await cleanup()

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -90,27 +90,59 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       ])
     )
     expect(await session.hasRedbox()).toBe(true)
-    expect(
-      next.normalizeTestDirContent(await session.getRedboxSource())
-    ).toMatchInlineSnapshot(
-      next.normalizeSnapshot(
-        process.env.TURBOPACK
-          ? `
-      "./pages/_app.js:2:11
-      Parsing ecmascript source code failed
-        1 | function MyApp({ Component, pageProps }) {
-      > 2 |   return <<Component {...pageProps} />;
-          |            ^^^^^^^^^
-        3 | }
-        4 | export default MyApp
+    const source = next.normalizeTestDirContent(await session.getRedboxSource())
+    if (process.env.TURBOPACK) {
+      expect(source).toMatchInlineSnapshot(
+        next.normalizeSnapshot(`"./pages/_app.js:2:11
+Parsing ecmascript source code failed
+  1 | function MyApp({ Component, pageProps }) {
+> 2 |   return <<Component {...pageProps} />;
+    |            ^^^^^^^^^
+  3 | }
+  4 | export default MyApp
 
-      Expression expected"
-    `
-          : `
+Expression expected"`),
+        `
+        "./pages/_app.js:2:11
+        Parsing ecmascript source code failed
+          1 | function MyApp({ Component, pageProps }) {
+        > 2 |   return <<Component {...pageProps} />;
+            |            ^^^^^^^^^
+          3 | }
+          4 | export default MyApp
+
+        Expression expected"
+      `
+      )
+    } else {
+      expect(source).toMatchInlineSnapshot(
+        next.normalizeSnapshot(`"./pages/_app.js
+Error: 
+  x Expression expected
+    ,-[TEST_DIR/pages/_app.js:1:1]
+  1 | function MyApp({ Component, pageProps }) {
+  2 |   return <<Component {...pageProps} />;
+    :           ^
+  3 | }
+  4 | export default MyApp
+    \`----
+
+  x Expression expected
+    ,-[TEST_DIR/pages/_app.js:1:1]
+  1 | function MyApp({ Component, pageProps }) {
+  2 |   return <<Component {...pageProps} />;
+    :            ^^^^^^^^^
+  3 | }
+  4 | export default MyApp
+    \`----
+
+Caused by:
+    Syntax Error"`),
+        `
         "./pages/_app.js
         Error: 
           x Expression expected
-           ,-[TEST_DIR/pages/_app.js:1:1]
+           ,-[1:1]
          1 | function MyApp({ Component, pageProps }) {
          2 |   return <<Component {...pageProps} />;
            :           ^
@@ -119,7 +151,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
            \`----
 
           x Expression expected
-           ,-[TEST_DIR/pages/_app.js:1:1]
+           ,-[1:1]
          1 | function MyApp({ Component, pageProps }) {
          2 |   return <<Component {...pageProps} />;
            :            ^^^^^^^^^
@@ -131,7 +163,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
             Syntax Error"
       `
       )
-    )
+    }
 
     await session.patch(
       'pages/_app.js',
@@ -180,29 +212,56 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       ])
     )
     expect(await session.hasRedbox()).toBe(true)
-    expect(
-      next.normalizeTestDirContent(await session.getRedboxSource())
-    ).toMatchInlineSnapshot(
-      next.normalizeSnapshot(
-        process.env.TURBOPACK
-          ? `
-      "./pages/_document.js:3:35
-      Parsing ecmascript source code failed
-        1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
-        2 |
-      > 3 | class MyDocument extends Document {{
-          |                                    ^
-        4 |   static async getInitialProps(ctx) {
-        5 |     const initialProps = await Document.getInitialProps(ctx)
-        6 |     return { ...initialProps }
+    const source = next.normalizeTestDirContent(await session.getRedboxSource())
+    if (process.env.TURBOPACK) {
+      expect(source).toMatchInlineSnapshot(
+        next.normalizeSnapshot(`"./pages/_document.js:3:35
+Parsing ecmascript source code failed
+  1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
+  2 |
+> 3 | class MyDocument extends Document {{
+    |                                    ^
+  4 |   static async getInitialProps(ctx) {
+  5 |     const initialProps = await Document.getInitialProps(ctx)
+  6 |     return { ...initialProps }
 
-      Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key"
-    `
-          : `
+Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key"`),
+        `
+        "./pages/_document.js:3:35
+        Parsing ecmascript source code failed
+          1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
+          2 |
+        > 3 | class MyDocument extends Document {{
+            |                                    ^
+          4 |   static async getInitialProps(ctx) {
+          5 |     const initialProps = await Document.getInitialProps(ctx)
+          6 |     return { ...initialProps }
+
+        Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key"
+      `
+      )
+    } else {
+      expect(source).toMatchInlineSnapshot(
+        next.normalizeSnapshot(`"./pages/_document.js
+Error: 
+  x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
+    ,-[TEST_DIR/pages/_document.js:1:1]
+  1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
+  2 | 
+  3 | class MyDocument extends Document {{
+    :                                    ^
+  4 |   static async getInitialProps(ctx) {
+  5 |     const initialProps = await Document.getInitialProps(ctx)
+  6 |     return { ...initialProps }
+    \`----
+
+Caused by:
+    Syntax Error"`),
+        `
         "./pages/_document.js
         Error: 
           x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
-           ,-[TEST_DIR/pages/_document.js:1:1]
+           ,-[1:1]
          1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
          2 | 
          3 | class MyDocument extends Document {{
@@ -216,7 +275,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
             Syntax Error"
       `
       )
-    )
+    }
 
     await session.patch(
       'pages/_document.js',

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -202,7 +202,7 @@ describe.each(['default', 'turbo'])(
         "./pages/_document.js
         Error: 
           x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
-           ,-[1:1]
+           ,-[TEST_DIR/pages/_document.js:1:1]
          1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
          2 | 
          3 | class MyDocument extends Document {{

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -92,17 +92,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(await session.hasRedbox()).toBe(true)
     const source = next.normalizeTestDirContent(await session.getRedboxSource())
     if (process.env.TURBOPACK) {
-      expect(source).toMatchInlineSnapshot(
-        next.normalizeSnapshot(`"./pages/_app.js:2:11
-Parsing ecmascript source code failed
-  1 | function MyApp({ Component, pageProps }) {
-> 2 |   return <<Component {...pageProps} />;
-    |            ^^^^^^^^^
-  3 | }
-  4 | export default MyApp
-
-Expression expected"`),
-        `
+      expect(source).toMatchInlineSnapshot(`
         "./pages/_app.js:2:11
         Parsing ecmascript source code failed
           1 | function MyApp({ Component, pageProps }) {
@@ -112,33 +102,9 @@ Expression expected"`),
           4 | export default MyApp
 
         Expression expected"
-      `
-      )
+      `)
     } else {
-      expect(source).toMatchInlineSnapshot(
-        next.normalizeSnapshot(`"./pages/_app.js
-Error: 
-  x Expression expected
-    ,-[TEST_DIR/pages/_app.js:1:1]
-  1 | function MyApp({ Component, pageProps }) {
-  2 |   return <<Component {...pageProps} />;
-    :           ^
-  3 | }
-  4 | export default MyApp
-    \`----
-
-  x Expression expected
-    ,-[TEST_DIR/pages/_app.js:1:1]
-  1 | function MyApp({ Component, pageProps }) {
-  2 |   return <<Component {...pageProps} />;
-    :            ^^^^^^^^^
-  3 | }
-  4 | export default MyApp
-    \`----
-
-Caused by:
-    Syntax Error"`),
-        `
+      expect(source).toMatchInlineSnapshot(`
         "./pages/_app.js
         Error: 
           x Expression expected
@@ -161,8 +127,7 @@ Caused by:
 
         Caused by:
             Syntax Error"
-      `
-      )
+      `)
     }
 
     await session.patch(
@@ -214,19 +179,7 @@ Caused by:
     expect(await session.hasRedbox()).toBe(true)
     const source = next.normalizeTestDirContent(await session.getRedboxSource())
     if (process.env.TURBOPACK) {
-      expect(source).toMatchInlineSnapshot(
-        next.normalizeSnapshot(`"./pages/_document.js:3:35
-Parsing ecmascript source code failed
-  1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
-  2 |
-> 3 | class MyDocument extends Document {{
-    |                                    ^
-  4 |   static async getInitialProps(ctx) {
-  5 |     const initialProps = await Document.getInitialProps(ctx)
-  6 |     return { ...initialProps }
-
-Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key"`),
-        `
+      expect(source).toMatchInlineSnapshot(`
         "./pages/_document.js:3:35
         Parsing ecmascript source code failed
           1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
@@ -238,26 +191,9 @@ Unexpected token \`{\`. Expected identifier, string literal, numeric literal or 
           6 |     return { ...initialProps }
 
         Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key"
-      `
-      )
+      `)
     } else {
-      expect(source).toMatchInlineSnapshot(
-        next.normalizeSnapshot(`"./pages/_document.js
-Error: 
-  x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
-    ,-[TEST_DIR/pages/_document.js:1:1]
-  1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
-  2 | 
-  3 | class MyDocument extends Document {{
-    :                                    ^
-  4 |   static async getInitialProps(ctx) {
-  5 |     const initialProps = await Document.getInitialProps(ctx)
-  6 |     return { ...initialProps }
-    \`----
-
-Caused by:
-    Syntax Error"`),
-        `
+      expect(source).toMatchInlineSnapshot(`
         "./pages/_document.js
         Error: 
           x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
@@ -273,8 +209,7 @@ Caused by:
 
         Caused by:
             Syntax Error"
-      `
-      )
+      `)
     }
 
     await session.patch(

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -4,48 +4,50 @@ import { describeVariants as describe } from 'next-test-utils'
 import { outdent } from 'outdent'
 import path from 'path'
 
-describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
-  const { next } = nextTestSetup({
-    files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    skipStart: true,
-  })
+describe.each(['default', 'turbo'])(
+  'ReactRefreshLogBox _app _document %s',
+  () => {
+    const { next } = nextTestSetup({
+      files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
+      skipStart: true,
+    })
 
-  test('empty _app shows logbox', async () => {
-    const { session, cleanup } = await sandbox(
-      next,
-      new Map([['pages/_app.js', ``]])
-    )
-    expect(await session.hasRedbox()).toBe(true)
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-      `"Error: The default export is not a React Component in page: "/_app""`
-    )
+    test('empty _app shows logbox', async () => {
+      const { session, cleanup } = await sandbox(
+        next,
+        new Map([['pages/_app.js', ``]])
+      )
+      expect(await session.hasRedbox()).toBe(true)
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Error: The default export is not a React Component in page: "/_app""`
+      )
 
-    await session.patch(
-      'pages/_app.js',
-      outdent`
+      await session.patch(
+        'pages/_app.js',
+        outdent`
         function MyApp({ Component, pageProps }) {
           return <Component {...pageProps} />;
         }
         export default MyApp
       `
-    )
-    expect(await session.hasRedbox()).toBe(false)
-    await cleanup()
-  })
+      )
+      expect(await session.hasRedbox()).toBe(false)
+      await cleanup()
+    })
 
-  test('empty _document shows logbox', async () => {
-    const { session, cleanup } = await sandbox(
-      next,
-      new Map([['pages/_document.js', ``]])
-    )
-    expect(await session.hasRedbox()).toBe(true)
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-      `"Error: The default export is not a React Component in page: "/_document""`
-    )
+    test('empty _document shows logbox', async () => {
+      const { session, cleanup } = await sandbox(
+        next,
+        new Map([['pages/_document.js', ``]])
+      )
+      expect(await session.hasRedbox()).toBe(true)
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Error: The default export is not a React Component in page: "/_document""`
+      )
 
-    await session.patch(
-      'pages/_document.js',
-      outdent`
+      await session.patch(
+        'pages/_document.js',
+        outdent`
         import Document, { Html, Head, Main, NextScript } from 'next/document'
 
         class MyDocument extends Document {
@@ -69,30 +71,31 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
         export default MyDocument
       `
-    )
-    expect(await session.hasRedbox()).toBe(false)
-    await cleanup()
-  })
+      )
+      expect(await session.hasRedbox()).toBe(false)
+      await cleanup()
+    })
 
-  test('_app syntax error shows logbox', async () => {
-    const { session, cleanup } = await sandbox(
-      next,
-      new Map([
-        [
-          'pages/_app.js',
-          outdent`
+    test('_app syntax error shows logbox', async () => {
+      const { session, cleanup } = await sandbox(
+        next,
+        new Map([
+          [
+            'pages/_app.js',
+            outdent`
             function MyApp({ Component, pageProps }) {
               return <<Component {...pageProps} />;
             }
             export default MyApp
           `,
-        ],
-      ])
-    )
-    expect(await session.hasRedbox()).toBe(true)
-    const source = next.normalizeTestDirContent(await session.getRedboxSource())
-    if (process.env.TURBOPACK) {
-      expect(source).toMatchInlineSnapshot(`
+          ],
+        ])
+      )
+      expect(await session.hasRedbox()).toBe(true)
+      const content = await session.getRedboxSource()
+      const source = next.normalizeTestDirContent(content)
+      if (process.env.TURBOPACK) {
+        expect(source).toMatchInlineSnapshot(`
         "./pages/_app.js:2:11
         Parsing ecmascript source code failed
           1 | function MyApp({ Component, pageProps }) {
@@ -103,12 +106,12 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
         Expression expected"
       `)
-    } else {
-      expect(source).toMatchInlineSnapshot(`
+      } else {
+        expect(source).toMatchInlineSnapshot(`
         "./pages/_app.js
         Error: 
           x Expression expected
-           ,-[1:1]
+           ,-[TEST_DIR/pages/_app.js:1:1]
          1 | function MyApp({ Component, pageProps }) {
          2 |   return <<Component {...pageProps} />;
            :           ^
@@ -117,7 +120,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
            \`----
 
           x Expression expected
-           ,-[1:1]
+           ,-[TEST_DIR/pages/_app.js:1:1]
          1 | function MyApp({ Component, pageProps }) {
          2 |   return <<Component {...pageProps} />;
            :            ^^^^^^^^^
@@ -128,28 +131,28 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         Caused by:
             Syntax Error"
       `)
-    }
+      }
 
-    await session.patch(
-      'pages/_app.js',
-      outdent`
+      await session.patch(
+        'pages/_app.js',
+        outdent`
         function MyApp({ Component, pageProps }) {
           return <Component {...pageProps} />;
         }
         export default MyApp
       `
-    )
-    expect(await session.hasRedbox()).toBe(false)
-    await cleanup()
-  })
+      )
+      expect(await session.hasRedbox()).toBe(false)
+      await cleanup()
+    })
 
-  test('_document syntax error shows logbox', async () => {
-    const { session, cleanup } = await sandbox(
-      next,
-      new Map([
-        [
-          'pages/_document.js',
-          outdent`
+    test('_document syntax error shows logbox', async () => {
+      const { session, cleanup } = await sandbox(
+        next,
+        new Map([
+          [
+            'pages/_document.js',
+            outdent`
             import Document, { Html, Head, Main, NextScript } from 'next/document'
 
             class MyDocument extends Document {{
@@ -173,13 +176,15 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
             export default MyDocument
           `,
-        ],
-      ])
-    )
-    expect(await session.hasRedbox()).toBe(true)
-    const source = next.normalizeTestDirContent(await session.getRedboxSource())
-    if (process.env.TURBOPACK) {
-      expect(source).toMatchInlineSnapshot(`
+          ],
+        ])
+      )
+      expect(await session.hasRedbox()).toBe(true)
+      const source = next.normalizeTestDirContent(
+        await session.getRedboxSource()
+      )
+      if (process.env.TURBOPACK) {
+        expect(source).toMatchInlineSnapshot(`
         "./pages/_document.js:3:35
         Parsing ecmascript source code failed
           1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
@@ -192,8 +197,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
         Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key"
       `)
-    } else {
-      expect(source).toMatchInlineSnapshot(`
+      } else {
+        expect(source).toMatchInlineSnapshot(`
         "./pages/_document.js
         Error: 
           x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
@@ -210,11 +215,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         Caused by:
             Syntax Error"
       `)
-    }
+      }
 
-    await session.patch(
-      'pages/_document.js',
-      outdent`
+      await session.patch(
+        'pages/_document.js',
+        outdent`
         import Document, { Html, Head, Main, NextScript } from 'next/document'
 
         class MyDocument extends Document {
@@ -238,8 +243,9 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
         export default MyDocument
       `
-    )
-    expect(await session.hasRedbox()).toBe(false)
-    await cleanup()
-  })
-})
+      )
+      expect(await session.hasRedbox()).toBe(false)
+      await cleanup()
+    })
+  }
+)

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -93,7 +93,20 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(
       next.normalizeTestDirContent(await session.getRedboxSource())
     ).toMatchInlineSnapshot(
-      next.normalizeSnapshot(`
+      next.normalizeSnapshot(
+        process.env.TURBOPACK
+          ? `
+      "./pages/_app.js:2:11
+      Parsing ecmascript source code failed
+        1 | function MyApp({ Component, pageProps }) {
+      > 2 |   return <<Component {...pageProps} />;
+          |            ^^^^^^^^^
+        3 | }
+        4 | export default MyApp
+
+      Expression expected"
+    `
+          : `
         "./pages/_app.js
         Error: 
           x Expression expected
@@ -116,7 +129,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
         Caused by:
             Syntax Error"
-      `)
+      `
+      )
     )
 
     await session.patch(
@@ -169,7 +183,22 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(
       next.normalizeTestDirContent(await session.getRedboxSource())
     ).toMatchInlineSnapshot(
-      next.normalizeSnapshot(`
+      next.normalizeSnapshot(
+        process.env.TURBOPACK
+          ? `
+      "./pages/_document.js:3:35
+      Parsing ecmascript source code failed
+        1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
+        2 |
+      > 3 | class MyDocument extends Document {{
+          |                                    ^
+        4 |   static async getInitialProps(ctx) {
+        5 |     const initialProps = await Document.getInitialProps(ctx)
+        6 |     return { ...initialProps }
+
+      Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key"
+    `
+          : `
         "./pages/_document.js
         Error: 
           x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
@@ -185,7 +214,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
         Caused by:
             Syntax Error"
-      `)
+      `
+      )
     )
 
     await session.patch(

--- a/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
@@ -45,16 +45,28 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       `
     )
     expect(await session.hasRedbox()).toBe(true)
-    expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-      "./node_modules/my-package/index.js:1:0
-      Module not found: Can't resolve 'dns'
+    expect(await session.getRedboxSource()).toMatchInlineSnapshot(
+      process.env.TURBOPACK
+        ? `
+    "./node_modules/my-package/index.js:1:12
+    Module not found: Can't resolve 'dns'
+    > 1 | const dns = require('dns')
+        |             ^^^^^^^^^^^^^^
+      2 | module.exports = dns
 
-      https://nextjs.org/docs/messages/module-not-found
+    https://nextjs.org/docs/messages/module-not-found"
+  `
+        : `
+  "./node_modules/my-package/index.js:1:0
+  Module not found: Can't resolve 'dns'
 
-      Import trace for requested module:
-      ./index.js
-      ./pages/index.js"
-    `)
+  https://nextjs.org/docs/messages/module-not-found
+
+  Import trace for requested module:
+  ./index.js
+  ./pages/index.js"
+`
+    )
 
     await cleanup()
   })
@@ -80,19 +92,33 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(await session.hasRedbox()).toBe(true)
 
     const source = await session.getRedboxSource()
-    expect(source).toMatchInlineSnapshot(`
-      "./index.js:1:0
-      Module not found: Can't resolve 'b'
-      > 1 | import Comp from 'b'
-        2 |
-        3 | export default function Oops() {
-        4 |   return (
+    expect(source).toMatchInlineSnapshot(
+      process.env.TURBOPACK
+        ? `
+    "./index.js:1:0
+    Module not found: Can't resolve 'b'
+    > 1 | import Comp from 'b'
+        | ^^^^^^^^^^^^^^^^^^^^
+      2 |
+      3 | export default function Oops() {
+      4 |   return (
 
-      https://nextjs.org/docs/messages/module-not-found
+    https://nextjs.org/docs/messages/module-not-found"
+      `
+        : `
+    "./index.js:1:0
+    Module not found: Can't resolve 'b'
+    > 1 | import Comp from 'b'
+      2 |
+      3 | export default function Oops() {
+      4 |   return (
 
-      Import trace for requested module:
-      ./pages/index.js"
-    `)
+    https://nextjs.org/docs/messages/module-not-found
+
+    Import trace for requested module:
+    ./pages/index.js"
+  `
+    )
 
     await cleanup()
   })
@@ -173,16 +199,30 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(await session.hasRedbox()).toBe(true)
 
     const source = await session.getRedboxSource()
-    expect(source).toMatchInlineSnapshot(`
+    expect(source).toMatchInlineSnapshot(
+      process.env.TURBOPACK
+        ? `
       "./pages/_app.js:1:0
       Module not found: Can't resolve './non-existent.css'
       > 1 | import './non-existent.css'
+          | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
         2 |
         3 | export default function App({ Component, pageProps }) {
         4 |   return <Component {...pageProps} />
 
       https://nextjs.org/docs/messages/module-not-found"
-    `)
+    `
+        : `
+    "./pages/_app.js:1:0
+    Module not found: Can't resolve './non-existent.css'
+    > 1 | import './non-existent.css'
+      2 |
+      3 | export default function App({ Component, pageProps }) {
+      4 |   return <Component {...pageProps} />
+
+    https://nextjs.org/docs/messages/module-not-found"
+  `
+    )
 
     await session.patch(
       'pages/_app.js',

--- a/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
@@ -92,33 +92,33 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(await session.hasRedbox()).toBe(true)
 
     const source = await session.getRedboxSource()
-    expect(source).toMatchInlineSnapshot(
-      process.env.TURBOPACK
-        ? `
-    "./index.js:1:0
-    Module not found: Can't resolve 'b'
-    > 1 | import Comp from 'b'
-        | ^^^^^^^^^^^^^^^^^^^^
-      2 |
-      3 | export default function Oops() {
-      4 |   return (
+    if (process.env.TURBOPACK) {
+      expect(source).toMatchInlineSnapshot(`
+        "./index.js:1:0
+        Module not found: Can't resolve 'b'
+        > 1 | import Comp from 'b'
+            | ^^^^^^^^^^^^^^^^^^^^
+          2 |
+          3 | export default function Oops() {
+          4 |   return (
 
-    https://nextjs.org/docs/messages/module-not-found"
-      `
-        : `
-    "./index.js:1:0
-    Module not found: Can't resolve 'b'
-    > 1 | import Comp from 'b'
-      2 |
-      3 | export default function Oops() {
-      4 |   return (
+        https://nextjs.org/docs/messages/module-not-found"
+      `)
+    } else {
+      expect(source).toMatchInlineSnapshot(`
+        "./index.js:1:0
+        Module not found: Can't resolve 'b'
+        > 1 | import Comp from 'b'
+          2 |
+          3 | export default function Oops() {
+          4 |   return (
 
-    https://nextjs.org/docs/messages/module-not-found
+        https://nextjs.org/docs/messages/module-not-found
 
-    Import trace for requested module:
-    ./pages/index.js"
-  `
-    )
+        Import trace for requested module:
+        ./pages/index.js"
+      `)
+    }
 
     await cleanup()
   })
@@ -158,15 +158,15 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       `)
     } else {
       expect(source).toMatchInlineSnapshot(`
-              "./pages/index.js:1:0
-              Module not found: Can't resolve 'b'
-              > 1 | import Comp from 'b'
-                2 |
-                3 | export default function Oops() {
-                4 |   return (
+        "./pages/index.js:1:0
+        Module not found: Can't resolve 'b'
+        > 1 | import Comp from 'b'
+          2 |
+          3 | export default function Oops() {
+          4 |   return (
 
-              https://nextjs.org/docs/messages/module-not-found"
-          `)
+        https://nextjs.org/docs/messages/module-not-found"
+      `)
     }
 
     await cleanup()
@@ -199,30 +199,30 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(await session.hasRedbox()).toBe(true)
 
     const source = await session.getRedboxSource()
-    expect(source).toMatchInlineSnapshot(
-      process.env.TURBOPACK
-        ? `
-      "./pages/_app.js:1:0
-      Module not found: Can't resolve './non-existent.css'
-      > 1 | import './non-existent.css'
-          | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        2 |
-        3 | export default function App({ Component, pageProps }) {
-        4 |   return <Component {...pageProps} />
+    if (process.env.TURBOPACK) {
+      expect(source).toMatchInlineSnapshot(`
+        "./pages/_app.js:1:0
+        Module not found: Can't resolve './non-existent.css'
+        > 1 | import './non-existent.css'
+            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          2 |
+          3 | export default function App({ Component, pageProps }) {
+          4 |   return <Component {...pageProps} />
 
-      https://nextjs.org/docs/messages/module-not-found"
-    `
-        : `
-    "./pages/_app.js:1:0
-    Module not found: Can't resolve './non-existent.css'
-    > 1 | import './non-existent.css'
-      2 |
-      3 | export default function App({ Component, pageProps }) {
-      4 |   return <Component {...pageProps} />
+        https://nextjs.org/docs/messages/module-not-found"
+      `)
+    } else {
+      expect(source).toMatchInlineSnapshot(`
+        "./pages/_app.js:1:0
+        Module not found: Can't resolve './non-existent.css'
+        > 1 | import './non-existent.css'
+          2 |
+          3 | export default function App({ Component, pageProps }) {
+          4 |   return <Component {...pageProps} />
 
-    https://nextjs.org/docs/messages/module-not-found"
-  `
-    )
+        https://nextjs.org/docs/messages/module-not-found"
+      `)
+    }
 
     await session.patch(
       'pages/_app.js',

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -226,7 +226,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         "./index.js
         Error: 
           x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
-           ,-[4:1]
+           ,-[TEST_DIR/index.js:4:1]
          4 |       <p>lol</p>
          5 |     div
          6 |   )
@@ -235,7 +235,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
            \`----
 
           x Unexpected eof
-           ,-[4:1]
+           ,-[TEST_DIR/index.js:4:1]
          4 |       <p>lol</p>
          5 |     div
          6 |   )

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -5,8 +5,6 @@ import { describeVariants as describe } from 'next-test-utils'
 import path from 'path'
 import { outdent } from 'outdent'
 
-const IS_TURBOPACK = Boolean(process.env.TURBOPACK)
-
 describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
@@ -211,49 +209,47 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
     expect(await session.hasRedbox()).toBe(true)
 
-    const source = await session.getRedboxSource()
-    expect(next.normalizeTestDirContent(source)).toMatchInlineSnapshot(
-      next.normalizeSnapshot(
-        IS_TURBOPACK
-          ? `
-      "./index.js:7:1
-      Parsing ecmascript source code failed
-        5 |     div
-        6 |   )
-      > 7 | }
-          |  ^
+    const source = next.normalizeTestDirContent(await session.getRedboxSource())
+    if (process.env.TURBOPACK) {
+      expect(source).toMatchInlineSnapshot(
+        next.normalizeSnapshot(`"./index.js:7:1
+Parsing ecmascript source code failed
+  5 |     div
+  6 |   )
+> 7 | }
+    |  ^
 
-      Unexpected eof"
-    `
-          : `
-        "./index.js
-        Error: 
-          x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
-           ,-[TEST_DIR/index.js:4:1]
-         4 |       <p>lol</p>
-         5 |     div
-         6 |   )
-         7 | }
-           : ^
-           \`----
-
-          x Unexpected eof
-           ,-[TEST_DIR/index.js:4:1]
-         4 |       <p>lol</p>
-         5 |     div
-         6 |   )
-         7 | }
-           \`----
-
-        Caused by:
-            Syntax Error
-
-        Import trace for requested module:
-        ./index.js
-        ./pages/index.js"
-      `
+Unexpected eof"`)
       )
-    )
+    } else {
+      expect(source).toMatchInlineSnapshot(
+        next.normalizeSnapshot(`"./index.js
+Error: 
+  x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
+    ,-[TEST_DIR/index.js:4:1]
+  4 |       <p>lol</p>
+  5 |     div
+  6 |   )
+  7 | }
+    : ^
+    \`----
+
+  x Unexpected eof
+    ,-[TEST_DIR/index.js:4:1]
+  4 |       <p>lol</p>
+  5 |     div
+  6 |   )
+  7 | }
+    \`----
+
+Caused by:
+    Syntax Error
+
+Import trace for requested module:
+./index.js
+./pages/index.js"`)
+      )
+    }
 
     await cleanup()
   })
@@ -351,14 +347,21 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(await session.hasRedbox()).toBe(true)
     const source = await session.getRedboxSource()
     expect(source).toMatch(
-      IS_TURBOPACK ? './index.module.css:1:8' : './index.module.css:1:1'
+      process.env.TURBOPACK
+        ? './index.module.css:1:8'
+        : './index.module.css:1:1'
     )
-    if (!IS_TURBOPACK) {
+    if (!process.env.TURBOPACK) {
       expect(source).toMatch('Syntax error: ')
       expect(source).toMatch('Unclosed block')
     }
-    expect(source).toMatch('> 1 | .button {')
-    expect(source).toMatch(IS_TURBOPACK ? '    |         ^' : '    | ^')
+    if (process.env.TURBOPACK) {
+      expect(source).toMatch('> 1 | .button {')
+      expect(source).toMatch('    |         ^')
+    } else {
+      expect(source).toMatch('> 1 | .button {')
+      expect(source).toMatch('    | ^')
+    }
 
     // Checks for selectors that can't be prefixed.
     // Selector "button" is not pure (pure selectors must contain at least one local class or id)

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -222,6 +222,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         6 |   )
       > 7 | }
           |  ^
+
       Unexpected eof"
     `
           : `

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -211,14 +211,16 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
     const source = next.normalizeTestDirContent(await session.getRedboxSource())
     if (process.env.TURBOPACK) {
-      expect(source).toMatchInlineSnapshot(`"./index.js:7:1
+      expect(source).toMatchInlineSnapshot(`
+        "./index.js:7:1
         Parsing ecmascript source code failed
           5 |     div
           6 |   )
         > 7 | }
             |  ^
 
-      Unexpected eof"`)
+        Unexpected eof"
+      `)
     } else {
       expect(source).toMatchInlineSnapshot(`
         "./index.js

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -212,39 +212,41 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     const source = next.normalizeTestDirContent(await session.getRedboxSource())
     if (process.env.TURBOPACK) {
       expect(source).toMatchInlineSnapshot(`"./index.js:7:1
-Parsing ecmascript source code failed
-  5 |     div
-  6 |   )
-> 7 | }
-    |  ^
+        Parsing ecmascript source code failed
+          5 |     div
+          6 |   )
+        > 7 | }
+            |  ^
 
-Unexpected eof"`)
+      Unexpected eof"`)
     } else {
-      expect(source).toMatchInlineSnapshot(`"./index.js
-Error: 
-  x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
-    ,-[TEST_DIR/index.js:4:1]
-  4 |       <p>lol</p>
-  5 |     div
-  6 |   )
-  7 | }
-    : ^
-    \`----
+      expect(source).toMatchInlineSnapshot(`
+        "./index.js
+        Error: 
+          x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
+           ,-[4:1]
+         4 |       <p>lol</p>
+         5 |     div
+         6 |   )
+         7 | }
+           : ^
+           \`----
 
-  x Unexpected eof
-    ,-[TEST_DIR/index.js:4:1]
-  4 |       <p>lol</p>
-  5 |     div
-  6 |   )
-  7 | }
-    \`----
+          x Unexpected eof
+           ,-[4:1]
+         4 |       <p>lol</p>
+         5 |     div
+         6 |   )
+         7 | }
+           \`----
 
-Caused by:
-    Syntax Error
+        Caused by:
+            Syntax Error
 
-Import trace for requested module:
-./index.js
-./pages/index.js"`)
+        Import trace for requested module:
+        ./index.js
+        ./pages/index.js"
+      `)
     }
 
     await cleanup()

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -211,8 +211,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
     const source = next.normalizeTestDirContent(await session.getRedboxSource())
     if (process.env.TURBOPACK) {
-      expect(source).toMatchInlineSnapshot(
-        next.normalizeSnapshot(`"./index.js:7:1
+      expect(source).toMatchInlineSnapshot(`"./index.js:7:1
 Parsing ecmascript source code failed
   5 |     div
   6 |   )
@@ -220,10 +219,8 @@ Parsing ecmascript source code failed
     |  ^
 
 Unexpected eof"`)
-      )
     } else {
-      expect(source).toMatchInlineSnapshot(
-        next.normalizeSnapshot(`"./index.js
+      expect(source).toMatchInlineSnapshot(`"./index.js
 Error: 
   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
     ,-[TEST_DIR/index.js:4:1]
@@ -248,7 +245,6 @@ Caused by:
 Import trace for requested module:
 ./index.js
 ./pages/index.js"`)
-      )
     }
 
     await cleanup()

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1238,16 +1238,18 @@
   },
   "test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts": {
     "passed": [
-      "ReactRefreshLogBox turbo empty _app shows logbox",
-      "ReactRefreshLogBox turbo empty _document shows logbox",
-      "ReactRefreshLogBox turbo _app syntax error shows logbox"
+      "ReactRefreshLogBox _app _document turbo empty _app shows logbox",
+      "ReactRefreshLogBox _app _document turbo empty _document shows logbox",
+      "ReactRefreshLogBox _app _document turbo _app syntax error shows logbox"
     ],
-    "failed": ["ReactRefreshLogBox turbo _document syntax error shows logbox"],
+    "failed": [
+      "ReactRefreshLogBox _app _document turbo _document syntax error shows logbox"
+    ],
     "pending": [
-      "ReactRefreshLogBox default _app syntax error shows logbox",
-      "ReactRefreshLogBox default _document syntax error shows logbox",
-      "ReactRefreshLogBox default empty _app shows logbox",
-      "ReactRefreshLogBox default empty _document shows logbox"
+      "ReactRefreshLogBox _app _document default _app syntax error shows logbox",
+      "ReactRefreshLogBox _app _document default _document syntax error shows logbox",
+      "ReactRefreshLogBox _app _document default empty _app shows logbox",
+      "ReactRefreshLogBox _app _document default empty _document shows logbox"
     ],
     "flakey": [],
     "runtimeError": false

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1239,10 +1239,10 @@
   "test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts": {
     "passed": [
       "ReactRefreshLogBox _app _document turbo empty _app shows logbox",
-      "ReactRefreshLogBox _app _document turbo empty _document shows logbox",
-      "ReactRefreshLogBox _app _document turbo _app syntax error shows logbox"
+      "ReactRefreshLogBox _app _document turbo empty _document shows logbox"
     ],
     "failed": [
+      "ReactRefreshLogBox _app _document turbo _app syntax error shows logbox",
       "ReactRefreshLogBox _app _document turbo _document syntax error shows logbox"
     ],
     "pending": [

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1239,10 +1239,12 @@
   "test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts": {
     "passed": [
       "ReactRefreshLogBox turbo empty _app shows logbox",
-      "ReactRefreshLogBox turbo empty _document shows logbox",
-      "ReactRefreshLogBox turbo _app syntax error shows logbox"
+      "ReactRefreshLogBox turbo empty _document shows logbox"
     ],
-    "failed": ["ReactRefreshLogBox turbo _document syntax error shows logbox"],
+    "failed": [
+      "ReactRefreshLogBox turbo _app syntax error shows logbox",
+      "ReactRefreshLogBox turbo _document syntax error shows logbox"
+    ],
     "pending": [
       "ReactRefreshLogBox default _app syntax error shows logbox",
       "ReactRefreshLogBox default _document syntax error shows logbox",

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1286,12 +1286,10 @@
       "ReactRefreshLogBox turbo logbox: anchors links in error messages",
       "ReactRefreshLogBox turbo module init error not shown",
       "ReactRefreshLogBox turbo non-Error errors are handled properly",
-      "ReactRefreshLogBox turbo should strip whitespace correctly with newline"
-    ],
-    "failed": [
-      "ReactRefreshLogBox turbo css syntax errors",
+      "ReactRefreshLogBox turbo should strip whitespace correctly with newline",
       "ReactRefreshLogBox turbo unterminated JSX"
     ],
+    "failed": ["ReactRefreshLogBox turbo css syntax errors"],
     "pending": [
       "ReactRefreshLogBox default boundaries",
       "ReactRefreshLogBox default conversion to class component (1)",

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1254,12 +1254,12 @@
   },
   "test/development/acceptance/ReactRefreshLogBox-builtins.test.ts": {
     "passed": [
-      "ReactRefreshLogBox turbo Module not found (empty import trace)"
+      "ReactRefreshLogBox turbo Module not found",
+      "ReactRefreshLogBox turbo Module not found (empty import trace)",
+      "ReactRefreshLogBox turbo Node.js builtins"
     ],
     "failed": [
-      "ReactRefreshLogBox turbo Module not found",
-      "ReactRefreshLogBox turbo Module not found (missing global CSS)",
-      "ReactRefreshLogBox turbo Node.js builtins"
+      "ReactRefreshLogBox turbo Module not found (missing global CSS)"
     ],
     "pending": [
       "ReactRefreshLogBox default Module not found",

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -898,13 +898,12 @@
   },
   "test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts": {
     "passed": [
-      "ReactRefreshLogBox app turbo Module not found empty import trace",
-      "ReactRefreshLogBox app turbo Module not found missing global CSS"
-    ],
-    "failed": [
       "ReactRefreshLogBox app turbo Module not found",
+      "ReactRefreshLogBox app turbo Module not found empty import trace",
+      "ReactRefreshLogBox app turbo Module not found missing global CSS",
       "ReactRefreshLogBox app turbo Node.js builtins"
     ],
+    "failed": [],
     "pending": [
       "ReactRefreshLogBox app default Module not found",
       "ReactRefreshLogBox app default Module not found empty import trace",

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1239,12 +1239,10 @@
   "test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts": {
     "passed": [
       "ReactRefreshLogBox turbo empty _app shows logbox",
-      "ReactRefreshLogBox turbo empty _document shows logbox"
+      "ReactRefreshLogBox turbo empty _document shows logbox",
+      "ReactRefreshLogBox turbo _app syntax error shows logbox"
     ],
-    "failed": [
-      "ReactRefreshLogBox turbo _app syntax error shows logbox",
-      "ReactRefreshLogBox turbo _document syntax error shows logbox"
-    ],
+    "failed": ["ReactRefreshLogBox turbo _document syntax error shows logbox"],
     "pending": [
       "ReactRefreshLogBox default _app syntax error shows logbox",
       "ReactRefreshLogBox default _document syntax error shows logbox",


### PR DESCRIPTION
## What?

Updates snapshots for Turbopack tests. They're slightly different than the webpack output. Generally better because column information is preserved. The import trace is not available in Turbopack as it would make the parent module a direct dependency of the module, meaning it would have to recompile every time you can the parent module. We'll figure out if it can be added in a different way at a later point.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2101