### PR TITLE
chore: fix core team members

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -40,8 +40,7 @@
       { "type": "user", "pattern": "molebox" },
       { "type": "user", "pattern": "delbaoliveira" },
       { "type": "user", "pattern": "lydiahallie" },
-      { "type": "user", "pattern": "steven-tey" },
-      { "type": "user", "pattern": "stephdietz" },
+      { "type": "user", "pattern": "StephDietz" },
       { "type": "user", "pattern": "timeyoutakeit" },
       { "type": "user", "pattern": "s3prototype" },
       { "type": "user", "pattern": "manovotny" }

--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -42,12 +42,10 @@
       { "type": "user", "pattern": "lydiahallie" },
       { "type": "user", "pattern": "StephDietz" },
       { "type": "user", "pattern": "timeyoutakeit" },
-      { "type": "user", "pattern": "s3prototype" },
       { "type": "user", "pattern": "manovotny" }
     ],
     "created-by: turbopack team": [
       { "type": "user", "pattern": "ForsakenHarmony" },
-      { "type": "user", "pattern": "jridgewell" },
       { "type": "user", "pattern": "kdy1" },
       { "type": "user", "pattern": "kwonoj" },
       { "type": "user", "pattern": "padmaia" },


### PR DESCRIPTION
### What?

Removing an outdated entry, and fixing the casing of another so Workflow runs are auto-approved.

### Why?

https://github.com/vercel/next.js/pull/60574 fails the CI Workflow Run, because of a mismatch in GitHub actor and the actual username set in `labeler.json`

[Ref](https://github.com/vercel/nextjs-hive-docker/blob/c26bc3f26520b41986a0f9467fdc2529f705d81f/validate-job.js#L39-L42), [Slack thread](https://vercel.slack.com/archives/C03S9JCH2Q5/p1705684536884389?thread_ts=1705436555.494229&cid=C03S9JCH2Q5)

Closes NEXT-2172