### PR TITLE
source map fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "serde",
  "smallvec",
@@ -3513,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "serde",
@@ -7557,7 +7557,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7589,7 +7589,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7601,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7647,7 +7647,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7678,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "base16",
  "hex",
@@ -7690,7 +7690,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "mimalloc",
 ]
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7747,7 +7747,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7779,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7820,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7845,7 +7845,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7863,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7876,6 +7876,7 @@ dependencies = [
  "once_cell",
  "patricia_tree",
  "qstring",
+ "ref-cast",
  "regex",
  "serde",
  "serde_json",
@@ -7893,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7921,7 +7922,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7946,7 +7947,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7983,7 +7984,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8018,7 +8019,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "serde",
  "serde_json",
@@ -8029,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8054,7 +8055,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8071,7 +8072,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8087,7 +8088,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8107,7 +8108,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "serde",
@@ -8122,7 +8123,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8137,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8172,7 +8173,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "serde",
@@ -8188,7 +8189,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8199,7 +8200,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8215,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240205.2#1796f1c950e4eef3cd6f73f93d72906d69f56617"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240207.1#ea7eea84c72222af8986dd0e802ffa5754b7e357"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.89.6", features = [
 testing = { version = "0.35.16" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240205.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240207.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240205.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240207.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240205.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240207.1" }
 
 # General Deps
 

--- a/packages/next-swc/crates/napi/src/next_api/project.rs
+++ b/packages/next-swc/crates/napi/src/next_api/project.rs
@@ -791,12 +791,12 @@ pub fn project_update_info_subscribe(
 #[derive(Debug)]
 #[napi(object)]
 pub struct StackFrame {
+    pub is_server: bool,
+    pub file: String,
+    // 1-indexed, unlike source map tokens
+    pub line: Option<u32>,
     // 1-indexed, unlike source map tokens
     pub column: Option<u32>,
-    // 1-indexed, unlike source map tokens
-    pub file: String,
-    pub is_server: bool,
-    pub line: u32,
     pub method_name: Option<String>,
 }
 
@@ -877,29 +877,46 @@ pub async fn project_trace_source(
                 }
             };
 
-            let token = map
-                .lookup_token(
-                    (frame.line as usize).saturating_sub(1),
-                    (frame.column.unwrap_or(1) as usize).saturating_sub(1),
-                )
-                .await?
-                .clone_value()
-                .context("Unable to trace token from sourcemap")?;
-
-            let Token::Original(token) = token else {
+            let Some(line) = frame.line else {
                 return Ok(None);
             };
 
-            let Some(source_file) = token.original_file.strip_prefix("/turbopack/[project]/")
-            else {
-                bail!("Original file outside project")
+            let token = map
+                .lookup_token(
+                    (line as usize).saturating_sub(1),
+                    (frame.column.unwrap_or(1) as usize).saturating_sub(1),
+                )
+                .await?;
+
+            let (original_file, line, column, name) = match &*token {
+                Token::Original(token) => (
+                    &token.original_file,
+                    // JS stack frames are 1-indexed, source map tokens are 0-indexed
+                    Some(token.original_line as u32 + 1),
+                    Some(token.original_column as u32 + 1),
+                    token.name.clone(),
+                ),
+                Token::Synthetic(token) => {
+                    let Some(file) = &token.guessed_original_file else {
+                        return Ok(None);
+                    };
+                    (file, None, None, None)
+                }
             };
+
+            let Some(source_file) = original_file.strip_prefix("/turbopack/") else {
+                bail!("Original file ({}) outside project", original_file)
+            };
+
+            let source_file = source_file
+                .strip_prefix("[project]/")
+                .unwrap_or(source_file);
 
             Ok(Some(StackFrame {
                 file: source_file.to_string(),
-                method_name: token.name,
-                line: token.original_line as u32 + 1,
-                column: Some(token.original_column as u32 + 1),
+                method_name: name,
+                line,
+                column,
                 is_server: frame.is_server,
             }))
         })

--- a/packages/next-swc/crates/next-api/src/project.rs
+++ b/packages/next-swc/crates/next-api/src/project.rs
@@ -44,6 +44,7 @@ use turbopack_binding::{
             output::{OutputAsset, OutputAssets},
             resolve::{find_context_file, FindContextFileResult},
             source::Source,
+            source_map::OptionSourceMap,
             version::{Update, Version, VersionState, VersionedContent},
             PROJECT_FILESYSTEM_NAME,
         },
@@ -270,6 +271,18 @@ impl ProjectContainer {
     ) -> Result<Vc<Box<dyn VersionedContent>>> {
         let this = self.await?;
         Ok(this.versioned_content_map.get(file_path))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn get_source_map(
+        self: Vc<Self>,
+        file_path: Vc<FileSystemPath>,
+        section: Option<String>,
+    ) -> Result<Vc<OptionSourceMap>> {
+        let this = self.await?;
+        Ok(this
+            .versioned_content_map
+            .get_source_map(file_path, section))
     }
 }
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -196,7 +196,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.3",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240205.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240207.1",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
+++ b/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
@@ -71,7 +71,8 @@ function getOriginalStackFrame(
       expanded: !Boolean(
         /* collapsed */
         (source.file?.includes('node_modules') ||
-          body.originalStackFrame?.file?.includes('node_modules')) ??
+          body.originalStackFrame?.file?.includes('node_modules') ||
+          body.originalStackFrame?.file?.startsWith('[turbopack]/')) ??
           true
       ),
       sourceStackFrame: source,

--- a/packages/react-dev-overlay/src/middleware-turbopack.ts
+++ b/packages/react-dev-overlay/src/middleware-turbopack.ts
@@ -21,7 +21,7 @@ interface TurbopackStackFrame {
   // 1-based
   file: string
   isServer: boolean
-  line: number
+  line: number | null
   methodName: string | null
 }
 
@@ -88,8 +88,10 @@ export async function createOriginalStackFrame(
             traced.source,
             {
               start: {
-                line: traced.frame.lineNumber,
-                column: traced.frame.column ?? 1,
+                // 1-based, but -1 means start line without highlighting
+                line: traced.frame.lineNumber ?? -1,
+                // 1-based, but 0 means whole line without column highlighting
+                column: traced.frame.column ?? 0,
               },
             },
             { forceColor: true }
@@ -159,7 +161,7 @@ export function getOverlayMiddleware(project: Project) {
       }
 
       try {
-        launchEditor(filePath, frame.line, frame.column ?? 1)
+        launchEditor(filePath, frame.line ?? 1, frame.column ?? 0)
       } catch (err) {
         console.log('Failed to launch editor:', err)
         res.statusCode = 500

--- a/packages/react-dev-overlay/src/middleware-turbopack.ts
+++ b/packages/react-dev-overlay/src/middleware-turbopack.ts
@@ -162,7 +162,7 @@ export function getOverlayMiddleware(project: Project) {
       }
 
       try {
-        launchEditor(filePath, frame.line ?? 1, frame.column ?? 0)
+        launchEditor(filePath, frame.line ?? 1, frame.column ?? 1)
       } catch (err) {
         console.log('Failed to launch editor:', err)
         res.statusCode = 500

--- a/packages/react-dev-overlay/src/middleware-turbopack.ts
+++ b/packages/react-dev-overlay/src/middleware-turbopack.ts
@@ -23,6 +23,7 @@ interface TurbopackStackFrame {
   isServer: boolean
   line: number | null
   methodName: string | null
+  isInternal?: boolean
 }
 
 const currentSourcesByFile: Map<string, Promise<string | null>> = new Map()
@@ -43,7 +44,7 @@ async function batchedTraceSource(
 
   let source
   // Don't show code frames for node_modules. These can also often be large bundled files.
-  if (!sourceFrame.file.includes('node_modules')) {
+  if (!sourceFrame.file.includes('node_modules') && !sourceFrame.isInternal) {
     let sourcePromise = currentSourcesByFile.get(sourceFrame.file)
     if (!sourcePromise) {
       sourcePromise = project.getSourceForAsset(sourceFrame.file)
@@ -82,7 +83,7 @@ export async function createOriginalStackFrame(
   return {
     originalStackFrame: traced.frame,
     originalCodeFrame:
-      traced.source === null || traced.frame.file.includes('node_modules')
+      traced.source === null
         ? null
         : codeFrameColumns(
             traced.source,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1078,8 +1078,8 @@ importers:
         specifier: 0.26.3
         version: 0.26.3
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240205.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240205.2(react-refresh@0.12.0)(webpack@5.90.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240207.1
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240207.1(react-refresh@0.12.0)(webpack@5.90.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25871,9 +25871,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240205.2(react-refresh@0.12.0)(webpack@5.90.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240205.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240205.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240207.1(react-refresh@0.12.0)(webpack@5.90.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240207.1}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240207.1'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

* show guessed original file for generate code
* avoid internal cast
* add get_source_map method
* hide turbopack runtime stack lines
* hide unmapped stack lines


Closes PACK-2400

Before:

![image](https://github.com/vercel/next.js/assets/1365881/29f24f59-7c77-4496-92de-efcc72d28ad5)

After:

![image](https://github.com/vercel/next.js/assets/1365881/ca07e9f9-71ea-440d-97a2-c2c731ab3899)

and expanded:

![image](https://github.com/vercel/next.js/assets/1365881/1f73e632-890d-4681-8f21-ef502c676aae)

### Other Turbopack changes


* https://github.com/vercel/turbo/pull/4235 <!-- Leah - chore(turborepo-lib): use compile error for feature validation  -->
* https://github.com/vercel/turbo/pull/7285 <!-- Tobias Koppers - resolve source maps that are attached in source code  -->
* https://github.com/vercel/turbo/pull/7301 <!-- Donny/강동윤 - fix(turbopack): Reverse order of css chunks to fix css module issues  -->
* https://github.com/vercel/turbo/pull/7286 <!-- Tobias Koppers - guess original source for generated code  -->
