### PR TITLE
Dev Server: Preserve globals overwrites in the initialization hook

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -102,7 +102,7 @@ export default class DevServer extends Server {
   private actualMiddlewareFile?: string
   private actualInstrumentationHookFile?: string
   private middleware?: MiddlewareRoutingItem
-  private originalFetch: typeof fetch
+  private originalFetch?: typeof fetch
   private readonly bundlerService: DevBundlerService
   private staticPathsCache: LRUCache<
     string,
@@ -152,7 +152,7 @@ export default class DevServer extends Server {
     this.bundlerService = options.bundlerService
     this.startServerSpan =
       options.startServerSpan ?? trace('start-next-dev-server')
-    this.originalFetch = global.fetch
+    this.storeGlobals()
     this.renderOpts.dev = true
     this.renderOpts.appDirDevErrorLogger = (err: any) =>
       this.logErrorWithOriginalStack(err, 'app-dir')
@@ -280,6 +280,9 @@ export default class DevServer extends Server {
       .traceChild('run-instrumentation-hook')
       .traceAsyncFn(() => this.runInstrumentationHookIfAvailable())
     await this.matchers.reload()
+
+    // Store globals again to preserve changes made by the instrumentation hook.
+    this.storeGlobals()
 
     this.ready?.resolve()
     this.ready = undefined
@@ -754,8 +757,12 @@ export default class DevServer extends Server {
     return nextInvoke as NonNullable<typeof result>
   }
 
+  private storeGlobals(): void {
+    this.originalFetch = global.fetch
+  }
+
   private restorePatchedGlobals(): void {
-    global.fetch = this.originalFetch
+    global.fetch = this.originalFetch ?? global.fetch
   }
 
   protected async ensurePage(opts: {


### PR DESCRIPTION
The original dev server implementation records globals in the server constructor and thus overwrites the values initialized in the instrumentation hook. This is a major delta from the `next start` where the instrumentation values are preserved.

Fixes: https://github.com/vercel/next.js/issues/47596
Fixes: https://github.com/vercel/next.js/issues/53407
