### PR TITLE
refactor(next-core): consolidate custom ecma transform rules

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -19,7 +19,7 @@ use turbopack_binding::{
             free_var_references,
             resolve::{parse::Request, pattern::Pattern},
         },
-        ecmascript::{references::esm::UrlRewriteBehavior, TransformPlugin, TreeShakingMode},
+        ecmascript::{references::esm::UrlRewriteBehavior, TreeShakingMode},
         ecmascript_plugin::transform::directives::client::ClientDirectiveTransformer,
         node::{
             execution_context::ExecutionContext,
@@ -28,8 +28,8 @@ use turbopack_binding::{
         turbopack::{
             condition::ContextCondition,
             module_options::{
-                CustomEcmascriptTransformPlugins, JsxTransformOptions, MdxTransformModuleOptions,
-                ModuleOptionsContext, TypescriptTransformOptions, WebpackLoadersOptions,
+                JsxTransformOptions, MdxTransformModuleOptions, ModuleOptionsContext, ModuleRule,
+                TypescriptTransformOptions, WebpackLoadersOptions,
             },
             resolve_options_context::ResolveOptionsContext,
             transition::Transition,
@@ -56,10 +56,11 @@ use crate::{
             NextNodeSharedRuntimeResolvePlugin, UnsupportedModulesResolvePlugin,
         },
         transforms::{
-            emotion::get_emotion_transform_plugin, get_relay_transform_plugin,
-            styled_components::get_styled_components_transform_plugin,
-            styled_jsx::get_styled_jsx_transform_plugin,
-            swc_ecma_transform_plugins::get_swc_ecma_transform_plugin,
+            emotion::get_emotion_transform_rule, get_ecma_transform_rule,
+            relay::get_relay_transform_rule,
+            styled_components::get_styled_components_transform_rule,
+            styled_jsx::get_styled_jsx_transform_rule,
+            swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
         },
     },
     sass::maybe_add_sass_loader,
@@ -277,7 +278,8 @@ pub async fn get_server_module_options_context(
     mode: NextMode,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<ModuleOptionsContext>> {
-    let custom_rules = get_next_server_transforms_rules(next_config, ty.into_value(), mode).await?;
+    let mut base_next_server_rules =
+        get_next_server_transforms_rules(next_config, ty.into_value(), mode).await?;
     let internal_custom_rules =
         get_next_server_internal_transforms_rules(ty.into_value(), *next_config.mdx_rs().await?)
             .await?;
@@ -334,12 +336,6 @@ pub async fn get_server_module_options_context(
     let use_lightningcss = *next_config.use_lightningcss().await?;
     let versions = RuntimeVersions(Default::default()).cell();
 
-    // EcmascriptTransformPlugins for custom transforms
-    let styled_components_transform_plugin =
-        *get_styled_components_transform_plugin(next_config).await?;
-    let styled_jsx_transform_plugin =
-        *get_styled_jsx_transform_plugin(use_lightningcss, versions).await?;
-
     // ModuleOptionsContext related options
     let tsconfig = get_typescript_transform_options(project_path);
     let decorators_options = get_decorators_transform_options(project_path);
@@ -366,44 +362,34 @@ pub async fn get_server_module_options_context(
     let rsc_jsx_runtime_options =
         get_jsx_transform_options(project_path, mode, None, true, next_config);
 
-    let source_transforms: Vec<Vc<TransformPlugin>> = vec![
-        *get_swc_ecma_transform_plugin(project_path, next_config).await?,
-        *get_relay_transform_plugin(next_config).await?,
-        *get_emotion_transform_plugin(next_config).await?,
+    // A set of custom ecma transform rules being applied to server context.
+    let source_transform_rules: Vec<ModuleRule> = vec![
+        get_swc_ecma_transform_plugin_rule(next_config, project_path).await?,
+        get_relay_transform_rule(next_config).await?,
+        get_emotion_transform_rule(next_config).await?,
     ]
     .into_iter()
     .flatten()
     .collect();
 
-    let output_transforms = vec![];
-
-    let custom_ecma_transform_plugins = Some(CustomEcmascriptTransformPlugins::cell(
-        CustomEcmascriptTransformPlugins {
-            source_transforms: source_transforms.clone(),
-            output_transforms: output_transforms.clone(),
-        },
-    ));
+    // Custom ecma transform rules selectively being applied depends on the server
+    // context type.
+    let styled_components_transform_rule =
+        get_styled_components_transform_rule(next_config).await?;
+    let styled_jsx_transform_rule = get_styled_jsx_transform_rule(next_config, versions).await?;
 
     let module_options_context = match ty.into_value() {
         ServerContextType::Pages { .. }
         | ServerContextType::PagesData { .. }
         | ServerContextType::PagesApi { .. } => {
-            let mut base_source_transforms: Vec<Vc<TransformPlugin>> = vec![
-                styled_components_transform_plugin,
-                styled_jsx_transform_plugin,
-            ]
-            .into_iter()
-            .flatten()
-            .collect();
+            let custom_source_transform_rules: Vec<ModuleRule> =
+                vec![styled_components_transform_rule, styled_jsx_transform_rule]
+                    .into_iter()
+                    .flatten()
+                    .collect();
 
-            base_source_transforms.extend(source_transforms);
-
-            let custom_ecma_transform_plugins = Some(CustomEcmascriptTransformPlugins::cell(
-                CustomEcmascriptTransformPlugins {
-                    source_transforms: base_source_transforms,
-                    output_transforms,
-                },
-            ));
+            base_next_server_rules.extend(custom_source_transform_rules);
+            base_next_server_rules.extend(source_transform_rules);
 
             let url_rewrite_behavior = Some(
                 //https://github.com/vercel/next.js/blob/bbb730e5ef10115ed76434f250379f6f53efe998/packages/next/src/build/webpack-config.ts#L1384
@@ -454,38 +440,22 @@ pub async fn get_server_module_options_context(
                         internal_module_options_context.cell(),
                     ),
                 ],
-                custom_rules,
-                custom_ecma_transform_plugins,
+                custom_rules: base_next_server_rules,
                 ..module_options_context
             }
         }
         ServerContextType::AppSSR { .. } => {
-            let mut base_source_transforms: Vec<Vc<TransformPlugin>> = vec![
-                styled_components_transform_plugin,
-                styled_jsx_transform_plugin,
-            ]
-            .into_iter()
-            .flatten()
-            .collect();
+            let custom_source_transform_rules: Vec<ModuleRule> =
+                vec![styled_components_transform_rule, styled_jsx_transform_rule]
+                    .into_iter()
+                    .flatten()
+                    .collect();
 
-            let base_ecma_transform_plugins = Some(CustomEcmascriptTransformPlugins::cell(
-                CustomEcmascriptTransformPlugins {
-                    source_transforms: base_source_transforms.clone(),
-                    output_transforms: vec![],
-                },
-            ));
-
-            base_source_transforms.extend(source_transforms);
-
-            let custom_ecma_transform_plugins = Some(CustomEcmascriptTransformPlugins::cell(
-                CustomEcmascriptTransformPlugins {
-                    source_transforms: base_source_transforms,
-                    output_transforms,
-                },
-            ));
+            base_next_server_rules.extend(custom_source_transform_rules.clone());
+            base_next_server_rules.extend(source_transform_rules);
 
             let module_options_context = ModuleOptionsContext {
-                custom_ecma_transform_plugins: base_ecma_transform_plugins,
+                custom_rules: custom_source_transform_rules,
                 execution_context: Some(execution_context),
                 use_lightningcss,
                 tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
@@ -521,8 +491,7 @@ pub async fn get_server_module_options_context(
                         internal_module_options_context.cell(),
                     ),
                 ],
-                custom_rules,
-                custom_ecma_transform_plugins,
+                custom_rules: base_next_server_rules,
                 ..module_options_context
             }
         }
@@ -530,8 +499,8 @@ pub async fn get_server_module_options_context(
             ecmascript_client_reference_transition_name,
             ..
         } => {
-            let mut base_source_transforms: Vec<Vc<TransformPlugin>> =
-                vec![styled_components_transform_plugin]
+            let mut custom_source_transform_rules: Vec<ModuleRule> =
+                vec![styled_components_transform_rule]
                     .into_iter()
                     .flatten()
                     .collect();
@@ -539,36 +508,28 @@ pub async fn get_server_module_options_context(
             if let Some(ecmascript_client_reference_transition_name) =
                 ecmascript_client_reference_transition_name
             {
-                base_source_transforms.push(Vc::cell(Box::new(ClientDirectiveTransformer::new(
-                    ecmascript_client_reference_transition_name,
-                )) as _));
+                custom_source_transform_rules.push(get_ecma_transform_rule(
+                    Box::new(ClientDirectiveTransformer::new(
+                        ecmascript_client_reference_transition_name,
+                    )),
+                    enable_mdx_rs.is_some(),
+                    true,
+                ));
             }
 
-            let base_ecma_transform_plugins = Some(CustomEcmascriptTransformPlugins::cell(
-                CustomEcmascriptTransformPlugins {
-                    source_transforms: base_source_transforms.clone(),
-                    output_transforms: vec![],
-                },
-            ));
-
-            base_source_transforms.extend(source_transforms);
-
-            let custom_ecma_transform_plugins = Some(CustomEcmascriptTransformPlugins::cell(
-                CustomEcmascriptTransformPlugins {
-                    source_transforms: base_source_transforms,
-                    output_transforms,
-                },
-            ));
+            base_next_server_rules.extend(custom_source_transform_rules.clone());
+            base_next_server_rules.extend(source_transform_rules);
 
             let module_options_context = ModuleOptionsContext {
-                custom_ecma_transform_plugins: base_ecma_transform_plugins,
                 execution_context: Some(execution_context),
                 use_lightningcss,
                 tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
                 ..Default::default()
             };
+
+            custom_source_transform_rules.extend(internal_custom_rules);
             let foreign_code_module_options_context = ModuleOptionsContext {
-                custom_rules: internal_custom_rules.clone(),
+                custom_rules: custom_source_transform_rules.clone(),
                 enable_webpack_loaders: foreign_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
@@ -576,7 +537,7 @@ pub async fn get_server_module_options_context(
             };
             let internal_module_options_context = ModuleOptionsContext {
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
-                custom_rules: internal_custom_rules,
+                custom_rules: custom_source_transform_rules,
                 ..module_options_context.clone()
             };
             ModuleOptionsContext {
@@ -596,12 +557,13 @@ pub async fn get_server_module_options_context(
                         internal_module_options_context.cell(),
                     ),
                 ],
-                custom_rules,
-                custom_ecma_transform_plugins,
+                custom_rules: base_next_server_rules,
                 ..module_options_context
             }
         }
         ServerContextType::AppRoute { .. } => {
+            base_next_server_rules.extend(source_transform_rules);
+
             let module_options_context = ModuleOptionsContext {
                 execution_context: Some(execution_context),
                 tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
@@ -635,28 +597,19 @@ pub async fn get_server_module_options_context(
                         internal_module_options_context.cell(),
                     ),
                 ],
-                custom_rules,
-                custom_ecma_transform_plugins,
+                custom_rules: base_next_server_rules,
                 ..module_options_context
             }
         }
         ServerContextType::Middleware | ServerContextType::Instrumentation => {
-            let mut base_source_transforms: Vec<Vc<TransformPlugin>> = vec![
-                styled_components_transform_plugin,
-                styled_jsx_transform_plugin,
-            ]
-            .into_iter()
-            .flatten()
-            .collect();
+            let custom_source_transform_rules: Vec<ModuleRule> =
+                vec![styled_components_transform_rule, styled_jsx_transform_rule]
+                    .into_iter()
+                    .flatten()
+                    .collect();
 
-            base_source_transforms.extend(source_transforms);
-
-            let custom_ecma_transform_plugins = Some(CustomEcmascriptTransformPlugins::cell(
-                CustomEcmascriptTransformPlugins {
-                    source_transforms: base_source_transforms,
-                    output_transforms,
-                },
-            ));
+            base_next_server_rules.extend(custom_source_transform_rules);
+            base_next_server_rules.extend(source_transform_rules);
 
             let module_options_context = ModuleOptionsContext {
                 execution_context: Some(execution_context),
@@ -692,8 +645,7 @@ pub async fn get_server_module_options_context(
                         internal_module_options_context.cell(),
                     ),
                 ],
-                custom_rules,
-                custom_ecma_transform_plugins,
+                custom_rules: base_next_server_rules,
                 ..module_options_context
             }
         }

--- a/packages/next-swc/crates/next-core/src/next_server/transforms.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/transforms.rs
@@ -74,9 +74,7 @@ pub async fn get_next_server_transforms_rules(
                 mdx_rs,
             ));
 
-            rules.push(get_next_react_server_components_transform_rule(
-                true, mdx_rs,
-            ));
+            rules.push(get_next_react_server_components_transform_rule(next_config, true).await?);
 
             if let Some(client_transition) = client_transition {
                 rules.push(get_next_css_client_reference_transforms_rule(

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/emotion.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/emotion.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
-    ecmascript::OptionTransformPlugin,
-    ecmascript_plugin::transform::emotion::{EmotionTransformConfig, EmotionTransformer},
+    ecmascript_plugin::transform::emotion::EmotionTransformer,
     turbopack::module_options::ModuleRule,
 };
 
@@ -26,42 +25,4 @@ pub async fn get_emotion_transform_rule(next_config: Vc<NextConfig>) -> Result<O
         .map(|transformer| get_ecma_transform_rule(Box::new(transformer), enable_mdx_rs, true));
 
     Ok(module_rule)
-}
-
-#[turbo_tasks::function]
-pub async fn get_emotion_transform_plugin(
-    next_config: Vc<NextConfig>,
-) -> Result<Vc<OptionTransformPlugin>> {
-    let transform_plugin = next_config
-        .await?
-        .compiler
-        .as_ref()
-        .map(|value| {
-            value
-                .emotion
-                .as_ref()
-                .map(|value| {
-                    let transformer = match value {
-                        EmotionTransformOptionsOrBoolean::Boolean(true) => {
-                            EmotionTransformer::new(&EmotionTransformConfig {
-                                ..Default::default()
-                            })
-                        }
-                        EmotionTransformOptionsOrBoolean::Boolean(false) => None,
-
-                        EmotionTransformOptionsOrBoolean::Options(value) => {
-                            EmotionTransformer::new(value)
-                        }
-                    };
-
-                    transformer.map_or_else(
-                        || Vc::cell(None),
-                        |v| Vc::cell(Some(Vc::cell(Box::new(v) as _))),
-                    )
-                })
-                .unwrap_or_default()
-        })
-        .unwrap_or_default();
-
-    Ok(transform_plugin)
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/emotion.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/emotion.rs
@@ -3,9 +3,32 @@ use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
     ecmascript::OptionTransformPlugin,
     ecmascript_plugin::transform::emotion::{EmotionTransformConfig, EmotionTransformer},
+    turbopack::module_options::ModuleRule,
 };
 
+use super::get_ecma_transform_rule;
 use crate::next_config::{EmotionTransformOptionsOrBoolean, NextConfig};
+
+pub async fn get_emotion_transform_rule(next_config: Vc<NextConfig>) -> Result<Option<ModuleRule>> {
+    let enable_mdx_rs = *next_config.mdx_rs().await?;
+    let module_rule = next_config
+        .await?
+        .compiler
+        .as_ref()
+        .map(|value| value.emotion.as_ref())
+        .flatten()
+        .map(|config| match config {
+            EmotionTransformOptionsOrBoolean::Boolean(true) => {
+                EmotionTransformer::new(&Default::default())
+            }
+            EmotionTransformOptionsOrBoolean::Options(value) => EmotionTransformer::new(value),
+            _ => None,
+        })
+        .flatten()
+        .map(|transformer| get_ecma_transform_rule(Box::new(transformer), enable_mdx_rs));
+
+    Ok(module_rule)
+}
 
 #[turbo_tasks::function]
 pub async fn get_emotion_transform_plugin(

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/emotion.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/emotion.rs
@@ -15,17 +15,15 @@ pub async fn get_emotion_transform_rule(next_config: Vc<NextConfig>) -> Result<O
         .await?
         .compiler
         .as_ref()
-        .map(|value| value.emotion.as_ref())
-        .flatten()
-        .map(|config| match config {
+        .and_then(|value| value.emotion.as_ref())
+        .and_then(|config| match config {
             EmotionTransformOptionsOrBoolean::Boolean(true) => {
                 EmotionTransformer::new(&Default::default())
             }
             EmotionTransformOptionsOrBoolean::Options(value) => EmotionTransformer::new(value),
             _ => None,
         })
-        .flatten()
-        .map(|transformer| get_ecma_transform_rule(Box::new(transformer), enable_mdx_rs));
+        .map(|transformer| get_ecma_transform_rule(Box::new(transformer), enable_mdx_rs, true));
 
     Ok(module_rule)
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
@@ -119,13 +119,17 @@ pub(crate) fn module_rule_match_pages_page_file(
 pub(crate) fn get_ecma_transform_rule(
     transformer: Box<dyn CustomTransformer + Send + Sync>,
     enable_mdx_rs: bool,
+    prepend: bool,
 ) -> ModuleRule {
     let transformer = EcmascriptInputTransform::Plugin(Vc::cell(transformer as _));
+    let (prepend, append) = if prepend {
+        (Vc::cell(vec![transformer]), Vc::cell(vec![]))
+    } else {
+        (Vc::cell(vec![]), Vc::cell(vec![transformer]))
+    };
 
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms { prepend, append }],
     )
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
@@ -27,6 +27,7 @@ use turbo_tasks::{ReadRef, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_binding::turbopack::{
     core::reference_type::{ReferenceType, UrlReferenceSubType},
+    ecmascript::{CustomTransformer, EcmascriptInputTransform},
     turbopack::module_options::{ModuleRule, ModuleRuleCondition, ModuleRuleEffect, ModuleType},
 };
 
@@ -84,7 +85,9 @@ fn match_js_extension(enable_mdx_rs: bool) -> Vec<ModuleRuleCondition> {
     conditions
 }
 
-/// Returns a rule which applies the Next.js dynamic transform.
+/// Returns a module rule condition matches to any ecmascript (with mdx if
+/// enabled) except url reference type. This is a typical custom rule matching
+/// condition for custom ecma specific transforms.
 pub(crate) fn module_rule_match_js_no_url(enable_mdx_rs: bool) -> ModuleRuleCondition {
     let conditions = match_js_extension(enable_mdx_rs);
 
@@ -109,4 +112,20 @@ pub(crate) fn module_rule_match_pages_page_file(
         ModuleRuleCondition::ResourcePathInExactDirectory(pages_directory),
         ModuleRuleCondition::any(conditions),
     ])
+}
+
+/// Create a new module rule for the given ecmatransform, runs against
+/// any ecmascript (with mdx if enabled) except url reference type
+pub(crate) fn get_ecma_transform_rule(
+    transformer: Box<dyn CustomTransformer + Send + Sync>,
+    enable_mdx_rs: bool,
+) -> ModuleRule {
+    let transformer = EcmascriptInputTransform::Plugin(Vc::cell(transformer as _));
+
+    ModuleRule::new(
+        module_rule_match_js_no_url(enable_mdx_rs),
+        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
+            transformer,
+        ]))],
+    )
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
@@ -21,7 +21,6 @@ pub use modularize_imports::{get_next_modularize_imports_rule, ModularizeImportP
 pub use next_dynamic::get_next_dynamic_transform_rule;
 pub use next_font::get_next_font_transform_rule;
 pub use next_strip_page_exports::get_next_pages_transforms_rule;
-pub use relay::get_relay_transform_plugin;
 pub use server_actions::get_server_actions_transform_rule;
 use turbo_tasks::{ReadRef, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/modularize_imports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/modularize_imports.rs
@@ -51,9 +51,10 @@ pub fn get_next_modularize_imports_rule(
     ) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![transformer]),
+        }],
     )
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
@@ -20,9 +20,10 @@ pub fn get_next_amp_attr_rule(enable_mdx_rs: bool) -> ModuleRule {
         EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextAmpAttributes {}) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![transformer]),
+        }],
     )
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
@@ -54,9 +54,10 @@ pub fn get_next_cjs_optimizer_rule(enable_mdx_rs: bool) -> ModuleRule {
         EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextCjsOptimizer { config }) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![transformer]),
