### PR TITLE
fix(turbopack): `react-dom/server` in rsc context

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -657,6 +657,9 @@ async fn rsc_aliases(
                 "react-server-dom-webpack/server.node" => format!("next/dist/server/future/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node"),
                 "react-server-dom-turbopack/server.edge" => format!("next/dist/server/future/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge"),
                 "react-server-dom-turbopack/server.node" => format!("next/dist/server/future/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node"),
+
+                // Needed to make `react-dom/server` work.
+                "next/dist/compiled/react" => format!("next/dist/compiled/react/index.js"),
             })
         }
     }


### PR DESCRIPTION
### What?
Probably not the right solution, next.js disables the `react-server` import condition in there somehow I think

### Why?

Resend uses `@react-email/render` which uses `renderToString` from `react-dom/server`.
Unfortunately importing `react-dom/server` with the `react-server` import condition leads to a broken bundle (which seems like a bug in react?).

Closes PACK-2243
Fixes #57936
