### PR TITLE
Fix gtm and ga custom data layer name support

### DIFF
--- a/packages/third-parties/src/google/ga.tsx
+++ b/packages/third-parties/src/google/ga.tsx
@@ -20,6 +20,8 @@ export function GoogleAnalytics(props: GAParams) {
     currDataLayerName = dataLayerName
   }
 
+  const gaLayer = dataLayerName !== 'dataLayer' ? `&l=${dataLayerName}` : ''
+
   useEffect(() => {
     // performance.mark is being used as a feature use signal. While it is traditionally used for performance
     // benchmarking it is low overhead and thus considered safe to use in production and it is a widely available
@@ -48,7 +50,7 @@ export function GoogleAnalytics(props: GAParams) {
       />
       <Script
         id="_next-ga"
-        src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+        src={`https://www.googletagmanager.com/gtag/js?id=${gaId}${gaLayer}`}
       />
     </>
   )

--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -14,7 +14,7 @@ export function GoogleTagManager(props: GTMParams) {
     currDataLayerName = dataLayerName
   }
 
-  const gtmLayer = dataLayerName !== 'dataLayer' ? `$l=${dataLayerName}` : ''
+  const gtmLayer = dataLayerName !== 'dataLayer' ? `&l=${dataLayerName}` : ''
   const gtmAuth = auth ? `&gtm_auth=${auth}` : ''
   const gtmPreview = preview ? `&gtm_preview=${preview}&gtm_cookies_win=x` : ''
 


### PR DESCRIPTION
The `dataLayerName` prop of the `<GoogleTagManager />` and `<GoogleAnalytics />` components is broken. This PR is submitted to address this issue.
