### PR TITLE
Upload npm publish log as artifact for debugging

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -443,6 +443,13 @@ jobs:
         env:
           RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
+      - name: Upload npm log artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: npm-publish-logs
+          path: /home/runner/.npm/_logs/*
+
   deployExamples:
     name: Deploy examples
     runs-on: ubuntu-latest


### PR DESCRIPTION
Continuing to debug our failed npm publish with adding the debug logs as an artifact

x-ref: https://github.com/vercel/next.js/actions/runs/7778346463/job/21207995884#step:11:828

Closes NEXT-2365