### PR TITLE
Fix preloadedConfig for next.js custom server

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -2,7 +2,7 @@
 import type { WorkerRequestHandler, WorkerUpgradeHandler } from './types'
 import type { DevBundler } from './router-utils/setup-dev-bundler'
 import type { NextUrlWithParsedQuery } from '../request-meta'
-import type { NextServer } from '../next'
+import type { NextServer, NextServerOptions } from '../next'
 
 // This is required before other imports to ensure the require hook is setup.
 import '../node-environment'
@@ -56,20 +56,22 @@ export interface LazyRenderServerInstance {
 
 const requestHandlers: Record<string, WorkerRequestHandler> = {}
 
-export async function initialize(opts: {
-  dir: string
-  port: number
-  dev: boolean
-  server?: import('http').Server
-  minimalMode?: boolean
-  hostname?: string
-  isNodeDebugging: boolean
-  keepAliveTimeout?: number
-  customServer?: boolean
-  experimentalTestProxy?: boolean
-  experimentalHttpsServer?: boolean
-  startServerSpan?: Span
-}): Promise<[WorkerRequestHandler, WorkerUpgradeHandler, NextServer]> {
+export async function initialize(
+  opts: {
+    dir: string
+    port: number
+    dev: boolean
+    server?: import('http').Server
+    minimalMode?: boolean
+    hostname?: string
+    isNodeDebugging: boolean
+    keepAliveTimeout?: number
+    customServer?: boolean
+    experimentalTestProxy?: boolean
+    experimentalHttpsServer?: boolean
+    startServerSpan?: Span
+  } & Pick<NextServerOptions, 'preloadedConfig'>
+): Promise<[WorkerRequestHandler, WorkerUpgradeHandler, NextServer]> {
   if (!process.env.NODE_ENV) {
     // @ts-ignore not readonly
     process.env.NODE_ENV = opts.dev ? 'development' : 'production'
@@ -78,7 +80,7 @@ export async function initialize(opts: {
   const config = await loadConfig(
     opts.dev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_SERVER,
     opts.dir,
-    { silent: false }
+    { silent: false, customConfig: opts.preloadedConfig }
   )
 
   let compress: ReturnType<typeof setupCompression> | undefined

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -1,3 +1,5 @@
+import type { NextServerOptions } from '../next'
+
 if (performance.getEntriesByName('next-start').length === 0) {
   performance.mark('next-start')
 }
@@ -54,6 +56,7 @@ export async function getRequestHandlers({
   keepAliveTimeout,
   experimentalTestProxy,
   experimentalHttpsServer,
+  preloadedConfig,
 }: {
   dir: string
   port: number
@@ -65,7 +68,7 @@ export async function getRequestHandlers({
   keepAliveTimeout?: number
   experimentalTestProxy?: boolean
   experimentalHttpsServer?: boolean
-}): ReturnType<typeof initialize> {
+} & Pick<NextServerOptions, 'preloadedConfig'>): ReturnType<typeof initialize> {
   return initialize({
     dir,
     port,
@@ -78,6 +81,7 @@ export async function getRequestHandlers({
     experimentalTestProxy,
     experimentalHttpsServer,
     startServerSpan,
+    preloadedConfig,
   })
 }
 

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -286,6 +286,7 @@ class NextCustomServer extends NextServer {
       hostname: this.options.hostname || 'localhost',
       minimalMode: this.options.minimalMode,
       isNodeDebugging: !!isNodeDebugging,
+      preloadedConfig: this.options.preloadedConfig,
     })
     this.requestHandler = initResult[0]
     this.upgradeHandler = initResult[1]


### PR DESCRIPTION
### What?

Allow creating a custom Next server from a config object instead of reading from next.config.js file.

### Why?

For use cases where you want to create multiple custom Next servers with different configs for the same Node.js application.

