### PR TITLE
Fix sendGAEvent function 

### DIFF
--- a/packages/third-parties/src/google/ga.tsx
+++ b/packages/third-parties/src/google/ga.tsx
@@ -54,14 +54,14 @@ export function GoogleAnalytics(props: GAParams) {
   )
 }
 
-export function sendGAEvent() {
+export const sendGAEvent = (...args: Object[]) => {
   if (currDataLayerName === undefined) {
     console.warn(`@next/third-parties: GA has not been initialized`)
     return
   }
 
   if (window[currDataLayerName]) {
-    window[currDataLayerName].push(arguments)
+    window[currDataLayerName].push(args)
   } else {
     console.warn(
       `@next/third-parties: GA dataLayer ${currDataLayerName} does not exist`

--- a/packages/third-parties/src/google/ga.tsx
+++ b/packages/third-parties/src/google/ga.tsx
@@ -54,14 +54,14 @@ export function GoogleAnalytics(props: GAParams) {
   )
 }
 
-export const sendGAEvent = (...args: Object[]) => {
+export function sendGAEvent() {
   if (currDataLayerName === undefined) {
     console.warn(`@next/third-parties: GA has not been initialized`)
     return
   }
 
   if (window[currDataLayerName]) {
-    window[currDataLayerName].push(...args)
+    window[currDataLayerName].push(arguments)
   } else {
     console.warn(
       `@next/third-parties: GA dataLayer ${currDataLayerName} does not exist`


### PR DESCRIPTION
Previous implementation of `sendGAEvent` was pushing arguments to `dataLayer` via rest parameter syntax, resulting in an actual array, which GA doesn't seem to process correctly (resulting in the event not showing up in GA reports).  This PR refactors it to a vanilla JS function passing data via the `arguments` array-like object, which is able to be processed correctly and results in the event showing up as expected.

fixes [61703](https://github.com/vercel/next.js/issues/61703)