### PR TITLE
test: add test for logging trace of dynamic = error

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -1,7 +1,11 @@
 /* eslint-env jest */
 import { sandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { check, describeVariants as describe } from 'next-test-utils'
+import {
+  check,
+  describeVariants as describe,
+  expandCallStack,
+} from 'next-test-utils'
 import path from 'path'
 import { outdent } from 'outdent'
 
@@ -817,10 +821,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
       expect(await session.hasRedbox()).toBe(true)
 
-      // Open full Call Stack
-      await browser
-        .elementByCss('[data-nextjs-data-runtime-error-collapsed-action]')
-        .click()
+      await expandCallStack(browser)
 
       // Expect more than the default amount of frames
       // The default stackTraceLimit results in max 9 [data-nextjs-call-stack-frame] elements

--- a/test/development/app-dir/dynamic-error-trace/app/layout.js
+++ b/test/development/app-dir/dynamic-error-trace/app/layout.js
@@ -1,0 +1,7 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/dynamic-error-trace/app/lib.js
+++ b/test/development/app-dir/dynamic-error-trace/app/lib.js
@@ -1,0 +1,6 @@
+import { useHeaders } from 'headers-lib'
+
+export function Foo() {
+  useHeaders()
+  return 'foo'
+}

--- a/test/development/app-dir/dynamic-error-trace/app/page.js
+++ b/test/development/app-dir/dynamic-error-trace/app/page.js
@@ -1,0 +1,6 @@
+import { Foo } from './lib'
+export default function Page() {
+  return <Foo />
+}
+
+export const dynamic = 'error'

--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -1,0 +1,45 @@
+import { createNextDescribe } from 'e2e-utils'
+import {
+  getRedboxCallStack,
+  hasRedbox,
+  shouldRunTurboDevTest,
+  expandCallStack,
+  getRedboxSource,
+} from 'next-test-utils'
+
+createNextDescribe(
+  'app dir - dynamic error trace',
+  {
+    files: __dirname,
+    dependencies: {
+      swr: 'latest',
+    },
+    packageJson: {
+      scripts: {
+        copy: `cp -r ./node_modules_bak/* ./node_modules`,
+        build: 'pnpm copy && next build',
+        dev: `pnpm copy && next ${
+          shouldRunTurboDevTest() ? 'dev --turbo' : 'dev'
+        }`,
+        start: 'next start',
+      },
+    },
+    installCommand: 'pnpm install',
+    startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+    buildCommand: 'pnpm build',
+    skipDeployment: true,
+  },
+  ({ next }) => {
+    it('should show the error trace', async () => {
+      const browser = await next.browser('/')
+      await hasRedbox(browser)
+      await expandCallStack(browser)
+      const callStack = await getRedboxCallStack(browser)
+
+      expect(callStack).toContain('node_modules/headers-lib/index.mjs')
+
+      const source = await getRedboxSource(browser)
+      expect(source).toContain('app/lib.js')
+    })
+  }
+)

--- a/test/development/app-dir/dynamic-error-trace/node_modules_bak/headers-lib/index.mjs
+++ b/test/development/app-dir/dynamic-error-trace/node_modules_bak/headers-lib/index.mjs
@@ -1,0 +1,5 @@
+import { headers } from 'next/headers'
+
+export function useHeaders() {
+  return headers()
+}

--- a/test/development/app-dir/dynamic-error-trace/node_modules_bak/headers-lib/package.json
+++ b/test/development/app-dir/dynamic-error-trace/node_modules_bak/headers-lib/package.json
@@ -1,0 +1,3 @@
+{
+  "exports": "./index.mjs"
+}

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1031,6 +1031,30 @@ export async function getRedboxComponentStack(
   return componentStackFrameTexts.join('\n').trim()
 }
 
+export async function expandCallStack(
+  browser: BrowserInterface
+): Promise<void> {
+  // Open full Call Stack
+  await browser
+    .elementByCss('[data-nextjs-data-runtime-error-collapsed-action]')
+    .click()
+}
+
+export async function getRedboxCallStack(
+  browser: BrowserInterface
+): Promise<string> {
+  await browser.waitForElementByCss('[data-nextjs-call-stack-frame]', 30000)
+
+  const callStackFrameElements: any = await browser.elementsByCss(
+    '[data-nextjs-call-stack-frame]'
+  )
+  const callStackFrameTexts = await Promise.all(
+    callStackFrameElements.map((f) => f.innerText())
+  )
+
+  return callStackFrameTexts.join('\n').trim()
+}
+
 export async function getVersionCheckerText(
   browser: BrowserInterface
 ): Promise<string> {


### PR DESCRIPTION
Add test that we can log the error trace when we found invalid dynamic usage when `dynamic = "error"`

![image](https://github.com/vercel/next.js/assets/4800338/e6710019-ab94-42e8-81b2-6362f828cf35)


Closes NEXT-2402
Closes NEXT-2383