### PR TITLE
Update split chunk handling for edge/node

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -921,6 +921,8 @@ export default async function getBaseWebpackConfig(
         const frameworkCacheGroup = {
           chunks: 'all' as const,
           name: 'framework',
+          // Ensures the framework chunk is not created for App Router.
+          layer: isWebpackDefaultLayer,
           test(module: any) {
             const resource = module.nameForCondition?.()
             return resource
@@ -993,53 +995,52 @@ export default async function getBaseWebpackConfig(
         }
 
         // server chunking
-        if (isNodeServer || isEdgeServer) {
-          if (dev) {
-            /*
+        if (isNodeServer && dev) {
+          /*
               In development, we want to split code that comes from `node_modules` into their own chunks.
               This is because in development, we often need to reload the user bundle due to changes in the code.
               To work around this, we put all the vendor code into separate chunks so that we don't need to reload them.
               This is safe because the vendor code doesn't change between reloads.
             */
-            const extractRootNodeModule = (modulePath: string) => {
-              // This regex is used to extract the root node module name to be used as the chunk group name.
-              // example: ../../node_modules/.pnpm/next@10/foo/node_modules/bar -> next@10
-              const regex =
-                /node_modules(?:\/|\\)\.?(?:pnpm(?:\/|\\))?([^/\\]+)/
-              const match = modulePath.match(regex)
-              return match ? match[1] : null
-            }
-            return {
-              cacheGroups: {
-                // this chunk configuration gives us a separate chunk for each top level module in node_modules
-                // or a hashed chunk if we can't extract the module name.
-                vendor: {
-                  chunks: 'all',
-                  reuseExistingChunk: true,
-                  test: /[\\/]node_modules[\\/]/,
-                  minSize: 0,
-                  minChunks: 1,
-                  maxAsyncRequests: 300,
-                  maxInitialRequests: 300,
-                  name: (module: webpack.Module) => {
-                    const moduleId = module.nameForCondition()!
-                    const rootModule = extractRootNodeModule(moduleId)
-                    if (rootModule) {
-                      return `vendor-chunks/${rootModule}`
-                    } else {
-                      const hash = crypto.createHash('sha1').update(moduleId)
-                      hash.update(moduleId)
-                      return `vendor-chunks/${hash.digest('hex')}`
-                    }
-                  },
-                },
-                // disable the default chunk groups
-                default: false,
-                defaultVendors: false,
-              },
-            }
+          const extractRootNodeModule = (modulePath: string) => {
+            // This regex is used to extract the root node module name to be used as the chunk group name.
+            // example: ../../node_modules/.pnpm/next@10/foo/node_modules/bar -> next@10
+            const regex = /node_modules(?:\/|\\)\.?(?:pnpm(?:\/|\\))?([^/\\]+)/
+            const match = modulePath.match(regex)
+            return match ? match[1] : null
           }
+          return {
+            cacheGroups: {
+              // this chunk configuration gives us a separate chunk for each top level module in node_modules
+              // or a hashed chunk if we can't extract the module name.
+              vendor: {
+                chunks: 'all',
+                reuseExistingChunk: true,
+                test: /[\\/]node_modules[\\/]/,
+                minSize: 0,
+                minChunks: 1,
+                maxAsyncRequests: 300,
+                maxInitialRequests: 300,
+                name: (module: webpack.Module) => {
+                  const moduleId = module.nameForCondition()!
+                  const rootModule = extractRootNodeModule(moduleId)
+                  if (rootModule) {
+                    return `vendor-chunks/${rootModule}`
+                  } else {
+                    const hash = crypto.createHash('sha1').update(moduleId)
+                    hash.update(moduleId)
+                    return `vendor-chunks/${hash.digest('hex')}`
+                  }
+                },
+              },
+              // disable the default chunk groups
+              default: false,
+              defaultVendors: false,
+            },
+          }
+        }
 
+        if (isNodeServer || isEdgeServer) {
           return {
             filename: `${isEdgeServer ? 'edge-chunks/' : ''}[name].js`,
             cacheGroups: {

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -995,49 +995,54 @@ export default async function getBaseWebpackConfig(
         }
 
         // server chunking
-        if (isNodeServer && dev) {
-          /*
+        if (dev) {
+          if (isNodeServer) {
+            /*
               In development, we want to split code that comes from `node_modules` into their own chunks.
               This is because in development, we often need to reload the user bundle due to changes in the code.
               To work around this, we put all the vendor code into separate chunks so that we don't need to reload them.
               This is safe because the vendor code doesn't change between reloads.
             */
-          const extractRootNodeModule = (modulePath: string) => {
-            // This regex is used to extract the root node module name to be used as the chunk group name.
-            // example: ../../node_modules/.pnpm/next@10/foo/node_modules/bar -> next@10
-            const regex = /node_modules(?:\/|\\)\.?(?:pnpm(?:\/|\\))?([^/\\]+)/
-            const match = modulePath.match(regex)
-            return match ? match[1] : null
-          }
-          return {
-            cacheGroups: {
-              // this chunk configuration gives us a separate chunk for each top level module in node_modules
-              // or a hashed chunk if we can't extract the module name.
-              vendor: {
-                chunks: 'all',
-                reuseExistingChunk: true,
-                test: /[\\/]node_modules[\\/]/,
-                minSize: 0,
-                minChunks: 1,
-                maxAsyncRequests: 300,
-                maxInitialRequests: 300,
-                name: (module: webpack.Module) => {
-                  const moduleId = module.nameForCondition()!
-                  const rootModule = extractRootNodeModule(moduleId)
-                  if (rootModule) {
-                    return `vendor-chunks/${rootModule}`
-                  } else {
-                    const hash = crypto.createHash('sha1').update(moduleId)
-                    hash.update(moduleId)
-                    return `vendor-chunks/${hash.digest('hex')}`
-                  }
+            const extractRootNodeModule = (modulePath: string) => {
+              // This regex is used to extract the root node module name to be used as the chunk group name.
+              // example: ../../node_modules/.pnpm/next@10/foo/node_modules/bar -> next@10
+              const regex =
+                /node_modules(?:\/|\\)\.?(?:pnpm(?:\/|\\))?([^/\\]+)/
+              const match = modulePath.match(regex)
+              return match ? match[1] : null
+            }
+            return {
+              cacheGroups: {
+                // this chunk configuration gives us a separate chunk for each top level module in node_modules
+                // or a hashed chunk if we can't extract the module name.
+                vendor: {
+                  chunks: 'all',
+                  reuseExistingChunk: true,
+                  test: /[\\/]node_modules[\\/]/,
+                  minSize: 0,
+                  minChunks: 1,
+                  maxAsyncRequests: 300,
+                  maxInitialRequests: 300,
+                  name: (module: webpack.Module) => {
+                    const moduleId = module.nameForCondition()!
+                    const rootModule = extractRootNodeModule(moduleId)
+                    if (rootModule) {
+                      return `vendor-chunks/${rootModule}`
+                    } else {
+                      const hash = crypto.createHash('sha1').update(moduleId)
+                      hash.update(moduleId)
+                      return `vendor-chunks/${hash.digest('hex')}`
+                    }
+                  },
                 },
+                // disable the default chunk groups
+                default: false,
+                defaultVendors: false,
               },
-              // disable the default chunk groups
-              default: false,
-              defaultVendors: false,
-            },
+            }
           }
+
+          return false
         }
 
         if (isNodeServer || isEdgeServer) {

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -918,6 +918,57 @@ export default async function getBaseWebpackConfig(
       splitChunks: (():
         | Required<webpack.Configuration>['optimization']['splitChunks']
         | false => {
+        // server chunking
+        if (dev) {
+          if (isNodeServer) {
+            /*
+              In development, we want to split code that comes from `node_modules` into their own chunks.
+              This is because in development, we often need to reload the user bundle due to changes in the code.
+              To work around this, we put all the vendor code into separate chunks so that we don't need to reload them.
+              This is safe because the vendor code doesn't change between reloads.
+            */
+            const extractRootNodeModule = (modulePath: string) => {
+              // This regex is used to extract the root node module name to be used as the chunk group name.
+              // example: ../../node_modules/.pnpm/next@10/foo/node_modules/bar -> next@10
+              const regex =
+                /node_modules(?:\/|\\)\.?(?:pnpm(?:\/|\\))?([^/\\]+)/
+              const match = modulePath.match(regex)
+              return match ? match[1] : null
+            }
+            return {
+              cacheGroups: {
+                // this chunk configuration gives us a separate chunk for each top level module in node_modules
+                // or a hashed chunk if we can't extract the module name.
+                vendor: {
+                  chunks: 'all',
+                  reuseExistingChunk: true,
+                  test: /[\\/]node_modules[\\/]/,
+                  minSize: 0,
+                  minChunks: 1,
+                  maxAsyncRequests: 300,
+                  maxInitialRequests: 300,
+                  name: (module: webpack.Module) => {
+                    const moduleId = module.nameForCondition()!
+                    const rootModule = extractRootNodeModule(moduleId)
+                    if (rootModule) {
+                      return `vendor-chunks/${rootModule}`
+                    } else {
+                      const hash = crypto.createHash('sha1').update(moduleId)
+                      hash.update(moduleId)
+                      return `vendor-chunks/${hash.digest('hex')}`
+                    }
+                  },
+                },
+                // disable the default chunk groups
+                default: false,
+                defaultVendors: false,
+              },
+            }
+          }
+
+          return false
+        }
+
         const frameworkCacheGroup = {
           chunks: 'all' as const,
           name: 'framework',
@@ -992,57 +1043,6 @@ export default async function getBaseWebpackConfig(
           priority: 30,
           minChunks: 1,
           reuseExistingChunk: true,
-        }
-
-        // server chunking
-        if (dev) {
-          if (isNodeServer) {
-            /*
-              In development, we want to split code that comes from `node_modules` into their own chunks.
-              This is because in development, we often need to reload the user bundle due to changes in the code.
-              To work around this, we put all the vendor code into separate chunks so that we don't need to reload them.
-              This is safe because the vendor code doesn't change between reloads.
-            */
-            const extractRootNodeModule = (modulePath: string) => {
-              // This regex is used to extract the root node module name to be used as the chunk group name.
-              // example: ../../node_modules/.pnpm/next@10/foo/node_modules/bar -> next@10
-              const regex =
-                /node_modules(?:\/|\\)\.?(?:pnpm(?:\/|\\))?([^/\\]+)/
-              const match = modulePath.match(regex)
-              return match ? match[1] : null
-            }
-            return {
-              cacheGroups: {
-                // this chunk configuration gives us a separate chunk for each top level module in node_modules
-                // or a hashed chunk if we can't extract the module name.
-                vendor: {
-                  chunks: 'all',
-                  reuseExistingChunk: true,
-                  test: /[\\/]node_modules[\\/]/,
-                  minSize: 0,
-                  minChunks: 1,
-                  maxAsyncRequests: 300,
-                  maxInitialRequests: 300,
-                  name: (module: webpack.Module) => {
-                    const moduleId = module.nameForCondition()!
-                    const rootModule = extractRootNodeModule(moduleId)
-                    if (rootModule) {
-                      return `vendor-chunks/${rootModule}`
-                    } else {
-                      const hash = crypto.createHash('sha1').update(moduleId)
-                      hash.update(moduleId)
-                      return `vendor-chunks/${hash.digest('hex')}`
-                    }
-                  },
-                },
-                // disable the default chunk groups
-                default: false,
-                defaultVendors: false,
-              },
-            }
-          }
-
-          return false
         }
 
         if (isNodeServer || isEdgeServer) {

--- a/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
@@ -98,16 +98,6 @@ export class TerserPlugin {
               return false
             }
 
-            // don't minify _middleware as it can break in some cases
-            // and doesn't provide too much of a benefit as it's server-side
-            if (
-              name.match(
-                /(edge-runtime-webpack\.js|edge-chunks|middleware\.js$)/
-              )
-            ) {
-              return false
-            }
-
             const { info } = res
 
             // Skip double minimize assets from child compilation

--- a/test/e2e/middleware-trailing-slash/test/index.test.ts
+++ b/test/e2e/middleware-trailing-slash/test/index.test.ts
@@ -111,11 +111,11 @@ describe('Middleware Runtime trailing slash', () => {
         )
         expect(manifest.middleware).toEqual({
           '/': {
-            files: [
+            files: expect.arrayContaining([
               'prerender-manifest.js',
               'server/edge-runtime-webpack.js',
               'server/middleware.js',
-            ],
+            ]),
             name: 'middleware',
             page: '/',
             matchers: [{ regexp: '^/.*$', originalSource: '/:path*' }],

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -187,10 +187,10 @@ describe('Switchable runtime', () => {
           expect(manifest).toMatchObject({
             functions: {
               '/api/hello': {
-                files: [
+                files: expect.arrayContaining([
                   'server/edge-runtime-webpack.js',
                   'server/pages/api/hello.js',
-                ],
+                ]),
                 name: 'pages/api/hello',
                 page: '/api/hello',
                 matchers: [
@@ -199,10 +199,10 @@ describe('Switchable runtime', () => {
                 wasm: [],
               },
               '/api/edge': {
-                files: [
+                files: expect.arrayContaining([
                   'server/edge-runtime-webpack.js',
                   'server/pages/api/edge.js',
-                ],
+                ]),
                 name: 'pages/api/edge',
                 page: '/api/edge',
                 matchers: [
@@ -621,11 +621,11 @@ describe('Switchable runtime', () => {
           expect(manifest).toMatchObject({
             functions: {
               '/api/hello': {
-                files: [
+                files: expect.arrayContaining([
                   'prerender-manifest.js',
                   'server/edge-runtime-webpack.js',
                   'server/pages/api/hello.js',
-                ],
+                ]),
                 name: 'pages/api/hello',
                 page: '/api/hello',
                 matchers: [
@@ -634,11 +634,11 @@ describe('Switchable runtime', () => {
                 wasm: [],
               },
               '/api/edge': {
-                files: [
+                files: expect.arrayContaining([
                   'prerender-manifest.js',
                   'server/edge-runtime-webpack.js',
                   'server/pages/api/edge.js',
-                ],
+                ]),
                 name: 'pages/api/edge',
                 page: '/api/edge',
                 matchers: [

--- a/test/integration/build-trace-extra-entries/test/index.test.js
+++ b/test/integration/build-trace-extra-entries/test/index.test.js
@@ -50,11 +50,6 @@ describe('build trace with extra entries', () => {
       expect(appTrace.files.some((file) => file.endsWith('hello.json'))).toBe(
         true
       )
-      expect(
-        appTrace.files.filter(
-          (file) => file.includes('chunks') && file.endsWith('.js')
-        ).length
-      ).toBe(0)
 
       expect(
         indexTrace.files.filter(


### PR DESCRIPTION
While investigating OOMs noticed that our split chunks handling for edge runtime isn't optimized properly causing a lot of duplicate transpiling/minification which causes exponential memory/cache usage. 

On a minimal app before this change the memory usage and cache size were over `2GB`s after this change they are under `200MB`. 

**Before**

![CleanShot 2024-02-17 at 16 08 46@2x](https://github.com/vercel/next.js/assets/22380829/5286e5fb-5e48-4296-a6be-d2ed1455eb95)


**After**

![CleanShot 2024-02-18 at 08 58 51@2x](https://github.com/vercel/next.js/assets/22380829/f813a185-51a7-40e0-b44b-e1ab95649194)

x-ref: [NEXT-2430](https://linear.app/vercel/issue/NEXT-2430)
x-ref: [NEXT-2395](https://linear.app/vercel/issue/NEXT-2395)
x-ref: [NEXT-2299](https://linear.app/vercel/issue/NEXT-2299)
x-ref: [NEXT-2324](https://linear.app/vercel/issue/NEXT-2324)
x-ref: [NEXT-2373](https://linear.app/vercel/issue/NEXT-2373)

Closes NEXT-2521