### PR TITLE
Remove normalizeSnapshot as it is no longer used

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -222,9 +222,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
     const source = await session.getRedboxSource()
     expect(next.normalizeTestDirContent(source)).toMatchInlineSnapshot(
-      next.normalizeSnapshot(
-        IS_TURBOPACK
-          ? `
+      IS_TURBOPACK
+        ? `
       "./index.js:7:1
       Parsing ecmascript source code failed
         5 |     div
@@ -234,7 +233,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
       Unexpected eof"
     `
-          : `
+        : `
         "./index.js
         Error: 
           x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
@@ -261,7 +260,6 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         ./index.js
         ./app/page.js"
       `
-      )
     )
 
     await cleanup()

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -392,7 +392,7 @@ describe('Error overlay - RSC build errors', () => {
 
     // TODO: investigate flakey snapshot due to spacing below
     // expect(next.normalizeTestDirContent(await session.getRedboxSource()))
-    //   .toMatchInlineSnapshot(next.normalizeSnapshot(`
+    //   .toMatchInlineSnapshot(n`
     //   "./app/server-with-errors/error-file/error.js
     //   ReactServerComponentsError:
 
@@ -405,7 +405,7 @@ describe('Error overlay - RSC build errors', () => {
 
     //   Import path:
     //   ./app/server-with-errors/error-file/error.js"
-    // `))
+    // `)
 
     await cleanup()
   })

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -208,9 +208,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     )
 
     expect(await session.hasRedbox()).toBe(true)
-    const content = await session.getRedboxSource()
-    console.log({ content })
-    const source = next.normalizeTestDirContent(content)
+    const source = next.normalizeTestDirContent(await session.getRedboxSource())
     if (process.env.TURBOPACK) {
       expect(source).toMatchInlineSnapshot(`
         "./index.js:7:1

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -208,8 +208,9 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     )
 
     expect(await session.hasRedbox()).toBe(true)
-
-    const source = next.normalizeTestDirContent(await session.getRedboxSource())
+    const content = await session.getRedboxSource()
+    console.log({ content })
+    const source = next.normalizeTestDirContent(content)
     if (process.env.TURBOPACK) {
       expect(source).toMatchInlineSnapshot(`
         "./index.js:7:1

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -421,10 +421,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 1000))
     expect(await session.hasRedbox()).toBe(true)
-    expect(
-      next.normalizeTestDirContent(await session.getRedboxSource())
-    ).toMatchInlineSnapshot(
-      next.normalizeSnapshot(`
+    expect(next.normalizeTestDirContent(await session.getRedboxSource()))
+      .toMatchInlineSnapshot(`
         "./index.js
         Error: 
           x Expected '}', got '<eof>'
@@ -443,7 +441,6 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         ./index.js
         ./pages/index.js"
       `)
-    )
 
     // Test that runtime error does not take over:
     await new Promise((resolve) => setTimeout(resolve, 2000))
@@ -451,7 +448,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(
       next.normalizeTestDirContent(await session.getRedboxSource())
     ).toMatchInlineSnapshot(
-      next.normalizeSnapshot(`
+      `
         "./index.js
         Error: 
           x Expected '}', got '<eof>'
@@ -469,7 +466,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         Import trace for requested module:
         ./index.js
         ./pages/index.js"
-      `)
+      `
     )
 
     await cleanup()

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -900,7 +900,7 @@ describe.each([[''], ['/docs']])(
           expect(
             next.normalizeTestDirContent(redboxSource)
           ).toMatchInlineSnapshot(
-            next.normalizeSnapshot(`
+            `
               "./components/parse-error.js
               Error: 
                 x Expression expected
@@ -912,7 +912,7 @@ describe.each([[''], ['/docs']])(
                4 | invalid
                5 | js
                  "
-            `)
+            `
           )
 
           await next.patchFile(aboutPage, aboutContent)
@@ -930,10 +930,6 @@ describe.each([[''], ['/docs']])(
               () => getBrowserBodyText(browser),
               /This is the about page/
             )
-          }
-
-          if (!process.env.NEXT_SWC_DEV_BIN) {
-            throw err
           }
         } finally {
           if (browser) {

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -300,20 +300,6 @@ export class NextInstance {
       new RegExp(escapeStringRegexp(this.testDir), 'g'),
       'TEST_DIR'
     )
-    if (process.env.NEXT_SWC_DEV_BIN) {
-      content = content.replace(/,----/, ',-[1:1]')
-      content = content.replace(/\[\.\/.*?:/, '[')
-    }
-    return content
-  }
-
-  // the dev binary for next-swc is missing file references
-  // so this normalizes to allow snapshots to match
-  public normalizeSnapshot(content) {
-    if (process.env.NEXT_SWC_DEV_BIN) {
-      content = content.replace(/TEST_DIR.*?:/g, '')
-      content = content.replace(/\[\.\/.*?:/, '[')
-    }
     return content
   }
 


### PR DESCRIPTION
## What?

Removes `normalizeSnapshot` helper in the test suite as it only replaces based on `NEXT_SWC_DEV_BIN` but that env var is no longer provided anywhere. This ensures that Jest can update the inline snapshots.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2104