### PR TITLE
fix(build-log): clarify static Route Handler behavior

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/12-route-handlers.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/12-route-handlers.mdx
@@ -49,7 +49,7 @@ In addition to supporting native [Request](https://developer.mozilla.org/docs/We
 
 ### Caching
 
-Route Handlers are cached by default (unless they use a [dynamic function](#dynamic-functions)) when using the `GET` method with the `Response` object.
+Route Handlers are cached by default when using the `GET` method with the `Response` object.
 
 ```ts filename="app/items/route.ts" switcher
 export async function GET() {

--- a/docs/02-app/01-building-your-application/01-routing/12-route-handlers.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/12-route-handlers.mdx
@@ -49,7 +49,7 @@ In addition to supporting native [Request](https://developer.mozilla.org/docs/We
 
 ### Caching
 
-Route Handlers are cached by default when using the `GET` method with the `Response` object.
+Route Handlers are cached by default (unless they use a [dynamic function](#dynamic-functions)) when using the `GET` method with the `Response` object.
 
 ```ts filename="app/items/route.ts" switcher
 export async function GET() {

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -50,7 +50,7 @@ import type { ServerRuntime } from '../../types'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import { encodeMatchers } from './webpack/loaders/next-middleware-loader'
 import type { EdgeFunctionLoaderOptions } from './webpack/loaders/next-edge-function-loader'
-import { isAppRouteRoute } from '../lib/is-app-route-route'
+import { isRouteHandler } from '../lib/is-app-route-route'
 import { normalizeMetadataRoute } from '../lib/metadata/get-metadata-route'
 import { getRouteLoaderEntry } from './webpack/loaders/next-route-loader'
 import {
@@ -342,7 +342,7 @@ export function getEdgeServerEntry(opts: {
 }) {
   if (
     opts.pagesType === 'app' &&
-    isAppRouteRoute(opts.page) &&
+    isRouteHandler(opts.page) &&
     opts.appDirLoader
   ) {
     const loaderParams: EdgeAppRouteLoaderQuery = {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1886,6 +1886,7 @@ export default async function build(
                 let isPPR = false
                 let isSSG = false
                 let isStatic = false
+                let isRouteHandler = false
                 let isServerComponent = false
                 let isHybridAmp = false
                 let ssgPageRoutes: string[] | null = null
@@ -2004,6 +2005,7 @@ export default async function build(
                       )
 
                       if (pageType === 'app' && originalAppPath) {
+                        isRouteHandler = isAppRouteRoute(originalAppPath)
                         appNormalizedPaths.set(originalAppPath, page)
                         // TODO-APP: handle prerendering with edge
                         if (isEdgeRuntime(pageRuntime)) {
@@ -2226,6 +2228,7 @@ export default async function build(
                   size,
                   totalSize,
                   isStatic,
+                  isRouteHandler,
                   isSSG,
                   isPPR,
                   isHybridAmp,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -148,7 +148,7 @@ import {
 import { webpackBuild } from './webpack-build'
 import { NextBuildContext, type MappedPages } from './build-context'
 import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
-import { isRouteHandler } from '../lib/is-app-route-route'
+import { isRouteHandler as isRouteHandlerFn } from '../lib/is-app-route-route'
 import { createClientRouterFilter } from '../lib/create-client-router-filter'
 import { createValidFileMatcher } from '../server/lib/find-page-file'
 import { startTypeChecking } from './type-check'
@@ -2005,7 +2005,7 @@ export default async function build(
                       )
 
                       if (pageType === 'app' && originalAppPath) {
-                        isRouteHandler = isRouteHandler(originalAppPath)
+                        isRouteHandler = isRouteHandlerFn(originalAppPath)
                         appNormalizedPaths.set(originalAppPath, page)
                         // TODO-APP: handle prerendering with edge
                         if (isEdgeRuntime(pageRuntime)) {
@@ -2099,7 +2099,7 @@ export default async function build(
                           // an app page.
                           if (
                             !isStatic &&
-                            !isRouteHandler(originalAppPath) &&
+                            !isRouteHandlerFn(originalAppPath) &&
                             !isDynamicRoute(originalAppPath) &&
                             !isPPR &&
                             !isInterceptionRoute
@@ -2642,7 +2642,7 @@ export default async function build(
               })
             }
 
-            const isRouteHandler = isRouteHandler(originalAppPath)
+            const isRouteHandler = isRouteHandlerFn(originalAppPath)
 
             // When this is an app page and PPR is enabled, the route supports
             // partial pre-rendering.

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -148,7 +148,7 @@ import {
 import { webpackBuild } from './webpack-build'
 import { NextBuildContext, type MappedPages } from './build-context'
 import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
-import { isAppRouteRoute } from '../lib/is-app-route-route'
+import { isRouteHandler } from '../lib/is-app-route-route'
 import { createClientRouterFilter } from '../lib/create-client-router-filter'
 import { createValidFileMatcher } from '../server/lib/find-page-file'
 import { startTypeChecking } from './type-check'
@@ -2005,7 +2005,7 @@ export default async function build(
                       )
 
                       if (pageType === 'app' && originalAppPath) {
-                        isRouteHandler = isAppRouteRoute(originalAppPath)
+                        isRouteHandler = isRouteHandler(originalAppPath)
                         appNormalizedPaths.set(originalAppPath, page)
                         // TODO-APP: handle prerendering with edge
                         if (isEdgeRuntime(pageRuntime)) {
@@ -2099,7 +2099,7 @@ export default async function build(
                           // an app page.
                           if (
                             !isStatic &&
-                            !isAppRouteRoute(originalAppPath) &&
+                            !isRouteHandler(originalAppPath) &&
                             !isDynamicRoute(originalAppPath) &&
                             !isPPR &&
                             !isInterceptionRoute
@@ -2642,7 +2642,7 @@ export default async function build(
               })
             }
 
-            const isRouteHandler = isAppRouteRoute(originalAppPath)
+            const isRouteHandler = isRouteHandler(originalAppPath)
 
             // When this is an app page and PPR is enabled, the route supports
             // partial pre-rendering.

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -732,7 +732,7 @@ export async function printTreeView(
         usedSymbols.has('◎') && [
           '◎',
           '(Static)',
-          "Route Handler without dynamic API usage. Won't re-run at runtime.\n             Read more: https://nextjs.org/docs/app/building-your-application/routing/route-handlers#caching",
+          "Route Handler without dynamic API usage. Won't re-run at runtime.\n             Read more: https://nextjs.org/docs/app/building-your-application/routing/route-handlers#opting-out-of-caching",
         ],
         usedSymbols.has('●') && [
           '●',

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -497,7 +497,7 @@ export async function printTreeView(
         }
       } else if (pageInfo?.isStatic) {
         symbol = '○'
-        if (pageInfo.isRouteHandler) symbol += '*'
+        if (pageInfo.isRouteHandler) symbol = '◎'
       } else if (pageInfo?.isSSG) {
         symbol = '●'
       } else {
@@ -727,39 +727,39 @@ export async function printTreeView(
         usedSymbols.has('○') && [
           '○',
           '(Static)',
-          'prerendered as static content',
+          'Prerendered as static content',
         ],
-        usedSymbols.has('○*') && [
-          '○*',
+        usedSymbols.has('◎') && [
+          '◎',
           '(Static)',
-          "Route Handler without dynamic API usage. Won't re-run at runtime.\n              Read more: https://nextjs.org/docs/app/building-your-application/routing/route-handlers#caching",
+          "Route Handler without dynamic API usage. Won't re-run at runtime.\n             Read more: https://nextjs.org/docs/app/building-your-application/routing/route-handlers#caching",
         ],
         usedSymbols.has('●') && [
           '●',
           '(SSG)',
-          `prerendered as static HTML (uses ${cyan('getStaticProps')})`,
+          `Prerendered as static HTML (uses ${cyan('getStaticProps')})`,
         ],
         usedSymbols.has('ISR') && [
           '',
           '(ISR)',
-          `incremental static regeneration (uses revalidate in ${cyan(
+          `Incremental Static Regeneration (uses revalidate in ${cyan(
             'getStaticProps'
           )})`,
         ],
         usedSymbols.has('◐') && [
           '◐',
           '(Partial Prerender)',
-          'prerendered as static HTML with dynamic server-streamed content',
+          'Prerendered as static HTML with dynamic server-streamed content',
         ],
         usedSymbols.has('λ') && [
           'λ',
           '(Dynamic)',
-          `server-rendered on demand using Node.js`,
+          `Server-rendered on demand using Node.js`,
         ],
         usedSymbols.has('ℇ') && [
           'ℇ',
           '(Edge Runtime)',
-          `server-rendered on demand using the Edge Runtime`,
+          `Server-rendered on demand using the Edge Runtime`,
         ],
       ].filter((x) => x) as [string, string, string][],
       {

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -84,7 +84,6 @@ import { interopDefault } from '../lib/interop-default'
 import type { PageExtensions } from './page-extensions-type'
 import { formatDynamicImportPath } from '../lib/format-dynamic-import-path'
 import { isInterceptionRouteAppPath } from '../server/future/helpers/interception-routes'
-import { isAppRouteRoute } from '../lib/is-app-route-route'
 
 export type ROUTER_TYPE = 'pages' | 'app'
 

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -84,6 +84,7 @@ import { interopDefault } from '../lib/interop-default'
 import type { PageExtensions } from './page-extensions-type'
 import { formatDynamicImportPath } from '../lib/format-dynamic-import-path'
 import { isInterceptionRouteAppPath } from '../server/future/helpers/interception-routes'
+import { isAppRouteRoute } from '../lib/is-app-route-route'
 
 export type ROUTER_TYPE = 'pages' | 'app'
 
@@ -345,6 +346,7 @@ export interface PageInfo {
   isStatic: boolean
   isSSG: boolean
   isPPR: boolean
+  isRouteHandler: boolean
   ssgPageRoutes: string[] | null
   initialRevalidateSeconds: number | false
   pageDuration: number | undefined
@@ -495,6 +497,7 @@ export async function printTreeView(
         }
       } else if (pageInfo?.isStatic) {
         symbol = '○'
+        if (pageInfo.isRouteHandler) symbol += '*'
       } else if (pageInfo?.isSSG) {
         symbol = '●'
       } else {
@@ -725,6 +728,11 @@ export async function printTreeView(
           '○',
           '(Static)',
           'prerendered as static content',
+        ],
+        usedSymbols.has('○*') && [
+          '○*',
+          '(Static)',
+          "Route Handler without dynamic API usage. Won't re-run at runtime.\n              Read more: https://nextjs.org/docs/app/building-your-application/routing/route-handlers#caching",
         ],
         usedSymbols.has('●') && [
           '●',

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -14,7 +14,7 @@ import {
   createStaticMetadataFromRoute,
 } from './metadata/discover'
 import { promises as fs } from 'fs'
-import { isAppRouteRoute } from '../../../lib/is-app-route-route'
+import { isRouteHandler } from '../../../lib/is-app-route-route'
 import { isMetadataRoute } from '../../../lib/metadata/is-metadata-route'
 import type { NextConfig } from '../../../server/config-shared'
 import { AppPathnameNormalizer } from '../../../server/future/normalizers/built/app/app-pathname-normalizer'
@@ -669,7 +669,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
     return result
   }
 
-  if (isAppRouteRoute(name)) {
+  if (isRouteHandler(name)) {
     return createAppRouteCode({
       // TODO: investigate if the local `page` is the same as the loaderOptions.page
       page: loaderOptions.page,

--- a/packages/next/src/build/webpack/utils.ts
+++ b/packages/next/src/build/webpack/utils.ts
@@ -1,5 +1,5 @@
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
-import { isAppRouteRoute } from '../../lib/is-app-route-route'
+import { isRouteHandler } from '../../lib/is-app-route-route'
 
 export function traverseModules(
   compilation: webpack.Compilation,
@@ -43,7 +43,7 @@ export function forEachEntryModule(
     if (
       name.startsWith('pages/') ||
       // Skip for route.js entries
-      (name.startsWith('app/') && isAppRouteRoute(name))
+      (name.startsWith('app/') && isRouteHandler(name))
     ) {
       continue
     }

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -49,7 +49,7 @@ import { getPagePath } from '../server/require'
 import type { Span } from '../trace'
 import type { FontConfig } from '../server/font-utils'
 import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plugin'
-import { isAppRouteRoute } from '../lib/is-app-route-route'
+import { isRouteHandler } from '../lib/is-app-route-route'
 import { isAppPageRoute } from '../lib/is-app-page-route'
 import isError from '../lib/is-error'
 import { needsExperimentalReact } from '../lib/needs-experimental-react'
@@ -803,7 +803,7 @@ export async function exportAppImpl(
         const appPageName = mapAppRouteToPage.get(srcRoute || '')
         const pageName = appPageName || srcRoute || route
         const isAppPath = Boolean(appPageName)
-        const isAppRouteHandler = appPageName && isAppRouteRoute(appPageName)
+        const isAppRouteHandler = appPageName && isRouteHandler(appPageName)
 
         // returning notFound: true from getStaticProps will not
         // output html/json files during the build

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -25,7 +25,7 @@ import { addRequestMeta } from '../server/request-meta'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 
 import { createRequestResponseMocks } from '../server/lib/mock-request'
-import { isAppRouteRoute } from '../lib/is-app-route-route'
+import { isRouteHandler } from '../lib/is-app-route-route'
 import { hasNextSupport } from '../telemetry/ci-info'
 import { exportAppRoute } from './routes/app-route'
 import { exportAppPage } from './routes/app-page'
@@ -240,7 +240,7 @@ async function exportPageImpl(
         : undefined
 
     // Handle App Routes.
-    if (isAppDir && isAppRouteRoute(page)) {
+    if (isAppDir && isRouteHandler(page)) {
       return await exportAppRoute(
         req,
         res,

--- a/packages/next/src/lib/is-app-route-route.ts
+++ b/packages/next/src/lib/is-app-route-route.ts
@@ -1,3 +1,3 @@
-export function isAppRouteRoute(route: string): boolean {
+export function isRouteHandler(route: string): boolean {
   return route.endsWith('/route')
 }

--- a/packages/next/src/server/future/route-matcher-providers/app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/app-route-route-matcher-provider.ts
@@ -1,4 +1,4 @@
-import { isAppRouteRoute } from '../../../lib/is-app-route-route'
+import { isRouteHandler } from '../../../lib/is-app-route-route'
 import { APP_PATHS_MANIFEST } from '../../../shared/lib/constants'
 import { RouteKind } from '../route-kind'
 import { AppRouteRouteMatcher } from '../route-matchers/app-route-route-matcher'
@@ -22,7 +22,7 @@ export class AppRouteRouteMatcherProvider extends ManifestRouteMatcherProvider<A
     manifest: Manifest
   ): Promise<ReadonlyArray<AppRouteRouteMatcher>> {
     // This matcher only matches app routes.
-    const pages = Object.keys(manifest).filter((page) => isAppRouteRoute(page))
+    const pages = Object.keys(manifest).filter((page) => isRouteHandler(page))
 
     // Format the routes.
     const matchers: Array<AppRouteRouteMatcher> = []

--- a/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/future/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
@@ -3,7 +3,7 @@ import type { Normalizer } from '../../normalizers/normalizer'
 import { AppRouteRouteMatcher } from '../../route-matchers/app-route-route-matcher'
 import { RouteKind } from '../../route-kind'
 import { FileCacheRouteMatcherProvider } from './file-cache-route-matcher-provider'
-import { isAppRouteRoute } from '../../../../lib/is-app-route-route'
+import { isRouteHandler } from '../../../../lib/is-app-route-route'
 import { DevAppNormalizers } from '../../normalizers/built/app'
 
 export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvider<AppRouteRouteMatcher> {
@@ -31,7 +31,7 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
       const page = this.normalizers.page.normalize(filename)
 
       // If the file isn't a match for this matcher, then skip it.
-      if (!isAppRouteRoute(page)) continue
+      if (!isRouteHandler(page)) continue
 
       // Validate that this is not an ignored page.
       if (page.includes('/_')) continue

--- a/test/production/app-dir/build-output/index.test.ts
+++ b/test/production/app-dir/build-output/index.test.ts
@@ -6,6 +6,7 @@ createNextDescribe(
   {
     files: {
       'app/page.tsx': `export default function Page() { return null }`,
+      'app/foo/route.ts': `export function GET() { return Response.json("foo") }`,
       'app/layout.tsx': `export default function Layout({ children }) {
         return (
           <html><body>{children}</body></html>
@@ -44,7 +45,10 @@ createNextDescribe(
       expect(output).toContain('└ other shared chunks (total)')
 
       // output type
-      expect(output).toContain('○  (Static)  prerendered as static content')
+      expect(output).toContain('○  (Static)  Prerendered as static content')
+      expect(output).toContain(
+        '◎  (Static)  Route Handler without dynamic API usage'
+      )
     })
   }
 )


### PR DESCRIPTION
### What?

Clarify the log messages what happens when a `GET` Route Handler is statically pre-rendered

### Why?

`GET` Route Handlers that do not call dynamic functions are [cached by default](https://nextjs.org/docs/app/building-your-application/routing/route-handlers#caching) and their result won't change during runtime (the method's output is saved and served back from cache, so for example `console.log` will only show up during build.)

### How?

Introducing a new category, similar to the existing `○   (Static)` legend type.

`◎` will get its description, with a link to the [relevant documentation](https://nextjs.org/docs/app/building-your-application/routing/route-handlers#opting-out-of-caching).

Example output:
```
Route (app)                              Size     First Load JS
┌ ○ /                                    5.02 kB        89.7 kB
├ ○ /_not-found                          864 B          85.5 kB
└ ◎ /foo                                 0 B                0 B
+ First Load JS shared by all            84.6 kB
  ├ chunks/main-app-631469d1fde5cd2d.js  83 kB
  └ other shared chunks (total)          1.64 kB


○   (Static)  Prerendered as static content
◎   (Static)  Route Handler without dynamic API usage. Won't be re-evaluated at runtime.
              Read more: https://nextjs.org/docs/app/building-your-application/routing/route-handlers#opting-out-of-caching
```

---

**Note**: I tried `○*` as an alternative symbol, but that shifts the `/foo` path as such:

```
├ ○ /_not-found                          864 B          85.5 kB
└ ○* /foo                                0 B                0 B
```

which would require additional logic to append an extra ` ` between every other symbol <-> path when this category is present, making the path positions variable. (This could for example be an issue if somebody relies on the format of our build logs)

- Additionally, renamed the internal `isAppRouteRoute` to `isRouteHandler` for clarity. (`Route` is the name of the primitive for both Route Handlers and pages inside the App Router. This should make it a bit clearer what this function asserts.)

- Also capitalized the legend descriptions, to be consistent, as most of the text is capitalized elsewhere too.

Closes NEXT-2368
Closes #59208