+        }],
     )
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
@@ -24,9 +24,10 @@ pub fn get_next_disallow_export_all_in_page_rule(
         EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextDisallowReExportAllInPage) as _));
     ModuleRule::new(
         module_rule_match_pages_page_file(enable_mdx_rs, pages_dir),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![transformer]),
+        }],
     )
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -41,9 +41,10 @@ pub async fn get_next_dynamic_transform_rule(
     }) as _));
     Ok(ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            dynamic_transform,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![dynamic_transform]),
+        }],
     ))
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_font.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_font.rs
@@ -24,9 +24,10 @@ pub fn get_next_font_transform_rule(enable_mdx_rs: bool) -> ModuleRule {
     ModuleRule::new(
         // TODO: Only match in pages (not pages/api), app/, etc.
         module_rule_match_js_no_url(enable_mdx_rs),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![transformer]),
+        }],
     )
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
@@ -26,9 +26,10 @@ pub fn get_next_optimize_server_react_rule(
         }) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![transformer]),
+        }],
     )
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_page_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_page_config.rs
@@ -26,9 +26,10 @@ pub fn get_next_page_config_rule(
     }) as _));
     ModuleRule::new(
         module_rule_match_pages_page_file(enable_mdx_rs, pages_dir),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![transformer]),
+        }],
     )
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_pure.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_pure.rs
@@ -16,9 +16,10 @@ pub fn get_next_pure_rule(enable_mdx_rs: bool) -> ModuleRule {
     let transformer = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextPure {}) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![transformer]),
