### PR TITLE
Skip resolving test in Turbopack

### DIFF
--- a/test/integration/typescript/test/index.test.js
+++ b/test/integration/typescript/test/index.test.js
@@ -77,6 +77,7 @@ describe('TypeScript Features', () => {
       'should resolve files in correct order',
       async () => {
         const $ = await get$('/hello')
+        // eslint-disable-next-line jest/no-standalone-expect
         expect($('#imported-value').text()).toBe('OK')
       }
     )

--- a/test/integration/typescript/test/index.test.js
+++ b/test/integration/typescript/test/index.test.js
@@ -72,10 +72,14 @@ describe('TypeScript Features', () => {
       expect($('#value').text()).toBe('test')
     })
 
-    it('should resolve files in correct order', async () => {
-      const $ = await get$('/hello')
-      expect($('#imported-value').text()).toBe('OK')
-    })
+    // Turbopack has the correct behavior where `.ts` / `.tsx` is preferred over `.js` / `.jsx`. Webpack prefers `.js` / `.jsx`.
+    ;(process.env.TURBOPACK ? it.skip : it)(
+      'should resolve files in correct order',
+      async () => {
+        const $ = await get$('/hello')
+        expect($('#imported-value').text()).toBe('OK')
+      }
+    )
 
     // old behavior:
     it.skip('should report type checking to stdout', async () => {


### PR DESCRIPTION
## What?

Turbopack has the correct behavior of preferring `.ts` / `.tsx` for first-party code. In Webpack we don't have a way to only resolve `.ts`/`.tsx` in first-party code. Turbopack doesn't resolve `.ts`/`.tsx` in `node_modules`.


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2254