### PR TITLE
Fix typo in page-bootstrap

### DIFF
--- a/packages/next/src/client/next-dev-turbopack.ts
+++ b/packages/next/src/client/next-dev-turbopack.ts
@@ -3,7 +3,7 @@ import { initialize, version, router, emitter } from './'
 import initHMR from './dev/hot-middleware-client'
 
 import './setup-hydration-warning'
-import { pageBootrap } from './page-bootstrap'
+import { pageBootstrap } from './page-bootstrap'
 //@ts-expect-error requires "moduleResolution": "node16" in tsconfig.json and not .ts extension
 import { connect } from '@vercel/turbopack-ecmascript-runtime/dev/client/hmr-client.ts'
 import type { TurbopackMsgToBrowser } from '../server/dev/hot-reloader-types'
@@ -46,7 +46,7 @@ initialize({
       sendMessage: devClient.sendTurbopackMessage,
     })
 
-    return pageBootrap(assetPrefix)
+    return pageBootstrap(assetPrefix)
   })
   .catch((err) => {
     console.error('Error was not caught', err)

--- a/packages/next/src/client/next-dev.ts
+++ b/packages/next/src/client/next-dev.ts
@@ -2,7 +2,7 @@
 import './webpack'
 import { initialize, version, router, emitter } from './'
 import initHMR from './dev/hot-middleware-client'
-import { pageBootrap } from './page-bootstrap'
+import { pageBootstrap } from './page-bootstrap'
 
 import './setup-hydration-warning'
 
@@ -18,7 +18,7 @@ window.next = {
 const devClient = initHMR('webpack')
 initialize({ devClient })
   .then(({ assetPrefix }) => {
-    return pageBootrap(assetPrefix)
+    return pageBootstrap(assetPrefix)
   })
   .catch((err) => {
     console.error('Error was not caught', err)

--- a/packages/next/src/client/page-bootstrap.ts
+++ b/packages/next/src/client/page-bootstrap.ts
@@ -10,7 +10,7 @@ import {
 } from '../shared/lib/router/utils/querystring'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from '../server/dev/hot-reloader-types'
 
-export function pageBootrap(assetPrefix: string) {
+export function pageBootstrap(assetPrefix: string) {
   connectHMR({ assetPrefix, path: '/_next/webpack-hmr' })
 
   return hydrate({ beforeRender: displayContent }).then(() => {


### PR DESCRIPTION
### What?

There was a typo in the exported function of the page-bootstrap inside of the next/client. 

### How?

I fixed the typo from `pageBootrap` to `pageBootstrap` and I updated the modules that are importing the `pageBootstrap` function.

