### PR TITLE
example(with-stripe-typescript): `use client` required for error components

### DIFF
--- a/examples/with-stripe-typescript/app/donate-with-checkout/result/error.tsx
+++ b/examples/with-stripe-typescript/app/donate-with-checkout/result/error.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 export default function Error({ error }: { error: Error }) {
   return <h2>{error.message}</h2>;
 }

--- a/examples/with-stripe-typescript/app/donate-with-elements/result/error.tsx
+++ b/examples/with-stripe-typescript/app/donate-with-elements/result/error.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 export default function Error({ error }: { error: Error }) {
   return <h2>{error.message}</h2>;
 }

--- a/examples/with-stripe-typescript/app/donate-with-embedded-checkout/result/error.tsx
+++ b/examples/with-stripe-typescript/app/donate-with-embedded-checkout/result/error.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 export default function Error({ error }: { error: Error }) {
   return <h2>{error.message}</h2>;
 }


### PR DESCRIPTION
### What?

* `error.tsx` components must be client components.