### PR TITLE
Ensure publish job has correct status on fail

### DIFF
--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -155,7 +155,7 @@ const cwd = process.cwd()
     }
   }
 
-  await Promise.allSettled(
+  const results = await Promise.allSettled(
     packageDirs.map(async (packageDir) => {
       const pkgJson = JSON.parse(
         await fs.promises.readFile(
@@ -172,5 +172,9 @@ const cwd = process.cwd()
     })
   )
 
+  if (results.some((item) => item.status === 'rejected')) {
+    console.error(`Not all packages published successfully`, results)
+    process.exit(1)
+  }
   await undraft()
 })()


### PR DESCRIPTION
This ensures we show the job as failed correctly when any of the packages didn't publish successfully. 

x-ref: https://github.com/vercel/next.js/actions/runs/7777481701/job/21205867173

Closes NEXT-2355