### PR TITLE
Fixing a case sensitivity error

### DIFF
--- a/examples/with-zustand/src/app/layout.tsx
+++ b/examples/with-zustand/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import StoreProvider from "@/lib/storeProvider";
+import StoreProvider from "@/lib/StoreProvider";
 
 export default function RootLayout({
   children,


### PR DESCRIPTION
Fixing a simple case sensitivity error in the import statement, "storeProvider" should be "StoreProvider".