### PR TITLE
Perf: Delay scripts instead of async to prevent blocking page rendering

### DIFF
--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -55,7 +55,7 @@ export async function createComponentStylesAndScripts({
 
   const scripts = jsHrefs
     ? jsHrefs.map((href) => (
-        <script src={`${ctx.assetPrefix}/_next/${href}`} async={true} />
+        <script src={`${ctx.assetPrefix}/_next/${href}`} defer={true} />
       ))
     : null
 


### PR DESCRIPTION
Scripts without `defer` will severely delay FCP.

https://stackoverflow.com/questions/10808109/script-tag-async-defer

![image](https://github.com/vercel/next.js/assets/33840671/84fdadea-2f0e-40a0-9b19-d2ad4b4663d0)

<img width="943" alt="Screenshot 2024-01-16 at 11 59 00 PM" src="https://github.com/vercel/next.js/assets/33840671/b0d3a62b-ab64-4f88-be0f-1ab208238ab9">

### (x) Currently using `async` causes some scripts to precede FCP.
<img width="807" alt="Screenshot 2024-01-17 at 11 33 41 AM" src="https://github.com/vercel/next.js/assets/33840671/38119ae9-40af-4dda-b5a3-9a0fca9254c7">

### (o) I changed the generated HTML to `defer`, which worked as expected.
<img width="1062" alt="Screenshot 2024-01-17 at 11 31 37 AM" src="https://github.com/vercel/next.js/assets/33840671/29602fd5-22b4-4cb5-9dce-f7d1ea537113">


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
