### PR TITLE
fix(turbopack): print missing slots in debug message

### DIFF
--- a/packages/next/src/client/components/parallel-route-default.tsx
+++ b/packages/next/src/client/components/parallel-route-default.tsx
@@ -1,7 +1,7 @@
 import { notFound } from './not-found'
 
 export const PARALLEL_ROUTE_DEFAULT_PATH =
-  'next/dist/client/components/parallel-route-default'
+  'next/dist/client/components/parallel-route-default.js'
 
 export default function ParallelRouteDefault() {
   notFound()

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -217,11 +217,7 @@ async function createComponentTreeInternal({
       }
     } else {
       staticGenerationStore.dynamicShouldError = false
-      if (dynamic === 'force-static') {
-        staticGenerationStore.forceStatic = true
-      } else {
-        staticGenerationStore.forceStatic = false
-      }
+      staticGenerationStore.forceStatic = dynamic === 'force-static'
     }
   }
 
@@ -427,7 +423,9 @@ async function createComponentTreeInternal({
             // When we detect the default fallback (which triggers a 404), we collect the missing slots
             // to provide more helpful debug information during development mode.
             const parsedTree = parseLoaderTree(parallelRoute)
-            if (parsedTree.layoutOrPagePath === PARALLEL_ROUTE_DEFAULT_PATH) {
+            if (
+              parsedTree.layoutOrPagePath?.endsWith(PARALLEL_ROUTE_DEFAULT_PATH)
+            ) {
               missingSlots.add(parallelRouteKey)
             }
           }

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -4029,13 +4029,12 @@
   },
   "test/e2e/app-dir/parallel-route-not-found/parallel-route-not-found.test.ts": {
     "passed": [
+      "parallel-route-not-found should handle a layout that attempts to render a missing parallel route",
+      "parallel-route-not-found should handle multiple missing parallel routes",
       "parallel-route-not-found should not log any warnings for a regular not found page",
       "parallel-route-not-found should render the page & slots if all parallel routes are found"
     ],
-    "failed": [
-      "parallel-route-not-found should handle a layout that attempts to render a missing parallel route",
-      "parallel-route-not-found should handle multiple missing parallel routes"
-    ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What?

The console message was added in https://github.com/vercel/next.js/pull/60186, but Turbopack outputs fully resolved paths.


Closes PACK-2548