### PR TITLE
feat: stabilize `unstable_getImgProps()` => `getImageProps()`

### DIFF
--- a/docs/02-app/02-api-reference/01-components/image.mdx
+++ b/docs/02-app/02-api-reference/01-components/image.mdx
@@ -795,9 +795,9 @@ Try it out:
 
 - [Demo light/dark mode theme detection](https://image-component.nextjs.gallery/theme)
 
-## getImgProps
+## getImageProps
 
-For more advanced use cases, you can call `getImgProps()` to get the props that would be passed to the underlying `<img>` element, and instead pass to them to another component, style, canvas, etc.
+For more advanced use cases, you can call `getImageProps()` to get the props that would be passed to the underlying `<img>` element, and instead pass to them to another component, style, canvas, etc.
 
 This also avoid calling React `useState()` so it can lead to better performance, but it cannot be used with the [`placeholder`](#placeholder) prop because the placeholder will never be removed.
 
@@ -806,12 +806,12 @@ This also avoid calling React `useState()` so it can lead to better performance,
 The example below uses the [`<picture>`](https://developer.mozilla.org/docs/Web/HTML/Element/picture) element to display a different image based on the user's [preferred color scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).
 
 ```jsx filename="app/page.js"
-import { getImgProps } from 'next/image'
+import { getImageProps } from 'next/image'
 
 export default function Page() {
   const common = { alt: 'Theme Example', width: 800, height: 400 }
-  const { props: { srcSet: dark } } = getImgProps({ ...common, src: '/dark.png' })
-  const { props: { srcSet: light, ...rest } } = getImgProps({ ...common, src: '/light.png' })
+  const { props: { srcSet: dark } } = getImageProps({ ...common, src: '/dark.png' })
+  const { props: { srcSet: light, ...rest } } = getImageProps({ ...common, src: '/light.png' })
 
   return (
   <picture>
@@ -827,18 +827,18 @@ export default function Page() {
 Similarly, you can implement [Art Direction](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#art_direction) with different `src` images.
 
 ```jsx filename="app/page.js"
-import { getImgProps } from 'next/image'
+import { getImageProps } from 'next/image'
 
 export default function Home() {
   const common = { alt: 'Art Direction Example', sizes: '100vw' }
-  const { props: desktop } = getImgProps({
+  const { props: desktop } = getImageProps({
     ...common,
     width: 1440,
     height: 875,
     quality: 80,
     src: '/desktop.jpg',
   })
-  const { props: mobile } = getImgProps({
+  const { props: mobile } = getImageProps({
     ...common,
     width: 750,
     height: 1334,
@@ -861,7 +861,7 @@ export default function Home() {
 You can even convert the `srcSet` string to the [`image-set()`](https://developer.mozilla.org/en-US/docs/Web/CSS/image/image-set) CSS function to optimize a background image.
 
 ```jsx filename="app/page.js"
-import { getImgProps } from 'next/image'
+import { getImageProps } from 'next/image'
 
 function getBackgroundImage(srcSet = '') {
   const imageSet = srcSet
@@ -877,7 +877,7 @@ function getBackgroundImage(srcSet = '') {
 export default function Home() {
   const {
     props: { srcSet },
-  } = getImgProps({ alt: '', width: 128, height: 128, src: '/img.png' })
+  } = getImageProps({ alt: '', width: 128, height: 128, src: '/img.png' })
   const backgroundImage = getBackgroundImage(srcSet)
   const style = { height: '100vh', width: '100vw', backgroundImage }
 
@@ -904,7 +904,7 @@ This `next/image` component uses browser native [lazy loading](https://caniuse.c
 
 | Version    | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `v14.1.0`  | `getImgProps()` is stable.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `v14.1.0`  | `getImageProps()` is stable.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `v14.0.0`  | `onLoadingComplete` prop and `domains` config deprecated.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `v13.4.14` | `placeholder` prop support for `data:/image...`                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `v13.2.0`  | `contentDispositionType` configuration added.                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |

--- a/docs/02-app/02-api-reference/01-components/image.mdx
+++ b/docs/02-app/02-api-reference/01-components/image.mdx
@@ -809,15 +809,84 @@ The example below uses the [`<picture>`](https://developer.mozilla.org/docs/Web/
 import { getImgProps } from 'next/image'
 
 export default function Page() {
-  const common = { alt: 'Example', width: 800, height: 400 }
+  const common = { alt: 'Theme Example', width: 800, height: 400 }
   const { props: { srcSet: dark } } = getImgProps({ ...common, src: '/dark.png' })
   const { props: { srcSet: light, ...rest } } = getImgProps({ ...common, src: '/light.png' })
 
-  return (<picture>
+  return (
+  <picture>
     <source media="(prefers-color-scheme: dark)" srcSet={dark} />
     <source media="(prefers-color-scheme: light)" srcSet={light} />
-  <img {...rest} />
-</picture>)
+    <img {...rest} />
+  </picture>
+)
+```
+
+### Art Direction
+
+Similarly, you can implement [Art Direction](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#art_direction) with different `src` images.
+
+```jsx filename="app/page.js"
+import { getImgProps } from 'next/image'
+
+export default function Home() {
+  const common = { alt: 'Art Direction Example', sizes: '100vw' }
+  const { props: desktop } = getImgProps({
+    ...common,
+    width: 1440,
+    height: 875,
+    quality: 80,
+    src: '/desktop.jpg',
+  })
+  const { props: mobile } = getImgProps({
+    ...common,
+    width: 750,
+    height: 1334,
+    quality: 70,
+    src: '/mobile.jpg',
+  })
+
+  return (
+    <picture>
+      <source media="(min-width: 1000px)" {...desktop} />
+      <source media="(min-width: 500px)" {...mobile} />
+      <img {...mobile} style={{ width: '100%', height: 'auto' }} />
+    </picture>
+  )
+}
+```
+
+### Background CSS
+
+You can even convert the `srcSet` string to the [`image-set()`](https://developer.mozilla.org/en-US/docs/Web/CSS/image/image-set) CSS function to optimize a background image.
+
+```jsx filename="app/page.js"
+import { getImgProps } from 'next/image'
+
+function getBackgroundImage(srcSet = '') {
+  const imageSet = srcSet
+    .split(', ')
+    .map((str) => {
+      const [url, dpi] = str.split(' ')
+      return `url("${url}") ${dpi}`
+    })
+    .join(', ')
+  return `image-set(${imageSet})`
+}
+
+export default function Home() {
+  const {
+    props: { srcSet },
+  } = getImgProps({ alt: '', width: 128, height: 128, src: '/img.png' })
+  const backgroundImage = getBackgroundImage(srcSet)
+  const style = { height: '100vh', width: '100vw', backgroundImage }
+
+  return (
+    <main style={style}>
+      <h1>Hello World</h1>
+    </main>
+  )
+}
 ```
 
 ## Known Browser Bugs

--- a/docs/02-app/02-api-reference/01-components/image.mdx
+++ b/docs/02-app/02-api-reference/01-components/image.mdx
@@ -795,6 +795,31 @@ Try it out:
 
 - [Demo light/dark mode theme detection](https://image-component.nextjs.gallery/theme)
 
+## getImgProps
+
+For more advanced use cases, you can call `getImgProps()` to get the props that would be passed to the underlying `<img>` element, and instead pass to them to another component, style, canvas, etc.
+
+This also avoid calling React `useState()` so it can lead to better performance, but it cannot be used with the [`placeholder`](#placeholder) prop because the placeholder will never be removed.
+
+### Picture
+
+The example below uses the [`<picture>`](https://developer.mozilla.org/docs/Web/HTML/Element/picture) element to display a different image based on the user's [preferred color scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).
+
+```jsx filename="app/page.js"
+import { getImgProps } from 'next/image'
+
+export default function Page() {
+  const common = { alt: 'Example', width: 800, height: 400 }
+  const { props: { srcSet: dark } } = getImgProps({ ...common, src: '/dark.png' })
+  const { props: { srcSet: light, ...rest } } = getImgProps({ ...common, src: '/light.png' })
+
+  return (<picture>
+    <source media="(prefers-color-scheme: dark)" srcSet={dark} />
+    <source media="(prefers-color-scheme: light)" srcSet={light} />
+  <img {...rest} />
+</picture>)
+```
+
 ## Known Browser Bugs
 
 This `next/image` component uses browser native [lazy loading](https://caniuse.com/loading-lazy-attr), which may fallback to eager loading for older browsers before Safari 15.4. When using the blur-up placeholder, older browsers before Safari 12 will fallback to empty placeholder. When using styles with `width`/`height` of `auto`, it is possible to cause [Layout Shift](https://web.dev/cls/) on older browsers before Safari 15 that don't [preserve the aspect ratio](https://caniuse.com/mdn-html_elements_img_aspect_ratio_computed_from_attributes). For more details, see [this MDN video](https://www.youtube.com/watch?v=4-d_SoCHeWE).
@@ -810,6 +835,7 @@ This `next/image` component uses browser native [lazy loading](https://caniuse.c
 
 | Version    | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v14.1.0`  | `getImgProps()` is stable.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `v14.0.0`  | `onLoadingComplete` prop and `domains` config deprecated.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `v13.4.14` | `placeholder` prop support for `data:/image...`                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `v13.2.0`  | `contentDispositionType` configuration added.                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |

--- a/packages/next/src/shared/lib/image-external.tsx
+++ b/packages/next/src/shared/lib/image-external.tsx
@@ -1,22 +1,21 @@
 import type { ImageConfigComplete, ImageLoaderProps } from './image-config'
 import type { ImageProps, ImageLoader, StaticImageData } from './get-img-props'
 
-import { getImgProps } from './get-img-props'
-import { warnOnce } from './utils/warn-once'
+import { getImgProps as gip } from './get-img-props'
 import { Image } from '../../client/image-component'
 
 // @ts-ignore - This is replaced by webpack alias
 import defaultLoader from 'next/dist/shared/lib/image-loader'
 
-export const unstable_getImgProps = (imgProps: ImageProps) => {
-  warnOnce(
-    'Warning: unstable_getImgProps() is experimental and may change or be removed at any time. Use at your own risk.'
-  )
-  const { props } = getImgProps(imgProps, {
+export const getImgProps = (imgProps: ImageProps) => {
+  const { props } = gip(imgProps, {
     defaultLoader,
     // This is replaced by webpack define plugin
     imgConf: process.env.__NEXT_IMAGE_OPTS as any as ImageConfigComplete,
   })
+  // Normally we don't care about undefined props because we pass to JSX,
+  // but this exported function could be used by the end user for anything
+  // so we delete undefined props to clean it up a little.
   for (const [key, value] of Object.entries(props)) {
     if (value === undefined) {
       delete props[key as keyof typeof props]

--- a/packages/next/src/shared/lib/image-external.tsx
+++ b/packages/next/src/shared/lib/image-external.tsx
@@ -1,14 +1,14 @@
 import type { ImageConfigComplete, ImageLoaderProps } from './image-config'
 import type { ImageProps, ImageLoader, StaticImageData } from './get-img-props'
 
-import { getImgProps as gip } from './get-img-props'
+import { getImgProps } from './get-img-props'
 import { Image } from '../../client/image-component'
 
 // @ts-ignore - This is replaced by webpack alias
 import defaultLoader from 'next/dist/shared/lib/image-loader'
 
-export const getImgProps = (imgProps: ImageProps) => {
-  const { props } = gip(imgProps, {
+export const getImageProps = (imgProps: ImageProps) => {
+  const { props } = getImgProps(imgProps, {
     defaultLoader,
     // This is replaced by webpack define plugin
     imgConf: process.env.__NEXT_IMAGE_OPTS as any as ImageConfigComplete,

--- a/test/e2e/app-dir/app-esm-js/app/app/components-ext.js
+++ b/test/e2e/app-dir/app-esm-js/app/app/components-ext.js
@@ -1,4 +1,4 @@
-import NextImage, { getImgProps } from 'next/image.js'
+import NextImage, { getImageProps } from 'next/image.js'
 import Link from 'next/link.js'
 import Script from 'next/script.js'
 
@@ -8,7 +8,7 @@ export function Components() {
   return (
     <>
       <NextImage className="img" src={src} />
-      <p className="typeof-getImgProps">{typeof getImgProps}</p>
+      <p className="typeof-getImageProps">{typeof getImageProps}</p>
       <Link className="link" href="/client">
         link
       </Link>

--- a/test/e2e/app-dir/app-esm-js/app/app/components-ext.js
+++ b/test/e2e/app-dir/app-esm-js/app/app/components-ext.js
@@ -1,4 +1,4 @@
-import NextImage, { unstable_getImgProps } from 'next/image.js'
+import NextImage, { getImgProps } from 'next/image.js'
 import Link from 'next/link.js'
 import Script from 'next/script.js'
 
@@ -8,7 +8,7 @@ export function Components() {
   return (
     <>
       <NextImage className="img" src={src} />
-      <p className="unstable_getImgProps">{typeof unstable_getImgProps}</p>
+      <p className="typeof-getImgProps">{typeof getImgProps}</p>
       <Link className="link" href="/client">
         link
       </Link>

--- a/test/e2e/app-dir/app-esm-js/app/app/components.js
+++ b/test/e2e/app-dir/app-esm-js/app/app/components.js
@@ -1,4 +1,4 @@
-import NextImage, { getImgProps } from 'next/image'
+import NextImage, { getImageProps } from 'next/image'
 import Link from 'next/link'
 import Script from 'next/script'
 
@@ -8,7 +8,7 @@ export function Components() {
   return (
     <>
       <NextImage className="img" src={src} />
-      <p className="typeof-getImgProps">{typeof getImgProps}</p>
+      <p className="typeof-getImageProps">{typeof getImageProps}</p>
       <Link className="link" href="/client">
         link
       </Link>

--- a/test/e2e/app-dir/app-esm-js/app/app/components.js
+++ b/test/e2e/app-dir/app-esm-js/app/app/components.js
@@ -1,4 +1,4 @@
-import NextImage, { unstable_getImgProps } from 'next/image'
+import NextImage, { getImgProps } from 'next/image'
 import Link from 'next/link'
 import Script from 'next/script'
 
@@ -8,7 +8,7 @@ export function Components() {
   return (
     <>
       <NextImage className="img" src={src} />
-      <p className="unstable_getImgProps">{typeof unstable_getImgProps}</p>
+      <p className="typeof-getImgProps">{typeof getImgProps}</p>
       <Link className="link" href="/client">
         link
       </Link>

--- a/test/e2e/app-dir/app-esm-js/index.test.ts
+++ b/test/e2e/app-dir/app-esm-js/index.test.ts
@@ -12,7 +12,7 @@ createNextDescribe(
       async function validateDomNodes(selector: string) {
         expect(await $(`${selector} .img`).prop('tagName')).toBe('IMG')
         expect(await $(`${selector} .link`).prop('tagName')).toBe('A')
-        expect(await $(`${selector} .typeof-getImgProps`).text()).toContain(
+        expect(await $(`${selector} .typeof-getImageProps`).text()).toContain(
           'function'
         )
       }

--- a/test/e2e/app-dir/app-esm-js/index.test.ts
+++ b/test/e2e/app-dir/app-esm-js/index.test.ts
@@ -12,7 +12,7 @@ createNextDescribe(
       async function validateDomNodes(selector: string) {
         expect(await $(`${selector} .img`).prop('tagName')).toBe('IMG')
         expect(await $(`${selector} .link`).prop('tagName')).toBe('A')
-        expect(await $(`${selector} .unstable_getImgProps`).text()).toContain(
+        expect(await $(`${selector} .typeof-getImgProps`).text()).toContain(
           'function'
         )
       }

--- a/test/integration/next-image-new/app-dir/app/picture/page.js
+++ b/test/integration/next-image-new/app-dir/app/picture/page.js
@@ -1,13 +1,13 @@
-import { getImgProps } from 'next/image'
+import { getImageProps } from 'next/image'
 
 export default function Page() {
   const common = { alt: 'Hero', width: 400, height: 400, priority: true }
   const {
     props: { srcSet: dark },
-  } = getImgProps({ ...common, src: '/test.png' })
+  } = getImageProps({ ...common, src: '/test.png' })
   const {
     props: { srcSet: light, ...rest },
-  } = getImgProps({ ...common, src: '/test_light.png' })
+  } = getImageProps({ ...common, src: '/test_light.png' })
   return (
     <picture>
       <source media="(prefers-color-scheme: dark)" srcSet={dark} />

--- a/test/integration/next-image-new/app-dir/app/picture/page.js
+++ b/test/integration/next-image-new/app-dir/app/picture/page.js
@@ -1,4 +1,4 @@
-import { unstable_getImgProps as getImgProps } from 'next/image'
+import { getImgProps } from 'next/image'
 
 export default function Page() {
   const common = { alt: 'Hero', width: 400, height: 400, priority: true }

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -795,7 +795,7 @@ function runTests(mode) {
     }
   })
 
-  it('should render picture via getImgProps', async () => {
+  it('should render picture via getImageProps', async () => {
     const browser = await webdriver(appPort, '/picture')
     // Wait for image to load:
     await check(async () => {

--- a/test/integration/next-image-new/default/pages/picture.js
+++ b/test/integration/next-image-new/default/pages/picture.js
@@ -1,13 +1,13 @@
-import { getImgProps } from 'next/image'
+import { getImageProps } from 'next/image'
 
 export default function Page() {
   const common = { alt: 'Hero', width: 400, height: 400, priority: true }
   const {
     props: { srcSet: dark },
-  } = getImgProps({ ...common, src: '/test.png' })
+  } = getImageProps({ ...common, src: '/test.png' })
   const {
     props: { srcSet: light, ...rest },
-  } = getImgProps({ ...common, src: '/test_light.png' })
+  } = getImageProps({ ...common, src: '/test_light.png' })
   return (
     <picture>
       <source media="(prefers-color-scheme: dark)" srcSet={dark} />

--- a/test/integration/next-image-new/default/pages/picture.js
+++ b/test/integration/next-image-new/default/pages/picture.js
@@ -1,4 +1,4 @@
-import { unstable_getImgProps as getImgProps } from 'next/image'
+import { getImgProps } from 'next/image'
 
 export default function Page() {
   const common = { alt: 'Hero', width: 400, height: 400, priority: true }

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -796,7 +796,7 @@ function runTests(mode) {
     }
   })
 
-  it('should render picture via getImgProps', async () => {
+  it('should render picture via getImageProps', async () => {
     const browser = await webdriver(appPort, '/picture')
     // Wait for image to load:
     await check(async () => {

--- a/test/integration/next-image-new/loader-config-default-loader-with-file/pages/get-img-props.js
+++ b/test/integration/next-image-new/loader-config-default-loader-with-file/pages/get-img-props.js
@@ -1,4 +1,4 @@
-import { unstable_getImgProps as getImgProps } from 'next/image'
+import { getImgProps } from 'next/image'
 
 function loader({ src, width, quality }) {
   return `${src}?wid=${width}&qual=${quality || 35}`

--- a/test/integration/next-image-new/loader-config-default-loader-with-file/pages/get-img-props.js
+++ b/test/integration/next-image-new/loader-config-default-loader-with-file/pages/get-img-props.js
@@ -1,11 +1,11 @@
-import { getImgProps } from 'next/image'
+import { getImageProps } from 'next/image'
 
 function loader({ src, width, quality }) {
   return `${src}?wid=${width}&qual=${quality || 35}`
 }
 
 export default function Page() {
-  const { props: img1 } = getImgProps({
+  const { props: img1 } = getImageProps({
     id: 'img1',
     alt: 'img1',
     src: '/logo.png',
@@ -13,7 +13,7 @@ export default function Page() {
     height: '400',
     priority: true,
   })
-  const { props: img2 } = getImgProps({
+  const { props: img2 } = getImageProps({
     id: 'img2',
     alt: 'img2',
     src: '/logo.png',

--- a/test/integration/next-image-new/loader-config-default-loader-with-file/test/index.test.ts
+++ b/test/integration/next-image-new/loader-config-default-loader-with-file/test/index.test.ts
@@ -69,7 +69,7 @@ describe('Image Loader Config', () => {
       runTests('/')
     }
   )
-  describe('dev mode - getImgProps', () => {
+  describe('dev mode - getImageProps', () => {
     beforeAll(async () => {
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
@@ -80,7 +80,7 @@ describe('Image Loader Config', () => {
     runTests('/get-img-props')
   })
   ;(process.env.TURBOPACK ? describe.skip : describe)(
-    'production mode - getImgProps',
+    'production mode - getImageProps',
     () => {
       beforeAll(async () => {
         await nextBuild(appDir)

--- a/test/integration/next-image-new/loader-config/pages/get-img-props.js
+++ b/test/integration/next-image-new/loader-config/pages/get-img-props.js
@@ -1,4 +1,4 @@
-import { unstable_getImgProps as getImgProps } from 'next/image'
+import { getImgProps } from 'next/image'
 
 function loader({ src, width, quality }) {
   return `${src}?wid=${width}&qual=${quality || 35}`

--- a/test/integration/next-image-new/loader-config/pages/get-img-props.js
+++ b/test/integration/next-image-new/loader-config/pages/get-img-props.js
@@ -1,11 +1,11 @@
-import { getImgProps } from 'next/image'
+import { getImageProps } from 'next/image'
 
 function loader({ src, width, quality }) {
   return `${src}?wid=${width}&qual=${quality || 35}`
 }
 
 export default function Page() {
-  const { props: img1 } = getImgProps({
+  const { props: img1 } = getImageProps({
     id: 'img1',
     alt: 'img1',
     src: '/logo.png',
@@ -13,7 +13,7 @@ export default function Page() {
     height: '400',
     priority: true,
   })
-  const { props: img2 } = getImgProps({
+  const { props: img2 } = getImageProps({
     id: 'img2',
     alt: 'img2',
     src: '/logo.png',

--- a/test/integration/next-image-new/loader-config/test/index.test.ts
+++ b/test/integration/next-image-new/loader-config/test/index.test.ts
@@ -62,7 +62,7 @@ describe('Image Loader Config new', () => {
       runTests('/')
     }
   )
-  describe('dev mode - getImgProps', () => {
+  describe('dev mode - getImageProps', () => {
     beforeAll(async () => {
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
@@ -73,7 +73,7 @@ describe('Image Loader Config new', () => {
     runTests('/get-img-props')
   })
   ;(process.env.TURBOPACK ? describe.skip : describe)(
-    'production mode - getImgProps',
+    'production mode - getImageProps',
     () => {
       beforeAll(async () => {
         await nextBuild(appDir)

--- a/test/integration/next-image-new/unoptimized/pages/get-img-props.js
+++ b/test/integration/next-image-new/unoptimized/pages/get-img-props.js
@@ -1,27 +1,27 @@
 import React from 'react'
-import { getImgProps } from 'next/image'
+import { getImageProps } from 'next/image'
 import testJpg from '../public/test.jpg'
 
 const Page = () => {
-  const { props: img1 } = getImgProps({
+  const { props: img1 } = getImageProps({
     id: 'internal-image',
     src: '/test.png',
     width: 400,
     height: 400,
   })
-  const { props: img2 } = getImgProps({
+  const { props: img2 } = getImageProps({
     id: 'static-image',
     src: testJpg,
     width: 400,
     height: 400,
   })
-  const { props: img3 } = getImgProps({
+  const { props: img3 } = getImageProps({
     id: 'external-image',
     src: 'https://image-optimization-test.vercel.app/test.jpg',
     width: 400,
     height: 400,
   })
-  const { props: img4 } = getImgProps({
+  const { props: img4 } = getImageProps({
     id: 'eager-image',
     src: '/test.webp',
     width: 400,

--- a/test/integration/next-image-new/unoptimized/pages/get-img-props.js
+++ b/test/integration/next-image-new/unoptimized/pages/get-img-props.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { unstable_getImgProps as getImgProps } from 'next/image'
+import { getImgProps } from 'next/image'
 import testJpg from '../public/test.jpg'
 
 const Page = () => {

--- a/test/integration/next-image-new/unoptimized/test/index.test.ts
+++ b/test/integration/next-image-new/unoptimized/test/index.test.ts
@@ -118,7 +118,7 @@ describe('Unoptimized Image Tests', () => {
       runTests('/')
     }
   )
-  describe('dev mode - getImgProps', () => {
+  describe('dev mode - getImageProps', () => {
     beforeAll(async () => {
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
@@ -130,7 +130,7 @@ describe('Unoptimized Image Tests', () => {
     runTests('/get-img-props')
   })
   ;(process.env.TURBOPACK ? describe.skip : describe)(
-    'production mode - getImgProps',
+    'production mode - getImageProps',
     () => {
       beforeAll(async () => {
         await nextBuild(appDir)

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -13136,7 +13136,7 @@
       "Image Component Default Tests dev mode should render correct objectFit when blurDataURL and fill",
       "Image Component Default Tests dev mode should render correct objectFit when data url placeholder and fill",
       "Image Component Default Tests dev mode should render no wrappers or sizers",
-      "Image Component Default Tests dev mode should render picture via getImgProps",
+      "Image Component Default Tests dev mode should render picture via getImageProps",
       "Image Component Default Tests dev mode should show empty string src error",
       "Image Component Default Tests dev mode should show error when CSS position changed on fill image",
       "Image Component Default Tests dev mode should show error when invalid Infinity width prop",
@@ -13195,7 +13195,7 @@
       "Image Component Default Tests production mode should render correct objectFit when blurDataURL and fill",
       "Image Component Default Tests production mode should render correct objectFit when data url placeholder and fill",
       "Image Component Default Tests production mode should render no wrappers or sizers",
-      "Image Component Default Tests production mode should render picture via getImgProps",
+      "Image Component Default Tests production mode should render picture via getImageProps",
       "Image Component Default Tests production mode should update the image on src change",
       "Image Component Default Tests production mode should warn when legacy prop layout=fill",
       "Image Component Default Tests production mode should warn when legacy prop layout=responsive",
@@ -13356,7 +13356,7 @@
       "Image Component Default Tests dev mode should render correct objectFit when blurDataURL and fill",
       "Image Component Default Tests dev mode should render correct objectFit when data url placeholder and fill",
       "Image Component Default Tests dev mode should render no wrappers or sizers",
-      "Image Component Default Tests dev mode should render picture via getImgProps",
+      "Image Component Default Tests dev mode should render picture via getImageProps",
       "Image Component Default Tests dev mode should show empty string src error",
       "Image Component Default Tests dev mode should show error when CSS position changed on fill image",
       "Image Component Default Tests dev mode should show error when invalid Infinity width prop",
@@ -13416,7 +13416,7 @@
       "Image Component Default Tests production mode should render correct objectFit when blurDataURL and fill",
       "Image Component Default Tests production mode should render correct objectFit when data url placeholder and fill",
       "Image Component Default Tests production mode should render no wrappers or sizers",
-      "Image Component Default Tests production mode should render picture via getImgProps",
+      "Image Component Default Tests production mode should render picture via getImageProps",
       "Image Component Default Tests production mode should update the image on src change",
       "Image Component Default Tests production mode should warn when legacy prop layout=fill",
       "Image Component Default Tests production mode should warn when legacy prop layout=responsive",
@@ -13495,17 +13495,17 @@
   "test/integration/next-image-new/loader-config-default-loader-with-file/test/index.test.ts": {
     "passed": [
       "Image Loader Config dev mode - component should work with loader prop",
-      "Image Loader Config dev mode - getImgProps should work with loader prop"
+      "Image Loader Config dev mode - getImageProps should work with loader prop"
     ],
     "failed": [
       "Image Loader Config dev mode - component should work with loaderFile config, leaving default image optimization enabled",
-      "Image Loader Config dev mode - getImgProps should work with loaderFile config, leaving default image optimization enabled"
+      "Image Loader Config dev mode - getImageProps should work with loaderFile config, leaving default image optimization enabled"
     ],
     "pending": [
       "Image Loader Config production mode - component should work with loader prop",
       "Image Loader Config production mode - component should work with loaderFile config, leaving default image optimization enabled",
-      "Image Loader Config production mode - getImgProps should work with loader prop",
-      "Image Loader Config production mode - getImgProps should work with loaderFile config, leaving default image optimization enabled"
+      "Image Loader Config production mode - getImageProps should work with loader prop",
+      "Image Loader Config production mode - getImageProps should work with loaderFile config, leaving default image optimization enabled"
     ],
     "flakey": [],
     "runtimeError": false
@@ -13532,14 +13532,14 @@
     "failed": [
       "Image Loader Config new dev mode - component should work with loader prop",
       "Image Loader Config new dev mode - component should work with loaderFile config",
-      "Image Loader Config new dev mode - getImgProps should work with loader prop",
-      "Image Loader Config new dev mode - getImgProps should work with loaderFile config"
+      "Image Loader Config new dev mode - getImageProps should work with loader prop",
+      "Image Loader Config new dev mode - getImageProps should work with loaderFile config"
     ],
     "pending": [
       "Image Loader Config new production mode - component should work with loader prop",
       "Image Loader Config new production mode - component should work with loaderFile config",
-      "Image Loader Config new production mode - getImgProps should work with loader prop",
-      "Image Loader Config new production mode - getImgProps should work with loaderFile config"
+      "Image Loader Config new production mode - getImageProps should work with loader prop",
+      "Image Loader Config new production mode - getImageProps should work with loaderFile config"
     ],
     "flakey": [],
     "runtimeError": false
@@ -13617,12 +13617,12 @@
   "test/integration/next-image-new/unoptimized/test/index.test.ts": {
     "passed": [
       "Unoptimized Image Tests dev mode - component should not optimize any image",
-      "Unoptimized Image Tests dev mode - getImgProps should not optimize any image"
+      "Unoptimized Image Tests dev mode - getImageProps should not optimize any image"
     ],
     "failed": [],
     "pending": [
       "Unoptimized Image Tests production mode - component should not optimize any image",
-      "Unoptimized Image Tests production mode - getImgProps should not optimize any image"
+      "Unoptimized Image Tests production mode - getImageProps should not optimize any image"
     ],
     "flakey": [],
     "runtimeError": false

--- a/test/unit/next-image-get-img-props.test.ts
+++ b/test/unit/next-image-get-img-props.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
-import { getImgProps } from 'next/image'
+import { getImageProps } from 'next/image'
 
-describe('getImgProps()', () => {
+describe('getImageProps()', () => {
   let warningMessages: string[]
   const originalConsoleWarn = console.warn
   beforeEach(() => {
@@ -15,7 +15,7 @@ describe('getImgProps()', () => {
     console.warn = originalConsoleWarn
   })
   it('should return props in correct order', async () => {
-    const { props } = getImgProps({
+    const { props } = getImageProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -38,7 +38,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle priority', async () => {
-    const { props } = getImgProps({
+    const { props } = getImageProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -63,7 +63,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle quality', async () => {
-    const { props } = getImgProps({
+    const { props } = getImageProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -88,7 +88,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle loading eager', async () => {
-    const { props } = getImgProps({
+    const { props } = getImageProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -113,7 +113,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle sizes', async () => {
-    const { props } = getImgProps({
+    const { props } = getImageProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -139,7 +139,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle fill', async () => {
-    const { props } = getImgProps({
+    const { props } = getImageProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -175,7 +175,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle style', async () => {
-    const { props } = getImgProps({
+    const { props } = getImageProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -200,7 +200,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle loader', async () => {
-    const { props } = getImgProps({
+    const { props } = getImageProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -226,7 +226,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle arbitrary props', async () => {
-    const { props } = getImgProps({
+    const { props } = getImageProps({
       alt: 'a nice desc',
       src: '/test.png',
       width: 100,

--- a/test/unit/next-image-get-img-props.test.ts
+++ b/test/unit/next-image-get-img-props.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { unstable_getImgProps } from 'next/image'
+import { getImgProps } from 'next/image'
 
 describe('getImgProps()', () => {
   let warningMessages: string[]
@@ -14,17 +14,14 @@ describe('getImgProps()', () => {
   afterEach(() => {
     console.warn = originalConsoleWarn
   })
-  it('should warn on first usage and return props in correct order', async () => {
-    const { props } = unstable_getImgProps({
+  it('should return props in correct order', async () => {
+    const { props } = getImgProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
       width: 100,
       height: 200,
     })
-    expect(warningMessages).toStrictEqual([
-      'Warning: unstable_getImgProps() is experimental and may change or be removed at any time. Use at your own risk.',
-    ])
     expect(Object.entries(props)).toStrictEqual([
       ['alt', 'a nice desc'],
       ['id', 'my-image'],
@@ -41,7 +38,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle priority', async () => {
-    const { props } = unstable_getImgProps({
+    const { props } = getImgProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -66,7 +63,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle quality', async () => {
-    const { props } = unstable_getImgProps({
+    const { props } = getImgProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -91,7 +88,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle loading eager', async () => {
-    const { props } = unstable_getImgProps({
+    const { props } = getImgProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -116,7 +113,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle sizes', async () => {
-    const { props } = unstable_getImgProps({
+    const { props } = getImgProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -142,7 +139,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle fill', async () => {
-    const { props } = unstable_getImgProps({
+    const { props } = getImgProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -178,7 +175,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle style', async () => {
-    const { props } = unstable_getImgProps({
+    const { props } = getImgProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -203,7 +200,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle loader', async () => {
-    const { props } = unstable_getImgProps({
+    const { props } = getImgProps({
       alt: 'a nice desc',
       id: 'my-image',
       src: '/test.png',
@@ -229,7 +226,7 @@ describe('getImgProps()', () => {
     ])
   })
   it('should handle arbitrary props', async () => {
-    const { props } = unstable_getImgProps({
+    const { props } = getImgProps({
       alt: 'a nice desc',
       src: '/test.png',
       width: 100,


### PR DESCRIPTION
This PR renames `unstable_getImgProps` to `getImageProps()` (originally introduced in PR #51205).

Most feedback [after announcing](https://twitter.com/leeerob/status/1674250190432116736) looks positive so it seems like we can safely stabilize this API now. Its unlikely to change.

I also added documentation with example usage.

Closes NEXT-2120
Fixes https://github.com/vercel/next.js/issues/56009