### PR TITLE
Ensure webpack build worker defaults on

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1525,12 +1525,8 @@ export default async function build(
       let buildTraceContext: undefined | BuildTraceContext
       let buildTracesPromise: Promise<any> | undefined = undefined
 
-      // If there's has a custom webpack config and disable the build worker.
-      // Otherwise respect the option if it's set.
-      const useBuildWorker =
-        config.experimental.webpackBuildWorker ||
-        (config.experimental.webpackBuildWorker === undefined &&
-          !config.webpack)
+      // webpack build worker is always enabled unless manually disabled
+      const useBuildWorker = config.experimental.webpackBuildWorker !== false
       const runServerAndEdgeInParallel =
         config.experimental.parallelServerCompiles
       const collectServerBuildTracesInParallel =

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -170,7 +170,11 @@ if (isNextProd) {
 
     it('should pass correct nextRuntime values', async () => {
       const content = await next.readFile('runtimes.txt')
-      expect(content.split('\n').sort()).toEqual(['client', 'edge', 'nodejs'])
+      expect([...new Set(content.split('\n'))].sort()).toEqual([
+        'client',
+        'edge',
+        'nodejs',
+      ])
     })
 
     it('should generate html response by streaming correctly', async () => {


### PR DESCRIPTION
As discussed almost all webpack plugins shouldn't have issues with this being enabled by default so removing the default condition where we disable this optimization due to custom webpack config is more beneficial and in the rare case a custom plugin has issues it can still be manually disabled. 

Closes NEXT-2523