### PR TITLE
Allow empty array in `generateStaticParams`

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2129,17 +2129,21 @@ export default async function build(
                           const appConfig = workerResult.appConfig || {}
                           if (appConfig.revalidate !== 0) {
                             const isDynamic = isDynamicRoute(page)
+                            const prerenderedRoutes =
+                              workerResult.prerenderedRoutes
+                            const generateStaticParamsIsDefined =
+                              prerenderedRoutes !== undefined
                             const hasGenerateStaticParams =
-                              workerResult.prerenderedRoutes &&
-                              workerResult.prerenderedRoutes.length > 0
+                              generateStaticParamsIsDefined &&
+                              prerenderedRoutes.length > 0
 
                             if (
                               config.output === 'export' &&
                               isDynamic &&
-                              !hasGenerateStaticParams
+                              !generateStaticParamsIsDefined
                             ) {
                               throw new Error(
-                                `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
+                                `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config. Return an empty array if no pages should be rendered.`
                               )
                             }
 

--- a/test/e2e/app-dir/empty-static-params/app/dynamic/[id]/page.tsx
+++ b/test/e2e/app-dir/empty-static-params/app/dynamic/[id]/page.tsx
@@ -1,0 +1,7 @@
+export default function Page({ params: { id } }) {
+  return <p>{id}</p>
+}
+
+export function generateStaticParams() {
+  return []
+}

--- a/test/e2e/app-dir/empty-static-params/app/layout.tsx
+++ b/test/e2e/app-dir/empty-static-params/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/empty-static-params/app/page.tsx
+++ b/test/e2e/app-dir/empty-static-params/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/empty-static-params/empty-static-params.test.ts
+++ b/test/e2e/app-dir/empty-static-params/empty-static-params.test.ts
@@ -6,7 +6,7 @@ createNextDescribe(
     files: __dirname,
   },
   () => {
-    // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
+    // Runs a dummy test to ensure the test suite has built while working around the fact that `next start` does not work with exports
     it('should have built', async () => {})
   }
 )

--- a/test/e2e/app-dir/empty-static-params/empty-static-params.test.ts
+++ b/test/e2e/app-dir/empty-static-params/empty-static-params.test.ts
@@ -1,0 +1,12 @@
+import { createNextDescribe } from 'e2e-utils'
+
+createNextDescribe(
+  'empty-static-params',
+  {
+    files: __dirname,
+  },
+  () => {
+    // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
+    it('should have built', async () => {})
+  }
+)

--- a/test/e2e/app-dir/empty-static-params/next.config.js
+++ b/test/e2e/app-dir/empty-static-params/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

This PR attempts to tweak Next's internal logic as little as is necessary to allow the `generateStaticParams` function to return an empty array. 
An e2e test has been added to catch regressions, but it relies on an ugly workaround: as `output: export` isn't quite handled in e2e tests we use an always-succeeding stub test to ensure the build works without using `next start`. It's possible an integration test would be more appropriate here, but the docs lightly discourage them so I figured this would be the best place to start.

Fixes #61213