### PR TITLE
fix(next-core): adjust server alias for the context

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -532,22 +532,21 @@ async fn insert_next_server_special_aliases(
 
     // see https://github.com/vercel/next.js/blob/8013ef7372fc545d49dbd060461224ceb563b454/packages/next/src/build/webpack-config.ts#L1449-L1531
     match ty {
-        ServerContextType::Pages { .. }
-        | ServerContextType::PagesData { .. }
-        | ServerContextType::PagesApi { .. } => {
+        ServerContextType::Pages { .. } => {
             insert_exact_alias_map(
                 import_map,
                 project_path,
                 indexmap! {
-                    "server-only" => "next/dist/compiled/server-only/index".to_string(),
+                    "server-only" => "next/dist/compiled/server-only/empty".to_string(),
                     "client-only" => "next/dist/compiled/client-only/index".to_string(),
-                    "next/dist/compiled/server-only" => "next/dist/compiled/server-only/index".to_string(),
+                    "next/dist/compiled/server-only" => "next/dist/compiled/server-only/empty".to_string(),
                     "next/dist/compiled/client-only" => "next/dist/compiled/client-only/index".to_string(),
                 },
             );
         }
-        // TODO: should include `ServerContextType::PagesApi` routes, but that type doesn't exist.
-        ServerContextType::AppRSC { .. }
+        ServerContextType::PagesData { .. }
+        | ServerContextType::PagesApi { .. }
+        | ServerContextType::AppRSC { .. }
         | ServerContextType::AppRoute { .. }
         | ServerContextType::Middleware
         | ServerContextType::Instrumentation => {

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -5764,14 +5764,13 @@
       "module layer with server-only in server targets should render routes marked with restriction marks without errors /app/route",
       "module layer with server-only in server targets should render routes marked with restriction marks without errors /app/route-edge",
       "module layer with server-only in server targets should render routes marked with restriction marks without errors /app/server",
-      "module layer with server-only in server targets should render routes marked with restriction marks without errors /app/server-edge"
-    ],
-    "failed": [
+      "module layer with server-only in server targets should render routes marked with restriction marks without errors /app/server-edge",
       "module layer no server-only in server targets should render routes marked with restriction marks without errors /api/hello",
       "module layer no server-only in server targets should render routes marked with restriction marks without errors /api/hello-edge",
       "module layer with server-only in server targets should render routes marked with restriction marks without errors /api/hello",
       "module layer with server-only in server targets should render routes marked with restriction marks without errors /api/hello-edge"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What

This PR attempts to adjust import map to `server-only`  / `client-only` close to the existing webpack configs, makes to pass more tests.

Closes PACK-2396