### PR TITLE
test(manifest): update test manifest

### DIFF
--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1024,10 +1024,10 @@
     "runtimeError": false
   },
   "test/development/acceptance-app/app-hmr-changes.test.ts": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "Error overlay - RSC build errors Skipped in webpack should handle successive HMR changes with errors correctly"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What?

Looks like HMR watcher fix fixed this test.

PACK-2437

Closes PACK-2471