### PR TITLE
test: Make css bundle assertion work also for turbopack

### DIFF
--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -291,7 +291,7 @@ createNextDescribe(
           expect(
             [
               ...html.matchAll(
-                /<link rel="stylesheet" href="[^.]+\.css(\?v=\d+)?"/g
+                /<link rel="stylesheet" href=".+\.css(\?v=\d+)?"/g
               ),
             ].length
           ).toBe(3)

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -288,10 +288,12 @@ createNextDescribe(
       describe('chunks', () => {
         it('should bundle css resources into chunks', async () => {
           const html = await next.render('/dashboard')
+
+          expect(html).toMatchSnapshot()
           expect(
             [
               ...html.matchAll(
-                /<link rel="stylesheet" href=".+\.css(\?v=\d+)?"/g
+                /<link rel="stylesheet" href="[^<]+\.css(\?v=\d+)?"/g
               ),
             ].length
           ).toBe(3)

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -289,7 +289,6 @@ createNextDescribe(
         it('should bundle css resources into chunks', async () => {
           const html = await next.render('/dashboard')
 
-          expect(html).toMatchSnapshot()
           expect(
             [
               ...html.matchAll(

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -2475,10 +2475,10 @@
       "app dir - css sass support server layouts should support sass/scss modules inside server layouts",
       "app dir - css sass support server pages should support global sass/scss inside server pages",
       "app dir - css sass support server pages should support sass/scss modules inside server pages",
-      "app dir - css HMR should not create duplicate link tags during HMR"
+      "app dir - css HMR should not create duplicate link tags during HMR",
+      "app dir - css css support chunks should bundle css resources into chunks"
     ],
     "failed": [
-      "app dir - css css support chunks should bundle css resources into chunks",
       "app dir - css css support should not preload styles twice during HMR"
     ],
     "pending": [


### PR DESCRIPTION
### What?

Fix one assertion about CSS files emitted by turbopack.

### Why?

Turbopack generates `/_next/static/chunks/2225ce._.css`, which does not match the regex.
Note that it has `._.css`. The previous assertions match on `[^.]+\.css`, which does not support two dots in the file name.

I tried `/<link rel="stylesheet" href=".+\.css(\?v=\d+)?"/g`, but it captured 3 `link` tags at once. So I used `/<link rel="stylesheet" href="[^<]+\.css(\?v=\d+)?"/g`.


### How?

Closes PACK-2413
