### PR TITLE
refactor(next-core): do not reexport turbopack_binding

### DIFF
--- a/packages/next-swc/crates/next-build/src/build_options.rs
+++ b/packages/next-swc/crates/next-build/src/build_options.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
-use next_core::{next_config::Rewrites, turbopack::core::issue::IssueSeverity};
+use next_core::next_config::Rewrites;
+use turbopack_binding::turbopack::core::issue::IssueSeverity;
 
 #[derive(Clone, Debug)]
 pub struct BuildOptions {

--- a/packages/next-swc/crates/next-core/src/lib.rs
+++ b/packages/next-swc/crates/next-core/src/lib.rs
@@ -48,8 +48,7 @@ pub use next_edge::context::{
     get_edge_chunking_context, get_edge_compile_time_info, get_edge_resolve_options_context,
 };
 pub use page_loader::{create_page_loader_entry_module, PageLoaderAsset};
-use turbopack_binding::turbo;
-pub use turbopack_binding::{turbopack, turbopack::node::source_map};
+use turbopack_binding::{turbo, turbopack};
 pub use util::{get_asset_path_from_pathname, pathname_for_path, PathType};
 
 pub fn register() {


### PR DESCRIPTION
### What

Minor correction to the imports, turbopack_binding should not be reexported.


Closes PACK-2490