### PR TITLE
Skip CSS Modules composes test in Turbopack

### DIFF
--- a/test/integration/css/test/css-modules.test.js
+++ b/test/integration/css/test/css-modules.test.js
@@ -288,49 +288,39 @@ describe('Ordering with Global CSS and Modules (prod)', () => {
 })
 
 // https://github.com/vercel/next.js/issues/12445
-describe('CSS Modules Composes Ordering', () => {
-  const appDir = join(fixturesDir, 'composes-ordering')
-  let app, appPort
+// This feature is not supported in Turbopack
+;(process.env.TURBOPACK ? describe.skip : describe)(
+  'CSS Modules Composes Ordering',
+  () => {
+    const appDir = join(fixturesDir, 'composes-ordering')
+    let app, appPort
 
-  function tests(isDev = false) {
-    async function checkBlackTitle(browser) {
-      await browser.waitForElementByCss('#black-title')
-      const titleColor = await browser.eval(
-        `window.getComputedStyle(document.querySelector('#black-title')).color`
-      )
-      expect(titleColor).toBe('rgb(17, 17, 17)')
-    }
-    async function checkRedTitle(browser) {
-      await browser.waitForElementByCss('#red-title')
-      const titleColor = await browser.eval(
-        `window.getComputedStyle(document.querySelector('#red-title')).color`
-      )
-      expect(titleColor).toBe('rgb(255, 0, 0)')
-    }
-
-    it('should have correct color on index page (on load)', async () => {
-      const browser = await webdriver(appPort, '/')
-      try {
-        await checkBlackTitle(browser)
-      } finally {
-        await browser.close()
+    function tests(isDev = false) {
+      async function checkBlackTitle(browser) {
+        await browser.waitForElementByCss('#black-title')
+        const titleColor = await browser.eval(
+          `window.getComputedStyle(document.querySelector('#black-title')).color`
+        )
+        expect(titleColor).toBe('rgb(17, 17, 17)')
       }
-    })
-
-    it('should have correct color on index page (on hover)', async () => {
-      const browser = await webdriver(appPort, '/')
-      try {
-        await checkBlackTitle(browser)
-        await browser.waitForElementByCss('#link-other').moveTo()
-        await waitFor(2000)
-        await checkBlackTitle(browser)
-      } finally {
-        await browser.close()
+      async function checkRedTitle(browser) {
+        await browser.waitForElementByCss('#red-title')
+        const titleColor = await browser.eval(
+          `window.getComputedStyle(document.querySelector('#red-title')).color`
+        )
+        expect(titleColor).toBe('rgb(255, 0, 0)')
       }
-    })
 
-    if (!isDev) {
-      it('should not change color on hover', async () => {
+      it('should have correct color on index page (on load)', async () => {
+        const browser = await webdriver(appPort, '/')
+        try {
+          await checkBlackTitle(browser)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('should have correct color on index page (on hover)', async () => {
         const browser = await webdriver(appPort, '/')
         try {
           await checkBlackTitle(browser)
@@ -342,117 +332,134 @@ describe('CSS Modules Composes Ordering', () => {
         }
       })
 
-      it('should have correct CSS injection order', async () => {
+      if (!isDev) {
+        it('should not change color on hover', async () => {
+          const browser = await webdriver(appPort, '/')
+          try {
+            await checkBlackTitle(browser)
+            await browser.waitForElementByCss('#link-other').moveTo()
+            await waitFor(2000)
+            await checkBlackTitle(browser)
+          } finally {
+            await browser.close()
+          }
+        })
+
+        it('should have correct CSS injection order', async () => {
+          const browser = await webdriver(appPort, '/')
+          try {
+            await checkBlackTitle(browser)
+
+            const prevSiblingHref = await browser.eval(
+              `document.querySelector('link[rel=stylesheet][data-n-p]').previousSibling.getAttribute('href')`
+            )
+            const currentPageHref = await browser.eval(
+              `document.querySelector('link[rel=stylesheet][data-n-p]').getAttribute('href')`
+            )
+            expect(prevSiblingHref).toBeDefined()
+            expect(prevSiblingHref).toBe(currentPageHref)
+
+            // Navigate to other:
+            await browser.waitForElementByCss('#link-other').click()
+            await checkRedTitle(browser)
+
+            const newPrevSibling = await browser.eval(
+              `document.querySelector('style[data-n-href]').previousSibling.getAttribute('data-n-css')`
+            )
+            const newPageHref = await browser.eval(
+              `document.querySelector('style[data-n-href]').getAttribute('data-n-href')`
+            )
+            expect(newPrevSibling).toBe('')
+            expect(newPageHref).toBeDefined()
+            expect(newPageHref).not.toBe(currentPageHref)
+
+            // Navigate to home:
+            await browser.waitForElementByCss('#link-index').click()
+            await checkBlackTitle(browser)
+
+            const newPrevSibling2 = await browser.eval(
+              `document.querySelector('style[data-n-href]').previousSibling.getAttribute('data-n-css')`
+            )
+            const newPageHref2 = await browser.eval(
+              `document.querySelector('style[data-n-href]').getAttribute('data-n-href')`
+            )
+            expect(newPrevSibling2).toBe('')
+            expect(newPageHref2).toBeDefined()
+            expect(newPageHref2).toBe(currentPageHref)
+          } finally {
+            await browser.close()
+          }
+        })
+      }
+
+      it('should have correct color on index page (on nav from index)', async () => {
         const browser = await webdriver(appPort, '/')
         try {
           await checkBlackTitle(browser)
-
-          const prevSiblingHref = await browser.eval(
-            `document.querySelector('link[rel=stylesheet][data-n-p]').previousSibling.getAttribute('href')`
-          )
-          const currentPageHref = await browser.eval(
-            `document.querySelector('link[rel=stylesheet][data-n-p]').getAttribute('href')`
-          )
-          expect(prevSiblingHref).toBeDefined()
-          expect(prevSiblingHref).toBe(currentPageHref)
-
-          // Navigate to other:
           await browser.waitForElementByCss('#link-other').click()
+
+          // Wait for navigation:
+          await browser.waitForElementByCss('#link-index')
           await checkRedTitle(browser)
 
-          const newPrevSibling = await browser.eval(
-            `document.querySelector('style[data-n-href]').previousSibling.getAttribute('data-n-css')`
-          )
-          const newPageHref = await browser.eval(
-            `document.querySelector('style[data-n-href]').getAttribute('data-n-href')`
-          )
-          expect(newPrevSibling).toBe('')
-          expect(newPageHref).toBeDefined()
-          expect(newPageHref).not.toBe(currentPageHref)
-
-          // Navigate to home:
+          // Navigate back to index:
           await browser.waitForElementByCss('#link-index').click()
           await checkBlackTitle(browser)
+        } finally {
+          await browser.close()
+        }
+      })
 
-          const newPrevSibling2 = await browser.eval(
-            `document.querySelector('style[data-n-href]').previousSibling.getAttribute('data-n-css')`
-          )
-          const newPageHref2 = await browser.eval(
-            `document.querySelector('style[data-n-href]').getAttribute('data-n-href')`
-          )
-          expect(newPrevSibling2).toBe('')
-          expect(newPageHref2).toBeDefined()
-          expect(newPageHref2).toBe(currentPageHref)
+      it('should have correct color on index page (on nav from other)', async () => {
+        const browser = await webdriver(appPort, '/other')
+        try {
+          await checkRedTitle(browser)
+          await browser.waitForElementByCss('#link-index').click()
+
+          // Wait for navigation:
+          await browser.waitForElementByCss('#link-other')
+          await checkBlackTitle(browser)
+
+          // Navigate back to other:
+          await browser.waitForElementByCss('#link-other').click()
+          await checkRedTitle(browser)
         } finally {
           await browser.close()
         }
       })
     }
 
-    it('should have correct color on index page (on nav from index)', async () => {
-      const browser = await webdriver(appPort, '/')
-      try {
-        await checkBlackTitle(browser)
-        await browser.waitForElementByCss('#link-other').click()
+    describe('Development Mode', () => {
+      beforeAll(async () => {
+        await remove(join(appDir, '.next'))
+      })
+      beforeAll(async () => {
+        appPort = await findPort()
+        app = await launchApp(appDir, appPort)
+      })
+      afterAll(async () => {
+        await killApp(app)
+      })
 
-        // Wait for navigation:
-        await browser.waitForElementByCss('#link-index')
-        await checkRedTitle(browser)
-
-        // Navigate back to index:
-        await browser.waitForElementByCss('#link-index').click()
-        await checkBlackTitle(browser)
-      } finally {
-        await browser.close()
-      }
+      tests(true)
     })
+    ;(process.env.TURBOPACK ? describe.skip : describe)(
+      'production mode',
+      () => {
+        beforeAll(async () => {
+          await remove(join(appDir, '.next'))
+        })
+        beforeAll(async () => {
+          await nextBuild(appDir, [], {})
+          appPort = await findPort()
+          app = await nextStart(appDir, appPort)
+        })
+        afterAll(async () => {
+          await killApp(app)
+        })
 
-    it('should have correct color on index page (on nav from other)', async () => {
-      const browser = await webdriver(appPort, '/other')
-      try {
-        await checkRedTitle(browser)
-        await browser.waitForElementByCss('#link-index').click()
-
-        // Wait for navigation:
-        await browser.waitForElementByCss('#link-other')
-        await checkBlackTitle(browser)
-
-        // Navigate back to other:
-        await browser.waitForElementByCss('#link-other').click()
-        await checkRedTitle(browser)
-      } finally {
-        await browser.close()
+        tests()
       }
-    })
+    )
   }
-
-  describe('Development Mode', () => {
-    beforeAll(async () => {
-      await remove(join(appDir, '.next'))
-    })
-    beforeAll(async () => {
-      appPort = await findPort()
-      app = await launchApp(appDir, appPort)
-    })
-    afterAll(async () => {
-      await killApp(app)
-    })
-
-    tests(true)
-  })
-  ;(process.env.TURBOPACK ? describe.skip : describe)('production mode', () => {
-    beforeAll(async () => {
-      await remove(join(appDir, '.next'))
-    })
-    beforeAll(async () => {
-      await nextBuild(appDir, [], {})
-      appPort = await findPort()
-      app = await nextStart(appDir, appPort)
-    })
-    afterAll(async () => {
-      await killApp(app)
-    })
-
-    tests()
-  })
-})
+)


### PR DESCRIPTION
## What?

The first version of Turbopack won't support the `composes` keyword.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2228