### PR TITLE
Fix locale domain public files check

### DIFF
--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -472,7 +472,13 @@ export async function setupFsCheck(opts: {
             itemPath,
             // legacy behavior allows visiting static assets under
             // default locale but no other locale
-            isDynamicOutput ? undefined : [i18n?.defaultLocale]
+            isDynamicOutput
+              ? undefined
+              : [
+                  i18n?.defaultLocale,
+                  // default locales from domains need to be matched too
+                  ...(i18n.domains?.map((item) => item.defaultLocale) || []),
+                ]
           )
 
           if (localeResult.pathname !== curItemPath) {

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -78,7 +78,7 @@ export function getResolveRoutes(
 
     // we check exact matches on fs before continuing to
     // after files rewrites
-    { match: () => ({}), name: 'check_fs' },
+    { match: () => ({}), name: 'check_fs', internal: true },
 
     ...(opts.minimalMode ? [] : fsChecker.rewrites.afterFiles),
 
@@ -405,19 +405,17 @@ export function getResolveRoutes(
         }
 
         if (route.name === 'check_fs') {
-          const pathname = parsedUrl.pathname || ''
-
-          if (invokedOutputs?.has(pathname) || checkLocaleApi(pathname)) {
+          if (invokedOutputs?.has(curPathname) || checkLocaleApi(curPathname)) {
             return
           }
-          const output = await fsChecker.getItem(pathname)
+          const output = await fsChecker.getItem(curPathname)
 
           if (
             output &&
             !(
               config.i18n &&
               initialLocaleResult?.detectedLocale &&
-              pathHasPrefix(pathname, '/api')
+              pathHasPrefix(curPathname, '/api')
             )
           ) {
             if (

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -78,7 +78,7 @@ export function getResolveRoutes(
 
     // we check exact matches on fs before continuing to
     // after files rewrites
-    { match: () => ({}), name: 'check_fs', internal: true },
+    { match: () => ({}), name: 'check_fs' },
 
     ...(opts.minimalMode ? [] : fsChecker.rewrites.afterFiles),
 
@@ -405,17 +405,19 @@ export function getResolveRoutes(
         }
 
         if (route.name === 'check_fs') {
-          if (invokedOutputs?.has(curPathname) || checkLocaleApi(curPathname)) {
+          const pathname = parsedUrl.pathname || ''
+
+          if (invokedOutputs?.has(pathname) || checkLocaleApi(pathname)) {
             return
           }
-          const output = await fsChecker.getItem(curPathname)
+          const output = await fsChecker.getItem(pathname)
 
           if (
             output &&
             !(
               config.i18n &&
               initialLocaleResult?.detectedLocale &&
-              pathHasPrefix(curPathname, '/api')
+              pathHasPrefix(pathname, '/api')
             )
           ) {
             if (

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -83,6 +83,23 @@ export function runTests(ctx) {
     }
   })
 
+  it('should serve public file on locale domain', async () => {
+    for (const host of ['example.do', 'example.com', 'localhost:3000']) {
+      const res = await fetchViaHTTP(
+        ctx.appPort,
+        `${ctx.basePath || '/'}files/texts/file.txt`,
+        undefined,
+        {
+          headers: {
+            host,
+          },
+        }
+      )
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('hello from file.txt')
+    }
+  })
+
   it('should 404 for locale prefixed public folder files', async () => {
     for (const locale of locales) {
       const res = await fetchViaHTTP(

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -26,6 +26,7 @@ export const nonDomainLocales = [
   'fr',
   'en',
 ]
+const defaultLocales = ['en-US', 'do', 'go']
 export const locales = [...nonDomainLocales, ...domainLocales]
 
 async function addDefaultLocaleCookie(browser) {
@@ -72,7 +73,7 @@ export function runTests(ctx) {
           { redirect: 'manual' }
         )
 
-        if (locale !== 'en-US') {
+        if (!defaultLocales.includes(locale)) {
           expect(res.status).toBe(404)
           expect(await res.text()).toContain('could not be found')
         } else {
@@ -84,10 +85,10 @@ export function runTests(ctx) {
   })
 
   it('should serve public file on locale domain', async () => {
-    for (const host of ['example.do', 'example.com', 'localhost:3000']) {
+    for (const host of ['example.do', 'example.com']) {
       const res = await fetchViaHTTP(
         ctx.appPort,
-        `${ctx.basePath || '/'}files/texts/file.txt`,
+        `${ctx.basePath || ''}/files/texts/file.txt`,
         undefined,
         {
           headers: {
@@ -109,7 +110,7 @@ export function runTests(ctx) {
         { redirect: 'manual' }
       )
 
-      if (locale !== 'en-US') {
+      if (!defaultLocales.includes(locale)) {
         expect(res.status).toBe(404)
         expect(await res.text()).toContain('could not be found')
       } else {


### PR DESCRIPTION
This ensures we properly handle serving public files when routing via a locale domain and adds regression tests for this case. 

Closes: https://github.com/vercel/next.js/issues/54765
Closes: https://github.com/vercel/next.js/pull/59773
Closes: https://github.com/vercel/next.js/pull/55137
Closes NEXT-2123