### PR TITLE
docs(turbopack): reduce documentation size

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -498,7 +498,7 @@ jobs:
           VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}
           DEPLOY_ENVIRONMENT: preview
       - name: Deploy production docs
-        if: ${{ needs.build.outputs.isRelease == 'true' }}
+        if: ${{ github.ref_name == 'canary' || needs.build.outputs.isRelease == 'true' }}
         run: ./scripts/deploy-turbopack-docs.sh
         env:
           VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,7 +3407,6 @@ dependencies = [
  "serde",
  "serde_json",
  "shadow-rs",
- "swc_core",
  "tokio",
  "tracing",
  "tracing-chrome",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "serde",
  "smallvec",
@@ -3422,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "serde",
@@ -7409,7 +7409,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7441,7 +7441,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7453,7 +7453,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7482,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7499,7 +7499,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7530,7 +7530,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "base16",
  "hex",
@@ -7542,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7556,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7566,7 +7566,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "mimalloc",
 ]
@@ -7574,7 +7574,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7599,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7631,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7672,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7697,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7715,7 +7715,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7746,7 +7746,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7774,7 +7774,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7799,7 +7799,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7836,7 +7836,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7872,7 +7872,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "serde",
  "serde_json",
@@ -7883,7 +7883,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7908,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7925,7 +7925,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7941,7 +7941,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "serde",
@@ -7976,7 +7976,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7991,7 +7991,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8026,7 +8026,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "serde",
@@ -8042,7 +8042,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8053,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8069,7 +8069,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.4#4025b02d9231f9fc5b25b669ac8ee8c6c00b4544"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240213.5#30295254bb4938489028b07fc724b082cac90c0e"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3350,7 +3350,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "swc_core",
  "thiserror",
  "tracing",
  "turbo-tasks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.7", features = [
 testing = { version = "0.35.18" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.4" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.5" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.4" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.5" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.4" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240213.5" }
 
 # General Deps
 

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -92,6 +92,7 @@ next-build = { workspace = true }
 next-core = { workspace = true }
 turbopack-binding = { workspace = true, features = [
   "__swc_core_binding_napi",
+  "__swc_core_serde",
   "__feature_node_file_trace",
   "__feature_mdx_rs",
   "__turbo",
@@ -105,10 +106,9 @@ turbopack-binding = { workspace = true, features = [
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.9", default-features = false, features = ["js"] }
 iana-time-zone = { version = "*", features = ["fallback"] }
-#[todo] turbopack-binding should expose serde serializable features
-swc_core = { workspace = true, features = ["ecma_ast_serde"] }
 turbopack-binding = { workspace = true, features = [
   "__swc_core_binding_napi",
+  "__swc_core_serde",
   "__feature_mdx_rs",
 ] }
 

--- a/packages/next-swc/crates/next-core/Cargo.toml
+++ b/packages/next-swc/crates/next-core/Cargo.toml
@@ -37,6 +37,7 @@ rustc-hash = { workspace = true }
 turbopack-binding = { workspace = true, features = [
   "__swc_transform_modularize_imports",
   "__swc_transform_relay",
+  "__swc_core_next_core",
   "__feature_auto_hash_map",
   "__turbo_tasks",
   "__turbo_tasks_bytes",
@@ -59,14 +60,9 @@ turbopack-binding = { workspace = true, features = [
   "__turbopack_node",
   "__turbopack_trace_utils",
 ] }
+
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }
-
-swc_core = { workspace = true, features = [
-  "ecma_ast",
-  "ecma_transforms",
-  "common",
-] }
 
 [build-dependencies]
 turbopack-binding = { workspace = true, features = ["__turbo_tasks_build"] }

--- a/packages/next-swc/crates/next-core/src/app_segment_config.rs
+++ b/packages/next-swc/crates/next-core/src/app_segment_config.rs
@@ -3,26 +3,28 @@ use std::ops::Deref;
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use swc_core::{
-    common::{source_map::Pos, Span, Spanned, GLOBALS},
-    ecma::ast::{Expr, Ident, Program},
-};
 use turbo_tasks::{trace::TraceRawVcs, TryJoinIterExt, ValueDefault, Vc};
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_binding::turbopack::{
-    core::{
-        file_source::FileSource,
-        ident::AssetIdent,
-        issue::{
-            Issue, IssueExt, IssueSeverity, IssueSource, OptionIssueSource, OptionStyledString,
-            StyledString,
-        },
-        source::Source,
+use turbopack_binding::{
+    swc::core::{
+        common::{source_map::Pos, Span, Spanned, GLOBALS},
+        ecma::ast::{Expr, Ident, Program},
     },
-    ecmascript::{
-        analyzer::{graph::EvalContext, ConstantNumber, ConstantValue, JsValue},
-        parse::{parse, ParseResult},
-        EcmascriptInputTransforms, EcmascriptModuleAssetType,
+    turbopack::{
+        core::{
+            file_source::FileSource,
+            ident::AssetIdent,
+            issue::{
+                Issue, IssueExt, IssueSeverity, IssueSource, OptionIssueSource, OptionStyledString,
+                StyledString,
+            },
+            source::Source,
+        },
+        ecmascript::{
+            analyzer::{graph::EvalContext, ConstantNumber, ConstantValue, JsValue},
+            parse::{parse, ParseResult},
+            EcmascriptInputTransforms, EcmascriptModuleAssetType,
+        },
     },
 };
 

--- a/packages/next-swc/crates/next-core/src/lib.rs
+++ b/packages/next-swc/crates/next-core/src/lib.rs
@@ -48,7 +48,8 @@ pub use next_edge::context::{
     get_edge_chunking_context, get_edge_compile_time_info, get_edge_resolve_options_context,
 };
 pub use page_loader::{create_page_loader_entry_module, PageLoaderAsset};
-pub use turbopack_binding::{turbopack::node::source_map, *};
+use turbopack_binding::turbo;
+pub use turbopack_binding::{turbopack, turbopack::node::source_map};
 pub use util::{get_asset_path_from_pathname, pathname_for_path, PathType};
 
 pub fn register() {

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/modularize_imports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/modularize_imports.rs
@@ -4,16 +4,18 @@ use anyhow::Result;
 use async_trait::async_trait;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use swc_core::{
-    common::util::take::Take,
-    ecma::{
-        ast::{Module, Program},
-        visit::FoldWith,
-    },
-};
 use turbo_tasks::{trace::TraceRawVcs, Vc};
 use turbopack_binding::{
-    swc::custom_transform::modularize_imports::{self, modularize_imports, PackageConfig},
+    swc::{
+        core::{
+            common::util::take::Take,
+            ecma::{
+                ast::{Module, Program},
+                visit::FoldWith,
+            },
+        },
+        custom_transform::modularize_imports::{self, modularize_imports, PackageConfig},
+    },
     turbopack::{
         ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
         turbopack::module_options::{ModuleRule, ModuleRuleEffect},

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -3,15 +3,15 @@ use std::path::PathBuf;
 use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::dynamic::{next_dynamic, NextDynamicMode};
-use swc_core::{
-    common::{util::take::Take, FileName},
-    ecma::{
-        ast::{Module, Program},
-        visit::FoldWith,
-    },
-};
 use turbo_tasks::Vc;
 use turbopack_binding::{
+    swc::core::{
+        common::{util::take::Take, FileName},
+        ecma::{
+            ast::{Module, Program},
+            visit::FoldWith,
+        },
+    },
     turbo::tasks_fs::FileSystemPath,
     turbopack::{
         ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_font.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_font.rs
@@ -1,11 +1,13 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::fonts::*;
-use swc_core::ecma::{ast::Program, atoms::JsWord, visit::VisitMutWith};
 use turbo_tasks::Vc;
-use turbopack_binding::turbopack::{
-    ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
-    turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+use turbopack_binding::{
+    swc::core::ecma::{ast::Program, atoms::JsWord, visit::VisitMutWith},
+    turbopack::{
+        ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
+        turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+    },
 };
 
 use super::module_rule_match_js_no_url;

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -1,15 +1,17 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::react_server_components::*;
-use swc_core::{
-    common::FileName,
-    ecma::{ast::Program, visit::VisitWith},
-};
 use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_binding::turbopack::{
-    ecmascript::{CustomTransformer, TransformContext},
-    turbopack::module_options::ModuleRule,
+use turbopack_binding::{
+    swc::core::{
+        common::FileName,
+        ecma::{ast::Program, visit::VisitWith},
+    },
+    turbopack::{
+        ecmascript::{CustomTransformer, TransformContext},
+        turbopack::module_options::ModuleRule,
+    },
 };
 
 use super::get_ecma_transform_rule;

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -3,15 +3,15 @@ use async_trait::async_trait;
 use next_custom_transforms::transforms::strip_page_exports::{
     next_transform_strip_page_exports, ExportFilter,
 };
-use swc_core::{
-    common::util::take::Take,
-    ecma::{
-        ast::{Module, Program},
-        visit::FoldWith,
-    },
-};
 use turbo_tasks::Vc;
 use turbopack_binding::{
+    swc::core::{
+        common::util::take::Take,
+        ecma::{
+            ast::{Module, Program},
+            visit::FoldWith,
+        },
+    },
     turbo::tasks_fs::FileSystemPath,
     turbopack::{
         ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -1,14 +1,16 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::server_actions::{server_actions, Config};
-use swc_core::{
-    common::FileName,
-    ecma::{ast::Program, visit::VisitMutWith},
-};
 use turbo_tasks::Vc;
-use turbopack_binding::turbopack::{
-    ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
-    turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+use turbopack_binding::{
+    swc::core::{
+        common::FileName,
+        ecma::{ast::Program, visit::VisitMutWith},
+    },
+    turbopack::{
+        ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext},
+        turbopack::module_options::{ModuleRule, ModuleRuleEffect},
+    },
 };
 
 use super::module_rule_match_js_no_url;

--- a/packages/next-swc/crates/next-core/src/util.rs
+++ b/packages/next-swc/crates/next-core/src/util.rs
@@ -1,13 +1,13 @@
 use anyhow::{bail, Context, Result};
 use indexmap::{IndexMap, IndexSet};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use swc_core::{
-    common::GLOBALS,
-    ecma::ast::{Expr, Lit, Program},
-};
 use turbo_tasks::{trace::TraceRawVcs, TaskInput, ValueDefault, ValueToString, Vc};
 use turbo_tasks_fs::{rope::Rope, util::join_path, File};
 use turbopack_binding::{
+    swc::core::{
+        common::GLOBALS,
+        ecma::ast::{Expr, Lit, Program},
+    },
     turbo::tasks_fs::{json::parse_json_rope_with_source_context, FileContent, FileSystemPath},
     turbopack::{
         core::{

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -193,7 +193,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.3",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.5",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,8 +1077,8 @@ importers:
         specifier: 0.26.3
         version: 0.26.3
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4(react-refresh@0.12.0)(webpack@5.90.0)'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.5
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.5(react-refresh@0.12.0)(webpack@5.90.0)'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -2169,7 +2169,6 @@ packages:
   /@babel/plugin-proposal-dynamic-import@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-dynamic-import instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2181,7 +2180,6 @@ packages:
   /@babel/plugin-proposal-export-namespace-from@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2205,7 +2203,6 @@ packages:
   /@babel/plugin-proposal-logical-assignment-operators@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2228,7 +2225,6 @@ packages:
   /@babel/plugin-proposal-numeric-separator@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2279,7 +2275,6 @@ packages:
   /@babel/plugin-proposal-private-methods@7.16.11(@babel/core@7.22.5):
     resolution: {integrity: sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -25655,9 +25650,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4(react-refresh@0.12.0)(webpack@5.90.0)':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4}
-    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.4'
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.5(react-refresh@0.12.0)(webpack@5.90.0)':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.5}
+    id: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240213.5'
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/scripts/deploy-turbopack-docs.sh
+++ b/scripts/deploy-turbopack-docs.sh
@@ -15,7 +15,7 @@ fi
 mdbook build --dest-dir $(pwd)/target/mdbook ./packages/next-swc/docs
 
 PACKAGES="-p next-swc-napi -p next-api -p next-build -p next-core -p next-custom-transforms"
-RUSTDOCFLAGS="-Z unstable-options --enable-index-page" cargo doc $PACKAGES --no-deps --document-private-items
+RUSTDOCFLAGS="-Z unstable-options --enable-index-page" cargo doc $PACKAGES --no-deps
 
 cp -r $(pwd)/target/doc $(pwd)/target/mdbook/rustdoc
 


### PR DESCRIPTION
### What

next_core unexpectedly reexports everything, makes documentation size too large.

Closes PACK-2480