### PR TITLE
Fix next phase for next build

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -803,7 +803,7 @@ export default async function build(
       )
 
       // Always log next version first then start rest jobs
-      const { envInfo, expFeatureInfo } = await getStartServerInfo(dir)
+      const { envInfo, expFeatureInfo } = await getStartServerInfo(dir, false)
       logStartInfo({
         networkUrl: null,
         appUrl: null,

--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -1,7 +1,10 @@
 import { loadEnvConfig } from '@next/env'
 import * as Log from '../../build/output/log'
 import { bold, purple } from '../../lib/picocolors'
-import { PHASE_DEVELOPMENT_SERVER } from '../../shared/lib/constants'
+import {
+  PHASE_DEVELOPMENT_SERVER,
+  PHASE_PRODUCTION_BUILD,
+} from '../../shared/lib/constants'
 import loadConfig, { getEnabledExperimentalFeatures } from '../config'
 
 export function logStartInfo({
@@ -50,21 +53,28 @@ export function logStartInfo({
   Log.info('')
 }
 
-export async function getStartServerInfo(dir: string): Promise<{
+export async function getStartServerInfo(
+  dir: string,
+  dev: boolean
+): Promise<{
   envInfo?: string[]
   expFeatureInfo?: string[]
 }> {
   let expFeatureInfo: string[] = []
-  await loadConfig(PHASE_DEVELOPMENT_SERVER, dir, {
-    onLoadUserConfig(userConfig) {
-      const userNextConfigExperimental = getEnabledExperimentalFeatures(
-        userConfig.experimental
-      )
-      expFeatureInfo = userNextConfigExperimental.sort(
-        (a, b) => a.length - b.length
-      )
-    },
-  })
+  await loadConfig(
+    dev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_BUILD,
+    dir,
+    {
+      onLoadUserConfig(userConfig) {
+        const userNextConfigExperimental = getEnabledExperimentalFeatures(
+          userConfig.experimental
+        )
+        expFeatureInfo = userNextConfigExperimental.sort(
+          (a, b) => a.length - b.length
+        )
+      },
+    }
+  )
 
   // we need to reset env if we are going to create
   // the worker process with the esm loader so that the

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -251,7 +251,7 @@ export async function startServer(
       let envInfo: string[] | undefined
       let expFeatureInfo: string[] | undefined
       if (isDev) {
-        const startServerInfo = await getStartServerInfo(dir)
+        const startServerInfo = await getStartServerInfo(dir, isDev)
         envInfo = startServerInfo.envInfo
         expFeatureInfo = startServerInfo.expFeatureInfo
       }

--- a/test/e2e/next-phase/index.test.ts
+++ b/test/e2e/next-phase/index.test.ts
@@ -1,0 +1,42 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'next-phase',
+  {
+    files: {
+      'app/layout.js': `export default function Layout({ children }) {
+        return <html><body>{children}</body></html>
+      }`,
+      'app/page.js': `export default function Page() { return <p>{'app'}</p> }`,
+      'pages/foo.js': `export default function Page() { return <p>{'pages'}</p> }`,
+      'next.config.js': `
+        module.exports = (phase, { defaultConfig }) => {
+          console.log('phase:', phase)
+          return defaultConfig
+        }
+      `,
+    },
+  },
+  ({ next, isNextDev }) => {
+    it('should render page with next phase correctly', async () => {
+      const phases = {
+        dev: 'phase-development-server',
+        build: 'phase-production-build',
+      }
+      const currentPhase = isNextDev ? phases.dev : phases.build
+      const nonExistedPhase = isNextDev ? phases.build : phases.dev
+
+      expect(next.cliOutput).toContain(currentPhase)
+      expect(next.cliOutput).not.toContain(nonExistedPhase)
+
+      await next.fetch('/')
+      await next.fetch('/foo')
+
+      if (isNextDev) {
+        expect(next.cliOutput).not.toContain('phase-production-server')
+      } else {
+        expect(next.cliOutput).toContain('phase-production-server')
+      }
+    })
+  }
+)

--- a/test/e2e/next-phase/index.test.ts
+++ b/test/e2e/next-phase/index.test.ts
@@ -11,7 +11,7 @@ createNextDescribe(
       'pages/foo.js': `export default function Page() { return <p>{'pages'}</p> }`,
       'next.config.js': `
         module.exports = (phase, { defaultConfig }) => {
-          console.log('phase:', phase)
+          console.log(phase)
           return defaultConfig
         }
       `,
@@ -22,6 +22,7 @@ createNextDescribe(
       const phases = {
         dev: 'phase-development-server',
         build: 'phase-production-build',
+        start: 'phase-production-server',
       }
       const currentPhase = isNextDev ? phases.dev : phases.build
       const nonExistedPhase = isNextDev ? phases.build : phases.dev
@@ -33,9 +34,9 @@ createNextDescribe(
       await next.fetch('/foo')
 
       if (isNextDev) {
-        expect(next.cliOutput).not.toContain('phase-production-server')
+        expect(next.cliOutput).not.toContain(phases.start)
       } else {
-        expect(next.cliOutput).toContain('phase-production-server')
+        expect(next.cliOutput).toContain(phases.start)
       }
     })
   }


### PR DESCRIPTION
In both dev server and production build we both use `getStartServerInfo` to log the basic info but for prod build we should always respect to use "build" phase 

Fixes #57927 
Closes NEXT-2179