+        }],
     )
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -16,7 +16,8 @@ use turbopack_binding::turbopack::{
     turbopack::module_options::{ModuleRule, ModuleRuleEffect},
 };
 
-use super::module_rule_match_js_no_url;
+use super::{get_ecma_transform_rule, module_rule_match_js_no_url};
+use crate::next_config::NextConfig;
 
 /// Returns a rule which applies the Next.js react server components transform.
 pub fn get_next_react_server_components_transform_rule(
@@ -36,9 +37,28 @@ pub fn get_next_react_server_components_transform_rule(
     )
 }
 
+pub async fn get_next_react_server_components_transform_rule2(
+    next_config: Vc<NextConfig>,
+    is_react_server_layer: bool,
+) -> Result<ModuleRule> {
+    let enable_mdx_rs = *next_config.mdx_rs().await?;
+    Ok(get_ecma_transform_rule(
+        Box::new(NextJsReactServerComponents::new(is_react_server_layer)),
+        enable_mdx_rs,
+    ))
+}
+
 #[derive(Debug)]
 struct NextJsReactServerComponents {
     is_react_server_layer: bool,
+}
+
+impl NextJsReactServerComponents {
+    fn new(is_react_server_layer: bool) -> Self {
+        Self {
+            is_react_server_layer,
+        }
+    }
 }
 
 #[async_trait]

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -45,6 +45,7 @@ pub async fn get_next_react_server_components_transform_rule2(
     Ok(get_ecma_transform_rule(
         Box::new(NextJsReactServerComponents::new(is_react_server_layer)),
         enable_mdx_rs,
+        true,
     ))
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -12,32 +12,15 @@ use swc_core::{
 };
 use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
-    ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
-    turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+    ecmascript::{CustomTransformer, TransformContext},
+    turbopack::module_options::ModuleRule,
 };
 
