### PR TITLE
chore: move transforms into a shared rule

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -7,43 +7,31 @@ use swc_core::{
 };
 use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_binding::turbopack::{
-    ecmascript::{CustomTransformer, TransformContext},
-    turbopack::module_options::ModuleRule,
+use turbopack_binding::turbopack::ecmascript::{
+    CustomTransformer, TransformContext, TransformPlugin,
 };
 
-use super::get_ecma_transform_rule;
-use crate::next_config::NextConfig;
-
-/// Returns a rule which applies the Next.js react server components transform.
+/// Applies the Next.js react server components transform.
 /// This transform owns responsibility to assert various import / usage
 /// conditions against each code's context. Refer below table how we are
-/// applying this rules against various contexts.
+/// applying these rules against various contexts.
 ///
-/// +-----------------+---------+--------------------+
-/// | Context\Enabled | Enabled | isReactServerLayer |
-/// +-----------------+---------+--------------------+
+/// | Context         | Enabled | isReactServerLayer |
+/// |-----------------|---------|--------------------|
 /// | SSR             | true    | false              |
 /// | Client          | true    | false              |
 /// | Middleware      | false   | false              |
 /// | Api             | false   | false              |
 /// | RSC             | true    | true               |
 /// | Pages           | true    | false              |
-/// +-----------------+---------+--------------------+
-pub async fn get_next_react_server_components_transform_rule(
-    next_config: Vc<NextConfig>,
+pub fn get_next_react_server_components_transform_plugin(
     is_react_server_layer: bool,
     app_dir: Option<Vc<FileSystemPath>>,
-) -> Result<ModuleRule> {
-    let enable_mdx_rs = *next_config.mdx_rs().await?;
-    Ok(get_ecma_transform_rule(
-        Box::new(NextJsReactServerComponents::new(
-            is_react_server_layer,
-            app_dir,
-        )),
-        enable_mdx_rs,
-        true,
-    ))
+) -> Vc<TransformPlugin> {
+    Vc::cell(Box::new(NextJsReactServerComponents::new(
+        is_react_server_layer,
+        app_dir,
+    )) as _)
 }
 
 #[derive(Debug)]

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/relay.rs
@@ -1,20 +1,30 @@
 use anyhow::Result;
 use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
-    ecmascript_plugin::transform::relay::RelayTransformer, turbopack::module_options::ModuleRule,
+    ecmascript::OptionTransformPlugin, ecmascript_plugin::transform::relay::RelayTransformer,
 };
 
-use super::get_ecma_transform_rule;
 use crate::next_config::NextConfig;
 
-/// Returns a transform rule for the relay graphql transform.
-pub async fn get_relay_transform_rule(next_config: Vc<NextConfig>) -> Result<Option<ModuleRule>> {
-    let enable_mdx_rs = *next_config.mdx_rs().await?;
-    let module_rule = next_config.await?.compiler.as_ref().and_then(|value| {
-        value.relay.as_ref().map(|config| {
-            get_ecma_transform_rule(Box::new(RelayTransformer::new(config)), enable_mdx_rs, true)
+/// Returns a transform plugin for the relay graphql transform.
+#[turbo_tasks::function]
+pub async fn get_relay_transform_plugin(
+    next_config: Vc<NextConfig>,
+) -> Result<Vc<OptionTransformPlugin>> {
+    let transform_plugin = next_config
+        .await?
+        .compiler
+        .as_ref()
+        .map(|value| {
+            value
+                .relay
+                .as_ref()
+                .map(|config| {
+                    Vc::cell(Some(Vc::cell(Box::new(RelayTransformer::new(config)) as _)))
+                })
+                .unwrap_or_default()
         })
-    });
+        .unwrap_or_default();
 
-    Ok(module_rule)
+    Ok(transform_plugin)
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_components.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_components.rs
@@ -1,35 +1,47 @@
 use anyhow::Result;
 use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
-    ecmascript_plugin::transform::styled_components::StyledComponentsTransformer,
-    turbopack::module_options::ModuleRule,
+    ecmascript::OptionTransformPlugin,
+    ecmascript_plugin::transform::styled_components::{
+        StyledComponentsTransformConfig, StyledComponentsTransformer,
+    },
 };
 
-use crate::{
-    next_config::{NextConfig, StyledComponentsTransformOptionsOrBoolean},
-    next_shared::transforms::get_ecma_transform_rule,
-};
+use crate::next_config::{NextConfig, StyledComponentsTransformOptionsOrBoolean};
 
-pub async fn get_styled_components_transform_rule(
+#[turbo_tasks::function]
+pub async fn get_styled_components_transform_plugin(
     next_config: Vc<NextConfig>,
-) -> Result<Option<ModuleRule>> {
-    let enable_mdx_rs = *next_config.mdx_rs().await?;
-
-    let module_rule = next_config
+) -> Result<Vc<OptionTransformPlugin>> {
+    let transform_plugin = next_config
         .await?
         .compiler
         .as_ref()
-        .and_then(|value| value.styled_components.as_ref())
-        .and_then(|config| match config {
-            StyledComponentsTransformOptionsOrBoolean::Boolean(true) => {
-                Some(StyledComponentsTransformer::new(&Default::default()))
-            }
-            StyledComponentsTransformOptionsOrBoolean::Options(value) => {
-                Some(StyledComponentsTransformer::new(value))
-            }
-            _ => None,
-        })
-        .map(|transformer| get_ecma_transform_rule(Box::new(transformer), enable_mdx_rs, true));
+        .map(|value| {
+            value
+                .styled_components
+                .as_ref()
+                .map(|value| {
+                    let transformer = match value {
+                        StyledComponentsTransformOptionsOrBoolean::Boolean(true) => Some(
+                            StyledComponentsTransformer::new(&StyledComponentsTransformConfig {
+                                ..Default::default()
+                            }),
+                        ),
+                        StyledComponentsTransformOptionsOrBoolean::Boolean(false) => None,
+                        StyledComponentsTransformOptionsOrBoolean::Options(value) => {
+                            Some(StyledComponentsTransformer::new(value))
+                        }
+                    };
 
-    Ok(module_rule)
+                    transformer.map_or_else(
+                        || Vc::cell(None),
+                        |v| Vc::cell(Some(Vc::cell(Box::new(v) as _))),
+                    )
+                })
+                .unwrap_or_default()
+        })
+        .unwrap_or_default();
+
+    Ok(transform_plugin)
 }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
@@ -1,27 +1,19 @@
 use anyhow::Result;
 use turbo_tasks::Vc;
 use turbopack_binding::turbopack::{
-    core::environment::RuntimeVersions,
+    core::environment::RuntimeVersions, ecmascript::OptionTransformPlugin,
     ecmascript_plugin::transform::styled_jsx::StyledJsxTransformer,
-    turbopack::module_options::ModuleRule,
 };
 
-use super::get_ecma_transform_rule;
-use crate::next_config::NextConfig;
-
-/// Returns a transform rule for the relay graphql transform.
-pub async fn get_styled_jsx_transform_rule(
-    next_config: Vc<NextConfig>,
+/// Returns a transform plugin for the relay graphql transform.
+#[turbo_tasks::function]
+pub async fn get_styled_jsx_transform_plugin(
+    use_lightningcss: bool,
     target_browsers: Vc<RuntimeVersions>,
-) -> Result<Option<ModuleRule>> {
-    let enable_mdx_rs = *next_config.mdx_rs().await?;
-    let use_lightningcss = *next_config.use_lightningcss().await?;
+) -> Result<Vc<OptionTransformPlugin>> {
     let versions = *target_browsers.await?;
 
-    let transformer = StyledJsxTransformer::new(use_lightningcss, versions);
-    Ok(Some(get_ecma_transform_rule(
-        Box::new(transformer),
-        enable_mdx_rs,
-        true,
-    )))
+    Ok(Vc::cell(Some(Vc::cell(
+        Box::new(StyledJsxTransformer::new(use_lightningcss, versions)) as _,
+    ))))
 }


### PR DESCRIPTION
### Why?

More (intuitive) control over the order and fewer rules with the exact same condition to be checked.



Closes PACK-2417