### PR TITLE
avoid sending issues turbopack messages to browser

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1042,7 +1042,9 @@ async function startWatcher(opts: SetupOpts) {
 
         for await (const data of subscription) {
           processIssues(id, data)
-          sendTurbopackMessage(data)
+          if (data.type !== 'issues') {
+            sendTurbopackMessage(data)
+          }
         }
       } catch (e) {
         // The client might be using an HMR session from a previous server, tell them


### PR DESCRIPTION
### What?

avoid sending issues turbopack messages to browser

### Why?

they trigger fake HMR events and are not used on client side anyway


Closes PACK-2338