### PR TITLE
Update app-index to only ever construct the initial data response once

### DIFF
--- a/test/development/acceptance-app/component-stack.test.ts
+++ b/test/development/acceptance-app/component-stack.test.ts
@@ -49,7 +49,6 @@ describe('Component Stack in error overlay', () => {
         ErrorBoundary
         AppRouter
         ServerRoot
-        RSCComponent
         Root"
       `)
     } else {


### PR DESCRIPTION
There was a bug where if the root hydrates and then an update happens the intitial server data response can be replaced by one that is completely empty and will never resolve. This can lead to a frozen hydration that blocks interactivity. This udpate makes it so it is impossible for the initial data response to ever be created more than once.

Making a regression test is tricky because this relies on subtle timing of hydration, updates, and when the inline chunks arrive in the stream. The original implementation is just not safe in that it violates the rules of react and the new one is self-evidently unable to produce a similar situation so as long as our existing test suite passes that must be sufficient absent a good alternative to making a specific regression test

Closes NEXT-2420