### PR TITLE
Fix build worker callback arg missing correct page path 

### DIFF
--- a/packages/next/src/build/handle-externals.ts
+++ b/packages/next/src/build/handle-externals.ts
@@ -9,7 +9,7 @@ import {
   NODE_ESM_RESOLVE_OPTIONS,
   NODE_RESOLVE_OPTIONS,
 } from './webpack-config'
-import { isWebpackAppLayer, isWebpackServerLayer } from './worker'
+import { isWebpackAppLayer, isWebpackServerLayer } from './utils'
 import type { NextConfigComplete } from '../server/config-shared'
 import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
 const reactPackagesRegex = /^(react|react-dom|react-server-dom-webpack)($|\/)/

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1788,12 +1788,17 @@ export async function isPageStatic({
     })
 }
 
-export async function hasCustomGetInitialProps(
-  page: string,
-  distDir: string,
-  runtimeEnvConfig: any,
+export async function hasCustomGetInitialProps({
+  page,
+  distDir,
+  runtimeEnvConfig,
+  checkingApp,
+}: {
+  page: string
+  distDir: string
+  runtimeEnvConfig: any
   checkingApp: boolean
-): Promise<boolean> {
+}): Promise<boolean> {
   require('../shared/lib/runtime-config.external').setConfig(runtimeEnvConfig)
 
   const components = await loadComponents({
@@ -1812,11 +1817,15 @@ export async function hasCustomGetInitialProps(
   return mod.getInitialProps !== mod.origGetInitialProps
 }
 
-export async function getDefinedNamedExports(
-  page: string,
-  distDir: string,
+export async function getDefinedNamedExports({
+  page,
+  distDir,
+  runtimeEnvConfig,
+}: {
+  page: string
+  distDir: string
   runtimeEnvConfig: any
-): Promise<ReadonlyArray<string>> {
+}): Promise<ReadonlyArray<string>> {
   require('../shared/lib/runtime-config.external').setConfig(runtimeEnvConfig)
   const components = await loadComponents({
     distDir,

--- a/packages/next/src/build/webpack/loaders/next-route-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-route-loader/index.ts
@@ -9,7 +9,7 @@ import {
 import { RouteKind } from '../../../../server/future/route-kind'
 import { normalizePagePath } from '../../../../shared/lib/page-path/normalize-page-path'
 import { decodeFromBase64, encodeToBase64 } from '../utils'
-import { isInstrumentationHookFile } from '../../../worker'
+import { isInstrumentationHookFile } from '../../../utils'
 import { loadEntrypoint } from '../../../load-entrypoint'
 import type { MappedPages } from '../../../build-context'
 

--- a/packages/next/src/build/worker.ts
+++ b/packages/next/src/build/worker.ts
@@ -1,5 +1,9 @@
 import '../server/require-hook'
 
-export * from './utils'
+export {
+  getDefinedNamedExports,
+  hasCustomGetInitialProps,
+  isPageStatic,
+} from './utils'
 import exportPage from '../export/worker'
 export { exportPage }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -97,7 +97,7 @@ import {
   isInstrumentationHookFile,
   getPossibleMiddlewareFilenames,
   getPossibleInstrumentationHookFilenames,
-} from '../../../build/worker'
+} from '../../../build/utils'
 import {
   createOriginalStackFrame,
   getErrorSource,


### PR DESCRIPTION
### What

The `arg` in the worker callback is alwasy `any`, when we access the page path the argument could be in different form as the arg types are different.

This PR align the argument type to object for `isPageStatic`, `getDefinedNamedExports`, `hasCustomGetInitialProps` methods in static worker. So they can share the similar shape of type of argument when accessing `page` path. This will avoid the case that logged `page` in the warning is `undefined`

Import the helpers from utils instead of workers as the worker itself don't need to contain other exports that is not used for static worker.

### Why

This PR align the callback type of callback argument type of static worker, so that we could get the actual page path value in a type-safe way. We have 4 methods for static worker, `exportPage`, `isPageStatic`, `getDefinedNamedExports`, `hasCustomGetInitialProps`, which the rest of 3 methods share the same format of warnings but their argument are different. It's easily ended up with wrong argument type, and log with a bad page path in the warning.


Closes NEXT-2289