### PR TITLE
Null safe window history state references

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -419,7 +419,7 @@ function Router({
       dispatch({
         type: ACTION_RESTORE,
         url: new URL(window.location.href),
-        tree: window.history.state.__PRIVATE_NEXTJS_INTERNALS_TREE,
+        tree: window.history.state.?__PRIVATE_NEXTJS_INTERNALS_TREE,
       })
     }
 
@@ -474,7 +474,7 @@ function Router({
         dispatch({
           type: ACTION_RESTORE,
           url: new URL(url ?? href, href),
-          tree: window.history.state.__PRIVATE_NEXTJS_INTERNALS_TREE,
+          tree: window.history.state?.__PRIVATE_NEXTJS_INTERNALS_TREE,
         })
       })
     }
@@ -548,7 +548,7 @@ function Router({
         dispatch({
           type: ACTION_RESTORE,
           url: new URL(window.location.href),
-          tree: state.__PRIVATE_NEXTJS_INTERNALS_TREE,
+          tree: state?.__PRIVATE_NEXTJS_INTERNALS_TREE,
         })
       })
     }

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -419,7 +419,7 @@ function Router({
       dispatch({
         type: ACTION_RESTORE,
         url: new URL(window.location.href),
-        tree: window.history.state.?__PRIVATE_NEXTJS_INTERNALS_TREE,
+        tree: window.history.state.__PRIVATE_NEXTJS_INTERNALS_TREE,
       })
     }
 
@@ -548,7 +548,7 @@ function Router({
         dispatch({
           type: ACTION_RESTORE,
           url: new URL(window.location.href),
-          tree: state?.__PRIVATE_NEXTJS_INTERNALS_TREE,
+          tree: state.__PRIVATE_NEXTJS_INTERNALS_TREE,
         })
       })
     }


### PR DESCRIPTION
## For Maintainers

Fixes MSAL issue:
https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/6851

### What?

Make the reference to window.history.state.__PRIVATE_NEXTJS_INTERNALS_TREE in applyUrlHistoryPushReplace null safe.

### Why?

All other references in app-router.tsx include checks that would prevent accessing window.history.state when it's null.

applyUrlFromHistoryPushReplace is the only spot missing that type of check.

Current behavior causes exceptions with MSAL redirect handling.

Redirects in MSAL have been broken since windowHistorySupport went live with 14.0.5.

### How?

Add an extra null check when referencing:
window.history.state.__PRIVATE_NEXTJS_INTERNALS_TREE