### PR TITLE
Fix version checker not displaying when version newer than npm

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/components/VersionStalenessInfo/VersionStalenessInfo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/VersionStalenessInfo/VersionStalenessInfo.tsx
@@ -14,7 +14,9 @@ export function VersionStalenessInfo(props: VersionInfo) {
       <small data-nextjs-version-checker title={title}>
         {text}
       </small>{' '}
-      {staleness === 'fresh' || staleness === 'unknown' ? null : (
+      {staleness === 'fresh' ||
+      staleness === 'newer-than-npm' ||
+      staleness === 'unknown' ? null : (
         <a
           target="_blank"
           rel="noopener noreferrer"
@@ -32,6 +34,7 @@ export function getStaleness({ installed, staleness, expected }: VersionInfo) {
   let title = ''
   let indicatorClass = ''
   switch (staleness) {
+    case 'newer-than-npm':
     case 'fresh':
       text = `Next.js is up to date${process.env.TURBOPACK ? ' (turbo)' : ''}`
       title = `Latest available version is detected (${installed}).`
@@ -55,7 +58,6 @@ export function getStaleness({ installed, staleness, expected }: VersionInfo) {
       indicatorClass = 'stale'
       break
     }
-    case 'newer-than-npm':
     case 'unknown':
       break
     default:

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -448,24 +448,4 @@ describe('Error overlay - RSC build errors', () => {
 
     await cleanup()
   })
-
-  it('should contain nextjs version check in error overlay', async () => {
-    const { session, cleanup } = await sandbox(
-      next,
-      undefined,
-      '/server-with-errors/error-file'
-    )
-
-    await session.patch(
-      'app/server-with-errors/error-file/error.js',
-      'export default function Error() { throw new Error("test") }'
-    )
-
-    expect(await session.hasRedbox()).toBe(true)
-    expect(await session.getVersionCheckerText()).toInclude(
-      `Next.js is up to date${process.env.TURBOPACK ? ' (turbo)' : ''}`
-    )
-
-    await cleanup()
-  })
 })

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -5,7 +5,9 @@ import {
   check,
   getRedboxDescription,
   getRedboxSource,
+  getVersionCheckerText,
   hasRedbox,
+  retry,
   shouldRunTurboDevTest,
 } from 'next-test-utils'
 
@@ -119,6 +121,25 @@ createNextDescribe(
       // Can show the original source code
       expect(source).toContain('app/server/page.js')
       expect(source).toContain(`await fetch('http://locahost:3000/xxxx')`)
+    })
+
+    it('should contain nextjs version check in error overlay', async () => {
+      await next.patchFile(
+        'app/server/page.js',
+        outdent`
+        export default function Page() {
+          throw new Error('test')
+        }
+        `
+      )
+      const browser = await next.browser('/server')
+
+      await retry(async () => {
+        expect(await hasRedbox(browser)).toBe(true)
+      })
+      await expect(await getVersionCheckerText(browser)).toContain(
+        `Next.js is up to date${process.env.TURBOPACK ? ' (turbo)' : ''}`
+      )
     })
   }
 )


### PR DESCRIPTION
Fixes flaky test of version checker display when local version is greater than latest canary, but not published yet

Closes NEXT-2216