### PR TITLE
docs: clarify `notFound`/`redirect`/`permanentRedirect` APIs

### DIFF
--- a/packages/next/src/client/components/not-found.ts
+++ b/packages/next/src/client/components/not-found.ts
@@ -16,7 +16,7 @@ type NotFoundError = Error & { digest: typeof NOT_FOUND_ERROR_CODE }
  *
  * Read more: [Next.js Docs: `notFound`](https://nextjs.org/docs/app/api-reference/functions/not-found)
  *
- * @note `notFound()` throws an Error instance with `NEXT_NOT_FOUND` as the error message. Make sure to not catch this error in your code.
+ * @note `notFound()` throws an Error instance with `NEXT_NOT_FOUND` as the error message.
  */
 export function notFound(): never {
   // eslint-disable-next-line no-throw-literal

--- a/packages/next/src/client/components/not-found.ts
+++ b/packages/next/src/client/components/not-found.ts
@@ -15,6 +15,8 @@ type NotFoundError = Error & { digest: typeof NOT_FOUND_ERROR_CODE }
  * - In a Route Handler or Server Action, it will serve a 404 to the caller.
  *
  * Read more: [Next.js Docs: `notFound`](https://nextjs.org/docs/app/api-reference/functions/not-found)
+ *
+ * @note `notFound()` throws an Error instance with `NEXT_NOT_FOUND` as the error message. Make sure to not catch this error in your code.
  */
 export function notFound(): never {
   // eslint-disable-next-line no-throw-literal

--- a/packages/next/src/client/components/redirect.ts
+++ b/packages/next/src/client/components/redirect.ts
@@ -39,6 +39,8 @@ export function getRedirectError(
  * - In a Route Handler or Server Action, it will serve a 307/303 to the caller.
  *
  * Read more: [Next.js Docs: `redirect`](https://nextjs.org/docs/app/api-reference/functions/redirect)
+ *
+ * @note `redirect()` throws an Error instance with `NEXT_REDIRECT` as the error message. Make sure to not catch this error in your code.
  */
 export function redirect(
   /** The URL to redirect to */
@@ -68,6 +70,8 @@ export function redirect(
  * - In a Route Handler or Server Action, it will serve a 308/303 to the caller.
  *
  * Read more: [Next.js Docs: `redirect`](https://nextjs.org/docs/app/api-reference/functions/redirect)
+ *
+ * @note `permanentRedirect()` throws an Error instance with `NEXT_REDIRECT` as the error message. Make sure to not catch this error in your code.
  */
 export function permanentRedirect(
   /** The URL to redirect to */

--- a/packages/next/src/client/components/redirect.ts
+++ b/packages/next/src/client/components/redirect.ts
@@ -40,7 +40,7 @@ export function getRedirectError(
  *
  * Read more: [Next.js Docs: `redirect`](https://nextjs.org/docs/app/api-reference/functions/redirect)
  *
- * @note `redirect()` throws an Error instance with `NEXT_REDIRECT` as the error message. Make sure to not catch this error in your code.
+ * @note `redirect()` throws an Error instance with `NEXT_REDIRECT` as the error message.
  */
 export function redirect(
   /** The URL to redirect to */

--- a/packages/next/src/client/components/redirect.ts
+++ b/packages/next/src/client/components/redirect.ts
@@ -71,7 +71,7 @@ export function redirect(
  *
  * Read more: [Next.js Docs: `redirect`](https://nextjs.org/docs/app/api-reference/functions/redirect)
  *
- * @note `permanentRedirect()` throws an Error instance with `NEXT_REDIRECT` as the error message. Make sure to not catch this error in your code.
+ * @note `permanentRedirect()` throws an Error instance with `NEXT_REDIRECT` as the error message.
  */
 export function permanentRedirect(
   /** The URL to redirect to */


### PR DESCRIPTION
### What?

We should explain that when certain APIs are called - `notFound`, `redirect`, `permanentRedirect` - they will throw an Error that Next.js should handle and not be caught in user code.

![image](https://github.com/vercel/next.js/assets/18369201/7d510830-815e-4d8e-8a55-06063dd8acf4)

### Why?

Some examples where this caused confusion:

https://github.com/vercel/next.js/issues/59930
https://github.com/vercel/next.js/issues/58002
https://github.com/vercel/next.js/issues/55586
https://github.com/vercel/next.js/issues/50757
https://github.com/vercel/next.js/issues/49298
https://github.com/nextauthjs/next-auth/issues/8027
https://github.com/nextauthjs/next-auth/issues/10056

### How?

As an immediate solution, this PR just adds some comments to the APIs for IDEs.

For the reviewer, see [this Slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1705918598465519) for a suggestion of a longer-term solution.

Closes NEXT-2520