### PR TITLE
Fix: respect init.cache if fetch input is request instance

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -236,7 +236,8 @@ export function patchFetch({
           typeof (input as Request).method === 'string'
 
         const getRequestMeta = (field: string) => {
-          let value = isRequestInput ? (input as any)[field] : null
+          // If request input is present but init is not, retrieve from input first.
+          const value = isRequestInput && !init ? (input as any)[field] : null
           return value || (init as any)?.[field]
         }
 

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -237,8 +237,8 @@ export function patchFetch({
 
         const getRequestMeta = (field: string) => {
           // If request input is present but init is not, retrieve from input first.
-          const value = isRequestInput && !init ? (input as any)[field] : null
-          return value || (init as any)?.[field]
+          const value = (init as any)?.[field]
+          return value || (isRequestInput ? (input as any)[field] : null)
         }
 
         // If the staticGenerationStore is not available, we can't do any

--- a/test/e2e/app-dir/logging/app/fetch-no-store/page.js
+++ b/test/e2e/app-dir/logging/app/fetch-no-store/page.js
@@ -1,0 +1,12 @@
+export default async function Page() {
+  await fetch(
+    new Request(
+      'https://next-data-api-endpoint.vercel.app/api/random?request-input'
+    ),
+    {
+      cache: 'no-store',
+    }
+  )
+
+  return <div>Hello World!</div>
+}

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -141,6 +141,16 @@ createNextDescribe(
               expect(output).toContain('Cache missed reason: (noStore call)')
             })
           })
+
+          it('should respect request.init.cache when use with fetch input is instance', async () => {
+            const logLength = next.cliOutput.length
+            await next.fetch('/fetch-no-store')
+
+            await retry(() => {
+              const output = stripAnsi(next.cliOutput.slice(logLength))
+              expect(output).toContain('Cache missed reason: (cache: no-store)')
+            })
+          })
         }
       } else {
         // No fetches logging enabled


### PR DESCRIPTION
When there’s a request input instance and init object present the same time, we should respect init as preferred

Closes NEXT-2149