### PR TITLE
ci(workflow): deploy rustdocs for turbopack

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -473,6 +473,31 @@ jobs:
           VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}
           DEPLOY_ENVIRONMENT: production
 
+  deployTurbopackDocs:
+    name: Deploy Turbopack docs
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 25
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+      - name: Install Rust
+        uses: ./.github/actions/setup-rust
+      - name: Deploy preview docs
+        if: ${{ needs.build.outputs.isRelease != 'true' }}
+        run: ./scripts/deploy-turbopack-docs.sh
+        env:
+          VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}
+          DEPLOY_ENVIRONMENT: preview
+      - name: Deploy production docs
+        if: ${{ needs.build.outputs.isRelease == 'true' }}
+        run: ./scripts/deploy-turbopack-docs.sh
+        env:
+          VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}
+          DEPLOY_ENVIRONMENT: production
+
   releaseStats:
     name: Release Stats
     runs-on:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -138,6 +138,20 @@ jobs:
       stepName: 'rust-check'
     secrets: inherit
 
+  rust-doc-check:
+    name: rustdoc check
+    needs: ['changes', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
+    uses: ./.github/workflows/build_reusable.yml
+    with:
+      needsRust: 'yes'
+      skipInstallBuild: 'yes'
+      skipNativeBuild: 'yes'
+      afterBuild: ./scripts/deploy-turbopack-docs.sh
+      stepName: 'rust-doc-check'
+    secrets: inherit
+
   test-turbopack-dev:
     name: test turbopack dev
     needs: ['changes', 'build-next']

--- a/packages/next-swc/docs/index.md
+++ b/packages/next-swc/docs/index.md
@@ -1,0 +1,7 @@
+# Turbopack
+
+Welcome to an overview of the Turbopack documentation.
+
+Currently it's work in progress, the only package available is [Turbo tasks-fs](turbo_tasks_fs/index.html)
+
+[comment]: # 'Temporary index page document'

--- a/scripts/deploy-turbopack-docs.sh
+++ b/scripts/deploy-turbopack-docs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+PROD=""
+
+if [ -z ${DEPLOY_ENVIRONMENT+x} ]; then
+    DEPLOY_ENVIRONMENT=""
+else
+    if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then
+      PROD="--prod"
+    fi
+fi
+
+RUSTDOCFLAGS="-Z unstable-options --index-page $(pwd)/packages/next-swc/docs/index.md" cargo doc -p turbo-tasks-fs --no-deps
+
+if [ -z ${VERCEL_API_TOKEN+x} ]; then
+  echo "VERCEL_API_TOKEN was not providing, skipping..."
+  exit 0
+fi
+
+
+DOCS_OUTDIR="$(pwd)/target/doc"
+PROJECT="turbopack-rust-docs"
+echo "Deploying directory $DOCS_OUTDIR as $PROJECT to Vercel..."
+
+vercel link --cwd $DOCS_OUTDIR --scope vercel --project $PROJECT --token "$VERCEL_API_TOKEN" --yes
+vercel deploy --cwd $DOCS_OUTDIR --token "$VERCEL_API_TOKEN" $PROD


### PR DESCRIPTION
### What

We'd like to deploy generated rustdocs from turbopack & related packages (next-swc), setting up a CI workflow to automate those.

Since we need next.js side packages to build docs, this CI sets up things in this repo.

Closes PACK-2375.