### PR TITLE
Turbopack: update more snapshots

### DIFF
--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -96,41 +96,41 @@ describe.each(['default', 'turbo'])(
       const source = next.normalizeTestDirContent(content)
       if (process.env.TURBOPACK) {
         expect(source).toMatchInlineSnapshot(`
-        "./pages/_app.js:2:11
-        Parsing ecmascript source code failed
-          1 | function MyApp({ Component, pageProps }) {
-        > 2 |   return <<Component {...pageProps} />;
-            |            ^^^^^^^^^
-          3 | }
-          4 | export default MyApp
+          "./pages/_app.js:2:11
+          Parsing ecmascript source code failed
+            1 | function MyApp({ Component, pageProps }) {
+          > 2 |   return <<Component {...pageProps} />;
+              |           ^
+            3 | }
+            4 | export default MyApp
 
-        Expression expected"
-      `)
+          Expression expected"
+        `)
       } else {
         expect(source).toMatchInlineSnapshot(`
-        "./pages/_app.js
-        Error: 
-          x Expression expected
-           ,-[TEST_DIR/pages/_app.js:1:1]
-         1 | function MyApp({ Component, pageProps }) {
-         2 |   return <<Component {...pageProps} />;
-           :           ^
-         3 | }
-         4 | export default MyApp
-           \`----
+                  "./pages/_app.js
+                  Error: 
+                    x Expression expected
+                     ,-[TEST_DIR/pages/_app.js:1:1]
+                   1 | function MyApp({ Component, pageProps }) {
+                   2 |   return <<Component {...pageProps} />;
+                     :           ^
+                   3 | }
+                   4 | export default MyApp
+                     \`----
 
-          x Expression expected
-           ,-[TEST_DIR/pages/_app.js:1:1]
-         1 | function MyApp({ Component, pageProps }) {
-         2 |   return <<Component {...pageProps} />;
-           :            ^^^^^^^^^
-         3 | }
-         4 | export default MyApp
-           \`----
+                    x Expression expected
+                     ,-[TEST_DIR/pages/_app.js:1:1]
+                   1 | function MyApp({ Component, pageProps }) {
+                   2 |   return <<Component {...pageProps} />;
+                     :            ^^^^^^^^^
+                   3 | }
+                   4 | export default MyApp
+                     \`----
 
-        Caused by:
-            Syntax Error"
-      `)
+                  Caused by:
+                      Syntax Error"
+              `)
       }
 
       await session.patch(
@@ -146,7 +146,7 @@ describe.each(['default', 'turbo'])(
       await cleanup()
     })
 
-    test('_document syntax error shows logbox', async () => {
+    test.only('_document syntax error shows logbox', async () => {
       const { session, cleanup } = await sandbox(
         next,
         new Map([
@@ -185,36 +185,36 @@ describe.each(['default', 'turbo'])(
       )
       if (process.env.TURBOPACK) {
         expect(source).toMatchInlineSnapshot(`
-        "./pages/_document.js:3:35
-        Parsing ecmascript source code failed
-          1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
-          2 |
-        > 3 | class MyDocument extends Document {{
-            |                                    ^
-          4 |   static async getInitialProps(ctx) {
-          5 |     const initialProps = await Document.getInitialProps(ctx)
-          6 |     return { ...initialProps }
+          "./pages/_document.js:3:36
+          Parsing ecmascript source code failed
+            1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
+            2 |
+          > 3 | class MyDocument extends Document {{
+              |                                    ^
+            4 |   static async getInitialProps(ctx) {
+            5 |     const initialProps = await Document.getInitialProps(ctx)
+            6 |     return { ...initialProps }
 
-        Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key"
-      `)
+          Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key"
+        `)
       } else {
         expect(source).toMatchInlineSnapshot(`
-        "./pages/_document.js
-        Error: 
-          x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
-           ,-[TEST_DIR/pages/_document.js:1:1]
-         1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
-         2 | 
-         3 | class MyDocument extends Document {{
-           :                                    ^
-         4 |   static async getInitialProps(ctx) {
-         5 |     const initialProps = await Document.getInitialProps(ctx)
-         6 |     return { ...initialProps }
-           \`----
+                  "./pages/_document.js
+                  Error: 
+                    x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
+                     ,-[TEST_DIR/pages/_document.js:1:1]
+                   1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
+                   2 | 
+                   3 | class MyDocument extends Document {{
+                     :                                    ^
+                   4 |   static async getInitialProps(ctx) {
+                   5 |     const initialProps = await Document.getInitialProps(ctx)
+                   6 |     return { ...initialProps }
+                     \`----
 
-        Caused by:
-            Syntax Error"
-      `)
+                  Caused by:
+                      Syntax Error"
+              `)
       }
 
       await session.patch(

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -146,7 +146,7 @@ describe.each(['default', 'turbo'])(
       await cleanup()
     })
 
-    test.only('_document syntax error shows logbox', async () => {
+    test('_document syntax error shows logbox', async () => {
       const { session, cleanup } = await sandbox(
         next,
         new Map([


### PR DESCRIPTION
These are correct since #61735 fixed tracing these. Unfortunately they don’t pass yet as the overlay is not properly dismissed when these errors are fixed.


Closes PACK-2439