### PR TITLE
Fix missing body size limits in Server Action handler

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -501,8 +501,16 @@ export async function handleAction({
 
         if (isMultipartAction) {
           if (isFetchAction) {
+            const readableLimit = serverActions?.bodySizeLimit ?? '1 MB'
+            const limit = require('next/dist/compiled/bytes').parse(
+              readableLimit
+            )
+
             const busboy = require('busboy')
-            const bb = busboy({ headers: req.headers })
+            const bb = busboy({
+              headers: req.headers,
+              limits: { fieldSize: limit, fileSize: limit },
+            })
             req.pipe(bb)
 
             bound = await decodeReplyFromBusboy(bb, serverModuleMap)


### PR DESCRIPTION
There is one place where we use `busboy` to parse the request body and we are not setting its size limits.

The fix is similar to what https://github.com/vercel/next.js/issues/59277#issuecomment-1867445275 suggested (thanks @TryingToImprove). Need to add a test case for it before shipping.

Closes #59277.

Closes NEXT-2314