### PR TITLE
Add test log prefix for otel

### DIFF
--- a/packages/next/src/client/tracing/tracer.ts
+++ b/packages/next/src/client/tracing/tracer.ts
@@ -1,4 +1,3 @@
-import { LogSpanAllowList } from '../../server/lib/trace/constants'
 import mitt from '../../shared/lib/mitt'
 import type { MittEmitter } from '../../shared/lib/mitt'
 

--- a/packages/next/src/client/tracing/tracer.ts
+++ b/packages/next/src/client/tracing/tracer.ts
@@ -53,22 +53,6 @@ class Span implements ISpan {
       endTime: endTime ?? Date.now(),
     }
 
-    if (
-      process.env.NEXT_OTEL_PERFORMANCE_PREFIX &&
-      LogSpanAllowList.includes(this.name || ('' as any))
-    ) {
-      const { timeOrigin } = performance
-      performance.measure(
-        `${process.env.NEXT_OTEL_LOG_PREFIX}:next-${(
-          this.name.split('.').pop() || ''
-        ).replace(/[A-Z]/g, (match: string) => '-' + match.toLowerCase())}`,
-        {
-          start: this.startTime - timeOrigin,
-          end: this.state.endTime - timeOrigin,
-        }
-      )
-    }
-
     this.onSpanEnd(this)
   }
 }

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -136,6 +136,13 @@ export const NextVanillaSpanAllowlist = [
   NextNodeServerSpan.startResponse,
 ]
 
+// These Spans are allowed to be always logged
+// when the otel log prefix env is set
+export const LogSpanAllowList = [
+  NextNodeServerSpan.findPageComponents,
+  NextNodeServerSpan.createComponentTree,
+]
+
 export {
   BaseServerSpan,
   LoadComponentsSpan,

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -1,5 +1,5 @@
 import type { SpanTypes } from './constants'
-import { NextVanillaSpanAllowlist } from './constants'
+import { LogSpanAllowList, NextVanillaSpanAllowlist } from './constants'
 
 import type {
   ContextAPI,
@@ -229,6 +229,18 @@ class NextTracerImpl implements NextTracer {
             options: { ...fnOrOptions },
           }
 
+    const spanName = options.spanName ?? type
+
+    if (process.env.NEXT_OTEL_LOG_PREFIX && LogSpanAllowList.includes(type)) {
+      performance.measure(
+        `${process.env.NEXT_OTEL_LOG_PREFIX}:next-${spanName.replace(
+          /[A-Z]/g,
+          (match: string) => '-' + match.toLowerCase()
+        )}`,
+        {}
+      )
+    }
+
     if (
       (!NextVanillaSpanAllowlist.includes(type) &&
         process.env.NEXT_OTEL_VERBOSE !== '1') ||
@@ -236,8 +248,6 @@ class NextTracerImpl implements NextTracer {
     ) {
       return fn()
     }
-
-    const spanName = options.spanName ?? type
 
     // Trying to get active scoped span to assign parent. If option specifies parent span manually, will try to use it.
     let spanContext = this.getSpanContext(


### PR DESCRIPTION
Adds a prefix to allow performance tracking for specific spans when env is present. 

cc @javivelasco @feedthejim 

Closes NEXT-2532