### PR TITLE
provide interception rewrites to edge runtime

### DIFF
--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -892,6 +892,7 @@ impl AppEndpoint {
                     "server/middleware-build-manifest.js".to_string(),
                     "server/middleware-react-loadable-manifest.js".to_string(),
                     "server/next-font-manifest.js".to_string(),
+                    "server/interception-route-rewrite-manifest.js".to_string(),
                 ];
                 let mut wasm_paths_from_root = vec![];
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -720,7 +720,6 @@ export default async function build(
         .traceAsyncFn(() => loadCustomRoutes(config))
 
       const { headers, rewrites, redirects } = customRoutes
-      NextBuildContext.rewrites = rewrites
       NextBuildContext.originalRewrites = config._originalRewrites
       NextBuildContext.originalRedirects = config._originalRedirects
 
@@ -983,6 +982,8 @@ export default async function build(
       rewrites.beforeFiles.push(
         ...generateInterceptionRoutesRewrites(appPaths, config.basePath)
       )
+
+      NextBuildContext.rewrites = rewrites
 
       const totalAppPagesCount = appPaths.length
 

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -44,6 +44,9 @@ const subresourceIntegrityManifest = sriEnabled
   : undefined
 const nextFontManifest = maybeJSONParse(self.__NEXT_FONT_MANIFEST)
 
+const interceptionRouteRewrites =
+  maybeJSONParse(self.__INTERCEPTION_ROUTE_REWRITE_MANIFEST) ?? []
+
 const render = getRender({
   pagesType: PAGE_TYPES.APP,
   dev,
@@ -65,6 +68,7 @@ const render = getRender({
   buildId: 'VAR_BUILD_ID',
   nextFontManifest,
   incrementalCacheHandler,
+  interceptionRouteRewrites,
 })
 
 export const ComponentMod = pageMod

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1803,6 +1803,7 @@ export default async function getBaseWebpackConfig(
         new MiddlewarePlugin({
           dev,
           sriEnabled: !dev && !!config.experimental.sri?.algorithm,
+          rewrites,
         }),
       isClient &&
         new BuildManifestPlugin({

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -13,7 +13,7 @@ import {
   WebNextResponse,
 } from '../../../../server/base-http/web'
 import { SERVER_RUNTIME } from '../../../../lib/constants'
-import type { PrerenderManifest } from '../../..'
+import type { ManifestRewriteRoute, PrerenderManifest } from '../../..'
 import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
 import type { SizeLimit } from '../../../../../types'
 import { internal_getCurrentFunctionWaitUntil } from '../../../../server/web/internal-edge-wait-until'
@@ -31,6 +31,7 @@ export function getRender({
   buildManifest,
   prerenderManifest,
   reactLoadableManifest,
+  interceptionRouteRewrites,
   renderToHTML,
   clientReferenceManifest,
   subresourceIntegrityManifest,
@@ -54,6 +55,7 @@ export function getRender({
   prerenderManifest: PrerenderManifest
   reactLoadableManifest: ReactLoadableManifest
   subresourceIntegrityManifest?: Record<string, string>
+  interceptionRouteRewrites?: ManifestRewriteRoute[]
   clientReferenceManifest?: ClientReferenceManifest
   serverActionsManifest?: any
   serverActions?: {
@@ -85,6 +87,7 @@ export function getRender({
       pathname: isAppPath ? normalizeAppPath(page) : page,
       pagesType,
       prerenderManifest,
+      interceptionRouteRewrites,
       extendRenderOpts: {
         buildId,
         runtime: SERVER_RUNTIME.experimentalEdge,

--- a/packages/next/src/client/route-loader.ts
+++ b/packages/next/src/client/route-loader.ts
@@ -23,6 +23,7 @@ declare global {
     __RSC_SERVER_MANIFEST?: any
     __NEXT_FONT_MANIFEST?: any
     __SUBRESOURCE_INTEGRITY_MANIFEST?: string
+    __INTERCEPTION_ROUTE_REWRITE_MANIFEST?: string
   }
 }
 

--- a/packages/next/src/lib/generate-interception-routes-rewrites.ts
+++ b/packages/next/src/lib/generate-interception-routes-rewrites.ts
@@ -6,7 +6,6 @@ import {
   isInterceptionRouteAppPath,
 } from '../server/future/helpers/interception-routes'
 import type { Rewrite } from './load-custom-routes'
-import type { ManifestRewriteRoute } from '../build'
 
 // a function that converts normalised paths (e.g. /foo/[bar]/[baz]) to the format expected by pathToRegexp (e.g. /foo/:bar/:baz)
 function toPathToRegexpPath(path: string): string {
@@ -88,7 +87,7 @@ export function generateInterceptionRoutesRewrites(
   return rewrites
 }
 
-export function isInterceptionRouteRewrite(route: ManifestRewriteRoute) {
+export function isInterceptionRouteRewrite(route: Rewrite) {
   // When we generate interception rewrites in the above implementation, we always do so with only a single `has` condition.
   return route.has?.[0].key === NEXT_URL
 }

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -325,7 +325,6 @@ export async function setupFsCheck(opts: {
     )
   )
   const rewrites = {
-    // TODO: add interception routes generateInterceptionRoutesRewrites()
     beforeFiles: customRoutes.rewrites.beforeFiles.map((item) =>
       buildCustomRoute('before_files_rewrite', item)
     ),
@@ -393,7 +392,7 @@ export async function setupFsCheck(opts: {
     dynamicRoutes,
     nextDataRoutes,
 
-    interceptionRoutes: undefined as
+    exportPathMapRoutes: undefined as
       | undefined
       | ReturnType<typeof buildCustomRoute<Rewrite>>[],
 

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -358,9 +358,12 @@ export function getResolveRoutes(
       }
 
       if (params) {
-        if (fsChecker.interceptionRoutes && route.name === 'before_files_end') {
-          for (const interceptionRoute of fsChecker.interceptionRoutes) {
-            const result = await handleRoute(interceptionRoute)
+        if (
+          fsChecker.exportPathMapRoutes &&
+          route.name === 'before_files_end'
+        ) {
+          for (const exportPathMapRoute of fsChecker.exportPathMapRoutes) {
+            const result = await handleRoute(exportPathMapRoute)
 
             if (result) {
               return result

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -373,6 +373,8 @@ export default class NextNodeServer extends BaseServer {
   }
 
   protected getinterceptionRoutePatterns(): RegExp[] {
+    if (!this.enabledDirectories.app) return []
+
     const routesManifest = this.getRoutesManifest()
     return (
       routesManifest?.rewrites.beforeFiles

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -30,6 +30,8 @@ import { getNamedRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
 import { IncrementalCache } from './lib/incremental-cache'
 import type { PAGE_TYPES } from '../lib/page-types'
+import type { Rewrite } from '../lib/load-custom-routes'
+import { buildCustomRoute } from '../lib/build-custom-route'
 
 interface WebServerOptions extends Options {
   webServerConfig: {
@@ -44,6 +46,7 @@ interface WebServerOptions extends Options {
       | undefined
     incrementalCacheHandler?: any
     prerenderManifest: PrerenderManifest | undefined
+    interceptionRouteRewrites?: Rewrite[]
   }
 }
 
@@ -395,7 +398,10 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
   }
 
   protected getinterceptionRoutePatterns(): RegExp[] {
-    // TODO: This needs to be implemented.
-    return []
+    return (
+      this.serverOptions.webServerConfig.interceptionRouteRewrites?.map(
+        (rewrite) => new RegExp(buildCustomRoute('rewrite', rewrite).regex)
+      ) ?? []
+    )
   }
 }

--- a/packages/next/src/shared/lib/constants.ts
+++ b/packages/next/src/shared/lib/constants.ts
@@ -77,6 +77,9 @@ export const MIDDLEWARE_BUILD_MANIFEST = 'middleware-build-manifest'
 // server/middleware-react-loadable-manifest.js
 export const MIDDLEWARE_REACT_LOADABLE_MANIFEST =
   'middleware-react-loadable-manifest'
+// server/interception-route-rewrite-manifest.js
+export const INTERCEPTION_ROUTE_REWRITE_MANIFEST =
+  'interception-route-rewrite-manifest'
 
 // static/runtime/main.js
 export const CLIENT_STATIC_FILES_RUNTIME_MAIN = `main`

--- a/test/e2e/app-dir/interception-route-prefetch-cache/app/layout-edge.tsx
+++ b/test/e2e/app-dir/interception-route-prefetch-cache/app/layout-edge.tsx
@@ -1,0 +1,17 @@
+// this file is swapped in for the normal layout file in the edge runtime test
+
+import Link from 'next/link'
+
+export const runtime = 'edge'
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>
+        <Link href="/">home</Link>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/interception-route-prefetch-cache/interception-route-prefetch-cache.test.ts
+++ b/test/e2e/app-dir/interception-route-prefetch-cache/interception-route-prefetch-cache.test.ts
@@ -1,13 +1,10 @@
-import { createNextDescribe } from 'e2e-utils'
+import { nextTestSetup, FileRef } from 'e2e-utils'
 import { check } from 'next-test-utils'
+import { join } from 'path'
 import { Response } from 'playwright-chromium'
 
-createNextDescribe(
-  'interception-route-prefetch-cache',
-  {
-    files: __dirname,
-  },
-  ({ next, isNextStart }) => {
+describe('interception-route-prefetch-cache', () => {
+  function runTests({ next }: ReturnType<typeof nextTestSetup>) {
     it('should render the correct interception when two distinct layouts share the same path structure', async () => {
       const browser = await next.browser('/')
 
@@ -42,7 +39,17 @@ createNextDescribe(
         /Intercepted on Bar Page/
       )
     })
+  }
 
+  describe('runtime = nodejs', () => {
+    const testSetup = nextTestSetup({
+      files: __dirname,
+    })
+    runTests(testSetup)
+
+    const { next, isNextStart } = testSetup
+
+    // this is a node runtime specific test as edge doesn't support static rendering
     if (isNextStart) {
       it('should not be a cache HIT when prefetching an interception route', async () => {
         const responses: { cacheStatus: string; pathname: string }[] = []
@@ -78,5 +85,16 @@ createNextDescribe(
         expect(interceptionPrefetchResponse.cacheStatus).toBeUndefined()
       })
     }
-  }
-)
+  })
+
+  describe('runtime = edge', () => {
+    runTests(
+      nextTestSetup({
+        files: {
+          app: new FileRef(join(__dirname, 'app')),
+          'app/layout.tsx': new FileRef(join(__dirname, 'app/layout-edge.tsx')),
+        },
+      })
+    )
+  })
+})


### PR DESCRIPTION
In #61794, the routes manifest is used to find the interception route rewrites in `next-server` and computed on the fly in `next-dev-server` based on `appPaths`.

The edge runtime doesn't have access to the routes manifest nor a full list of app paths. This writes an entry for the edge runtime to make the interception routes readable, and adds plumbing to return them in the `getInterceptionRouteRewrites` handling in `web-server`. This is what we use to signal to the server whether to return ‘Next-URL’ in the Vary for RSC requests. 

This piggybacks on the existing interception routes test but adds an edge runtime case.

Closes NEXT-2304