### PR TITLE
Disable Yarn PnP tests for Turbopack

### DIFF
--- a/test/e2e/yarn-pnp/test/with-eslint.test.ts
+++ b/test/e2e/yarn-pnp/test/with-eslint.test.ts
@@ -1,5 +1,4 @@
 import { runTests } from './utils'
-
-describe('yarn PnP', () => {
+;(process.env.TURBOPACK ? describe.skip : describe)('yarn PnP', () => {
   runTests('with-eslint', '/', ['<html', 'Home', 'fake-script'])
 })

--- a/test/e2e/yarn-pnp/test/with-mdx.test.ts
+++ b/test/e2e/yarn-pnp/test/with-mdx.test.ts
@@ -1,5 +1,6 @@
 import { runTests } from './utils'
 
-describe('yarn PnP', () => {
+// Skip in Turbopack as Yarn PnP is not supported.
+;(process.env.TURBOPACK ? describe.skip : describe)('yarn PnP', () => {
   runTests('with-mdx', '/', ['Look, a button', 'Hello'])
 })

--- a/test/e2e/yarn-pnp/test/with-next-sass.test.ts
+++ b/test/e2e/yarn-pnp/test/with-next-sass.test.ts
@@ -1,6 +1,7 @@
 import { runTests } from './utils'
 
-describe('yarn PnP', () => {
+// Skip in Turbopack as Yarn PnP is not supported.
+;(process.env.TURBOPACK ? describe.skip : describe)('yarn PnP', () => {
   runTests('with-next-sass', '/', [
     'Hello World, I am being styled using SCSS Modules',
   ])


### PR DESCRIPTION
## What?

We won't have support for Yarn PnP in the first version of Next.js with Turbopack as it requires every resolve to go through Node.js.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2198