### PR TITLE
Add stack trace to client rendering bailout error

### DIFF
--- a/packages/next/src/lib/format-server-error.ts
+++ b/packages/next/src/lib/format-server-error.ts
@@ -22,6 +22,22 @@ function setMessage(error: Error, message: string): void {
   }
 }
 
+/**
+ * Input:
+ * Error: Something went wrong
+    at funcName (/path/to/file.js:10:5)
+    at anotherFunc (/path/to/file.js:15:10)
+ 
+ * Output:
+    at funcName (/path/to/file.js:10:5)
+    at anotherFunc (/path/to/file.js:15:10) 
+ */
+export function getStackWithoutErrorMessage(error: Error): string {
+  const stack = error.stack
+  if (!stack) return ''
+  return stack.replace(/^[^\n]*\n/, '')
+}
+
 export function formatServerError(error: Error): void {
   if (typeof error?.message !== 'string') return
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -81,6 +81,7 @@ import { isDynamicServerError } from '../../client/components/hooks-server-conte
 import { useFlightResponse } from './use-flight-response'
 import { isStaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import { isInterceptionRouteAppPath } from '../future/helpers/interception-routes'
+import { getStackWithoutErrorMessage } from '../../lib/format-server-error'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -1014,8 +1015,9 @@ async function renderToHTMLOrFlightImpl(
           console.log()
 
           if (renderOpts.experimental.missingSuspenseWithCSRBailout) {
+            const stack = getStackWithoutErrorMessage(err)
             error(
-              `${err.reason} should be wrapped in a suspense boundary at page "${pagePath}". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout`
+              `${err.reason} should be wrapped in a suspense boundary at page "${pagePath}". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout\n${stack}`
             )
 
             throw err

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -77,8 +77,7 @@ export function createErrorHandler({
             const { logAppDirError } =
               require('../dev/log-app-dir-error') as typeof import('../dev/log-app-dir-error')
             logAppDirError(err)
-          }
-          if (process.env.NODE_ENV === 'production') {
+          } else {
             console.error(err)
           }
         }

--- a/test/e2e/app-dir/missing-suspense-with-csr-bailout/app/layout-no-suspense.js
+++ b/test/e2e/app-dir/missing-suspense-with-csr-bailout/app/layout-no-suspense.js
@@ -1,8 +1,0 @@
-export default function Layout({ children }) {
-  return (
-    <html>
-      <head />
-      <body>{children}</body>
-    </html>
-  )
-}

--- a/test/e2e/app-dir/missing-suspense-with-csr-bailout/app/layout-suspense.js
+++ b/test/e2e/app-dir/missing-suspense-with-csr-bailout/app/layout-suspense.js
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+
+export default function Layout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>
+        <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/missing-suspense-with-csr-bailout/app/layout.js
+++ b/test/e2e/app-dir/missing-suspense-with-csr-bailout/app/layout.js
@@ -1,12 +1,8 @@
-import { Suspense } from 'react'
-
 export default function Layout({ children }) {
   return (
     <html>
       <head />
-      <body>
-        <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
-      </body>
+      <body>{children}</body>
     </html>
   )
 }

--- a/test/e2e/app-dir/missing-suspense-with-csr-bailout/app/page.js
+++ b/test/e2e/app-dir/missing-suspense-with-csr-bailout/app/page.js
@@ -2,7 +2,16 @@
 
 import { useSearchParams } from 'next/navigation'
 
-export default function Page() {
+function SearchParams() {
   useSearchParams()
-  return <div>Page</div>
+  return null
+}
+
+export default function Page() {
+  return (
+    <>
+      <SearchParams />
+      <div>Page</div>
+    </>
+  )
 }


### PR DESCRIPTION
When there's `useSearchParams` hook triggers the bailout to client side rendering, users might hard to find where it's from since it could either from users code base or third party libraries. Adding the stack trace for it so they could at least investigate which line is throwing from the server bundle. Will improve it in the later future when we can give more insights.

#### After
```
 ⨯ useSearchParams() should be wrapped in a suspense boundary at page "/". Read more: https://
nextjs.org/docs/messages/missing-suspense-with-csr-bailout
    at a (/private/var/folders/gy/kq4zjn8s0ljf9sfjyyh_nj640000gn/T/next-install-aa5f331b7f6af2
82fd9bab0f69685454d1f50dc8f3c775da23d4e5e807a970cb/.next/server/chunks/846.js:1:9912)
    at h (/private/var/folders/gy/kq4zjn8s0ljf9sfjyyh_nj640000gn/T/next-install-aa5f331b7f6af2
82fd9bab0f69685454d1f50dc8f3c775da23d4e5e807a970cb/.next/server/chunks/846.js:1:22018)
    at a (/private/var/folders/gy/kq4zjn8s0ljf9sfjyyh_nj640000gn/T/next-install-aa5f331b7f6af2
82fd9bab0f69685454d1f50dc8f3c775da23d4e5e807a970cb/.next/server/app/page.js:1:2518)
```

#### Before
```
 ⨯ useSearchParams() should be wrapped in a suspense boundary at page "/". Read more: https://
nextjs.org/docs/messages/missing-suspense-with-csr-bailout
```

Closes NEXT-2239