### PR TITLE
Fix sendGAEvent function (for real?)

### DIFF
--- a/packages/third-parties/src/google/ga.tsx
+++ b/packages/third-parties/src/google/ga.tsx
@@ -54,14 +54,14 @@ export function GoogleAnalytics(props: GAParams) {
   )
 }
 
-export const sendGAEvent = (...args: Object[]) => {
+export function sendGAEvent(..._args: Object[]) {
   if (currDataLayerName === undefined) {
     console.warn(`@next/third-parties: GA has not been initialized`)
     return
   }
 
   if (window[currDataLayerName]) {
-    window[currDataLayerName].push(args)
+    window[currDataLayerName].push(arguments)
   } else {
     console.warn(
       `@next/third-parties: GA dataLayer ${currDataLayerName} does not exist`


### PR DESCRIPTION
The recently merged PR - https://github.com/vercel/next.js/pull/62065, doesn't seem to fix the issue. As per the comment this seems to be related to `dataLayer` that does not like working with Arrays, but works with [arguments object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments). Also, when using window.gtag(...) an Arguments() is pushed instead of Array().

Fixes #61703 
