### PR TITLE
fix: add `zeromq` to server-external-packages.json

### DIFF
--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -50,5 +50,6 @@
   "typescript",
   "vscode-oniguruma",
   "webpack",
-  "websocket"
+  "websocket",
+  "zeromq"
 ]


### PR DESCRIPTION
The package [`zeromq`](https://unpkg.com/browse/zeromq@6.0.0-beta.19/) contains native `.node` files that cannot be bundled (similar to https://github.com/vercel/next.js/pull/60243)

- Fixes https://github.com/vercel/next.js/issues/61844

Closes NEXT-2507