### PR TITLE
Update build worker warning to use debug

### DIFF
--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -58,7 +58,7 @@ async function webpackBuildWithWorker(
     }[]) {
       worker._child.on('exit', (code, signal) => {
         if (code || (signal && signal !== 'SIGINT')) {
-          console.error(
+          debug(
             `Compiler ${compilerName} unexpectedly exited with code: ${code} and signal: ${signal}`
           )
         }


### PR DESCRIPTION
Since we are enabling `webpackBuildWorker` by default now we should move this warning to debug since it can be confusing without additional context. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04KC8A53T7/p1705612748627769?thread_ts=1705599489.811039&cid=C04KC8A53T7)

Closes NEXT-2158