### PR TITLE
Fix debugger port

### DIFF
--- a/packages/next/src/server/lib/utils.ts
+++ b/packages/next/src/server/lib/utils.ts
@@ -20,7 +20,15 @@ export const getDebugPort = () => {
       )
       ?.split('=', 2)[1] ??
     process.env.NODE_OPTIONS?.match?.(/--inspect(-brk)?(=(\S+))?( |$)/)?.[3]
-  return debugPortStr ? parseInt(debugPortStr, 10) : 9229
+  const matched = debugPortStr ? debugPortStr.match(/(?<=:)\d+$/) : undefined
+  let parsedDebugPort =
+    matched && Array.isArray(matched) && matched.length > 0
+      ? parseInt(matched[0], 10)
+      : 9229
+  if (!matched && debugPortStr) {
+    parsedDebugPort = parseInt(debugPortStr, 10)
+  }
+  return parsedDebugPort
 }
 
 const NODE_INSPECT_RE = /--inspect(-brk)?(=\S+)?( |$)/

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -559,6 +559,41 @@ describe('CLI Usage', () => {
       }
     })
 
+    const testAllIPsAndPorts = async (someIp) => {
+      const testIps = [
+        '0.0.0.0',
+        '127.0.0.1',
+        'localhost',
+        '192.168.18.90',
+        'barcos.co',
+        'app.barcos.co',
+      ]
+      for (const someIp of testIps) {
+        const port = await findPort()
+        test(`NODE_OPTIONS='--inspect=${someIp}:${port}'`, async () => {
+          let output = ''
+          const app = await runNextCommandDev(
+            [dirBasic, '--port', port],
+            undefined,
+            {
+              onStdout(msg) {
+                output += stripAnsi(msg)
+              },
+              env: { NODE_OPTIONS: `--inspect=${someIp}:${port}` },
+            }
+          )
+          try {
+            await check(() => output, new RegExp(`on ${someIp}:${port}`))
+            await check(() => output, new RegExp(`http://${someIp}:${port}`))
+          } finally {
+            await killApp(app)
+          }
+        })
+      }
+    }
+
+    testAllIPsAndPorts()
+
     test('-p', async () => {
       const port = await findPort()
       let output = ''

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -559,40 +559,37 @@ describe('CLI Usage', () => {
       }
     })
 
-    const testAllIPsAndPorts = async (someIp) => {
-      const testIps = [
+    test("NODE_OPTIONS='--inspect=<host>:<port>'", async () => {
+      const hosts = [
         '0.0.0.0',
         '127.0.0.1',
         'localhost',
         '192.168.18.90',
         'barcos.co',
         'app.barcos.co',
+        null,
       ]
-      for (const someIp of testIps) {
+      for (const someHost of hosts) {
         const port = await findPort()
-        test(`NODE_OPTIONS='--inspect=${someIp}:${port}'`, async () => {
-          let output = ''
-          const app = await runNextCommandDev(
-            [dirBasic, '--port', port],
-            undefined,
-            {
-              onStdout(msg) {
-                output += stripAnsi(msg)
-              },
-              env: { NODE_OPTIONS: `--inspect=${someIp}:${port}` },
-            }
-          )
-          try {
-            await check(() => output, new RegExp(`on ${someIp}:${port}`))
-            await check(() => output, new RegExp(`http://${someIp}:${port}`))
-          } finally {
-            await killApp(app)
+        let output = ''
+        const app = await runNextCommandDev(
+          [dirBasic, '--port', port],
+          undefined,
+          {
+            onStdout(msg) {
+              output += stripAnsi(msg)
+            },
+            env: { NODE_OPTIONS: `--inspect=${someHost}:${port}` },
           }
-        })
+        )
+        try {
+          await check(() => output, new RegExp(`on ${someHost}:${port}`))
+          await check(() => output, new RegExp(`http://${someHost}:${port}`))
+        } finally {
+          await killApp(app)
+        }
       }
-    }
-
-    testAllIPsAndPorts()
+    })
 
     test('-p', async () => {
       const port = await findPort()


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
# What?
This PR is clone of https://github.com/vercel/next.js/pull/53683 after Tim's recommendation. See https://github.com/vercel/next.js/pull/53683#issuecomment-1766187734

This enables debugging sessions from a remote host. This is helpful while debugging a Next.js application that runs inside a Docker container with following possibilities inside the `package.json`:

```
    "dev": "NODE_OPTIONS='--inspect=localhost:9250' next dev",
    "dev": "NODE_OPTIONS='--inspect=co.localhost:9250' next dev",
    "dev": "NODE_OPTIONS='--inspect=barcos.co:9250' next dev",
    "dev": "NODE_OPTIONS='--inspect=barcos.co.co.hzoe.com:9250' next dev",
    "dev": "NODE_OPTIONS='--inspect=0.0.0.0:9250' next dev",
    "dev": "NODE_OPTIONS='--inspect=9250' next dev",
    "dev": "NODE_OPTIONS='--inspect' next dev",
    "dev": "NODE_OPTIONS='--inspect=127.0.0.1:9250' next dev",
```

# Bug
This fixes:
- https://github.com/vercel/next.js/issues/53127
- https://github.com/vercel/next.js/issues/53757

Other "fixed" bugs
- https://github.com/vercel/next.js/issues/47083
- https://github.com/vercel/next.js/issues/50489



# Why?
It was an attempt to fix the bug, but it didn't work for all the cases. 
- https://github.com/vercel/next.js/pull/48019

Keep in mind that the default host will be `127.0.0.1`, and this will be blocked for external hosts trying to attach to the debugger. The `NODE_OPTIONS` should be set to `NODE_OPTIONS='--inspect=0.0.0.0:SOME_PORT'`. 
https://nodejs.org/en/docs/guides/debugging-getting-started#security-implications

# How? 

By improving the regex used for matching a debug port and adding some conditions to be met.