### PR TITLE
fix: remove duplicate handlers post condition in hasNonStaticMethods

### DIFF
--- a/packages/next/src/server/future/route-modules/app-route/module.ts
+++ b/packages/next/src/server/future/route-modules/app-route/module.ts
@@ -511,7 +511,6 @@ export function hasNonStaticMethods(handlers: AppRouteHandlers): boolean {
   if (
     // Order these by how common they are to be used
     handlers.POST ||
-    handlers.POST ||
     handlers.DELETE ||
     handlers.PATCH ||
     handlers.OPTIONS


### PR DESCRIPTION
### What 
While looking at the API Route code, I noticed that the ```handler.POST```  condition was duplicated.
It seems the code was not removed when the naming was changed during the feature development.

related issue: #60645

### Why
I believe that, for the sake of code readability and clarity, the mentioned code should be deleted.

### How
```hasNonStaticMethods``` internal ```handlers.POST``` duplicate code delete.