### PR TITLE
revert changes to process default routes at build

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -115,7 +115,6 @@ import {
   isReservedPage,
   isAppBuiltinNotFoundPage,
   serializePageInfos,
-  isReservedAppPage,
 } from './utils'
 import type { PageInfo, PageInfos, AppConfig } from './utils'
 import { writeBuildId } from './write-build-id'
@@ -162,7 +161,6 @@ import type { NextEnabledDirectories } from '../server/base-server'
 import { hasCustomExportOutput } from '../export/utils'
 import { interopDefault } from '../lib/interop-default'
 import { formatDynamicImportPath } from '../lib/format-dynamic-import-path'
-import { isDefaultRoute } from '../lib/is-default-route'
 import { isInterceptionRouteAppPath } from '../server/future/helpers/interception-routes'
 
 interface ExperimentalBypassForInfo {
@@ -934,9 +932,7 @@ export default async function build(
                 validFileMatcher.isAppRouterPage(absolutePath) ||
                 // For now we only collect the root /not-found page in the app
                 // directory as the 404 fallback
-                validFileMatcher.isRootNotFound(absolutePath) ||
-                // Default slots are also valid pages, and need to be considered during path normalization
-                validFileMatcher.isDefaultSlot(absolutePath),
+                validFileMatcher.isRootNotFound(absolutePath),
               ignorePartFilter: (part) => part.startsWith('_'),
             })
           )
@@ -1795,10 +1791,7 @@ export default async function build(
                     pageType === 'app' &&
                     staticInfo?.rsc !== RSC_MODULE_TYPES.client
 
-                  if (
-                    (pageType === 'app' && !isReservedAppPage(page)) ||
-                    (pageType === 'pages' && !isReservedPage(page))
-                  ) {
+                  if (pageType === 'app' || !isReservedPage(page)) {
                     try {
                       let edgeInfo: any
 
@@ -2499,7 +2492,6 @@ export default async function build(
             routes.forEach((route) => {
               if (isDynamicRoute(page) && route === page) return
               if (route === '/_not-found') return
-              if (isDefaultRoute(page)) return
 
               const {
                 revalidate = appConfig.revalidate ?? false,

--- a/packages/next/src/build/normalize-catchall-routes.ts
+++ b/packages/next/src/build/normalize-catchall-routes.ts
@@ -44,8 +44,6 @@ export function normalizeCatchAllRoutes(
         !appPaths[appPath].some((path) =>
           hasMatchedSlots(path, catchAllRoute)
         ) &&
-        // check if the catch-all is not already matched by a default route or page route
-        !appPaths[`${appPath}/default`] &&
         // check if appPath is a catch-all OR is not more specific than the catch-all
         (isCatchAllRoute(appPath) || !isMoreSpecific(appPath, catchAllRoute))
       ) {

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -84,7 +84,6 @@ import { interopDefault } from '../lib/interop-default'
 import type { PageExtensions } from './page-extensions-type'
 import { formatDynamicImportPath } from '../lib/format-dynamic-import-path'
 import { isInterceptionRouteAppPath } from '../server/future/helpers/interception-routes'
-import { isDefaultRoute } from '../lib/is-default-route'
 
 export type ROUTER_TYPE = 'pages' | 'app'
 
@@ -2122,10 +2121,6 @@ startServer({
 
 export function isReservedPage(page: string) {
   return RESERVED_PAGE.test(page)
-}
-
-export function isReservedAppPage(page: string) {
-  return isDefaultRoute(page)
 }
 
 export function isAppBuiltinNotFoundPage(page: string) {

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -55,7 +55,6 @@ import isError from '../lib/is-error'
 import { needsExperimentalReact } from '../lib/needs-experimental-react'
 import { formatManifest } from '../build/manifests/formatter/format-manifest'
 import { validateRevalidate } from '../server/lib/patch-fetch'
-import { isDefaultRoute } from '../lib/is-default-route'
 
 function divideSegments(number: number, segments: number): number[] {
   const result = []
@@ -565,12 +564,9 @@ export async function exportAppImpl(
 
   const filteredPaths = exportPaths.filter(
     (route) =>
-      // Remove default routes -- they don't need to be exported
-      // and are only used for parallel route normalization
-      !isDefaultRoute(exportPathMap[route].page) &&
-      (exportPathMap[route]._isAppDir ||
-        // Remove API routes
-        !isAPIRoute(exportPathMap[route].page))
+      exportPathMap[route]._isAppDir ||
+      // Remove API routes
+      !isAPIRoute(exportPathMap[route].page)
   )
 
   if (filteredPaths.length !== exportPaths.length) {

--- a/packages/next/src/lib/is-default-route.ts
+++ b/packages/next/src/lib/is-default-route.ts
@@ -1,3 +1,0 @@
-export function isDefaultRoute(value?: string) {
-  return value?.endsWith('/default')
-}

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -127,10 +127,6 @@ export function createValidFileMatcher(
     return validExtensionFileRegex.test(filePath) || isMetadataFile(filePath)
   }
 
-  function isDefaultSlot(filePath: string) {
-    return filePath.endsWith(`default.${pageExtensions[0]}`)
-  }
-
   function isRootNotFound(filePath: string) {
     if (!appDirPath) {
       return false
@@ -147,6 +143,5 @@ export function createValidFileMatcher(
     isAppRouterPage,
     isMetadataFile,
     isRootNotFound,
-    isDefaultSlot,
   }
 }


### PR DESCRIPTION
Reverts changes from #61173 & #60240 (while leaving the tests that were added).

There are too many spots where considering `/default` routes as pages needs to be carefully considered in different runtimes, and it turns out that it's not actually needed to handle the case that it was originally added for. I confirmed that the test that added the case it was intended to fix (`parallel-routes-catchall-default`, along with the unit tests in `normalize-catchall-routes`) are still passing as expected.