### PR TITLE
internal: waitUntil should execute promises after the response is returned

### DIFF
--- a/packages/next/src/server/web/internal-edge-wait-until.ts
+++ b/packages/next/src/server/web/internal-edge-wait-until.ts
@@ -26,8 +26,8 @@ export function internal_getCurrentFunctionWaitUntil() {
 }
 
 export function internal_runWithWaitUntil<T>(fn: () => Promise<T>) {
-  // We don't want to start executing the tasks until the function has returned.
-  // `internal_getCurrentFunctionWaitUntil` is called when a function is done executing, and we'll walk
+  // We don't want to start executing the tasks until the route handler has returned.
+  // `internal_getCurrentFunctionWaitUntil` is called when a route handler is done executing, and we'll walk
   // through the tasks then.
   tasks.push(fn)
 }

--- a/packages/next/src/server/web/internal-edge-wait-until.ts
+++ b/packages/next/src/server/web/internal-edge-wait-until.ts
@@ -6,13 +6,19 @@ const tasks: (() => Promise<any>)[] = []
 async function resolveTasksSequentially(): Promise<void> {
   let result = Promise.resolve()
 
-  for (let i = 0; i < tasks.length; i++) {
-    const task = tasks[i]
-    result = result.then(() => task())
+  function handleNext() {
+    if (tasks.length) {
+      const task = tasks.shift()
+      result = result.then(() => {
+        handleNext()
+        return task?.()
+      })
+    }
   }
 
-  await result
-  tasks.length = 0 // Clear tasks after all are executed
+  handleNext()
+
+  return result
 }
 
 export function internal_getCurrentFunctionWaitUntil() {

--- a/packages/next/src/server/web/internal-edge-wait-until.ts
+++ b/packages/next/src/server/web/internal-edge-wait-until.ts
@@ -5,9 +5,12 @@ const tasks: (() => Promise<any>)[] = []
 
 async function resolveTasksSequentially(): Promise<void> {
   let result = Promise.resolve()
-  tasks.forEach((task) => {
+
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i]
     result = result.then(() => task())
-  })
+  }
+
   await result
   tasks.length = 0 // Clear tasks after all are executed
 }

--- a/packages/next/src/server/web/internal-edge-wait-until.ts
+++ b/packages/next/src/server/web/internal-edge-wait-until.ts
@@ -1,59 +1,21 @@
 // An internal module to expose the "waitUntil" API to Edge SSR and Edge Route Handler functions.
 // This is highly experimental and subject to change.
 
-// We still need a global key to bypass Webpack's layering of modules.
-const GLOBAL_KEY = Symbol.for('__next_internal_waitUntil__')
+const tasks: (() => Promise<any>)[] = []
 
-const state: {
-  waitUntilCounter: number
-  waitUntilResolve: () => void
-  waitUntilPromise: Promise<void> | null
-} =
-  // @ts-ignore
-  globalThis[GLOBAL_KEY] ||
-  // @ts-ignore
-  (globalThis[GLOBAL_KEY] = {
-    waitUntilCounter: 0,
-    waitUntilResolve: undefined,
-    waitUntilPromise: null,
+async function resolveTasksSequentially(): Promise<void> {
+  let result = Promise.resolve()
+  tasks.forEach((task) => {
+    result = result.then(() => task())
   })
-
-// No matter how many concurrent requests are being handled, we want to make sure
-// that the final promise is only resolved once all of the waitUntil promises have
-// settled.
-function resolveOnePromise() {
-  state.waitUntilCounter--
-  if (state.waitUntilCounter === 0) {
-    state.waitUntilResolve()
-    state.waitUntilPromise = null
-  }
+  await result
+  tasks.length = 0 // Clear tasks after all are executed
 }
 
 export function internal_getCurrentFunctionWaitUntil() {
-  return state.waitUntilPromise
+  return resolveTasksSequentially()
 }
 
-export function internal_runWithWaitUntil<T>(fn: () => T): T {
-  const result = fn()
-  if (
-    result &&
-    typeof result === 'object' &&
-    'then' in result &&
-    'finally' in result &&
-    typeof result.then === 'function' &&
-    typeof result.finally === 'function'
-  ) {
-    if (!state.waitUntilCounter) {
-      // Create the promise for the next batch of waitUntil calls.
-      state.waitUntilPromise = new Promise<void>((resolve) => {
-        state.waitUntilResolve = resolve
-      })
-    }
-    state.waitUntilCounter++
-    return result.finally(() => {
-      resolveOnePromise()
-    })
-  }
-
-  return result
+export function internal_runWithWaitUntil<T>(fn: () => Promise<T>) {
+  tasks.push(fn)
 }

--- a/packages/next/src/server/web/internal-edge-wait-until.ts
+++ b/packages/next/src/server/web/internal-edge-wait-until.ts
@@ -26,5 +26,8 @@ export function internal_getCurrentFunctionWaitUntil() {
 }
 
 export function internal_runWithWaitUntil<T>(fn: () => Promise<T>) {
+  // We don't want to start executing the tasks until the function has returned.
+  // `internal_getCurrentFunctionWaitUntil` is called when a function is done executing, and we'll walk
+  // through the tasks then.
   tasks.push(fn)
 }


### PR DESCRIPTION
Certain cloud runtimes enforce concurrency limits. If too many network requests are being executed concurrently via `internal_runWithWaitUntil` this limit can be reached and a deadlock can occur.

This change switches internal_runWithWaitUntil from immediately calling the promises provided, and instead constructs a queue to be processed sequentially after the function returns.

I recommend reviewing without whitespace: https://github.com/vercel/next.js/pull/62068/files?diff=unified&w=1

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
