### PR TITLE
Fix recursive ignoring case in build traces

### DIFF
--- a/test/production/sharp-basic/pages/index.tsx
+++ b/test/production/sharp-basic/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/sharp-basic/sharp-basic.test.ts
+++ b/test/production/sharp-basic/sharp-basic.test.ts
@@ -1,0 +1,22 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'sharp support with hasNextSupport',
+  {
+    files: __dirname,
+    dependencies: {
+      sharp: 'latest',
+    },
+    env: {
+      NOW_BUILDER: '1',
+    },
+  },
+  ({ next }) => {
+    // we're mainly checking if build/start were successful so
+    // we have a basic assertion here
+    it('should work using cheerio', async () => {
+      const $ = await next.render$('/')
+      expect($('p').text()).toBe('hello world')
+    })
+  }
+)


### PR DESCRIPTION
This ensures when a dependency has a recursive require our should ignore handling doesn't accidentally loop back and forth. 

x-ref: https://github.com/lovell/sharp/issues/3944

Closes NEXT-2121