### PR TITLE
feat(next-core): expand matching js extensions for the rules

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
@@ -70,6 +70,8 @@ fn match_js_extension(enable_mdx_rs: bool) -> Vec<ModuleRuleCondition> {
         ModuleRuleCondition::ResourcePathEndsWith(".jsx".to_string()),
         ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
         ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
+        ModuleRuleCondition::ResourcePathEndsWith(".mjs".to_string()),
+        ModuleRuleCondition::ResourcePathEndsWith(".cjs".to_string()),
     ];
 
     if enable_mdx_rs {


### PR DESCRIPTION
### What?

fixes unexpected use client build warning in some applications.

We've consolidated all the ecmaplugins into custom rules. It behaves different for the ecma inputs, while plugin runs any ecmascript inputs rules only runs with matching target. The culprit module in question was published as `.mjs`, so the necessary transform didn't ran.

Closes PACK-2419