### PR TITLE
chore: Update `@swc/helpers` to `v0.5.5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@svgr/webpack": "5.5.0",
     "@swc/cli": "0.1.55",
     "@swc/core": "1.3.85",
-    "@swc/helpers": "0.5.2",
+    "@swc/helpers": "0.5.5",
     "@testing-library/jest-dom": "6.1.2",
     "@testing-library/react": "13.0.0",
     "@types/cheerio": "0.22.16",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@next/env": "14.1.1-canary.33",
-    "@swc/helpers": "0.5.2",
+    "@swc/helpers": "0.5.5",
     "busboy": "1.6.0",
     "caniuse-lite": "^1.0.30001579",
     "graceful-fs": "^4.2.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,10 +116,10 @@ importers:
         version: 0.1.55(@swc/core@1.3.85)
       '@swc/core':
         specifier: 1.3.85
-        version: 1.3.85(@swc/helpers@0.5.2)
+        version: 1.3.85(@swc/helpers@0.5.5)
       '@swc/helpers':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.5.5
+        version: 0.5.5
       '@testing-library/jest-dom':
         specifier: 6.1.2
         version: 6.1.2(@types/jest@29.5.5)(jest@29.7.0)
@@ -816,8 +816,8 @@ importers:
         specifier: 14.1.1-canary.33
         version: link:../next-env
       '@swc/helpers':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.5.5
+        version: 0.5.5
       busboy:
         specifier: 1.6.0
         version: 1.6.0
@@ -6418,7 +6418,7 @@ packages:
       chokidar:
         optional: true
     dependencies:
-      '@swc/core': 1.3.85(@swc/helpers@0.5.2)
+      '@swc/core': 1.3.85(@swc/helpers@0.5.5)
       commander: 7.2.0
       fast-glob: 3.3.1
       slash: 3.0.0
@@ -6505,7 +6505,7 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@swc/core@1.3.85(@swc/helpers@0.5.2):
+  /@swc/core@1.3.85(@swc/helpers@0.5.5):
     resolution: {integrity: sha512-qnoxp+2O0GtvRdYnXgR1v8J7iymGGYpx6f6yCK9KxipOZOjrlKILFANYlghQxZyPUfXwK++TFxfSlX4r9wK+kg==}
     engines: {node: '>=10'}
     requiresBuild: true
@@ -6515,7 +6515,7 @@ packages:
       '@swc/helpers':
         optional: true
     dependencies:
-      '@swc/helpers': 0.5.2
+      '@swc/helpers': 0.5.5
       '@swc/types': 0.1.4
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.3.85
@@ -6529,15 +6529,19 @@ packages:
       '@swc/core-win32-ia32-msvc': 1.3.85
       '@swc/core-win32-x64-msvc': 1.3.85
 
+  /@swc/counter@0.1.3:
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
   /@swc/helpers@0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
       tslib: 2.6.2
     dev: true
 
-  /@swc/helpers@0.5.2:
-    resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
+  /@swc/helpers@0.5.5:
+    resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
     dependencies:
+      '@swc/counter': 0.1.3
       tslib: 2.6.2
 
   /@swc/types@0.1.4:
@@ -23692,7 +23696,7 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.22
-      '@swc/core': 1.3.85(@swc/helpers@0.5.2)
+      '@swc/core': 1.3.85(@swc/helpers@0.5.5)
       jest-worker: 27.5.1
       schema-utils: 3.2.0
       serialize-javascript: 6.0.1
@@ -23716,7 +23720,7 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
-      '@swc/core': 1.3.85(@swc/helpers@0.5.2)
+      '@swc/core': 1.3.85(@swc/helpers@0.5.5)
       jest-worker: 27.5.1
       schema-utils: 3.2.0
       serialize-javascript: 6.0.1


### PR DESCRIPTION
### What?

Update `@swc/helpers` to `v0.5.5`.

### Why?

 - To apply https://github.com/swc-project/swc/pull/8574. This fixes a bug in helper, which can prevent useful operation while testing with `@next/jest`.

(https://github.com/swc-project/swc/pull/8097 is also included, but it's not used by next.js)

### How?



Closes PACK-2388