### PR TITLE
DX: fix error overlay flash

### DIFF
--- a/packages/next/src/build/output/store.ts
+++ b/packages/next/src/build/output/store.ts
@@ -105,6 +105,7 @@ store.subscribe((state) => {
   }
 
   if (state.errors) {
+    // Log compilation errors
     Log.error(state.errors[0])
 
     const cleanError = stripAnsi(state.errors[0])

--- a/packages/react-dev-overlay/src/client.ts
+++ b/packages/react-dev-overlay/src/client.ts
@@ -39,9 +39,9 @@ function onUnhandledError(ev: ErrorEvent) {
         )
       : undefined
 
-  // Skip ModuleBuildError, as it will be sent through onBuildError callback.
+  // Skip ModuleBuildError and ModuleNotFoundError, as it will be sent through onBuildError callback.
   // This is to avoid same error as different type showing up on client to cause flashing.
-  if (e.name !== 'ModuleBuildError') {
+  if (e.name !== 'ModuleBuildError' && e.name !== 'ModuleNotFoundError') {
     Bus.emit({
       type: Bus.TYPE_UNHANDLED_ERROR,
       reason: error,

--- a/packages/react-dev-overlay/src/client.ts
+++ b/packages/react-dev-overlay/src/client.ts
@@ -38,12 +38,17 @@ function onUnhandledError(ev: ErrorEvent) {
           (frame: any) => frame.component
         )
       : undefined
-  Bus.emit({
-    type: Bus.TYPE_UNHANDLED_ERROR,
-    reason: error,
-    frames: parseStack(e.stack!),
-    componentStack,
-  })
+
+  // Skip ModuleBuildError, as it will be sent through onBuildError callback.
+  // This is to avoid same error as different type showing up on client to cause flashing.
+  if (e.name !== 'ModuleBuildError') {
+    Bus.emit({
+      type: Bus.TYPE_UNHANDLED_ERROR,
+      reason: error,
+      frames: parseStack(e.stack!),
+      componentStack,
+    })
+  }
 }
 
 function onUnhandledRejection(ev: PromiseRejectionEvent) {

--- a/packages/react-dev-overlay/src/internal/ReactDevOverlay.tsx
+++ b/packages/react-dev-overlay/src/internal/ReactDevOverlay.tsx
@@ -164,6 +164,8 @@ const ReactDevOverlay: React.FunctionComponent<ReactDevOverlayProps> =
       : null
     const isMounted = errorType !== null
 
+    const displayPrevented = shouldPreventDisplay(errorType, preventDisplay)
+
     return (
       <React.Fragment>
         <ErrorBoundary
@@ -179,10 +181,7 @@ const ReactDevOverlay: React.FunctionComponent<ReactDevOverlayProps> =
             <Base />
             <ComponentStyles />
 
-            {shouldPreventDisplay(
-              errorType,
-              preventDisplay
-            ) ? null : hasBuildError ? (
+            {displayPrevented ? null : hasBuildError ? (
               <BuildError message={state.buildError!} />
             ) : hasRuntimeErrors ? (
               <Errors errors={state.errors} />


### PR DESCRIPTION
### What

Skipping module build error and module not found error in `onUnhandledError` handler from pages router dev overlay, to avoid the build error being caught twice by error overlay in both unhandled error and build error type. The unhandled error is slightly eariler than build error, which causes the flash. We skipped it to avoid display same duplicated errors.

### Why

This change fixes a flashing UX on error overlay when build error occurred, it will go from a white background with red text to a source panel with actual code where triggered build error, such as synatx error. I recodered two videos to show them properly. Since it happens too fast, hard to address them with test, more like fixing a minor frustration in the UI.


### After
https://github.com/vercel/next.js/assets/4800338/59dcde0f-3ac7-419f-ba5c-c28c9d5a7205

### Before
https://github.com/vercel/next.js/assets/4800338/e64e8855-2c5f-43a5-948c-8137cad538a1



Closes NEXT-2403
Closes NEXT-2145