### PR TITLE
feat: first pass of `next/font` manifest

### DIFF
--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -63,6 +63,7 @@ use crate::{
         collect_chunk_group, collect_evaluated_chunk_group, collect_next_dynamic_imports,
         DynamicImportedChunks,
     },
+    font::create_font_manifest,
     middleware::{get_js_paths_from_root, get_wasm_paths_from_root, wasm_paths_to_bindings},
     project::Project,
     route::{Endpoint, Route, Routes, WrittenEndpoint},
@@ -817,6 +818,21 @@ impl AppEndpoint {
             Ok(Vc::cell(output))
         }
 
+        let client_assets = OutputAssets::new(client_assets);
+
+        let next_font_manifest_output = create_font_manifest(
+            this.app_project.project().client_root(),
+            node_root,
+            this.app_project.app_dir(),
+            ty,
+            &app_entry.pathname,
+            &app_entry.original_name,
+            client_assets,
+            true,
+        )
+        .await?;
+        server_assets.push(next_font_manifest_output);
+
         let endpoint_output = match app_entry.config.await?.runtime.unwrap_or_default() {
             NextRuntime::Edge => {
                 // create edge chunks
@@ -957,7 +973,7 @@ impl AppEndpoint {
                 AppEndpointOutput::Edge {
                     files,
                     server_assets: Vc::cell(server_assets),
-                    client_assets: Vc::cell(client_assets),
+                    client_assets,
                 }
             }
             NextRuntime::NodeJs => {
@@ -1032,7 +1048,7 @@ impl AppEndpoint {
                 AppEndpointOutput::NodeJs {
                     rsc_chunk,
                     server_assets: Vc::cell(server_assets),
-                    client_assets: Vc::cell(client_assets),
+                    client_assets,
                 }
             }
         }

--- a/packages/next-swc/crates/next-api/src/font.rs
+++ b/packages/next-swc/crates/next-api/src/font.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use next_core::{
+    all_assets_from_entries, next_manifests::NextFontManifest, util::get_asset_prefix_from_pathname,
+};
+use turbo_tasks::{ValueToString, Vc};
+use turbopack_binding::{
+    turbo::tasks_fs::{File, FileSystemPath},
+    turbopack::core::{
+        asset::AssetContent,
+        output::{OutputAsset, OutputAssets},
+        virtual_output::VirtualOutputAsset,
+    },
+};
+
+use crate::middleware::get_font_paths_from_root;
+
+pub(crate) async fn create_font_manifest(
+    client_root: Vc<FileSystemPath>,
+    node_root: Vc<FileSystemPath>,
+    dir: Vc<FileSystemPath>,
+    ty: &'static str,
+    pathname: &str,
+    original_name: &str,
+    client_assets: Vc<OutputAssets>,
+    app_dir: bool,
+) -> Result<Vc<Box<dyn OutputAsset>>> {
+    // `_next` gets added again later, so we "strip" it here via
+    // `get_font_paths_from_root`.
+    let client_root_value = client_root.join("_next".to_string()).await?;
+
+    let all_client_output_assets = all_assets_from_entries(client_assets).await?;
+
+    let font_paths =
+        get_font_paths_from_root(&client_root_value, &all_client_output_assets).await?;
+
+    let manifest_path_prefix = get_asset_prefix_from_pathname(pathname);
+
+    let path = if app_dir {
+        node_root.join(format!(
+            "server/app{manifest_path_prefix}/{ty}/next-font-manifest.json",
+        ))
+    } else {
+        node_root.join(format!(
+            "server/pages{manifest_path_prefix}/next-font-manifest.json"
+        ))
+    };
+
+    let next_font_manifest = if font_paths.is_empty() {
+        Default::default()
+    } else if app_dir {
+        let dir_str = dir.to_string().await?;
+        let page_path = format!("{}{}", dir_str, original_name);
+
+        NextFontManifest {
+            app: [(page_path, font_paths)].into_iter().collect(),
+            // TODO
+            app_using_size_adjust: true,
+            ..Default::default()
+        }
+    } else {
+        NextFontManifest {
+            pages: [(original_name.to_string(), font_paths)]
+                .into_iter()
+                .collect(),
+            // TODO
+            pages_using_size_adjust: true,
+            ..Default::default()
+        }
+    };
+
+    Ok(Vc::upcast(VirtualOutputAsset::new(
+        path,
+        AssetContent::file(File::from(serde_json::to_string_pretty(&next_font_manifest)?).into()),
+    )))
+}

--- a/packages/next-swc/crates/next-api/src/lib.rs
+++ b/packages/next-swc/crates/next-api/src/lib.rs
@@ -4,6 +4,7 @@
 mod app;
 mod dynamic_imports;
 pub mod entrypoints;
+mod font;
 mod instrumentation;
 mod middleware;
 mod pages;

--- a/packages/next-swc/crates/next-api/src/middleware.rs
+++ b/packages/next-swc/crates/next-api/src/middleware.rs
@@ -254,6 +254,20 @@ pub(crate) async fn get_wasm_paths_from_root(
     get_paths_from_root(root, output_assets, |path| path.ends_with(".wasm")).await
 }
 
+pub(crate) async fn get_font_paths_from_root(
+    root: &FileSystemPath,
+    output_assets: &[Vc<Box<dyn OutputAsset>>],
+) -> Result<Vec<String>> {
+    get_paths_from_root(root, output_assets, |path| {
+        path.ends_with(".woff")
+            || path.ends_with(".woff2")
+            || path.ends_with(".eot")
+            || path.ends_with(".ttf")
+            || path.ends_with(".otf")
+    })
+    .await
+}
+
 fn get_file_stem(path: &str) -> &str {
     let file_name = if let Some((_, file_name)) = path.rsplit_once('/') {
         file_name

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -136,6 +136,7 @@ import { writeFileAtomic } from '../../../lib/fs/write-atomic'
 import { PAGE_TYPES } from '../../../lib/page-types'
 import { trace } from '../../../trace'
 import type { VersionInfo } from '../../dev/parse-version-info'
+import type { NextFontManifest } from '../../../build/webpack/plugins/next-font-manifest-plugin'
 
 const MILLISECONDS_IN_NANOSECOND = 1_000_000
 const wsServer = new ws.Server({ noServer: true })
@@ -331,15 +332,11 @@ async function startWatcher(opts: SetupOpts) {
 
       let message
 
-      if (source) {
-        if (source.range) {
-          const { start } = source.range
-          message = `${formattedFilePath}:${start.line + 1}:${
-            start.column
-          }\n${formattedTitle}`
-        } else {
-          message = formattedFilePath
-        }
+      if (source && source.range) {
+        const { start } = source.range
+        message = `${formattedFilePath}:${start.line + 1}:${
+          start.column
+        }\n${formattedTitle}`
       } else if (formattedFilePath) {
         message = `${formattedFilePath}\n${formattedTitle}`
       } else {
@@ -373,6 +370,11 @@ async function startWatcher(opts: SetupOpts) {
       if (description) {
         message += renderStyledStringToErrorAnsi(description) + '\n\n'
       }
+
+      // TODO: make it possible to enable this for debugging, but not in tests.
+      // if (detail) {
+      //   message += renderStyledStringToErrorAnsi(detail) + '\n\n'
+      // }
 
       // TODO: Include a trace from the issue.
 
@@ -581,11 +583,12 @@ async function startWatcher(opts: SetupOpts) {
     const appPathsManifests = new Map<string, PagesManifest>()
     const middlewareManifests = new Map<string, TurbopackMiddlewareManifest>()
     const actionManifests = new Map<string, ActionManifest>()
+    const fontManifests = new Map<string, NextFontManifest>()
+    const loadableManifests = new Map<string, LoadableManifest>()
     const clientToHmrSubscription = new Map<
       ws,
       Map<string, AsyncIterator<any>>
     >()
-    const loadbleManifests = new Map<string, LoadableManifest>()
     const clients = new Set<ws>()
 
     async function loadMiddlewareManifest(
@@ -643,11 +646,21 @@ async function startWatcher(opts: SetupOpts) {
       )
     }
 
+    async function loadFontManifest(
+      pageName: string,
+      type: 'app' | 'pages' = 'pages'
+    ): Promise<void> {
+      fontManifests.set(
+        pageName,
+        await loadPartialManifest(`${NEXT_FONT_MANIFEST}.json`, pageName, type)
+      )
+    }
+
     async function loadLoadableManifest(
       pageName: string,
       type: 'app' | 'pages' = 'pages'
     ): Promise<void> {
-      loadbleManifests.set(
+      loadableManifests.set(
         pageName,
         await loadPartialManifest(REACT_LOADABLE_MANIFEST, pageName, type)
       )
@@ -814,6 +827,25 @@ async function startWatcher(opts: SetupOpts) {
       return manifest
     }
 
+    function mergeFontManifests(manifests: Iterable<NextFontManifest>) {
+      const manifest: NextFontManifest = {
+        app: {},
+        appUsingSizeAdjust: false,
+        pages: {},
+        pagesUsingSizeAdjust: false,
+      }
+      for (const m of manifests) {
+        Object.assign(manifest.app, m.app)
+        Object.assign(manifest.pages, m.pages)
+
+        manifest.appUsingSizeAdjust =
+          manifest.appUsingSizeAdjust || m.appUsingSizeAdjust
+        manifest.pagesUsingSizeAdjust =
+          manifest.pagesUsingSizeAdjust || m.pagesUsingSizeAdjust
+      }
+      return manifest
+    }
+
     function mergeLoadableManifests(manifests: Iterable<LoadableManifest>) {
       const manifest: LoadableManifest = {}
       for (const m of manifests) {
@@ -963,16 +995,9 @@ async function startWatcher(opts: SetupOpts) {
     }
 
     async function writeFontManifest(): Promise<void> {
-      // TODO: turbopack should write the correct
-      // version of this
-      const fontManifest = {
-        pages: {},
-        app: {},
-        appUsingSizeAdjust: false,
-        pagesUsingSizeAdjust: false,
-      }
-
+      const fontManifest = mergeFontManifests(fontManifests.values())
       const json = JSON.stringify(fontManifest, null, 2)
+
       const fontManifestJsonPath = path.join(
         distDir,
         'server',
@@ -993,7 +1018,9 @@ async function startWatcher(opts: SetupOpts) {
     }
 
     async function writeLoadableManifest(): Promise<void> {
-      const loadableManifest = mergeLoadableManifests(loadbleManifests.values())
+      const loadableManifest = mergeLoadableManifests(
+        loadableManifests.values()
+      )
       const loadableManifestPath = path.join(distDir, REACT_LOADABLE_MANIFEST)
       const middlewareloadableManifestPath = path.join(
         distDir,
@@ -1459,6 +1486,7 @@ async function startWatcher(opts: SetupOpts) {
             }
             await loadBuildManifest('_app')
             await loadPagesManifest('_app')
+            await loadFontManifest('_app')
 
             if (globalEntries.document) {
               const writtenEndpoint = await processResult(
@@ -1487,6 +1515,7 @@ async function startWatcher(opts: SetupOpts) {
             }
             await loadBuildManifest('_error')
             await loadPagesManifest('_error')
+            await loadFontManifest('_error')
 
             await writeManifests()
           } finally {
@@ -1561,6 +1590,7 @@ async function startWatcher(opts: SetupOpts) {
                 } else {
                   middlewareManifests.delete(page)
                 }
+                await loadFontManifest(page, 'pages')
                 await loadLoadableManifest(page, 'pages')
 
                 await writeManifests()
@@ -1675,6 +1705,7 @@ async function startWatcher(opts: SetupOpts) {
               await loadBuildManifest(page, 'app')
               await loadAppPathManifest(page, 'app')
               await loadActionManifest(page)
+              await loadFontManifest(page, 'app')
               await writeManifests()
 
               processIssues(page, writtenEndpoint, true)


### PR DESCRIPTION
### What?

We need the manifest to pass a bunch of preloading tests.

Currently, this is just a dumb implementation that preloads all fonts and always sets size-adjust to true.

Google fonts are also still requested from Google directly it seems and therefore never preloaded.