### PR TITLE
double default stack size

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,9 +7,15 @@ rustdocflags = []
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
-rustflags = ["-C", "target-feature=+crt-static"]
+rustflags = [
+  "-C", "target-feature=+crt-static",
+  "-C", "link-args=-Wl,-zstack-size=4194304",
+]
 [target.i686-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
+rustflags = [
+  "-C", "target-feature=+crt-static",
+  "-C", "link-args=-Wl,-zstack-size=4194304",
+]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
@@ -20,6 +26,7 @@ rustflags = [
   "--cfg",
   "tokio_unstable",
   "-Zshare-generics=y",
+  "-C", "link-args=-Wl,-zstack-size=4194304",
   "-Csymbol-mangling-version=v0",
   "-Ctarget-feature=-crt-static",
   "-Clink-arg=-lgcc",
@@ -33,5 +40,6 @@ rustflags = [
   "--cfg",
   "tokio_unstable",
   "-Zshare-generics=y",
+  "-C", "link-args=-Wl,-zstack-size=4194304",
   "-Csymbol-mangling-version=v0",
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -35,11 +35,15 @@ rustflags = [
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
 
+[target.'any(not(target.wasm32-unknown-unknown), not(wasm32-wasi-preview1-threads))']
+rustflags = [
+  "-C", "link-args=-Wl,-zstack-size=4194304",
+]
+
 [target.'cfg(all())']
 rustflags = [
   "--cfg",
   "tokio_unstable",
   "-Zshare-generics=y",
-  "-C", "link-args=-Wl,-zstack-size=4194304",
   "-Csymbol-mangling-version=v0",
 ]


### PR DESCRIPTION
### Why?

Some packages require larger stack to compile correctly

Native build: https://github.com/vercel/next.js/actions/runs/7818270269


Closes PACK-2433