### PR TITLE
chore(github-workflow): update pull_request_popular name

### DIFF
--- a/.github/workflows/pull_request_popular.yml
+++ b/.github/workflows/pull_request_popular.yml
@@ -1,4 +1,4 @@
-name: Notify about the top 15 PRs (most reacted) in the last 90 days
+name: Notify about the top PRs (most reacted) in the last 90 days
 
 on:
   schedule:


### PR DESCRIPTION
## Changes

It's dynamic now, no longer a fixed 15.

### Before

```
name: Notify about the top 15 PRs (most reacted) in the last 90 days
```

### After

```
name: Notify about the top PRs (most reacted) in the last 90 days
```