### PR TITLE
Fall back loading chunks for sourcemap tracing

### DIFF
--- a/packages/next-swc/crates/napi/src/next_api/project.rs
+++ b/packages/next-swc/crates/napi/src/next_api/project.rs
@@ -830,25 +830,33 @@ pub async fn project_trace_source(
                 return Ok(None);
             };
 
-            let path = if frame.is_server {
-                project
-                    .container
-                    .project()
-                    .node_root()
-                    .join(chunk_base.to_owned())
-            } else {
-                project
-                    .container
-                    .project()
-                    .client_relative_path()
-                    .join(chunk_base.to_owned())
-            };
-
-            let map = project
+            let server_path = project
                 .container
-                .get_source_map(path, module)
-                .await?
-                .context("chunk/module is missing a sourcemap")?;
+                .project()
+                .node_root()
+                .join(chunk_base.to_owned());
+
+            let client_path = project
+                .container
+                .project()
+                .client_relative_path()
+                .join(chunk_base.to_owned());
+
+            let mut map_result = project
+                .container
+                .get_source_map(server_path, module.clone())
+                .await?;
+            if map_result.is_none() {
+                // If the chunk doesn't exist as a server chunk, try a client chunk.
+                // TODO: Properly tag all server chunks and use the `isServer` query param.
+                // Currently, this is inaccurate as it does not cover RSC server
+                // chunks.
+                map_result = project
+                    .container
+                    .get_source_map(client_path, module)
+                    .await?;
+            }
+            let map = map_result.context("chunk/module is missing a sourcemap")?;
 
             let Some(line) = frame.line else {
                 return Ok(None);

--- a/packages/next-swc/crates/napi/src/next_api/project.rs
+++ b/packages/next-swc/crates/napi/src/next_api/project.rs
@@ -845,18 +845,15 @@ pub async fn project_trace_source(
             let mut map_result = project
                 .container
                 .get_source_map(server_path, module.clone())
-                .await?;
-            if map_result.is_none() {
+                .await;
+            if map_result.is_err() {
                 // If the chunk doesn't exist as a server chunk, try a client chunk.
                 // TODO: Properly tag all server chunks and use the `isServer` query param.
                 // Currently, this is inaccurate as it does not cover RSC server
                 // chunks.
-                map_result = project
-                    .container
-                    .get_source_map(client_path, module)
-                    .await?;
+                map_result = project.container.get_source_map(client_path, module).await;
             }
-            let map = map_result.context("chunk/module is missing a sourcemap")?;
+            let map = map_result?.context("chunk/module is missing a sourcemap")?;
 
             let Some(line) = frame.line else {
                 return Ok(None);

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -39,7 +39,10 @@ function getOriginalStackFrame(
 ): Promise<OriginalStackFrame> {
   async function _getOriginalStackFrame(): Promise<OriginalStackFrame> {
     const params = new URLSearchParams()
-    params.append('isServer', String(type === 'server'))
+    params.append(
+      'isServer',
+      String(type === 'server' || source.file?.startsWith('/'))
+    )
     params.append('isEdgeServer', String(type === 'edge-server'))
     params.append('isAppDirectory', 'true')
     params.append('errorMessage', errorMessage)

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -39,10 +39,7 @@ function getOriginalStackFrame(
 ): Promise<OriginalStackFrame> {
   async function _getOriginalStackFrame(): Promise<OriginalStackFrame> {
     const params = new URLSearchParams()
-    params.append(
-      'isServer',
-      String(type === 'server' || source.file?.startsWith('/'))
-    )
+    params.append('isServer', String(type === 'server'))
     params.append('isEdgeServer', String(type === 'edge-server'))
     params.append('isAppDirectory', 'true')
     params.append('errorMessage', errorMessage)

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -982,12 +982,11 @@
   "test/development/acceptance-app/ReactRefreshRegression.test.ts": {
     "passed": [
       "ReactRefreshRegression app can fast refresh a page with static generation",
-      "ReactRefreshRegression app shows an overlay for server-side error in client component"
-    ],
-    "failed": [
       "ReactRefreshRegression app shows an overlay for anonymous function server-side error",
+      "ReactRefreshRegression app shows an overlay for server-side error in client component",
       "ReactRefreshRegression app shows an overlay for server-side error in server component"
     ],
+    "failed": [],
     "pending": [
       "ReactRefreshRegression app Turbopack skipped tests custom loader mdx should have Fast Refresh enabled",
       "ReactRefreshRegression app styled-components hydration mismatch"


### PR DESCRIPTION
This implements falling back to try multiple locations loading chunks for sourcemap tracing.

Unfortunately, when RSC replays server errors on the client, it does not carry over the [0] symbol used to annotate server frames. Instead, errors are recreated by React and only include the message and stack.

This allows more tests to pass, as we are able to correctly trace stack frames by loading the appropriate server chunk.

Closes PACK-2442