### PR TITLE
Refine logging message of experiments

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -312,7 +312,7 @@ const nextDev: CliCommand = async (args) => {
     try {
       if (!!args['--experimental-https']) {
         Log.warn(
-          'Self-signed certificates are currently an experimental feature, use at your own risk.'
+          'Self-signed certificates are currently an experimental feature, use with caution.'
         )
 
         let certificate: SelfSignedCertificate | undefined

--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -38,7 +38,7 @@ export function logStartInfo({
   if (envInfo?.length) Log.bootstrap(` - Environments: ${envInfo.join(', ')}`)
 
   if (expFeatureInfo?.length) {
-    Log.bootstrap(` - Experiments (use at your own risk):`)
+    Log.bootstrap(` - Experiments (use with caution):`)
     // only show maximum 3 flags
     for (const exp of expFeatureInfo.slice(0, maxExperimentalFeatures)) {
       Log.bootstrap(`   · ${exp}`)

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -214,9 +214,8 @@ createNextDescribe(
       it('should not have duplicate config warnings', async () => {
         await next.fetch('/')
         expect(
-          stripAnsi(next.cliOutput).match(
-            /Experiments \(use at your own risk\):/g
-          ).length
+          stripAnsi(next.cliOutput).match(/Experiments \(use with caution\):/g)
+            .length
         ).toBe(1)
       })
     }

--- a/test/e2e/app-dir/ppr/ppr.test.ts
+++ b/test/e2e/app-dir/ppr/ppr.test.ts
@@ -9,7 +9,7 @@ createNextDescribe(
   ({ next, isNextDev, isNextStart }) => {
     it('should indicate the feature is experimental', async () => {
       await check(() => {
-        return next.cliOutput.includes('Experiments (use at your own risk)') &&
+        return next.cliOutput.includes('Experiments (with caution)') &&
           next.cliOutput.includes('ppr')
           ? 'success'
           : 'fail'

--- a/test/e2e/app-dir/ppr/ppr.test.ts
+++ b/test/e2e/app-dir/ppr/ppr.test.ts
@@ -9,7 +9,7 @@ createNextDescribe(
   ({ next, isNextDev, isNextStart }) => {
     it('should indicate the feature is experimental', async () => {
       await check(() => {
-        return next.cliOutput.includes('Experiments (with caution)') &&
+        return next.cliOutput.includes('Experiments (use with caution)') &&
           next.cliOutput.includes('ppr')
           ? 'success'
           : 'fail'

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -16,7 +16,7 @@ const appDir = join(__dirname, '..')
 const configFile = new File(join(appDir, '/next.config.js'))
 const configFileMjs = new File(join(appDir, '/next.config.mjs'))
 
-const experimentalHeader = ' - Experiments (with caution):'
+const experimentalHeader = ' - Experiments (use with caution):'
 
 let app
 async function collectStdoutFromDev(appDir) {

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -16,6 +16,8 @@ const appDir = join(__dirname, '..')
 const configFile = new File(join(appDir, '/next.config.js'))
 const configFileMjs = new File(join(appDir, '/next.config.mjs'))
 
+const experimentalHeader = ' - Experiments (with caution):'
+
 let app
 async function collectStdoutFromDev(appDir) {
   let stdout = ''
@@ -57,7 +59,7 @@ describe('Config Experimental Warning', () => {
     `)
 
     const stdout = await collectStdoutFromDev(appDir)
-    expect(stdout).not.toMatch(' - Experiments (use at your own risk):')
+    expect(stdout).not.toMatch(experimentalHeader)
   })
 
   it('should not show warning with config from object', async () => {
@@ -68,7 +70,7 @@ describe('Config Experimental Warning', () => {
     `)
 
     const stdout = await collectStdoutFromDev(appDir)
-    expect(stdout).not.toMatch(' - Experiments (use at your own risk):')
+    expect(stdout).not.toMatch(experimentalHeader)
   })
 
   it('should show warning with config from object with experimental', async () => {
@@ -81,7 +83,7 @@ describe('Config Experimental Warning', () => {
     `)
 
     const stdout = await collectStdoutFromDev(appDir)
-    expect(stdout).toMatch(' - Experiments (use at your own risk):')
+    expect(stdout).toMatch(experimentalHeader)
     expect(stdout).toMatch(' · workerThreads')
   })
 
@@ -95,7 +97,7 @@ describe('Config Experimental Warning', () => {
     `)
 
     const stdout = await collectStdoutFromDev(appDir)
-    expect(stdout).toMatch(' - Experiments (use at your own risk):')
+    expect(stdout).toMatch(experimentalHeader)
     expect(stdout).toMatch(' · workerThreads')
   })
 
@@ -109,7 +111,7 @@ describe('Config Experimental Warning', () => {
     `)
 
     const stdout = await collectStdoutFromDev(appDir)
-    expect(stdout).not.toContain(' - Experiments (use at your own risk):')
+    expect(stdout).not.toContain(experimentalHeader)
     expect(stdout).not.toContain(' · workerThreads')
   })
 
@@ -124,7 +126,7 @@ describe('Config Experimental Warning', () => {
     `)
 
     const stdout = await collectStdoutFromDev(appDir)
-    expect(stdout).toContain(' - Experiments (use at your own risk):')
+    expect(stdout).toContain(experimentalHeader)
     expect(stdout).toContain(' · workerThreads')
     expect(stdout).toContain(' · scrollRestoration')
   })
@@ -149,7 +151,7 @@ describe('Config Experimental Warning', () => {
           stdout += msg
         },
       })
-      expect(stdout).not.toMatch(' - Experiments (use at your own risk):')
+      expect(stdout).not.toMatch(experimentalHeader)
     })
 
     it('should show next app info with all experimental features in next build', async () => {
@@ -164,7 +166,7 @@ describe('Config Experimental Warning', () => {
         }
       `)
       const stdout = await collectStdoutFromBuild(appDir)
-      expect(stdout).toMatch(' - Experiments (use at your own risk):')
+      expect(stdout).toMatch(experimentalHeader)
       expect(stdout).toMatch(' · cpus')
       expect(stdout).toMatch(' · workerThreads')
       expect(stdout).toMatch(' · scrollRestoration')
@@ -196,9 +198,7 @@ describe('Config Experimental Warning', () => {
       await check(() => {
         const cliOutput = stripAnsi(stdout)
         const cliOutputErr = stripAnsi(stderr)
-        expect(cliOutput).not.toContain(
-          ' - Experiments (use at your own risk):'
-        )
+        expect(cliOutput).not.toContain(experimentalHeader)
         expect(cliOutputErr).toContain(
           `Unrecognized key(s) in object: 'appDir' at "experimental"`
         )


### PR DESCRIPTION
Refining the message that uses "use with caution" instead of "use at your own risk" as some experimental features was functionally stable but we can't bring them as default for now and need to test as experiments

Closes NEXT-2286