### PR TITLE
chore: stricter reproduction links

### DIFF
--- a/.github/workflows/issue_validator.yml
+++ b/.github/workflows/issue_validator.yml
@@ -30,7 +30,7 @@ jobs:
             }
           reproduction-comment: '.github/invalid-link.md'
           reproduction-hosts: 'github.com,codesandbox.io'
-          reproduction-blocklist: 'github.com/vercel/next.js.*,github.com/\w*/?$,github.com'
+          reproduction-blocklist: 'github.com/vercel/next.js.*,github.com/\\w*/?$,github.com'
           reproduction-link-section: '### Link to the code that reproduces this issue(.*)### To Reproduce'
           reproduction-invalid-label: 'invalid link'
           reproduction-issue-labels: 'template: bug'

--- a/.github/workflows/issue_validator.yml
+++ b/.github/workflows/issue_validator.yml
@@ -30,7 +30,7 @@ jobs:
             }
           reproduction-comment: '.github/invalid-link.md'
           reproduction-hosts: 'github.com,codesandbox.io'
-          reproduction-blocklist: 'github.com/vercel/next.js.*'
+          reproduction-blocklist: 'github.com/vercel/next.js.*,github.com/\w*/?$,github.com'
           reproduction-link-section: '### Link to the code that reproduces this issue(.*)### To Reproduce'
           reproduction-invalid-label: 'invalid link'
           reproduction-issue-labels: 'template: bug'


### PR DESCRIPTION
### What?

Add some regex patterns to not allow certain github links as reproduction URLs

### Why?

See https://github.com/vercel/next.js/issues/58248

### How?

See https://github.com/balazsorban44/nissuer#validate-reproduction-urls


Closes NEXT-2185