### PR TITLE
Fix next-image-new/asset-prefix for Turbopack

### DIFF
--- a/test/integration/next-image-new/asset-prefix/test/index.test.js
+++ b/test/integration/next-image-new/asset-prefix/test/index.test.js
@@ -38,9 +38,13 @@ describe('Image Component assetPrefix Tests', () => {
       const bgImage = await browser.eval(
         `document.getElementById('${id}').style['background-image']`
       )
-      expect(bgImage).toMatch(
-        /\/_next\/image\?url=https%3A%2F%2Fexample\.vercel\.sh%2Fpre%2F_next%2Fstatic%2Fmedia%2Ftest(.+).jpg&w=8&q=70/
-      )
+      if (process.env.TURBOPACK) {
+        expect(bgImage).toContain('data:image/svg+xml;')
+      } else {
+        expect(bgImage).toMatch(
+          /\/_next\/image\?url=https%3A%2F%2Fexample\.vercel\.sh%2Fpre%2F_next%2Fstatic%2Fmedia%2Ftest(.+).jpg&w=8&q=70/
+        )
+      }
     })
 
     it('should not log a deprecation warning about using `images.domains`', async () => {


### PR DESCRIPTION
## What?

Fixes the condition being checked to match for Turbopack which always adds the blur.

Webpack needed to lazy eval blur during `next dev` but Turbopack can always blur since its much faster.

Closes NEXT-2259