### PR TITLE
docs: typo in page title

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/11-static-assets.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/11-static-assets.mdx
@@ -1,5 +1,5 @@
 ---
-title: Statics Assets in `public`
+title: Static Assets in `public`
 nav_title: Static Assets
 description: Next.js allows you to serve static files, like images, in the public directory. You can learn how it works here.
 ---


### PR DESCRIPTION
Simple docs update, title on app router Static Assets page reads as Statics Assets