### PR TITLE
Adds a link to CSP where it's first referenced in the headers docs

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/headers.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/headers.mdx
@@ -457,7 +457,7 @@ If you're deploying to [Vercel](https://vercel.com/docs/concepts/edge-network/he
 
 [This header](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Frame-Options) indicates whether the site should be allowed to be displayed within an `iframe`. This can prevent against clickjacking attacks.
 
-**This header has been superseded by CSP's `frame-ancestors` option**, which has better support in modern browsers.
+**This header has been superseded by CSP's `frame-ancestors` option**, which has better support in modern browsers (see [Content Security Policy](/docs/app/building-your-application/configuring/content-security-policy) for configuration details).
 
 ```js
 {


### PR DESCRIPTION
### What?
Adds a link to CSP documentation the first time it's mentioned in the headers page here: https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy

### Why?
Convenience for users, as it's unclear at that point in the document that `CSP` is discussing `Content-Security-Policy`, and the first reference to its docs are at the end of the page. 

### How?
Added a link to the CSP doc here https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy