### PR TITLE
Support next/og usage in ESM nextjs app

### DIFF
--- a/packages/next/src/build/handle-externals.ts
+++ b/packages/next/src/build/handle-externals.ts
@@ -328,7 +328,7 @@ export function makeExternalHandler({
 
     // ESM externals can only be imported (and not required).
     // Make an exception in loose mode.
-    if (!isEsmRequested && isEsm && !looseEsmExternals) {
+    if (!isEsmRequested && isEsm && !looseEsmExternals && !isLocal) {
       throw new Error(
         `ESM packages (${request}) need to be imported. Use 'import' to reference the package instead. https://nextjs.org/docs/messages/import-esm-externals`
       )

--- a/test/e2e/app-dir/app-esm-js/app/opengraph-image.js
+++ b/test/e2e/app-dir/app-esm-js/app/opengraph-image.js
@@ -1,0 +1,23 @@
+import { ImageResponse } from 'next/og'
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: 1200,
+          height: 630,
+          backgroundColor: '#000',
+          color: '#fff',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        OG
+      </div>
+    )
+  )
+}

--- a/test/e2e/app-dir/app-esm-js/index.test.ts
+++ b/test/e2e/app-dir/app-esm-js/index.test.ts
@@ -35,5 +35,11 @@ createNextDescribe(
       )
       expect(await $('.root').text()).toContain('pages')
     })
+
+    it('should support next/og image', async () => {
+      const res = await next.fetch('/opengraph-image')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('image/png')
+    })
   }
 )


### PR DESCRIPTION
### What 

Follow up for #59852 , now you can use `next/og` if your nextjs app is marked as ESM with `"type": "module"` in package.json.

### How

It's a bug in external handling, we shouldn't ESM import error for local requests. Previously you'll see the below error but the 
og import shouldn't be errored as it's not external package

```
Module not found: ESM packages (/.../app/opengraph-image.js) need to be imported. Use 'import' to reference the package instead
 https://nextjs.org/docs/messages/import-esm-externals
```


Closes NEXT-2147