### PR TITLE
Renew prefetch cache entry after update from server

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -63,6 +63,7 @@ import { removeBasePath } from '../remove-base-path'
 import { hasBasePath } from '../has-base-path'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import type { Params } from '../../shared/lib/router/utils/route-matcher'
+import type { FlightRouterState } from '../../server/app-render/types'
 const isServer = typeof window === 'undefined'
 
 // Ensure the initialParallelRoutes are not combined because of double-rendering in the browser with Strict Mode.

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -20,10 +20,6 @@ import type {
   CacheNode,
   AppRouterInstance,
 } from '../../shared/lib/app-router-context.shared-runtime'
-import type {
-  FlightRouterState,
-  FlightData,
-} from '../../server/app-render/types'
 import type { ErrorComponent } from './error-boundary'
 import {
   ACTION_FAST_REFRESH,
@@ -211,17 +207,12 @@ function useChangeByServerResponse(
   dispatch: React.Dispatch<ReducerActions>
 ): RouterChangeByServerResponse {
   return useCallback(
-    (
-      previousTree: FlightRouterState,
-      flightData: FlightData,
-      overrideCanonicalUrl: URL | undefined
-    ) => {
+    ({ previousTree, serverResponse }) => {
       startTransition(() => {
         dispatch({
           type: ACTION_SERVER_PATCH,
-          flightData,
           previousTree,
-          overrideCanonicalUrl,
+          serverResponse,
         })
       })
     },

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -417,12 +417,15 @@ function InnerLayoutRouter({
      * Flight response data
      */
     // When the data has not resolved yet `use` will suspend here.
-    const [flightData, overrideCanonicalUrl] = use(lazyData)
+    const serverResponse = use(lazyData)
 
     // setTimeout is used to start a new transition during render, this is an intentional hack around React.
     setTimeout(() => {
       startTransition(() => {
-        changeByServerResponse(fullTree, flightData, overrideCanonicalUrl)
+        changeByServerResponse({
+          previousTree: fullTree,
+          serverResponse,
+        })
       })
     })
     // Suspend infinitely as `changeByServerResponse` will cause a different part of the tree to be rendered.

--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -7,7 +7,7 @@ export function applyFlightData(
   existingCache: CacheNode,
   cache: CacheNode,
   flightDataPath: FlightDataPath,
-  wasPrefetched: boolean = false
+  hasReusablePrefetch: boolean = false
 ): boolean {
   // The one before last item is the router state tree patch
   const [treePatch, cacheNodeSeedData, head] = flightDataPath.slice(-3)
@@ -32,7 +32,7 @@ export function applyFlightData(
       treePatch,
       cacheNodeSeedData,
       head,
-      wasPrefetched
+      hasReusablePrefetch
     )
   } else {
     // Copy rsc for the root node of the cache.
@@ -47,7 +47,7 @@ export function applyFlightData(
       cache,
       existingCache,
       flightDataPath,
-      wasPrefetched
+      hasReusablePrefetch
     )
   }
 

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -14,7 +14,7 @@ export function fillCacheWithNewSubTreeData(
   newCache: CacheNode,
   existingCache: CacheNode,
   flightDataPath: FlightDataPath,
-  wasPrefetched?: boolean
+  hasReusablePrefetch?: boolean
 ): void {
   const isLastEntry = flightDataPath.length <= 5
   const [parallelRouteKey, segment] = flightDataPath
@@ -71,7 +71,7 @@ export function fillCacheWithNewSubTreeData(
         flightDataPath[2],
         seedData,
         flightDataPath[4],
-        wasPrefetched
+        hasReusablePrefetch
       )
 
       childSegmentMap.set(cacheKey, childCacheNode)
@@ -99,6 +99,6 @@ export function fillCacheWithNewSubTreeData(
     childCacheNode,
     existingChildCacheNode,
     flightDataPath.slice(2),
-    wasPrefetched
+    hasReusablePrefetch
   )
 }

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -11,7 +11,7 @@ export function fillLazyItemsTillLeafWithHead(
   routerState: FlightRouterState,
   cacheNodeSeedData: CacheNodeSeedData | null,
   head: React.ReactNode,
-  wasPrefetched?: boolean
+  hasReusablePrefetch?: boolean
 ): void {
   const isLastSegment = Object.keys(routerState[1]).length === 0
   if (isLastSegment) {
@@ -59,7 +59,7 @@ export function fillLazyItemsTillLeafWithHead(
             prefetchRsc: null,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
           }
-        } else if (wasPrefetched && existingCacheNode) {
+        } else if (hasReusablePrefetch && existingCacheNode) {
           // No new data was sent from the server, but the existing cache node
           // was prefetched, so we should reuse that.
           newCacheNode = {
@@ -91,7 +91,7 @@ export function fillLazyItemsTillLeafWithHead(
           parallelRouteState,
           parallelSeedData ? parallelSeedData : null,
           head,
-          wasPrefetched
+          hasReusablePrefetch
         )
 
         newCache.parallelRoutes.set(key, parallelRouteCacheNode)
@@ -133,7 +133,7 @@ export function fillLazyItemsTillLeafWithHead(
       parallelRouteState,
       parallelSeedData,
       head,
-      wasPrefetched
+      hasReusablePrefetch
     )
   }
 }

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -67,8 +67,7 @@ export function updateCacheNodeOnNavigation(
   oldRouterState: FlightRouterState,
   newRouterState: FlightRouterState,
   prefetchData: CacheNodeSeedData,
-  prefetchHead: React.ReactNode,
-  isPrefetchStale: boolean
+  prefetchHead: React.ReactNode
 ): Task | null {
   // Diff the old and new trees to reuse the shared layouts.
   const oldRouterStateChildren = oldRouterState[1]
@@ -126,8 +125,7 @@ export function updateCacheNodeOnNavigation(
       taskChild = spawnPendingTask(
         newRouterStateChild,
         prefetchDataChild !== undefined ? prefetchDataChild : null,
-        prefetchHead,
-        isPrefetchStale
+        prefetchHead
       )
     } else if (newSegmentChild === DEFAULT_SEGMENT_KEY) {
       // This is another kind of leaf segment — a default route.
@@ -147,8 +145,7 @@ export function updateCacheNodeOnNavigation(
         taskChild = spawnPendingTask(
           newRouterStateChild,
           prefetchDataChild !== undefined ? prefetchDataChild : null,
-          prefetchHead,
-          isPrefetchStale
+          prefetchHead
         )
       }
     } else if (
@@ -167,8 +164,7 @@ export function updateCacheNodeOnNavigation(
             oldRouterStateChild,
             newRouterStateChild,
             prefetchDataChild,
-            prefetchHead,
-            isPrefetchStale
+            prefetchHead
           )
         } else {
           // The server didn't send any prefetch data for this segment. This
@@ -185,8 +181,7 @@ export function updateCacheNodeOnNavigation(
         taskChild = spawnPendingTask(
           newRouterStateChild,
           prefetchDataChild !== undefined ? prefetchDataChild : null,
-          prefetchHead,
-          isPrefetchStale
+          prefetchHead
         )
       }
     } else {
@@ -194,8 +189,7 @@ export function updateCacheNodeOnNavigation(
       taskChild = spawnPendingTask(
         newRouterStateChild,
         prefetchDataChild !== undefined ? prefetchDataChild : null,
-        prefetchHead,
-        isPrefetchStale
+        prefetchHead
       )
     }
 
@@ -278,15 +272,13 @@ function patchRouterStateWithNewChildren(
 function spawnPendingTask(
   routerState: FlightRouterState,
   prefetchData: CacheNodeSeedData | null,
-  prefetchHead: React.ReactNode,
-  isPrefetchStale: boolean
+  prefetchHead: React.ReactNode
 ): Task {
   // Create a task that will later be fulfilled by data from the server.
   const pendingCacheNode = createPendingCacheNode(
     routerState,
     prefetchData,
-    prefetchHead,
-    isPrefetchStale
+    prefetchHead
   )
   return {
     route: routerState,
@@ -309,12 +301,7 @@ function spawnTaskForMissingData(routerState: FlightRouterState): Task {
   // Create a task for a new subtree that wasn't prefetched by the server.
   // This shouldn't really ever happen but it's here just in case the Seed Data
   // Tree and the Router State Tree disagree unexpectedly.
-  const pendingCacheNode = createPendingCacheNode(
-    routerState,
-    null,
-    null,
-    false
-  )
+  const pendingCacheNode = createPendingCacheNode(routerState, null, null)
   return {
     route: routerState,
     node: pendingCacheNode,
@@ -491,8 +478,7 @@ function finishTaskUsingDynamicDataPayload(
 function createPendingCacheNode(
   routerState: FlightRouterState,
   prefetchData: CacheNodeSeedData | null,
-  prefetchHead: React.ReactNode,
-  isPrefetchStale: boolean
+  prefetchHead: React.ReactNode
 ): ReadyCacheNode {
   const routerStateChildren = routerState[1]
   const prefetchDataChildren = prefetchData !== null ? prefetchData[1] : null
@@ -512,8 +498,7 @@ function createPendingCacheNode(
     const newCacheNodeChild = createPendingCacheNode(
       routerStateChild,
       prefetchDataChild === undefined ? null : prefetchDataChild,
-      prefetchHead,
-      isPrefetchStale
+      prefetchHead
     )
 
     const newSegmentMapChild: ChildSegmentMap = new Map()
@@ -531,15 +516,8 @@ function createPendingCacheNode(
     lazyData: null,
     parallelRoutes: parallelRoutes,
 
-    prefetchRsc:
-      // If the prefetched cache entry is stale, we don't show it. We wait for the
-      // dynamic data to stream in.
-      // TODO: This check is aruably too deep in the stack. Might be better to
-      // pass an empty prefetchData Cache Seed object instead.
-      !isPrefetchStale && maybePrefetchRsc !== undefined
-        ? maybePrefetchRsc
-        : null,
-    prefetchHead: !isPrefetchStale && isLeafSegment ? prefetchHead : null,
+    prefetchRsc: maybePrefetchRsc !== undefined ? maybePrefetchRsc : null,
+    prefetchHead: isLeafSegment ? prefetchHead : null,
 
     // Create a deferred promise. This will be fulfilled once the dynamic
     // response is received from the server.

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -195,13 +195,21 @@ function navigateReducer_noPPR(
           }
 
           const cache: CacheNode = createEmptyCacheNode()
+          const hasReusablePrefetch =
+            prefetchValues.kind === 'auto' &&
+            prefetchEntryCacheStatus === PrefetchCacheEntryStatus.reusable
           let applied = applyFlightData(
             currentCache,
             cache,
             flightDataPath,
-            prefetchValues.kind === 'auto' &&
-              prefetchEntryCacheStatus === PrefetchCacheEntryStatus.reusable
+            hasReusablePrefetch
           )
+
+          if (!hasReusablePrefetch) {
+            // Once the prefetch entry no longer reusable, `applyFlightData` will signal to layout router that it needs to lazy fetch the data
+            // We update the `lastUsedTime` so that we renew the 30s cache for this entry
+            prefetchValues.lastUsedTime = Date.now()
+          }
 
           if (
             !applied &&
@@ -450,13 +458,21 @@ function navigateReducer_PPR(
             // tree. Or in the meantime we could factor it out into a
             // separate function.
             const cache: CacheNode = createEmptyCacheNode()
+            const hasReusablePrefetch =
+              prefetchValues.kind === 'auto' &&
+              prefetchEntryCacheStatus === PrefetchCacheEntryStatus.reusable
             let applied = applyFlightData(
               currentCache,
               cache,
               flightDataPath,
-              prefetchValues.kind === 'auto' &&
-                prefetchEntryCacheStatus === PrefetchCacheEntryStatus.reusable
+              hasReusablePrefetch
             )
+
+            if (!hasReusablePrefetch) {
+              // Once the prefetch entry no longer reusable, `applyFlightData` will signal to layout router that it needs to lazy fetch the data
+              // We update the `lastUsedTime` so that we renew the 30s cache for this entry
+              prefetchValues.lastUsedTime = Date.now()
+            }
 
             if (
               !applied &&

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -195,28 +195,19 @@ function navigateReducer_noPPR(
           }
 
           const cache: CacheNode = createEmptyCacheNode()
-          const hasReusablePrefetch =
-            prefetchValues.kind === 'auto' &&
-            prefetchEntryCacheStatus === PrefetchCacheEntryStatus.reusable
           let applied = applyFlightData(
             currentCache,
             cache,
             flightDataPath,
-            hasReusablePrefetch
+            prefetchValues.kind === 'auto' &&
+              prefetchEntryCacheStatus === PrefetchCacheEntryStatus.reusable
           )
-
-          if (!hasReusablePrefetch) {
-            // Once the prefetch entry no longer reusable, `applyFlightData` will signal to layout router that it needs to lazy fetch the data
-            // We update the `lastUsedTime` so that we renew the 30s cache for this entry
-            prefetchValues.lastUsedTime = Date.now()
-          }
 
           if (
             !applied &&
-            (prefetchEntryCacheStatus === PrefetchCacheEntryStatus.stale ||
-              // if we've navigated away from the global not found segment but didn't apply the flight data, we need to refetch
-              // as otherwise we'd be incorrectly using the global not found cache node for the incoming page
-              currentTree[0] === GLOBAL_NOT_FOUND_SEGMENT_KEY)
+            // if we've navigated away from the global not found segment but didn't apply the flight data, we need to refetch
+            // as otherwise we'd be incorrectly using the global not found cache node for the incoming page
+            currentTree[0] === GLOBAL_NOT_FOUND_SEGMENT_KEY
           ) {
             applied = addRefetchToLeafSegments(
               cache,
@@ -391,19 +382,12 @@ function navigateReducer_PPR(
             const seedData = flightDataPath[1]
             const head = flightDataPath[2]
 
-            // Check whether the prefetched data is stale. If so, we'll
-            // ignore it and wait for the dynamic data to stream in before
-            // showing new segments.
-            const isPrefetchStale =
-              prefetchEntryCacheStatus === PrefetchCacheEntryStatus.stale
-
             const task = updateCacheNodeOnNavigation(
               currentCache,
               currentTree,
               prefetchedTree,
               seedData,
-              head,
-              isPrefetchStale
+              head
             )
             if (task !== null && task.node !== null) {
               // We've created a new Cache Node tree that contains a prefetched
@@ -458,28 +442,19 @@ function navigateReducer_PPR(
             // tree. Or in the meantime we could factor it out into a
             // separate function.
             const cache: CacheNode = createEmptyCacheNode()
-            const hasReusablePrefetch =
-              prefetchValues.kind === 'auto' &&
-              prefetchEntryCacheStatus === PrefetchCacheEntryStatus.reusable
             let applied = applyFlightData(
               currentCache,
               cache,
               flightDataPath,
-              hasReusablePrefetch
+              prefetchValues.kind === 'auto' &&
+                prefetchEntryCacheStatus === PrefetchCacheEntryStatus.reusable
             )
-
-            if (!hasReusablePrefetch) {
-              // Once the prefetch entry no longer reusable, `applyFlightData` will signal to layout router that it needs to lazy fetch the data
-              // We update the `lastUsedTime` so that we renew the 30s cache for this entry
-              prefetchValues.lastUsedTime = Date.now()
-            }
 
             if (
               !applied &&
-              (prefetchEntryCacheStatus === PrefetchCacheEntryStatus.stale ||
-                // if we've navigated away from the global not found segment but didn't apply the flight data, we need to refetch
-                // as otherwise we'd be incorrectly using the global not found cache node for the incoming page
-                currentTree[0] === GLOBAL_NOT_FOUND_SEGMENT_KEY)
+              // if we've navigated away from the global not found segment but didn't apply the flight data, we need to refetch
+              // as otherwise we'd be incorrectly using the global not found cache node for the incoming page
+              currentTree[0] === GLOBAL_NOT_FOUND_SEGMENT_KEY
             ) {
               applied = addRefetchToLeafSegments(
                 cache,

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
@@ -129,6 +129,7 @@ describe('serverPatchReducer', () => {
       ],
     ])
 
+    const url = new URL('/linking/about', 'https://localhost') as any
     const state = createInitialRouterState({
       buildId,
       initialTree,
@@ -136,11 +137,11 @@ describe('serverPatchReducer', () => {
       initialCanonicalUrl,
       initialSeedData: ['', {}, children],
       initialParallelRoutes,
-      location: new URL('/linking/about', 'https://localhost') as any,
+      location: url,
     })
     const action: ServerPatchAction = {
       type: ACTION_SERVER_PATCH,
-      flightData: flightDataForPatch,
+      serverResponse: [flightDataForPatch, undefined],
       previousTree: [
         '',
         {
@@ -155,7 +156,6 @@ describe('serverPatchReducer', () => {
         undefined,
         true,
       ],
-      overrideCanonicalUrl: undefined,
     }
 
     const newState = await serverPatchReducer(state, action)
@@ -339,6 +339,7 @@ describe('serverPatchReducer', () => {
       shouldScroll: true,
     }
 
+    const url = new URL(initialCanonicalUrl, 'https://localhost') as any
     const state = createInitialRouterState({
       buildId,
       initialTree,
@@ -346,14 +347,14 @@ describe('serverPatchReducer', () => {
       initialCanonicalUrl,
       initialSeedData: ['', {}, children],
       initialParallelRoutes,
-      location: new URL(initialCanonicalUrl, 'https://localhost') as any,
+      location: url,
     })
 
     const stateAfterNavigate = await navigateReducer(state, navigateAction)
 
     const action: ServerPatchAction = {
       type: ACTION_SERVER_PATCH,
-      flightData: flightDataForPatch,
+      serverResponse: [flightDataForPatch, undefined],
       previousTree: [
         '',
         {
@@ -368,7 +369,6 @@ describe('serverPatchReducer', () => {
         undefined,
         true,
       ],
-      overrideCanonicalUrl: undefined,
     }
 
     const newState = await serverPatchReducer(stateAfterNavigate, action)
@@ -573,6 +573,7 @@ describe('serverPatchReducer', () => {
       </html>
     )
 
+    const url = new URL('/linking/about', 'https://localhost') as any
     const state = createInitialRouterState({
       buildId,
       initialTree,
@@ -580,22 +581,25 @@ describe('serverPatchReducer', () => {
       initialCanonicalUrl,
       initialSeedData: ['', {}, children],
       initialParallelRoutes: new Map(),
-      location: new URL('/linking/about', 'https://localhost') as any,
+      location: url,
     })
 
     const action: ServerPatchAction = {
       type: ACTION_SERVER_PATCH,
       // this flight data is intentionally completely unrelated to the existing tree
-      flightData: [
+      serverResponse: [
         [
-          'children',
-          'tree-patch-failure',
-          'children',
-          'new-page',
-          ['new-page', { children: ['__PAGE__', {}] }],
-          null,
-          null,
+          [
+            'children',
+            'tree-patch-failure',
+            'children',
+            'new-page',
+            ['new-page', { children: ['__PAGE__', {}] }],
+            null,
+            null,
+          ],
         ],
+        undefined,
       ],
       previousTree: [
         '',
@@ -611,7 +615,6 @@ describe('serverPatchReducer', () => {
         undefined,
         true,
       ],
-      overrideCanonicalUrl: undefined,
     }
 
     const newState = await serverPatchReducer(state, action)

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -18,7 +18,8 @@ export function serverPatchReducer(
   state: ReadonlyReducerState,
   action: ServerPatchAction
 ): ReducerState {
-  const { flightData, overrideCanonicalUrl } = action
+  const { serverResponse } = action
+  const [flightData, overrideCanonicalUrl] = serverResponse
 
   const mutable: Mutable = {}
 

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -1,7 +1,6 @@
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import type {
   FlightRouterState,
-  FlightData,
   FlightSegmentPath,
 } from '../../../server/app-render/types'
 import type { FetchServerResponseResult } from './fetch-server-response'
@@ -14,11 +13,13 @@ export const ACTION_PREFETCH = 'prefetch'
 export const ACTION_FAST_REFRESH = 'fast-refresh'
 export const ACTION_SERVER_ACTION = 'server-action'
 
-export type RouterChangeByServerResponse = (
-  previousTree: FlightRouterState,
-  flightData: FlightData,
-  overrideCanonicalUrl: URL | undefined
-) => void
+export type RouterChangeByServerResponse = ({
+  previousTree,
+  serverResponse,
+}: {
+  previousTree: FlightRouterState
+  serverResponse: FetchServerResponseResult
+}) => void
 
 export type RouterNavigate = (
   href: string,
@@ -134,9 +135,8 @@ export interface RestoreAction {
  */
 export interface ServerPatchAction {
   type: typeof ACTION_SERVER_PATCH
-  flightData: FlightData
+  serverResponse: FetchServerResponseResult
   previousTree: FlightRouterState
-  overrideCanonicalUrl: URL | undefined
 }
 
 /**

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -3,12 +3,10 @@
 import type {
   FocusAndScrollRef,
   PrefetchKind,
+  RouterChangeByServerResponse,
 } from '../../client/components/router-reducer/router-reducer-types'
 import type { FetchServerResponseResult } from '../../client/components/router-reducer/fetch-server-response'
-import type {
-  FlightRouterState,
-  FlightData,
-} from '../../server/app-render/types'
+import type { FlightRouterState } from '../../server/app-render/types'
 import React from 'react'
 
 export type ChildSegmentMap = Map<string, CacheNode>
@@ -144,11 +142,7 @@ export const LayoutRouterContext = React.createContext<{
 export const GlobalLayoutRouterContext = React.createContext<{
   buildId: string
   tree: FlightRouterState
-  changeByServerResponse: (
-    previousTree: FlightRouterState,
-    flightData: FlightData,
-    overrideCanonicalUrl: URL | undefined
-  ) => void
+  changeByServerResponse: RouterChangeByServerResponse
   focusAndScrollRef: FocusAndScrollRef
   nextUrl: string | null
 }>(null as any)

--- a/test/e2e/app-dir/app-client-cache/client-cache.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.test.ts
@@ -328,6 +328,51 @@ createNextDescribe(
 
           expect(newNumber2).not.toBe(newNumber)
         })
+
+        it('should renew the 30s cache once the data is revalidated', async () => {
+          // navigate to prefetch-auto page
+          await browser.elementByCss('[href="/1"]').click()
+
+          let initialNumber = await browser.elementById('random-number').text()
+
+          // Navigate back to the index, and then back to the prefetch-auto page
+          await browser.elementByCss('[href="/"]').click()
+          await browser.eval(fastForwardTo, 5 * 1000)
+          await browser.elementByCss('[href="/1"]').click()
+
+          let newNumber = await browser.elementById('random-number').text()
+
+          // the number should be the same, as we navigated within 30s.
+          expect(newNumber).toBe(initialNumber)
+
+          // Fast forward to expire the cache
+          await browser.eval(fastForwardTo, 30 * 1000)
+
+          // Navigate back to the index, and then back to the prefetch-auto page
+          await browser.elementByCss('[href="/"]').click()
+          await browser.elementByCss('[href="/1"]').click()
+
+          newNumber = await browser.elementById('random-number').text()
+
+          // ~35s have passed, so the cache should be expired and the number should be different
+          expect(newNumber).not.toBe(initialNumber)
+
+          // once the number is updated, we should have a renewed 30s cache for this entry
+          // store this new number so we can check that it stays the same
+          initialNumber = newNumber
+
+          await browser.eval(fastForwardTo, 5 * 1000)
+
+          // Navigate back to the index, and then back to the prefetch-auto page
+          await browser.elementByCss('[href="/"]').click()
+          await browser.elementByCss('[href="/1"]').click()
+
+          newNumber = await browser.elementById('random-number').text()
+
+          // the number should be the same, as we navigated within 30s (part 2).
+          expect(newNumber).toBe(initialNumber)
+        })
+
         it('should refetch below the fold after 30 seconds', async () => {
           const randomLoadingNumber = await browser
             .elementByCss('[href="/1?timeout=1000"]')

--- a/test/e2e/app-dir/app-client-cache/client-cache.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.test.ts
@@ -373,7 +373,9 @@ createNextDescribe(
           expect(newNumber).toBe(initialNumber)
         })
 
-        it('should refetch below the fold after 30 seconds', async () => {
+        // TODO: Rather than reusing parts of a stale prefetch cache entry to make this work,
+        // we should be able to copy over the existing loading from a previous cache node on navigation.
+        it.skip('should refetch below the fold after 30 seconds', async () => {
           const randomLoadingNumber = await browser
             .elementByCss('[href="/1?timeout=1000"]')
             .click()

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -12,7 +12,8 @@
     "test/e2e/app-dir/app-client-cache/client-cache.test.ts": {
       "failed": [
         "app dir client cache semantics prefetch={undefined} - default should re-use the full cache for only 30 seconds",
-        "app dir client cache semantics prefetch={undefined} - default should refetch below the fold after 30 seconds"
+        "app dir client cache semantics prefetch={undefined} - default should refetch below the fold after 30 seconds",
+        "app dir client cache semantics prefetch={undefined} - default should renew the 30s cache once the data is revalidated"
       ]
     },
     "test/e2e/app-dir/headers-static-bailout/headers-static-bailout.test.ts": {


### PR DESCRIPTION
### What
When a prefetch cache entry becomes "stale", it'll remain stale until eventually it gets evicted. However during that stale window, the cache is never revalidated, and so instant navigations stop working and data is fetched from origin every navigation.

### Why
The `lastUsedTime` entry on the prefetch cache is currently only updated after the first read. Once it becomes stale, `applyFlightData`'s recursive functions will see that there is no longer a reusable prefetch cache entry, and will trigger a lazy fetch of the new data on every subsequent navigation. 

### How
This updates prefetch cache handling to always ensure we’re using a fresh or reusable prefetch cache entry. This means that stale prefetch entries will be refreshed on a navigation event. As a result of this, I’ve had to disable one of our tests that relies on this stale cache behavior. It’s not ideal that we’re blocked on the loading boundary when fetching child segment data—ideally we can refactor this to cache the loading component in the CacheNode and copy it over on navigations, similar to how ‘head’ is handled. I’ll work on this in a separate PR. 

Note: The new client cache test for this is disabled in PPR for the same reason as the other tests: auto prefetching with PPR navigations is currently loading fresh data rather than reusing the prefetch cache. 


Fixes #58969
Fixes #58723
Closes NEXT-1904
