### PR TITLE
fix hmr telemetry reporting

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hot-reloader-client.tsx
@@ -78,6 +78,7 @@ function reportHmrLatency(
   sendMessage: (message: string) => void,
   updatedModules: ReadonlyArray<string>
 ) {
+  if (!startLatency) return
   let endLatency = Date.now()
   sendMessage(
     JSON.stringify({


### PR DESCRIPTION
### What?

We sometimes send events with `start: null`...


Closes PACK-2327