### PR TITLE
Fix last stable tag for release stats

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -27,7 +27,9 @@ module.exports = (actionInfo) => {
         )
       }
       // last stable tag will always be 1 patch less than canary
-      return `${major}.${minor}.${Number(patch) - 1}`
+      return `${major}.${minor}.${
+        Number(patch) - tag.includes('-canary') ? 1 : 0
+      }`
     },
     async getCommitId(repoDir = '') {
       const { stdout } = await exec(`cd ${repoDir} && git rev-parse HEAD`)


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/actions/runs/7576301894/job/20635069339

Closes NEXT-2159