-use super::{get_ecma_transform_rule, module_rule_match_js_no_url};
+use super::get_ecma_transform_rule;
 use crate::next_config::NextConfig;
 
 /// Returns a rule which applies the Next.js react server components transform.
-pub fn get_next_react_server_components_transform_rule(
-    is_react_server_layer: bool,
-    enable_mdx_rs: bool,
-) -> ModuleRule {
-    let transformer =
-        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextJsReactServerComponents {
-            is_react_server_layer,
-        }) as _));
-
-    ModuleRule::new(
-        module_rule_match_js_no_url(enable_mdx_rs),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
-    )
-}
-
-pub async fn get_next_react_server_components_transform_rule2(
+pub async fn get_next_react_server_components_transform_rule(
     next_config: Vc<NextConfig>,
     is_react_server_layer: bool,
 ) -> Result<ModuleRule> {

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
@@ -21,9 +21,10 @@ pub fn get_next_shake_exports_rule(enable_mdx_rs: bool, ignore: Vec<String>) -> 
         EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextShakeExports { ignore }) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![transformer]),
+        }],
     )
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -56,9 +56,10 @@ pub async fn get_next_pages_transforms_rule(
             ]),
             module_rule_match_js_no_url(enable_mdx_rs),
         ]),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            strip_transform,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![strip_transform]),
