### PR TITLE
dx: warn the deprecated cache configs are used

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -178,6 +178,15 @@ export interface ExperimentalConfig {
   optimisticClientCache?: boolean
   middlewarePrefetch?: 'strict' | 'flexible'
   manualClientBasePath?: boolean
+  /**
+   * @deprecated use config.cacheHandler instead
+   */
+  incrementalCacheHandlerPath?: string
+  /**
+   * @deprecated use config.cacheMaxMemorySize instead
+   *
+   */
+  isrMemoryCacheSize?: number
   disablePostcssPresetEnv?: boolean
   swcMinify?: boolean
   cpus?: number

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -456,6 +456,26 @@ function assignDefaults(
     }
   }
 
+  if (result.experimental?.incrementalCacheHandlerPath) {
+    // TODO: Remove this warning in Next.js 15
+    warnOptionHasBeenDeprecated(
+      result,
+      'experimental.incrementalCacheHandlerPath',
+      'The "experimental.incrementalCacheHandlerPath" option has been renamed to "cacheHandler". Please update your next.config.js.',
+      silent
+    )
+  }
+
+  if (result.experimental?.isrMemoryCacheSize) {
+    // TODO: Remove this warning in Next.js 15
+    warnOptionHasBeenDeprecated(
+      result,
+      'experimental.isrMemoryCacheSize',
+      'The "experimental.isrMemoryCacheSize" option has been renamed to "cacheMaxMemorySize". Please update your next.config.js.',
+      silent
+    )
+  }
+
   if (typeof result.experimental?.serverActions === 'boolean') {
     // TODO: Remove this warning in Next.js 15
     warnOptionHasBeenDeprecated(


### PR DESCRIPTION
Follow up for #57953 for DX, give better warnings

x-ref: https://github.com/vercel/next.js/pull/60828#discussion_r1457736645

Closes NEXT-2156