### PR TITLE
Rust: update `http` to 0.2.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
This aligns the version with that in https://github.com/vercel/turbo


Closes PACK-2272