### PR TITLE
Turbopack: skip tests for import trace links

### DIFF
--- a/test/development/acceptance-app/editor-links.test.ts
+++ b/test/development/acceptance-app/editor-links.test.ts
@@ -75,90 +75,94 @@ describe('Error overlay - editor links', () => {
 
     await cleanup()
   })
-
-  it('should be possible to open import trace files on RSC parse error', async () => {
-    let editorRequestsCount = 0
-    const { session, browser, cleanup } = await sandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
+  ;(process.env.TURBOPACK ? describe.skip : describe)(
+    'opening links in import traces',
+    () => {
+      it('should be possible to open import trace files on RSC parse error', async () => {
+        let editorRequestsCount = 0
+        const { session, browser, cleanup } = await sandbox(
+          next,
+          new Map([
+            [
+              'app/page.js',
+              outdent`
             import Component from '../index'
             export default function Page() {
               return <Component />
             }
           `,
-        ],
-        ['mod1.js', "import './mod2.js'"],
-        ['mod2.js', '{{{{{'],
-      ]),
-      undefined,
-      {
-        beforePageLoad(page) {
-          page.route('**/__nextjs_launch-editor**', (route) => {
-            editorRequestsCount += 1
-            route.fulfill()
-          })
-        },
-      }
-    )
+            ],
+            ['mod1.js', "import './mod2.js'"],
+            ['mod2.js', '{{{{{'],
+          ]),
+          undefined,
+          {
+            beforePageLoad(page) {
+              page.route('**/__nextjs_launch-editor**', (route) => {
+                editorRequestsCount += 1
+                route.fulfill()
+              })
+            },
+          }
+        )
 
-    await session.patch(
-      'index.js',
-      outdent`
+        await session.patch(
+          'index.js',
+          outdent`
         import './mod1' 
         export default () => 'hello world'
       `
-    )
+        )
 
-    expect(await session.hasRedbox()).toBe(true)
-    await clickImportTraceFiles(browser)
-    await check(() => editorRequestsCount, /4/)
+        expect(await session.hasRedbox()).toBe(true)
+        await clickImportTraceFiles(browser)
+        await check(() => editorRequestsCount, /4/)
 
-    await cleanup()
-  })
+        await cleanup()
+      })
 
-  it('should be possible to open import trace files on module not found error', async () => {
-    let editorRequestsCount = 0
-    const { session, browser, cleanup } = await sandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
+      it('should be possible to open import trace files on module not found error', async () => {
+        let editorRequestsCount = 0
+        const { session, browser, cleanup } = await sandbox(
+          next,
+          new Map([
+            [
+              'app/page.js',
+              outdent`
             import Component from '../index'
             export default function Page() {
               return <Component />
             }
           `,
-        ],
-        ['mod1.js', "import './mod2.js'"],
-        ['mod2.js', 'import "boom"'],
-      ]),
-      undefined,
-      {
-        beforePageLoad(page) {
-          page.route('**/__nextjs_launch-editor**', (route) => {
-            editorRequestsCount += 1
-            route.fulfill()
-          })
-        },
-      }
-    )
+            ],
+            ['mod1.js', "import './mod2.js'"],
+            ['mod2.js', 'import "boom"'],
+          ]),
+          undefined,
+          {
+            beforePageLoad(page) {
+              page.route('**/__nextjs_launch-editor**', (route) => {
+                editorRequestsCount += 1
+                route.fulfill()
+              })
+            },
+          }
+        )
 
-    await session.patch(
-      'index.js',
-      outdent`
+        await session.patch(
+          'index.js',
+          outdent`
         import './mod1' 
         export default () => 'hello world'
       `
-    )
+        )
 
-    expect(await session.hasRedbox()).toBe(true)
-    await clickImportTraceFiles(browser)
-    await check(() => editorRequestsCount, /3/)
+        expect(await session.hasRedbox()).toBe(true)
+        await clickImportTraceFiles(browser)
+        await check(() => editorRequestsCount, /3/)
 
-    await cleanup()
-  })
+        await cleanup()
+      })
+    }
+  )
 })

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1054,11 +1054,11 @@
     "passed": [
       "Error overlay - editor links should be possible to open source file on build error"
     ],
-    "failed": [
-      "Error overlay - editor links should be possible to open import trace files on RSC parse error",
-      "Error overlay - editor links should be possible to open import trace files on module not found error"
+    "failed": [],
+    "pending": [
+      "Error overlay - editor opening links in import traces links should be possible to open import trace files on RSC parse error",
+      "Error overlay - editor opening links in import traces links should be possible to open import trace files on module not found error"
     ],
-    "pending": [],
     "flakey": [],
     "runtimeError": false
   },


### PR DESCRIPTION
Some tests in `test/development/acceptance-app/editor-links.test.ts` test that links in the import trace can be clicked. This is currently deprioritized with Turbopack, so skip them.


Closes PACK-2450