### PR TITLE
Fix image-optimizer tests for Turbopack

### DIFF
--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -1320,6 +1320,12 @@ export const setupTests = (ctx) => {
       }
 
       beforeAll(async () => {
+        const json = JSON.stringify({
+          experimental: {
+            outputFileTracingRoot: join(__dirname, '../../../..'),
+          },
+        })
+        nextConfig.replace('{ /* replaceme */ }', json)
         curCtx.nextOutput = ''
         curCtx.appPort = await findPort()
         curCtx.app = await launchApp(curCtx.appDir, curCtx.appPort, {
@@ -1336,6 +1342,7 @@ export const setupTests = (ctx) => {
         await cleanImagesDir(ctx)
       })
       afterAll(async () => {
+        nextConfig.restore()
         if (curCtx.app) await killApp(curCtx.app)
       })
 
@@ -1365,6 +1372,9 @@ export const setupTests = (ctx) => {
       beforeAll(async () => {
         const json = JSON.stringify({
           images: curCtx.nextConfigImages,
+          experimental: {
+            outputFileTracingRoot: join(__dirname, '../../../..'),
+          },
         })
         curCtx.nextOutput = ''
         nextConfig.replace('{ /* replaceme */ }', json)
@@ -1403,6 +1413,12 @@ export const setupTests = (ctx) => {
           isDev: false,
         }
         beforeAll(async () => {
+          const json = JSON.stringify({
+            experimental: {
+              outputFileTracingRoot: join(__dirname, '../../../..'),
+            },
+          })
+          nextConfig.replace('{ /* replaceme */ }', json)
           curCtx.nextOutput = ''
           await nextBuild(curCtx.appDir)
           await cleanImagesDir(ctx)
@@ -1420,6 +1436,7 @@ export const setupTests = (ctx) => {
           })
         })
         afterAll(async () => {
+          nextConfig.restore()
           if (curCtx.app) await killApp(curCtx.app)
         })
 
@@ -1452,6 +1469,9 @@ export const setupTests = (ctx) => {
       beforeAll(async () => {
         const json = JSON.stringify({
           images: curCtx.nextConfigImages,
+          experimental: {
+            outputFileTracingRoot: join(__dirname, '../../../..'),
+          },
         })
         curCtx.nextOutput = ''
         nextConfig.replace('{ /* replaceme */ }', json)


### PR DESCRIPTION
## What?

There were a bunch of Sharp related tests failing when running the test suite with Turbopack. The reason for this was that we automatically detect the root of the project based on the closest lockfile (i.e. package-lock.json). In this particular test a new package-lock.json was added and since this suite is not yet isolated it cases problems.

This PR adds `outputFileTracingRoot` to explicitly provide the root of the project, which ensures the right files are resolved. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2180