### PR TITLE
feat(cli): show available memory/CPU cores in `next info`

### DIFF
--- a/packages/next/src/cli/next-info.ts
+++ b/packages/next/src/cli/next-info.ts
@@ -137,12 +137,14 @@ async function printDefaultInfo() {
     )
   }
 
+  const cpuCores = os.cpus().length
   console.log(`
 Operating System:
   Platform: ${os.platform()}
   Arch: ${os.arch()}
   Version: ${os.version()}
   Available memory (MB): ${Math.ceil(os.totalmem() / 1024 / 1024)}
+  Available CPU cores: ${cpuCores > 0 ? cpuCores : 'N/A'}
 Binaries:
   Node: ${process.versions.node}
   npm: ${getBinaryVersion('npm')}

--- a/packages/next/src/cli/next-info.ts
+++ b/packages/next/src/cli/next-info.ts
@@ -142,6 +142,7 @@ Operating System:
   Platform: ${os.platform()}
   Arch: ${os.arch()}
   Version: ${os.version()}
+  Available memory (MB): ${Math.ceil(os.totalmem() / 1024 / 1024)}
 Binaries:
   Node: ${process.versions.node}
   npm: ${getBinaryVersion('npm')}

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -782,6 +782,7 @@ Operating System:
   Arch: .*
   Version: .*
   Available memory \\(MB\\): .*
+  Available CPU cores: .*
 Binaries:
   Node: .*
   npm: .*

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -781,6 +781,7 @@ Operating System:
   Platform: .*
   Arch: .*
   Version: .*
+  Available memory \\(MB\\): .*
 Binaries:
   Node: .*
   npm: .*


### PR DESCRIPTION
### What?

Adds a new line to the `next info` output:

```diff
Operating System:
  Platform: linux
  Arch: x64
  Version: #18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2
+ Available memory (MB): 31795
+ Available CPU cores: 16
Binaries:
  Node: 18.18.2
  npm: 9.8.1
  Yarn: N/A
  pnpm: 8.15.1
Relevant Packages:
  next: 14.1.1-canary.61 // Latest available version is detected (14.1.1-canary.61).
  eslint-config-next: 14.1.1-canary.61
  react: 18.2.0
  react-dom: 18.2.0
  typescript: 5.2.2
Next.js Config:
  output: N/A
```

### Why?

This can help in debugging

### How?

Using [`os.totalmem()`](https://nodejs.org/api/os.html#ostotalmem) and [`os.cpus()`](https://nodejs.org/api/os.html#oscpus)

Closes NEXT-2529
[Slack thread](https://vercel.slack.com/archives/C046HAU4H7F/p1708359702870269?thread_ts=1708355509.771049&cid=C046HAU4H7F)