### PR TITLE
fix(next-core): apply image-loader alias to the remaining context

### DIFF
--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -13677,13 +13677,13 @@
     "runtimeError": false
   },
   "test/integration/next-image-new/loader-config-edge-runtime/test/index.test.ts": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "Image Loader Config with Edge Runtime dev mode should add \"src\" to img1 based on the loader config",
       "Image Loader Config with Edge Runtime dev mode should add \"src\" to img2 based on the loader prop",
       "Image Loader Config with Edge Runtime dev mode should add \"srcset\" to img1 based on the loader config",
       "Image Loader Config with Edge Runtime dev mode should add \"srcset\" to img2 based on the loader prop"
     ],
+    "failed": [],
     "pending": [
       "Image Loader Config with Edge Runtime production mode should add \"src\" to img1 based on the loader config",
       "Image Loader Config with Edge Runtime production mode should add \"src\" to img2 based on the loader prop",


### PR DESCRIPTION
### What?

Fix custom image loader not being reflected in some contexts and running the default image loader when next.config.js is present. For Webpack, this alias is specified in `createWebpackAlias` (https://github.com/vercel/next.js/blob/8d28d5954e98060e3a478c6b82acb0fb11c5d6f2/packages/next/src/build/create-compiler-aliases.ts#L22) and this setting seems to be context-agnostic in base (https://github.com/vercel/next.js/blob/8d28d5954e98060e3a478c6b82acb0fb11c5d6f2/packages/next/src/build/webpack-config.ts#L649).

Closes PACK-2509