### PR TITLE
build(cargo): bump up turbopack to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "serde",
  "smallvec",
@@ -3513,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "serde",
@@ -7557,7 +7557,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7589,7 +7589,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7601,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7647,7 +7647,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7678,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "base16",
  "hex",
@@ -7690,7 +7690,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "mimalloc",
 ]
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7747,7 +7747,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7779,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7820,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7845,7 +7845,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7863,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7894,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7922,7 +7922,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7947,7 +7947,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7984,7 +7984,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8020,7 +8020,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "serde",
  "serde_json",
@@ -8031,7 +8031,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8056,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8073,7 +8073,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8089,7 +8089,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8109,7 +8109,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "serde",
@@ -8124,7 +8124,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -8139,7 +8139,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8174,7 +8174,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "serde",
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8201,7 +8201,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8217,7 +8217,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240209.2#d9639a4ad4f0d95de7aa71599c332cd06350b3f5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240212.2#178a2948eeb795ba925838b2380bd5c532a2cd5f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.89.6", features = [
 testing = { version = "0.35.16" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240209.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240212.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240209.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240212.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240209.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240212.2" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -193,7 +193,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.3",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240209.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240212.2",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.26.3
         version: 0.26.3
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240209.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240209.2(react-refresh@0.12.0)(webpack@5.90.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240212.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240212.2(react-refresh@0.12.0)(webpack@5.90.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -2169,7 +2169,6 @@ packages:
   /@babel/plugin-proposal-dynamic-import@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-dynamic-import instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2181,7 +2180,6 @@ packages:
   /@babel/plugin-proposal-export-namespace-from@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2205,7 +2203,6 @@ packages:
   /@babel/plugin-proposal-logical-assignment-operators@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2228,7 +2225,6 @@ packages:
   /@babel/plugin-proposal-numeric-separator@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2279,7 +2275,6 @@ packages:
   /@babel/plugin-proposal-private-methods@7.16.11(@babel/core@7.22.5):
     resolution: {integrity: sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -25655,9 +25650,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240209.2(react-refresh@0.12.0)(webpack@5.90.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240209.2}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240209.2'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240212.2(react-refresh@0.12.0)(webpack@5.90.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240212.2}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240212.2'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

Bump up turbopack to latest. This is to cut off turbopack **before** including filewatcher changes, so we can easily bisect & revert if watcher have regressions.