### PR TITLE
Enable missing suspense bailout by default

### DIFF
--- a/errors/missing-suspense-with-csr-bailout.mdx
+++ b/errors/missing-suspense-with-csr-bailout.mdx
@@ -10,7 +10,7 @@ Certain methods like `useSearchParams()` opt Next.js into client-side rendering.
 
 Make sure that the method is wrapped in a suspense boundary. This way Next.js will only opt the component into client-side rendering up to the suspense boundary.
 
-> Note: There's an option `experimental.missingSuspenseWithCSRBailout` to disable the bailout behavior while you investigating the missing suspense boundary. But it will be removed in next major version.
+> Note: There's an option `experimental.missingSuspenseWithCSRBailout` to disable the bailout behavior while you are investigating the missing suspense boundary. But it will be removed in next major version as this is a performance de-opt.
 
 ### Useful Links
 

--- a/errors/missing-suspense-with-csr-bailout.mdx
+++ b/errors/missing-suspense-with-csr-bailout.mdx
@@ -10,6 +10,8 @@ Certain methods like `useSearchParams()` opt Next.js into client-side rendering.
 
 Make sure that the method is wrapped in a suspense boundary. This way Next.js will only opt the component into client-side rendering up to the suspense boundary.
 
+> Note: There's an option `experimental.missingSuspenseWithCSRBailout` to disable the bailout behavior while you investigating the missing suspense boundary. But it will be removed in next major version.
+
 ### Useful Links
 
 - [`useSearchParams`](https://nextjs.org/docs/app/api-reference/functions/use-search-params)

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -387,7 +387,7 @@ export interface ExperimentalConfig {
    *
    * When this flag is set to `true`, Next.js will break the build instead of warning, to force the developer to add a suspense boundary above the method call.
    *
-   * @note This flag will be deprecated in Next.js 15.
+   * @note This flag will be removed in Next.js 15.
    * @default true
    */
   missingSuspenseWithCSRBailout?: boolean

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -387,7 +387,8 @@ export interface ExperimentalConfig {
    *
    * When this flag is set to `true`, Next.js will break the build instead of warning, to force the developer to add a suspense boundary above the method call.
    *
-   * @default false
+   * @note This flag will be deprecated in Next.js 15.
+   * @default true
    */
   missingSuspenseWithCSRBailout?: boolean
 }
@@ -866,7 +867,7 @@ export const defaultConfig: NextConfig = {
         ? true
         : false,
     webpackBuildWorker: undefined,
-    missingSuspenseWithCSRBailout: false,
+    missingSuspenseWithCSRBailout: true,
   },
 }
 

--- a/test/e2e/app-dir/missing-suspense-with-csr-bailout/next.config.js
+++ b/test/e2e/app-dir/missing-suspense-with-csr-bailout/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import("next").NextConfig} */
-const config = {
-  experimental: {
-    missingSuspenseWithCSRBailout: true,
-  },
-}
+const config = {}
 
 module.exports = config

--- a/test/e2e/app-dir/params-hooks-compat/app/app/[slug]/page.js
+++ b/test/e2e/app-dir/params-hooks-compat/app/app/[slug]/page.js
@@ -1,5 +1,12 @@
 'use client'
 
+import { Suspense } from 'react'
 import { ParamsComponent } from '../../../shared/params-component'
 
-export default ParamsComponent
+export default function Page() {
+  return (
+    <Suspense>
+      <ParamsComponent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/params-hooks-compat/shared/params-component.js
+++ b/test/e2e/app-dir/params-hooks-compat/shared/params-component.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useParams, useSearchParams } from 'next/navigation'
 
 export function ParamsComponent() {

--- a/test/e2e/app-dir/shallow-routing/app/(shallow)/pushstate-new-searchparams/page.tsx
+++ b/test/e2e/app-dir/shallow-routing/app/(shallow)/pushstate-new-searchparams/page.tsx
@@ -1,7 +1,9 @@
 'use client'
+
+import { Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 
-export default function Page() {
+function InnerPage() {
   const searchParams = useSearchParams()
   return (
     <>
@@ -22,5 +24,13 @@ export default function Page() {
         Push searchParam
       </button>
     </>
+  )
+}
+
+export default function Page() {
+  return (
+    <Suspense>
+      <InnerPage />
+    </Suspense>
   )
 }

--- a/test/e2e/app-dir/shallow-routing/app/(shallow)/pushstate-string-url/page.tsx
+++ b/test/e2e/app-dir/shallow-routing/app/(shallow)/pushstate-string-url/page.tsx
@@ -1,7 +1,9 @@
 'use client'
+
+import { Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 
-export default function Page() {
+function InnerPage() {
   const searchParams = useSearchParams()
   return (
     <>
@@ -55,5 +57,13 @@ export default function Page() {
         Push searchParam with undefined data param
       </button>
     </>
+  )
+}
+
+export default function Page() {
+  return (
+    <Suspense>
+      <InnerPage />
+    </Suspense>
   )
 }

--- a/test/e2e/app-dir/shallow-routing/app/(shallow)/replacestate-new-searchparams/page.tsx
+++ b/test/e2e/app-dir/shallow-routing/app/(shallow)/replacestate-new-searchparams/page.tsx
@@ -1,7 +1,9 @@
 'use client'
+
+import { Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 
-export default function Page() {
+function InnerPage() {
   const searchParams = useSearchParams()
   return (
     <>
@@ -22,5 +24,13 @@ export default function Page() {
         Replace searchParam
       </button>
     </>
+  )
+}
+
+export default function Page() {
+  return (
+    <Suspense>
+      <InnerPage />
+    </Suspense>
   )
 }

--- a/test/e2e/app-dir/shallow-routing/app/(shallow)/replacestate-string-url/page.tsx
+++ b/test/e2e/app-dir/shallow-routing/app/(shallow)/replacestate-string-url/page.tsx
@@ -1,7 +1,9 @@
 'use client'
+
+import { Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 
-export default function Page() {
+function InnerPage() {
   const searchParams = useSearchParams()
   return (
     <>
@@ -55,5 +57,13 @@ export default function Page() {
         Replace searchParam with undefined data param
       </button>
     </>
+  )
+}
+
+export default function Page() {
+  return (
+    <Suspense>
+      <InnerPage />
+    </Suspense>
   )
 }


### PR DESCRIPTION
`experimental.missingSuspenseWithCSRBailout` should be enabled by default to help users to disciver unwrapped suspense boundaries.

Add more notes in the error doc about deprecation and temporary workaround to disable it.

Closes NEXT-2157