### PR TITLE
test(fixture): add missing deps for the emotion test

### DIFF
--- a/test/development/basic/emotion-swc/emotion-swc.test.ts
+++ b/test/development/basic/emotion-swc/emotion-swc.test.ts
@@ -6,8 +6,9 @@ createNextDescribe(
   {
     files: join(__dirname, 'fixture'),
     dependencies: {
-      '@emotion/react': '11.10.4',
-      '@emotion/styled': '11.10.4',
+      '@emotion/react': '11.10.5',
+      '@emotion/styled': '11.10.5',
+      '@emotion/cache': '11.10.5',
     },
   },
   ({ next }) => {

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1544,8 +1544,8 @@
     "runtimeError": false
   },
   "test/development/basic/emotion-swc/emotion-swc.test.ts": {
-    "passed": [],
-    "failed": ["emotion SWC option should have styling from the css prop"],
+    "passed": ["emotion SWC option should have styling from the css prop"],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What

Fixing fixture setup to list the dependencies test actually uses.

I fixed this before, but looks like PR https://github.com/vercel/next.js/pull/57828/files#diff-9aa2b2c62f41b995c6713471e2fa060a8b8d9bdf737b2482ce91ab133369a040L9 removed dependency again. For some reason, normal next-swc can resolve if the dependency is implicitly included, while turbopack doesn't. In any case, since the app actually relies on @emotion/cache so having it as dep is a correct fixture setup.


Closes PACK-2313

Note the origin bug is PACK-863, however it may need to be investegated separately.