### PR TITLE
fix(ts): `ReadonlyURLSearchParams` should extend `URLSearchParams`

### DIFF
--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -14,10 +14,6 @@ import { clientHookInServerComponentError } from './client-hook-in-server-compon
 import { getSegmentValue } from './router-reducer/reducers/get-segment-value'
 import { PAGE_SEGMENT_KEY, DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
 
-const INTERNAL_URLSEARCHPARAMS_INSTANCE = Symbol(
-  'internal for urlsearchparams readonly'
-)
-
 /** @internal */
 class ReadonlyURLSearchParamsError extends Error {
   constructor() {
@@ -28,17 +24,6 @@ class ReadonlyURLSearchParamsError extends Error {
 }
 
 export class ReadonlyURLSearchParams extends URLSearchParams {
-  [INTERNAL_URLSEARCHPARAMS_INSTANCE]: URLSearchParams
-
-  constructor(init: URLSearchParams) {
-    super(init)
-
-    this[INTERNAL_URLSEARCHPARAMS_INSTANCE] = init
-  }
-  [Symbol.iterator]() {
-    return this[INTERNAL_URLSEARCHPARAMS_INSTANCE][Symbol.iterator]()
-  }
-
   /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
   append() {
     throw new ReadonlyURLSearchParamsError()

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -18,8 +18,13 @@ const INTERNAL_URLSEARCHPARAMS_INSTANCE = Symbol(
   'internal for urlsearchparams readonly'
 )
 
-function readonlyURLSearchParamsError() {
-  return new Error('ReadonlyURLSearchParams cannot be modified')
+/** @internal */
+export class ReadonlyURLSearchParamsError extends Error {
+  constructor() {
+    super(
+      'Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */'
+    )
+  }
 }
 
 export class ReadonlyURLSearchParams extends URLSearchParams {
@@ -36,19 +41,19 @@ export class ReadonlyURLSearchParams extends URLSearchParams {
 
   /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
   append() {
-    throw readonlyURLSearchParamsError()
+    throw new ReadonlyURLSearchParamsError()
   }
   /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
   delete() {
-    throw readonlyURLSearchParamsError()
+    throw new ReadonlyURLSearchParamsError()
   }
   /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
   set() {
-    throw readonlyURLSearchParamsError()
+    throw new ReadonlyURLSearchParamsError()
   }
   /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
   sort() {
-    throw readonlyURLSearchParamsError()
+    throw new ReadonlyURLSearchParamsError()
   }
 }
 

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -25,30 +25,10 @@ function readonlyURLSearchParamsError() {
 export class ReadonlyURLSearchParams extends URLSearchParams {
   [INTERNAL_URLSEARCHPARAMS_INSTANCE]: URLSearchParams
 
-  entries: URLSearchParams['entries']
-  forEach: URLSearchParams['forEach']
-  get: URLSearchParams['get']
-  getAll: URLSearchParams['getAll']
-  has: URLSearchParams['has']
-  keys: URLSearchParams['keys']
-  values: URLSearchParams['values']
-  toString: URLSearchParams['toString']
-  size: any | URLSearchParams['size']
-
   constructor(init: URLSearchParams) {
     super(init)
 
     this[INTERNAL_URLSEARCHPARAMS_INSTANCE] = init
-
-    this.entries = init.entries.bind(init)
-    this.forEach = init.forEach.bind(init)
-    this.get = init.get.bind(init)
-    this.getAll = init.getAll.bind(init)
-    this.has = init.has.bind(init)
-    this.keys = init.keys.bind(init)
-    this.values = init.values.bind(init)
-    this.toString = init.toString.bind(init)
-    this.size = init.size
   }
   [Symbol.iterator]() {
     return this[INTERNAL_URLSEARCHPARAMS_INSTANCE][Symbol.iterator]()

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -22,7 +22,7 @@ function readonlyURLSearchParamsError() {
   return new Error('ReadonlyURLSearchParams cannot be modified')
 }
 
-export class ReadonlyURLSearchParams {
+export class ReadonlyURLSearchParams extends URLSearchParams {
   [INTERNAL_URLSEARCHPARAMS_INSTANCE]: URLSearchParams
 
   entries: URLSearchParams['entries']
@@ -35,32 +35,38 @@ export class ReadonlyURLSearchParams {
   toString: URLSearchParams['toString']
   size: any | URLSearchParams['size']
 
-  constructor(urlSearchParams: URLSearchParams) {
-    this[INTERNAL_URLSEARCHPARAMS_INSTANCE] = urlSearchParams
+  constructor(init: URLSearchParams) {
+    super(init)
 
-    this.entries = urlSearchParams.entries.bind(urlSearchParams)
-    this.forEach = urlSearchParams.forEach.bind(urlSearchParams)
-    this.get = urlSearchParams.get.bind(urlSearchParams)
-    this.getAll = urlSearchParams.getAll.bind(urlSearchParams)
-    this.has = urlSearchParams.has.bind(urlSearchParams)
-    this.keys = urlSearchParams.keys.bind(urlSearchParams)
-    this.values = urlSearchParams.values.bind(urlSearchParams)
-    this.toString = urlSearchParams.toString.bind(urlSearchParams)
-    this.size = urlSearchParams.size
+    this[INTERNAL_URLSEARCHPARAMS_INSTANCE] = init
+
+    this.entries = init.entries.bind(init)
+    this.forEach = init.forEach.bind(init)
+    this.get = init.get.bind(init)
+    this.getAll = init.getAll.bind(init)
+    this.has = init.has.bind(init)
+    this.keys = init.keys.bind(init)
+    this.values = init.values.bind(init)
+    this.toString = init.toString.bind(init)
+    this.size = init.size
   }
   [Symbol.iterator]() {
     return this[INTERNAL_URLSEARCHPARAMS_INSTANCE][Symbol.iterator]()
   }
 
+  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
   append() {
     throw readonlyURLSearchParamsError()
   }
+  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
   delete() {
     throw readonlyURLSearchParamsError()
   }
+  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
   set() {
     throw readonlyURLSearchParamsError()
   }
+  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
   sort() {
     throw readonlyURLSearchParamsError()
   }

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -19,10 +19,10 @@ const INTERNAL_URLSEARCHPARAMS_INSTANCE = Symbol(
 )
 
 /** @internal */
-export class ReadonlyURLSearchParamsError extends Error {
+class ReadonlyURLSearchParamsError extends Error {
   constructor() {
     super(
-      'Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */'
+      'Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams'
     )
   }
 }


### PR DESCRIPTION
### What?

Let the developer check the instance of `ReadonlyURLSearchParams` to match against `URLSearchParams`

### Why?

`useSearchParams()`'s return type is `ReadonlyURLSearchParams` which implements all the methods of `URLSearchParams`, therefore its type should be extended from `URLSearchParams` as well. Deprecated methods are also implemented to throw an error, so no runtime behavior is being changed

### How?

Mark the unavailable methods as `@deprecated` which will visually mark them in IDEs:

![image](https://github.com/vercel/next.js/assets/18369201/f3de2858-14ac-4021-981d-b0267610faa7)

This is similar how `ReadonlyHeaders` extends `Headers`, added in: #49075

[Slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1706628877916779)

Closes NEXT-2305
