### PR TITLE
tweak prefetched argument to router cache utils

### DIFF
--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -7,7 +7,7 @@ export function applyFlightData(
   existingCache: CacheNode,
   cache: CacheNode,
   flightDataPath: FlightDataPath,
-  wasPrefetched: boolean = false
+  hasReusablePrefetch: boolean = false
 ): boolean {
   // The one before last item is the router state tree patch
   const [treePatch, cacheNodeSeedData, head] = flightDataPath.slice(-3)
@@ -32,7 +32,7 @@ export function applyFlightData(
       treePatch,
       cacheNodeSeedData,
       head,
-      wasPrefetched
+      hasReusablePrefetch
     )
   } else {
     // Copy rsc for the root node of the cache.
@@ -47,7 +47,7 @@ export function applyFlightData(
       cache,
       existingCache,
       flightDataPath,
-      wasPrefetched
+      hasReusablePrefetch
     )
   }
 

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -14,7 +14,7 @@ export function fillCacheWithNewSubTreeData(
   newCache: CacheNode,
   existingCache: CacheNode,
   flightDataPath: FlightDataPath,
-  wasPrefetched?: boolean
+  hasReusablePrefetch?: boolean
 ): void {
   const isLastEntry = flightDataPath.length <= 5
   const [parallelRouteKey, segment] = flightDataPath
@@ -71,7 +71,7 @@ export function fillCacheWithNewSubTreeData(
         flightDataPath[2],
         seedData,
         flightDataPath[4],
-        wasPrefetched
+        hasReusablePrefetch
       )
 
       childSegmentMap.set(cacheKey, childCacheNode)
@@ -99,6 +99,6 @@ export function fillCacheWithNewSubTreeData(
     childCacheNode,
     existingChildCacheNode,
     flightDataPath.slice(2),
-    wasPrefetched
+    hasReusablePrefetch
   )
 }

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -11,7 +11,7 @@ export function fillLazyItemsTillLeafWithHead(
   routerState: FlightRouterState,
   cacheNodeSeedData: CacheNodeSeedData | null,
   head: React.ReactNode,
-  wasPrefetched?: boolean
+  hasReusablePrefetch?: boolean
 ): void {
   const isLastSegment = Object.keys(routerState[1]).length === 0
   if (isLastSegment) {
@@ -59,9 +59,9 @@ export function fillLazyItemsTillLeafWithHead(
             prefetchRsc: null,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
           }
-        } else if (wasPrefetched && existingCacheNode) {
+        } else if (hasReusablePrefetch && existingCacheNode) {
           // No new data was sent from the server, but the existing cache node
-          // was prefetched, so we should reuse that.
+          // has a non-expired prefetch, so we should reuse that.
           newCacheNode = {
             lazyData: existingCacheNode.lazyData,
             rsc: existingCacheNode.rsc,
@@ -72,7 +72,7 @@ export function fillLazyItemsTillLeafWithHead(
             parallelRoutes: new Map(existingCacheNode.parallelRoutes),
           } as CacheNode
         } else {
-          // No data available for this node. This will trigger a lazy fetch
+          // No data available for this node, or the prefetch entry expired. This will trigger a lazy fetch
           // during render.
           newCacheNode = {
             lazyData: null,
@@ -91,7 +91,7 @@ export function fillLazyItemsTillLeafWithHead(
           parallelRouteState,
           parallelSeedData ? parallelSeedData : null,
           head,
-          wasPrefetched
+          hasReusablePrefetch
         )
 
         newCache.parallelRoutes.set(key, parallelRouteCacheNode)
@@ -133,7 +133,7 @@ export function fillLazyItemsTillLeafWithHead(
       parallelRouteState,
       parallelSeedData,
       head,
-      wasPrefetched
+      hasReusablePrefetch
     )
   }
 }

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -166,7 +166,7 @@ function navigateReducer_noPPR(
   prefetchQueue.bump(data!)
 
   return data!.then(
-    ([flightData, canonicalUrlOverride, postponed]) => {
+    ([flightData, canonicalUrlOverride]) => {
       // we only want to mark this once
       if (prefetchValues && !prefetchValues.lastUsedTime) {
         // important: we should only mark the cache node as dirty after we unsuspend from the call above
@@ -226,11 +226,8 @@ function navigateReducer_noPPR(
           )
 
           if (
-            (!applied &&
-              prefetchEntryCacheStatus === PrefetchCacheEntryStatus.stale) ||
-            // TODO-APP: If the prefetch was postponed, we don't want to apply it
-            // until we land router changes to handle the postponed case.
-            postponed
+            !applied &&
+            prefetchEntryCacheStatus === PrefetchCacheEntryStatus.stale
           ) {
             applied = addRefetchToLeafSegments(
               cache,


### PR DESCRIPTION
No behavior changes here, purely renaming this argument as I found it confusing while working on a router cache bug. It's not strictly representing if a cache node was prefetched, but rather if the prefetch entry exists & can be re-used, since it could be that it was prefetched but had a prefetch status of stale/expired.

Closes NEXT-2245