### PR TITLE
fix(turbopack): use correct layout for 404 page

### DIFF
--- a/packages/next-swc/crates/next-core/src/app_structure.rs
+++ b/packages/next-swc/crates/next-core/src/app_structure.rs
@@ -697,7 +697,13 @@ async fn directory_tree_to_loader_tree(
 
     components.metadata.base_page = Some(app_page.clone());
 
-    if app_page.is_root() && components.not_found.is_none() {
+    // the root directory in the app dir.
+    let is_root_directory = app_page.is_root();
+    // an alternative root layout (in a route group which affects the page, but not
+    // the path).
+    let is_root_layout = app_path.is_root() && components.layout.is_some();
+
+    if (is_root_directory || is_root_layout) && components.not_found.is_none() {
         components.not_found = Some(
             get_next_package(app_dir).join("dist/client/components/not-found-error.js".to_string()),
         );
@@ -985,66 +991,58 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                 *meta,
             );
         }
+
         // Next.js has this logic in "collect-app-paths", where the root not-found page
         // is considered as its own entry point.
-        if let Some(_not_found) = components.not_found {
-            let dev_not_found_tree = LoaderTree {
-                    page: app_page.clone(),
-                    segment: directory_name.clone(),
-                    parallel_routes: indexmap! {
-                        "children".to_string() => LoaderTree {
-                            page: app_page.clone(),
-                            segment: "__DEFAULT__".to_string(),
-                            parallel_routes: IndexMap::new(),
-                            components: Components {
-                                default: Some(get_next_package(app_dir).join("dist/client/components/parallel-route-default.js".to_string())),
-                                ..Default::default()
-                            }
-                            .cell(),
-                    global_metadata,
-                        }
-                        .cell(),
-                    },
-                    components: components.without_leafs().cell(),
-                    global_metadata,
-                }
-                .cell();
-
-            {
-                let app_page = app_page.clone_push_str("not-found")?;
-                add_app_page(app_dir, &mut result, app_page, dev_not_found_tree).await?;
-            }
-            {
-                let app_page = app_page.clone_push_str("_not-found")?;
-                add_app_page(app_dir, &mut result, app_page, dev_not_found_tree).await?;
-            }
+        let not_found_tree = if components.not_found.is_some() {
+            LoaderTree {
+                page: app_page.clone(),
+                segment: directory_name.clone(),
+                parallel_routes: indexmap! {
+                    "children".to_string() => LoaderTree {
+                        page: app_page.clone(),
+                        segment: "__DEFAULT__".to_string(),
+                        parallel_routes: IndexMap::new(),
+                        components: Components {
+                            default: Some(get_next_package(app_dir).join("dist/client/components/parallel-route-default.js".to_string())),
+                            ..Default::default()
+                        }.cell(),
+                        global_metadata,
+                    }.cell(),
+                },
+                components: components.without_leafs().cell(),
+                global_metadata,
+            }.cell()
         } else {
             // Create default not-found page for production if there's no customized
             // not-found
-            let prod_not_found_tree = LoaderTree {
-                    page: app_page.clone(),
-                    segment: directory_name.to_string(),
-                    parallel_routes: indexmap! {
-                        "children".to_string() => LoaderTree {
-                            page: app_page.clone(),
-                            segment: "__PAGE__".to_string(),
-                            parallel_routes: IndexMap::new(),
-                            components: Components {
-                                page: Some(get_next_package(app_dir).join("dist/client/components/not-found-error.js".to_string())),
-                                ..Default::default()
-                            }
-                            .cell(),
-                    global_metadata,
-                        }
-                        .cell(),
-                    },
-                    components: components.without_leafs().cell(),
-                    global_metadata,
-                }
-                .cell();
+            LoaderTree {
+                page: app_page.clone(),
+                segment: directory_name.to_string(),
+                parallel_routes: indexmap! {
+                    "children".to_string() => LoaderTree {
+                        page: app_page.clone(),
+                        segment: "__PAGE__".to_string(),
+                        parallel_routes: IndexMap::new(),
+                        components: Components {
+                            page: Some(get_next_package(app_dir).join("dist/client/components/not-found-error.js".to_string())),
+                            ..Default::default()
+                        }.cell(),
+                        global_metadata,
+                    }.cell(),
+                },
+                components: components.without_leafs().cell(),
+                global_metadata,
+            }.cell()
+        };
 
+        {
+            let app_page = app_page.clone_push_str("not-found")?;
+            add_app_page(app_dir, &mut result, app_page, not_found_tree).await?;
+        }
+        {
             let app_page = app_page.clone_push_str("_not-found")?;
-            add_app_page(app_dir, &mut result, app_page, prod_not_found_tree).await?;
+            add_app_page(app_dir, &mut result, app_page, not_found_tree).await?;
         }
     }
 

--- a/packages/next-swc/crates/next-core/src/next_app/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/mod.rs
@@ -296,6 +296,10 @@ impl AppPath {
         })
     }
 
+    pub fn is_root(&self) -> bool {
+        self.0.is_empty()
+    }
+
     pub fn contains(&self, other: &AppPath) -> bool {
         for (i, segment) in other.0.iter().enumerate() {
             if self.0.get(i) != Some(segment) {

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -239,6 +239,7 @@ describe('next.rs api', () => {
       '/app',
       '/app-edge',
       '/app-nodejs',
+      '/not-found',
       '/page-edge',
       '/page-nodejs',
       '/route-edge',

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -3874,12 +3874,11 @@
       "app dir - not found with default 404 page should be able to navigate to page calling not-found",
       "app dir - not found with default 404 page should be able to navigate to page with calling not-found in metadata",
       "app dir - not found with default 404 page should error on client notFound from root layout in browser",
-      "app dir - not found with default 404 page should error on server notFound from root layout on server-side"
-    ],
-    "failed": [
+      "app dir - not found with default 404 page should error on server notFound from root layout on server-side",
       "app dir - not found with default 404 page should render default 404 with root layout for non-existent page",
       "app dir - not found with default 404 page should render default not found for group routes if not found is not defined"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What?

This fixes 2 issues with app 404 pages.
1. The root layout in a group was previously ignored when hitting the 404 page.
2. The default app 404 page was missing the correct path for dev `/not-found` so it would fall back to the pages 404 page.

Closes PACK-2241
Fixes #60688 
