### PR TITLE
chore: update turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "serde",
  "smallvec",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "serde",
@@ -7550,7 +7550,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7582,7 +7582,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7594,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7609,7 +7609,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7623,7 +7623,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7640,7 +7640,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7671,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "base16",
  "hex",
@@ -7683,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7697,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "mimalloc",
 ]
@@ -7715,7 +7715,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7772,7 +7772,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7813,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7885,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7912,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7936,7 +7936,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7973,7 +7973,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8008,7 +8008,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "serde",
  "serde_json",
@@ -8019,7 +8019,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8044,7 +8044,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8061,7 +8061,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8077,7 +8077,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8097,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "serde",
@@ -8112,7 +8112,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8127,7 +8127,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8162,7 +8162,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "serde",
@@ -8178,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8189,7 +8189,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8205,7 +8205,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.1#53fa9b451f9fc6ef697adee5a475e7da257341be"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240124.3#7f728f98c9cdfedfa761039ec1a13c4170a48c11"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8227,7 +8227,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.87.28", features = [
 testing = { version = "0.35.14" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240124.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240124.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240124.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240124.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240124.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240124.3" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -194,7 +194,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.2",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.3",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.26.2
         version: 0.26.2
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1(react-refresh@0.12.0)(webpack@5.86.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.3
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.3(react-refresh@0.12.0)(webpack@5.86.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25590,9 +25590,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1(react-refresh@0.12.0)(webpack@5.86.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.1'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.3(react-refresh@0.12.0)(webpack@5.86.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.3}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240124.3'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### Turbopack Updates

* https://github.com/vercel/turbo/pull/7091 <!-- Tobias Koppers - lock reqwest to 0.11.17 due to build issues  -->
* https://github.com/vercel/turbo/pull/7080 <!-- Tobias Koppers - reduce work and tasks during module analysis  -->
* https://github.com/vercel/turbo/pull/7093 <!-- Leah - fix: don't escape base path in ecmascript runtime to allow for URLs  -->

Closes PACK-2282
Fixes #60891 via https://github.com/vercel/turbo/pull/7093
