### PR TITLE
docs: fix typo

### DIFF
--- a/docs/02-app/01-building-your-application/11-upgrading/05-from-create-react-app.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/05-from-create-react-app.mdx
@@ -555,7 +555,7 @@ Create React App and Next.js both default to using webpack for bundling.
 
 When migrating your CRA application to Next.js, you might have a custom webpack configuration you're looking to migrate. Next.js supports providing a [custom webpack configuration](/docs/app/api-reference/next-config-js/webpack).
 
-Further, Next.js has support for [Turbopack](/docs/app/api-reference/next-config-js/turbo) through `next dev --turbo` to improve your local dev performance. Turbopack supports some [webpack loaders](/docs/app/api-reference/next-config-js/turbo) as well for compatability and incremental adoption.
+Further, Next.js has support for [Turbopack](/docs/app/api-reference/next-config-js/turbo) through `next dev --turbo` to improve your local dev performance. Turbopack supports some [webpack loaders](/docs/app/api-reference/next-config-js/turbo) as well for compatibility and incremental adoption.
 
 ## Next Steps
 


### PR DESCRIPTION
### Why?
`compatability` is not a correct word.

### How?
Use `compatibility` instead.
