### PR TITLE
Acceptance/error-recovery.test.js: Fork Turbopack test

### DIFF
--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -6,7 +6,7 @@ import { outdent } from 'outdent'
 import path from 'path'
 
 describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     skipStart: true,
   })
@@ -105,18 +105,31 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     ).toBe('1')
 
     expect(await session.hasRedbox()).toBe(true)
-    expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-      "index.js (7:10) @ eval
+    if (isTurbopack) {
+      expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
+        "index.js (7:5) @ <unknown>
 
-         5 | const increment = useCallback(() => {
-         6 |   setCount(c => c + 1)
-      >  7 |   throw new Error('oops')
-           |        ^
-         8 | }, [setCount])
-         9 | return (
-        10 |   <main>"
-    `)
+           5 | const increment = useCallback(() => {
+           6 |   setCount(c => c + 1)
+        >  7 |   throw new Error('oops')
+             |   ^
+           8 | }, [setCount])
+           9 | return (
+          10 |   <main>"
+      `)
+    } else {
+      expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
+              "index.js (7:10) @ eval
 
+                 5 | const increment = useCallback(() => {
+                 6 |   setCount(c => c + 1)
+              >  7 |   throw new Error('oops')
+                   |        ^
+                 8 | }, [setCount])
+                 9 | return (
+                10 |   <main>"
+          `)
+    }
     await session.patch(
       'index.js',
       outdent`

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1379,12 +1379,12 @@
   },
   "test/development/acceptance/error-recovery.test.ts": {
     "passed": [
+      "ReactRefreshLogBox turbo logbox: can recover from a event handler error",
       "ReactRefreshLogBox turbo logbox: can recover from a syntax error without losing state",
       "ReactRefreshLogBox turbo stuck error"
     ],
     "failed": [
       "ReactRefreshLogBox turbo logbox: can recover from a component error",
-      "ReactRefreshLogBox turbo logbox: can recover from a event handler error",
       "ReactRefreshLogBox turbo render error not shown right after syntax error",
       "ReactRefreshLogBox turbo syntax > runtime error"
     ],


### PR DESCRIPTION
Turbopack provides an improved message, which won’t match webpack’s snapshot.


Closes PACK-2283