### PR TITLE
remove unnecessary PPR branch in non-PPR reducer

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -166,7 +166,7 @@ function navigateReducer_noPPR(
   prefetchQueue.bump(data!)
 
   return data!.then(
-    ([flightData, canonicalUrlOverride, postponed]) => {
+    ([flightData, canonicalUrlOverride]) => {
       // we only want to mark this once
       if (prefetchValues && !prefetchValues.lastUsedTime) {
         // important: we should only mark the cache node as dirty after we unsuspend from the call above
@@ -226,11 +226,8 @@ function navigateReducer_noPPR(
           )
 
           if (
-            (!applied &&
-              prefetchEntryCacheStatus === PrefetchCacheEntryStatus.stale) ||
-            // TODO-APP: If the prefetch was postponed, we don't want to apply it
-            // until we land router changes to handle the postponed case.
-            postponed
+            !applied &&
+            prefetchEntryCacheStatus === PrefetchCacheEntryStatus.stale
           ) {
             applied = addRefetchToLeafSegments(
               cache,


### PR DESCRIPTION
PPR flows through the `navigateReducer_PPR` branch. This handling is vestigial from before proper PPR navigation support was added.

Closes NEXT-2244