### PR TITLE
Add case-sensitive note for revalidateTag/revalidatePath

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/revalidatePath.mdx
+++ b/docs/02-app/02-api-reference/04-functions/revalidatePath.mdx
@@ -18,7 +18,7 @@ description: API Reference for the revalidatePath function.
 revalidatePath(path: string, type?: 'page' | 'layout'): void;
 ```
 
-- `path`: Either a string representing the filesystem path associated with the data you want to revalidate (for example, `/product/[slug]/page`), or the literal route segment (for example, `/product/123`). Must be less than 1024 characters.
+- `path`: Either a string representing the filesystem path associated with the data you want to revalidate (for example, `/product/[slug]/page`), or the literal route segment (for example, `/product/123`). Must be less than 1024 characters. This value is case-sensitive.
 - `type`: (optional) `'page'` or `'layout'` string to change the type of path to revalidate. If `path` contains a dynamic segment (for example, `/product/[slug]/page`), this parameter is required.
 
 ## Returns

--- a/docs/02-app/02-api-reference/04-functions/revalidateTag.mdx
+++ b/docs/02-app/02-api-reference/04-functions/revalidateTag.mdx
@@ -16,7 +16,7 @@ description: API Reference for the revalidateTag function.
 revalidateTag(tag: string): void;
 ```
 
-- `tag`: A string representing the cache tag associated with the data you want to revalidate. Must be less than or equal to 256 characters.
+- `tag`: A string representing the cache tag associated with the data you want to revalidate. Must be less than or equal to 256 characters. This value is case-sensitive.
 
 You can add tags to `fetch` as follows:
 


### PR DESCRIPTION
Our tag values are case-sensitive so this ensures we properly document this so users are aware of this caveat. 

x-ref: https://github.com/vercel/next.js/pull/61392#issuecomment-1926004777

Closes NEXT-2379