### PR TITLE
docs: updated the getStaticProps function name

### DIFF
--- a/docs/03-pages/02-api-reference/02-functions/get-static-props.mdx
+++ b/docs/03-pages/02-api-reference/02-functions/get-static-props.mdx
@@ -29,7 +29,7 @@ export default function Page({
 ```
 
 ```jsx filename="pages/index.js" switcher
-export async function getStaticPaths() {
+export async function getStaticProps() {
   const res = await fetch('https://api.github.com/repos/vercel/next.js')
   const repo = await res.json()
   return { props: { repo } }


### PR DESCRIPTION
Fix: function name getStaticPaths is written in getStaticProps function, issue exist in get-static-props.mdx under pages/api-reference/functions folder. This issue was pushed as part of -
Pull Request: 55205
Commit Id: 80fba152f2add326a1520ffd2b530d00c75983f6

![image](https://github.com/vercel/next.js/assets/55828197/90923d4e-9d7b-4bc3-aaf9-7f5ce377410e)

