### PR TITLE
Update `swc_core` to `v0.87.28`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3483,6 +3483,7 @@ dependencies = [
  "hex",
  "once_cell",
  "pathdiff",
+ "preset_env_base",
  "react_remove_properties",
  "regex",
  "remove_console",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4477,9 +4477,9 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bcbde8369667c2c776c0f025f91944b3692a480496e0f4ef4b774674ae5e4ed"
+checksum = "4e95cedc4e243e8e9bcf33101a24ab2a7aa5d1b3c626bd54f3ce2af01774b29b"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -4620,9 +4620,9 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39aa6fbc267aada3d272adae986196a9aa573eb360e9a3677c95b91329b85e24"
+checksum = "e24f7647beb43e19265a19d4afe7937d51440de1fbb8214428b177340bed7ab1"
 dependencies = [
  "serde",
  "swc_atoms",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "serde",
  "smallvec",
@@ -610,27 +610,6 @@ checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
-]
-
-[[package]]
-name = "browserslist-rs"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33066f72a558361eeb1077b0aff0f1dce1ac75bdc20b38a642f155f767b2824"
-dependencies = [
- "ahash 0.8.6",
- "anyhow",
- "chrono",
- "either",
- "itertools 0.10.5",
- "nom",
- "once_cell",
- "quote",
- "serde",
- "serde_json",
- "string_cache",
- "string_cache_codegen",
- "thiserror",
 ]
 
 [[package]]
@@ -3248,9 +3227,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.63.0"
+version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae13302a671df594637d7a97c0c17132f0e312ccceec599971c9a003d05d8c7"
+checksum = "03ba62fb8ab2a603ee6e85470f5dd9563a4809dc0b6f749c721b5c0ef313c83f"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -3481,6 +3460,8 @@ dependencies = [
  "either",
  "fxhash",
  "hex",
+ "lazy_static",
+ "lightningcss",
  "once_cell",
  "pathdiff",
  "preset_env_base",
@@ -3530,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "serde",
@@ -4173,7 +4154,7 @@ checksum = "d4e9bedef66806cb32828719aa5cad298e363ad50d190538db40b5631b89d456"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
- "browserslist-rs 0.14.0",
+ "browserslist-rs",
  "dashmap",
  "from_variant",
  "once_cell",
@@ -5555,9 +5536,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.91.0"
+version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70839c116ea418685475d63254fbbbfa84805a29be9643bd4c0ff853df933165"
+checksum = "36c5c51bb8528cceebba8f28b82dcdbc811ba2f8934e85c519e815c6756206a8"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -5573,11 +5554,11 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.68.0"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf86552e4835ca26343bbbdd26fa56ac3954e390b8f9dd4b3f7f159ec354f42b"
+checksum = "b8ba4b5878a8de959cc40fdbcbe2b4e74b206db55dbb71b17f07fcd8007e26bb"
 dependencies = [
- "easy-error",
+ "anyhow",
  "lightningcss",
  "parcel_selectors",
  "preset_env_base",
@@ -6724,9 +6705,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.67.0"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e429f66f612c42bef6b202419a79ccbe7317a09da00107a56c24dbc3dbaf0d"
+checksum = "3e10ea9a961413be44879c2b16d04b6bb8f8d9f9ca09ef2772c363d81dee0fe6"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -6882,9 +6863,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.39.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168aaf1e1477292379be03b713a4a9c8bf7969551d90c6dcad2e44b936d3e86b"
+checksum = "08b37cd8b8acc422343aae385f29a51a59a22d1bb0087c7ea3ee05ea51b87088"
 dependencies = [
  "once_cell",
  "regex",
@@ -7594,7 +7575,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7626,7 +7607,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7638,7 +7619,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7653,7 +7634,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7667,7 +7648,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7684,7 +7665,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7715,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "base16",
  "hex",
@@ -7727,7 +7708,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7741,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7751,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "mimalloc",
 ]
@@ -7759,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7784,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7816,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7857,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7881,7 +7862,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7899,13 +7880,13 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
  "auto-hash-map",
- "browserslist-rs 0.13.0",
+ "browserslist-rs",
  "futures",
  "indexmap 1.9.3",
  "lazy_static",
@@ -7929,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7956,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7980,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8017,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8052,7 +8033,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8063,12 +8044,14 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "async-trait",
  "indexmap 1.9.3",
+ "lightningcss",
  "modularize_imports",
+ "parcel_selectors",
  "serde",
  "serde_json",
  "styled_components",
@@ -8086,7 +8069,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8103,7 +8086,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8119,7 +8102,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8139,7 +8122,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "serde",
@@ -8154,7 +8137,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8169,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8204,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "serde",
@@ -8220,7 +8203,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8231,7 +8214,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8247,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240123.3#31816d1f102caa1968b7d0962002413c6fd9a5ad"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "serde",
  "smallvec",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "serde",
@@ -7575,7 +7575,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7607,7 +7607,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7619,7 +7619,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7634,7 +7634,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7648,7 +7648,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7665,7 +7665,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "base16",
  "hex",
@@ -7708,7 +7708,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7732,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "mimalloc",
 ]
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7765,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7838,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7862,7 +7862,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7880,7 +7880,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7910,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7937,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7998,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8033,7 +8033,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "serde",
  "serde_json",
@@ -8044,7 +8044,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8069,7 +8069,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8086,7 +8086,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8102,7 +8102,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8122,7 +8122,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "serde",
@@ -8137,7 +8137,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8187,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "serde",
@@ -8203,7 +8203,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8214,7 +8214,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8230,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-87-3#9b910c81b7f84f5296d37c55a3a0f3605e7450e1"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.61.18"
+version = "0.61.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f223044d1a486a04e27ae0012400169aeb9f6fba2e86f72537c1e827a2f8c1c"
+checksum = "90f8ca4ea35370e23973c27353575db560b8bd3f595af49efe8ae128b295b04c"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -779,9 +779,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -3689,9 +3689,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
@@ -4447,9 +4447,9 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c088c3738818b00b599ebe28329ff05772c7c2672572639206a0fa4045f13a9"
+checksum = "8bcbde8369667c2c776c0f025f91944b3692a480496e0f4ef4b774674ae5e4ed"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -4590,9 +4590,9 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52656d967939369419688702206df3bd68a688e583947572d4a8ea66773b4bf2"
+checksum = "39aa6fbc267aada3d272adae986196a9aa573eb360e9a3677c95b91329b85e24"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5603,9 +5603,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.270.18"
+version = "0.270.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a27aa57c85cbd942540fe5e50f5d665723a1666305506f0cf0daf423903e2a9"
+checksum = "8555a06557bfc8572bacd5dd8d5bb3042a8c164ab8033dd5930c2df2e24975e9"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5669,9 +5669,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.223.15"
+version = "0.223.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e912d8387fc8592465c081b2e6b8df89443117ae4ca5160f21e08d47d7d58d7a"
+checksum = "3f45e9f11deca8acd79fb02371c46d61dbabeb62643562a2fc347275ef3550b8"
 dependencies = [
  "anyhow",
  "crc",
@@ -5748,9 +5748,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.4.16"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8a76c7c388f1db934d10ba7fd293ea69e6ed8bd031855b579e4794aff5af85"
+checksum = "49881e24dbe646dec45e733e5ede5483aaf0759e97586d3a6ffbb9d9ae7736da"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5796,9 +5796,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.87.19"
+version = "0.87.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455c32b15bcdf8cddd87ce4c5d51f89bc16dfb3e6e58959e1cead7634ab2e828"
+checksum = "50c00b4b074d8d58475080254bd54eb33127aa185f750e1402f7325003924e04"
 dependencies = [
  "binding_macros",
  "swc",
@@ -6034,9 +6034,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a69ac870b965a458340c6a5a31059f8473093595a1f9efb169002f23bc05261"
+checksum = "0337067ede6103a274191a20c4de238ded32bb8b3d3e99561ca3e7811e089b21"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6064,9 +6064,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6189b89270bca5d3b103818a49c8decca0f9a63b4507f4f5301b052b0fb42d51"
+checksum = "a6912d92bcfc313d7b05d1da0ae8d283bce24baf4e1fd09541acd52f32ab1e32"
 dependencies = [
  "arrayvec",
  "indexmap 2.0.0",
@@ -6090,9 +6090,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0708c1ae05f82d4e19da2f02a5b093e4e50d581e9bfac527f4aa7693bd791cf7"
+checksum = "52f4824f2bd45b02b70bc85824daa35c9c07477589f008f888748c115d4b0b97"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6107,9 +6107,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3701ee2c0321f79258a2acc3633b875af7770cd0173e17a0615d9e707ba32ac"
+checksum = "c85bcb454c2d69e38777fd739864938fbc18ed45b6ee4dd314b9fc0a463a63c1"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6125,9 +6125,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def1e23336a20ca46d297685c2f5c60703eb2d7aea0b8996fefa577be3fad508"
+checksum = "3d47d63860994814c49e8ad5996d182d1d7804e96d6f7bdab0bf1282716d9884"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6144,9 +6144,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd4288e3dfbba53a72410daf190d84d7601f91300e6c524ddea1f0708f2495"
+checksum = "f20b2d70b26e48926bba3b7629b6bc10de724a8f076fdf4eb9267fe12a1db17b"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6160,9 +6160,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f654fe803d73320c723ba25e88b4b561fd1d53ad59ad8622f209fe03f6849b3b"
+checksum = "973a0bca6c9e85869d62b38937b80e13ee5e105df4eb18576177c4ebb41e5bb9"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6213,9 +6213,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2f3ac54636b7690f17adc9430318d83bf8423635ca848bbb9f9c045e01e377"
+checksum = "ce5624a8b906965af30484a0b8e2ed9b0d68675a1b8bdba6a242882f38e3270e"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6283,9 +6283,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.190.15"
+version = "0.190.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd196fa7d01ddd4eaa935f0ddd12854df57db21243aebde9169882d22d381f3"
+checksum = "b3142eaa2d4b80d5279d8b4d840fc2d006a9f3129d78063b3cd864b8c225fefd"
 dependencies = [
  "arrayvec",
  "indexmap 2.0.0",
@@ -6340,9 +6340,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.204.15"
+version = "0.204.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94556b1404aa1c8e9f22312fe83a11b5c882b0122557daae1187826575162627"
+checksum = "25c04f9800e67c97938a60f3c90f9455ba1984abe169ba70b1776428dcc6ee25"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6395,9 +6395,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.227.15"
+version = "0.227.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b319ba24f6311afa72c5d7e81f06f52b1cd9ad4debf0524eac599b7640b9039a"
+checksum = "d91e52749e37685afa9bcb3ad58c945e31b1bf51259c8438c4cc6787366ae3cd"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6453,9 +6453,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.161.14"
+version = "0.161.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a7192ebd94fa4454114ff79513000260ac583d3b80067d9037daa119f318df"
+checksum = "f46cfe232648c0994922d136d686c0a598c73a30334d92b14ba5a61e768bb4e7"
 dependencies = [
  "arrayvec",
  "indexmap 2.0.0",
@@ -6502,9 +6502,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.178.15"
+version = "0.178.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1ba85cf4620c7690eb67f00bf2b1efa0d88265bbbf8cea60dfc7aec59c3e99"
+checksum = "48e51136811754dcbd7400cdd62da7117deabd029c8049a6740cff75934e3f40"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -6529,9 +6529,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.196.14"
+version = "0.196.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eefef9f5a80afdbd4b517401dc053825d1ac0d95bb63f3ae92d2b335d8d7d4f8"
+checksum = "95b7acea7f3306e5b9c3b19abc02f85885309f154901c951c63c3bcef4b0ff82"
 dependencies = [
  "dashmap",
  "indexmap 2.0.0",
@@ -6554,9 +6554,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.169.14"
+version = "0.169.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86de99757fc31d8977f47c02a26e5c9a243cb63b03fe8aa8b36d79924b8fa29c"
+checksum = "ed89d6ff74f60de490fb56e1cc505b057905e36c13d405d7d61dd5c9f6ee8fc9"
 dependencies = [
  "either",
  "rustc-hash",
@@ -6574,9 +6574,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.181.15"
+version = "0.181.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9918e22caf1ea4a71085f5d818d6c0bf5c19d669cfb9d38f9fdc3da0496abdc7"
+checksum = "e31a2f879fd21d18080b6c42e633e0ae8c6f3d54b83c1de876767d82b458c999"
 dependencies = [
  "base64 0.21.4",
  "dashmap",
@@ -6599,9 +6599,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.138.10"
+version = "0.138.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9def5b4509c1764173a5cfce81d46d3d64ae479fbc7f1975ba3758dda4abc79"
+checksum = "bbff87379f76ecb3d159f6c73e140c7b95d3ee37facfdf4e539e648fe616c95c"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -6625,9 +6625,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.186.14"
+version = "0.186.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d1495c969ffdc224384f1fb73646b9c1b170779f20fdb984518deb054aa522"
+checksum = "6460d1e6a9ffade4b89b15fa38944fa0f7da877d7e79aa69e9f9c6a83a23b031"
 dependencies = [
  "ryu-js",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "glyph-names",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "libc",
  "log",
@@ -352,7 +352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "996ce95bbdb0203e5b91d4a0c9b81c0d67d11c80f884482a0c1ea19e732e3530"
 dependencies = [
  "crossbeam",
- "itertools",
+ "itertools 0.10.5",
  "lab",
  "num-traits",
  "rayon",
@@ -368,7 +368,7 @@ checksum = "6f6ca6f0c18c02c2fbfc119df551b8aeb8a385f6d5980f1475ba0255f1e97f1e"
 dependencies = [
  "anyhow",
  "arrayvec",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "nom",
  "num-rational",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.61.25"
+version = "0.61.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f8ca4ea35370e23973c27353575db560b8bd3f595af49efe8ae128b295b04c"
+checksum = "a5ccc161009146c42b3c0d5a3f1d66666b0ea16301d89b0292bc61ee4d3a0039"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -622,7 +622,28 @@ dependencies = [
  "anyhow",
  "chrono",
  "either",
- "itertools",
+ "itertools 0.10.5",
+ "nom",
+ "once_cell",
+ "quote",
+ "serde",
+ "serde_json",
+ "string_cache",
+ "string_cache_codegen",
+ "thiserror",
+]
+
+[[package]]
+name = "browserslist-rs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2557836820eed97f79071bb3294b2640e71e0bc4301336a210a1b8b4947c15"
+dependencies = [
+ "ahash 0.8.6",
+ "anyhow",
+ "chrono",
+ "either",
+ "itertools 0.12.0",
  "nom",
  "once_cell",
  "quote",
@@ -2589,6 +2610,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2874,7 +2904,7 @@ dependencies = [
  "cssparser-color",
  "dashmap",
  "data-encoding",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "lightningcss-derive",
  "parcel_selectors",
@@ -4136,13 +4166,13 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "preset_env_base"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff96707a8ddcf6230b2249554d5dc78bbe93cfe28af5ef880174a0f2e63d0d53"
+checksum = "d4e9bedef66806cb32828719aa5cad298e363ad50d190538db40b5631b89d456"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
- "browserslist-rs",
+ "browserslist-rs 0.14.0",
  "dashmap",
  "from_variant",
  "once_cell",
@@ -4238,7 +4268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4380,7 +4410,7 @@ dependencies = [
  "const_fn_assert",
  "fern",
  "interpolate_name",
- "itertools",
+ "itertools 0.10.5",
  "ivf",
  "libc",
  "libfuzzer-sys",
@@ -5603,9 +5633,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.270.25"
+version = "0.270.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8555a06557bfc8572bacd5dd8d5bb3042a8c164ab8033dd5930c2df2e24975e9"
+checksum = "722794f5f68ffaba34e0ef7e0c0fc04208d7e1c284f4df2f827890cdd20d0ca7"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5669,9 +5699,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.223.22"
+version = "0.223.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f45e9f11deca8acd79fb02371c46d61dbabeb62643562a2fc347275ef3550b8"
+checksum = "fefa09161d201f04a2d6c553c4b726819ec44dcfff6e40dc1a68342803b8cd12"
 dependencies = [
  "anyhow",
  "crc",
@@ -5748,9 +5778,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49881e24dbe646dec45e733e5ede5483aaf0759e97586d3a6ffbb9d9ae7736da"
+checksum = "b68297972f09d21dea054f1ba5ee611faaf43d6ff3903ba34a52bfa00342d7d7"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5796,9 +5826,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.87.27"
+version = "0.87.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c00b4b074d8d58475080254bd54eb33127aa185f750e1402f7325003924e04"
+checksum = "8b3e389aed344d9d738f7e0901a1778a8402f10e459556c6d3a7a5b4501bf4cf"
 dependencies = [
  "binding_macros",
  "swc",
@@ -6003,9 +6033,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.146.54"
+version = "0.146.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b61ca275e3663238b71c4b5da8e6fb745bde9989ef37d94984dfc81fc6d009"
+checksum = "aa20d5c61563c5ec9ba469a7701512f4d6bc29790718cd198f43e61148e8aff2"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -6034,9 +6064,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0337067ede6103a274191a20c4de238ded32bb8b3d3e99561ca3e7811e089b21"
+checksum = "b51b895bd387f4c1e3aa5de21936d12a02a4de7d2b88b8efea0949ac0220c2a2"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6064,9 +6094,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6912d92bcfc313d7b05d1da0ae8d283bce24baf4e1fd09541acd52f32ab1e32"
+checksum = "b85ca741acb73cbc79d5bf7716dfd502fd43a035a1f3509cc5ddfff1995477a4"
 dependencies = [
  "arrayvec",
  "indexmap 2.0.0",
@@ -6090,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f4824f2bd45b02b70bc85824daa35c9c07477589f008f888748c115d4b0b97"
+checksum = "c60d1e68eed4bce1ac480a95694b200fc1482d98adb22dcd8aa174472df8eb42"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6107,9 +6137,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85bcb454c2d69e38777fd739864938fbc18ed45b6ee4dd314b9fc0a463a63c1"
+checksum = "ad96684e095c793c44989c63d7195f309ac4bfed66d4fa8ab3b1e2a79d641bc2"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6125,9 +6155,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d47d63860994814c49e8ad5996d182d1d7804e96d6f7bdab0bf1282716d9884"
+checksum = "3c25b188098603928dd3f310ea029b5ca3e52cb0f7b20698cf9328ea6fab3425"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6144,9 +6174,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20b2d70b26e48926bba3b7629b6bc10de724a8f076fdf4eb9267fe12a1db17b"
+checksum = "d2689f136599fddd7be1f4e2f665ecce539d7f9bd04c314fa2ad4304f63ed965"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6160,9 +6190,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973a0bca6c9e85869d62b38937b80e13ee5e105df4eb18576177c4ebb41e5bb9"
+checksum = "6388c05a061570b00f453be00fcf9703e5b7d5f33b8d8457ea3b20d134ff50a3"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6178,9 +6208,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a33089b3b121acadc052ca636905c1dd465db3cc94fa456c26eacc65d5074db"
+checksum = "5752c00c792e92c8ce56b2a656058d554a104599e9f4b5c3675b02223f217ee0"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6194,9 +6224,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe2a334c1ed213b0a58adb09518c63c63229afad705e5ab027e2fd0f3ff20bd"
+checksum = "0169d78892b5185d0b3195326a65b34b306a9f802c978deba660227675fb4004"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6213,9 +6243,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5624a8b906965af30484a0b8e2ed9b0d68675a1b8bdba6a242882f38e3270e"
+checksum = "76988033af2b8b94629d60a1a86d9463e3cd0298820dd54bccda57c1d9e40a46"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6242,9 +6272,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.90.10"
+version = "0.90.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5afe579c82fe80a24e8c815fa19e7f1126c8114db0985f211c985d5b4db4137e"
+checksum = "22e407eb2703a200d6eed65ad4444afb029bf6979fda6c99007ca0a638a99696"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -6283,9 +6313,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.190.22"
+version = "0.190.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3142eaa2d4b80d5279d8b4d840fc2d006a9f3129d78063b3cd864b8c225fefd"
+checksum = "5efcbaa6db6fb13d485139e2e8b831326b99055a61dd0c1b3c4e9c94e5439c4d"
 dependencies = [
  "arrayvec",
  "indexmap 2.0.0",
@@ -6340,9 +6370,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.204.19"
+version = "0.204.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25c04f9800e67c97938a60f3c90f9455ba1984abe169ba70b1776428dcc6ee25"
+checksum = "9a9037704b83704a517d6c6b88f0b4f519d77cd6acaa25fe3db97fc4ca77d784"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6395,9 +6425,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.227.19"
+version = "0.227.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e52749e37685afa9bcb3ad58c945e31b1bf51259c8438c4cc6787366ae3cd"
+checksum = "03f5ad7385ba6664106fc60c8b147d2c7ea2f2630d62ccb4a29a6d86f9fa1e4e"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6415,9 +6445,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.135.11"
+version = "0.135.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d4ab26ec124b03e47f54d4daade8e9a9dcd66d3a4ca3cd47045f138d267a60e"
+checksum = "f6f0efec63cc56f3f2b93d1367d16e684d1c6f4a6cb85436db2c91448867df2b"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -6439,9 +6469,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.124.11"
+version = "0.124.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe4376c024fa04394cafb8faecafb4623722b92dbbe46532258cc0a6b569d9c"
+checksum = "65a3a39bc56f271afba7e48be14f43a071226c27890da2fabaefa822cc89e3f2"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6453,9 +6483,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.161.16"
+version = "0.161.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46cfe232648c0994922d136d686c0a598c73a30334d92b14ba5a61e768bb4e7"
+checksum = "26bfa9040b0ff31ff2b50b47b72ff02f4cd3e090a156e587e43fdc08ce1a7d36"
 dependencies = [
  "arrayvec",
  "indexmap 2.0.0",
@@ -6502,9 +6532,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.178.18"
+version = "0.178.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e51136811754dcbd7400cdd62da7117deabd029c8049a6740cff75934e3f40"
+checksum = "684e80a3e847ae41c79c2c4af005c464ff9b0b0bb636009f588f64d14070ca35"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -6529,9 +6559,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.196.18"
+version = "0.196.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b7acea7f3306e5b9c3b19abc02f85885309f154901c951c63c3bcef4b0ff82"
+checksum = "f2b3b63a290c20600a3844fe3f842cad19eddc3e05b58752a9cd967978d54574"
 dependencies = [
  "dashmap",
  "indexmap 2.0.0",
@@ -6554,9 +6584,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.169.16"
+version = "0.169.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed89d6ff74f60de490fb56e1cc505b057905e36c13d405d7d61dd5c9f6ee8fc9"
+checksum = "23d71a5d911918e4d7698df9f08925071e6993179e5e9331932051ff4e6ecf93"
 dependencies = [
  "either",
  "rustc-hash",
@@ -6574,9 +6604,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.181.18"
+version = "0.181.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31a2f879fd21d18080b6c42e633e0ae8c6f3d54b83c1de876767d82b458c999"
+checksum = "f0c6f16101c8eda9420435b62fc50f127e15fb58ae73ce99df293609d23fb9b7"
 dependencies = [
  "base64 0.21.4",
  "dashmap",
@@ -6599,9 +6629,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.138.11"
+version = "0.138.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbff87379f76ecb3d159f6c73e140c7b95d3ee37facfdf4e539e648fe616c95c"
+checksum = "ecfd5d3bdcb529c4db2ac27fac59a9e1ce66975543d34f9ce60e7ee2cbc73f78"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -6625,9 +6655,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.186.18"
+version = "0.186.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6460d1e6a9ffade4b89b15fa38944fa0f7da877d7e79aa69e9f9c6a83a23b031"
+checksum = "e951251870f036f549145c8eb6226d5b6bf7dac83b68b959cf2cca6b511f4b3f"
 dependencies = [
  "ryu-js",
  "serde",
@@ -7874,7 +7904,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "auto-hash-map",
- "browserslist-rs",
+ "browserslist-rs 0.13.0",
  "futures",
  "indexmap 1.9.3",
  "lazy_static",
@@ -8238,7 +8268,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.87.28", features = [
 testing = { version = "0.35.14" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240123.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-87-3" } # last tag: "turbopack-240123.3"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240123.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-87-3" } # last tag: "turbopack-240123.3"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240123.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-87-3" } # last tag: "turbopack-240123.3"
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ next-core = { path = "packages/next-swc/crates/next-core" }
 next-custom-transforms = { path = "packages/next-swc/crates/next-custom-transforms" }
 
 # SWC crates
-swc_core = { version = "0.87.27", features = [
+swc_core = { version = "0.87.28", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.87.28", features = [
 testing = { version = "0.35.14" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-87-3" } # last tag: "turbopack-240123.3"
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240124.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-87-3" } # last tag: "turbopack-240123.3"
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240124.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-87-3" } # last tag: "turbopack-240123.3"
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240124.1" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,10 +92,16 @@ indoc = "2.0.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 log = "0.4.17"
+lightningcss = { version = "1.0.0-alpha.50", features = [
+  "serde",
+  "visitor",
+  "into_owned",
+] }
 mime = "0.3.16"
 nohash-hasher = "0.2.0"
 once_cell = "1.17.1"
 owo-colors = "3.5.0"
+parcel_selectors = "0.26.0"
 parking_lot = "0.12.1"
 pathdiff = "0.2.1"
 pin-project-lite = "0.2.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ next-core = { path = "packages/next-swc/crates/next-core" }
 next-custom-transforms = { path = "packages/next-swc/crates/next-custom-transforms" }
 
 # SWC crates
-swc_core = { version = "0.87.16", features = [
+swc_core = { version = "0.87.27", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -242,13 +242,14 @@ pub async fn get_client_module_options_context(
     });
 
     let use_lightningcss = *next_config.use_lightningcss().await?;
+    let target_browsers = env.runtime_versions();
 
     let source_transforms = vec![
         *get_swc_ecma_transform_plugin(project_path, next_config).await?,
         *get_relay_transform_plugin(next_config).await?,
         *get_emotion_transform_plugin(next_config).await?,
         *get_styled_components_transform_plugin(next_config).await?,
-        *get_styled_jsx_transform_plugin(use_lightningcss).await?,
+        *get_styled_jsx_transform_plugin(use_lightningcss, target_browsers).await?,
     ]
     .into_iter()
     .flatten()

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -330,11 +330,13 @@ pub async fn get_server_module_options_context(
     });
 
     let use_lightningcss = *next_config.use_lightningcss().await?;
+    let versions = *env.runtime_versions().await?;
 
     // EcmascriptTransformPlugins for custom transforms
     let styled_components_transform_plugin =
         *get_styled_components_transform_plugin(next_config).await?;
-    let styled_jsx_transform_plugin = *get_styled_jsx_transform_plugin(use_lightningcss).await?;
+    let styled_jsx_transform_plugin =
+        *get_styled_jsx_transform_plugin(use_lightningcss, versions).await?;
 
     // ModuleOptionsContext related options
     let tsconfig = get_typescript_transform_options(project_path);

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -13,7 +13,9 @@ use turbopack_binding::{
             compile_time_info::{
                 CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, FreeVarReferences,
             },
-            environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, ServerAddr},
+            environment::{
+                Environment, ExecutionEnvironment, NodeJsEnvironment, RuntimeVersions, ServerAddr,
+            },
             free_var_references,
             resolve::{parse::Request, pattern::Pattern},
         },
@@ -330,7 +332,7 @@ pub async fn get_server_module_options_context(
     });
 
     let use_lightningcss = *next_config.use_lightningcss().await?;
-    let versions = *env.runtime_versions().await?;
+    let versions = RuntimeVersions(Default::default()).cell();
 
     // EcmascriptTransformPlugins for custom transforms
     let styled_components_transform_plugin =

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
-    ecmascript::OptionTransformPlugin,
+    core::environment::RuntimeVersions, ecmascript::OptionTransformPlugin,
     ecmascript_plugin::transform::styled_jsx::StyledJsxTransformer,
 };
 
@@ -9,8 +9,11 @@ use turbopack_binding::turbopack::{
 #[turbo_tasks::function]
 pub async fn get_styled_jsx_transform_plugin(
     use_lightningcss: bool,
+    target_browsers: Vc<RuntimeVersions>,
 ) -> Result<Vc<OptionTransformPlugin>> {
+    let versions = *target_browsers.await?;
+
     Ok(Vc::cell(Some(Vc::cell(
-        Box::new(StyledJsxTransformer::new(use_lightningcss)) as _,
+        Box::new(StyledJsxTransformer::new(use_lightningcss, versions)) as _,
     ))))
 }

--- a/packages/next-swc/crates/next-custom-transforms/Cargo.toml
+++ b/packages/next-swc/crates/next-custom-transforms/Cargo.toml
@@ -38,8 +38,8 @@ turbopack-binding = { workspace = true, features = [
 ] }
 # To allow quote! macro works
 swc_core = { workspace = true, features = ["ecma_quote"]}
-react_remove_properties = "0.21.0"
-remove_console = "0.22.0"
+react_remove_properties = "0.22.0"
+remove_console = "0.23.0"
 
 [dev-dependencies]
 turbopack-binding = { workspace = true, features = [

--- a/packages/next-swc/crates/next-custom-transforms/Cargo.toml
+++ b/packages/next-swc/crates/next-custom-transforms/Cargo.toml
@@ -26,6 +26,8 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 sha1 = "0.10.1"
 tracing = { version = "0.1.37" }
 anyhow = { workspace = true }
+lazy_static = { workspace = true }
+lightningcss = {workspace = true}
 
 turbopack-binding = { workspace = true, features = [
   "__swc_core",

--- a/packages/next-swc/crates/next-custom-transforms/Cargo.toml
+++ b/packages/next-swc/crates/next-custom-transforms/Cargo.toml
@@ -38,8 +38,8 @@ turbopack-binding = { workspace = true, features = [
 ] }
 # To allow quote! macro works
 swc_core = { workspace = true, features = ["ecma_quote"]}
-react_remove_properties = "0.19.0"
-remove_console = "0.20.0"
+react_remove_properties = "0.21.0"
+remove_console = "0.22.0"
 
 [dev-dependencies]
 turbopack-binding = { workspace = true, features = [

--- a/packages/next-swc/crates/next-custom-transforms/Cargo.toml
+++ b/packages/next-swc/crates/next-custom-transforms/Cargo.toml
@@ -42,6 +42,7 @@ turbopack-binding = { workspace = true, features = [
 swc_core = { workspace = true, features = ["ecma_quote"]}
 react_remove_properties = "0.22.0"
 remove_console = "0.23.0"
+preset_env_base = "0.4.10"
 
 [dev-dependencies]
 turbopack-binding = { workspace = true, features = [

--- a/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
@@ -193,7 +193,7 @@ where
                             };
 
                             let output = ss.to_css(lightningcss::stylesheet::PrinterOptions {
-                                minify: true,
+                                minify: false,
                                 source_map: None,
                                 project_root: None,
                                 targets,

--- a/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
@@ -157,9 +157,9 @@ where
         .config
         .env
         .as_ref()
-        .map(|env| {
-            env.targets.and_then(|v| match v {
-                turbopack_binding::swc::core::ecma::preset_env::Targets::Versions(v) => v,
+        .and_then(|env| {
+            env.targets.as_ref().map(|v| match v {
+                turbopack_binding::swc::core::ecma::preset_env::Targets::Versions(v) => *v,
                 _ => {
                     unreachable!(
                         "env.targets should be `Versions`. next-swc should pass Versions after \
@@ -168,7 +168,6 @@ where
                 }
             })
         })
-        .flatten()
         .unwrap_or_default();
 
     let styled_jsx = if let Some(config) = opts.styled_jsx {

--- a/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
@@ -193,7 +193,7 @@ where
                             };
 
                             let output = ss.to_css(lightningcss::stylesheet::PrinterOptions {
-                                minify: false,
+                                minify: true,
                                 source_map: None,
                                 project_root: None,
                                 targets,

--- a/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
@@ -185,16 +185,12 @@ where
                                 Default::default(),
                             );
 
-                            let mut ss = match ss {
+                            let ss = match ss {
                                 Ok(v) => v,
                                 Err(err) => {
                                     bail!("failed to parse css: {}", err)
                                 }
                             };
-                            ss.minify(lightningcss::stylesheet::MinifyOptions {
-                                targets,
-                                ..Default::default()
-                            })?;
 
                             let output = ss.to_css(lightningcss::stylesheet::PrinterOptions {
                                 minify: true,

--- a/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
@@ -4,6 +4,7 @@ use anyhow::bail;
 use either::Either;
 use fxhash::FxHashSet;
 use lightningcss::targets::Browsers;
+use preset_env_base::query::targets_to_versions;
 use serde::Deserialize;
 use swc_core::ecma::visit::as_folder;
 use turbopack_binding::swc::{
@@ -157,18 +158,7 @@ where
         .config
         .env
         .as_ref()
-        .and_then(|env| {
-            env.targets.as_ref().map(|v| match v {
-                turbopack_binding::swc::core::ecma::preset_env::Targets::Versions(v) => *v,
-                _ => {
-                    unreachable!(
-                        "env.targets should be `Versions`. next-swc should pass Versions after \
-                         invoking browserslist from js\nGot: {:?}",
-                        v
-                    )
-                }
-            })
-        })
+        .map(|env| targets_to_versions(env.targets.clone()).expect("failed to parse env.targets"))
         .unwrap_or_default();
 
     let styled_jsx = if let Some(config) = opts.styled_jsx {

--- a/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
@@ -163,7 +163,8 @@ where
                 _ => {
                     unreachable!(
                         "env.targets should be `Versions`. next-swc should pass Versions after \
-                         invoking browserslist from js"
+                         invoking browserslist from js\nGot: {:?}",
+                        v
                     )
                 }
             })

--- a/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
@@ -171,7 +171,7 @@ where
                     browsers: target_browsers,
                 },
                 turbopack_binding::swc::custom_transform::styled_jsx::visitor::NativeConfig {
-                    process_css: if config.use_lightningcss {
+                    process_css: if config.use_lightningcss || target_browsers.is_any_target() {
                         None
                     } else {
                         let targets = lightningcss::targets::Targets {

--- a/packages/next-swc/crates/next-custom-transforms/tests/loader/css-hygiene-1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/loader/css-hygiene-1/output.js
@@ -1,3 +1,3 @@
-var _defaultExport = new String("@media(max-width:870px){th.expiration-date-cell,td.expiration-date-cell{display:none}}");
+var _defaultExport = new String("@media(width<=870px){th.expiration-date-cell,td.expiration-date-cell{display:none}}");
 _defaultExport.__hash = "fd71bf06ba8860bb";
 export default _defaultExport;

--- a/packages/next-swc/crates/next-custom-transforms/tests/loader/css-hygiene-1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/loader/css-hygiene-1/output.js
@@ -1,3 +1,3 @@
-var _defaultExport = new String("@media(width<=870px){th.expiration-date-cell,td.expiration-date-cell{display:none}}");
+var _defaultExport = new String("@media(max-width:870px){th.expiration-date-cell,td.expiration-date-cell{display:none}}");
 _defaultExport.__hash = "fd71bf06ba8860bb";
 export default _defaultExport;

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -194,7 +194,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.2",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -194,7 +194,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.2",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240123.3",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.26.2
         version: 0.26.2
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240123.3
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240123.3(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25626,9 +25626,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240123.3(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240123.3}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240123.3'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.26.2
         version: 0.26.2
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25626,9 +25626,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?9b910c81b7f84f5296d37c55a3a0f3605e7450e1'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/test/development/pages-dir/client-navigation/rendering.ts
+++ b/test/development/pages-dir/client-navigation/rendering.ts
@@ -226,10 +226,9 @@ export default function (next: NextInstance, render, fetch, ctx) {
       const styleId = $('#blue-box').attr('class')
       const style = $('style')
 
-      expect(
-        style.text().includes(`p.${styleId}{color:blue`) ||
-          style.text().includes(`p.${styleId}{color:#00f`)
-      ).toBeTruthy()
+      expect(style.text()).toMatch(
+        new RegExp(`p.${styleId}{color:(?:blue|#00f)`)
+      )
     })
 
     test('renders styled jsx external', async () => {
@@ -237,10 +236,9 @@ export default function (next: NextInstance, render, fetch, ctx) {
       const styleId = $('#blue-box').attr('class')
       const style = $('style')
 
-      expect(
-        style.text().includes(`p.${styleId}{color:blue`) ||
-          style.text().includes(`p.${styleId}{color:#00f`)
-      ).toBeTruthy()
+      expect(style.text()).toMatch(
+        new RegExp(`p.${styleId}{color:(?:blue|#00f)`)
+      )
     })
 
     test('renders properties populated asynchronously', async () => {

--- a/test/development/pages-dir/client-navigation/rendering.ts
+++ b/test/development/pages-dir/client-navigation/rendering.ts
@@ -226,7 +226,7 @@ export default function (next: NextInstance, render, fetch, ctx) {
       const styleId = $('#blue-box').attr('class')
       const style = $('style')
 
-      expect(style.text().includes(`p.${styleId}{color:blue`)).toBeTruthy()
+      expect(style.text().includes(`p.${styleId}{color:#00f`)).toBeTruthy()
     })
 
     test('renders styled jsx external', async () => {
@@ -234,7 +234,7 @@ export default function (next: NextInstance, render, fetch, ctx) {
       const styleId = $('#blue-box').attr('class')
       const style = $('style')
 
-      expect(style.text().includes(`p.${styleId}{color:blue`)).toBeTruthy()
+      expect(style.text().includes(`p.${styleId}{color:#00f`)).toBeTruthy()
     })
 
     test('renders properties populated asynchronously', async () => {

--- a/test/development/pages-dir/client-navigation/rendering.ts
+++ b/test/development/pages-dir/client-navigation/rendering.ts
@@ -226,7 +226,10 @@ export default function (next: NextInstance, render, fetch, ctx) {
       const styleId = $('#blue-box').attr('class')
       const style = $('style')
 
-      expect(style.text().includes(`p.${styleId}{color:blue`)).toBeTruthy()
+      expect(
+        style.text().includes(`p.${styleId}{color:blue`) ||
+          style.text().includes(`p.${styleId}{color:#00f`)
+      ).toBeTruthy()
     })
 
     test('renders styled jsx external', async () => {
@@ -234,7 +237,10 @@ export default function (next: NextInstance, render, fetch, ctx) {
       const styleId = $('#blue-box').attr('class')
       const style = $('style')
 
-      expect(style.text().includes(`p.${styleId}{color:blue`)).toBeTruthy()
+      expect(
+        style.text().includes(`p.${styleId}{color:blue`) ||
+          style.text().includes(`p.${styleId}{color:#00f`)
+      ).toBeTruthy()
     })
 
     test('renders properties populated asynchronously', async () => {

--- a/test/development/pages-dir/client-navigation/rendering.ts
+++ b/test/development/pages-dir/client-navigation/rendering.ts
@@ -226,7 +226,7 @@ export default function (next: NextInstance, render, fetch, ctx) {
       const styleId = $('#blue-box').attr('class')
       const style = $('style')
 
-      expect(style.text().includes(`p.${styleId}{color:#00f`)).toBeTruthy()
+      expect(style.text().includes(`p.${styleId}{color:blue`)).toBeTruthy()
     })
 
     test('renders styled jsx external', async () => {
@@ -234,7 +234,7 @@ export default function (next: NextInstance, render, fetch, ctx) {
       const styleId = $('#blue-box').attr('class')
       const style = $('style')
 
-      expect(style.text().includes(`p.${styleId}{color:#00f`)).toBeTruthy()
+      expect(style.text().includes(`p.${styleId}{color:blue`)).toBeTruthy()
     })
 
     test('renders properties populated asynchronously', async () => {

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -340,7 +340,7 @@ createNextDescribe(
 
       // from styled-jsx
       expect(head).toMatch(/{color:(\s*)purple;?}/) // styled-jsx/style
-      expect(head).toMatch(/{color:(\s*)hotpink;?}/) // styled-jsx/css
+      expect(head).toMatch(/{color:(\s*)(?:hotpink|#ff69b4);?}/) // styled-jsx/css
 
       // from styled-components
       expect(head).toMatch(/{color:(\s*)(?:blue|#00f);?}/)

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -343,7 +343,7 @@ createNextDescribe(
       expect(head).toMatch(/{color:(\s*)hotpink;?}/) // styled-jsx/css
 
       // from styled-components
-      expect(head).toMatch(/{color:(\s*)blue;?}/)
+      expect(head).toMatch(/{color:(\s*)(?:blue|#00f);?}/)
     })
 
     it('should render initial styles of css-in-js in edge SSR correctly', async () => {
@@ -352,10 +352,10 @@ createNextDescribe(
 
       // from styled-jsx
       expect(head).toMatch(/{color:(\s*)purple;?}/) // styled-jsx/style
-      expect(head).toMatch(/{color:(\s*)hotpink;?}/) // styled-jsx/css
+      expect(head).toMatch(/{color:(\s*)(?:hotpink|#ff69b4);?}/) // styled-jsx/css
 
       // from styled-components
-      expect(head).toMatch(/{color:(\s*)blue;?}/)
+      expect(head).toMatch(/{color:(\s*)(?:blue|#00f);?}/)
     })
 
     it('should render css-in-js suspense boundary correctly', async () => {

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -343,7 +343,7 @@ createNextDescribe(
       expect(head).toMatch(/{color:(\s*)hotpink;?}/) // styled-jsx/css
 
       // from styled-components
-      expect(head).toMatch(/{color:(\s*)blue;?}/)
+      expect(head).toMatch(/{color:(\s*)#00f;?}/)
     })
 
     it('should render initial styles of css-in-js in edge SSR correctly', async () => {
@@ -355,7 +355,7 @@ createNextDescribe(
       expect(head).toMatch(/{color:(\s*)hotpink;?}/) // styled-jsx/css
 
       // from styled-components
-      expect(head).toMatch(/{color:(\s*)blue;?}/)
+      expect(head).toMatch(/{color:(\s*)#00f;?}/)
     })
 
     it('should render css-in-js suspense boundary correctly', async () => {

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -343,7 +343,7 @@ createNextDescribe(
       expect(head).toMatch(/{color:(\s*)#ff69b4;?}/) // styled-jsx/css
 
       // from styled-components
-      expect(head).toMatch(/{color:(\s*)#00f;?}/)
+      expect(head).toMatch(/{color:(\s*)blue;?}/)
     })
 
     it('should render initial styles of css-in-js in edge SSR correctly', async () => {
@@ -355,7 +355,7 @@ createNextDescribe(
       expect(head).toMatch(/{color:(\s*)#ff69b4;?}/) // styled-jsx/css
 
       // from styled-components
-      expect(head).toMatch(/{color:(\s*)#00f;?}/)
+      expect(head).toMatch(/{color:(\s*)blue;?}/)
     })
 
     it('should render css-in-js suspense boundary correctly', async () => {

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -340,7 +340,7 @@ createNextDescribe(
 
       // from styled-jsx
       expect(head).toMatch(/{color:(\s*)purple;?}/) // styled-jsx/style
-      expect(head).toMatch(/{color:(\s*)hotpink;?}/) // styled-jsx/css
+      expect(head).toMatch(/{color:(\s*)#ff69b4;?}/) // styled-jsx/css
 
       // from styled-components
       expect(head).toMatch(/{color:(\s*)#00f;?}/)
@@ -352,7 +352,7 @@ createNextDescribe(
 
       // from styled-jsx
       expect(head).toMatch(/{color:(\s*)purple;?}/) // styled-jsx/style
-      expect(head).toMatch(/{color:(\s*)hotpink;?}/) // styled-jsx/css
+      expect(head).toMatch(/{color:(\s*)#ff69b4;?}/) // styled-jsx/css
 
       // from styled-components
       expect(head).toMatch(/{color:(\s*)#00f;?}/)

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -340,7 +340,7 @@ createNextDescribe(
 
       // from styled-jsx
       expect(head).toMatch(/{color:(\s*)purple;?}/) // styled-jsx/style
-      expect(head).toMatch(/{color:(\s*)#ff69b4;?}/) // styled-jsx/css
+      expect(head).toMatch(/{color:(\s*)hotpink;?}/) // styled-jsx/css
 
       // from styled-components
       expect(head).toMatch(/{color:(\s*)blue;?}/)
@@ -352,7 +352,7 @@ createNextDescribe(
 
       // from styled-jsx
       expect(head).toMatch(/{color:(\s*)purple;?}/) // styled-jsx/style
-      expect(head).toMatch(/{color:(\s*)#ff69b4;?}/) // styled-jsx/css
+      expect(head).toMatch(/{color:(\s*)hotpink;?}/) // styled-jsx/css
 
       // from styled-components
       expect(head).toMatch(/{color:(\s*)blue;?}/)

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -27,7 +27,7 @@ createNextDescribe(
 
     it('should render styled-jsx styles in streaming', async () => {
       const html = await renderViaHTTP(next.url, '/')
-      expect(html).toContain(/color:(?:blue|#00f)/)
+      expect(html).toMatch(/color:(?:blue|#00f)/)
     })
 
     it('should redirect paths without trailing-slash and render when slash is appended', async () => {

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -27,7 +27,7 @@ createNextDescribe(
 
     it('should render styled-jsx styles in streaming', async () => {
       const html = await renderViaHTTP(next.url, '/')
-      expect(html).toContain('color:blue')
+      expect(html).toContain('color:#00f')
     })
 
     it('should redirect paths without trailing-slash and render when slash is appended', async () => {

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -27,7 +27,7 @@ createNextDescribe(
 
     it('should render styled-jsx styles in streaming', async () => {
       const html = await renderViaHTTP(next.url, '/')
-      expect(html).toContain('color:#00f')
+      expect(html).toContain('color:blue')
     })
 
     it('should redirect paths without trailing-slash and render when slash is appended', async () => {

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -27,7 +27,7 @@ createNextDescribe(
 
     it('should render styled-jsx styles in streaming', async () => {
       const html = await renderViaHTTP(next.url, '/')
-      expect(html).toContain('color:blue')
+      expect(html).toContain(/color:(?:blue|#00f)/)
     })
 
     it('should redirect paths without trailing-slash and render when slash is appended', async () => {

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -230,7 +230,7 @@ describe('AMP Usage', () => {
         const html = await renderViaHTTP(appPort, '/styled?amp=1')
         const $ = cheerio.load(html)
         expect($('style[amp-custom]').first().text()).toMatch(
-          /div.jsx-[a-zA-Z0-9]{1,}{color:red}span.jsx-[a-zA-Z0-9]{1,}{color:#00f}body{background-color:green}/
+          /div.jsx-[a-zA-Z0-9]{1,}{color:red}span.jsx-[a-zA-Z0-9]{1,}{color:blue}body{background-color:green}/
         )
       })
 

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -230,7 +230,7 @@ describe('AMP Usage', () => {
         const html = await renderViaHTTP(appPort, '/styled?amp=1')
         const $ = cheerio.load(html)
         expect($('style[amp-custom]').first().text()).toMatch(
-          /div.jsx-[a-zA-Z0-9]{1,}{color:red}span.jsx-[a-zA-Z0-9]{1,}{color:blue}body{background-color:green}/
+          /div.jsx-[a-zA-Z0-9]{1,}{color:red}span.jsx-[a-zA-Z0-9]{1,}{color:(?:blue|#00f)}body{background-color:green}/
         )
       })
 

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -230,7 +230,7 @@ describe('AMP Usage', () => {
         const html = await renderViaHTTP(appPort, '/styled?amp=1')
         const $ = cheerio.load(html)
         expect($('style[amp-custom]').first().text()).toMatch(
-          /div.jsx-[a-zA-Z0-9]{1,}{color:red}span.jsx-[a-zA-Z0-9]{1,}{color:blue}body{background-color:green}/
+          /div.jsx-[a-zA-Z0-9]{1,}{color:red}span.jsx-[a-zA-Z0-9]{1,}{color:#00f}body{background-color:green}/
         )
       })
 

--- a/test/integration/react-18/test/concurrent.js
+++ b/test/integration/react-18/test/concurrent.js
@@ -21,7 +21,7 @@ export default (context, _render) => {
       context.appPort,
       '/use-flush-effect/styled-jsx'
     )
-    const stylesOccurrence = html.match(/color:(\s)*blue/g) || []
+    const stylesOccurrence = html.match(/color:(\s)*(?:blue|#00f)/g) || []
     expect(stylesOccurrence.length).toBe(1)
 
     await withBrowser('/use-flush-effect/styled-jsx', async (browser) => {

--- a/test/integration/react-18/test/concurrent.js
+++ b/test/integration/react-18/test/concurrent.js
@@ -21,7 +21,7 @@ export default (context, _render) => {
       context.appPort,
       '/use-flush-effect/styled-jsx'
     )
-    const stylesOccurrence = html.match(/color:(\s)*#00f/g) || []
+    const stylesOccurrence = html.match(/color:(\s)*blue/g) || []
     expect(stylesOccurrence.length).toBe(1)
 
     await withBrowser('/use-flush-effect/styled-jsx', async (browser) => {

--- a/test/integration/react-18/test/concurrent.js
+++ b/test/integration/react-18/test/concurrent.js
@@ -21,7 +21,7 @@ export default (context, _render) => {
       context.appPort,
       '/use-flush-effect/styled-jsx'
     )
-    const stylesOccurrence = html.match(/color:(\s)*blue/g) || []
+    const stylesOccurrence = html.match(/color:(\s)*#00f/g) || []
     expect(stylesOccurrence.length).toBe(1)
 
     await withBrowser('/use-flush-effect/styled-jsx', async (browser) => {

--- a/test/integration/react-18/test/concurrent.js
+++ b/test/integration/react-18/test/concurrent.js
@@ -27,7 +27,7 @@ export default (context, _render) => {
     await withBrowser('/use-flush-effect/styled-jsx', async (browser) => {
       await check(
         () => browser.waitForElementByCss('#__jsx-900f996af369fc74').text(),
-        /blue/
+        /(?:blue|#00f)/
       )
       await check(
         () => browser.waitForElementByCss('#__jsx-8b0811664c4e575e').text(),


### PR DESCRIPTION
# Turbopack

* https://github.com/vercel/turbo/pull/7027 <!-- Donny/강동윤 - Update `swc_core` to `v0.87.28`  -->

---

### What?

Update swc crates

### Why?

Required for #57718.
`styled-jsx` crate now have a hook to transform CSS code using a Rust-side API

### How?

Fixes #57718



Closes PACK-2256