### PR TITLE
Fix empty white page with parallel routes + loading boundaries

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -178,7 +178,7 @@ function navigateReducer_noPPR(
       }
 
       let currentTree = state.tree
-      let currentCache = state.cache
+      const currentCache = state.cache
       let scrollableSegments: FlightSegmentPath[] = []
       for (const flightDataPath of flightData) {
         const flightSegmentPath = flightDataPath.slice(
@@ -266,7 +266,6 @@ function navigateReducer_noPPR(
             mutable.cache = cache
           }
 
-          currentCache = cache
           currentTree = newTree
 
           for (const subSegment of generateSegmentsFromPatch(treePatch)) {
@@ -370,7 +369,7 @@ function navigateReducer_PPR(
       }
 
       let currentTree = state.tree
-      let currentCache = state.cache
+      const currentCache = state.cache
       let scrollableSegments: FlightSegmentPath[] = []
       // TODO: In practice, this is always a single item array. We probably
       // aren't going to every send multiple segments, at least not in this

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/@slot/foo/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/@slot/foo/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Nested Slot</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/@slot/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/@slot/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Root Slot</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/foo/loading.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/foo/loading.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div id="loading-page">Loading...</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/foo/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/foo/page.tsx
@@ -1,0 +1,7 @@
+// we want to verify that the loading behavior is triggered during Next build, so we opt out of static generation
+export const dynamic = 'force-dynamic'
+
+export default async function TestPage() {
+  await new Promise((resolve) => setTimeout(resolve, 2000))
+  return <div>Welcome to Foo Page</div>
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/layout.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+export default function Layout({
+  children,
+  slot,
+}: {
+  children: ReactNode
+  slot: ReactNode
+}) {
+  return (
+    <>
+      <div>
+        <Link href="/with-loading">Home</Link>
+      </div>
+      <div>
+        <Link href="/with-loading/foo">To Loading Page</Link>
+      </div>
+      <div id="slot">{slot}</div>
+      <div id="children">{children}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Root Page</div>
+}


### PR DESCRIPTION
### What
When navigating to a page that uses a loading boundary + parallel route, an empty white screen would be displayed rather than the loading state / final state

### Why
With parallel routes, the RSC data is an array of data paths, each corresponding with one of the parallel segments rendered on the page. 

During the navigation event, when we iterate over this data, we call `applyFlightData` with this data path & an empty cache node. `applyFlightData` checks to see if the flight data contains cache nodes ("seed data"). If it doesn't, then that means it has no work to do, and it bails out.  Pre-PPR and in the case of having a `loading.js` file, `walkTreeWithFlightRouterState` doesn't return any seed data, just router state. This means that `applyFlightData` will not have any work to do on the new cache node, and leaves it untouched. 

Once `applyFlightData` is finished, but while still in the flight data path loop, we reassign `currentCache` to the empty cache object we created prior to `applyFlightData`. But since that cache node has remained empty, the next iteration of the loop is going to be inspecting a now empty cache, rather than the actual "current" cache. Now there's no existing cache to copy into the new cache. The app now doesn't know about any cache nodes.

### How
It doesn't seem like we should be re-assigning `currentCache` to the new cache. In the context of a navigation, it seems more accurate to always assume `currentCache` is the cache _now_, since it won't actually be applied to the state until the action has finished (`mutable.cache` is currently taking care of this).

Closes NEXT-2223
Fixes #61080
Fixes #60682
Fixes #56701