### PR TITLE
Fix next/server api alias for ESM pkg

### DIFF
--- a/packages/next/server.js
+++ b/packages/next/server.js
@@ -9,11 +9,8 @@ const serverExports = {
     .userAgentFromString,
   userAgent: require('next/dist/server/web/spec-extension/user-agent')
     .userAgent,
-}
-
-if (typeof URLPattern !== 'undefined') {
-  // eslint-disable-next-line no-undef
-  serverExports.URLPattern = URLPattern
+  URLPattern: require('next/dist/server/web/spec-extension/url-pattern')
+    .URLPattern,
 }
 
 // https://nodejs.org/api/esm.html#commonjs-namespaces

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -205,6 +205,7 @@ export function createNextApiEsmAliases() {
     navigation: 'next/dist/api/navigation',
     headers: 'next/dist/api/headers',
     og: 'next/dist/api/og',
+    server: 'next/dist/api/server',
     // pages api
     document: 'next/dist/api/document',
     app: 'next/dist/api/app',

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -831,9 +831,6 @@ function assignDefaults(
     lodash: {
       transform: 'lodash/{{member}}',
     },
-    'next/server': {
-      transform: 'next/dist/server/web/exports/{{ kebabCase member }}',
-    },
   }
 
   const userProvidedOptimizePackageImports =

--- a/packages/next/src/server/web/exports/image-response.ts
+++ b/packages/next/src/server/web/exports/image-response.ts
@@ -1,2 +1,0 @@
-// This file is for modularized imports for next/server to get fully-treeshaking.
-export { ImageResponse as default } from '../spec-extension/image-response'

--- a/packages/next/src/server/web/exports/index.ts
+++ b/packages/next/src/server/web/exports/index.ts
@@ -1,8 +1,7 @@
 // Alias index file of next/server for edge runtime for tree-shaking purpose
 
-export { default as ImageResponse } from './image-response'
-export { default as NextRequest } from './next-request'
-export { default as NextResponse } from './next-response'
-export { default as userAgent } from './user-agent'
-export { default as userAgentFromString } from './user-agent-from-string'
-export { default as URLPattern } from './url-pattern'
+export { ImageResponse } from '../spec-extension/image-response'
+export { NextRequest } from '../spec-extension/request'
+export { NextResponse } from '../spec-extension/response'
+export { userAgent, userAgentFromString } from '../spec-extension/user-agent'
+export { URLPattern } from '../spec-extension/url-pattern'

--- a/packages/next/src/server/web/exports/next-request.ts
+++ b/packages/next/src/server/web/exports/next-request.ts
@@ -1,2 +1,0 @@
-// This file is for modularized imports for next/server to get fully-treeshaking.
-export { NextRequest as default } from '../spec-extension/request'

--- a/packages/next/src/server/web/exports/next-response.ts
+++ b/packages/next/src/server/web/exports/next-response.ts
@@ -1,2 +1,0 @@
-// This file is for modularized imports for next/server to get fully-treeshaking.
-export { NextResponse as default } from '../spec-extension/response'

--- a/packages/next/src/server/web/exports/revalidate-path.ts
+++ b/packages/next/src/server/web/exports/revalidate-path.ts
@@ -1,2 +1,0 @@
-// This file is for modularized imports for next/server to get fully-treeshaking.
-export { revalidatePath as default } from '../spec-extension/revalidate'

--- a/packages/next/src/server/web/exports/revalidate-tag.ts
+++ b/packages/next/src/server/web/exports/revalidate-tag.ts
@@ -1,2 +1,0 @@
-// This file is for modularized imports for next/server to get fully-treeshaking.
-export { revalidateTag as default } from '../spec-extension/revalidate'

--- a/packages/next/src/server/web/exports/unstable-cache.ts
+++ b/packages/next/src/server/web/exports/unstable-cache.ts
@@ -1,2 +1,0 @@
-// This file is for modularized imports for next/server to get fully-treeshaking.
-export { unstable_cache as default } from '../spec-extension/unstable-cache'

--- a/packages/next/src/server/web/exports/unstable-no-store.ts
+++ b/packages/next/src/server/web/exports/unstable-no-store.ts
@@ -1,2 +1,0 @@
-// This file is for modularized imports for next/server to get fully-treeshaking.
-export { unstable_noStore as default } from '../spec-extension/unstable-no-store'

--- a/packages/next/src/server/web/exports/user-agent-from-string.ts
+++ b/packages/next/src/server/web/exports/user-agent-from-string.ts
@@ -1,2 +1,0 @@
-// This file is for modularized imports for next/server to get fully-treeshaking.
-export { userAgentFromString as default } from '../spec-extension/user-agent'

--- a/packages/next/src/server/web/exports/user-agent.ts
+++ b/packages/next/src/server/web/exports/user-agent.ts
@@ -1,2 +1,0 @@
-// This file is for modularized imports for next/server to get fully-treeshaking.
-export { userAgent as default } from '../spec-extension/user-agent'

--- a/packages/next/src/server/web/spec-extension/url-pattern.ts
+++ b/packages/next/src/server/web/spec-extension/url-pattern.ts
@@ -2,4 +2,4 @@ const GlobalURLPattern =
   // @ts-expect-error: URLPattern is not available in Node.js
   typeof URLPattern === 'undefined' ? undefined : URLPattern
 
-export default GlobalURLPattern
+export { GlobalURLPattern as URLPattern }

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -283,5 +283,14 @@ createNextDescribe(
         }, /success/)
       })
     })
