### PR TITLE
docs: fix static robots.txt directory in the docs (app -> public)

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/robots.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/robots.mdx
@@ -7,7 +7,7 @@ Add or generate a `robots.txt` file that matches the [Robots Exclusion Standard]
 
 ## Static `robots.txt`
 
-```txt filename="app/robots.txt"
+```txt filename="public/robots.txt"
 User-Agent: *
 Allow: /
 Disallow: /private/


### PR DESCRIPTION
### What?
The [documentation for static `robots.txt`](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots#static-robotstxt) seem to indicate (by the code snippet's header) that static robot.txt files should be placed inside `app`. However it seems these files need to be placed inside the `public` folder so I've updated the code snippet's file name to reflect that.



