### PR TITLE
Use destructured object for #61993

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -463,8 +463,8 @@ export async function createHotReloaderTurbopack(
             'instrumentation',
             'instrumentation'
           )
-          await writeManifests(
-            opts.fsChecker.rewrites,
+          await writeManifests({
+            rewrites: opts.fsChecker.rewrites,
             distDir,
             buildManifests,
             appBuildManifests,
@@ -474,8 +474,8 @@ export async function createHotReloaderTurbopack(
             actionManifests,
             fontManifests,
             loadableManifests,
-            currentEntrypoints
-          )
+            currentEntrypoints,
+          })
 
           serverFields.actualInstrumentationHookFile = '/instrumentation'
           await propagateServerField(
@@ -533,8 +533,8 @@ export async function createHotReloaderTurbopack(
                 'middleware',
                 serverFields.middleware
               )
-              await writeManifests(
-                opts.fsChecker.rewrites,
+              await writeManifests({
+                rewrites: opts.fsChecker.rewrites,
                 distDir,
                 buildManifests,
                 appBuildManifests,
@@ -544,8 +544,8 @@ export async function createHotReloaderTurbopack(
                 actionManifests,
                 fontManifests,
                 loadableManifests,
-                currentEntrypoints
-              )
+                currentEntrypoints,
+              })
 
               finishBuilding()
               return { event: HMR_ACTIONS_SENT_TO_BROWSER.MIDDLEWARE_CHANGES }
@@ -592,8 +592,8 @@ export async function createHotReloaderTurbopack(
     )
   )
   await currentEntriesHandling
-  await writeManifests(
-    opts.fsChecker.rewrites,
+  await writeManifests({
+    rewrites: opts.fsChecker.rewrites,
     distDir,
     buildManifests,
     appBuildManifests,
@@ -603,8 +603,8 @@ export async function createHotReloaderTurbopack(
     actionManifests,
     fontManifests,
     loadableManifests,
-    currentEntrypoints
-  )
+    currentEntrypoints,
+  })
   const overlayMiddleware = getOverlayMiddleware(project)
   const versionInfo: VersionInfo = await getVersionInfo(
     isTestMode || opts.telemetry.isEnabled
@@ -840,8 +840,8 @@ export async function createHotReloaderTurbopack(
           await loadPagesManifest(distDir, pagesManifests, '_error')
           await loadFontManifest(distDir, fontManifests, '_error')
 
-          await writeManifests(
-            opts.fsChecker.rewrites,
+          await writeManifests({
+            rewrites: opts.fsChecker.rewrites,
             distDir,
             buildManifests,
             appBuildManifests,
@@ -851,8 +851,8 @@ export async function createHotReloaderTurbopack(
             actionManifests,
             fontManifests,
             loadableManifests,
-            currentEntrypoints
-          )
+            currentEntrypoints,
+          })
         } finally {
           finishBuilding()
         }
@@ -888,8 +888,8 @@ export async function createHotReloaderTurbopack(
 
       const finishBuilding = startBuilding(page, requestUrl)
       try {
-        await handleRouteType(
-          opts.fsChecker.rewrites,
+        await handleRouteType({
+          rewrites: opts.fsChecker.rewrites,
           distDir,
           globalEntrypoints,
           currentIssues,
@@ -906,8 +906,8 @@ export async function createHotReloaderTurbopack(
           changeSubscription,
           readyIds,
           page,
-          route
-        )
+          route,
+        })
       } finally {
         finishBuilding()
       }

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -578,19 +578,31 @@ async function writeLoadableManifest(
   )
 }
 
-export async function writeManifests(
-  rewrites: SetupOpts['fsChecker']['rewrites'],
-  distDir: string,
-  buildManifests: BuildManifests,
-  appBuildManifests: AppBuildManifests,
-  pagesManifests: PagesManifests,
-  appPathsManifests: AppPathsManifests,
-  middlewareManifests: MiddlewareManifests,
-  actionManifests: ActionManifests,
-  fontManifests: FontManifests,
-  loadableManifests: LoadableManifests,
+export async function writeManifests({
+  rewrites,
+  distDir,
+  buildManifests,
+  appBuildManifests,
+  pagesManifests,
+  appPathsManifests,
+  middlewareManifests,
+  actionManifests,
+  fontManifests,
+  loadableManifests,
+  currentEntrypoints,
+}: {
+  rewrites: SetupOpts['fsChecker']['rewrites']
+  distDir: string
+  buildManifests: BuildManifests
+  appBuildManifests: AppBuildManifests
+  pagesManifests: PagesManifests
+  appPathsManifests: AppPathsManifests
+  middlewareManifests: MiddlewareManifests
+  actionManifests: ActionManifests
+  fontManifests: FontManifests
+  loadableManifests: LoadableManifests
   currentEntrypoints: CurrentEntrypoints
-): Promise<void> {
+}): Promise<void> {
   await writeBuildManifest(
     distDir,
     buildManifests,
@@ -778,26 +790,45 @@ export type ChangeSubscription = (
 
 export type ReadyIds = Set<string>
 
-export async function handleRouteType(
-  rewrites: SetupOpts['fsChecker']['rewrites'],
-  distDir: string,
-  globalEntrypoints: GlobalEntrypoints,
-  currentIssues: CurrentIssues,
-  buildManifests: BuildManifests,
-  appBuildManifests: AppBuildManifests,
-  pagesManifests: PagesManifests,
-  appPathsManifests: AppPathsManifests,
-  middlewareManifests: MiddlewareManifests,
-  actionManifests: ActionManifests,
-  fontManifests: FontManifests,
-  loadableManifests: LoadableManifests,
-  currentEntrypoints: CurrentEntrypoints,
-  handleRequireCacheClearing: HandleRequireCacheClearing | undefined,
-  changeSubscription: ChangeSubscription | undefined,
-  readyIds: ReadyIds,
-  page: string,
+export async function handleRouteType({
+  rewrites,
+  distDir,
+  globalEntrypoints,
+  currentIssues,
+  buildManifests,
+  appBuildManifests,
+  pagesManifests,
+  appPathsManifests,
+  middlewareManifests,
+  actionManifests,
+  fontManifests,
+  loadableManifests,
+  currentEntrypoints,
+  handleRequireCacheClearing,
+  changeSubscription,
+  readyIds,
+  page,
+  route,
+}: {
+  rewrites: SetupOpts['fsChecker']['rewrites']
+  distDir: string
+  globalEntrypoints: GlobalEntrypoints
+  currentIssues: CurrentIssues
+  buildManifests: BuildManifests
+  appBuildManifests: AppBuildManifests
+  pagesManifests: PagesManifests
+  appPathsManifests: AppPathsManifests
+  middlewareManifests: MiddlewareManifests
+  actionManifests: ActionManifests
+  fontManifests: FontManifests
+  loadableManifests: LoadableManifests
+  currentEntrypoints: CurrentEntrypoints
+  handleRequireCacheClearing: HandleRequireCacheClearing | undefined
+  changeSubscription: ChangeSubscription | undefined
+  readyIds: ReadyIds
+  page: string
   route: Route
-) {
+}) {
   switch (route.type) {
     case 'page': {
       try {
@@ -836,7 +867,7 @@ export async function handleRouteType(
         await loadFontManifest(distDir, fontManifests, page, 'pages')
         await loadLoadableManifest(distDir, loadableManifests, page, 'pages')
 
-        await writeManifests(
+        await writeManifests({
           rewrites,
           distDir,
           buildManifests,
@@ -847,8 +878,8 @@ export async function handleRouteType(
           actionManifests,
           fontManifests,
           loadableManifests,
-          currentEntrypoints
-        )
+          currentEntrypoints,
+        })
 
         processIssues(currentIssues, page, writtenEndpoint)
       } finally {
@@ -905,7 +936,7 @@ export async function handleRouteType(
       }
       await loadLoadableManifest(distDir, loadableManifests, page, 'pages')
 
-      await writeManifests(
+      await writeManifests({
         rewrites,
         distDir,
         buildManifests,
@@ -916,8 +947,8 @@ export async function handleRouteType(
         actionManifests,
         fontManifests,
         loadableManifests,
-        currentEntrypoints
-      )
+        currentEntrypoints,
+      })
 
       processIssues(currentIssues, page, writtenEndpoint)
 
@@ -959,7 +990,7 @@ export async function handleRouteType(
       await loadAppPathManifest(distDir, appPathsManifests, page, 'app')
       await loadActionManifest(distDir, actionManifests, page)
       await loadFontManifest(distDir, fontManifests, page, 'app')
-      await writeManifests(
+      await writeManifests({
         rewrites,
         distDir,
         buildManifests,
@@ -970,8 +1001,8 @@ export async function handleRouteType(
         actionManifests,
         fontManifests,
         loadableManifests,
-        currentEntrypoints
-      )
+        currentEntrypoints,
+      })
 
       processIssues(currentIssues, page, writtenEndpoint, true)
 
@@ -995,7 +1026,7 @@ export async function handleRouteType(
         middlewareManifests.delete(page)
       }
 
-      await writeManifests(
+      await writeManifests({
         rewrites,
         distDir,
         buildManifests,
@@ -1006,8 +1037,8 @@ export async function handleRouteType(
         actionManifests,
         fontManifests,
         loadableManifests,
-        currentEntrypoints
-      )
+        currentEntrypoints,
+      })
       processIssues(currentIssues, page, writtenEndpoint, true)
 
       break


### PR DESCRIPTION
## What?

Applies the suggestion to use an object for the parameter from #61993.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2475