### PR TITLE
fix(with-stripe-typescript): Bump `apiVersion` when initialising Stripe client

### DIFF
--- a/examples/with-stripe-typescript/lib/stripe.ts
+++ b/examples/with-stripe-typescript/lib/stripe.ts
@@ -4,7 +4,7 @@ import Stripe from "stripe";
 
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   // https://github.com/stripe/stripe-node#configuration
-  apiVersion: "2022-11-15",
+  apiVersion: "2023-10-16",
   appInfo: {
     name: "nextjs-with-stripe-typescript-demo",
     url: "https://nextjs-with-stripe-typescript-demo.vercel.app",


### PR DESCRIPTION
### What?

* fix(with-stripe-typescript): Bump `apiVersion` when initialising Stripe client