+        }],
     ))
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/relay.rs
@@ -2,8 +2,10 @@ use anyhow::Result;
 use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
     ecmascript::OptionTransformPlugin, ecmascript_plugin::transform::relay::RelayTransformer,
+    turbopack::module_options::ModuleRule,
 };
 
+use super::get_ecma_transform_rule;
 use crate::next_config::NextConfig;
 
 /// Returns a transform plugin for the relay graphql transform.
@@ -27,4 +29,20 @@ pub async fn get_relay_transform_plugin(
         .unwrap_or_default();
 
     Ok(transform_plugin)
+}
+
+pub async fn get_relay_transform_rule(next_config: Vc<NextConfig>) -> Result<Option<ModuleRule>> {
+    let enable_mdx_rs = *next_config.mdx_rs().await?;
+    let module_rule = next_config
+        .await?
+        .compiler
+        .as_ref()
+        .map(|value| {
+            value.relay.as_ref().map(|config| {
+                get_ecma_transform_rule(Box::new(RelayTransformer::new(config)), enable_mdx_rs)
+            })
+        })
+        .flatten();
+
+    Ok(module_rule)
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/relay.rs
@@ -1,36 +1,13 @@
 use anyhow::Result;
 use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
-    ecmascript::OptionTransformPlugin, ecmascript_plugin::transform::relay::RelayTransformer,
-    turbopack::module_options::ModuleRule,
+    ecmascript_plugin::transform::relay::RelayTransformer, turbopack::module_options::ModuleRule,
 };
 
 use super::get_ecma_transform_rule;
 use crate::next_config::NextConfig;
 
