### PR TITLE
Improve the Server Actions SWC transform

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -47,23 +47,24 @@ pub fn server_actions<C: Comments>(
         in_default_export_decl: false,
         has_action: false,
 
-        ident_cnt: 0,
-        in_module: true,
+        action_cnt: 0,
+        in_module_level: true,
         in_action_fn: false,
-        in_action_closure: false,
-        closure_idents: Default::default(),
-        action_closure_idents: Default::default(),
+        should_track_names: false,
+
+        names: Default::default(),
+        declared_idents: Default::default(),
+
         exported_idents: Default::default(),
-        inlined_action_closure_idents: Default::default(),
 
         // This flag allows us to rewrite `function foo() {}` to `const foo = createProxy(...)`.
         rewrite_fn_decl_to_proxy_decl: None,
         rewrite_default_fn_expr_to_proxy_expr: None,
+        rewrite_expr_to_proxy_expr: None,
 
         annotations: Default::default(),
         extra_items: Default::default(),
         export_actions: Default::default(),
-        replaced_action_proxies: Default::default(),
     })
 }
 
@@ -88,21 +89,21 @@ struct ServerActions<C: Comments> {
     in_default_export_decl: bool,
     has_action: bool,
 
-    ident_cnt: u32,
-    in_module: bool,
+    action_cnt: u32,
+    in_module_level: bool,
     in_action_fn: bool,
-    in_action_closure: bool,
-    closure_idents: Vec<Id>,
-    action_closure_idents: Vec<Name>,
-    inlined_action_closure_idents: Vec<(Id, Id)>,
+    should_track_names: bool,
+
+    names: Vec<Name>,
+    declared_idents: Vec<Id>,
 
     // This flag allows us to rewrite `function foo() {}` to `const foo = createProxy(...)`.
     rewrite_fn_decl_to_proxy_decl: Option<VarDecl>,
     rewrite_default_fn_expr_to_proxy_expr: Option<Box<Expr>>,
+    rewrite_expr_to_proxy_expr: Option<Box<Expr>>,
 
     // (ident, export name)
     exported_idents: Vec<(Id, String)>,
-    replaced_action_proxies: Vec<(Ident, Box<Expr>)>,
 
     annotations: Vec<Stmt>,
     extra_items: Vec<ModuleItem>,
@@ -149,38 +150,16 @@ impl<C: Comments> ServerActions<C> {
 
     fn maybe_hoist_and_create_proxy(
         &mut self,
-        ident: &Ident,
+        ids_from_closure: Vec<Name>,
         function: Option<&mut Box<Function>>,
         arrow: Option<&mut ArrowExpr>,
-    ) -> (Option<Box<Expr>>, Option<Box<Expr>>) {
-        let action_name: JsWord = gen_ident(&mut self.ident_cnt);
+    ) -> Option<Box<Expr>> {
+        let action_name: JsWord = gen_ident(&mut self.action_cnt);
         let action_ident = private_ident!(action_name.clone());
-
-        if !self.in_action_file {
-            self.inlined_action_closure_idents
-                .push((ident.to_id(), action_ident.to_id()));
-        }
-
         let export_name: JsWord = action_name;
 
         self.has_action = true;
         self.export_actions.push(export_name.to_string());
-
-        // Hoist the function to the top level and export it. To hoist it, we need to
-        // first Collect all the identifiers defined in the closure and used
-        // in the action function. Dedup the identifiers.
-        let mut added_ids = Vec::new();
-        let mut ids_from_closure = self.action_closure_idents.clone();
-        ids_from_closure.retain(|id| {
-            if added_ids.contains(id) {
-                false
-            } else if self.closure_idents.contains(&id.0) {
-                added_ids.push(id.clone());
-                true
-            } else {
-                false
-            }
-        });
 
         if let Some(a) = arrow {
             let register_action_expr = annotate_ident_as_action(
@@ -198,9 +177,6 @@ impl<C: Comments> ServerActions<C> {
                 block.visit_mut_with(&mut ClosureReplacer {
                     used_ids: &ids_from_closure,
                 });
-
-                self.replaced_action_proxies
-                    .push((ident.clone(), Box::new(register_action_expr.clone())));
             }
 
             // export const $ACTION_myAction = async () => {}
@@ -309,10 +285,7 @@ impl<C: Comments> ServerActions<C> {
                     .into(),
                 })));
 
-            return (
-                Some(Box::new(Expr::Ident(ident.clone()))),
-                Some(Box::new(register_action_expr)),
-            );
+            return Some(Box::new(register_action_expr.clone()));
         } else if let Some(f) = function {
             let register_action_expr = annotate_ident_as_action(
                 action_ident.clone(),
@@ -328,9 +301,6 @@ impl<C: Comments> ServerActions<C> {
             f.body.visit_mut_with(&mut ClosureReplacer {
                 used_ids: &ids_from_closure,
             });
-
-            self.replaced_action_proxies
-                .push((ident.clone(), Box::new(register_action_expr.clone())));
 
             // export async function $ACTION_myAction () {}
             let mut new_params: Vec<Param> = vec![];
@@ -411,13 +381,10 @@ impl<C: Comments> ServerActions<C> {
                     .into(),
                 })));
 
-            return (
-                Some(Box::new(Expr::Ident(ident.clone()))),
-                Some(Box::new(register_action_expr)),
-            );
+            return Some(Box::new(register_action_expr));
         }
 
