### PR TITLE
Add GoogleOther and Google-Extended tokens to known bot UA list

### DIFF
--- a/packages/next/src/server/web/spec-extension/user-agent.ts
+++ b/packages/next/src/server/web/spec-extension/user-agent.ts
@@ -26,7 +26,7 @@ interface UserAgent {
 }
 
 export function isBot(input: string): boolean {
-  return /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Google-InspectionTool|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver/i.test(
+  return /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Google-InspectionTool|GoogleOther|Google-Extended|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver/i.test(
     input
   )
 }


### PR DESCRIPTION
Google has started using two new bots since the UA token list was last updated
- [GoogleOther](https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers#googleother)
- [Google-Extended](https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers#google-extended)
