### PR TITLE
fix(custom-transform): allow to assert empty program for rsc

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use regex::Regex;
 use serde::Deserialize;
-use swc_core::ecma::visit::VisitWith;
+use swc_core::{common::util::take::Take, ecma::visit::VisitWith};
 use turbopack_binding::swc::core::{
     common::{
         comments::{Comment, CommentKind, Comments},
@@ -576,6 +576,7 @@ impl ReactServerComponentValidator {
         let is_error_file = Regex::new(r"[\\/]error\.(ts|js)x?$")
             .unwrap()
             .is_match(&self.filepath);
+
         if is_error_file {
             if let Some(app_dir) = &self.app_dir {
                 if let Some(app_dir) = app_dir.to_str() {
@@ -726,6 +727,14 @@ impl ReactServerComponentValidator {
 
 impl Visit for ReactServerComponentValidator {
     noop_visit_type!();
+
+    // coerce parsed script to run validation for the context, which is still
+    // required even if file is empty
+    fn visit_script(&mut self, script: &swc_core::ecma::ast::Script) {
+        if script.body.is_empty() {
+            self.visit_module(&Module::dummy());
+        }
+    }
 
     fn visit_module(&mut self, module: &Module) {
         let (is_client_entry, is_action_file, imports, export_names) =

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1162,11 +1162,10 @@
       "Error overlay - RSC build errors should throw an error when error file is a server component",
       "Error overlay - RSC build errors should throw an error when getServerSideProps is used",
       "Error overlay - RSC build errors should throw an error when metadata export is used in client components",
-      "Error overlay - RSC build errors should throw an error when metadata exports are used together in server components"
-    ],
-    "failed": [
+      "Error overlay - RSC build errors should throw an error when metadata exports are used together in server components",
       "Error overlay - RSC build errors should throw an error when error file is a server component with empty error file"
     ],
+    "failed": [],
     "pending": [
       "Error overlay - RSC build errors should throw an error when getStaticProps is used"
     ],


### PR DESCRIPTION
### What?
Turbopack uses `parse_as_prorgram`, and in case of empty file it returns script instead of module so none of visitor runs for the rsc module.

This PR attempts to workaround, however need double clarification if upstream swc behavior is desired.

Closes PACK-2460