-        (None, None)
+        None
     }
 }
 
@@ -451,29 +418,34 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     fn visit_mut_fn_expr(&mut self, f: &mut FnExpr) {
-        let is_action_fn = self.get_action_info(f.function.body.as_mut(), false);
+        let is_action_fn = self.get_action_info(f.function.body.as_mut(), true);
 
+        let current_declared_idents = self.declared_idents.clone();
+        let current_names = self.names.clone();
+        self.names = vec![];
+
+        // Visit children
         {
-            // Visit children
             let old_in_action_fn = self.in_action_fn;
-            let old_in_module = self.in_module;
-            let old_in_action_closure = self.in_action_closure;
+            let old_in_module = self.in_module_level;
+            let old_should_track_names = self.should_track_names;
             let old_in_export_decl = self.in_export_decl;
             let old_in_default_export_decl = self.in_default_export_decl;
-            let old_closure_idents = self.closure_idents.clone();
             self.in_action_fn = is_action_fn;
-            self.in_module = false;
-            self.in_action_closure = true;
+            self.in_module_level = false;
+            self.should_track_names = true;
             self.in_export_decl = false;
             self.in_default_export_decl = false;
             f.visit_mut_children_with(self);
             self.in_action_fn = old_in_action_fn;
-            self.in_module = old_in_module;
-            self.in_action_closure = old_in_action_closure;
+            self.in_module_level = old_in_module;
+            self.should_track_names = old_should_track_names;
             self.in_export_decl = old_in_export_decl;
             self.in_default_export_decl = old_in_default_export_decl;
-            self.closure_idents = old_closure_idents;
         }
+
+        let mut child_names = self.names.clone();
+        self.names.extend(current_names);
 
         if !is_action_fn {
             return;
@@ -487,25 +459,32 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             });
         }
 
