### PR TITLE
Fix tests exit race condition

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -124,7 +124,15 @@ ${output}
   }
 }
 
+let exiting = false
+
 const cleanUpAndExit = async (code) => {
+  if (exiting) {
+    return
+  }
+  exiting = true
+  console.log(`exiting with code ${code}`)
+
   if (process.env.NEXT_TEST_STARTER) {
     await fsp.rm(process.env.NEXT_TEST_STARTER, {
       recursive: true,
@@ -140,11 +148,7 @@ const cleanUpAndExit = async (code) => {
   if (process.env.CI) {
     await maybeLogSummary()
   }
-  console.log(`exiting with code ${code}`)
-
-  setTimeout(() => {
-    process.exit(code)
-  }, 1)
+  process.exit(1)
 }
 
 const isMatchingPattern = (pattern, file) => {

--- a/run-tests.js
+++ b/run-tests.js
@@ -148,7 +148,7 @@ const cleanUpAndExit = async (code) => {
   if (process.env.CI) {
     await maybeLogSummary()
   }
-  process.exit(1)
+  process.exit(code)
 }
 
 const isMatchingPattern = (pattern, file) => {


### PR DESCRIPTION
This ensures we don't allow a following exit condition to override a previous as async work is done before the `process.exit` actually occurs so a follow-up one could override the first giving a false negative. 

Closes NEXT-1911