### PR TITLE
Turbopack: remove server addr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "serde",
  "smallvec",
@@ -3423,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "serde",
@@ -7410,7 +7410,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7442,7 +7442,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7454,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7469,7 +7469,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7500,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7531,7 +7531,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "base16",
  "hex",
@@ -7543,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7557,7 +7557,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "mimalloc",
 ]
@@ -7575,7 +7575,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7600,7 +7600,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7632,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7673,7 +7673,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7698,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7716,7 +7716,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7747,7 +7747,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7775,7 +7775,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7800,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7873,7 +7873,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "serde",
  "serde_json",
@@ -7884,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7909,7 +7909,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7942,7 +7942,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7962,7 +7962,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "serde",
@@ -7977,7 +7977,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7992,7 +7992,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8027,7 +8027,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "serde",
@@ -8043,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8054,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8070,7 +8070,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.2#67019098b6125e629e1c259722e1701fd363b6c5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.7", features = [
 testing = { version = "0.35.18" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.4" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.4" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.4" }
 
 # General Deps
 

--- a/packages/next-swc/crates/napi/src/next_api/project.rs
+++ b/packages/next-swc/crates/napi/src/next_api/project.rs
@@ -90,9 +90,6 @@ pub struct NapiProjectOptions {
     /// A map of environment variables which should get injected at compile
     /// time.
     pub define_env: NapiDefineEnv,
-
-    /// The address of the dev server.
-    pub server_addr: String,
 }
 
 /// [NapiProjectOptions] with all fields optional.
@@ -124,9 +121,6 @@ pub struct NapiPartialProjectOptions {
     /// A map of environment variables which should get injected at compile
     /// time.
     pub define_env: Option<NapiDefineEnv>,
-
-    /// The address of the dev server.
-    pub server_addr: Option<String>,
 }
 
 #[napi(object)]
@@ -157,7 +151,6 @@ impl From<NapiProjectOptions> for ProjectOptions {
                 .map(|var| (var.name, var.value))
                 .collect(),
             define_env: val.define_env.into(),
-            server_addr: val.server_addr,
         }
     }
 }
@@ -174,7 +167,6 @@ impl From<NapiPartialProjectOptions> for PartialProjectOptions {
                 .env
                 .map(|env| env.into_iter().map(|var| (var.name, var.value)).collect()),
             define_env: val.define_env.map(|env| env.into()),
-            server_addr: val.server_addr,
         }
     }
 }

--- a/packages/next-swc/crates/next-api/src/project.rs
+++ b/packages/next-swc/crates/next-api/src/project.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::MAIN_SEPARATOR};
+use std::path::MAIN_SEPARATOR;
 
 use anyhow::Result;
 use indexmap::{map::Entry, IndexMap};
