### PR TITLE
Fix experimental react support in app-route runtime

### DIFF
--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -7,7 +7,6 @@ import origDebug from 'next/dist/compiled/debug'
 import type { ChildProcess } from 'child_process'
 import path from 'path'
 import { exportTraceState, recordTraceEvents } from '../../trace'
-import { needsExperimentalReact } from '../../lib/needs-experimental-react'
 
 const debug = origDebug('next:build:webpack-build')
 
@@ -48,9 +47,6 @@ async function webpackBuildWithWorker(
         env: {
           ...process.env,
           NEXT_PRIVATE_BUILD_WORKER: '1',
-          NEXT_EXPERIMENTAL_REACT: JSON.stringify(
-            needsExperimentalReact(NextBuildContext.config!)
-          ),
         },
       },
     }) as Worker & typeof import('./impl')

--- a/packages/next/src/server/future/route-modules/app-route/module.compiled.js
+++ b/packages/next/src/server/future/route-modules/app-route/module.compiled.js
@@ -1,11 +1,21 @@
 if (process.env.NEXT_RUNTIME === 'edge') {
   module.exports = require('next/dist/server/future/route-modules/app-route/module.js')
 } else {
-  if (process.env.NODE_ENV === 'development') {
-    module.exports = require('next/dist/compiled/next-server/app-route.runtime.dev.js')
-  } else if (process.env.TURBOPACK) {
-    module.exports = require('next/dist/compiled/next-server/app-route-turbo.runtime.prod.js')
+  if (process.env.__NEXT_EXPERIMENTAL_REACT) {
+    if (process.env.NODE_ENV === 'development') {
+      module.exports = require('next/dist/compiled/next-server/app-route-experimental.runtime.dev.js')
+    } else if (process.env.TURBOPACK) {
+      module.exports = require('next/dist/compiled/next-server/app-route-turbo-experimental.runtime.prod.js')
+    } else {
+      module.exports = require('next/dist/compiled/next-server/app-route-experimental.runtime.prod.js')
+    }
   } else {
-    module.exports = require('next/dist/compiled/next-server/app-route.runtime.prod.js')
+    if (process.env.NODE_ENV === 'development') {
+      module.exports = require('next/dist/compiled/next-server/app-route.runtime.dev.js')
+    } else if (process.env.TURBOPACK) {
+      module.exports = require('next/dist/compiled/next-server/app-route-turbo.runtime.prod.js')
+    } else {
+      module.exports = require('next/dist/compiled/next-server/app-route.runtime.prod.js')
+    }
   }
 }


### PR DESCRIPTION
Follow up for #61463

Basically the fix in #61463 was not correct. I added a log to see which react is resolved in `dynmiac-rendering` module, and the got this:

The module with incorrect react version is from `next.js/packages/next/dist/compiled/next-server/app-route.runtime.prod.js` which resolves `react` as `./dist/compiled/react/index.js` even experimental react should pop in here.

Then I found the app-route runtime doesn't have check for the react exp env, then I added there to make it aligned with app-page runtime


Closes NEXT-2327
Closes NEXT-2294