### PR TITLE
chore: update test template to use `nextTestSetup`

### DIFF
--- a/test/e2e/app-dir/test-template/{{ toFileName name }}/{{ toFileName name }}.test.ts
+++ b/test/e2e/app-dir/test-template/{{ toFileName name }}/{{ toFileName name }}.test.ts
@@ -1,34 +1,32 @@
-import { createNextDescribe } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
-createNextDescribe(
-  '{{name}}',
-  {
+describe('{{name}}', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-  },
-  ({ next }) => {
-    // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
-    it('should work using cheerio', async () => {
-      const $ = await next.render$('/')
-      expect($('p').text()).toBe('hello world')
-    })
+  })
 
-    // Recommended for tests that need a full browser
-    it('should work using browser', async () => {
-      const browser = await next.browser('/')
-      expect(await browser.elementByCss('p').text()).toBe('hello world')
-    })
+  // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
+  it('should work using cheerio', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
 
-    // In case you need the full HTML. Can also use $.html() with cheerio.
-    it('should work with html', async () => {
-      const html = await next.render('/')
-      expect(html).toContain('hello world')
-    })
+  // Recommended for tests that need a full browser
+  it('should work using browser', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+  })
 
-    // In case you need to test the response object
-    it('should work with fetch', async () => {
-      const res = await next.fetch('/')
-      const html = await res.text()
-      expect(html).toContain('hello world')
-    })
-  }
-)
+  // In case you need the full HTML. Can also use $.html() with cheerio.
+  it('should work with html', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('hello world')
+  })
+
+  // In case you need to test the response object
+  it('should work with fetch', async () => {
+    const res = await next.fetch('/')
+    const html = await res.text()
+    expect(html).toContain('hello world')
+  })
+})

--- a/test/e2e/example.txt
+++ b/test/e2e/example.txt
@@ -1,34 +1,32 @@
-import { createNextDescribe } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
-createNextDescribe(
-  '{{name}}',
-  {
+describe('{{name}}', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-  },
-  ({ next }) => {
-    // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
-    it('should work using cheerio', async () => {
-      const $ = await next.render$('/')
-      expect($('p').text()).toBe('hello world')
-    })
+  })
 
-    // Recommended for tests that need a full browser
-    it('should work using browser', async () => {
-      const browser = await next.browser('/')
-      expect(await browser.elementByCss('p').text()).toBe('hello world')
-    })
+  // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
+  it('should work using cheerio', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
 
-    // In case you need the full HTML. Can also use $.html() with cheerio.
-    it('should work with html', async () => {
-      const html = await next.render('/')
-      expect(html).toContain('hello world')
-    })
+  // Recommended for tests that need a full browser
+  it('should work using browser', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+  })
 
-    // In case you need to test the response object
-    it('should work with fetch', async () => {
-      const res = await next.fetch('/')
-      const html = await res.text()
-      expect(html).toContain('hello world')
-    })
-  }
-)
+  // In case you need the full HTML. Can also use $.html() with cheerio.
+  it('should work with html', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('hello world')
+  })
+
+  // In case you need to test the response object
+  it('should work with fetch', async () => {
+    const res = await next.fetch('/')
+    const html = await res.text()
+    expect(html).toContain('hello world')
+  })
+})

--- a/test/e2e/test-template/{{ toFileName name }}/{{ toFileName name }}.test.ts
+++ b/test/e2e/test-template/{{ toFileName name }}/{{ toFileName name }}.test.ts
@@ -1,34 +1,32 @@
-import { createNextDescribe } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
-createNextDescribe(
-  '{{name}}',
-  {
+describe('{{name}}', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-  },
-  ({ next }) => {
-    // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
-    it('should work using cheerio', async () => {
-      const $ = await next.render$('/')
-      expect($('p').text()).toBe('hello world')
-    })
+  })
 
-    // Recommended for tests that need a full browser
-    it('should work using browser', async () => {
-      const browser = await next.browser('/')
-      expect(await browser.elementByCss('p').text()).toBe('hello world')
-    })
+  // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
+  it('should work using cheerio', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
 
-    // In case you need the full HTML. Can also use $.html() with cheerio.
-    it('should work with html', async () => {
-      const html = await next.render('/')
-      expect(html).toContain('hello world')
-    })
+  // Recommended for tests that need a full browser
+  it('should work using browser', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+  })
 
-    // In case you need to test the response object
-    it('should work with fetch', async () => {
-      const res = await next.fetch('/')
-      const html = await res.text()
-      expect(html).toContain('hello world')
-    })
-  }
-)
+  // In case you need the full HTML. Can also use $.html() with cheerio.
+  it('should work with html', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('hello world')
+  })
+
+  // In case you need to test the response object
+  it('should work with fetch', async () => {
+    const res = await next.fetch('/')
+    const html = await res.text()
+    expect(html).toContain('hello world')
+  })
+})

--- a/test/e2e/test-utils-tests/basic/basic.test.ts
+++ b/test/e2e/test-utils-tests/basic/basic.test.ts
@@ -1,14 +1,12 @@
-import { createNextDescribe } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
-createNextDescribe(
-  'createNextDescribe',
-  {
+describe('nextTestSetup', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-  },
-  ({ next }) => {
-    it('should work', async () => {
-      const res = await next.fetch('/')
-      expect(await res.text()).toContain('Hello World')
-    })
-  }
-)
+  })
+
+  it('should work', async () => {
+    const res = await next.fetch('/')
+    expect(await res.text()).toContain('Hello World')
+  })
+})

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -6394,7 +6394,7 @@
     "runtimeError": false
   },
   "test/e2e/test-utils-tests/basic/basic.test.ts": {
-    "passed": ["createNextDescribe should work"],
+    "passed": ["nextTestSetup should work"],
     "failed": [],
     "pending": [],
     "flakey": [],


### PR DESCRIPTION
### Why?

Less indentation and allows for IDE integration.



Closes PACK-2523