### PR TITLE
chore: add `good first issue` label comment

### DIFF
--- a/.github/good-first-issue.md
+++ b/.github/good-first-issue.md
@@ -9,4 +9,4 @@ Please remember to add tests to confirm your code changes will fix the issue and
 If you have any questions, feel free to ask below or on the PR. Generally, you don't need to `@mention` anyone directly, as we will get notified anyway and will respond as soon as we can.
 
 > [!NOTE]  
-> There is no need to ask for permission "can I work on this?" Please, go ahead if there is no linked PR :slightly_smiling_face:_
+> There is no need to ask for permission "can I work on this?" Please, go ahead if there is no linked PR :slightly_smiling_face:

--- a/.github/good-first-issue.md
+++ b/.github/good-first-issue.md
@@ -1,0 +1,13 @@
+The issue was marked with the `good first issue` label by a maintainer.
+
+This means that it is a good candidate for someone interested in contributing to the project, but does not know where to start.
+
+Have a look at the [Contributing Guide](https://github.com/vercel/next.js/blob/canary/contributing.md) first.
+
+This will help you set up your development environment to get started. When you are ready, open a PR, and link back to this issue in the form of adding "Fixes #1234" to the PR description, where "1234" is the issue number. This will auto-close the issue when the PR gets merged, making it easier for us to keep track of what has been fixed.
+
+Please make sure that - if applicable - you add tests for the changes you make.
+
+If you have any questions, feel free to ask below or on the PR. Generally, you don't need to `@mention` anyone directly, as we will get notified anyway and will respond as soon as we can.
+
+_NOTE: if nobody has picked up the issue yet, there is no need to ask for permission "can I work on this?" Please, go ahead :slightly_smiling_face:_

--- a/.github/good-first-issue.md
+++ b/.github/good-first-issue.md
@@ -2,12 +2,11 @@ The issue was marked with the `good first issue` label by a maintainer.
 
 This means that it is a good candidate for someone interested in contributing to the project, but does not know where to start.
 
-Have a look at the [Contributing Guide](https://github.com/vercel/next.js/blob/canary/contributing.md) first.
+To get started, read the [Contributing Guide](https://github.com/vercel/next.js/blob/canary/contributing.md). When you are ready, open a PR and link back to this issue in the form of adding `Fixes #1234` to the PR description, where `1234` is the issue number. This will automatically close the issue when the PR gets merged, making it easier for us to keep track of what has been fixed.
 
-This will help you set up your development environment to get started. When you are ready, open a PR, and link back to this issue in the form of adding "Fixes #1234" to the PR description, where "1234" is the issue number. This will auto-close the issue when the PR gets merged, making it easier for us to keep track of what has been fixed.
-
-Please make sure that - if applicable - you add tests for the changes you make.
+Please remember to add tests to confirm your code changes will fix the issue and we do not regress in the future.
 
 If you have any questions, feel free to ask below or on the PR. Generally, you don't need to `@mention` anyone directly, as we will get notified anyway and will respond as soon as we can.
 
-_NOTE: if nobody has picked up the issue yet, there is no need to ask for permission "can I work on this?" Please, go ahead :slightly_smiling_face:_
+> [!NOTE]  
+> There is no need to ask for permission "can I work on this?" Please, go ahead if there is no linked PR :slightly_smiling_face:_

--- a/.github/workflows/issue_validator.yml
+++ b/.github/workflows/issue_validator.yml
@@ -26,7 +26,8 @@ jobs:
             {
               "please add a complete reproduction": ".github/invalid-reproduction.md",
               "please simplify reproduction": ".github/simplify-reproduction.md",
-              "please verify canary": ".github/verify-canary.md"
+              "please verify canary": ".github/verify-canary.md",
+              "good first issue": ".github/good-first-issue.md"
             }
           reproduction-comment: '.github/invalid-link.md'
           reproduction-hosts: 'github.com,codesandbox.io'

--- a/contributing/repository/triaging.md
+++ b/contributing/repository/triaging.md
@@ -41,6 +41,11 @@ The issue will receive [this comment](https://github.com/vercel/next.js/blob/can
 The provided reproduction is too complex or requires too many steps to reproduce. If a simplified reproduction is not provided for more than 30 days, the issue becomes stale and will be automatically closed. If a reproduction is provided within 30 days, a `needs triage` label is added, indicating that the issue needs another look from a maintainer.
 The issue will receive [this comment](https://github.com/vercel/next.js/blob/canary/.github/simplify-reproduction.md)
 
+4. `good first issue`
+
+The issue is considered beginner-friendly enough to be a good starting point for someone new to the project who wants to contribute.
+The issue will receive [this comment](https://github.com/vercel/next.js/blob/canary/.github/good-first-issue.md)
+
 ## Verified issues
 
 If an issue is verified, it will receive the `linear: next`, `linear: dx` or `linear: web` label and will be tracked by the maintainers. Additionally, one or more `area:` label(s) can be added to indicate which part of Next.js is affected.


### PR DESCRIPTION
### What?

Add a comment to issues labeled with `good first issue`. Rendered comment [here](https://github.com/vercel/next.js/blob/b868cf95f29a305bca1afabdb8db76e64a1cce30/.github/good-first-issue.md).

### Why?

We have historically marked issues with this label, but rarely did it make someone contribute. A few times I have seen people asking for permission first instead of contributing. This comment will clarify the fact that they can just do so.

### How?

Using `nissuer`'s [comment-label](https://github.com/balazsorban44/nissuer#label-management).


Closes NEXT-2256