### PR TITLE
Improve file paths handling in `next lint`

### DIFF
--- a/packages/next/src/cli/next-lint.ts
+++ b/packages/next/src/cli/next-lint.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import type arg from 'next/dist/compiled/arg/index.js'
 import { existsSync } from 'fs'
-import { join } from 'path'
+import { join, resolve } from 'path'
 import { green } from '../lib/picocolors'
 
 import type { CliCommand } from '../lib/commands'
@@ -123,7 +123,7 @@ const nextLint: CliCommand = async (args) => {
   const pathsToLint = (
     filesToLint.length ? filesToLint : ESLINT_DEFAULT_DIRS
   ).reduce((res: string[], d: string) => {
-    const currDir = join(baseDir, d)
+    const currDir = resolve(baseDir, d)
     if (!existsSync(currDir)) return res
     res.push(currDir)
     return res

--- a/packages/next/src/cli/next-lint.ts
+++ b/packages/next/src/cli/next-lint.ts
@@ -55,7 +55,7 @@ const nextLint: CliCommand = async (args) => {
         If not configured, ESLint will be set up for the first time.
 
       Usage
-        $ next lint <baseDir> [options]
+        $ next lint <baseDir> [options] [files]
 
       <baseDir> represents the directory of the Next.js application.
       If no directory is provided, the current directory will be used.
@@ -118,7 +118,7 @@ const nextLint: CliCommand = async (args) => {
 
   const files: string[] = args['--file'] ?? []
   const dirs: string[] = args['--dir'] ?? nextConfig.eslint?.dirs
-  const filesToLint = [...(dirs ?? []), ...files]
+  const filesToLint = [...(dirs ?? []), ...files, ...args._.slice(1)]
 
   const pathsToLint = (
     filesToLint.length ? filesToLint : ESLINT_DEFAULT_DIRS

--- a/test/integration/eslint/test/next-lint.test.js
+++ b/test/integration/eslint/test/next-lint.test.js
@@ -458,6 +458,58 @@ describe('Next Lint', () => {
     expect(output).not.toContain('Synchronous scripts should not be used.')
   })
 
+  test('not consumed positional arguments are passed as file paths', async () => {
+    const { stdout, stderr } = await nextLint(
+      dirFileLinting,
+      ['utils/math.js', 'pages/bar.js'],
+      {
+        stdout: true,
+        stderr: true,
+      }
+    )
+
+    const output = stdout + stderr
+
+    expect(output).toContain('utils/math.js')
+    expect(output).toContain(
+      'Comments inside children section of tag should be placed inside braces'
+    )
+
+    expect(output).toContain('pages/bar.js')
+    expect(output).toContain(
+      'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images.'
+    )
+
+    expect(output).not.toContain('pages/index.js')
+    expect(output).not.toContain('Synchronous scripts should not be used.')
+  })
+
+  test('supports absolute file paths', async () => {
+    const { stdout, stderr } = await nextLint(
+      dirFileLinting,
+      [join(dirFileLinting, 'utils/math.js'), join(dirFileLinting, 'pages/bar.js')],
+      {
+        stdout: true,
+        stderr: true,
+      }
+    )
+
+    const output = stdout + stderr
+
+    expect(output).toContain('utils/math.js')
+    expect(output).toContain(
+      'Comments inside children section of tag should be placed inside braces'
+    )
+
+    expect(output).toContain('pages/bar.js')
+    expect(output).toContain(
+      'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images.'
+    )
+
+    expect(output).not.toContain('pages/index.js')
+    expect(output).not.toContain('Synchronous scripts should not be used.')
+  })
+
   test('output flag create a file respecting the chosen format', async () => {
     const filePath = `${__dirname}/output/output.json`
     const { stdout, stderr } = await nextLint(


### PR DESCRIPTION
This PR improves handling of command line arguments for `next lint` by passing not consumed arguments as files (as does [eslint](https://eslint.org/docs/latest/use/command-line-interface#run-the-cli) and many other linters). This greatly simplifies its usage with tools like [pre-commit](https://pre-commit.com/).

Also this PR fixes processing files with absolute paths, previously they were joined with base directory and skipped as incorrect. Replacing `join` with `resolve` allows to preserve absolute paths if they were given by a user or tool.

I have added tests to existing test suite.