-        if !self.in_action_file && self.in_default_export_decl {
-            // This function expression is also the default export:
-            // `export default async function() {}`
-            // In this case, we need to collect the action and hoist, because this specific
-            // case (default export) isn't handled by `visit_mut_expr`.
-            let ident = match f.ident.as_mut() {
+        if !self.in_action_file {
+            match f.ident.as_mut() {
                 None => {
-                    let action_name = gen_ident(&mut self.ident_cnt);
+                    let action_name = gen_ident(&mut self.action_cnt);
                     let ident = Ident::new(action_name, DUMMY_SP);
                     f.ident.insert(ident)
                 }
                 Some(i) => i,
             };
 
-            let (_, register_action_expr) =
-                self.maybe_hoist_and_create_proxy(ident, Some(&mut f.function), None);
+            // Collect all the identifiers defined inside the closure and used
+            // in the action function. With deduplication.
+            retain_names_from_declared_idents(&mut child_names, &current_declared_idents);
 
-            // Replace the original function expr with a action proxy expr.
-            self.rewrite_default_fn_expr_to_proxy_expr = register_action_expr;
+            let maybe_new_expr =
+                self.maybe_hoist_and_create_proxy(child_names, Some(&mut f.function), None);
+
+            if self.in_default_export_decl {
+                // This function expression is also the default export:
+                // `export default async function() {}`
+                // This specific case (default export) isn't handled by `visit_mut_expr`.
+                // Replace the original function expr with a action proxy expr.
+                self.rewrite_default_fn_expr_to_proxy_expr = maybe_new_expr;
+            } else {
+                self.rewrite_expr_to_proxy_expr = maybe_new_expr;
+            }
         }
     }
 
@@ -523,27 +502,32 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     fn visit_mut_fn_decl(&mut self, f: &mut FnDecl) {
         let is_action_fn = self.get_action_info(f.function.body.as_mut(), true);
 
+        let current_declared_idents = self.declared_idents.clone();
+        let current_names = self.names.clone();
+        self.names = vec![];
+
         {
             // Visit children
             let old_in_action_fn = self.in_action_fn;
-            let old_in_module = self.in_module;
-            let old_in_action_closure = self.in_action_closure;
+            let old_in_module = self.in_module_level;
+            let old_should_track_names = self.should_track_names;
             let old_in_export_decl = self.in_export_decl;
             let old_in_default_export_decl = self.in_default_export_decl;
-            let old_closure_idents = self.closure_idents.clone();
             self.in_action_fn = is_action_fn;
-            self.in_module = false;
-            self.in_action_closure = true;
+            self.in_module_level = false;
+            self.should_track_names = true;
             self.in_export_decl = false;
             self.in_default_export_decl = false;
             f.visit_mut_children_with(self);
             self.in_action_fn = old_in_action_fn;
-            self.in_module = old_in_module;
-            self.in_action_closure = old_in_action_closure;
+            self.in_module_level = old_in_module;
+            self.should_track_names = old_should_track_names;
             self.in_export_decl = old_in_export_decl;
             self.in_default_export_decl = old_in_default_export_decl;
-            self.closure_idents = old_closure_idents;
         }
+
+        let mut child_names = self.names.clone();
+        self.names.extend(current_names);
 
         if !is_action_fn {
             return;
@@ -555,9 +539,15 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                     .struct_span_err(f.ident.span, "Server actions must be async functions")
                     .emit();
             });
-        } else if !self.in_action_file {
-            let (_, register_action_expr) =
-                self.maybe_hoist_and_create_proxy(&f.ident, Some(&mut f.function), None);
+        }
+
+        if !self.in_action_file {
+            // Collect all the identifiers defined inside the closure and used
+            // in the action function. With deduplication.
+            retain_names_from_declared_idents(&mut child_names, &current_declared_idents);
+
+            let maybe_new_expr =
+                self.maybe_hoist_and_create_proxy(child_names, Some(&mut f.function), None);
 
             // Replace the original function declaration with a action proxy declaration
             // expr.
@@ -568,7 +558,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                 decls: vec![VarDeclarator {
                     span: DUMMY_SP,
                     name: Pat::Ident(f.ident.clone().into()),
-                    init: register_action_expr,
+                    init: maybe_new_expr,
                     definite: false,
                 }],
             });
@@ -584,37 +574,40 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             } else {
                 None
             },
-            false,
+            true,
         );
+
+        let current_declared_idents = self.declared_idents.clone();
+        let current_names = self.names.clone();
+        self.names = vec![];
 
         {
             // Visit children
             let old_in_action_fn = self.in_action_fn;
-            let old_in_module = self.in_module;
-            let old_in_action_closure = self.in_action_closure;
+            let old_in_module = self.in_module_level;
+            let old_should_track_names = self.should_track_names;
             let old_in_export_decl = self.in_export_decl;
             let old_in_default_export_decl = self.in_default_export_decl;
-            let old_closure_idents = self.closure_idents.clone();
             self.in_action_fn = is_action_fn;
-            self.in_module = false;
-            self.in_action_closure = true;
+            self.in_module_level = false;
+            self.should_track_names = true;
             self.in_export_decl = false;
             self.in_default_export_decl = false;
             {
-                if !self.in_action_fn && !self.in_action_file {
-                    for n in &mut a.params {
-                        collect_pat_idents(n, &mut self.closure_idents);
-                    }
+                for n in &mut a.params {
+                    collect_pat_idents(n, &mut self.declared_idents);
                 }
             }
             a.visit_mut_children_with(self);
             self.in_action_fn = old_in_action_fn;
-            self.in_module = old_in_module;
-            self.in_action_closure = old_in_action_closure;
+            self.in_module_level = old_in_module;
+            self.should_track_names = old_should_track_names;
             self.in_export_decl = old_in_export_decl;
             self.in_default_export_decl = old_in_default_export_decl;
-            self.closure_idents = old_closure_idents;
         }
+
+        let mut child_names = self.names.clone();
+        self.names.extend(current_names);
 
         if !is_action_fn {
             return;
@@ -627,6 +620,13 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                     .emit();
             });
         }
