### PR TITLE
Revert "Fix: Throw an error for empty array return in `generateStaticParams` with `output:export`"

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1887,19 +1887,15 @@ export default async function build(
                             const isDynamic = isDynamicRoute(page)
                             const hasGenerateStaticParams =
                               !!workerResult.prerenderRoutes?.length
-                            const isEmptyGenerateStaticParams =
-                              workerResult.prerenderRoutes?.length === 0
 
-                            if (config.output === 'export' && isDynamic) {
-                              if (isEmptyGenerateStaticParams) {
-                                throw new Error(
-                                  `Page "${page}"'s "generateStaticParams()" returned an empty array, which is not allowed with "output: export" config.`
-                                )
-                              } else if (!hasGenerateStaticParams) {
-                                throw new Error(
-                                  `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
-                                )
-                              }
+                            if (
+                              config.output === 'export' &&
+                              isDynamic &&
+                              !hasGenerateStaticParams
+                            ) {
+                              throw new Error(
+                                `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
+                              )
                             }
 
                             if (

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1797,12 +1797,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           )
         }
         const resolvedWithoutSlash = removeTrailingSlash(resolvedUrlPathname)
-        if (!staticPaths || staticPaths.length === 0) {
-          throw new Error(
-            `Page "${page}"'s "generateStaticParams()" returned an empty array, which is not allowed with "output: export" config.`
-          )
-        }
-        if (!staticPaths.includes(resolvedWithoutSlash)) {
+        if (!staticPaths?.includes(resolvedWithoutSlash)) {
           throw new Error(
             `Page "${page}" is missing param "${resolvedWithoutSlash}" in "generateStaticParams()", which is required with "output: export" config.`
           )

--- a/test/integration/app-dir-export/test/dynamic-missing-gsp-dev.test.ts
+++ b/test/integration/app-dir-export/test/dynamic-missing-gsp-dev.test.ts
@@ -21,15 +21,5 @@ describe('app dir - with output export - dynamic missing gsp dev', () => {
           'Page "/another/[slug]/page" cannot use both "use client" and export function "generateStaticParams()".',
       })
     })
-
-    it('should error when generateStaticParams returns an empty array', async () => {
-      await runTests({
-        isDev: true,
-        dynamicPage: 'undefined',
-        generateStaticParamsOpt: 'set empty',
-        expectedErrMsg:
-          'Page "/another/[slug]/page"\'s "generateStaticParams()" returned an empty array, which is not allowed with "output: export" config.',
-      })
-    })
   })
 })

--- a/test/integration/app-dir-export/test/dynamic-missing-gsp-prod.test.ts
+++ b/test/integration/app-dir-export/test/dynamic-missing-gsp-prod.test.ts
@@ -21,15 +21,5 @@ describe('app dir - with output export - dynamic missing gsp prod', () => {
           'Page "/another/[slug]/page" cannot use both "use client" and export function "generateStaticParams()".',
       })
     })
-
-    it('should error when generateStaticParams returns an empty array', async () => {
-      await runTests({
-        isDev: false,
-        dynamicPage: 'undefined',
-        generateStaticParamsOpt: 'set empty',
-        expectedErrMsg:
-          'Page "/another/[slug]"\'s "generateStaticParams()" returned an empty array, which is not allowed with "output: export" config.',
-      })
-    })
   })
 })

--- a/test/integration/app-dir-export/test/utils.ts
+++ b/test/integration/app-dir-export/test/utils.ts
@@ -99,7 +99,7 @@ export async function runTests({
   trailingSlash?: boolean
   dynamicPage?: string
   dynamicApiRoute?: string
-  generateStaticParamsOpt?: 'set noop' | 'set client' | 'set empty'
+  generateStaticParamsOpt?: 'set noop' | 'set client'
   expectedErrMsg?: string
 }) {
   if (trailingSlash !== undefined) {
@@ -124,11 +124,6 @@ export async function runTests({
     slugPage.replace('export function generateStaticParams', 'function noop')
   } else if (generateStaticParamsOpt === 'set client') {
     slugPage.prepend('"use client"\n')
-  } else if (generateStaticParamsOpt === 'set empty') {
-    slugPage.replace(
-      "return [{ slug: 'first' }, { slug: 'second' }]",
-      'return []'
-    )
   }
   await fs.remove(distDir)
   await fs.remove(exportDir)


### PR DESCRIPTION
Reverts vercel/next.js#57053 per this comment: https://github.com/vercel/next.js/pull/57053#issuecomment-1892747474

Instead of erroring, we should warn (and only in dev mode). That can be added in a future PR.

Closes NEXT-2155