### PR TITLE
[Docs] Adds external redirects section for App Router

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
@@ -262,13 +262,10 @@ The App Router fully supports programmatic redirects to external links using the
 'use server'
 
 import { redirect } from 'next/navigation'
-import { createCheckout } from './payment'
 
 export async function checkout(data: FormData) {
-  // Do validation and / or generate url
-  const { url } = await createCheckout(data)
-
-  redirect(url) // Redirect to hosted checkout
+  // Do validation, etc. and then redirect to hosted checkout
+  redirect('https://checkout.stripe.com/c/pay')
 }
 ```
 
@@ -276,13 +273,10 @@ export async function checkout(data: FormData) {
 'use server'
 
 import { redirect } from 'next/navigation'
-import { createCheckout } from './payment'
 
 export async function checkout(data) {
-  // Do validation and / or generate url
-  const { url } = await createCheckout(data)
-
-  redirect(url) // Redirect to hosted checkout
+  // Do validation, etc. and then redirect to hosted checkout
+  redirect('https://checkout.stripe.com/c/pay')
 }
 ```
 

--- a/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
@@ -157,7 +157,7 @@ export default function Page() {
 
 > **Good to know**:
 >
-> - If you don't need to programatically navigate a user, you should use a [`<Link>`](/docs/app/api-reference/components/link) component
+> - If you don't need to programmatically navigate a user, you should use a [`<Link>`](/docs/app/api-reference/components/link) component
 
 See the [`useRouter` API reference](/docs/app/api-reference/functions/use-router) for more information.
 
@@ -251,6 +251,86 @@ export const config = {
 > - Middleware runs **after** `redirects` in `next.config.js` and **before** rendering.
 
 See the [Middleware](/docs/app/building-your-application/routing/middleware) documentation for more information.
+
+## External redirects
+
+App Router fully supports programmatic external redirects to other sites (ie. `https://google.com`) using the same methods mentioned above.
+
+An example of when this would be useful is when generating checkout urls for hosted payment providers, such as Stripe and Shopify.
+
+[`redirect`](#redirect-function) and [permanentRedirect`](#permanentredirect-function) work on the server and in [Server Actions]().
+
+```ts filename="app/actions.ts" switcher
+'use server'
+
+import { redirect } from 'next/navigation'
+import { createCheckout } from './payment'
+
+export async function checkout(data: FormData) {
+  // Do validation and / or generate url
+  const { url } = await createCheckout(data)
+
+  redirect(url) // Redirect to hosted checkout
+}
+```
+
+```jsx filename="app/actions.js" switcher
+'use server'
+
+import { redirect } from 'next/navigation'
+import { createCheckout } from './payment'
+
+export async function checkout(data) {
+  // Do validation and / or generate url
+  const { url } = await createCheckout(data)
+
+  redirect(url) // Redirect to hosted checkout
+}
+```
+
+`router.push` and `router.replace` from [`useRouter`](#userouter-hook) work in client-side components and event handlers.
+
+```tsx filename="app/page.tsx" switcher
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export default function Page() {
+  const router = useRouter()
+
+  return (
+    <button
+      type="button"
+      onClick={() => router.push('https://checkout.stripe.com/c/pay')}
+    >
+      Checkout
+    </button>
+  )
+}
+```
+
+```jsx filename="app/page.js" switcher
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export default function Page() {
+  const router = useRouter()
+
+  return (
+    <button
+      type="button"
+      onClick={() => router.push('https://checkout.stripe.com/c/pay')}
+    >
+      Checkout
+    </button>
+  )
+}
+```
+
+> **Good to know**:
+>
+> - If you don't need to programmatically navigate a user, you should use a [`<Link>`](/docs/app/api-reference/components/link) component
 
 ## Managing redirects at scale (advanced)
 

--- a/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
@@ -252,6 +252,8 @@ export const config = {
 
 See the [Middleware](/docs/app/building-your-application/routing/middleware) documentation for more information.
 
+<AppOnly>
+
 ## External redirects
 
 The App Router fully supports programmatic redirects to external links using the same methods mentioned above.
@@ -323,7 +325,7 @@ export default function Page() {
 > **Good to know**:
 >
 > - If you don't need to programmatically navigate a user, you should use a [`<Link>`](/docs/app/api-reference/components/link) component
-
+</AppOnly>
 ## Managing redirects at scale (advanced)
 
 To manage a large number of redirects (1000+), you may consider creating a custom solution using Middleware. This allows you to handle redirects programmatically without having to redeploy your application.

--- a/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
@@ -258,7 +258,7 @@ App Router fully supports programmatic external redirects to other sites (ie. `h
 
 An example of when this would be useful is when generating checkout urls for hosted payment providers, such as Stripe and Shopify.
 
-[`redirect`](#redirect-function) and [permanentRedirect`](#permanentredirect-function) work on the server and in [Server Actions]().
+[`redirect`](#redirect-function) and [permanentRedirect`](#permanentredirect-function) work on the server and in [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
 
 ```ts filename="app/actions.ts" switcher
 'use server'

--- a/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
@@ -326,6 +326,7 @@ export default function Page() {
 >
 > - If you don't need to programmatically navigate a user, you should use a [`<Link>`](/docs/app/api-reference/components/link) component
 </AppOnly>
+
 ## Managing redirects at scale (advanced)
 
 To manage a large number of redirects (1000+), you may consider creating a custom solution using Middleware. This allows you to handle redirects programmatically without having to redeploy your application.

--- a/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
@@ -254,9 +254,7 @@ See the [Middleware](/docs/app/building-your-application/routing/middleware) doc
 
 ## External redirects
 
-App Router fully supports programmatic external redirects to other sites (ie. `https://google.com`) using the same methods mentioned above.
-
-An example of when this would be useful is when generating checkout urls for hosted payment providers, such as Stripe and Shopify.
+The App Router fully supports programmatic redirects to external links using the same methods mentioned above.
 
 [`redirect`](#redirect-function) and [permanentRedirect`](#permanentredirect-function) work on the server and in [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
 

--- a/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
@@ -256,7 +256,7 @@ See the [Middleware](/docs/app/building-your-application/routing/middleware) doc
 
 The App Router fully supports programmatic redirects to external links using the same methods mentioned above.
 
-[`redirect`](#redirect-function) and [`permanentRedirect`](#permanentredirect-function) work server-side and in [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+On the server-side and in [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations), [`redirect`](#redirect-function) and [`permanentRedirect`](#permanentredirect-function) methods can be used to navigate to external links:
 
 ```ts filename="app/actions.ts" switcher
 'use server'
@@ -280,7 +280,7 @@ export async function checkout(data) {
 }
 ```
 
-`router.push` and `router.replace` from [`useRouter`](#userouter-hook) work in client-side components and event handlers.
+In event handlers, `router.push` and `router.replace` methods form [`useRouter`](#userouter-hook) can be used to navigate to external links:
 
 ```tsx filename="app/page.tsx" switcher
 'use client'

--- a/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/06-redirecting.mdx
@@ -256,7 +256,7 @@ See the [Middleware](/docs/app/building-your-application/routing/middleware) doc
 
 The App Router fully supports programmatic redirects to external links using the same methods mentioned above.
 
-[`redirect`](#redirect-function) and [permanentRedirect`](#permanentredirect-function) work on the server and in [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+[`redirect`](#redirect-function) and [`permanentRedirect`](#permanentredirect-function) work server-side and in [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
 
 ```ts filename="app/actions.ts" switcher
 'use server'


### PR DESCRIPTION
Pages Router [recommended](https://nextjs.org/docs/pages/api-reference/functions/use-router#routerpush:~:text=You%20don%27t%20need,for%20those%20cases) the use of `window.location`.

However, support for external redirects has improved significantly in App Router were we can use `redirect`, `router.push`, etc. natively now.

Slack conversations, for reference: 

* [Initial questions](https://vercel.slack.com/archives/C03S8ED1DKM/p1706021114794229)
* [Continued conversation and experimentation](https://vercel.slack.com/archives/C03S9JCH2Q5/p1706050234819819)