### PR TITLE
docs: fix rustup download link

### DIFF
--- a/contributing/core/developing.md
+++ b/contributing/core/developing.md
@@ -6,7 +6,7 @@
 
 To develop locally:
 
-1. Install [Rust and Cargo](https://doc.rust-lang.org/cargo/getting-started/installation)
+1. Install Rust and Cargo via [rustup](https://rustup.rs).
 1. Install the [GitHub CLI](https://github.com/cli/cli#installation).
 1. Clone the Next.js repository (download only recent commits for faster clone):
    ```


### PR DESCRIPTION
## Changes

- Fix URL to `rustup` (Previous URL https://doc.rust-lang.org/cargo/getting-started/installation  is now a `404`)

Closes NEXT-2191