### PR TITLE
Update turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "serde",
  "smallvec",
@@ -3226,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.68.0"
+version = "0.68.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ac0edf8641e481ae132ce791c86c7941414eb9863a8c14c9094b4dededa30a"
+checksum = "e6458a247b9a21987475d6286e9b8c01fedab1e7be5d8a1a52fad9fa4756cbdd"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "serde",
@@ -5531,9 +5531,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.96.1"
+version = "0.96.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d020b203225068a63edc9b58ff7ff4bf9d83109a860cd896377a8d0223c25af"
+checksum = "1a0db141a50acf297a815bcd1fe9d958ef56c19aeb36bd12182a7e72567ee499"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -6704,9 +6704,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.72.1"
+version = "0.72.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695a666a2b3b1dac06a097464cd7852f6cec303aa2ddf7e3f82fc8fa2659cf2"
+checksum = "8b759380eee487f70b74126ed51fae2273fbfa27fb51165a31a61a5ee3890a20"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -6862,9 +6862,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.44.0"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae7a666d65809ebbcf58ee4c7d751ed5ff6d6304734d23aa5e084b1368cce9"
+checksum = "d8be7da204b399ef338858f5d2b690d3bd6335e4a1aa703fe32a76c8802b4608"
 dependencies = [
  "once_cell",
  "regex",
@@ -7554,7 +7554,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7586,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7598,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7613,7 +7613,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7627,7 +7627,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7644,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7675,7 +7675,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "base16",
  "hex",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7701,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7711,7 +7711,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "mimalloc",
 ]
@@ -7719,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7776,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7841,7 +7841,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7859,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7889,7 +7889,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7916,7 +7916,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7940,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7977,7 +7977,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "serde",
  "serde_json",
@@ -8023,7 +8023,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8048,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8065,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8081,7 +8081,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "serde",
@@ -8116,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8131,7 +8131,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8166,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "serde",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8193,7 +8193,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8209,7 +8209,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.3#15a819b34f88e09266ac8aece2cac79b65510c00"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "serde",
  "smallvec",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "serde",
@@ -5549,9 +5549,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.73.1"
+version = "0.73.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1011d28e2c9b5e4bf83250af70b984c12228029ebf7f8acb564404500ccc9177"
+checksum = "41d0bbff046c61205f33bb18b782cb8ca69483d07ca980a476cab2042b816250"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -7554,7 +7554,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7586,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7598,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7613,7 +7613,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7627,7 +7627,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7644,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7675,7 +7675,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "base16",
  "hex",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7701,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7711,7 +7711,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "mimalloc",
 ]
@@ -7719,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7776,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7841,7 +7841,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7859,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7889,7 +7889,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7916,7 +7916,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7940,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7977,7 +7977,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "serde",
  "serde_json",
@@ -8023,7 +8023,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8048,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8065,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8081,7 +8081,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "serde",
@@ -8116,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8131,7 +8131,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8166,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "serde",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8193,7 +8193,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8209,7 +8209,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240130.4#7ce5ba0c1f97595d616706e3bfe937d5654ffdad"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240131.1#193cb447f48d2d18c2df5084659ebdb74ede3455"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.89.6", features = [
 testing = { version = "0.35.16" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240131.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240131.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240131.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240131.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240131.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240131.3" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.89.6", features = [
 testing = { version = "0.35.16" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240130.4" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240131.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240130.4" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240131.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240130.4" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240131.1" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -194,7 +194,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.2",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -194,7 +194,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.2",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.3",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.26.2
         version: 0.26.2
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4(react-refresh@0.12.0)(webpack@5.90.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1(react-refresh@0.12.0)(webpack@5.90.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25611,9 +25611,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4(react-refresh@0.12.0)(webpack@5.90.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240130.4'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1(react-refresh@0.12.0)(webpack@5.90.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.26.2
         version: 0.26.2
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1(react-refresh@0.12.0)(webpack@5.90.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.3
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.3(react-refresh@0.12.0)(webpack@5.90.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25611,9 +25611,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1(react-refresh@0.12.0)(webpack@5.90.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.1'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.3(react-refresh@0.12.0)(webpack@5.90.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.3}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240131.3'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
# Turbopack

* https://github.com/vercel/turbo/pull/7167 <!-- Leah - fix: catch import map lookup error properly in `ResolvingIssue`  -->
* https://github.com/vercel/turbo/pull/7182 <!-- Donny/강동윤 - feat: Re-enable `preset-env` mode of `styled-jsx` in turbopack  -->
* https://github.com/vercel/turbo/pull/7161 <!-- Tobias Koppers - add support for globs in sideEffects field in package.json  -->
* https://github.com/vercel/turbo/pull/7184 <!-- Donny/강동윤 - chore: Update `swc_core` to `v0.89.6`  -->

### What?

Update turbopack

### Why?

To test https://github.com/vercel/turbo/pull/7182 against internal webapps.

### How?

 - Closes #57718

Closes PACK-2334