### PR TITLE
Optimize build trace ignores

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -320,7 +320,7 @@ export async function collectBuildTraces({
         // we shouldn't be tracing .next/server assets from
         // inside .next/server as that relationship is pulled
         // from webpack itself as it's more accurate
-        '**/.next/server/**/*',
+        '**/.next/server/chunks/**/*',
       ].filter(Boolean) as string[]
 
       const serverIgnores = [


### PR DESCRIPTION
It seems that when tracing build dependencies our server tracing was analyzing all server chunks un-necessarily and when a very large dependency like `ace-builds` is creating large chunks it can slow down builds drastically so this ensures we eagerly apply our shared ignores to avoid this over tracing. 

Build times before [with provided repro](https://github.com/MartinXPN/next-slow-build-reproduction):

```sh
▲ Next.js 14.1.0

   Creating an optimized production build ...
 ✓ Compiled successfully
 ✓ Linting and checking validity of types
 ✓ Collecting page data
 ✓ Generating static pages (5/5)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

✨  Done in 437.29s.
```

Build times after [with provided repro](https://github.com/MartinXPN/next-slow-build-reproduction):

```sh
▲ Next.js 14.1.1-canary.0

   Creating an optimized production build ...
 ✓ Compiled successfully
 ✓ Linting and checking validity of types
 ✓ Collecting page data
 ✓ Generating static pages (5/5)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

✨  Done in 42.38s.
```


Closes: https://github.com/vercel/next.js/issues/58759
Closes NEXT-2161