### PR TITLE
Revert actions/setup-node v4 bump

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -25,7 +25,7 @@ jobs:
       isRelease: ${{ github.event_name != 'workflow_dispatch' && steps.check-release.outputs.IS_RELEASE }}
     steps:
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
@@ -248,7 +248,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         if: ${{ !matrix.settings.docker }}
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
@@ -355,7 +355,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
@@ -407,7 +407,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
     steps:
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
       - run: corepack enable

--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -27,7 +27,7 @@ jobs:
     environment: release-${{ github.event.inputs.releaseType }}
     steps:
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: 18
           check-latest: true

--- a/.github/workflows/issue_popular.yml
+++ b/.github/workflows/issue_popular.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
       - run: corepack enable

--- a/.github/workflows/test_e2e_deploy.yml
+++ b/.github/workflows/test_e2e_deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -35,7 +35,7 @@ jobs:
         run: sudo ethtool -K eth0 tx off rx off
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: 18
           check-latest: true

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -45,7 +45,7 @@ jobs:
     environment: release-${{ github.event.inputs.releaseType || 'canary' }}
     steps:
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: 18
           check-latest: true

--- a/.github/workflows/update-turbopack-test-manifest.yml
+++ b/.github/workflows/update-turbopack-test-manifest.yml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true

--- a/.github/workflows/update_fonts_data.yml
+++ b/.github/workflows/update_fonts_data.yml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true


### PR DESCRIPTION
Aims to revert back to previous npm version most likely bumped when this action was bumped causing our publish to fail

x-ref: https://github.com/vercel/next.js/actions/runs/7770035719/job/21189787242#step:11:307

Closes NEXT-2350