-/// Returns a transform plugin for the relay graphql transform.
-#[turbo_tasks::function]
-pub async fn get_relay_transform_plugin(
-    next_config: Vc<NextConfig>,
-) -> Result<Vc<OptionTransformPlugin>> {
-    let transform_plugin = next_config
-        .await?
-        .compiler
-        .as_ref()
-        .map(|value| {
-            value
-                .relay
-                .as_ref()
-                .map(|config| {
-                    Vc::cell(Some(Vc::cell(Box::new(RelayTransformer::new(config)) as _)))
-                })
-                .unwrap_or_default()
-        })
-        .unwrap_or_default();
-
-    Ok(transform_plugin)
-}
-
+/// Returns a transform rule for the relay graphql transform.
 pub async fn get_relay_transform_rule(next_config: Vc<NextConfig>) -> Result<Option<ModuleRule>> {
     let enable_mdx_rs = *next_config.mdx_rs().await?;
     let module_rule = next_config.await?.compiler.as_ref().and_then(|value| {

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/relay.rs
@@ -33,16 +33,11 @@ pub async fn get_relay_transform_plugin(
 
 pub async fn get_relay_transform_rule(next_config: Vc<NextConfig>) -> Result<Option<ModuleRule>> {
     let enable_mdx_rs = *next_config.mdx_rs().await?;
-    let module_rule = next_config
-        .await?
-        .compiler
-        .as_ref()
-        .map(|value| {
-            value.relay.as_ref().map(|config| {
-                get_ecma_transform_rule(Box::new(RelayTransformer::new(config)), enable_mdx_rs)
-            })
+    let module_rule = next_config.await?.compiler.as_ref().and_then(|value| {
+        value.relay.as_ref().map(|config| {
+            get_ecma_transform_rule(Box::new(RelayTransformer::new(config)), enable_mdx_rs, true)
         })
-        .flatten();
+    });
 
     Ok(module_rule)
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -28,9 +28,10 @@ pub fn get_server_actions_transform_rule(
         EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextServerActions { transform }) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
-        vec![ModuleRuleEffect::AddEcmascriptTransforms(Vc::cell(vec![
-            transformer,
-        ]))],
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![transformer]),
+        }],
     )
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_components.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_components.rs
@@ -1,10 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
-    ecmascript::OptionTransformPlugin,
-    ecmascript_plugin::transform::styled_components::{
-        StyledComponentsTransformConfig, StyledComponentsTransformer,
-    },
+    ecmascript_plugin::transform::styled_components::StyledComponentsTransformer,
     turbopack::module_options::ModuleRule,
 };
 
@@ -12,43 +9,6 @@ use crate::{
     next_config::{NextConfig, StyledComponentsTransformOptionsOrBoolean},
     next_shared::transforms::get_ecma_transform_rule,
 };
-
-#[turbo_tasks::function]
-pub async fn get_styled_components_transform_plugin(
-    next_config: Vc<NextConfig>,
-) -> Result<Vc<OptionTransformPlugin>> {
-    let transform_plugin = next_config
-        .await?
-        .compiler
-        .as_ref()
-        .map(|value| {
-            value
-                .styled_components
-                .as_ref()
-                .map(|value| {
-                    let transformer = match value {
-                        StyledComponentsTransformOptionsOrBoolean::Boolean(true) => Some(
-                            StyledComponentsTransformer::new(&StyledComponentsTransformConfig {
-                                ..Default::default()
-                            }),
-                        ),
-                        StyledComponentsTransformOptionsOrBoolean::Boolean(false) => None,
-                        StyledComponentsTransformOptionsOrBoolean::Options(value) => {
-                            Some(StyledComponentsTransformer::new(value))
-                        }
-                    };
-
-                    transformer.map_or_else(
-                        || Vc::cell(None),
-                        |v| Vc::cell(Some(Vc::cell(Box::new(v) as _))),
-                    )
-                })
-                .unwrap_or_default()
-        })
-        .unwrap_or_default();
-
-    Ok(transform_plugin)
-}
 
 pub async fn get_styled_components_transform_rule(
     next_config: Vc<NextConfig>,

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_components.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_components.rs
@@ -59,9 +59,8 @@ pub async fn get_styled_components_transform_rule(
         .await?
         .compiler
         .as_ref()
-        .map(|value| value.styled_components.as_ref())
-        .flatten()
-        .map(|config| match config {
+        .and_then(|value| value.styled_components.as_ref())
+        .and_then(|config| match config {
             StyledComponentsTransformOptionsOrBoolean::Boolean(true) => {
                 Some(StyledComponentsTransformer::new(&Default::default()))
             }
@@ -70,8 +69,7 @@ pub async fn get_styled_components_transform_rule(
             }
             _ => None,
         })
-        .flatten()
-        .map(|transformer| get_ecma_transform_rule(Box::new(transformer), enable_mdx_rs));
+        .map(|transformer| get_ecma_transform_rule(Box::new(transformer), enable_mdx_rs, true));
 
     Ok(module_rule)
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
-    core::environment::RuntimeVersions, ecmascript::OptionTransformPlugin,
+    core::environment::RuntimeVersions,
     ecmascript_plugin::transform::styled_jsx::StyledJsxTransformer,
     turbopack::module_options::ModuleRule,
 };
@@ -9,19 +9,7 @@ use turbopack_binding::turbopack::{
 use super::get_ecma_transform_rule;
 use crate::next_config::NextConfig;
 
-/// Returns a transform plugin for the relay graphql transform.
-#[turbo_tasks::function]
-pub async fn get_styled_jsx_transform_plugin(
-    use_lightningcss: bool,
-    target_browsers: Vc<RuntimeVersions>,
-) -> Result<Vc<OptionTransformPlugin>> {
-    let versions = *target_browsers.await?;
-
-    Ok(Vc::cell(Some(Vc::cell(
-        Box::new(StyledJsxTransformer::new(use_lightningcss, versions)) as _,
-    ))))
-}
-
+/// Returns a transform rule for the relay graphql transform.
 pub async fn get_styled_jsx_transform_rule(
     next_config: Vc<NextConfig>,
     target_browsers: Vc<RuntimeVersions>,

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
@@ -34,5 +34,6 @@ pub async fn get_styled_jsx_transform_rule(
     Ok(Some(get_ecma_transform_rule(
         Box::new(transformer),
         enable_mdx_rs,
+        true,
     )))
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
@@ -3,7 +3,11 @@ use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
     core::environment::RuntimeVersions, ecmascript::OptionTransformPlugin,
     ecmascript_plugin::transform::styled_jsx::StyledJsxTransformer,
+    turbopack::module_options::ModuleRule,
 };
+
+use super::get_ecma_transform_rule;
+use crate::next_config::NextConfig;
 
 /// Returns a transform plugin for the relay graphql transform.
 #[turbo_tasks::function]
@@ -16,4 +20,19 @@ pub async fn get_styled_jsx_transform_plugin(
     Ok(Vc::cell(Some(Vc::cell(
         Box::new(StyledJsxTransformer::new(use_lightningcss, versions)) as _,
     ))))
+}
+
+pub async fn get_styled_jsx_transform_rule(
+    next_config: Vc<NextConfig>,
+    target_browsers: Vc<RuntimeVersions>,
+) -> Result<Option<ModuleRule>> {
+    let enable_mdx_rs = *next_config.mdx_rs().await?;
+    let use_lightningcss = *next_config.use_lightningcss().await?;
+    let versions = *target_browsers.await?;
+
+    let transformer = StyledJsxTransformer::new(use_lightningcss, versions);
+    Ok(Some(get_ecma_transform_rule(
+        Box::new(transformer),
+        enable_mdx_rs,
+    )))
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -1,9 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_binding::turbopack::{
-    ecmascript::OptionTransformPlugin, turbopack::module_options::ModuleRule,
-};
+use turbopack_binding::turbopack::turbopack::module_options::ModuleRule;
 
 use crate::next_config::NextConfig;
 
@@ -112,107 +110,4 @@ pub async fn get_swc_ecma_transform_rule_impl(
         enable_mdx_rs,
         true,
     )))
-}
-
-#[turbo_tasks::function]
-pub async fn get_swc_ecma_transform_plugin(
-    project_path: Vc<FileSystemPath>,
-    next_config: Vc<NextConfig>,
-) -> Result<Vc<OptionTransformPlugin>> {
-    let config = next_config.await?;
-    match config.experimental.swc_plugins.as_ref() {
-        Some(plugin_configs) if !plugin_configs.is_empty() => {
-            #[cfg(feature = "plugin")]
-            {
-                get_swc_ecma_transform_plugin_impl(project_path, plugin_configs).await
-            }
-
-            #[cfg(not(feature = "plugin"))]
-            {
-                let _ = project_path;
-                Ok(Vc::cell(None))
-            }
-        }
-        _ => Ok(Vc::cell(None)),
-    }
-}
-
-#[cfg(feature = "plugin")]
-pub async fn get_swc_ecma_transform_plugin_impl(
-    project_path: Vc<FileSystemPath>,
-    plugin_configs: &[(String, serde_json::Value)],
-) -> Result<Vc<OptionTransformPlugin>> {
-    use anyhow::{bail, Context};
-    use turbo_tasks::Value;
-    use turbo_tasks_fs::FileContent;
-    use turbopack_binding::turbopack::{
-        core::{
-            asset::Asset,
-            issue::IssueSeverity,
-            reference_type::{CommonJsReferenceSubType, ReferenceType},
-            resolve::{handle_resolve_error, parse::Request, pattern::Pattern, resolve},
-        },
-        ecmascript_plugin::transform::swc_ecma_transform_plugins::{
-            SwcEcmaTransformPluginsTransformer, SwcPluginModule,
-        },
-        turbopack::{resolve_options, resolve_options_context::ResolveOptionsContext},
-    };
-
-    let mut plugins = vec![];
-    for (name, config) in plugin_configs.iter() {
-        // [TODO]: SWC's current experimental config supports
-        // two forms of plugin path,
-        // one for implicit package name resolves to node_modules,
-        // and one for explicit path to a .wasm binary.
-        // Current resolve will fail with latter.
-        let request = Request::parse(Value::new(Pattern::Constant(name.to_string())));
-        let resolve_options = resolve_options(
-            project_path,
-            ResolveOptionsContext {
-                enable_node_modules: Some(project_path.root().resolve().await?),
-                enable_node_native_modules: true,
-                ..Default::default()
-            }
-            .cell(),
-        );
-
-        let plugin_wasm_module_resolve_result = handle_resolve_error(
-            resolve(
-                project_path,
-                Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
-                request,
-                resolve_options,
-            )
-            .as_raw_module_result(),
-            Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
-            project_path,
-            request,
-            resolve_options,
-            IssueSeverity::Error.cell(),
-            None,
-        )
-        .await?;
-        let plugin_module = plugin_wasm_module_resolve_result
-            .first_module()
-            .await?
-            .context("Expected to find module")?;
-
-        let content = &*plugin_module.content().file_content().await?;
-
-        let FileContent::Content(file) = content else {
-            bail!("Expected file content for plugin module");
-        };
-
-        plugins.push((
-            SwcPluginModule::cell(SwcPluginModule::new(
-                name,
-                file.content().to_bytes()?.to_vec(),
-            )),
-            config.clone(),
-        ));
-    }
-
-    return Ok(Vc::cell(Some(Vc::cell(
-        Box::new(SwcEcmaTransformPluginsTransformer::new(plugins)) as _,
-    ))));
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -110,6 +110,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
     Ok(Some(get_ecma_transform_rule(
         Box::new(SwcEcmaTransformPluginsTransformer::new(plugins)),
         enable_mdx_rs,
+        true,
     )))
 }
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -1,9 +1,117 @@
 use anyhow::Result;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_binding::turbopack::ecmascript::OptionTransformPlugin;
+use turbopack_binding::turbopack::{
+    ecmascript::OptionTransformPlugin, turbopack::module_options::ModuleRule,
+};
 
 use crate::next_config::NextConfig;
+
+pub async fn get_swc_ecma_transform_plugin_rule(
+    next_config: Vc<NextConfig>,
+    project_path: Vc<FileSystemPath>,
+) -> Result<Option<ModuleRule>> {
+    match next_config.await?.experimental.swc_plugins.as_ref() {
+        Some(plugin_configs) if !plugin_configs.is_empty() => {
+            #[cfg(feature = "plugin")]
+            {
+                let enable_mdx_rs = *next_config.mdx_rs().await?;
+                get_swc_ecma_transform_rule_impl(project_path, plugin_configs, enable_mdx_rs).await
+            }
+
+            #[cfg(not(feature = "plugin"))]
+            {
+                let _ = project_path; // To satisfiy lint
+                Ok(None)
+            }
+        }
+        _ => Ok(None),
+    }
+}
+
+#[cfg(feature = "plugin")]
+pub async fn get_swc_ecma_transform_rule_impl(
+    project_path: Vc<FileSystemPath>,
+    plugin_configs: &[(String, serde_json::Value)],
+    enable_mdx_rs: bool,
+) -> Result<Option<ModuleRule>> {
+    use anyhow::{bail, Context};
+    use turbo_tasks::Value;
+    use turbo_tasks_fs::FileContent;
+    use turbopack_binding::turbopack::{
+        core::{
+            asset::Asset,
+            issue::IssueSeverity,
+            reference_type::{CommonJsReferenceSubType, ReferenceType},
+            resolve::{handle_resolve_error, parse::Request, pattern::Pattern, resolve},
+        },
+        ecmascript_plugin::transform::swc_ecma_transform_plugins::{
+            SwcEcmaTransformPluginsTransformer, SwcPluginModule,
+        },
+        turbopack::{resolve_options, resolve_options_context::ResolveOptionsContext},
+    };
+
+    use crate::next_shared::transforms::get_ecma_transform_rule;
+
+    let mut plugins = vec![];
+    for (name, config) in plugin_configs.iter() {
+        // [TODO]: SWC's current experimental config supports
+        // two forms of plugin path,
+        // one for implicit package name resolves to node_modules,
+        // and one for explicit path to a .wasm binary.
+        // Current resolve will fail with latter.
+        let request = Request::parse(Value::new(Pattern::Constant(name.to_string())));
+        let resolve_options = resolve_options(
+            project_path,
+            ResolveOptionsContext {
+                enable_node_modules: Some(project_path.root().resolve().await?),
+                enable_node_native_modules: true,
+                ..Default::default()
+            }
+            .cell(),
+        );
+
+        let plugin_wasm_module_resolve_result = handle_resolve_error(
+            resolve(
+                project_path,
+                Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+                request,
+                resolve_options,
+            )
+            .as_raw_module_result(),
+            Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+            project_path,
+            request,
+            resolve_options,
+            IssueSeverity::Error.cell(),
+            None,
+        )
+        .await?;
+        let plugin_module = plugin_wasm_module_resolve_result
+            .first_module()
+            .await?
+            .context("Expected to find module")?;
+
+        let content = &*plugin_module.content().file_content().await?;
+
+        let FileContent::Content(file) = content else {
+            bail!("Expected file content for plugin module");
+        };
+
+        plugins.push((
+            SwcPluginModule::cell(SwcPluginModule::new(
+                name,
+                file.content().to_bytes()?.to_vec(),
+            )),
+            config.clone(),
+        ));
+    }
+
+    Ok(Some(get_ecma_transform_rule(
+        Box::new(SwcEcmaTransformPluginsTransformer::new(plugins)),
+        enable_mdx_rs,
+    )))
+}
 
 #[turbo_tasks::function]
 pub async fn get_swc_ecma_transform_plugin(


### PR DESCRIPTION
This PR consolidates how we inject specific, custom ecma transforms for the each context. 

Previously we had 2 different way to apply custom transforms via ecmatransform plugin / custom rules, but it could create some conflict in order as well as can be confusing between how it gets created. PR uses new moduleruleeffect instead, consolidates all of the references into single way.

Closes PACK-2342