### PR TITLE
docs(02-jest): fixes failing test in the tutorial

### DIFF
--- a/docs/02-app/01-building-your-application/08-testing/02-jest.mdx
+++ b/docs/02-app/01-building-your-application/08-testing/02-jest.mdx
@@ -303,7 +303,7 @@ For example, we can add a test to check if the `<Page />` component successfully
 ```jsx filename="app/page.js
 import Link from 'next/link'
 
-export default async function Home() {
+export default function Home() {
   return (
     <div>
       <h1>Home</h1>


### PR DESCRIPTION
### What?

This PR fixes the example test provided on [Setting up Jest with Next.js: Creating your first test:](https://nextjs.org/docs/app/building-your-application/testing/jest#creating-your-first-test) not passing due to Jest not being compatible with async Server Components.

### Why?

Although it's noted at the start of the tutorial that async Server Components aren't currently supported by Jest, the example test failing might confuse the reader.

### How?

This PR makes the example test pass by removing async from the `<Home>` component