### PR TITLE
Fix Server Reference being double registered

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1021,11 +1021,11 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         }
 
         if self.has_action {
-            let actions = if self.in_action_file {
-                self.exported_idents.iter().map(|e| e.1.clone()).collect()
-            } else {
-                self.export_actions.clone()
+            let mut actions = self.export_actions.clone();
+            if self.in_action_file {
+                actions.extend(self.exported_idents.iter().map(|e| e.1.clone()));
             };
+
             let actions = actions
                 .into_iter()
                 .map(|name| (generate_action_id(&self.file_name, &name), name))

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default $$ACTION_0 = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
 var $$ACTION_0;

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export const foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default","f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default","f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { validator } from 'auth';
 export const action = validator(createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0));

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/29/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/29/input.js
@@ -1,0 +1,8 @@
+'use server'
+
+export const dec = async (value) => {
+  return value - 1
+}
+
+// Test case for https://github.com/vercel/next.js/issues/54655
+export default dec

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/29/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/29/output.js
@@ -1,0 +1,15 @@
+/* __next_internal_action_entry_do_not_use__ {"28baf972d345b86b747ad0df73d75a0088a42214":"dec","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+export const dec = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export async function $$ACTION_0(value) {
+    return value - 1;
+}
+// Test case for https://github.com/vercel/next.js/issues/54655
+export default dec;
+import { ensureServerEntryExports } from "private-next-rsc-action-validate";
+ensureServerEntryExports([
+    dec,
+    dec
+]);
+createActionProxy("28baf972d345b86b747ad0df73d75a0088a42214", dec);
+createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", dec);

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
@@ -1,6 +1,17 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { registerServerReference } from 'react-server-dom-webpack/server.edge'
 
+const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference')
+
+function isServerReference(reference: any) {
+  return reference && reference.$$typeof === SERVER_REFERENCE_TAG
+}
+
 export function createActionProxy(id: string, action: any) {
+  // Avoid registering the same action twice
+  if (isServerReference(action)) {
+    return action
+  }
+
   return registerServerReference(action, id, null)
 }

--- a/test/e2e/app-dir/actions/app/server/actions.js
+++ b/test/e2e/app-dir/actions/app/server/actions.js
@@ -7,9 +7,12 @@ export async function slowInc(value) {
   return value + 1
 }
 
-export default async function dec(value) {
+export const dec = async (value) => {
   return value - 1
 }
+
+// Test case for https://github.com/vercel/next.js/issues/54655
+export default dec
 
 export async function redirectAction(formData) {
   'use server'
@@ -20,3 +23,6 @@ export async function redirectAction(formData) {
       formData.get('hidden-info')
   )
 }
+
+// Test case for https://github.com/vercel/next.js/issues/61183
+export const dummyServerAction = () => new Promise((r) => setTimeout(r, 2000))


### PR DESCRIPTION
When we apply `createActionProxy` twice to the same value, it currently errors because we can't override the ID of it.

This PR makes sure that 1) when the value already have an ID defined, we skip setting it again; 2) all the action IDs are being tracked even for duplicated ones.

Note that it's technically impossible to "detect" the duplication here (via static analyzation) and only set it once. For example:

```ts
'use server'

export async function foo () {}
export const bar = a_value_we_dont_know_yet ? foo : async () => {}
```

So, the compiler will always wrap `createActionProxy` for every exported value and assume they're different Server Actions (hence different IDs). With this fix, if we find that it's already defined before, we just return the defined reference as they're strictly identical so the ID does't matter.

Closes #54655, closes #61183.

Closes NEXT-2264