### PR TITLE
Telemetry: createComponentTree span

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -38,7 +38,30 @@ export const Postpone = ({
 /**
  * Use the provided loader tree to create the React Component tree.
  */
-export async function createComponentTree({
+export function createComponentTree(props: {
+  createSegmentPath: CreateSegmentPath
+  loaderTree: LoaderTree
+  parentParams: Params
+  rootLayoutIncluded: boolean
+  firstItem?: boolean
+  injectedCSS: Set<string>
+  injectedJS: Set<string>
+  injectedFontPreloadTags: Set<string>
+  asNotFound?: boolean
+  metadataOutlet?: React.ReactNode
+  ctx: AppRenderContext
+  missingSlots?: Set<string>
+}): Promise<ComponentTree> {
+  return getTracer().trace(
+    NextNodeServerSpan.createComponentTree,
+    {
+      spanName: 'build component tree',
+    },
+    () => createComponentTreeInternal(props)
+  )
+}
+
+async function createComponentTreeInternal({
   createSegmentPath,
   loaderTree: tree,
   parentParams,
@@ -413,7 +436,7 @@ export async function createComponentTree({
           }
 
           const { seedData, styles: childComponentStyles } =
-            await createComponentTree({
+            await createComponentTreeInternal({
               createSegmentPath: (child) => {
                 return createSegmentPath([...currentSegmentPath, ...child])
               },

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -38,6 +38,7 @@ enum NextServerSpan {
 enum NextNodeServerSpan {
   compression = 'NextNodeServer.compression',
   getBuildId = 'NextNodeServer.getBuildId',
+  createComponentTree = 'NextNodeServer.createComponentTree',
   getLayoutOrPageModule = 'NextNodeServer.getLayoutOrPageModule',
   generateStaticRoutes = 'NextNodeServer.generateStaticRoutes',
   generateFsStaticRoutes = 'NextNodeServer.generateFsStaticRoutes',
@@ -128,6 +129,7 @@ export const NextVanillaSpanAllowlist = [
   AppRouteRouteHandlersSpan.runHandler,
   ResolveMetadataSpan.generateMetadata,
   ResolveMetadataSpan.generateViewport,
+  NextNodeServerSpan.createComponentTree,
   NextNodeServerSpan.findPageComponents,
   NextNodeServerSpan.getLayoutOrPageModule,
 ]

--- a/test/e2e/opentelemetry/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/opentelemetry.test.ts
@@ -114,8 +114,8 @@ createNextDescribe(
               const numberOfRootTraces =
                 env.span.rootParentId === undefined ? 1 : 0
               const traces = await getSanitizedTraces(numberOfRootTraces)
-              if (traces.length < 8) {
-                return `not enough traces, expected 8, but got ${traces.length}`
+              if (traces.length < 9) {
+                return `not enough traces, expected 9, but got ${traces.length}`
               }
               expect(traces).toMatchInlineSnapshot(`
                 [
@@ -166,6 +166,19 @@ createNextDescribe(
                         ? `"${env.span.rootParentId}"`
                         : undefined
                     },
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "${env.span.traceId}",
+                  },
+                  {
+                    "attributes": {
+                      "next.span_name": "build component tree",
+                      "next.span_type": "NextNodeServer.createComponentTree",
+                    },
+                    "kind": 0,
+                    "name": "build component tree",
+                    "parentId": "[parent-id]",
                     "status": {
                       "code": 0,
                     },
@@ -625,8 +638,8 @@ createNextDescribe(
 
           await check(async () => {
             const traces = await getSanitizedTraces(1)
-            if (traces.length < 4) {
-              return `not enough traces, expected 4, but got ${traces.length}`
+            if (traces.length < 5) {
+              return `not enough traces, expected 5, but got ${traces.length}`
             }
             expect(traces).toMatchInlineSnapshot(`
                 [
@@ -657,6 +670,19 @@ createNextDescribe(
                     "kind": 1,
                     "name": "GET /app/[param]/rsc-fetch",
                     "parentId": undefined,
+                    "status": {
+                      "code": 0,
+                    },
+                    "traceId": "[trace-id]",
+                  },
+                  {
+                    "attributes": {
+                      "next.span_name": "build component tree",
+                      "next.span_type": "NextNodeServer.createComponentTree",
+                    },
+                    "kind": 0,
+                    "name": "build component tree",
+                    "parentId": "[parent-id]",
                     "status": {
                       "code": 0,
                     },


### PR DESCRIPTION
This span is meant to be a parent for all "resolve segment modules" spans.