### PR TITLE
chore(docs): add `// @ts-check` to `next.config.js` docs

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/index.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/index.mdx
@@ -8,6 +8,8 @@ description: Learn how to configure your application with next.config.js.
 Next.js can be configured through a `next.config.js` file in the root of your project directory (for example, by `package.json`).
 
 ```js filename="next.config.js"
+// @ts-check
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   /* config options here */
@@ -21,6 +23,8 @@ module.exports = nextConfig
 If you need [ECMAScript modules](https://nodejs.org/api/esm.html), you can use `next.config.mjs`:
 
 ```js filename="next.config.mjs"
+// @ts-check
+
 /**
  * @type {import('next').NextConfig}
  */
@@ -34,6 +38,8 @@ export default nextConfig
 You can also use a function:
 
 ```js filename="next.config.mjs"
+// @ts-check
+
 export default (phase, { defaultConfig }) => {
   /**
    * @type {import('next').NextConfig}
@@ -48,6 +54,8 @@ export default (phase, { defaultConfig }) => {
 Since Next.js 12.1.0, you can use an async function:
 
 ```js filename="next.config.js"
+// @ts-check
+
 module.exports = async (phase, { defaultConfig }) => {
   /**
    * @type {import('next').NextConfig}
@@ -62,6 +70,8 @@ module.exports = async (phase, { defaultConfig }) => {
 `phase` is the current context in which the configuration is loaded. You can see the [available phases](https://github.com/vercel/next.js/blob/5e6b008b561caf2710ab7be63320a3d549474a5b/packages/next/shared/lib/constants.ts#L19-L23). Phases can be imported from `next/constants`:
 
 ```js
+// @ts-check
+
 const { PHASE_DEVELOPMENT_SERVER } = require('next/constants')
 
 module.exports = (phase, { defaultConfig }) => {


### PR DESCRIPTION
This PR updates the docs to add `// @ts-check` at the top of each `next.config.js` or `next.config.mjs`.

Even though you can't use `next.config.ts`, you can still get some type checking to catch typos such as wrong type or even duplicate keys.


<img width="322" alt="image" src="https://github.com/vercel/next.js/assets/229881/fcaba393-3560-4d16-95bf-a0504e66fa26">

<img width="325" alt="image" src="https://github.com/vercel/next.js/assets/229881/e7156dd4-7b79-4f08-b843-4431b56b1c50">



Closes NEXT-2335