### PR TITLE
docs: update useParams examples and pages usage

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/use-params.mdx
+++ b/docs/02-app/02-api-reference/04-functions/use-params.mdx
@@ -55,13 +55,13 @@ const params = useParams()
 - The properties name is the segment's name, and the properties value is what the segment is filled in with.
 - The properties value will either be a `string` or array of `string`'s depending on the [type of dynamic segment](/docs/app/building-your-application/routing/dynamic-routes).
 - If the route contains no dynamic parameters, `useParams` returns an empty object.
-- If used in `pages`, `useParams` will return `null`.
+- If used in `pages`, `useParams` will return `null` on the initial render and updates with properties following the rules above once the router is ready.
 
 For example:
 
 | Route                           | URL         | `useParams()`             |
 | ------------------------------- | ----------- | ------------------------- |
-| `app/shop/page.js`              | `/shop`     | `null`                    |
+| `app/shop/page.js`              | `/shop`     | `{}`                      |
 | `app/shop/[slug]/page.js`       | `/shop/1`   | `{ slug: '1' }`           |
 | `app/shop/[tag]/[item]/page.js` | `/shop/1/2` | `{ tag: '1', item: '2' }` |
 | `app/shop/[...slug]/page.js`    | `/shop/1/2` | `{ slug: ['1', '2'] }`    |

--- a/docs/02-app/02-api-reference/04-functions/use-params.mdx
+++ b/docs/02-app/02-api-reference/04-functions/use-params.mdx
@@ -55,7 +55,7 @@ const params = useParams()
 - The properties name is the segment's name, and the properties value is what the segment is filled in with.
 - The properties value will either be a `string` or array of `string`'s depending on the [type of dynamic segment](/docs/app/building-your-application/routing/dynamic-routes).
 - If the route contains no dynamic parameters, `useParams` returns an empty object.
-- If used in `pages`, `useParams` will return `null` on the initial render and updates with properties following the rules above once the router is ready.
+- If used in Pages Router, `useParams` will return `null` on the initial render and updates with properties following the rules above once the router is ready.
 
 For example:
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

Updated https://nextjs.org/docs/app/api-reference/functions/use-params with:
* returns block, examples table: route with no dynamic parameters should return an empty object
* returns block, `pages` usage: if `useParams` is used in `pages` it will return `null` only for the initial render and will update its value with dynamic parameters following the same rules as stated in the doc above this point.
