### PR TITLE
Enable next.js version checker in turbopack

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/components/VersionStalenessInfo/VersionStalenessInfo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/VersionStalenessInfo/VersionStalenessInfo.tsx
@@ -11,10 +11,7 @@ export function VersionStalenessInfo(props: VersionInfo) {
   return (
     <small className="nextjs-container-build-error-version-status">
       <span className={indicatorClass} />
-      <small
-        className="nextjs-container-build-error-version-status"
-        title={title}
-      >
+      <small data-nextjs-version-checker title={title}>
         {text}
       </small>{' '}
       {staleness === 'fresh' || staleness === 'unknown' ? null : (
@@ -36,7 +33,7 @@ export function getStaleness({ installed, staleness, expected }: VersionInfo) {
   let indicatorClass = ''
   switch (staleness) {
     case 'fresh':
-      text = `Next.js is up to date${process.env.TURBOPACK ? ' (Turbo)' : ''}`
+      text = `Next.js is up to date${process.env.TURBOPACK ? ' (turbo)' : ''}`
       title = `Latest available version is detected (${installed}).`
       indicatorClass = 'fresh'
       break

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/VersionStalenessInfo/VersionStalenessInfo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/VersionStalenessInfo/VersionStalenessInfo.tsx
@@ -36,7 +36,7 @@ export function getStaleness({ installed, staleness, expected }: VersionInfo) {
   let indicatorClass = ''
   switch (staleness) {
     case 'fresh':
-      text = 'Next.js is up to date'
+      text = `Next.js is up to date${process.env.TURBOPACK ? ' (Turbo)' : ''}`
       title = `Latest available version is detected (${installed}).`
       indicatorClass = 'fresh'
       break

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -80,6 +80,11 @@ import type { WebpackError } from 'webpack'
 import { PAGE_TYPES } from '../../lib/page-types'
 
 const MILLISECONDS_IN_NANOSECOND = 1_000_000
+const isTestMode = !!(
+  process.env.NEXT_TEST_MODE ||
+  process.env.__NEXT_TEST_MODE ||
+  process.env.DEBUG
+)
 
 function diff(a: Set<any>, b: Set<any>) {
   return new Set([...a].filter((v) => !b.has(v)))
@@ -725,9 +730,6 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     const startSpan = this.hotReloaderSpan.traceChild('start')
     startSpan.stop() // Stop immediately to create an artificial parent span
 
-    const isTestMode = !!(
-      process.env.NEXT_TEST_MODE || process.env.__NEXT_TEST_MODE
-    )
     this.versionInfo = await this.tracedGetVersionInfo(
       startSpan,
       isTestMode || this.telemetry.isEnabled

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -185,6 +185,34 @@ function erroredPages(compilation: webpack.Compilation) {
   return failedPages
 }
 
+export async function getVersionInfo(enabled: boolean): Promise<VersionInfo> {
+  let installed = '0.0.0'
+
+  if (!enabled) {
+    return { installed, staleness: 'unknown' }
+  }
+
+  try {
+    installed = require('next/package.json').version
+
+    const registry = getRegistry()
+    const res = await fetch(`${registry}-/package/next/dist-tags`)
+
+    if (!res.ok) return { installed, staleness: 'unknown' }
+
+    const tags = await res.json()
+
+    return parseVersionInfo({
+      installed,
+      latest: tags.latest,
+      canary: tags.canary,
+    })
+  } catch (e) {
+    console.error('parse version e', e)
+    return { installed, staleness: 'unknown' }
+  }
+}
+
 export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
   private hasAmpEntrypoints: boolean
   private hasAppRouterEntrypoints: boolean
@@ -524,36 +552,6 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       )
   }
 
-  private async getVersionInfo(span: Span, enabled: boolean) {
-    const versionInfoSpan = span.traceChild('get-version-info')
-    return versionInfoSpan.traceAsyncFn<VersionInfo>(async () => {
-      let installed = '0.0.0'
-
-      if (!enabled) {
-        return { installed, staleness: 'unknown' }
-      }
-
-      try {
-        installed = require('next/package.json').version
-
-        const registry = getRegistry()
-        const res = await fetch(`${registry}-/package/next/dist-tags`)
-
-        if (!res.ok) return { installed, staleness: 'unknown' }
-
-        const tags = await res.json()
-
-        return parseVersionInfo({
-          installed,
-          latest: tags.latest,
-          canary: tags.canary,
-        })
-      } catch {
-        return { installed, staleness: 'unknown' }
-      }
-    })
-  }
-
   private async getWebpackConfig(span: Span) {
     const webpackConfigSpan = span.traceChild('get-webpack-config')
 
@@ -716,15 +714,23 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     })
   }
 
+  private async tracedGetVersionInfo(span: Span, enabled: boolean) {
+    const versionInfoSpan = span.traceChild('get-version-info')
+    return versionInfoSpan.traceAsyncFn<VersionInfo>(async () =>
+      getVersionInfo(enabled)
+    )
+  }
+
   public async start(): Promise<void> {
     const startSpan = this.hotReloaderSpan.traceChild('start')
     startSpan.stop() // Stop immediately to create an artificial parent span
 
-    const testMode = process.env.NEXT_TEST_MODE || process.env.__NEXT_TEST_MODE
-
-    this.versionInfo = await this.getVersionInfo(
+    const isTestMode = !!(
+      process.env.NEXT_TEST_MODE || process.env.__NEXT_TEST_MODE
+    )
+    this.versionInfo = await this.tracedGetVersionInfo(
       startSpan,
-      !!testMode || this.telemetry.isEnabled
+      isTestMode || this.telemetry.isEnabled
     )
 
     await this.clean(startSpan)

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -140,7 +140,9 @@ import type { VersionInfo } from '../../dev/parse-version-info'
 const MILLISECONDS_IN_NANOSECOND = 1_000_000
 const wsServer = new ws.Server({ noServer: true })
 const isTestMode = !!(
-  process.env.NEXT_TEST_MODE || process.env.__NEXT_TEST_MODE
+  process.env.NEXT_TEST_MODE ||
+  process.env.__NEXT_TEST_MODE ||
+  process.env.DEBUG
 )
 
 type SetupOpts = {

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -448,4 +448,24 @@ describe('Error overlay - RSC build errors', () => {
 
     await cleanup()
   })
+
+  it('should contain nextjs version check in error overlay', async () => {
+    const { session, cleanup } = await sandbox(
+      next,
+      undefined,
+      '/server-with-errors/error-file'
+    )
+
+    await session.patch(
+      'app/server-with-errors/error-file/error.js',
+      'export default function Error() { throw new Error("test") }'
+    )
+
+    expect(await session.hasRedbox()).toBe(true)
+    expect(await session.getVersionCheckerText()).toInclude(
+      `Next.js is up to date${process.env.TURBOPACK ? ' (turbo)' : ''}`
+    )
+
+    await cleanup()
+  })
 })

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -3,6 +3,7 @@ import {
   getRedboxDescription,
   getRedboxHeader,
   getRedboxSource,
+  getVersionCheckerText,
   hasRedbox,
   waitFor,
 } from './next-test-utils'
@@ -136,6 +137,9 @@ export async function sandbox(
       },
       async waitForAndOpenRuntimeError() {
         return browser.waitForElementByCss('[data-nextjs-toast]').click()
+      },
+      async getVersionCheckerText() {
+        return getVersionCheckerText(browser)
       },
     },
     async cleanup() {

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1031,6 +1031,17 @@ export async function getRedboxComponentStack(
   return componentStackFrameTexts.join('\n').trim()
 }
 
+export async function getVersionCheckerText(
+  browser: BrowserInterface
+): Promise<string> {
+  await browser.waitForElementByCss('[data-nextjs-version-checker]', 30000)
+  const versionCheckerElement = await browser.elementByCss(
+    '[data-nextjs-version-checker]'
+  )
+  const versionCheckerText = await versionCheckerElement.innerText()
+  return versionCheckerText.trim()
+}
+
 /**
  * For better editor support, pass in the variants this should run on (`default` and/or `turbo`) as cases.
  *


### PR DESCRIPTION
### What

We've had the Next.js version checker in dev overlay of webpack mode. But it was missing for turbopack. Add it in turbopack mode and also give a small marker `"(turbo)"` to highlight turbopack mode.

Screenshot

<img width="576" alt="image" src="https://github.com/vercel/next.js/assets/4800338/1bb1500c-fd92-43bd-a60a-ddc7cd63ce6f">


Closes NEXT-2196
Closes NEXT-2106