### PR TITLE
Pass down __NEXT_EXPERIMENTAL_REACT env to webpack build worker explicitly

### DIFF
--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -7,6 +7,7 @@ import origDebug from 'next/dist/compiled/debug'
 import type { ChildProcess } from 'child_process'
 import path from 'path'
 import { exportTraceState, recordTraceEvents } from '../../trace'
+import { needsExperimentalReact } from '../../lib/needs-experimental-react'
 
 const debug = origDebug('next:build:webpack-build')
 
@@ -47,6 +48,9 @@ async function webpackBuildWithWorker(
         env: {
           ...process.env,
           NEXT_PRIVATE_BUILD_WORKER: '1',
+          NEXT_EXPERIMENTAL_REACT: JSON.stringify(
+            needsExperimentalReact(NextBuildContext.config!)
+          ),
         },
       },
     }) as Worker & typeof import('./impl')


### PR DESCRIPTION
Make sure `__NEXT_EXPERIMENTAL_REACT` env is alwasy available in webpack build worker, like we've done for the other worker before

Closes NEXT-2294