### PR TITLE
docs(cli): fix next info section title and re-order

### DIFF
--- a/docs/02-app/02-api-reference/08-next-cli.mdx
+++ b/docs/02-app/02-api-reference/08-next-cli.mdx
@@ -67,7 +67,7 @@ next build --debug
 
 With this flag enabled additional build output like rewrites, redirects, and headers will be shown.
 
-## Development
+## Development Mode
 
 `next dev` starts the application in development mode with hot-code reloading, error reporting, and more:
 
@@ -107,7 +107,7 @@ next dev --experimental-https --experimental-https-key ./certificates/localhost-
 
 `next dev --experimental-https` is only intended for development and creates a locally-trusted certificate with `mkcert`. In production, use properly issued certificates from trusted authorities. When deploying to Vercel, HTTPS is [automatically configured](https://vercel.com/docs/security/encryption) for your Next.js application.
 
-## Production
+## Production Mode
 
 `next start` starts the application in production mode. The application should be compiled with [`next build`](#build) first.
 
@@ -139,27 +139,7 @@ To configure the timeout values for the production Next.js server, pass `--keepA
 npx next start --keepAliveTimeout 70000
 ```
 
-## Lint
-
-`next lint` runs ESLint for all files in the `pages/`, `app/`, `components/`, `lib/`, and `src/` directories. It also
-provides a guided setup to install any required dependencies if ESLint is not already configured in
-your application.
-
-If you have other directories that you would like to lint, you can specify them using the `--dir`
-flag:
-
-```bash filename="Terminal"
-next lint --dir utils
-```
-
-## Telemetry
-
-Next.js collects **completely anonymous** telemetry data about general usage.
-Participation in this anonymous program is optional, and you may opt-out if you'd not like to share any information.
-
-To learn more about Telemetry, [please read this document](https://nextjs.org/telemetry/).
-
-## Next Info
+## Info
 
 `next info` prints relevant details about the current system which can be used to report Next.js bugs.
 This information includes Operating System platform/arch/version, Binaries (Node.js, npm, Yarn, pnpm) and npm package versions (`next`, `react`, `react-dom`).
@@ -193,3 +173,23 @@ Relevant packages:
 This information should then be pasted into GitHub Issues.
 
 In order to diagnose installation issues, you can run `next info --verbose` to print additional information about system and the installation of next-related packages.
+
+## Lint
+
+`next lint` runs ESLint for all files in the `pages/`, `app/`, `components/`, `lib/`, and `src/` directories. It also
+provides a guided setup to install any required dependencies if ESLint is not already configured in
+your application.
+
+If you have other directories that you would like to lint, you can specify them using the `--dir`
+flag:
+
+```bash filename="Terminal"
+next lint --dir utils
+```
+
+## Telemetry
+
+Next.js collects **completely anonymous** telemetry data about general usage.
+Participation in this anonymous program is optional, and you may opt-out if you'd not like to share any information.
+
+To learn more about Telemetry, [please read this document](https://nextjs.org/telemetry/).

--- a/docs/02-app/02-api-reference/08-next-cli.mdx
+++ b/docs/02-app/02-api-reference/08-next-cli.mdx
@@ -67,7 +67,7 @@ next build --debug
 
 With this flag enabled additional build output like rewrites, redirects, and headers will be shown.
 
-## Development Mode
+## Development
 
 `next dev` starts the application in development mode with hot-code reloading, error reporting, and more:
 
@@ -107,7 +107,7 @@ next dev --experimental-https --experimental-https-key ./certificates/localhost-
 
 `next dev --experimental-https` is only intended for development and creates a locally-trusted certificate with `mkcert`. In production, use properly issued certificates from trusted authorities. When deploying to Vercel, HTTPS is [automatically configured](https://vercel.com/docs/security/encryption) for your Next.js application.
 
-## Production Mode
+## Production
 
 `next start` starts the application in production mode. The application should be compiled with [`next build`](#build) first.
 


### PR DESCRIPTION
## Changes

- Update section title from `Next Info` to `Info`
    - Adds consistency with other section titles and fixes broken link → https://github.com/vercel/next.js/blob/09a764d0fc5d143e401526153d73fab901844a38/packages/next/src/cli/next-info.ts#L100

Closes NEXT-2425