+
+        // Collect all the identifiers defined inside the closure and used
+        // in the action function. With deduplication.
+        retain_names_from_declared_idents(&mut child_names, &current_declared_idents);
+
+        let maybe_new_expr = self.maybe_hoist_and_create_proxy(child_names, None, Some(a));
+        self.rewrite_expr_to_proxy_expr = maybe_new_expr;
     }
 
     fn visit_mut_module(&mut self, m: &mut Module) {
@@ -637,31 +637,32 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     fn visit_mut_stmt(&mut self, n: &mut Stmt) {
         n.visit_mut_children_with(self);
 
-        if self.in_module {
+        if self.in_module_level {
             return;
         }
 
-        let ids = collect_idents_in_stmt(n);
-        if !self.in_action_fn && !self.in_action_file {
-            self.closure_idents.extend(ids);
-        }
+        // If it's a closure (not in the module level), we need to collect
+        // identifiers defined in the closure.
+        self.declared_idents.extend(collect_decl_idents_in_stmt(n));
     }
 
     fn visit_mut_param(&mut self, n: &mut Param) {
         n.visit_mut_children_with(self);
 
-        if !self.in_action_fn && !self.in_action_file {
-            collect_pat_idents(&n.pat, &mut self.closure_idents);
+        if self.in_module_level {
+            return;
         }
+
+        collect_pat_idents(&n.pat, &mut self.declared_idents);
     }
 
     fn visit_mut_prop_or_spread(&mut self, n: &mut PropOrSpread) {
-        if self.in_action_fn && self.in_action_closure {
+        if !self.in_module_level && self.should_track_names {
             if let PropOrSpread::Prop(box Prop::Shorthand(i)) = n {
-                self.in_action_closure = false;
-                self.action_closure_idents.push(Name::from(&*i));
+                self.names.push(Name::from(&*i));
+                self.should_track_names = false;
                 n.visit_mut_children_with(self);
-                self.in_action_closure = true;
+                self.should_track_names = true;
                 return;
             }
         }
@@ -670,73 +671,21 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     fn visit_mut_expr(&mut self, n: &mut Expr) {
-        if self.in_action_fn && self.in_action_closure {
+        if !self.in_module_level && self.should_track_names {
             if let Ok(name) = Name::try_from(&*n) {
-                self.in_action_closure = false;
-                self.action_closure_idents.push(name);
+                self.names.push(name);
+                self.should_track_names = false;
                 n.visit_mut_children_with(self);
-                self.in_action_closure = true;
+                self.should_track_names = true;
                 return;
             }
         }
 
+        self.rewrite_expr_to_proxy_expr = None;
         n.visit_mut_children_with(self);
-
-        if self.in_action_file {
-            return;
-        }
-
-        match n {
-            Expr::Arrow(a) => {
-                let is_action_fn = self.get_action_info(
-                    if let BlockStmtOrExpr::BlockStmt(block) = &mut *a.body {
-                        Some(block)
-                    } else {
-                        None
-                    },
-                    true,
-                );
-
-                if !is_action_fn {
-                    return;
-                }
-
-                // We need to give a name to the arrow function
-                // action and hoist it to the top.
-                let action_name = gen_ident(&mut self.ident_cnt);
-                let ident = private_ident!(action_name);
-
-                let (maybe_new_expr, _) = self.maybe_hoist_and_create_proxy(&ident, None, Some(a));
-
-                *n = if let Some(new_expr) = maybe_new_expr {
-                    *new_expr
-                } else {
-                    Expr::Arrow(a.clone())
-                };
-            }
-            Expr::Fn(f) => {
-                let is_action_fn = self.get_action_info(f.function.body.as_mut(), true);
-
-                if !is_action_fn {
-                    return;
-                }
-                let ident = match f.ident.as_mut() {
-                    None => {
-                        let action_name = gen_ident(&mut self.ident_cnt);
-                        let ident = Ident::new(action_name, DUMMY_SP);
-                        f.ident.insert(ident)
-                    }
-                    Some(i) => i,
-                };
-
-                let (maybe_new_expr, _) =
-                    self.maybe_hoist_and_create_proxy(ident, Some(&mut f.function), None);
-
-                if let Some(new_expr) = maybe_new_expr {
-                    *n = *new_expr;
-                }
-            }
-            _ => {}
+        if let Some(expr) = &self.rewrite_expr_to_proxy_expr {
+            *n = (**expr).clone().into();
+            self.rewrite_expr_to_proxy_expr = None;
         }
     }
 
@@ -833,7 +782,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                             } else {
                                 // export default function() {}
                                 let new_ident =
-                                    Ident::new(gen_ident(&mut self.ident_cnt), DUMMY_SP);
+                                    Ident::new(gen_ident(&mut self.action_cnt), DUMMY_SP);
                                 f.ident = Some(new_ident.clone());
                                 self.exported_idents
                                     .push((new_ident.to_id(), "default".into()));
@@ -852,7 +801,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                 } else {
                                     // export default async () => {}
                                     let new_ident =
-                                        Ident::new(gen_ident(&mut self.ident_cnt), DUMMY_SP);
+                                        Ident::new(gen_ident(&mut self.action_cnt), DUMMY_SP);
 
                                     self.exported_idents
                                         .push((new_ident.to_id(), "default".into()));
@@ -871,7 +820,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                             Expr::Call(call) => {
                                 // export default fn()
                                 let new_ident =
-                                    Ident::new(gen_ident(&mut self.ident_cnt), DUMMY_SP);
+                                    Ident::new(gen_ident(&mut self.action_cnt), DUMMY_SP);
 
                                 self.exported_idents
                                     .push((new_ident.to_id(), "default".into()));
@@ -1150,10 +1099,6 @@ impl<C: Comments> VisitMut for ServerActions<C> {
 
         *stmts = new;
 
-        stmts.visit_mut_with(&mut ClosureActionReplacer {
-            replaced_action_proxies: &self.replaced_action_proxies,
-        });
-
         self.annotations = old_annotations;
     }
 
@@ -1174,6 +1119,25 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     noop_visit_mut_type!();
+}
+
+fn retain_names_from_declared_idents(
+    child_names: &mut Vec<Name>,
+    current_declared_idents: &Vec<Id>,
+) {
+    // Collect all the identifiers defined inside the closure and used
+    // in the action function. With deduplication.
+    let mut added_names = Vec::new();
+    child_names.retain(|name| {
+        if added_names.contains(name) {
+            false
+        } else if current_declared_idents.contains(&name.0) {
+            added_names.push(name.clone());
+            true
+        } else {
+            false
+        }
+    });
 }
 
 fn gen_ident(cnt: &mut u32) -> JsWord {
@@ -1574,7 +1538,7 @@ fn collect_idents_in_var_decls(decls: &[VarDeclarator]) -> Vec<Id> {
     ids
 }
 
-fn collect_idents_in_stmt(stmt: &Stmt) -> Vec<Id> {
+fn collect_decl_idents_in_stmt(stmt: &Stmt) -> Vec<Id> {
     let mut ids = Vec::new();
 
     if let Stmt::Decl(Decl::Var(var)) = &stmt {
@@ -1582,45 +1546,6 @@ fn collect_idents_in_stmt(stmt: &Stmt) -> Vec<Id> {
     }
 
     ids
-}
-
-pub(crate) struct ClosureActionReplacer<'a> {
-    replaced_action_proxies: &'a Vec<(Ident, Box<Expr>)>,
-}
-
-impl ClosureActionReplacer<'_> {
-    fn index(&self, i: &Ident) -> Option<usize> {
-        self.replaced_action_proxies
-            .iter()
-            .position(|(ident, _)| ident.sym == i.sym && ident.span.ctxt == i.span.ctxt)
-    }
-}
-
-impl VisitMut for ClosureActionReplacer<'_> {
-    fn visit_mut_expr(&mut self, e: &mut Expr) {
-        e.visit_mut_children_with(self);
-
-        if let Expr::Ident(i) = e {
-            if let Some(index) = self.index(i) {
-                *e = *self.replaced_action_proxies[index].1.clone();
-            }
-        }
-    }
-
-    fn visit_mut_prop_or_spread(&mut self, n: &mut PropOrSpread) {
-        n.visit_mut_children_with(self);
-
-        if let PropOrSpread::Prop(box Prop::Shorthand(i)) = n {
-            if let Some(index) = self.index(i) {
-                *n = PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
-                    key: PropName::Ident(i.clone()),
-                    value: Box::new(*self.replaced_action_proxies[index].1.clone()),
-                })));
-            }
-        }
-    }
-
-    noop_visit_mut_type!();
 }
 
 pub(crate) struct ClosureReplacer<'a> {

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -684,7 +684,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         self.rewrite_expr_to_proxy_expr = None;
         n.visit_mut_children_with(self);
         if let Some(expr) = &self.rewrite_expr_to_proxy_expr {
-            *n = (**expr).clone().into();
+            *n = (**expr).clone();
             self.rewrite_expr_to_proxy_expr = None;
         }
     }
@@ -1121,10 +1121,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     noop_visit_mut_type!();
 }
 
-fn retain_names_from_declared_idents(
-    child_names: &mut Vec<Name>,
-    current_declared_idents: &Vec<Id>,
-) {
+fn retain_names_from_declared_idents(child_names: &mut Vec<Name>, current_declared_idents: &[Id]) {
     // Collect all the identifiers defined inside the closure and used
     // in the action function. With deduplication.
     let mut added_names = Vec::new();

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
@@ -1,5 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ {} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export default (()=>{});
+export default createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export async function $$ACTION_0() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([]);

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/7/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/7/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-const foo = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
-export async function $$ACTION_1() {}
+const foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export async function $$ACTION_0() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/8/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/8/output.js
@@ -1,7 +1,7 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-const foo = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
-export async function $$ACTION_1() {
+const foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export async function $$ACTION_0() {
     'use strict';
 }
 const bar = async ()=>{

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 export function Item({ id1, id2 }) {
@@ -6,10 +6,7 @@ export function Item({ id1, id2 }) {
         id1,
         id2
     ]));
-    return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-        id1,
-        id2
-    ]))}>Delete</Button>;
+    return <Button action={deleteItem}>Delete</Button>;
 }
 export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
