### PR TITLE
Guard against restoring router state with missing data

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -470,10 +470,18 @@ function Router({
       url: string | URL | null | undefined
     ) => {
       const href = window.location.href
+      const urlToRestore = new URL(url ?? href, href)
+      if (!window.history.state?.__PRIVATE_NEXTJS_INTERNALS_TREE) {
+        // we cannot safely recover from a missing tree -- we need trigger an MPA navigation
+        // to restore the router history to the correct state.
+        window.location.href = urlToRestore.pathname
+        return
+      }
+
       startTransition(() => {
         dispatch({
           type: ACTION_RESTORE,
-          url: new URL(url ?? href, href),
+          url: urlToRestore,
           tree: window.history.state.__PRIVATE_NEXTJS_INTERNALS_TREE,
         })
       })


### PR DESCRIPTION
Unclear when this can happen currently (hence missing a test), but this adds a safeguard to `applyUrlFromHistoryPushReplace` to ensure that we don't potentially call `ACTION_RESTORE` with data that might be missing from `window.history.state`. 

This is consistent with other spots where we're reading this internal flag from state.

The function that calls `applyUrlFromHistoryPushReplace` first calls `copyNextJsInternalHistoryState` to copy over `__PRIVATE_NEXTJS_INTERNALS_TREE` into the data argument of `pushState`/`replaceState`.  But technically it does so with the possibility that `__PRIVATE_NEXTJS_INTERNALS_TREE` is undefined. Since that's the case, this is more typesafe. 

Closes NEXT-2406
