### PR TITLE
Always show version text in error overlay

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/components/VersionStalenessInfo/VersionStalenessInfo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/VersionStalenessInfo/VersionStalenessInfo.tsx
@@ -33,27 +33,28 @@ export function getStaleness({ installed, staleness, expected }: VersionInfo) {
   let text = ''
   let title = ''
   let indicatorClass = ''
+  const versionLabel = `Next.js (${installed})`
   switch (staleness) {
     case 'newer-than-npm':
     case 'fresh':
-      text = `Next.js is up to date${process.env.TURBOPACK ? ' (turbo)' : ''}`
+      text = `${versionLabel} ${process.env.TURBOPACK ? ' (turbo)' : ''}`
       title = `Latest available version is detected (${installed}).`
       indicatorClass = 'fresh'
       break
     case 'stale-patch':
     case 'stale-minor':
-      text = `Next.js (${installed}) out of date`
+      text = `${versionLabel} out of date`
       title = `There is a newer version (${expected}) available, upgrade recommended! `
       indicatorClass = 'stale'
       break
     case 'stale-major': {
-      text = `Next.js (${installed}) is outdated`
+      text = `${versionLabel} is outdated`
       title = `An outdated version detected (latest is ${expected}), upgrade is highly recommended!`
       indicatorClass = 'outdated'
       break
     }
     case 'stale-prerelease': {
-      text = `Next.js (${installed}) is outdated`
+      text = `${versionLabel} is outdated`
       title = `There is a newer canary version (${expected}) available, please upgrade! `
       indicatorClass = 'stale'
       break

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1250,10 +1250,9 @@ async function startWatcher(opts: SetupOpts) {
     await writeManifests()
 
     const overlayMiddleware = getOverlayMiddleware(project)
-    let versionInfo: VersionInfo = {
-      installed: '0.0.0',
-      staleness: 'unknown',
-    }
+    let versionInfo: VersionInfo = await getVersionInfo(
+      true || isTestMode || opts.telemetry.isEnabled
+    )
     const hotReloader: NextJsHotReloaderInterface = {
       turbopackProject: project,
       activeWebpackConfigs: undefined,

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -138,7 +138,7 @@ createNextDescribe(
         expect(await hasRedbox(browser)).toBe(true)
       })
       const versionText = await getVersionCheckerText(browser)
-      await expect(versionText).toMatch(/Next.js \(\w+\)/)
+      await expect(versionText).toMatch(/Next.js \([\w\.-]+\)/)
       if (process.env.TURBOPACK) {
         await expect(versionText).toContain('(turbo)')
       } else {

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -138,7 +138,7 @@ createNextDescribe(
         expect(await hasRedbox(browser)).toBe(true)
       })
       const versionText = await getVersionCheckerText(browser)
-      await expect(versionText).toMatch(/Next.js \([\w\.-]+\)/)
+      await expect(versionText).toMatch(/Next.js \([\w.-]+\)/)
       if (process.env.TURBOPACK) {
         await expect(versionText).toContain('(turbo)')
       } else {

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -137,9 +137,13 @@ createNextDescribe(
       await retry(async () => {
         expect(await hasRedbox(browser)).toBe(true)
       })
-      await expect(await getVersionCheckerText(browser)).toContain(
-        `Next.js is up to date${process.env.TURBOPACK ? ' (turbo)' : ''}`
-      )
+      const versionText = await getVersionCheckerText(browser)
+      await expect(versionText).toMatch(/Next.js \(\w+\)/)
+      if (process.env.TURBOPACK) {
+        await expect(versionText).toContain('(turbo)')
+      } else {
+        await expect(versionText).not.toContain('(turbo)')
+      }
     })
   }
 )


### PR DESCRIPTION
Make sure the version is always display on error overlay if possible, to avoid that we saw it's "update to date" in screenshot but still no idea about the version

![image](https://github.com/vercel/next.js/assets/4800338/22d932ce-6176-4cbd-be66-3db1eda259aa)


Closes NEXT-2307