### PR TITLE
DX: add route context to the dynamic errors

### DIFF
--- a/packages/next/src/lib/url.ts
+++ b/packages/next/src/lib/url.ts
@@ -1,0 +1,7 @@
+function getUrlWithoutHost(url: string) {
+  return new URL(url, 'http://n')
+}
+
+export function getPathname(url: string) {
+  return getUrlWithoutHost(url).pathname
+}

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -47,7 +47,7 @@ export function markCurrentScopeAsDynamic(
     return
   } else if (store.dynamicShouldError) {
     throw new StaticGenBailoutError(
-      `Page with \`dynamic = "error"\` couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
+      `Route ${store.urlPathname} with \`dynamic = "error"\` couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
     )
   } else if (
     // We are in a prerender (PPR enabled, during build)
@@ -58,14 +58,14 @@ export function markCurrentScopeAsDynamic(
     // This will be used by the renderer to decide whether
     // the prerender requires a resume
     store.prerenderState.hasDynamic = true
-    React.unstable_postpone(createPostponeReason(expression))
+    React.unstable_postpone(createPostponeReason(expression, store.urlPathname))
   } else {
     store.revalidate = 0
 
     if (store.isStaticGeneration) {
       // We aren't prerendering but we are generating a static page. We need to bail out of static generation
       const err = new DynamicServerError(
-        `Page couldn't be rendered statically because it used ${expression}. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+        `Route couldn't be rendered statically because it used ${expression}. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
       )
       store.dynamicUsageDescription = expression
       store.dynamicUsageStack = err.stack
@@ -90,11 +90,11 @@ export function trackDynamicDataAccessed(
 ): void {
   if (store.isUnstableCacheCallback) {
     throw new Error(
-      `used "${expression}" inside a function cached with "unstable_cache(...)". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "${expression}" oustide of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
+      `Route ${store.urlPathname} used "${expression}" inside a function cached with "unstable_cache(...)". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "${expression}" oustide of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
     )
   } else if (store.dynamicShouldError) {
     throw new StaticGenBailoutError(
-      `Page with \`dynamic = "error"\` couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
+      `Route ${store.urlPathname} with \`dynamic = "error"\` couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
     )
   } else if (
     // We are in a prerender (PPR enabled, during build)
@@ -105,14 +105,14 @@ export function trackDynamicDataAccessed(
     // This will be used by the renderer to decide whether
     // the prerender requires a resume
     store.prerenderState.hasDynamic = true
-    React.unstable_postpone(createPostponeReason(expression))
+    React.unstable_postpone(createPostponeReason(expression, store.urlPathname))
   } else {
     store.revalidate = 0
 
     if (store.isStaticGeneration) {
       // We aren't prerendering but we are generating a static page. We need to bail out of static generation
       const err = new DynamicServerError(
-        `Page couldn't be rendered statically because it used ${expression}. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+        `Route ${store.urlPathname} couldn't be rendered statically because it used ${expression}. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
       )
       store.dynamicUsageDescription = expression
       store.dynamicUsageStack = err.stack
@@ -144,13 +144,13 @@ export function trackDynamicFetch(
   if (store.prerenderState) {
     assertPostpone()
     store.prerenderState.hasDynamic = true
-    React.unstable_postpone(createPostponeReason(expression))
+    React.unstable_postpone(createPostponeReason(expression, store.urlPathname))
   }
 }
 
-function createPostponeReason(expression: string) {
+function createPostponeReason(expression: string, urlPathname: string) {
   return (
-    `This page needs to bail out of prerendering at this point because it used ${expression}. ` +
+    `Route ${urlPathname} needs to bail out of prerendering at this point because it used ${expression}. ` +
     `React throws this special object to indicate where. It should not be caught by ` +
     `your own try/catch. Learn more: https://nextjs.org/docs/messages/ppr-caught-error`
   )

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -25,7 +25,6 @@ import React from 'react'
 
 import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
 import { DynamicServerError } from '../../client/components/hooks-server-context'
-
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 
 const hasPostpone = typeof React.unstable_postpone === 'function'
@@ -88,13 +87,14 @@ export function trackDynamicDataAccessed(
   store: StaticGenerationStore,
   expression: string
 ): void {
+  const pathname = store.urlPathname
   if (store.isUnstableCacheCallback) {
     throw new Error(
-      `Route ${store.urlPathname} used "${expression}" inside a function cached with "unstable_cache(...)". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "${expression}" oustide of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
+      `Route ${pathname} used "${expression}" inside a function cached with "unstable_cache(...)". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "${expression}" oustide of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
     )
   } else if (store.dynamicShouldError) {
     throw new StaticGenBailoutError(
-      `Route ${store.urlPathname} with \`dynamic = "error"\` couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
+      `Route ${pathname} with \`dynamic = "error"\` couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
     )
   } else if (
     // We are in a prerender (PPR enabled, during build)
@@ -105,14 +105,14 @@ export function trackDynamicDataAccessed(
     // This will be used by the renderer to decide whether
     // the prerender requires a resume
     store.prerenderState.hasDynamic = true
-    React.unstable_postpone(createPostponeReason(expression, store.urlPathname))
+    React.unstable_postpone(createPostponeReason(expression, pathname))
   } else {
     store.revalidate = 0
 
     if (store.isStaticGeneration) {
       // We aren't prerendering but we are generating a static page. We need to bail out of static generation
       const err = new DynamicServerError(
-        `Route ${store.urlPathname} couldn't be rendered statically because it used ${expression}. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+        `Route ${pathname} couldn't be rendered statically because it used ${expression}. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
       )
       store.dynamicUsageDescription = expression
       store.dynamicUsageStack = err.stack
@@ -149,8 +149,9 @@ export function trackDynamicFetch(
 }
 
 function createPostponeReason(expression: string, urlPathname: string) {
+  const pathname = new URL(urlPathname, 'http://n').pathname // remove queries such like `_rsc` for flight
   return (
-    `Route ${urlPathname} needs to bail out of prerendering at this point because it used ${expression}. ` +
+    `Route ${pathname} needs to bail out of prerendering at this point because it used ${expression}. ` +
     `React throws this special object to indicate where. It should not be caught by ` +
     `your own try/catch. Learn more: https://nextjs.org/docs/messages/ppr-caught-error`
   )

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -8,6 +8,7 @@ import {
   NEXT_CACHE_IMPLICIT_TAG_ID,
   NEXT_CACHE_SOFT_TAG_MAX_LENGTH,
 } from '../../../lib/constants'
+import { getPathname } from '../../../lib/url'
 
 export function revalidateTag(tag: string) {
   return revalidate(tag, `revalidateTag ${tag}`)
@@ -49,7 +50,9 @@ function revalidate(tag: string, expression: string) {
 
   if (store.isUnstableCacheCallback) {
     throw new Error(
-      `used "${expression}" inside a function cached with "unstable_cache(...)" which is unsupported. To ensure revalidation is performed consistently it must always happen outside of renders and cached functions. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
+      `Route ${getPathname(
+        store.urlPathname
+      )} used "${expression}" inside a function cached with "unstable_cache(...)" which is unsupported. To ensure revalidation is performed consistently it must always happen outside of renders and cached functions. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
     )
   }
 

--- a/test/development/acceptance-app/dynamic-error.test.ts
+++ b/test/development/acceptance-app/dynamic-error.test.ts
@@ -33,7 +33,7 @@ describe('dynamic = "error" in devmode', () => {
     await session.hasRedbox()
     console.log(await session.getRedboxDescription())
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-      `"Error: Page with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering"`
+      `"Error: Route /server with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering"`
     )
 
     await cleanup()

--- a/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
+++ b/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
@@ -184,7 +184,7 @@ createNextDescribe(
         try {
           expect(await hasRedbox(browser)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatch(
-            'Error: Page with `dynamic = "error"` couldn\'t be rendered statically because it used `cookies`'
+            'Error: Route /cookies with `dynamic = "error"` couldn\'t be rendered statically because it used `cookies`'
           )
         } finally {
           await browser.close()
@@ -194,7 +194,7 @@ createNextDescribe(
         try {
           expect(await hasRedbox(browser)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatch(
-            'Error: Page with `dynamic = "error"` couldn\'t be rendered statically because it used `headers`'
+            'Error: Route /headers with `dynamic = "error"` couldn\'t be rendered statically because it used `headers`'
           )
         } finally {
           await browser.close()
@@ -204,7 +204,7 @@ createNextDescribe(
         try {
           expect(await hasRedbox(browser)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatch(
-            'Error: Page with `dynamic = "error"` couldn\'t be rendered statically because it used `searchParams`'
+            'Error: Route /search with `dynamic = "error"` couldn\'t be rendered statically because it used `searchParams`'
           )
         } finally {
           await browser.close()
@@ -219,13 +219,13 @@ createNextDescribe(
         }
         // Error: Page with `dynamic = "error"` couldn't be rendered statically because it used `headers`
         expect(next.cliOutput).toMatch(
-          'Error: Page with `dynamic = "error"` couldn\'t be rendered statically because it used `cookies`'
+          'Error: Route /cookies with `dynamic = "error"` couldn\'t be rendered statically because it used `cookies`'
         )
         expect(next.cliOutput).toMatch(
-          'Error: Page with `dynamic = "error"` couldn\'t be rendered statically because it used `headers`'
+          'Error: Route /headers with `dynamic = "error"` couldn\'t be rendered statically because it used `headers`'
         )
         expect(next.cliOutput).toMatch(
-          'Error: Page with `dynamic = "error"` couldn\'t be rendered statically because it used `searchParams`.'
+          'Error: Route /search with `dynamic = "error"` couldn\'t be rendered statically because it used `searchParams`.'
         )
       })
     }
@@ -254,7 +254,7 @@ createNextDescribe(
         try {
           expect(await hasRedbox(browser)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatch(
-            'Error: used "cookies" inside a function cached with "unstable_cache(...)".'
+            'Error: Route /cookies used "cookies" inside a function cached with "unstable_cache(...)".'
           )
         } finally {
           await browser.close()
@@ -264,7 +264,7 @@ createNextDescribe(
         try {
           expect(await hasRedbox(browser)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatch(
-            'Error: used "headers" inside a function cached with "unstable_cache(...)".'
+            'Error: Route /headers used "headers" inside a function cached with "unstable_cache(...)".'
           )
         } finally {
           await browser.close()
@@ -278,10 +278,10 @@ createNextDescribe(
           // We expect this to fail
         }
         expect(next.cliOutput).toMatch(
-          'Error: used "cookies" inside a function cached with "unstable_cache(...)".'
+          'Error: Route /cookies used "cookies" inside a function cached with "unstable_cache(...)".'
         )
         expect(next.cliOutput).toMatch(
-          'Error: used "headers" inside a function cached with "unstable_cache(...)".'
+          'Error: Route /headers used "headers" inside a function cached with "unstable_cache(...)".'
         )
       })
     }

--- a/test/e2e/app-dir/ppr-errors/app/logging-error/page.jsx
+++ b/test/e2e/app-dir/ppr-errors/app/logging-error/page.jsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react'
+import { Suspense } from 'react'
 import { cookies } from 'next/headers'
 
 export default async function Page() {
@@ -13,7 +13,7 @@ async function Foobar() {
   try {
     cookies()
   } catch (err) {
-    console.log('Logged error: ' + err.message)
+    console.log('User land logged error: ' + err.message)
   }
   cookies() // still postpones so doesn't fail build
   return null

--- a/test/e2e/app-dir/ppr-errors/ppr-errors.test.ts
+++ b/test/e2e/app-dir/ppr-errors/ppr-errors.test.ts
@@ -90,7 +90,7 @@ describe('ppr build errors', () => {
     describe('when a postpone call is caught and logged it should', () => {
       it('should include a message telling why', async () => {
         expect(stdout).toContain(
-          'Logged error: This page needs to bail out of prerendering at this point because it used cookies.'
+          'User land logged error: Route /logging-error needs to bail out of prerendering at this point because it used cookies.'
         )
       })
     })


### PR DESCRIPTION
### What 

Given user infomation when the dynamic errors are thrown, e.g. bad `cookies` or `headers` usages. Now users can tell through the error information to see which pathname is broken, and trace down the usage.

#### before

```
Page couldn't be rendered statically because ...
This page needs to bail out of prerendering at this point because ...
```

#### after

```
Route /cookies couldn't be rendered statically because ...
Route /server needs to bail out of prerendering at this point because ...
```

### Why

When you have multi pages in your app, such as 100+, and many page might uses these. This is hard to trace down where exactly the error is from

Closes NEXT-2283
Cloese NEXT-2265