### PR TITLE
Disable trace uploads with NEXT_TRACE_UPLOAD_DISABLE

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -292,7 +292,7 @@ const nextDev: CliCommand = async (args) => {
           // Starting the dev server will overwrite the `.next/trace` file, so we
           // must upload the existing contents before restarting the server to
           // preserve the metrics.
-          if (traceUploadUrl) {
+          if (traceUploadUrl && !process.env.NEXT_TRACE_UPLOAD_DISABLE) {
             uploadTrace({
               traceUploadUrl,
               mode: 'dev',

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -292,7 +292,7 @@ const nextDev: CliCommand = async (args) => {
           // Starting the dev server will overwrite the `.next/trace` file, so we
           // must upload the existing contents before restarting the server to
           // preserve the metrics.
-          if (traceUploadUrl && !process.env.NEXT_TRACE_UPLOAD_DISABLE) {
+          if (traceUploadUrl && !process.env.NEXT_TRACE_UPLOAD_DISABLED) {
             uploadTrace({
               traceUploadUrl,
               mode: 'dev',


### PR DESCRIPTION
While traces are never uploaded without an explicit opt-in, this option prevents them from being sent even when one is provided.


Closes PACK-2289