### PR TITLE
Simplify Redirect Error Parsing

### DIFF
--- a/packages/next/src/client/components/redirect-boundary.tsx
+++ b/packages/next/src/client/components/redirect-boundary.tsx
@@ -2,12 +2,7 @@
 import React, { useEffect } from 'react'
 import type { AppRouterInstance } from '../../shared/lib/app-router-context.shared-runtime'
 import { useRouter } from './navigation'
-import {
-  RedirectType,
-  getRedirectTypeFromError,
-  getURLFromRedirectError,
-  isRedirectError,
-} from './redirect'
+import { RedirectType, isRedirectError, parseRedirectError } from './redirect'
 
 interface RedirectBoundaryProps {
   router: AppRouterInstance
@@ -50,9 +45,8 @@ export class RedirectErrorBoundary extends React.Component<
 
   static getDerivedStateFromError(error: any) {
     if (isRedirectError(error)) {
-      const url = getURLFromRedirectError(error)
-      const redirectType = getRedirectTypeFromError(error)
-      return { redirect: url, redirectType }
+      const { url, type } = parseRedirectError(error)
+      return { redirect: url, redirectType: type }
     }
     // Re-throw if error is not for redirect
     throw error

--- a/packages/next/src/client/components/redirect.test.ts
+++ b/packages/next/src/client/components/redirect.test.ts
@@ -1,4 +1,4 @@
-import { getURLFromRedirectError, isRedirectError, redirect } from './redirect'
+import { isRedirectError, parseRedirectError, redirect } from './redirect'
 describe('test', () => {
   it('should throw a redirect error', () => {
     try {
@@ -6,7 +6,8 @@ describe('test', () => {
       throw new Error('did not throw')
     } catch (err: any) {
       expect(isRedirectError(err)).toBeTruthy()
-      expect(getURLFromRedirectError(err)).toEqual('/dashboard')
+      const parsed = parseRedirectError(err)
+      expect(parsed.url).toEqual('/dashboard')
     }
   })
 })

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -16,9 +16,8 @@ import {
 } from '../../client/components/app-router-headers'
 import { isNotFoundError } from '../../client/components/not-found'
 import {
-  getRedirectStatusCodeFromError,
-  getURLFromRedirectError,
   isRedirectError,
+  parseRedirectError,
 } from '../../client/components/redirect'
 import RenderResult from '../render-result'
 import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
@@ -635,8 +634,7 @@ To configure the body size limit for Server Actions, see: https://nextjs.org/doc
     }
   } catch (err) {
     if (isRedirectError(err)) {
-      const redirectUrl = getURLFromRedirectError(err)
-      const statusCode = getRedirectStatusCodeFromError(err)
+      const { url: redirectUrl, statusCode } = parseRedirectError(err)
 
       await addRevalidationHeader(res, {
         staticGenerationStore,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -44,9 +44,8 @@ import { RequestAsyncStorageWrapper } from '../async-storage/request-async-stora
 import { StaticGenerationAsyncStorageWrapper } from '../async-storage/static-generation-async-storage-wrapper'
 import { isNotFoundError } from '../../client/components/not-found'
 import {
-  getURLFromRedirectError,
   isRedirectError,
-  getRedirectStatusCodeFromError,
+  parseRedirectError,
 } from '../../client/components/redirect'
 import { addImplicitTags } from '../lib/patch-fetch'
 import { AppRenderSpan } from '../lib/trace/constants'
@@ -1040,10 +1039,13 @@ async function renderToHTMLOrFlightImpl(
         if (isNotFoundError(err)) {
           res.statusCode = 404
         }
-        let hasRedirectError = false
-        if (isRedirectError(err)) {
-          hasRedirectError = true
-          res.statusCode = getRedirectStatusCodeFromError(err)
+
+        const hasRedirectError = isRedirectError(err)
+        if (hasRedirectError) {
+          const parsed = parseRedirectError(err)
+
+          res.statusCode = parsed.statusCode
+
           if (err.mutableCookies) {
             const headers = new Headers()
 
@@ -1053,10 +1055,8 @@ async function renderToHTMLOrFlightImpl(
               res.setHeader('set-cookie', Array.from(headers.values()))
             }
           }
-          const redirectUrl = addPathPrefix(
-            getURLFromRedirectError(err),
-            renderOpts.basePath
-          )
+
+          const redirectUrl = addPathPrefix(parsed.url, renderOpts.basePath)
           res.setHeader('Location', redirectUrl)
         }
 

--- a/packages/next/src/server/future/route-modules/app-route/helpers/resolve-handler-error.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/resolve-handler-error.ts
@@ -1,8 +1,7 @@
 import { isNotFoundError } from '../../../../../client/components/not-found'
 import {
-  getURLFromRedirectError,
   isRedirectError,
-  getRedirectStatusCodeFromError,
+  parseRedirectError,
 } from '../../../../../client/components/redirect'
 import {
   handleNotFoundResponse,
@@ -11,15 +10,13 @@ import {
 
 export function resolveHandlerError(err: any): Response | false {
   if (isRedirectError(err)) {
-    const redirect = getURLFromRedirectError(err)
-    if (!redirect) {
+    const { url, statusCode } = parseRedirectError(err)
+    if (!url) {
       throw new Error('Invariant: Unexpected redirect url format')
     }
 
-    const status = getRedirectStatusCodeFromError(err)
-
     // This is a redirect error! Send the redirect response.
-    return handleRedirectResponse(redirect, err.mutableCookies, status)
+    return handleRedirectResponse(url, err.mutableCookies, statusCode)
   }
 
   if (isNotFoundError(err)) {


### PR DESCRIPTION
This simplifies the redirect error handling to reduce the duplicate validation and parsing of the redirect error. The parsing code already requires that the given error has been type checked (we still provide the type guard) so there's no real reduction in safety here, just a reduction of compute.

Closes NEXT-2333