### PR TITLE
exclude default routes from isPageStatic check

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -115,6 +115,7 @@ import {
   isReservedPage,
   isAppBuiltinNotFoundPage,
   serializePageInfos,
+  isReservedAppPage,
 } from './utils'
 import type { PageInfo, PageInfos, AppConfig } from './utils'
 import { writeBuildId } from './write-build-id'
@@ -1794,7 +1795,10 @@ export default async function build(
                     pageType === 'app' &&
                     staticInfo?.rsc !== RSC_MODULE_TYPES.client
 
-                  if (pageType === 'app' || !isReservedPage(page)) {
+                  if (
+                    (pageType === 'app' && !isReservedAppPage(page)) ||
+                    (pageType === 'pages' && !isReservedPage(page))
+                  ) {
                     try {
                       let edgeInfo: any
 

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -84,6 +84,7 @@ import { interopDefault } from '../lib/interop-default'
 import type { PageExtensions } from './page-extensions-type'
 import { formatDynamicImportPath } from '../lib/format-dynamic-import-path'
 import { isInterceptionRouteAppPath } from '../server/future/helpers/interception-routes'
+import { isDefaultRoute } from '../lib/is-default-route'
 
 export type ROUTER_TYPE = 'pages' | 'app'
 
@@ -2121,6 +2122,10 @@ startServer({
 
 export function isReservedPage(page: string) {
   return RESERVED_PAGE.test(page)
+}
+
+export function isReservedAppPage(page: string) {
+  return isDefaultRoute(page)
 }
 
 export function isAppBuiltinNotFoundPage(page: string) {

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/edge-runtime/@slot/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/edge-runtime/@slot/default.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'default'
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/edge-runtime/@slot/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/edge-runtime/@slot/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return '@slot'
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/edge-runtime/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/edge-runtime/layout.tsx
@@ -1,0 +1,17 @@
+export const runtime = 'edge'
+
+export default function Layout({
+  children,
+  slot,
+}: {
+  children: React.ReactNode
+  slot: React.ReactNode
+}) {
+  return (
+    <div>
+      <h1>Layout</h1>
+      {children}
+      {slot}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/edge-runtime/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/edge-runtime/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello World</div>
+}


### PR DESCRIPTION
### What & Why
Using parallel routes with edge runtime would cause a build error when using a default segment, because edge runtime has special handling to [read the client reference manifests](https://github.com/vercel/next.js/blob/12c90405681cf4120e3fa7f3e10d9466f598f9bb/packages/next/src/build/utils.ts#L1543-L1555) for these when determining if a page is static.

### How
In a similar fashion to how we exclude static checks on reserved pages, I added similar handling for app pages. 

Fixes #60917
Closes NEXT-2241
