### PR TITLE
React refresh: don’t register components under different keys

### DIFF
--- a/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -42,14 +42,14 @@ exports[`ReactRefreshLogBox app default boundaries 1`] = `
 `;
 
 exports[`ReactRefreshLogBox app default conversion to class component (1) 1`] = `
-"Child.js (6:11) @ ClickCount.render
+"Child.js (4:11) @ ClickCount.render
 
-  4 | export default class ClickCount extends Component {
-  5 |   render() {
-> 6 |     throw new Error()
+  2 | export default class ClickCount extends Component {
+  3 |   render() {
+> 4 |     throw new Error()
     |           ^
-  7 |   }
-  8 | }"
+  5 |   }
+  6 | }"
 `;
 
 exports[`ReactRefreshLogBox app default css syntax errors 1`] = `

--- a/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -42,14 +42,14 @@ exports[`ReactRefreshLogBox app default boundaries 1`] = `
 `;
 
 exports[`ReactRefreshLogBox app default conversion to class component (1) 1`] = `
-"Child.js (4:11) @ ClickCount.render
+"Child.js (6:11) @ ClickCount.render
 
-  2 | export default class ClickCount extends Component {
-  3 |   render() {
-> 4 |     throw new Error()
+  4 | export default class ClickCount extends Component {
+  5 |   render() {
+> 6 |     throw new Error()
     |           ^
-  5 |   }
-  6 | }"
+  7 |   }
+  8 | }"
 `;
 
 exports[`ReactRefreshLogBox app default css syntax errors 1`] = `
@@ -135,6 +135,17 @@ exports[`ReactRefreshLogBox app turbo boundaries 1`] = `
 
 > 1 | export default function FunctionDefault() { throw new Error('no'); }
     |                                                   ^"
+`;
+
+exports[`ReactRefreshLogBox app turbo conversion to class component (1) 1`] = `
+"Child.js (4:11) @ ClickCount.render
+
+  2 | export default class ClickCount extends Component {
+  3 |   render() {
+> 4 |     throw new Error()
+    |           ^
+  5 |   }
+  6 | }"
 `;
 
 exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 1`] = `"Error: end http://nextjs.org"`;

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -927,16 +927,14 @@
       "ReactRefreshLogBox app turbo Should not show __webpack_exports__ when exporting anonymous arrow function",
       "ReactRefreshLogBox app turbo Unhandled errors and rejections opens up in the minimized state",
       "ReactRefreshLogBox app turbo boundaries",
+      "ReactRefreshLogBox app turbo conversion to class component (1)",
       "ReactRefreshLogBox app turbo logbox: anchors links in error messages",
       "ReactRefreshLogBox app turbo module init error not shown",
       "ReactRefreshLogBox app turbo server component can recover from error thrown in the module",
       "ReactRefreshLogBox app turbo should strip whitespace correctly with newline",
       "ReactRefreshLogBox app turbo unterminated JSX"
     ],
-    "failed": [
-      "ReactRefreshLogBox app turbo conversion to class component (1)",
-      "ReactRefreshLogBox app turbo css syntax errors"
-    ],
+    "failed": ["ReactRefreshLogBox app turbo css syntax errors"],
     "pending": [
       "ReactRefreshLogBox app default Call stack count is correct for client error",
       "ReactRefreshLogBox app default Call stack count is correct for server error",


### PR DESCRIPTION
Previously, components would be registered under different keys, as the react refresh transform statically inserts calls to `$RefreshReg$` for function components, but they were also registered when module instantiation is intercepted.

This restricts dynamic registration (during module instantiation) to class-based components only.

Test Plan: Integration tests


Closes PACK-2491