### PR TITLE
Update userScalable property in viewport object and user-scalable in meta tag

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-viewport.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-viewport.mdx
@@ -127,7 +127,7 @@ export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
-  userScalable: 'no',
+  userScalable: false,
   // Also supported by less commonly used
   // interactiveWidget: 'resizes-visual',
 }
@@ -138,7 +138,7 @@ export const viewport = {
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
-  userScalable: 'no',
+  userScalable: false,
   // Also supported by less commonly used
   // interactiveWidget: 'resizes-visual',
 }
@@ -147,7 +147,7 @@ export const viewport = {
 ```html filename="<head> output" hideLineNumbers
 <meta
   name="viewport"
-  content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=1"
+  content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
 />
 ```
 


### PR DESCRIPTION
This PR introduces changes to the `generateViewport` documentation.

- Changes the line that says `userScalable: 'no'` to `userScalable: false` because according to **TypeScript** `userScalable` is of type `boolean | undefined` _because it's an optional property._
     - Whenever a **string** is used this error message is shown: `Type 'string' is not assignable to type 'boolean | undefined'.`
- Also updates `user-scalable` in meta tag from `user-scalable=1` to `user-scalable=no`
 
This is an extension of my previous PR where I omitted these: https://github.com/vercel/next.js/pull/60396#issue-2071093755