### PR TITLE
Update to latest version of npm for publishing

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -436,7 +436,7 @@ jobs:
           merge-multiple: true
           path: packages/next-swc/crates/wasm
 
-      - run: npm i -g npm@9.6.7 # need latest version for provenance (pinning to avoid bugs)
+      - run: npm i -g npm@10.4.0 # need latest version for provenance (pinning to avoid bugs)
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: ./scripts/publish-native.js
       - run: ./scripts/publish-release.js


### PR DESCRIPTION
Seems https://github.com/vercel/next.js/pull/61641 also did not resolve the `npm publish` error so going to upgrade to latest version as well as we pinned to a previous major. 

Closes NEXT-2354