@@ -39,7 +39,6 @@ use turbopack_binding::{
             compile_time_info::CompileTimeInfo,
             context::AssetContext,
             diagnostics::DiagnosticExt,
-            environment::ServerAddr,
             file_source::FileSource,
             output::{OutputAsset, OutputAssets},
             resolve::{find_context_file, FindContextFileResult},
@@ -91,9 +90,6 @@ pub struct ProjectOptions {
 
     /// Whether to watch the filesystem for file changes.
     pub watch: bool,
-
-    /// The address of the dev server.
-    pub server_addr: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, TaskInput, PartialEq, Eq, TraceRawVcs)]
@@ -121,9 +117,6 @@ pub struct PartialProjectOptions {
 
     /// Whether to watch the filesystem for file changes.
     pub watch: Option<bool>,
-
-    /// The address of the dev server.
-    pub server_addr: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, TaskInput, PartialEq, Eq, TraceRawVcs)]
@@ -187,9 +180,6 @@ impl ProjectContainer {
         if let Some(watch) = options.watch {
             new_options.watch = watch;
         }
-        if let Some(server_addr) = options.server_addr {
-            new_options.server_addr = server_addr;
-        }
 
         self.options_state.set(new_options);
 
@@ -200,7 +190,7 @@ impl ProjectContainer {
     pub async fn project(self: Vc<Self>) -> Result<Vc<Project>> {
         let this = self.await?;
 
-        let (env, define_env, next_config, js_config, root_path, project_path, watch, server_addr) = {
+        let (env, define_env, next_config, js_config, root_path, project_path, watch) = {
             let options = this.options_state.get();
             let env: Vc<EnvMap> = Vc::cell(options.env.iter().cloned().collect());
             let define_env: Vc<ProjectDefineEnv> = ProjectDefineEnv {
@@ -214,7 +204,6 @@ impl ProjectContainer {
             let root_path = options.root_path.clone();
             let project_path = options.project_path.clone();
             let watch = options.watch;
-            let server_addr = options.server_addr.parse()?;
             (
                 env,
                 define_env,
@@ -223,7 +212,6 @@ impl ProjectContainer {
                 root_path,
                 project_path,
                 watch,
-                server_addr,
             )
         };
 
@@ -237,7 +225,6 @@ impl ProjectContainer {
             root_path,
             project_path,
             watch,
-            server_addr,
             next_config,
             js_config,
             dist_dir,
@@ -300,10 +287,6 @@ pub struct Project {
 
     /// Whether to watch the filesystem for file changes.
     watch: bool,
-
-    /// The address of the dev server.
-    #[turbo_tasks(trace_ignore)]
-    server_addr: SocketAddr,
 
     /// Next config.
     next_config: Vc<NextConfig>,
@@ -395,11 +378,6 @@ impl Project {
         let disk_fs = DiskFileSystem::new("node".to_string(), this.project_path.clone());
         disk_fs.await?.start_watching_with_invalidation_reason()?;
         Ok(Vc::upcast(disk_fs))
-    }
-
-    #[turbo_tasks::function]
-    fn server_addr(&self) -> Vc<ServerAddr> {
-        ServerAddr::new(self.server_addr).cell()
     }
 
     #[turbo_tasks::function]
@@ -498,7 +476,6 @@ impl Project {
         let this = self.await?;
         Ok(get_server_compile_time_info(
             self.env(),
-            self.server_addr(),
             this.define_env.nodejs(),
         ))
     }
@@ -508,7 +485,6 @@ impl Project {
         let this = self.await?;
         Ok(get_edge_compile_time_info(
             self.project_path(),
-            self.server_addr(),
             this.define_env.edge(),
         ))
     }

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -9,7 +9,7 @@ use turbopack_binding::{
                 CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, FreeVarReference,
                 FreeVarReferences,
             },
-            environment::{EdgeWorkerEnvironment, Environment, ExecutionEnvironment, ServerAddr},
+            environment::{EdgeWorkerEnvironment, Environment, ExecutionEnvironment},
             free_var_references,
         },
         dev::DevChunkingContext,
@@ -79,11 +79,10 @@ async fn next_edge_free_vars(
 #[turbo_tasks::function]
 pub fn get_edge_compile_time_info(
     project_path: Vc<FileSystemPath>,
-    server_addr: Vc<ServerAddr>,
     define_env: Vc<EnvMap>,
 ) -> Vc<CompileTimeInfo> {
     CompileTimeInfo::builder(Environment::new(Value::new(
-        ExecutionEnvironment::EdgeWorker(EdgeWorkerEnvironment { server_addr }.into()),
+        ExecutionEnvironment::EdgeWorker(EdgeWorkerEnvironment {}.into()),
     )))
     .defines(next_edge_defines(define_env))
     .free_var_references(next_edge_free_vars(project_path, define_env))

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -13,9 +13,7 @@ use turbopack_binding::{
             compile_time_info::{
                 CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, FreeVarReferences,
             },
-            environment::{
-                Environment, ExecutionEnvironment, NodeJsEnvironment, RuntimeVersions, ServerAddr,
-            },
+            environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, RuntimeVersions},
             free_var_references,
             resolve::{parse::Request, pattern::Pattern},
         },
@@ -290,11 +288,10 @@ async fn next_server_free_vars(define_env: Vc<EnvMap>) -> Result<Vc<FreeVarRefer
 #[turbo_tasks::function]
 pub async fn get_server_compile_time_info(
     process_env: Vc<Box<dyn ProcessEnv>>,
-    server_addr: Vc<ServerAddr>,
     define_env: Vc<EnvMap>,
 ) -> Vc<CompileTimeInfo> {
     CompileTimeInfo::builder(Environment::new(Value::new(
-        ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::current(process_env, server_addr)),
+        ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::current(process_env)),
     )))
     .defines(next_server_defines(define_env))
     .free_var_references(next_server_free_vars(define_env))

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -193,7 +193,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.3",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.26.3
         version: 0.26.3
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.2(react-refresh@0.12.0)(webpack@5.90.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4(react-refresh@0.12.0)(webpack@5.90.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25655,9 +25655,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.2(react-refresh@0.12.0)(webpack@5.90.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4(react-refresh@0.12.0)(webpack@5.90.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

remove server_addr option

### Why?

We no longer need the server addr for bundling.


Closes PACK-2462