### PR TITLE
Fix sitemap generateSitemaps support for string id

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -187,20 +187,15 @@ ${errorOnBadHandler(resourcePath)}
 ${'' /* re-export the userland route configs */}
 export * from ${JSON.stringify(resourcePath)}
 
-function appendXmlExtension(id) {
-  return id && !id.endsWith('.xml') ? id + '.xml' : id 
-}
 
 export async function GET(_, ctx) {
   const { __metadata_id__, ...params } = ctx.params || {}
   ${
     '' /* sitemap will be optimized to [__metadata_id__] from [[..._metadata_id__]] in production */
   }
-  let targetId = process.env.NODE_ENV !== 'production'
+  const targetId = process.env.NODE_ENV !== 'production'
     ? __metadata_id__?.[0]
     : __metadata_id__
-
-  targetId = appendXmlExtension(targetId)
 
   let id = undefined
   const sitemaps = generateSitemaps ? await generateSitemaps() : null
@@ -212,8 +207,8 @@ export async function GET(_, ctx) {
           throw new Error('id property is required for every item returned from generateSitemaps')
         }
       }
-      const currentId = appendXmlExtension(item.id.toString())
-      return currentId === targetId
+
+      return item.id.toString() === targetId
     })?.id
     if (id == null) {
       return new NextResponse('Not Found', {

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -119,8 +119,8 @@ const generateImageMetadata = imageModule.generateImageMetadata
 ${errorOnBadHandler(resourcePath)}
 
 export async function GET(_, ctx) {
-  const { __metadata_id__ = [], ...params } = ctx.params || {}
-  const targetId = __metadata_id__[0]
+  const { __metadata_id__, ...params } = ctx.params || {}
+  const targetId = __metadata_id__?.[0]
   let id = undefined
   const imageMetadata = generateImageMetadata ? await generateImageMetadata({ params }) : null
 
@@ -187,9 +187,21 @@ ${errorOnBadHandler(resourcePath)}
 ${'' /* re-export the userland route configs */}
 export * from ${JSON.stringify(resourcePath)}
 
+function appendXmlExtension(id) {
+  return id && !id.endsWith('.xml') ? id + '.xml' : id 
+}
+
 export async function GET(_, ctx) {
-  const { __metadata_id__ = [], ...params } = ctx.params || {}
-  const targetId = __metadata_id__[0]
+  const { __metadata_id__, ...params } = ctx.params || {}
+  ${
+    '' /* sitemap will be optimized to [__metadata_id__] from [[..._metadata_id__]] in production */
+  }
+  let targetId = process.env.NODE_ENV !== 'production'
+    ? __metadata_id__?.[0]
+    : __metadata_id__
+
+  targetId = appendXmlExtension(targetId)
+
   let id = undefined
   const sitemaps = generateSitemaps ? await generateSitemaps() : null
 
@@ -200,7 +212,8 @@ export async function GET(_, ctx) {
           throw new Error('id property is required for every item returned from generateSitemaps')
         }
       }
-      return item.id.toString() === targetId
+      const currentId = appendXmlExtension(item.id.toString())
+      return currentId === targetId
     })?.id
     if (id == null) {
       return new NextResponse('Not Found', {

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/gsp/sitemap.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/gsp/sitemap.ts
@@ -1,7 +1,12 @@
 import { MetadataRoute } from 'next'
 
 export async function generateSitemaps() {
-  return [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }]
+  return [
+    { id: 'child0' },
+    { id: 'child1' },
+    { id: 'child2' },
+    { id: 'child3' },
+  ]
 }
 
 export default function sitemap({ id }): MetadataRoute.Sitemap {

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -197,11 +197,13 @@ createNextDescribe(
       })
 
       it('should support generate multi sitemaps with generateSitemaps', async () => {
-        const ids = [0, 1, 2]
+        const ids = ['child0', 'child1', 'child2', 'child3']
         function fetchSitemap(id) {
           return next
             .fetch(
-              isNextDev ? `/gsp/sitemap.xml/${id}` : `/gsp/sitemap/${id}.xml`
+              isNextDev
+                ? `/gsp/sitemap.xml/${id}.xml`
+                : `/gsp/sitemap/${id}.xml`
             )
             .then((res) => res.text())
         }

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -556,7 +556,7 @@ createNextDescribe(
       })
 
       it('should generate static paths of dynamic sitemap in production', async () => {
-        const sitemapPaths = [0, 1, 2].map(
+        const sitemapPaths = ['child0', 'child1', 'child2', 'child3'].map(
           (id) => `.next/server/app/gsp/sitemap/${id}.xml.meta`
         )
         const promises = sitemapPaths.map(async (filePath) => {

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -200,11 +200,7 @@ createNextDescribe(
         const ids = ['child0', 'child1', 'child2', 'child3']
         function fetchSitemap(id) {
           return next
-            .fetch(
-              isNextDev
-                ? `/gsp/sitemap.xml/${id}.xml`
-                : `/gsp/sitemap/${id}.xml`
-            )
+            .fetch(isNextDev ? `/gsp/sitemap.xml/${id}` : `/gsp/sitemap/${id}`)
             .then((res) => res.text())
         }
 


### PR DESCRIPTION
### What

Fixes the string id that broken when sitemap is optimized to static route.

### Why

When sitemap is optimized to static route in production, the route argument is changed from `[[...__metadata_id__]]` to `[__metadata_id__]`, so the type of it is also changed from array to string that should reflect in the loader code.

Fixes #60894 
Closes NEXT-2154
