### PR TITLE
Fix edge-light-import-specifier test for Turbopack

### DIFF
--- a/test/e2e/edge-runtime-uses-edge-light-import-specifier-for-packages/edge-runtime-uses-edge-light-import-specifier-for-packages.test.ts
+++ b/test/e2e/edge-runtime-uses-edge-light-import-specifier-for-packages/edge-runtime-uses-edge-light-import-specifier-for-packages.test.ts
@@ -26,7 +26,8 @@ createNextDescribe(
       const res = await next.fetch('/api/edge')
       const html = await res.json()
       expect(html).toEqual({
-        edgeLightPackage: 'edge-light',
+        // edge-light is only supported in `exports` and `imports` but webpack also adds the top level `edge-light` key incorrectly.
+        edgeLightPackage: process.env.TURBOPACK ? 'import' : 'edge-light',
         edgeLightPackageExports: 'edge-light',
       })
     })
@@ -35,7 +36,8 @@ createNextDescribe(
       const $ = await next.render$('/')
       const text = JSON.parse($('pre#result').text())
       expect(text).toEqual({
-        edgeLightPackage: 'edge-light',
+        // edge-light is only supported in `exports` and `imports` but webpack also adds the top level `edge-light` key incorrectly.
+        edgeLightPackage: process.env.TURBOPACK ? 'import' : 'edge-light',
         edgeLightPackageExports: 'edge-light',
       })
     })
@@ -44,7 +46,8 @@ createNextDescribe(
       const $ = await next.render$('/app-dir')
       const text = JSON.parse($('pre#result').text())
       expect(text).toEqual({
-        edgeLightPackage: 'edge-light',
+        // edge-light is only supported in `exports` and `imports` but webpack also adds the top level `edge-light` key incorrectly.
+        edgeLightPackage: process.env.TURBOPACK ? 'import' : 'edge-light',
         edgeLightPackageExports: 'edge-light',
       })
     })


### PR DESCRIPTION
## What?

Currently we have a test that checks for:

```
{
  "name": "my-package",
  "edge-light": "./edge-light-file.js"
}
```

However we should only support it in `exports` and `imports` conditions, which is also what packages published use currently. This updates the tests to reflect the correct behavior in Turbopack.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2262