+
+    describe('app route', () => {
+      it('should resolve next/server api from external esm package', async () => {
+        const res = await next.fetch('/app-routes')
+        const text = await res.text()
+        expect(res.status).toBe(200)
+        expect(text).toBe('get route')
+      })
+    })
   }
 )

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -37,7 +37,7 @@ createNextDescribe(
     buildCommand: 'yarn build',
     skipDeployment: true,
   },
-  ({ next }) => {
+  ({ next, isNextStart }) => {
     it('should be able to opt-out 3rd party packages being bundled in server components', async () => {
       await next.fetch('/react-server/optout').then(async (response) => {
         const result = await resolveStreamResponse(response)
@@ -249,8 +249,12 @@ createNextDescribe(
       const html = await next.render('/test-middleware')
       expect(html).toContain('it works')
 
-      const middlewareBundle = await next.readFile('.next/server/middleware.js')
-      expect(middlewareBundle).not.toContain('image-response')
+      if (isNextStart) {
+        const middlewareBundle = await next.readFile(
+          '.next/server/middleware.js'
+        )
+        expect(middlewareBundle).not.toContain('image-response')
+      }
     })
 
     it('should use the same async storages if imported directly', async () => {

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -37,7 +37,7 @@ createNextDescribe(
     buildCommand: 'yarn build',
     skipDeployment: true,
   },
-  ({ next, isNextStart }) => {
+  ({ next }) => {
     it('should be able to opt-out 3rd party packages being bundled in server components', async () => {
       await next.fetch('/react-server/optout').then(async (response) => {
         const result = await resolveStreamResponse(response)
@@ -246,15 +246,13 @@ createNextDescribe(
     })
 
     it('should have proper tree-shaking for known modules in CJS', async () => {
-      const html = await next.render('/test-middleware')
-      expect(html).toContain('it works')
+      const html = await next.render('/cjs/server')
+      expect(html).toContain('resolve response')
 
-      if (isNextStart) {
-        const middlewareBundle = await next.readFile(
-          '.next/server/middleware.js'
-        )
-        expect(middlewareBundle).not.toContain('image-response')
-      }
+      const outputFile = await next.readFile(
+        '.next/server/app/cjs/server/page.js'
+      )
+      expect(outputFile).not.toContain('image-response')
     })
 
     it('should use the same async storages if imported directly', async () => {

--- a/test/e2e/app-dir/app-external/app/app-routes/route.js
+++ b/test/e2e/app-dir/app-external/app/app-routes/route.js
@@ -1,0 +1,6 @@
+import { serverApi } from 'server-api-esm'
+
+export function GET(req) {
+  serverApi(req)
+  return new Response('get route')
+}

--- a/test/e2e/app-dir/app-external/app/cjs/server/page.js
+++ b/test/e2e/app-dir/app-external/app/cjs/server/page.js
@@ -1,0 +1,7 @@
+import { createResponse } from 'next-server-cjs-lib'
+
+export default async function Page() {
+  const response = createResponse('resolve response')
+  const text = await response.text()
+  return <p>{text}</p>
+}

--- a/test/e2e/app-dir/app-external/middleware.js
+++ b/test/e2e/app-dir/app-external/middleware.js
@@ -1,10 +1,5 @@
-import { createResponse } from 'next-server-cjs-lib'
 import { respond } from 'compat-next-server-module'
 
 export async function middleware(request) {
-  if (request.nextUrl.pathname === '/test-middleware') {
-    return createResponse('it works')
-  }
-
   return await respond()
 }

--- a/test/e2e/app-dir/app-external/node_modules_bak/server-api-esm/index.js
+++ b/test/e2e/app-dir/app-external/node_modules_bak/server-api-esm/index.js
@@ -1,0 +1,5 @@
+import { NextRequest } from 'next/server'
+
+export function serverApi(req) {
+  return new NextRequest(req)
+}

--- a/test/e2e/app-dir/app-external/node_modules_bak/server-api-esm/package.json
+++ b/test/e2e/app-dir/app-external/node_modules_bak/server-api-esm/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "server-api-module",
+  "type": "module",
+  "exports": "./index.js"
+}


### PR DESCRIPTION
### What & Why

We have a modularize imports config for `next/server` before, which will transform the `next/server` imports to directly import from the actual file, for instance: `import { NextRequest } from 'next/server'` will become `import { NextRequest } from 'next/dist/server/web/exports/next-request'`, where the NextRequest is exported as default export. This is fine in most case until you're using a ESM pkg, then it will be resolved as `{ default: NextRequest }` according to the spec. Since it's a ESM import to a CJS module in `next/dist`.

Since we already have the ESM alias introduced in #59852 , this can handle the case more properly.

### How

Remove the modularize imports config for `next/server`, use the ESM api alias instead.

Migrate the cjs optimizer tests from middleware to a separate endpoint `/cjs/server`. As now ESM imports for next/server are not going to get tree-shaken in dev, but since we don't have image response there it's still fine.

Closes NEXT-2376
Closes NEXT-2374