@@ -21,14 +18,14 @@ export default function Home() {
         name: 'John',
         test: 'test'
     };
-    const action = createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+    const action = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         info.name,
         info.test
     ]));
     return null;
 }
-export async function $$ACTION_2($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
     console.log($$ACTION_ARG_0);
     console.log($$ACTION_ARG_1);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
@@ -1,9 +1,10 @@
 /* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export default $$ACTION_0 = async (a, b)=>{
-    console.log(a, b);
-};
+export default $$ACTION_0 = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
 var $$ACTION_0;
+export async function $$ACTION_1(a, b) {
+    console.log(a, b);
+}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     $$ACTION_0

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/16/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/16/output.js
@@ -1,36 +1,36 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 const v1 = 'v1';
 export function Item({ id1, id2 }) {
     const v2 = id2;
-    const deleteItem = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+    const deleteItem = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
         v2
     ]));
     return <Button action={deleteItem}>Delete</Button>;
 }
-export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
     await deleteFromDb($$ACTION_ARG_0);
     await deleteFromDb(v1);
     await deleteFromDb($$ACTION_ARG_1);
 }
 const f = (x)=>{
-    var g = createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+    var g = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+        x
+    ]));
+};
+export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, y, ...z) {
+    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+    return $$ACTION_ARG_0 + y + z[0];
+}
+const g = (x)=>{
+    f = createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
         x
     ]));
 };
 export async function $$ACTION_2($$ACTION_CLOSURE_BOUND, y, ...z) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);
-    return $$ACTION_ARG_0 + y + z[0];
-}
-const g = (x)=>{
-    f = createActionProxy("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4).bind(null, encryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", [
-        x
-    ]));
-};
-export async function $$ACTION_4($$ACTION_CLOSURE_BOUND, y, ...z) {
-    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_CLOSURE_BOUND);
     return $$ACTION_ARG_0 + y + z[0];
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
@@ -1,6 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export const foo = async ()=>{};
+export const foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export async function $$ACTION_0() {}
 const bar = async ()=>{};
 export { bar };
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/18/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/18/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 const v1 = 'v1';
@@ -6,7 +6,7 @@ export function Item({ id1, id2 }) {
     const v2 = id2;
     return <>
 
-      <Button action={createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+      <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
         v2
     ]))}>
@@ -15,7 +15,7 @@ export function Item({ id1, id2 }) {
 
       </Button>
 
-      <Button action={createActionProxy("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3).bind(null, encryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", [
+      <Button action={createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
         id1,
         v2
     ]))}>
@@ -26,14 +26,14 @@ export function Item({ id1, id2 }) {
 
     </>;
 }
-export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
     await deleteFromDb($$ACTION_ARG_0);
     await deleteFromDb(v1);
     await deleteFromDb($$ACTION_ARG_1);
 }
-export async function $$ACTION_3($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_2($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);
     await deleteFromDb($$ACTION_ARG_0);
     await deleteFromDb(v1);
     await deleteFromDb($$ACTION_ARG_1);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/19/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/19/output.js
@@ -1,9 +1,9 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export function Item({ value }) {
     return <>
 
-      <Button action={createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+      <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         value
     ]))}>
 
@@ -13,7 +13,7 @@ export function Item({ value }) {
 
     </>;
 }
-export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, value2) {
-    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_0($$ACTION_CLOSURE_BOUND, value2) {
+    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
     return $$ACTION_ARG_0 * value2;
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/2/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/2/output.js
@@ -1,11 +1,11 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 var myAction = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0(a, b, c) {
     console.log('a');
 }
 export default function Page() {
-    return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0)}>Delete</Button>;
+    return <Button action={myAction}>Delete</Button>;
 }
-export const action = withValidate(createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2));
-export async function $$ACTION_2() {}
+export const action = withValidate(createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1));
+export async function $$ACTION_1() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/21/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/21/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc":"$$ACTION_5","188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { validator, another } from 'auth';
 const x = 1;
@@ -12,7 +12,7 @@ export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, z) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
     return x + $$ACTION_ARG_0 + z;
 }
-validator(createActionProxy("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3));
+validator(createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2));
+export async function $$ACTION_2() {}
+another(validator(createActionProxy("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3)));
 export async function $$ACTION_3() {}
-another(validator(createActionProxy("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", $$ACTION_5)));
-export async function $$ACTION_5() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
@@ -1,13 +1,15 @@
 /* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default","f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { validator } from 'auth';
-export const action = validator(async ()=>{});
-export default $$ACTION_0 = validator(async ()=>{});
-var $$ACTION_0;
+export const action = validator(createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0));
+export async function $$ACTION_0() {}
+export default $$ACTION_1 = validator(createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2));
+var $$ACTION_1;
+export async function $$ACTION_2() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     action,
-    $$ACTION_0
+    $$ACTION_1
 ]);
 createActionProxy("f14702b5a021dd117f7ec7a3c838f397c2046d3b", action);
-createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$ACTION_0);
+createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$ACTION_1);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/23/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/23/output.js
@@ -1,13 +1,11 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default function Page({ foo, x, y }) {
     var action = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         x
     ]));
-    createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-        x
-    ])).bind(null, foo[0], foo[1], foo.x, foo[y]);
-    const action2 = createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+    action.bind(null, foo[0], foo[1], foo.x, foo[y]);
+    const action2 = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         x
     ]));
     action2.bind(null, foo[0], foo[1], foo.x, foo[y]);
@@ -16,7 +14,7 @@ export async function $$ACTION_0($$ACTION_CLOSURE_BOUND, a, b, c, d) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
     console.log(a, b, $$ACTION_ARG_0, c, d);
 }
-export async function $$ACTION_2($$ACTION_CLOSURE_BOUND, a, b, c, d) {
-    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, a, b, c, d) {
+    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
     console.log(a, b, $$ACTION_ARG_0, c, d);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/25/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/25/output.js
@@ -5,10 +5,7 @@ export function Item({ id1, id2 }) {
     id1++;
     return (()=>{
         id1++;
-        return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-            id1,
-            id2
-        ]))}>Delete</Button>;
+        return <Button action={deleteItem}>Delete</Button>;
     })();
     var deleteItem = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
@@ -25,15 +22,9 @@ export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
 export function Item2({ id1, id2 }) {
     id1++;
     const temp = [];
-    temp.push(<Button action={createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
-        id1,
-        id2
-    ]))}>Delete</Button>);
+    temp.push(<Button action={deleteItem}>Delete</Button>);
     id1++;
-    temp.push(<Button action={createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
-        id1,
-        id2
-    ]))}>Delete</Button>);
+    temp.push(<Button action={deleteItem}>Delete</Button>);
     return temp;
     var deleteItem = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         id1,

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/26/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/26/output.js
@@ -1,7 +1,7 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 const noop = (action)=>action;
-export const log = noop(createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1));
-export async function $$ACTION_1(data) {
+export const log = noop(createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0));
+export async function $$ACTION_0(data) {
     console.log(data);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/output.js
@@ -1,7 +1,7 @@
 // Rules here:
 // 1. Each exported function should still be exported, but as a reference `createActionProxy(...)`.
 // 2. Actual action functions should be renamed to `$$ACTION_...` and got exported.
-/* __next_internal_action_entry_do_not_use__ {"1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc":"$$ACTION_5","188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 var foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0() {
@@ -14,14 +14,13 @@ export async function $$ACTION_1() {
 }
 export default createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2);
 export async function $$ACTION_2() {
-    'use server';
     console.log(3);
 }
-export const qux = createActionProxy("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4);
-export async function $$ACTION_4() {
+export const qux = createActionProxy("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3);
+export async function $$ACTION_3() {
     console.log(4);
 }
-export const quux = createActionProxy("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", $$ACTION_5);
-export async function $$ACTION_5() {
+export const quux = createActionProxy("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4);
+export async function $$ACTION_4() {
     console.log(5);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/28/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/28/input.js
@@ -1,0 +1,24 @@
+let a, f
+
+function Comp(b, c, ...g) {
+  return async function action1(d) {
+    'use server'
+    let f
+    console.log(...window, { window })
+    console.log(a, b, action2)
+
+    async function action2(e) {
+      'use server'
+      console.log(a, c, d, e, f, g)
+    }
+
+    return [
+      action2,
+      async function action3(e) {
+        'use server'
+        action2(e)
+        console.log(a, c, d, e)
+      },
+    ]
+  }
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/28/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/28/output.js
@@ -1,0 +1,41 @@
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+let a, f;
+function Comp(b, c, ...g) {
+    return createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+        c,
+        g,
+        b
+    ]));
+}
+export async function $$ACTION_0($$ACTION_CLOSURE_BOUND, e) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
+    console.log(a, $$ACTION_ARG_0, $$ACTION_ARG_1, e, $$ACTION_ARG_2, $$ACTION_ARG_3);
+}
+export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, e) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+    $$ACTION_ARG_0(e);
+    console.log(a, $$ACTION_ARG_1, $$ACTION_ARG_2, e);
+}
+export async function $$ACTION_2($$ACTION_CLOSURE_BOUND, d) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);
+    let f;
+    console.log(...window, {
+        window
+    });
+    console.log(a, $$ACTION_ARG_2, action2);
+    var action2 = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+        $$ACTION_ARG_0,
+        d,
+        f,
+        $$ACTION_ARG_1
+    ]));
+    return [
+        action2,
+        createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+            action2,
+            $$ACTION_ARG_0,
+            d
+        ]))
+    ];
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
@@ -10,12 +10,7 @@ export function Item({ id1, id2, id3, id4 }) {
         id3,
         id4.x
     ]));
-    return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-        id1,
-        v2,
-        id3,
-        id4.x
-    ]))}>Delete</Button>;
+    return <Button action={deleteItem}>Delete</Button>;
 }
 export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/6/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/6/output.js
@@ -27,14 +27,7 @@ export function y(p, [p1, { p2 }], ...p3) {
         p2,
         p3
     ]));
-    return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-        f2,
-        f11,
-        p,
-        p1,
-        p2,
-        p3
-    ]))}>Delete</Button>;
+    return <Button action={action}>Delete</Button>;
 }
 export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc":"$$ACTION_5","188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 export function Item1(product, foo, bar) {
@@ -25,14 +25,7 @@ export function Item2(product, foo, bar) {
         foo,
         bar
     ]));
-    return <Button action={createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
-        product.id,
-        product?.foo,
-        product.bar.baz,
-        product,
-        foo,
-        bar
-    ]))}>Delete</Button>;
+    return <Button action={deleteItem2}>Delete</Button>;
 }
 export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
@@ -54,7 +47,7 @@ export async function $$ACTION_3($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
 }
 export function Item4(product, foo, bar) {
-    const deleteItem4 = createActionProxy("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", $$ACTION_5).bind(null, encryptActionBoundArgs("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", [
+    const deleteItem4 = createActionProxy("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4).bind(null, encryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", [
         product.id,
         product?.foo,
         product.bar.baz,
@@ -64,7 +57,7 @@ export function Item4(product, foo, bar) {
     ]));
     return <Button action={deleteItem4}>Delete</Button>;
 }
-export async function $$ACTION_5($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_4($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_CLOSURE_BOUND);
     await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/8/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/8/output.js
@@ -7,5 +7,5 @@ export async function $$ACTION_0(a, b, c) {
     console.log('a');
 }
 export default function Page() {
-    return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0)}>Delete</Button>;
+    return <Button action={myAction}>Delete</Button>;
 }


### PR DESCRIPTION
This PR improves the Server Actions SWC transform to make it able to handle nested Action declarations (check `fixture/server-actions/server/28/input.js` for more details).

It is also a simplification of that transform's internal states and methods, with the removal of an extra AST pass (`stmts.visit_mut_with(&mut ClosureActionReplacer { replaced_action_proxies: &self.replaced_action_proxies, })`). The generated code is also smaller in some cases. So overall I'd expect the compilation and runtime performance to improve as well.

## Details

With this change, we're now using `self.declared_idents` and `self.names` to track closure arguments. `declared_idents` keeps the identifiers **declared** in the current closure and above. `names` keeps identifiers **appeared** in the current closure and above. In an example of the following cursor:

```ts
let x

async function foo() {
  "use server"
  let y

  async function bar() {
    "use server"
    let z
    console.log(x, y, z)
  }

  // <- cursor
}
```

`declared_idents` would be `y` (`x` isn't in a closure), and `names` would be `x, y, z`. By manipulating these two states we're able to track closure closed-up variables recursively.

Closes NEXT-2189