### PR TITLE
Builds continue when `output` and `target` are specified at the same time

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1051,10 +1051,16 @@ export default async function loadConfig(
     }
 
     if (userConfig.target && userConfig.target !== 'server') {
-      throw new Error(
-        `The "target" property is no longer supported in ${configFileName}.\n` +
-          'See more info here https://nextjs.org/docs/messages/deprecated-target-config'
-      )
+      if (userConfig.output) {
+        console.warn(
+          `The "target" property is ignored because the "output" property is specified.`
+        )
+      } else {
+        throw new Error(
+          `The "target" property is no longer supported in ${configFileName}.\n` +
+            'See more info here https://nextjs.org/docs/messages/deprecated-target-config'
+        )
+      }
     }
 
     if (userConfig.amp?.canonicalBase) {


### PR DESCRIPTION
### What?
If `output` and `export` are specified at the same time, a warning is displayed instead of an error and the build continues.

### Why?
Both are specified so the user is aware of the new option. There is no need for failure build.

To be honest, the `target` is automatically specified in the amplify environment.
https://github.com/aws-amplify/amplify-hosting/issues/3840
I still use v13 because of this. 😭

### How?
Check for the existence of `userConfig.output` before throwing an error.


