### PR TITLE
fix(turbopack): custom page extensions for `_app`

### DIFF
--- a/packages/next-swc/crates/next-build/src/next_pages/page_entries.rs
+++ b/packages/next-swc/crates/next-build/src/next_pages/page_entries.rs
@@ -350,6 +350,7 @@ async fn get_page_entry_for_file(
         ssr_module_context,
         source,
         Vc::cell(original_name),
+        todo_get_pages_structure(),
         NextRuntime::NodeJs,
         next_config,
     );
@@ -368,6 +369,10 @@ async fn get_page_entry_for_file(
         client_module,
     }
     .cell())
+}
+
+fn todo_get_pages_structure() -> Vc<PagesStructure> {
+    todo!("add pages structure to next-build");
 }
 
 /// Computes the pathname for a given path.

--- a/packages/next-swc/crates/next-core/js/src/entry/pages/_app.tsx
+++ b/packages/next-swc/crates/next-core/js/src/entry/pages/_app.tsx
@@ -1,2 +1,0 @@
-export * from '@vercel/turbopack-next/pages/_app'
-export { default } from '@vercel/turbopack-next/pages/_app'

--- a/packages/next-swc/crates/next-core/js/src/entry/pages/_document.tsx
+++ b/packages/next-swc/crates/next-core/js/src/entry/pages/_document.tsx
@@ -1,2 +1,0 @@
-export * from '@vercel/turbopack-next/pages/_document'
-export { default } from '@vercel/turbopack-next/pages/_document'

