### PR TITLE
Fix Server Actions compiler bug

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/client-graph/1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/client-graph/1/output.js
@@ -1,5 +1,5 @@
 /* __next_internal_client_entry_do_not_use__ default auto */ /* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ export async function $$ACTION_0() {}
 export default function App() {
-    function fn() {}
+    var fn = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
     return <div>App</div>;
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
@@ -2,7 +2,10 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 export function Item({ id1, id2 }) {
-    function deleteItem() {}
+    var deleteItem = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+        id1,
+        id2
+    ]));
     return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
         id2

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/16/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/16/output.js
@@ -17,7 +17,9 @@ export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_1);
 }
 const f = (x)=>{
-    function g() {}
+    var g = createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+        x
+    ]));
 };
 export async function $$ACTION_2($$ACTION_CLOSURE_BOUND, y, ...z) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/2/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/2/output.js
@@ -1,6 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-function myAction() {}
+var myAction = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0(a, b, c) {
     console.log('a');
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/23/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/23/output.js
@@ -1,7 +1,9 @@
 /* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default function Page({ foo, x, y }) {
-    function action() {}
+    var action = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+        x
+    ]));
     createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         x
     ])).bind(null, foo[0], foo[1], foo.x, foo[y]);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/24/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/24/output.js
@@ -1,7 +1,9 @@
 /* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default function Page({ foo, x, y }) {
-    function action() {}
+    var action = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+        foo
+    ]));
 }
 export async function $$ACTION_0($$ACTION_CLOSURE_BOUND, a, b, c, { d }) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/25/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/25/output.js
@@ -10,7 +10,10 @@ export function Item({ id1, id2 }) {
             id2
         ]))}>Delete</Button>;
     })();
-    function deleteItem() {}
+    var deleteItem = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+        id1,
+        id2
+    ]));
 }
 export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
@@ -32,7 +35,10 @@ export function Item2({ id1, id2 }) {
         id2
     ]))}>Delete</Button>);
     return temp;
-    function deleteItem() {}
+    var deleteItem = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+        id1,
+        id2
+    ]));
 }
 export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/input.js
@@ -1,0 +1,30 @@
+// Rules here:
+// 1. Each exported function should still be exported, but as a reference `createActionProxy(...)`.
+// 2. Actual action functions should be renamed to `$$ACTION_...` and got exported.
+
+async function foo() {
+  'use server'
+  console.log(1)
+}
+
+export { foo }
+
+export async function bar() {
+  'use server'
+  console.log(2)
+}
+
+export default async function baz() {
+  'use server'
+  console.log(3)
+}
+
+export const qux = async () => {
+  'use server'
+  console.log(4)
+}
+
+export const quux = async function quuux() {
+  'use server'
+  console.log(5)
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/output.js
@@ -1,0 +1,27 @@
+// Rules here:
+// 1. Each exported function should still be exported, but as a reference `createActionProxy(...)`.
+// 2. Actual action functions should be renamed to `$$ACTION_...` and got exported.
+/* __next_internal_action_entry_do_not_use__ {"1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc":"$$ACTION_5","188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+var foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export async function $$ACTION_0() {
+    console.log(1);
+}
+export { foo };
+export var bar = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
+export async function $$ACTION_1() {
+    console.log(2);
+}
+export default createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2);
+export async function $$ACTION_2() {
+    'use server';
+    console.log(3);
+}
+export const qux = createActionProxy("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4);
+export async function $$ACTION_4() {
+    console.log(4);
+}
+export const quux = createActionProxy("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", $$ACTION_5);
+export async function $$ACTION_5() {
+    console.log(5);
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
@@ -4,7 +4,12 @@ import deleteFromDb from 'db';
 const v1 = 'v1';
 export function Item({ id1, id2, id3, id4 }) {
     const v2 = id2;
-    function deleteItem() {}
+    var deleteItem = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+        id1,
+        v2,
+        id3,
+        id4.x
+    ]));
     return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
         v2,

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/6/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/6/output.js
@@ -19,7 +19,14 @@ export function y(p, [p1, { p2 }], ...p3) {
     if (true) {
         const f8 = 1;
     }
-    function action() {}
+    var action = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+        f2,
+        f11,
+        p,
+        p1,
+        p2,
+        p3
+    ]));
     return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         f2,
         f11,

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
@@ -17,7 +17,14 @@ export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
 }
 export function Item2(product, foo, bar) {
-    function deleteItem2() {}
+    var deleteItem2 = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+        product.id,
+        product?.foo,
+        product.bar.baz,
+        product,
+        foo,
+        bar
+    ]));
     return <Button action={createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         product.id,
         product?.foo,

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/8/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/8/output.js
@@ -1,6 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-function myAction() {}
+var myAction = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0(a, b, c) {
     // comment
     'use strict';

--- a/test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts
+++ b/test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts
@@ -35,7 +35,7 @@ createNextDescribe(
 
       await check(() => {
         return browser.eval('window.location.pathname + window.location.search')
-      }, '/header?name=test&constructor=_FormData&hidden-info=hi')
+      }, '/header?name=test&hidden-info=hi')
 
       expect(responseCode).toBe(303)
     })
@@ -52,7 +52,7 @@ createNextDescribe(
 
       await check(() => {
         return browser.eval('window.location.pathname + window.location.search')
-      }, '/header?name=test&constructor=_FormData&hidden-info=hi')
+      }, '/header?name=test&hidden-info=hi')
     })
   }
 )

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -465,7 +465,7 @@ createNextDescribe(
     if (isNextDev) {
       describe('HMR', () => {
         it('should support updating the action', async () => {
-          const filePath = 'app/server/actions.js'
+          const filePath = 'app/server/actions-3.js'
           const origContent = await next.readFile(filePath)
 
           try {

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -134,7 +134,7 @@ createNextDescribe(
 
       await check(() => {
         return browser.eval('window.location.pathname + window.location.search')
-      }, '/header?name=test&constructor=_FormData&hidden-info=hi')
+      }, '/header?name=test&hidden-info=hi')
     })
 
     it('should support .bind', async () => {

--- a/test/e2e/app-dir/actions/app/server/actions-3.js
+++ b/test/e2e/app-dir/actions/app/server/actions-3.js
@@ -1,0 +1,4 @@
+export async function inc(value) {
+  'use server'
+  return value + 1
+}

--- a/test/e2e/app-dir/actions/app/server/actions.js
+++ b/test/e2e/app-dir/actions/app/server/actions.js
@@ -2,10 +2,6 @@
 
 import { redirect } from 'next/navigation'
 
-export async function inc(value) {
-  return value + 1
-}
-
 export async function slowInc(value) {
   await new Promise((resolve) => setTimeout(resolve, 10000))
   return value + 1

--- a/test/e2e/app-dir/actions/app/server/actions.js
+++ b/test/e2e/app-dir/actions/app/server/actions.js
@@ -16,8 +16,6 @@ export async function redirectAction(formData) {
   redirect(
     '/header?name=' +
       formData.get('name') +
-      '&constructor=' +
-      formData.constructor.name +
       '&hidden-info=' +
       formData.get('hidden-info')
   )

--- a/test/e2e/app-dir/actions/app/server/edge/page.js
+++ b/test/e2e/app-dir/actions/app/server/edge/page.js
@@ -1,7 +1,8 @@
 import Counter from '../counter'
 import Form from '../form'
 
-import dec, { inc } from '../actions'
+import dec from '../actions'
+import { inc } from '../actions-3'
 
 export default function Page() {
   const two = 2

--- a/test/e2e/app-dir/actions/app/server/form.js
+++ b/test/e2e/app-dir/actions/app/server/form.js
@@ -5,8 +5,6 @@ async function action(formData) {
   redirect(
     '/header?name=' +
       formData.get('name') +
-      '&constructor=' +
-      formData.constructor.name +
       '&hidden-info=' +
       formData.get('hidden-info')
   )

--- a/test/e2e/app-dir/actions/app/server/page.js
+++ b/test/e2e/app-dir/actions/app/server/page.js
@@ -2,8 +2,9 @@ import Counter from './counter'
 import Form from './form'
 import ClientForm from './client-form'
 
-import dec, { inc, slowInc } from './actions'
+import dec, { slowInc } from './actions'
 import { log } from './actions-2'
+import { inc } from './actions-3'
 
 export default function Page() {
   const two = { value: 2 }


### PR DESCRIPTION
This PR fixes the issue where an inline Server Action gets exported. As this isn't the designed use case for inline Server Actions (they're supposed to be defined and used inside another closure, such as components), we are not handling the export cases currently:

```ts
export async function action() {
  "use server"
  ...
}

<form action={action}/>
```

...which gets compiled into:

```ts
export async function action() {} // No-op function

<form action={...actionReference...}/>
```

Note that everything works inside this module until you `import` that action and use it in another module.

To tackle that, this PR changes how that works as described in `server/27/output.js`.

Closes NEXT-2140