### PR TITLE
chore: hide version info network error

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -213,8 +213,7 @@ export async function getVersionInfo(enabled: boolean): Promise<VersionInfo> {
       latest: tags.latest,
       canary: tags.canary,
     })
-  } catch (e) {
-    console.error('parse version e', e)
+  } catch {
     return { installed, staleness: 'unknown' }
   }
 }

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -191,6 +191,14 @@ function erroredPages(compilation: webpack.Compilation) {
   return failedPages
 }
 
+const networkErrors = [
+  'EADDRINFO',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+]
+
 export async function getVersionInfo(enabled: boolean): Promise<VersionInfo> {
   let installed = '0.0.0'
 
@@ -206,14 +214,11 @@ export async function getVersionInfo(enabled: boolean): Promise<VersionInfo> {
 
     if (!res.ok) return { installed, staleness: 'unknown' }
 
-    const tags = await res.json()
+    const { latest, canary } = await res.json()
 
-    return parseVersionInfo({
-      installed,
-      latest: tags.latest,
-      canary: tags.canary,
-    })
-  } catch {
+    return parseVersionInfo({ installed, latest, canary })
+  } catch (e: any) {
+    if (!networkErrors.includes(e?.code)) console.error(e)
     return { installed, staleness: 'unknown' }
   }
 }

--- a/test/development/acceptance-app/version-staleness.test.ts
+++ b/test/development/acceptance-app/version-staleness.test.ts
@@ -7,10 +7,6 @@ import { outdent } from 'outdent'
 describe('Error Overlay version staleness', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: 'latest',
-      'react-dom': 'latest',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/version-staleness.test.ts
+++ b/test/development/acceptance-app/version-staleness.test.ts
@@ -4,7 +4,7 @@ import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
 
-describe.skip('Error Overlay version staleness', () => {
+describe('Error Overlay version staleness', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     dependencies: {


### PR DESCRIPTION
### What?

Currently, if the network call to the `https://registry.npmjs.org/-/package/next/dist-tags` endpoint fails, the error is still logged to the terminal.

### Why?

This might be unnecessary as it is likely unactionable and only creates noise for the user.

### How?

Drop the logging of the error if it's network-related, but log as before otherwise.
I.e: any other error should still show up:

![image](https://github.com/vercel/next.js/assets/18369201/1e01fe35-aed9-418c-8e0e-f4ee34624eb5)

But network errors should not:

![image](https://github.com/vercel/next.js/assets/18369201/9e350a27-0cb2-4160-a80a-7e8d990cf6fe)


I also re-enabled some related tests that were skipped.

Closes NEXT-2393

[Slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1707326242303969)