### PR TITLE
fix(with-docker): resolve build with pnpm

### DIFF
--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -30,7 +30,7 @@ COPY . .
 RUN \
   if [ -f yarn.lock ]; then yarn run build; \
   elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then pnpm run build; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
   else echo "Lockfile not found." && exit 1; \
   fi
 


### PR DESCRIPTION
### Adding or Updating Examples

- Example: [with-docker](https://github.com/vercel/next.js/tree/canary/examples/with-docker)
- Update: The latest change introduced in #61466 on the building process of NextJS when the package manager is PNPM is currently throwing an error (it works for npm though).

**To replicate the error:**

1. Checkout on the **with-docker** example
2. Install with PNPM so that it generates the pnpm-lock.yaml
3. Build the Docker image -> This will fail on the _builder stage_ step that runs `pnpm run build`.

**Possible Solution:**
- Run `corepack enable pnpm` before building with pnpm