--- a/packages/next-swc/crates/next-core/js/src/entry/pages/_error.tsx
+++ b/packages/next-swc/crates/next-core/js/src/entry/pages/_error.tsx
@@ -1,2 +1,0 @@
-export * from '@vercel/turbopack-next/pages/_error'
-export { default } from '@vercel/turbopack-next/pages/_error'

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -64,32 +64,7 @@ pub async fn get_next_client_import_map(
     .await?;
 
     match ty.into_value() {
-        ClientContextType::Pages { pages_dir } => {
-            insert_alias_to_alternatives(
-                &mut import_map,
-                format!("{VIRTUAL_PACKAGE_NAME}/pages/_app"),
-                vec![
-                    request_to_import_mapping(pages_dir, "./_app"),
-                    request_to_import_mapping(pages_dir, "next/app"),
-                ],
-            );
-            insert_alias_to_alternatives(
-                &mut import_map,
-                format!("{VIRTUAL_PACKAGE_NAME}/pages/_document"),
-                vec![
-                    request_to_import_mapping(pages_dir, "./_document"),
-                    request_to_import_mapping(pages_dir, "next/document"),
-                ],
-            );
-            insert_alias_to_alternatives(
-                &mut import_map,
-                format!("{VIRTUAL_PACKAGE_NAME}/pages/_error"),
-                vec![
-                    request_to_import_mapping(pages_dir, "./_error"),
-                    request_to_import_mapping(pages_dir, "next/error"),
-                ],
-            );
-        }
+        ClientContextType::Pages { .. } => {}
         ClientContextType::App { app_dir } => {
             let react_flavor =
                 if *next_config.enable_ppr().await? || *next_config.enable_taint().await? {
@@ -531,32 +506,7 @@ async fn insert_next_server_special_aliases(
     }
 
     match ty {
-        ServerContextType::Pages { pages_dir } | ServerContextType::PagesApi { pages_dir } => {
-            insert_alias_to_alternatives(
-                import_map,
-                format!("{VIRTUAL_PACKAGE_NAME}/pages/_app"),
-                vec![
-                    request_to_import_mapping(pages_dir, "./_app"),
-                    external_if_node(pages_dir, "next/app"),
-                ],
-            );
-            insert_alias_to_alternatives(
-                import_map,
-                format!("{VIRTUAL_PACKAGE_NAME}/pages/_document"),
-                vec![
-                    request_to_import_mapping(pages_dir, "./_document"),
-                    external_if_node(pages_dir, "next/document"),
-                ],
-            );
-            insert_alias_to_alternatives(
-                import_map,
-                format!("{VIRTUAL_PACKAGE_NAME}/pages/_error"),
-                vec![
-                    request_to_import_mapping(pages_dir, "./_error"),
-                    external_if_node(pages_dir, "next/error"),
-                ],
-            );
-        }
+        ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {}
         ServerContextType::PagesData { .. } => {}
         // the logic closely follows the one in createRSCAliases in webpack-config.ts
         ServerContextType::AppSSR { app_dir }

--- a/packages/next-swc/crates/next-core/src/next_pages/page_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_pages/page_entry.rs
@@ -14,8 +14,9 @@ use turbopack_binding::{
         core::{
             asset::{Asset, AssetContent},
             context::AssetContext,
+            file_source::FileSource,
             module::Module,
-            reference_type::{EntryReferenceSubType, ReferenceType},
+            reference_type::{EntryReferenceSubType, InnerAssets, ReferenceType},
             source::Source,
             virtual_source::VirtualSource,
         },
@@ -26,6 +27,7 @@ use turbopack_binding::{
 use crate::{
     next_config::NextConfig,
     next_edge::entry::wrap_edge_entry,
+    pages_structure::{PagesStructure, PagesStructureItem},
     util::{file_content_rope, load_next_js_template, NextRuntime},
 };
 
@@ -37,6 +39,7 @@ pub async fn create_page_ssr_entry_module(
     ssr_module_context: Vc<Box<dyn AssetContext>>,
     source: Vc<Box<dyn Source>>,
     next_original_name: Vc<String>,
+    pages_structure: Vc<PagesStructure>,
     runtime: NextRuntime,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<Box<dyn EcmascriptChunkPlaceable>>> {
@@ -67,6 +70,9 @@ pub async fn create_page_ssr_entry_module(
 
     const INNER: &str = "INNER_PAGE";
 
+    const INNER_DOCUMENT: &str = "INNER_DOCUMENT";
+    const INNER_APP: &str = "INNER_APP";
+
     let mut replacements = indexmap! {
         "VAR_DEFINITION_PAGE" => definition_page.clone(),
         "VAR_DEFINITION_PATHNAME" => definition_pathname.clone(),
@@ -74,14 +80,8 @@ pub async fn create_page_ssr_entry_module(
     };
 
     if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page) {
-        replacements.insert(
-            "VAR_MODULE_DOCUMENT",
-            "@vercel/turbopack-next/pages/_document".to_string(),
-        );
-        replacements.insert(
-            "VAR_MODULE_APP",
-            "@vercel/turbopack-next/pages/_app".to_string(),
-        );
+        replacements.insert("VAR_MODULE_DOCUMENT", INNER_DOCUMENT.to_string());
+        replacements.insert("VAR_MODULE_APP", INNER_APP.to_string());
     }
 
     // Load the file from the next.js codebase.
@@ -118,12 +118,25 @@ pub async fn create_page_ssr_entry_module(
         ));
     }
 
+    let mut inner_assets = indexmap! {
+        INNER.to_string() => ssr_module,
+    };
+
+    if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page) {
+        inner_assets.insert(
+            INNER_DOCUMENT.to_string(),
+            process_global_item(pages_structure.document(), ssr_module_context),
+        );
+        inner_assets.insert(
+            INNER_APP.to_string(),
+            process_global_item(pages_structure.app(), ssr_module_context),
+        );
+    }
+
     let mut ssr_module = ssr_module_context
         .process(
             source,
-            Value::new(ReferenceType::Internal(Vc::cell(indexmap! {
-                INNER.to_string() => ssr_module,
-            }))),
+            Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
         )
         .module();
 
@@ -135,6 +148,7 @@ pub async fn create_page_ssr_entry_module(
                 ssr_module,
                 definition_page.clone(),
                 definition_pathname.clone(),
+                pages_structure,
                 next_config,
             );
         } else {
@@ -157,15 +171,37 @@ pub async fn create_page_ssr_entry_module(
 }
 
 #[turbo_tasks::function]
+async fn process_global_item(
+    item: Vc<PagesStructureItem>,
+    module_context: Vc<Box<dyn AssetContext>>,
+) -> Result<Vc<Box<dyn Module>>> {
+    let source = Vc::upcast(FileSource::new(item.project_path()));
+
+    let module = module_context
+        .process(
+            source,
+            Value::new(ReferenceType::Internal(InnerAssets::empty())),
+        )
+        .module();
+
+    Ok(module)
+}
+
+#[turbo_tasks::function]
 async fn wrap_edge_page(
     context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
     entry: Vc<Box<dyn Module>>,
     page: String,
     pathname: String,
+    pages_structure: Vc<PagesStructure>,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<Box<dyn Module>>> {
     const INNER: &str = "INNER_PAGE_ENTRY";
+
+    const INNER_DOCUMENT: &str = "INNER_DOCUMENT";
+    const INNER_APP: &str = "INNER_APP";
+    const INNER_ERROR: &str = "INNER_ERROR";
 
     let next_config = &*next_config.await?;
 
@@ -188,9 +224,9 @@ async fn wrap_edge_page(
             "VAR_USERLAND" => INNER.to_string(),
             "VAR_PAGE" => pathname.clone(),
             "VAR_BUILD_ID" => build_id.to_string(),
-            "VAR_MODULE_DOCUMENT" => "@vercel/turbopack-next/pages/_document".to_string(),
-            "VAR_MODULE_APP" => "@vercel/turbopack-next/pages/_app".to_string(),
-            "VAR_MODULE_GLOBAL_ERROR" => "@vercel/turbopack-next/pages/_error".to_string(),
+            "VAR_MODULE_DOCUMENT" => INNER_DOCUMENT.to_string(),
+            "VAR_MODULE_APP" => INNER_APP.to_string(),
+            "VAR_MODULE_GLOBAL_ERROR" => INNER_ERROR.to_string(),
         },
         indexmap! {
             "pagesType" => StringifyJs("pages").to_string(),
@@ -210,7 +246,10 @@ async fn wrap_edge_page(
     .await?;
 
     let inner_assets = indexmap! {
-        INNER.to_string() => entry
+        INNER.to_string() => entry,
+        INNER_DOCUMENT.to_string() => process_global_item(pages_structure.document(), context),
+        INNER_APP.to_string() => process_global_item(pages_structure.app(), context),
+        INNER_ERROR.to_string() => process_global_item(pages_structure.error(), context),
     };
 
     let wrapped = context

--- a/packages/next-swc/crates/next-core/src/pages_structure.rs
+++ b/packages/next-swc/crates/next-core/src/pages_structure.rs
@@ -6,7 +6,7 @@ use turbopack_binding::turbo::tasks_fs::{
     DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPath,
 };
 
-use crate::embed_js::next_js_file_path;
+use crate::next_import_map::get_next_package;
 
 /// A final route in the pages directory.
 #[turbo_tasks::value]
@@ -45,6 +45,11 @@ impl PagesStructureItem {
         this.next_router_path.await?;
         Ok(Completion::new())
     }
+
+    #[turbo_tasks::function]
+    pub fn project_path(&self) -> Vc<FileSystemPath> {
+        self.project_path
+    }
 }
 
 /// A (sub)directory in the pages directory with all analyzed routes and
@@ -81,6 +86,21 @@ impl PagesStructure {
             pages.routes_changed().await?;
         }
         Ok(Completion::new())
+    }
+
+    #[turbo_tasks::function]
+    pub fn app(&self) -> Vc<PagesStructureItem> {
+        self.app
+    }
+
+    #[turbo_tasks::function]
+    pub fn document(&self) -> Vc<PagesStructureItem> {
+        self.document
+    }
+
+    #[turbo_tasks::function]
+    pub fn error(&self) -> Vc<PagesStructureItem> {
+        self.error
     }
 }
 
@@ -148,6 +168,7 @@ pub async fn find_pages_structure(
     .await?;
 
     Ok(get_pages_structure_for_root_directory(
+        project_root,
         pages_root,
         next_router_root,
         page_extensions,
@@ -157,6 +178,7 @@ pub async fn find_pages_structure(
 /// Handles the root pages directory.
 #[turbo_tasks::function]
 async fn get_pages_structure_for_root_directory(
+    project_root: Vc<FileSystemPath>,
     project_path: Vc<FileSystemPathOption>,
     next_router_path: Vc<FileSystemPath>,
     page_extensions: Vc<Vec<String>>,
@@ -184,7 +206,7 @@ async fn get_pages_structure_for_root_directory(
                             "_app" => {
                                 let item_next_router_path =
                                     next_router_path.join("_app".to_string());
-                                let _ = app_item.insert(PagesStructureItem::new(
+                                app_item = Some(PagesStructureItem::new(
                                     *file_project_path,
                                     item_next_router_path,
                                     item_next_router_path,
@@ -193,7 +215,7 @@ async fn get_pages_structure_for_root_directory(
                             "_document" => {
                                 let item_next_router_path =
                                     next_router_path.join("_document".to_string());
-                                let _ = document_item.insert(PagesStructureItem::new(
+                                document_item = Some(PagesStructureItem::new(
                                     *file_project_path,
                                     item_next_router_path,
                                     item_next_router_path,
@@ -202,7 +224,7 @@ async fn get_pages_structure_for_root_directory(
                             "_error" => {
                                 let item_next_router_path =
                                     next_router_path.join("_error".to_string());
-                                let _ = error_item.insert(PagesStructureItem::new(
+                                error_item = Some(PagesStructureItem::new(
                                     *file_project_path,
                                     item_next_router_path,
                                     item_next_router_path,
@@ -226,7 +248,7 @@ async fn get_pages_structure_for_root_directory(
                     }
                     DirectoryEntry::Directory(dir_project_path) => match name.as_ref() {
                         "api" => {
-                            let _ = api_directory.insert(get_pages_structure_for_directory(
+                            api_directory = Some(get_pages_structure_for_directory(
                                 *dir_project_path,
                                 next_router_path.join(name.clone()),
                                 1,
@@ -272,7 +294,7 @@ async fn get_pages_structure_for_root_directory(
     } else {
         let app_router_path = next_router_path.join("_app".to_string());
         PagesStructureItem::new(
-            next_js_file_path("entry/pages/_app.tsx".to_string()),
+            get_next_package(project_root).join("app.js".to_string()),
             app_router_path,
             app_router_path,
         )
@@ -283,7 +305,7 @@ async fn get_pages_structure_for_root_directory(
     } else {
         let document_router_path = next_router_path.join("_document".to_string());
         PagesStructureItem::new(
-            next_js_file_path("entry/pages/_document.tsx".to_string()),
+            get_next_package(project_root).join("document.js".to_string()),
             document_router_path,
             document_router_path,
         )
@@ -294,7 +316,7 @@ async fn get_pages_structure_for_root_directory(
     } else {
         let error_router_path = next_router_path.join("_error".to_string());
         PagesStructureItem::new(
-            next_js_file_path("entry/pages/_error.tsx".to_string()),
+            get_next_package(project_root).join("error.js".to_string()),
             error_router_path,
             error_router_path,
         )
@@ -386,10 +408,9 @@ async fn get_pages_structure_for_directory(
 }
 
 fn page_basename<'a>(name: &'a str, page_extensions: &'a [String]) -> Option<&'a str> {
-    page_extensions.iter().find_map(|allowed| {
-        name.strip_suffix(allowed)
-            .and_then(|name| name.strip_suffix('.'))
-    })
+    page_extensions
+        .iter()
+        .find_map(|allowed| name.strip_suffix(allowed)?.strip_suffix('.'))
 }
 
 fn next_router_path_for_basename(


### PR DESCRIPTION
### What?
The import alias had no way to resolve the page extensions and we already have them resolved in the `PagesStructure`, so with this PR we use the already resolved paths.

Closes PACK-2085
Fixes #59264 
