### PR TITLE
avoid output of webpack stats

### DIFF
--- a/packages/next/taskfile-webpack.js
+++ b/packages/next/taskfile-webpack.js
@@ -26,7 +26,7 @@ module.exports = function (task) {
           })
         }
 
-        if (process.env.ANALYZE) {
+        if (process.env.ANALYZE_STATS) {
           require('fs').writeFileSync(
             require('path').join(__dirname, options.name + '-stats.json'),
             JSON.stringify(stats.toJson())


### PR DESCRIPTION
### What?

`ANALYZE=1` is set in CI, but this shouldn't emit stats.

### Why?

It sometimes causes the `lint` step to fail as prettier checks these stats files too


Closes PACK-2280