### PR TITLE
docs: update style9 to stylex

### DIFF
--- a/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
+++ b/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
@@ -19,7 +19,7 @@ The following libraries are supported in Client Components in the `app` director
 - [`pandacss`](https://panda-css.com)
 - [`styled-jsx`](#styled-jsx)
 - [`styled-components`](#styled-components)
-- [`styleX`](https://stylexjs.com)
+- [`stylex`](https://stylexjs.com)
 - [`tamagui`](https://tamagui.dev/docs/guides/next-js#server-components)
 - [`tss-react`](https://tss-react.dev/)
 - [`vanilla-extract`](https://github.com/vercel/next.js/tree/canary/examples/with-vanilla-extract)

--- a/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
+++ b/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
@@ -19,7 +19,7 @@ The following libraries are supported in Client Components in the `app` director
 - [`pandacss`](https://panda-css.com)
 - [`styled-jsx`](#styled-jsx)
 - [`styled-components`](#styled-components)
-- [`style9`](https://github.com/johanholmerin/style9)
+- [`styleX`](https://stylexjs.com)
 - [`tamagui`](https://tamagui.dev/docs/guides/next-js#server-components)
 - [`tss-react`](https://tss-react.dev/)
 - [`vanilla-extract`](https://github.com/vercel/next.js/tree/canary/examples/with-vanilla-extract)

--- a/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
+++ b/docs/02-app/01-building-your-application/05-styling/03-css-in-js.mdx
@@ -22,7 +22,7 @@ The following libraries are supported in Client Components in the `app` director
 - [`stylex`](https://stylexjs.com)
 - [`tamagui`](https://tamagui.dev/docs/guides/next-js#server-components)
 - [`tss-react`](https://tss-react.dev/)
-- [`vanilla-extract`](https://github.com/vercel/next.js/tree/canary/examples/with-vanilla-extract)
+- [`vanilla-extract`](https://vanilla-extract.style)
 
 The following are currently working on support:
 


### PR DESCRIPTION
## Description

The `style9` [repo](https://github.com/johanholmerin/style9) now recommends `stylex` since `stylex` has been open sourced.

Closes NEXT-2356