### PR TITLE
test: Make css deduplication assertion work for turbopack

### DIFF
--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -457,11 +457,22 @@ createNextDescribe(
           it('should only include the same style once in the flight data', async () => {
             const initialHtml = await next.render('/css/css-duplicate-2/server')
 
-            // Even if it's deduped by Float, it should still only be included once in the payload.
-            // There are 3 matches, one for the rendered <link>, one for float preload and one for the <link> inside flight payload.
-            expect(
-              initialHtml.match(/css-duplicate-2\/layout\.css\?v=/g).length
-            ).toBe(3)
+            if (process.env.TURBOPACK) {
+              expect(
+                initialHtml.match(/app_css_css-duplicate-2_[\w]+\.css/g).length
+              ).toBe(5)
+            } else {
+              // Even if it's deduped by Float, it should still only be included once in the payload.
+              // There are 3 matches, one for the rendered <link>, one for float preload and one for the <link> inside flight payload.
+
+              expect(
+                initialHtml.match(/css-duplicate-2\/layout\.css\?v=/g).length
+              ).toBe(3)
+              // Links in data-precedence does not have `?v=` query
+              expect(
+                initialHtml.match(/css-duplicate-2\/layout\.css/g).length
+              ).toBe(5)
+            }
           })
 
           it.skip('should only load chunks for the css module that is used by the specific entrypoint', async () => {

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -2451,6 +2451,7 @@
       "app dir - css css support client pages should support global css inside client pages",
       "app dir - css css support css ordering should have inner layers take precedence over outer layers",
       "app dir - css css support multiple entries should deduplicate styles on the module level",
+      "app dir - css css support multiple entries should only include the same style once in the flight data",
       "app dir - css css support page extensions should include css imported in MDX pages",
       "app dir - css css support server layouts should support css modules inside server layouts",
       "app dir - css css support server pages should not contain pages css in app dir page",
@@ -2478,7 +2479,6 @@
     ],
     "failed": [
       "app dir - css css support chunks should bundle css resources into chunks",
-      "app dir - css css support multiple entries should only include the same style once in the flight data",
       "app dir - css css support should not preload styles twice during HMR"
     ],
     "pending": [


### PR DESCRIPTION
### What?

Fix one assertion about CSS files emitted by turbopack.

### Why?

Webpack generates 3 links with `?v=` query, and 2 extra links without `?v=` query. Turbopack does not have query string, so we match 5 links.

### How?

Closes PACK-2414
