### PR TITLE
fix(ts): match `MiddlewareConfig` with documentation

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -384,29 +384,24 @@ export function getMiddlewareMatchers(
 
 function getMiddlewareConfig(
   pageFilePath: string,
-  config: unknown,
+  config: any,
   nextConfig: NextConfig
 ): Partial<MiddlewareConfigParsed> {
-  if (typeof config !== 'object' || config === null) {
-    throw new TypeError('config must be an object')
-  }
   const result: Partial<MiddlewareConfigParsed> = {}
 
-  if ('matcher' in config) {
+  if (config.matcher) {
     result.matchers = getMiddlewareMatchers(config.matcher, nextConfig)
   }
 
-  if ('regions' in config) {
-    if (typeof config.regions === 'string' || Array.isArray(config.regions)) {
-      result.regions = config.regions
-    } else if (typeof config.regions !== 'undefined') {
-      Log.warn(
-        `The \`regions\` config was ignored: config must be empty, a string or an array of strings. (${pageFilePath})`
-      )
-    }
+  if (typeof config.regions === 'string' || Array.isArray(config.regions)) {
+    result.regions = config.regions
+  } else if (typeof config.regions !== 'undefined') {
+    Log.warn(
+      `The \`regions\` config was ignored: config must be empty, a string or an array of strings. (${pageFilePath})`
+    )
   }
 
-  if ('unstable_allowDynamic' in config) {
+  if (config.unstable_allowDynamic) {
     result.unstable_allowDynamicGlobs = Array.isArray(
       config.unstable_allowDynamic
     )

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -5,6 +5,7 @@ import type { EdgeAppRouteLoaderQuery } from './webpack/loaders/next-edge-app-ro
 import type { NextConfigComplete } from '../server/config-shared'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type {
+  MiddlewareConfigParsed,
   MiddlewareConfig,
   MiddlewareMatcher,
   PageStaticInfo,
@@ -332,7 +333,7 @@ export function getEdgeServerEntry(opts: {
   isServerComponent: boolean
   page: string
   pages: MappedPages
-  middleware?: Partial<MiddlewareConfig>
+  middleware?: Partial<MiddlewareConfigParsed>
   pagesType: PAGE_TYPES
   appDirLoader?: string
   hasInstrumentationHook?: boolean

--- a/test/production/middleware-typescript/app/middleware.ts
+++ b/test/production/middleware-typescript/app/middleware.ts
@@ -24,8 +24,8 @@ export const middleware: NextMiddleware = function (request) {
   }
 }
 
-export const config: MiddlewareConfig = {
-  matchers: [],
+export const config = {
+  matcher: [],
   regions: [],
   unstable_allowDynamicGlobs: undefined,
-}
+} satisfies MiddlewareConfig


### PR DESCRIPTION
### What?

Fix the user-facing `MiddlewareConfig` interface.

~While in the codebase, I also made the incoming config object type a bit more strict by converting from `any` to `unknown`.~ Reverted, as we do a config assertion already in a [different place](https://github.com/vercel/next.js/blob/canary/packages/next-swc/crates/next-custom-transforms/src/transforms/page_config.rs/#L171-L180).

### Why?

The interface we previously exposed was the one we used internally, _after_ we did some parsing on the config object, which is different from what the user is expected to pass.

### How?

I separated the internal type to its own `MiddlewareConfigParsed` interface.

Closes NEXT-2375
Fixes #61705

Ref: #61576
