### PR TITLE
Attempt to polyfill globalThis for old chrome

### DIFF
--- a/packages/next/src/client/components/async-local-storage.ts
+++ b/packages/next/src/client/components/async-local-storage.ts
@@ -1,5 +1,16 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 
+// polyfill for globalThis
+if (typeof window !== "undefined" && window.globalThis === undefined) {
+  document.documentElement
+    .appendChild(
+      Object.assign(document.createElement("script"), {
+        textContent: "window.globalThis = window",
+      }),
+    )
+    .remove();
+}
+
 const sharedAsyncLocalStorageNotAvailableError = new Error(
   'Invariant: AsyncLocalStorage accessed in runtime where it is not available'
 )


### PR DESCRIPTION
### Fixing a bug

https://github.com/vercel/next.js/discussions/58818#discussioncomment-8422873

Haven't actually tested this - setting up local next.js development is too big of lift at the moment.

---

Since this code seems to tolerate a `FakeAsyncLocalStorage`, perhaps a simpler fix is [this one](https://github.com/vercel/next.js/pull/61873). Feel free to close _this_ PR without comment if the other way is preferable.