### PR TITLE
Fix output: export with custom distDir

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -372,7 +372,7 @@ export default async function getBaseWebpackConfig(
 
   const babelConfigFile = getBabelConfigFile(dir)
 
-  if (hasCustomExportOutput(config)) {
+  if (!dev && hasCustomExportOutput(config)) {
     config.distDir = '.next'
   }
   const distDir = path.join(dir, config.distDir)

--- a/test/integration/app-dir-export/next.config.js
+++ b/test/integration/app-dir-export/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  // distDir: '.next-custom',
   trailingSlash: true,
   generateBuildId() {
     return 'test-build-id'

--- a/test/integration/app-dir-export/test/dev-custom-dist-dir.test.ts
+++ b/test/integration/app-dir-export/test/dev-custom-dist-dir.test.ts
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import fs from 'fs-extra'
+import {
+  fetchViaHTTP,
+  File,
+  findPort,
+  killApp,
+  launchApp,
+} from 'next-test-utils'
+
+const appDir = join(__dirname, '..')
+const distDir = join(appDir, '.next-custom')
+const nextConfig = new File(join(appDir, 'next.config.js'))
+let app
+let appPort
+
+describe('app dir - with output export and custom distDir (next dev)', () => {
+  beforeAll(async () => {
+    nextConfig.replace('// distDir', 'distDir')
+    appPort = await findPort()
+    app = await launchApp(appDir, appPort)
+  })
+  afterAll(async () => {
+    nextConfig.restore()
+    await fs.remove(distDir)
+    await killApp(app)
+  })
+
+  it('should render properly', async () => {
+    const res = await fetchViaHTTP(appPort, '/')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('Home')
+  })
+})


### PR DESCRIPTION
This ensures we don't normalize the `distDir` in the webpack config in dev mode as it won't be moved to the right location like it is during build. 

Fixes: https://github.com/vercel/next.js/issues/61105

Closes NEXT-2495