### PR TITLE
tests: push all errors on the page to the console as error logs

### DIFF
--- a/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
+++ b/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
@@ -46,9 +46,7 @@ createNextDescribe(
       })
 
       it('does not emit errors related to bailing out of client side rendering', async () => {
-        const browser = await next.browser('/dynamic', {
-          pushErrorAsConsoleLog: true,
-        })
+        const browser = await next.browser('/dynamic')
 
         try {
           await browser.waitForElementByCss('#dynamic')

--- a/test/lib/browsers/base.ts
+++ b/test/lib/browsers/base.ts
@@ -129,12 +129,10 @@ export abstract class BrowserInterface implements PromiseLike<any> {
       disableCache,
       cpuThrottleRate,
       beforePageLoad,
-      pushErrorAsConsoleLog,
     }: {
       disableCache?: boolean
       cpuThrottleRate?: number
       beforePageLoad?: Function
-      pushErrorAsConsoleLog?: boolean
     }
   ): Promise<void> {}
   async get(url: string): Promise<void> {}

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -197,7 +197,6 @@ export class Playwright extends BrowserInterface {
     opts?: {
       disableCache: boolean
       cpuThrottleRate: number
-      pushErrorAsConsoleLog?: boolean
       beforePageLoad?: (...args: any[]) => void
     }
   ) {
@@ -226,10 +225,7 @@ export class Playwright extends BrowserInterface {
     })
     page.on('pageerror', (error) => {
       console.error('page error', error)
-
-      if (opts?.pushErrorAsConsoleLog) {
-        pageLogs.push({ source: 'error', message: error.message })
-      }
+      pageLogs.push({ source: 'error', message: error.message })
     })
     page.on('request', (req) => {
       this.eventCallbacks.request.forEach((cb) => cb(req))

--- a/test/lib/next-webdriver.ts
+++ b/test/lib/next-webdriver.ts
@@ -69,7 +69,6 @@ export default async function webdriver(
     headless?: boolean
     ignoreHTTPSErrors?: boolean
     cpuThrottleRate?: number
-    pushErrorAsConsoleLog?: boolean
   }
 ): Promise<BrowserInterface> {
   let CurrentInterface: new () => BrowserInterface
@@ -90,7 +89,6 @@ export default async function webdriver(
     ignoreHTTPSErrors,
     headless,
     cpuThrottleRate,
-    pushErrorAsConsoleLog,
   } = options
 
   // we import only the needed interface
@@ -135,7 +133,6 @@ export default async function webdriver(
     disableCache,
     cpuThrottleRate,
     beforePageLoad,
-    pushErrorAsConsoleLog,
   })
   console.log(`\n> Loaded browser with ${fullUrl}\n`)
 


### PR DESCRIPTION
This removes the extra configuration that optionally forwarded browser errors to the browser logs that was introduced in the previous PR to make it the default.

Closes NEXT-2125