### PR TITLE
Fix filesystempublicroutes test for Turbopack

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1095,7 +1095,8 @@ function bindingToApi(binding: any, _wasm: boolean) {
     if (nextConfigSerializable.images.loaderFile) {
       nextConfigSerializable.images = {
         ...nextConfig.images,
-        loaderFile: path.relative(projectPath, nextConfig.images.loaderFile),
+        loaderFile:
+          './' + path.relative(projectPath, nextConfig.images.loaderFile),
       }
     }
 

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1056,7 +1056,8 @@ function bindingToApi(binding: any, _wasm: boolean) {
     nextConfig: NextConfigComplete,
     projectPath: string
   ): Promise<string> {
-    let nextConfigSerializable = nextConfig as any
+    // Avoid mutating the existing `nextConfig` object.
+    let nextConfigSerializable = { ...(nextConfig as any) }
 
     nextConfigSerializable.generateBuildId =
       await nextConfig.generateBuildId?.()
@@ -1091,9 +1092,11 @@ function bindingToApi(binding: any, _wasm: boolean) {
         : undefined
 
     // loaderFile is an absolute path, we need it to be relative for turbopack.
-    if (nextConfig.images.loaderFile) {
-      nextConfig.images.loaderFile =
-        './' + path.relative(projectPath, nextConfig.images.loaderFile)
+    if (nextConfigSerializable.images.loaderFile) {
+      nextConfigSerializable.images = {
+        ...nextConfig.images,
+        loaderFile: path.relative(projectPath, nextConfig.images.loaderFile),
+      }
     }
 
     return JSON.stringify(nextConfigSerializable, null, 2)

--- a/test/integration/filesystempublicroutes/pages/exportpathmap-route.js
+++ b/test/integration/filesystempublicroutes/pages/exportpathmap-route.js
@@ -4,7 +4,7 @@ export default function ExportPathMapRoute() {
   const [mounted, setMounted] = useState(false)
   useEffect(() => {
     setMounted(true)
-  })
+  }, [])
   return (
     <div>
       <h1>exportpathmap was here</h1>

--- a/test/integration/filesystempublicroutes/pages/exportpathmap-route.js
+++ b/test/integration/filesystempublicroutes/pages/exportpathmap-route.js
@@ -1,1 +1,14 @@
-export default () => <div>exportpathmap was here</div>
+import { useEffect } from 'react'
+import { useState } from 'react'
+export default function ExportPathMapRoute() {
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    setMounted(true)
+  })
+  return (
+    <div>
+      <h1>exportpathmap was here</h1>
+      {mounted ? <div id="page-was-loaded">Hello World</div> : null}
+    </div>
+  )
+}

--- a/test/integration/filesystempublicroutes/test/index.test.js
+++ b/test/integration/filesystempublicroutes/test/index.test.js
@@ -2,12 +2,8 @@
 
 import { join } from 'path'
 import getPort from 'get-port'
-import {
-  fetchViaHTTP,
-  initNextServerScript,
-  killApp,
-  getPageFileFromBuildManifest,
-} from 'next-test-utils'
+import { fetchViaHTTP, initNextServerScript, killApp } from 'next-test-utils'
+import webdriver from 'next-webdriver'
 
 const appDir = join(__dirname, '../')
 let appPort
@@ -40,23 +36,14 @@ describe('FileSystemPublicRoutes', () => {
     const res = await fetch('/exportpathmap-route')
     expect(res.status).toBe(200)
     const body = await res.text()
-    expect(body).toMatch(
-      process.env.TURBOPACK ? /turbopack/ : /exportpathmap was here/
-    )
+    expect(body).toMatch(/exportpathmap was here/)
   })
 
-  it('should still handle /_next routes', async () => {
-    await fetch('/exportpathmap-route') // make sure it's built
-    const pageFile = getPageFileFromBuildManifest(
-      appDir,
-      '/exportpathmap-route'
-    )
-    const res = await fetch(join('/_next', pageFile))
-    expect(res.status).toBe(200)
-    const body = await res.text()
-    expect(body).toMatch(
-      process.env.TURBOPACK ? /turbopack/ : /exportpathmap was here/
-    )
+  it('should serve JavaScript files correctly', async () => {
+    const browser = await webdriver(context.appPort, '/exportpathmap-route')
+
+    const text = await browser.waitForElementByCss('#page-was-loaded').text()
+    expect(text).toBe('Hello World')
   })
 
   it('should route to public folder files', async () => {

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -10749,13 +10749,12 @@
   },
   "test/integration/filesystempublicroutes/test/index.test.js": {
     "passed": [
+      "FileSystemPublicRoutes should not route to the index page",
+      "FileSystemPublicRoutes should route to exportPathMap defined routes in development",
       "FileSystemPublicRoutes should route to public folder files",
       "FileSystemPublicRoutes should still handle /_next routes"
     ],
-    "failed": [
-      "FileSystemPublicRoutes should not route to the index page",
-      "FileSystemPublicRoutes should route to exportPathMap defined routes in development"
-    ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -10752,7 +10752,7 @@
       "FileSystemPublicRoutes should not route to the index page",
       "FileSystemPublicRoutes should route to exportPathMap defined routes in development",
       "FileSystemPublicRoutes should route to public folder files",
-      "FileSystemPublicRoutes should still handle /_next routes"
+      "FileSystemPublicRoutes should serve JavaScript files correctly"
     ],
     "failed": [],
     "pending": [],


### PR DESCRIPTION
## What?

`exportPathMap` didn't work when Turbopack was enabled because the `serializeNextConfig` function mutates the original values, overriding `exportPathMap`.

This PR changes the serialization to copy the object and mutate only the copied object.

Also refactored the test that was checking `_next`, the better way to test that is to have the page render something dynamically, which is what is added in this PR.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2225