### PR TITLE
Refactor interception routes

### DIFF
--- a/packages/next/src/server/future/helpers/interception-routes.test.ts
+++ b/packages/next/src/server/future/helpers/interception-routes.test.ts
@@ -50,17 +50,17 @@ describe('Interception Route helper', () => {
       expect(() =>
         extractInterceptionRouteInformation('/foo/(..')
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid interception route: /foo/(... Must be in the format /<intercepting route>/(..|...|..)(..)/<intercepted route>"`
+        `"Invalid interception route: /foo/(... Must be in the format /<intercepting route>/(...)|(..)(..)|(..)|(.)<intercepted route>"`
       )
       expect(() =>
         extractInterceptionRouteInformation('/foo/..)/bar')
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid interception route: /foo/..)/bar. Must be in the format /<intercepting route>/(..|...|..)(..)/<intercepted route>"`
+        `"Invalid interception route: /foo/..)/bar. Must be in the format /<intercepting route>/(...)|(..)(..)|(..)|(.)<intercepted route>"`
       )
       expect(() =>
         extractInterceptionRouteInformation('/foo')
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid interception route: /foo. Must be in the format /<intercepting route>/(..|...|..)(..)/<intercepted route>"`
+        `"Invalid interception route: /foo. Must be in the format /<intercepting route>/(...)|(..)(..)|(..)|(.)<intercepted route>"`
       )
     })
     it('should check the segment length', () => {

--- a/packages/next/src/server/future/helpers/interception-routes.ts
+++ b/packages/next/src/server/future/helpers/interception-routes.ts
@@ -8,36 +8,24 @@ export const INTERCEPTION_ROUTE_MARKERS = [
   '(...)',
 ] as const
 
+export const INTERCEPTION_ROUTE_REGEXP =
+  /(?<interceptingRoute>.*\/)(?<marker>\(\.\.\)\(\.\.\)|\(\.{1,3}\))(?<interceptedRoute>.+)/
+
 export function isInterceptionRouteAppPath(path: string): boolean {
-  // TODO-APP: add more serious validation
-  return (
-    path
-      .split('/')
-      .find((segment) =>
-        INTERCEPTION_ROUTE_MARKERS.find((m) => segment.startsWith(m))
-      ) !== undefined
-  )
+  return Boolean(path.match(INTERCEPTION_ROUTE_REGEXP))
 }
 
 export function extractInterceptionRouteInformation(path: string) {
-  let interceptingRoute: string | undefined,
-    marker: (typeof INTERCEPTION_ROUTE_MARKERS)[number] | undefined,
-    interceptedRoute: string | undefined
+  const interceptedRouteMatch = path.match(INTERCEPTION_ROUTE_REGEXP)
 
-  for (const segment of path.split('/')) {
-    marker = INTERCEPTION_ROUTE_MARKERS.find((m) => segment.startsWith(m))
-    if (marker) {
-      ;[interceptingRoute, interceptedRoute] = path.split(marker, 2)
-      break
-    }
-  }
-
-  if (!interceptingRoute || !marker || !interceptedRoute) {
+  if (!interceptedRouteMatch?.groups) {
     throw new Error(
-      `Invalid interception route: ${path}. Must be in the format /<intercepting route>/(..|...|..)(..)/<intercepted route>`
+      `Invalid interception route: ${path}. Must be in the format /<intercepting route>/(...)|(..)(..)|(..)|(.)<intercepted route>`
     )
   }
 
+  let { interceptingRoute, marker, interceptedRoute } =
+    interceptedRouteMatch.groups
   interceptingRoute = normalizeAppPath(interceptingRoute) // normalize the path, e.g. /(blog)/feed -> /feed
 
   switch (marker) {


### PR DESCRIPTION
I saw a todo while editing basePath and finally got around to looking at it.

You had too many cycles and splits, when the exact same logic is perfectly executed by this quite simple regular expression.

P.S. Are there enough tests for for interception-routes or is it worth adding something?