### PR TITLE
feat: Allow specifying `useLightningcss`  for `styled-jsx`

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/chain_transforms.rs
@@ -61,7 +61,7 @@ pub struct TransformOptions {
     pub server_components: Option<react_server_components::Config>,
 
     #[serde(default)]
-    pub styled_jsx: Option<turbopack_binding::swc::custom_transform::styled_jsx::visitor::Config>,
+    pub styled_jsx: BoolOr<turbopack_binding::swc::custom_transform::styled_jsx::visitor::Config>,
 
     #[serde(default)]
     pub styled_components:
@@ -155,7 +155,7 @@ where
         .map(|env| targets_to_versions(env.targets.clone()).expect("failed to parse env.targets"))
         .unwrap_or_default();
 
-    let styled_jsx = if let Some(config) = opts.styled_jsx {
+    let styled_jsx = if let Some(config) = opts.styled_jsx.to_option() {
         Either::Left(
             turbopack_binding::swc::custom_transform::styled_jsx::visitor::styled_jsx(
                 cm.clone(),
@@ -337,6 +337,19 @@ pub enum BoolOr<T> {
 impl<T> Default for BoolOr<T> {
     fn default() -> Self {
         BoolOr::Bool(false)
+    }
+}
+
+impl<T> BoolOr<T> {
+    pub fn to_option(&self) -> Option<T>
+    where
+        T: Default + Clone,
+    {
+        match self {
+            BoolOr::Bool(false) => None,
+            BoolOr::Bool(true) => Some(Default::default()),
+            BoolOr::Data(v) => Some(v.clone()),
+        }
     }
 }
 

--- a/packages/next-swc/crates/next-custom-transforms/tests/full.rs
+++ b/packages/next-swc/crates/next-custom-transforms/tests/full.rs
@@ -67,7 +67,7 @@ fn test(input: &Path, minify: bool) {
                 is_server_compiler: false,
                 server_components: None,
                 styled_components: Some(assert_json("{}")),
-                styled_jsx: Some(assert_json("{}")),
+                styled_jsx: assert_json("{}"),
                 remove_console: None,
                 react_remove_properties: None,
                 relay: None,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -193,11 +193,12 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             cssProp: z.boolean().optional(),
           }),
         ]),
-        styledJsx: z.optional(
+        styledJsx: z.union([
+          z.boolean().optional(),
           z.object({
             useLightningcss: z.boolean().optional(),
-          })
-        ),
+          }),
+        ]),
       })
       .optional(),
     compress: z.boolean().optional(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -193,6 +193,11 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             cssProp: z.boolean().optional(),
           }),
         ]),
+        styledJsx: z.optional(
+          z.object({
+            useLightningcss: z.boolean().optional(),
+          })
+        ),
       })
       .optional(),
     compress: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -711,9 +711,11 @@ export interface NextConfig extends Record<string, any> {
     styledComponents?: boolean | StyledComponentsConfig
     emotion?: boolean | EmotionConfig
 
-    styledJsx?: {
-      useLightningcss?: boolean
-    }
+    styledJsx?:
+      | boolean
+      | {
+          useLightningcss?: boolean
+        }
   }
 
   /**

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -710,6 +710,10 @@ export interface NextConfig extends Record<string, any> {
         }
     styledComponents?: boolean | StyledComponentsConfig
     emotion?: boolean | EmotionConfig
+
+    styledJsx?: {
+      useLightningcss?: boolean
+    }
   }
 
   /**


### PR DESCRIPTION
### What?

Add `styledJsx` option to the schema.

### Why?

This is required to test `lightningcss` against internal apps.

### How?



Closes PACK-2316