### PR TITLE
docs(cli): tweak `next info` docs

### DIFF
--- a/docs/02-app/02-api-reference/08-next-cli.mdx
+++ b/docs/02-app/02-api-reference/08-next-cli.mdx
@@ -158,21 +158,25 @@ Operating System:
   Platform: linux
   Arch: x64
   Version: #22-Ubuntu SMP Fri Nov 5 13:21:36 UTC 2021
+  Available memory (MB): 31795
+  Available CPU cores: 16
 Binaries:
   Node: 16.13.0
   npm: 8.1.0
   Yarn: 1.22.17
   pnpm: 6.24.2
-Relevant packages:
-  next: 12.0.8
-  react: 17.0.2
-  react-dom: 17.0.2
+Relevant Packages:
+  next: 14.1.1-canary.61 // Latest available version is detected (14.1.1-canary.61).
+  react: 18.2.0
+  react-dom: 18.2.0
+Next.js Config:
+  output: N/A
 
 ```
 
 This information should then be pasted into GitHub Issues.
 
-In order to diagnose installation issues, you can run `next info --verbose` to print additional information about system and the installation of next-related packages.
+You can also run `next info --verbose` which will print additional information about the system and the installation of packages related to `next`.
 
 ## Lint
 


### PR DESCRIPTION
### What?

Follow-up on #62249

### Why?

I noticed the example `next info` output was outdated/missing a few parts in the docs.

Closes NEXT-2533