### PR TITLE
fixed bug when script-src-attr or script-src-elem are contained in the CSP

### DIFF
--- a/packages/next/src/server/app-render/get-script-nonce-from-header.tsx
+++ b/packages/next/src/server/app-render/get-script-nonce-from-header.tsx
@@ -10,8 +10,9 @@ export function getScriptNonceFromHeader(
 
   // First try to find the directive for the 'script-src', otherwise try to
   // fallback to the 'default-src'.
+  // Note the space after 'script-src' is required to ignore script-src-attr and script-src-elem
   const directive =
-    directives.find((dir) => dir.startsWith('script-src')) ||
+    directives.find((dir) => dir.startsWith('script-src ')) ||
     directives.find((dir) => dir.startsWith('default-src'))
 
   // If no directive could be found, then we're done.


### PR DESCRIPTION
if script-src-attr or script-src-elem are contained in the CSP before script-src, then this would cause the nonce not to be found and breaking all inline script tags
