### PR TITLE
fix(ts): auto-complete `next/headers`

### DIFF
--- a/packages/next/index.d.ts
+++ b/packages/next/index.d.ts
@@ -15,6 +15,7 @@
 /// <reference path="./router.d.ts" />
 /// <reference path="./script.d.ts" />
 /// <reference path="./server.d.ts" />
+/// <reference path="./headers.d.ts" />
 
 export { default } from './types'
 export * from './types'

--- a/packages/next/index.d.ts
+++ b/packages/next/index.d.ts
@@ -1,8 +1,10 @@
+/// <reference types="./types/global" />
+/// <reference types="./types/compiled" />
+/// <reference path="./dist/styled-jsx/types/global.d.ts" />
 /// <reference path="./amp.d.ts" />
 /// <reference path="./app.d.ts" />
 /// <reference path="./cache.d.ts" />
 /// <reference path="./config.d.ts" />
-/// <reference path="./dist/styled-jsx/types/global.d.ts" />
 /// <reference path="./document.d.ts" />
 /// <reference path="./dynamic.d.ts" />
 /// <reference path="./error.d.ts" />
@@ -14,8 +16,6 @@
 /// <reference path="./router.d.ts" />
 /// <reference path="./script.d.ts" />
 /// <reference path="./server.d.ts" />
-/// <reference types="./types/compiled" />
-/// <reference types="./types/global" />
 
 export { default } from './types'
 export * from './types'

--- a/packages/next/index.d.ts
+++ b/packages/next/index.d.ts
@@ -1,21 +1,21 @@
-/// <reference types="./types/global" />
-/// <reference types="./types/compiled" />
-/// <reference path="./dist/styled-jsx/types/global.d.ts" />
 /// <reference path="./amp.d.ts" />
 /// <reference path="./app.d.ts" />
 /// <reference path="./cache.d.ts" />
 /// <reference path="./config.d.ts" />
+/// <reference path="./dist/styled-jsx/types/global.d.ts" />
 /// <reference path="./document.d.ts" />
 /// <reference path="./dynamic.d.ts" />
 /// <reference path="./error.d.ts" />
 /// <reference path="./head.d.ts" />
+/// <reference path="./headers.d.ts" />
 /// <reference path="./image.d.ts" />
 /// <reference path="./link.d.ts" />
 /// <reference path="./navigation.d.ts" />
 /// <reference path="./router.d.ts" />
 /// <reference path="./script.d.ts" />
 /// <reference path="./server.d.ts" />
-/// <reference path="./headers.d.ts" />
+/// <reference types="./types/compiled" />
+/// <reference types="./types/global" />
 
 export { default } from './types'
 export * from './types'


### PR DESCRIPTION
### What?

Add support for auto-importing `headers()` and `cookies()`

### Why?

Improve the auto-import experience in IDEs like VSCode

### How?

Re-export the `next/headers` type references

Closes NEXT-2146