### PR TITLE
Update turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "serde",
  "smallvec",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "serde",
@@ -7554,7 +7554,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7586,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7598,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7613,7 +7613,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7627,7 +7627,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7644,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7675,7 +7675,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "base16",
  "hex",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7701,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7711,7 +7711,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "mimalloc",
 ]
@@ -7719,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7776,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7841,7 +7841,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7859,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7889,7 +7889,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7916,7 +7916,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7940,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7977,7 +7977,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "serde",
  "serde_json",
@@ -8023,7 +8023,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8048,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8065,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8081,7 +8081,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "serde",
@@ -8116,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8131,7 +8131,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8166,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "serde",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8193,7 +8193,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8209,7 +8209,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240129.3#550126e4a3bf84616bcd205ff49cdb50adb5754e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.89.4", features = [
 testing = { version = "0.35.16" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240129.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240130.4" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240129.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240130.4" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240129.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240130.4" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -194,7 +194,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.2",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240129.3",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.26.2
         version: 0.26.2
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240129.3
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240129.3(react-refresh@0.12.0)(webpack@5.90.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4(react-refresh@0.12.0)(webpack@5.90.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25611,9 +25611,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240129.3(react-refresh@0.12.0)(webpack@5.90.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240129.3}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240129.3'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4(react-refresh@0.12.0)(webpack@5.90.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
# Turbopack changes
* https://github.com/vercel/turbo/pull/7160 <!-- Will Binns-Smith - Make `EcmascriptDevChunkContent` public to other crates  -->
* https://github.com/vercel/turbo/pull/7162 <!-- Tim Neutkens - Fix sourcemap PR compile error  -->
* https://github.com/vercel/turbo/pull/7163 <!-- Donny/강동윤 - fix: Revert `preset-env` mode of `styled-jsx` in turbopack  -->


### What?

Update turbopack

### Why?

To apply https://github.com/vercel/turbo/pull/7163

### How?



Closes PACK-2323