### PR TITLE
Fix middleware next data calls

### DIFF
--- a/test/production/standalone-mode/required-server-files/middleware.js
+++ b/test/production/standalone-mode/required-server-files/middleware.js
@@ -9,5 +9,9 @@ export async function middleware(req) {
       height: 600,
     })
   }
+  if (req.nextUrl.pathname.startsWith('/rewrite-me')) {
+    // strip the leading `/rewrite-me` from the path
+    return NextResponse.rewrite(`/${req.nextUrl.pathname.substr(11)}`)
+  }
   return NextResponse.next()
 }

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -1337,4 +1337,19 @@ describe('required server files', () => {
 
     expect(res.status).toBe(404)
   })
+
+  it('should correctly handle a mismatch in buildIds when normalizing next data with middleware', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      `/_next/data/${nanoid()}/rewrite-me/index.json`,
+      undefined,
+      {
+        headers: {
+          'x-matched-path': '/[teamSlug]/[project]/[id]/[suffix]',
+        },
+      }
+    )
+
+    expect(res.status).toBe(404)
+  })
 })


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### Fixes Bug

When the middleware is involved in rewriting URLs, the nextData handler will not return 404 when the `buildId` changed. This breaks the Link component which will soft-navigate with empty props.

This is broken since 13.4.13 where the handler logic was refactored. There was a fix applied which did not account for involved middlewares.
