### PR TITLE
Fix app-document-import-order for Turbopack

### DIFF
--- a/test/integration/app-document-import-order/test/index.test.js
+++ b/test/integration/app-document-import-order/test/index.test.js
@@ -83,8 +83,14 @@ describe('development mode', () => {
     respectsSideEffects
   )
 
-  it(
-    '_app chunks should be attached to de dom before page chunks',
-    respectsChunkAttachmentOrder
+  // Test relies on webpack splitChunks overrides.
+  ;(process.env.TURBOPACK ? describe.skip : describe)(
+    'Skipped in Turbopack',
+    () => {
+      it(
+        '_app chunks should be attached to de dom before page chunks',
+        respectsChunkAttachmentOrder
+      )
+    }
   )
 })

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -6950,12 +6950,11 @@
     "passed": [
       "development mode root components should be imported in this order _document > _app > page in order to respect side effects"
     ],
-    "failed": [
-      "development mode _app chunks should be attached to de dom before page chunks"
-    ],
+    "failed": [],
     "pending": [
       "Root components import order production mode _app chunks should be attached to de dom before page chunks",
-      "Root components import order production mode root components should be imported in this order _document > _app > page in order to respect side effects"
+      "Root components import order production mode root components should be imported in this order _document > _app > page in order to respect side effects",
+      "development mode _app chunks should be attached to de dom before page chunks"
     ],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

This test uses webpack splitChunks (custom webpack config) so it's not relevant for Turbopack.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2278