### PR TITLE
fix(next-swc): Fix span for invalid `'use server'` directives

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/client-graph/1/output.stderr
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/client-graph/1/output.stderr
@@ -4,10 +4,9 @@
   | 
   | Read more: https://nextjs.org/docs/app/api-reference/functions/server-actions#with-client-components
   | 
-   ,-[input.js:3:1]
- 3 |     export default function App() {
- 4 | ,->   async function fn() {
- 5 | |       'use server'
- 6 | `->   }
- 7 |       return <div>App</div>
+   ,-[input.js:4:1]
+ 4 |   async function fn() {
+ 5 |     'use server'
+   :     ^^^^^^^^^^^^
+ 6 |   }
    `----


### PR DESCRIPTION
### What?

Highlight only `'use server'`, instead of the whole function body.

### Why?

Other statements of the body is not related to the error.


### How?

x-ref: https://vercel.slack.com/archives/C04CAN8CGCE/p1708353068632249?thread_ts=1708351927.544179&cid=C04CAN8CGCE

Closes PACK-2538
