### PR TITLE
Allow Custom Domain For GTM

### DIFF
--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -8,7 +8,7 @@ import type { GTMParams } from '../types/google'
 let currDataLayerName: string | undefined = undefined
 
 export function GoogleTagManager(props: GTMParams) {
-  const { gtmId, dataLayerName = 'dataLayer', auth, preview, dataLayer } = props
+  const { gtmId, dataLayerName = 'dataLayer', auth, preview, dataLayer, domain = 'https://www.googletagmanager.com/gtm.js' } = props
 
   if (currDataLayerName === undefined) {
     currDataLayerName = dataLayerName
@@ -47,7 +47,7 @@ export function GoogleTagManager(props: GTMParams) {
       <Script
         id="_next-gtm"
         data-ntpc="GTM"
-        src={`https://www.googletagmanager.com/gtm.js?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
+        src={`${domain}?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
       />
     </>
   )

--- a/packages/third-parties/src/types/google.ts
+++ b/packages/third-parties/src/types/google.ts
@@ -11,6 +11,7 @@ export type GTMParams = {
   dataLayerName?: string
   auth?: string
   preview?: string
+  domain?: string
 }
 
 export type GAParams = {


### PR DESCRIPTION
### What/Why

Allows overriding the default google tag manager domain with your own. Useful for people who reverse proxy the 
google domain to their own so it doesn't get ad blocked. (ie. https://stape.io/solutions/custom-gtm-loader)

### How?

Simple update to the `GoogleTagManager` props