### PR TITLE
ensure server action errors notify rejection handlers

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -165,8 +165,6 @@ export function serverActionReducer(
   mutable.preserveCustomHistoryState = false
   mutable.inFlightServerAction = fetchServerAction(state, action)
 
-  // suspends until the server action is resolved.
-
   return mutable.inFlightServerAction.then(
     ({ actionResult, actionFlightData: flightData, redirectLocation }) => {
       // Make sure the redirection is a push instead of a replace.
@@ -177,10 +175,7 @@ export function serverActionReducer(
       }
 
       if (!flightData) {
-        if (!mutable.actionResultResolved) {
-          resolve(actionResult)
-          mutable.actionResultResolved = true
-        }
+        resolve(actionResult)
 
         // If there is a redirect but no flight data we need to do a mpaNavigation.
         if (redirectLocation) {
@@ -269,24 +264,15 @@ export function serverActionReducer(
         mutable.canonicalUrl = newHref
       }
 
-      if (!mutable.actionResultResolved) {
-        resolve(actionResult)
-        mutable.actionResultResolved = true
-      }
+      resolve(actionResult)
+
       return handleMutable(state, mutable)
     },
     (e: any) => {
-      if (e.status === 'rejected') {
-        if (!mutable.actionResultResolved) {
-          reject(e.reason)
-          mutable.actionResultResolved = true
-        }
+      // When the server action is rejected we don't update the state and instead call the reject handler of the promise.
+      reject(e.reason)
 
-        // When the server action is rejected we don't update the state and instead call the reject handler of the promise.
-        return state
-      }
-
-      throw e
+      return state
     }
   )
 }

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -41,7 +41,6 @@ export interface Mutable {
 
 export interface ServerActionMutable extends Mutable {
   inFlightServerAction?: Promise<any> | null
-  actionResultResolved?: boolean
 }
 
 /**

--- a/test/e2e/app-dir/actions/app/catching-error/actions.ts
+++ b/test/e2e/app-dir/actions/app/catching-error/actions.ts
@@ -1,0 +1,9 @@
+'use server'
+
+export async function getServerData() {
+  return Math.random()
+}
+
+export async function badAction() {
+  throw new Error('oops')
+}

--- a/test/e2e/app-dir/actions/app/catching-error/page.tsx
+++ b/test/e2e/app-dir/actions/app/catching-error/page.tsx
@@ -1,0 +1,48 @@
+'use client'
+import { useTransition, useState } from 'react'
+import { badAction, getServerData } from './actions'
+
+export default function Component() {
+  const [isPending, startTransition] = useTransition()
+  const [wasSubmitted, setWasSubmitted] = useState(false)
+  return (
+    <>
+      {wasSubmitted && <div id="submitted-msg">Submitted!</div>}
+      <button
+        id="good-action"
+        disabled={isPending}
+        onClick={() => {
+          startTransition(() => {
+            getServerData()
+              .catch(() => {
+                console.log('error caught in user code')
+              })
+              .finally(() => {
+                setWasSubmitted(true)
+              })
+          })
+        }}
+      >
+        Submit Action
+      </button>
+
+      <button
+        id="bad-action"
+        disabled={isPending}
+        onClick={() => {
+          startTransition(() => {
+            badAction()
+              .catch(() => {
+                console.log('error caught in user code')
+              })
+              .finally(() => {
+                setWasSubmitted(true)
+              })
+          })
+        }}
+      >
+        Submit Action (Throws)
+      </button>
+    </>
+  )
+}


### PR DESCRIPTION
### What
When attaching a rejection listener to a server action promise, in the case of network errors, the rejection handler would be skipped and it'd throw an error that crashes the application.

### Why
When we refactored these reducers to no longer suspend, it caused the rejection handling logic we have to no longer make sense. In this case we're working with a native promise that won't have a `status` property, so we'd re-throw the error and not call `reject`. 

### How
This removes the special status handling logic and makes the rejection handler always call `reject` with the error. This will either be handled by user code or let the error bubble to an error boundary. 

I also cleaned up some mutable code that is no longer needed now that these reducers aren't replayed. 

Closes NEXT-1715
Closes NEXT-2323
Fixes #58638
