### PR TITLE
fix: emotion import source should be enabled in SSR contexts

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -353,7 +353,17 @@ pub async fn get_server_module_options_context(
     } else {
         None
     };
+
+    // Get the jsx transform options for the `client` side.
+    // This matches to the behavior of existing webpack config, if issuer layer is
+    // ssr or pages-browser (client bundle for the browser)
+    // applies client specific swc transforms.
+    //
+    // This enables correct emotion transform and other hydration between server and
+    // client bundles. ref: https://github.com/vercel/next.js/blob/4bbf9b6c70d2aa4237defe2bebfa790cdb7e334e/packages/next/src/build/webpack-config.ts#L1421-L1426
     let jsx_runtime_options =
+        get_jsx_transform_options(project_path, mode, None, false, next_config);
+    let rsc_jsx_runtime_options =
         get_jsx_transform_options(project_path, mode, None, true, next_config);
 
     let source_transforms: Vec<Vc<TransformPlugin>> = vec![
@@ -494,16 +504,6 @@ pub async fn get_server_module_options_context(
                 ..module_options_context.clone()
             };
 
-            // Get the jsx transform options for the `client` side.
-            // This matches to the behavior of existing webpack config, if issuer layer is
-            // ssr or pages-browser (client bundle for the browser)
-            // applies client specific swc transforms.
-            //
-            // This enables correct emotion transform and other hydration between server and
-            // client bundles. ref: https://github.com/vercel/next.js/blob/4bbf9b6c70d2aa4237defe2bebfa790cdb7e334e/packages/next/src/build/webpack-config.ts#L1421-L1426
-            let jsx_runtime_options =
-                get_jsx_transform_options(project_path, mode, None, false, next_config);
-
             ModuleOptionsContext {
                 enable_jsx: Some(jsx_runtime_options),
                 enable_webpack_loaders,
@@ -580,7 +580,7 @@ pub async fn get_server_module_options_context(
                 ..module_options_context.clone()
             };
             ModuleOptionsContext {
-                enable_jsx: Some(jsx_runtime_options),
+                enable_jsx: Some(rsc_jsx_runtime_options),
                 enable_webpack_loaders,
                 enable_postcss_transform,
                 enable_typescript_transform: Some(tsconfig),

--- a/packages/next-swc/crates/next-core/src/transform_options.rs
+++ b/packages/next-swc/crates/next-core/src/transform_options.rs
@@ -127,7 +127,7 @@ pub async fn get_jsx_transform_options(
     project_path: Vc<FileSystemPath>,
     mode: NextMode,
     resolve_options_context: Option<Vc<ResolveOptionsContext>>,
-    is_server_context: bool,
+    is_rsc_context: bool,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<JsxTransformOptions>> {
     let tsconfig = get_typescript_options(project_path).await;
@@ -155,7 +155,7 @@ pub async fn get_jsx_transform_options(
         development: mode.is_react_development(),
         // https://github.com/vercel/next.js/blob/3dc2c1c7f8441cdee31da9f7e0986d654c7fd2e7/packages/next/src/build/swc/options.ts#L112
         // This'll be ignored if ts|jsconfig explicitly specifies importSource
-        import_source: if is_emotion_enabled && !is_server_context {
+        import_source: if is_emotion_enabled && !is_rsc_context {
             Some("@emotion/react".to_string())
         } else {
             None


### PR DESCRIPTION
### What?

Due to probably a confusing argument name the correct import source for emotion wasn't used.

Closes PACK-2084
Fixes #59269
